### PR TITLE
Ignoring the 'build' and 'out' directories.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,10 +26,12 @@ x86/
 [Aa][Rr][Mm]/
 [Aa][Rr][Mm]64/
 bld/
+build/
 [Bb]in/
 [Oo]bj/
 [Ll]og/
 [Ll]ogs/
+out/
 
 # Visual Studio 2015/2017 cache/options directory
 .vs/


### PR DESCRIPTION
#### Summary

Adding the `build` and `out` directories to `.gitignore`, since they are created by the toolkit during every build and should never be checked into the repository.

#### Change Log

- Added `build` and `out` to `.gitignore`.

#### Does this affect the toolchain?

No.