### PR TITLE
Remove kernel-signed packages from kernel subpackage requires

### DIFF
--- a/SPECS-SIGNED/kernel-signed-aarch64/kernel-signed-aarch64.spec
+++ b/SPECS-SIGNED/kernel-signed-aarch64/kernel-signed-aarch64.spec
@@ -2,7 +2,7 @@
 Summary:        Signed Linux Kernel for aarch64 systems
 Name:           kernel-signed-aarch64
 Version:        5.4.42
-Release:        11%{?dist}
+Release:        12%{?dist}
 License:        GPLv2
 URL:            https://github.com/microsoft/WSL2-Linux-Kernel
 Group:          System Environment/Kernel
@@ -80,5 +80,7 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %config %{_localstatedir}/lib/initramfs/kernel/%{uname_r}
 
 %changelog
+*   Wed Aug 19 2020 Chris Co <chrco@microsoft.com> 5.4.42-12
+-   Update release number
 *   Tue Aug 18 2020 Chris Co <chrco@microsoft.com> 5.4.42-11
 -   Original version

--- a/SPECS-SIGNED/kernel-signed-x64/kernel-signed-x64.spec
+++ b/SPECS-SIGNED/kernel-signed-x64/kernel-signed-x64.spec
@@ -2,7 +2,7 @@
 Summary:        Signed Linux Kernel for x86_64 systems
 Name:           kernel-signed-x64
 Version:        5.4.42
-Release:        11%{?dist}
+Release:        12%{?dist}
 License:        GPLv2
 URL:            https://github.com/microsoft/WSL2-Linux-Kernel
 Group:          System Environment/Kernel
@@ -80,5 +80,7 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %config %{_localstatedir}/lib/initramfs/kernel/%{uname_r}
 
 %changelog
+*   Wed Aug 19 2020 Chris Co <chrco@microsoft.com> 5.4.42-12
+-   Update release number
 *   Tue Aug 18 2020 Chris Co <chrco@microsoft.com> 5.4.42-11
 -   Original version

--- a/SPECS/kernel/kernel.spec
+++ b/SPECS/kernel/kernel.spec
@@ -2,7 +2,7 @@
 Summary:        Linux Kernel
 Name:           kernel
 Version:        5.4.42
-Release:        11%{?dist}
+Release:        12%{?dist}
 License:        GPLv2
 URL:            https://github.com/microsoft/WSL2-Linux-Kernel
 Group:          System Environment/Kernel
@@ -41,7 +41,7 @@ The kernel package contains the Linux kernel.
 Summary:        Kernel Dev
 Group:          System Environment/Kernel
 Obsoletes:      linux-dev
-Requires:       (%{name} = %{version}-%{release} or kernel-signed-x64 = %{version}-%{release} or kernel-signed-aarch64 = %{version}-%{release})
+Requires:       %{name} = %{version}-%{release}
 Requires:       python3 gawk
 %description devel
 This package contains the Linux kernel dev files
@@ -49,7 +49,7 @@ This package contains the Linux kernel dev files
 %package drivers-sound
 Summary:        Kernel Sound modules
 Group:          System Environment/Kernel
-Requires:       (%{name} = %{version}-%{release} or kernel-signed-x64 = %{version}-%{release} or kernel-signed-aarch64 = %{version}-%{release})
+Requires:       %{name} = %{version}-%{release}
 %description drivers-sound
 This package contains the Linux kernel sound support
 
@@ -64,7 +64,7 @@ This package contains the Linux kernel doc files
 %package oprofile
 Summary:        Kernel driver for oprofile, a statistical profiler for Linux systems
 Group:          System Environment/Kernel
-Requires:       (%{name} = %{version}-%{release} or kernel-signed-x64 = %{version}-%{release} or kernel-signed-aarch64 = %{version}-%{release})
+Requires:       %{name} = %{version}-%{release}
 %description oprofile
 Kernel driver for oprofile, a statistical profiler for Linux systems
 %endif
@@ -72,7 +72,7 @@ Kernel driver for oprofile, a statistical profiler for Linux systems
 %package tools
 Summary:        This package contains the 'perf' performance analysis tools for Linux kernel
 Group:          System/Tools
-Requires:       (%{name} = %{version}-%{release} or kernel-signed-x64 = %{version}-%{release} or kernel-signed-aarch64 = %{version}-%{release})
+Requires:       %{name} = %{version}-%{release}
 Requires:       audit
 %description tools
 This package contains the 'perf' performance analysis tools for Linux kernel.
@@ -282,6 +282,8 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %{_libdir}/perf/include/bpf/*
 
 %changelog
+*   Wed Aug 19 2020 Chris Co <chrco@microsoft.com> 5.4.42-12
+-   Remove the signed package depends
 *   Tue Aug 18 2020 Chris Co <chrco@microsoft.com> 5.4.42-11
 -   Remove signed subpackage
 *   Mon Aug 17 2020 Chris Co <chrco@microsoft.com> 5.4.42-10


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details

Checklist:
1. Make PRs from either a forked repo, or a feature branch (user/feature).
2. Either use a squash merge PR, or squash your commits locally before creating the PR.
-->

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
This change is an immediate fix for a kernel package build break. The tooling attempts to build all packages in a `Requires` list. This includes "or" packages. Since the UEFI Secure Boot specs are in a separate folder and are not immediately buildable like normal packages, the tooling are unable to resolve these requires and fails the build.

One possible ramification of this change is that the kernel subpackages like kernel-devel may fail to install on a system that has the kernel-signed package installed. This is being investigated.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Remove the signed packages from the kernel subpackage's Requires
- Increment the kernel, kernel-signed-x64, kernel-signed-aarch64 package release

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Merge Checklist  <!-- REQUIRED -->
<!-- These should all be checked before merging a PR -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
- [x] The toolchain has been rebuilt successfully if any changes were made to it
- [x] The toolchain/worker package manifests have been updated if this is a toolchain package
- [x] Updated packages have been successfully built
- [x] New source files have updated hashes in the `*.signatures.json` files
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge
