### PR TITLE
Fix toolchain RPM downloading

### DIFF
--- a/toolkit/scripts/toolchain.mk
+++ b/toolkit/scripts/toolchain.mk
@@ -179,7 +179,6 @@ $(toolchain_rpms):
 	for url in $(toolchain_package_urls); do \
 		wget $${url}/$(notdir $@) \
 			--no-verbose \
-			--no-check-certificate \
 			$(if $(TLS_CERT),--certificate=$(TLS_CERT)) \
 			$(if $(TLS_KEY),--private-key=$(TLS_KEY)) \
 			&& \


### PR DESCRIPTION
This PR fixes two issues with downloading toolchain RPMs:
1) The package URL was malformed. It was using: `{url}/{arch}/{rpm_name}`. However, there should not be a nested `{arch}` folder in the URL path.
2) `--private-key=` and `--certificate=` were always be set in the `wget` command, even if no TLS certificates were provided. With this PR, these options are only passed if the TLS cert arguments are set.

