### PR TITLE
Add a pull request template to auto fill PR descriptions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,33 @@
+<!--
+COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
+Feel free to delete sections of the template which do not apply to your PR, or add additional details
+
+Checklist:
+1. Make PRs from either a forked repo, or a feature branch (user/feature).
+2. Either use a squash merge PR, or squash your commits locally before creating the PR.
+3. Make sure the documentation is updated if your change affects the build system.
+-->
+
+#### Summary <!-- REQUIRED -->
+<!-- Quick explanation of the changes. -->
+What does the PR accomplish, why was it needed?
+
+#### Change Log  <!-- REQUIRED -->
+<!-- Detail the changes made here. -->
+<!-- Please list any packages which will be affected by this change, if applicable. -->
+<!-- Please list any CVES fixed by this change, if applicable. -->
+- Change
+- Change
+- Change
+
+#### Does this affect the toolchain?  <!-- REQUIRED -->
+<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
+<!-- [ ] or [x] -->
+[] Will this affect the toolchain?
+
+#### Associated issues  <!-- optional -->
+<!-- Link to Github issues if possible. -->
+- #xxxx
+
+#### Links to CVEs  <!-- optional -->
+- https://nvd.nist.gov/...


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
Checklist:
1. Make PRs from either a forked repo, or a feature branch (user/feature).
2. Either use a squash merge PR, or squash your commits locally before creating the PR.
3. Make sure the documentation is updated if your change affects the build system.
-->

#### Summary <!-- REQUIRED -->
<!-- Please list any packages which will be affected by this change, if applicable-->
<!-- Please list any CVES fixed by this change, if applicable-->
Github supports PR templates which automatically pre-fill the PR description field. Add a template so our PRs look more uniform and will be more searchable in the future.

#### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here -->
- Add `.github/pull_request_template.md` which will auto fill future PR descriptions.

#### Does this affect the toolchain?  <!-- REQUIRED -->
[ ] Will this affect the toolchain?
