### PR TITLE
Use SearchAndClone to resolve files to packages

### DIFF
--- a/toolkit/tools/internal/packagerepo/repocloner/repocloner.go
+++ b/toolkit/tools/internal/packagerepo/repocloner/repocloner.go
@@ -27,6 +27,7 @@ type RepoCloner interface {
 	Initialize(destinationDir, tmpDir, workerTar, existingRpmsDir string, useUpdateRepo bool, repoDefinitions []string) error
 	AddNetworkFiles(tlsClientCert, tlsClientKey string) error
 	Clone(cloneDeps bool, packagesToClone ...*pkgjson.PackageVer) error
+	SearchAndClone(cloneDeps bool, singlePackageToClone *pkgjson.PackageVer) error
 	ConvertDownloadedPackagesIntoRepo() error
 	ClonedRepoContents() (repoContents *RepoContents, err error)
 	CloneDirectory() string


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details

Checklist:
1. Make PRs from either a forked repo, or a feature branch (user/feature).
2. Either use a squash merge PR, or squash your commits locally before creating the PR.
-->

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
This PR restores `SearchAndClone` to resolve files (e.g. `/bin/foo`) to specific packages during `graphpkgfetcher`. Issues were observed resolving files to packages when relying on TDNF's capability matching.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Restore `SearchAndClone` to `repocloner` and use it in `graphpkgfetcher`

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Merge Checklist  <!-- REQUIRED -->
<!-- These should all be checked before merging a PR -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
- [x] The toolchain has been rebuilt successfully if any changes were made to it
- [x] The toolchain/worker package manifests have been updated if this is a toolchain package
- [x] Updated packages have been successfully built
- [x] New source files have updated hashes in the `*.signatures.json` files
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge
