### PR TITLE
Updating 'curl' to 7.68.0 to verify partial certificate chains

### DIFF
--- a/SPECS/curl/curl.signatures.json
+++ b/SPECS/curl/curl.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "curl-7.66.0.tar.gz": "d0393da38ac74ffac67313072d7fe75b1fa1010eb5987f63f349b024a36b7ffb"
+  "curl-7.68.0.tar.gz": "1dd7604e418b0b9a9077f62f763f6684c1b092a7bc17e3f354b8ad5c964d7358"
  }
 }

--- a/SPECS/curl/curl.spec
+++ b/SPECS/curl/curl.spec
@@ -1,6 +1,6 @@
 Summary:        An URL retrieval utility and library
 Name:           curl
-Version:        7.66.0
+Version:        7.68.0
 Release:        1%{?dist}
 License:        MIT
 URL:            http://curl.haxx.se
@@ -87,6 +87,8 @@ rm -rf %{buildroot}/*
 %{_libdir}/libcurl.so.*
 
 %changelog
+*   Tue Aug 11 2020 Pawel Winogrodzki <pawelwi@microsoft.com> 7.68.0-1
+-   Upgrading to 7.68.0 to enable verification against a partial cert chain.
 *   Thu May 14 2020 Nicolas Ontiveros <niontive@microsoft.com> 7.66.0-1
 -   Upgrade to version 7.66.0, which fixes CVE-2018-16890 and CVE-2019-3822/3833.
 *   Sat May 09 00:21:39 PST 2020 Nick Samson <nisamson@microsoft.com> - 7.61.1-6

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -129,9 +129,9 @@ libsolv-0.7.7-4.cm1.aarch64.rpm
 libsolv-devel-0.7.7-4.cm1.aarch64.rpm
 libssh2-1.9.0-1.cm1.aarch64.rpm
 libssh2-devel-1.9.0-1.cm1.aarch64.rpm
-curl-7.66.0-1.cm1.aarch64.rpm
-curl-devel-7.66.0-1.cm1.aarch64.rpm
-curl-libs-7.66.0-1.cm1.aarch64.rpm
+curl-7.68.0-1.cm1.aarch64.rpm
+curl-devel-7.68.0-1.cm1.aarch64.rpm
+curl-libs-7.68.0-1.cm1.aarch64.rpm
 tdnf-2.1.0-3.cm1.aarch64.rpm
 tdnf-cli-libs-2.1.0-3.cm1.aarch64.rpm
 tdnf-devel-2.1.0-3.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -129,9 +129,9 @@ libsolv-0.7.7-4.cm1.x86_64.rpm
 libsolv-devel-0.7.7-4.cm1.x86_64.rpm
 libssh2-1.9.0-1.cm1.x86_64.rpm
 libssh2-devel-1.9.0-1.cm1.x86_64.rpm
-curl-7.66.0-1.cm1.x86_64.rpm
-curl-devel-7.66.0-1.cm1.x86_64.rpm
-curl-libs-7.66.0-1.cm1.x86_64.rpm
+curl-7.68.0-1.cm1.x86_64.rpm
+curl-devel-7.68.0-1.cm1.x86_64.rpm
+curl-libs-7.68.0-1.cm1.x86_64.rpm
 tdnf-2.1.0-3.cm1.x86_64.rpm
 tdnf-cli-libs-2.1.0-3.cm1.x86_64.rpm
 tdnf-devel-2.1.0-3.cm1.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -45,10 +45,10 @@ cryptsetup-debuginfo-2.3.3-2.cm1.aarch64.rpm
 cryptsetup-devel-2.3.3-2.cm1.aarch64.rpm
 cryptsetup-libs-2.3.3-2.cm1.aarch64.rpm
 cryptsetup-reencrypt-2.3.3-2.cm1.aarch64.rpm
-curl-7.66.0-1.cm1.aarch64.rpm
-curl-debuginfo-7.66.0-1.cm1.aarch64.rpm
-curl-devel-7.66.0-1.cm1.aarch64.rpm
-curl-libs-7.66.0-1.cm1.aarch64.rpm
+curl-7.68.0-1.cm1.aarch64.rpm
+curl-debuginfo-7.68.0-1.cm1.aarch64.rpm
+curl-devel-7.68.0-1.cm1.aarch64.rpm
+curl-libs-7.68.0-1.cm1.aarch64.rpm
 device-mapper-2.03.05-5.cm1.aarch64.rpm
 device-mapper-devel-2.03.05-5.cm1.aarch64.rpm
 device-mapper-event-2.03.05-5.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -45,10 +45,10 @@ cryptsetup-debuginfo-2.3.3-2.cm1.x86_64.rpm
 cryptsetup-devel-2.3.3-2.cm1.x86_64.rpm
 cryptsetup-libs-2.3.3-2.cm1.x86_64.rpm
 cryptsetup-reencrypt-2.3.3-2.cm1.x86_64.rpm
-curl-7.66.0-1.cm1.x86_64.rpm
-curl-debuginfo-7.66.0-1.cm1.x86_64.rpm
-curl-devel-7.66.0-1.cm1.x86_64.rpm
-curl-libs-7.66.0-1.cm1.x86_64.rpm
+curl-7.68.0-1.cm1.x86_64.rpm
+curl-debuginfo-7.68.0-1.cm1.x86_64.rpm
+curl-devel-7.68.0-1.cm1.x86_64.rpm
+curl-libs-7.68.0-1.cm1.x86_64.rpm
 device-mapper-2.03.05-5.cm1.x86_64.rpm
 device-mapper-devel-2.03.05-5.cm1.x86_64.rpm
 device-mapper-event-2.03.05-5.cm1.x86_64.rpm


### PR DESCRIPTION
Updating `curl` to 7.68.0 to verify partial certificate chains.

Context for the change:

There are 2 requirements imposed on the trusted CAs (Certificate Authorities) provided by the `ca-certificates-base` package:
1. The CAs are expected to be owned by Microsoft so that Microsoft has full control over the trusted entities, thus limiting the attack surface.
2. The certs must enable authentication of the domain hosting CBL-Mariner packages repository (`packages.microsoft.com` at the moment).

DNF and TDNF rely on `curl` for downloading packages and authentication of the package repositories. For the foreseeable future `packages.microsoft.com` is expected to be using a certificate signed by an **intermediate** CA owned by Microsoft **BUT** the **root** CA will remain owned by a different entity. This forces us to only include the intermediate CA as our trust anchor. The 7.66.0 version of `curl` did not support authenticating against an intermediate CA (the trust anchor had to be a root CA), which became a default option in 7.68.0 (see: [curl issue 4655](https://github.com/curl/curl/pull/4655) and [the documentation](https://curl.haxx.se/libcurl/c/CURLOPT_SSL_OPTIONS.html) for `CURLSSLOPT_NO_PARTIALCHAIN`), thus the update.