### PR TITLE
Disable networking inside of package build chroots

### DIFF
--- a/toolkit/tools/pkgworker/pkgworker.go
+++ b/toolkit/tools/pkgworker/pkgworker.go
@@ -358,7 +358,6 @@ func removeLibArchivesFromSystem() (err error) {
 // copyFilesIntoChroot copies several required build specific files into the chroot.
 func copyFilesIntoChroot(chroot *safechroot.Chroot, srpmFile, repoFile, rpmmacrosFile string) (srpmFileInChroot string, err error) {
 	const (
-		resolv            = "/etc/resolv.conf"
 		chrootRepoDestDir = "/etc/yum.repos.d"
 		chrootSrpmDestDir = "/home/root/SRPMS"
 		rpmmacrosDest     = "/usr/lib/rpm/macros.d/macros.override"
@@ -375,10 +374,6 @@ func copyFilesIntoChroot(chroot *safechroot.Chroot, srpmFile, repoFile, rpmmacro
 		safechroot.FileToCopy{
 			Src:  srpmFile,
 			Dest: srpmFileInChroot,
-		},
-		safechroot.FileToCopy{
-			Src:  resolv,
-			Dest: resolv,
 		},
 	}
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details

Checklist:
1. Make PRs from either a forked repo, or a feature branch (user/feature).
2. Either use a squash merge PR, or squash your commits locally before creating the PR.
3. Make sure the documentation is updated if your change affects the build system.
-->

#### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
During package build, we expect all collateral necessary for a package
build to be available locally. Therefore, we should not allow network access
from inside the chroot.

This change disables networking specifically in the package build chroot.
Other build chroots are unaffected.

#### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change removes the addition of resolv.conf to the chroot

#### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- [ ] or [x] -->
[] Will this affect the toolchain?