### PR TITLE
Add libgcrypt dependency to libxslt

### DIFF
--- a/SPECS/libxslt/libxslt.spec
+++ b/SPECS/libxslt/libxslt.spec
@@ -1,7 +1,7 @@
 Summary:        Libxslt is the XSLT C library developed for the GNOME project. XSLT is a an XML language to define transformation for XML.
 Name:           libxslt
 Version:        1.1.34
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        MIT
 URL:            http://xmlsoft.org/libxslt/
 Group:          System Environment/General Libraries
@@ -9,7 +9,10 @@ Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Source0:        http://xmlsoft.org/sources/%{name}-%{version}.tar.gz
 Requires:       libxml2-devel
+Requires:       libgcrypt
 BuildRequires:  libxml2-devel
+BuildRequires:  libgcrypt-devel
+
 %description
 The libxslt package contains XSLT libraries used for extending libxml2 libraries to support XSLT files.
 
@@ -62,6 +65,8 @@ rm -rf %{buildroot}/*
 %{_mandir}/man3/*
 
 %changelog
+*   Wed Aug 19 2020 Henry Beberman <henry.beberman@microsoft.com> 1.1.34-2
+-   Add dependency on libgcrypt
 *   Mon Jun 08 2020 Joe Schmitt <joschmit@microsoft.com> 1.1.34-1
 -   Update to version 1.1.34 to resolve CVE-2019-11068.
 -   Remove patch for CVE-2019-5815 since it is fixed in 1.1.34.

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -220,9 +220,9 @@ libxml2-2.9.10-1.cm1.aarch64.rpm
 libxml2-debuginfo-2.9.10-1.cm1.aarch64.rpm
 libxml2-devel-2.9.10-1.cm1.aarch64.rpm
 libxml2-python-2.9.10-1.cm1.aarch64.rpm
-libxslt-1.1.34-1.cm1.aarch64.rpm
-libxslt-debuginfo-1.1.34-1.cm1.aarch64.rpm
-libxslt-devel-1.1.34-1.cm1.aarch64.rpm
+libxslt-1.1.34-2.cm1.aarch64.rpm
+libxslt-debuginfo-1.1.34-2.cm1.aarch64.rpm
+libxslt-devel-1.1.34-2.cm1.aarch64.rpm
 lua-5.3.5-6.cm1.aarch64.rpm
 lua-debuginfo-5.3.5-6.cm1.aarch64.rpm
 lua-devel-5.3.5-6.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -220,9 +220,9 @@ libxml2-2.9.10-1.cm1.x86_64.rpm
 libxml2-debuginfo-2.9.10-1.cm1.x86_64.rpm
 libxml2-devel-2.9.10-1.cm1.x86_64.rpm
 libxml2-python-2.9.10-1.cm1.x86_64.rpm
-libxslt-1.1.34-1.cm1.x86_64.rpm
-libxslt-debuginfo-1.1.34-1.cm1.x86_64.rpm
-libxslt-devel-1.1.34-1.cm1.x86_64.rpm
+libxslt-1.1.34-2.cm1.x86_64.rpm
+libxslt-debuginfo-1.1.34-2.cm1.x86_64.rpm
+libxslt-devel-1.1.34-2.cm1.x86_64.rpm
 lua-5.3.5-6.cm1.x86_64.rpm
 lua-debuginfo-5.3.5-6.cm1.x86_64.rpm
 lua-devel-5.3.5-6.cm1.x86_64.rpm

--- a/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
+++ b/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
@@ -356,8 +356,9 @@ build_rpm_in_chroot_no_install cmake
 build_rpm_in_chroot_no_install pam
 build_rpm_in_chroot_no_install docbook-dtd-xml
 
-# libxslt needs libxml2
+# libxslt needs libxml2, libgcrypt
 chroot_and_install_rpms libxml2
+chroot_and_install_rpms libgcrypt
 build_rpm_in_chroot_no_install libxslt
 
 # docbook-style-xsl needs pam
@@ -385,14 +386,13 @@ build_rpm_in_chroot_no_install libassuan
 build_rpm_in_chroot_no_install npth
 build_rpm_in_chroot_no_install libksba
 
-# gnupg2 requires zlib, bzip2, readline, npth, libassuan, libksba, libgcrypt
+# gnupg2 requires zlib, bzip2, readline, npth, libassuan, libksba
 chroot_and_install_rpms zlib
 chroot_and_install_rpms bzip2
 chroot_and_install_rpms readline
 chroot_and_install_rpms npth
 chroot_and_install_rpms libassuan
 chroot_and_install_rpms libksba
-chroot_and_install_rpms libgcrypt
 build_rpm_in_chroot_no_install gnupg2
 build_rpm_in_chroot_no_install swig
 


### PR DESCRIPTION
###### Summary
The worker chroot now contains libgcrypt by default to support gpg.
libxslt recognizes that it's there and attempts to take a dependency on it.
Take that implicit dependency and make it explicit so the devel package is included.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Update libxslt to take an explicit dependency on libgcrypt. libgcrypt is now in the worker chroot by default and libxslt was picking that up with autoconf but did not have the libgcrypt-devel package.
- libgcrypt has been set to install earlier in build_official_toolchain_rpms.sh

###### Does this affect the toolchain?  <!-- REQUIRED -->
**YES**

###### Merge Checklist  <!-- REQUIRED -->
<!-- These should all be checked before merging a PR -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
- [ ] The toolchain has been rebuilt successfully if any changes were made to it
- [x] The toolchain/worker package manifests have been updated if this is a toolchain package
- [x] Updated packages have been successfully built
- [x] New source files have updated hashes in the `*.signatures.json` files
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge
