### PR TITLE
Fix building derivatives without TLS certificates

### DIFF
--- a/toolkit/tools/graphpkgfetcher/graphpkgfetcher.go
+++ b/toolkit/tools/graphpkgfetcher/graphpkgfetcher.go
@@ -93,11 +93,9 @@ func resolveGraphNodes(dependencyGraph *pkggraph.PkgGraph, inputSummaryFile, out
 	}
 	defer cloner.Close()
 
-	if tlsKey != "" || tlsCert != "" {
-		err = cloner.AddNetworkFiles(tlsCert, tlsKey)
-		if err != nil {
-			logger.Log.Panicf("Failed to customize RPM repo cloner. Error: %s", err)
-		}
+	err = cloner.AddNetworkFiles(tlsCert, tlsKey)
+	if err != nil {
+		logger.Log.Panicf("Failed to customize RPM repo cloner. Error: %s", err)
 	}
 
 	if strings.TrimSpace(inputSummaryFile) == "" {

--- a/toolkit/tools/imagepkgfetcher/imagepkgfetcher.go
+++ b/toolkit/tools/imagepkgfetcher/imagepkgfetcher.go
@@ -64,11 +64,9 @@ func main() {
 	}
 	defer cloner.Close()
 
-	if tlsKey != "" || tlsCert != "" {
-		err = cloner.AddNetworkFiles(tlsCert, tlsKey)
-		if err != nil {
-			logger.Log.Panicf("Failed to customize RPM repo cloner. Error: %s", err)
-		}
+	err = cloner.AddNetworkFiles(tlsCert, tlsKey)
+	if err != nil {
+		logger.Log.Panicf("Failed to customize RPM repo cloner. Error: %s", err)
 	}
 
 	if strings.TrimSpace(*inputSummaryFile) != "" {

--- a/toolkit/tools/internal/packagerepo/repocloner/rpmrepocloner/rpmrepocloner.go
+++ b/toolkit/tools/internal/packagerepo/repocloner/rpmrepocloner/rpmrepocloner.go
@@ -146,16 +146,21 @@ func (r *RpmRepoCloner) Initialize(destinationDir, tmpDir, workerTar, existingRp
 }
 
 // AddNetworkFiles adds files needed for networking capabilities into the cloner.
+// tlsClientCert and tlsClientKey are optional.
 func (r *RpmRepoCloner) AddNetworkFiles(tlsClientCert, tlsClientKey string) (err error) {
-	if tlsClientCert == "" || tlsClientKey == "" {
-		err = fmt.Errorf("one of tlsClientCert(%s) or tlsClientKey(%s) is not set", tlsClientCert, tlsClientKey)
-		return
-	}
 	files := []safechroot.FileToCopy{
 		{Src: "/etc/resolv.conf", Dest: "/etc/resolv.conf"},
-		{Src: tlsClientCert, Dest: "/etc/tdnf/mariner_user.crt"},
-		{Src: tlsClientKey, Dest: "/etc/tdnf/mariner_user.key"},
 	}
+
+	if tlsClientCert != "" && tlsClientKey != "" {
+		tlsFiles := []safechroot.FileToCopy{
+			{Src: tlsClientCert, Dest: "/etc/tdnf/mariner_user.crt"},
+			{Src: tlsClientKey, Dest: "/etc/tdnf/mariner_user.key"},
+		}
+
+		files = append(files, tlsFiles...)
+	}
+
 	err = r.chroot.AddFiles(files...)
 	return
 }


### PR DESCRIPTION
The package fetchers (`imagepkgfetcher` and `graphpkgfetcher`) were not enabling network support if no TLS certificates were provided. This resulted in derivative images failing to build if they were not using certificates.

The fix is to always add `/etc/resolve.conf` into the chroots, but conditionally add the TLS certificates if provided.