### PR TITLE
Applying a patch to fix CVE-2020-24330/24331 in the 'trousers' package.

### DIFF
--- a/SPECS/trousers/CVE-2020-24330.patch
+++ b/SPECS/trousers/CVE-2020-24330.patch
@@ -1,0 +1,58 @@
+Index: trousers-0.3.14/src/tcs/ps/tcsps.c
+===================================================================
+--- trousers-0.3.14.orig/src/tcs/ps/tcsps.c
++++ trousers-0.3.14/src/tcs/ps/tcsps.c
+@@ -72,7 +72,7 @@ get_file()
+ 	}
+ 
+ 	/* open and lock the file */
+-	system_ps_fd = open(tcsd_options.system_ps_file, O_CREAT|O_RDWR, 0600);
++	system_ps_fd = open(tcsd_options.system_ps_file, O_CREAT|O_RDWR|O_NOFOLLOW, 0600);
+ 	if (system_ps_fd < 0) {
+ 		LogError("system PS: open() of %s failed: %s",
+ 				tcsd_options.system_ps_file, strerror(errno));
+Index: trousers-0.3.14/src/tcsd/svrside.c
+===================================================================
+--- trousers-0.3.14.orig/src/tcsd/svrside.c
++++ trousers-0.3.14/src/tcsd/svrside.c
+@@ -473,6 +473,7 @@ main(int argc, char **argv)
+ 		}
+ 		return TCSERR(TSS_E_INTERNAL_ERROR);
+ 	}
++	setgid(pwd->pw_gid);
+ 	setuid(pwd->pw_uid);
+ #endif
+ #endif
+Index: trousers-0.3.14/src/tcsd/tcsd_conf.c
+===================================================================
+--- trousers-0.3.14.orig/src/tcsd/tcsd_conf.c
++++ trousers-0.3.14/src/tcsd/tcsd_conf.c
+@@ -743,7 +743,7 @@ conf_file_init(struct tcsd_config *conf)
+ #ifndef SOLARIS
+ 	struct group *grp;
+ 	struct passwd *pw;
+-	mode_t mode = (S_IRUSR|S_IWUSR);
++	mode_t mode = (S_IRUSR|S_IWUSR|S_IRGRP);
+ #endif /* SOLARIS */
+ 	TSS_RESULT result;
+ 
+@@ -798,15 +798,15 @@ conf_file_init(struct tcsd_config *conf)
+ 	}
+ 
+ 	/* make sure user/group TSS owns the conf file */
+-	if (pw->pw_uid != stat_buf.st_uid || grp->gr_gid != stat_buf.st_gid) {
++	if (stat_buf.st_uid != 0 || grp->gr_gid != stat_buf.st_gid) {
+ 		LogError("TCSD config file (%s) must be user/group %s/%s", tcsd_config_file,
+-				TSS_USER_NAME, TSS_GROUP_NAME);
++				"root", TSS_GROUP_NAME);
+ 		return TCSERR(TSS_E_INTERNAL_ERROR);
+ 	}
+ 
+-	/* make sure only the tss user can manipulate the config file */
++	/* make sure only the tss user can read (but not manipulate) the config file */
+ 	if (((stat_buf.st_mode & 0777) ^ mode) != 0) {
+-		LogError("TCSD config file (%s) must be mode 0600", tcsd_config_file);
++		LogError("TCSD config file (%s) must be mode 0640", tcsd_config_file);
+ 		return TCSERR(TSS_E_INTERNAL_ERROR);
+ 	}
+ #endif /* SOLARIS */

--- a/SPECS/trousers/CVE-2020-24331.nopatch
+++ b/SPECS/trousers/CVE-2020-24331.nopatch
@@ -1,0 +1,1 @@
+CVE-2020-24330.patch fixes this CVE as well.

--- a/SPECS/trousers/trousers.spec
+++ b/SPECS/trousers/trousers.spec
@@ -1,13 +1,18 @@
 Summary:      TCG Software Stack (TSS)
 Name:         trousers
 Version:      0.3.14
-Release:      5%{?dist}
+Release:      6%{?dist}
 License:      BSD-3-Clause
 URL:          https://sourceforge.net/projects/trousers/
 Group:        System Environment/Security
 Vendor:       Microsoft Corporation
 Distribution: Mariner
 Source0:      https://sourceforge.net/projects/%{name}/files/%{name}/%{version}/%{name}-%{version}.tar.gz
+
+# CVE-2020-24330.patch fixes both CVE-2020-24330 and CVE-2020-24331.
+Patch0:       CVE-2020-24330.patch
+Patch1:       CVE-2020-24331.nopatch
+
 Requires:     libtspi = %{version}-%{release}
 
 %description
@@ -28,6 +33,8 @@ TSPI library
 
 %prep
 %setup -q -c %{name}-%{version}
+%patch0 -p1
+
 %build
 %configure \
     --disable-static
@@ -62,7 +69,7 @@ if [ $1 -eq 0 ]; then
 fi
 
 %post -n libtspi -p /sbin/ldconfig
-%postun	-n libtspi -p /sbin/ldconfig
+%postun -n libtspi -p /sbin/ldconfig
 
 %files
 %defattr(-,root,root)
@@ -88,9 +95,10 @@ fi
 %exclude %{_libdir}/libtddl.a
 
 %changelog
-* Sat May 09 00:20:43 PST 2020 Nick Samson <nisamson@microsoft.com> - 0.3.14-5
-- Added %%license line automatically
-
+*   Thu Aug 20 2020 Pawel Winogrodzki <pawelwi@microsoft.com> 0.3.14-6
+-   Applying a patch for CVE-2020-24330 and CVE-2020-24331.
+*   Sat May 09 2020 Nick Samson <nisamson@microsoft.com> 0.3.14-5
+-   Added %%license line automatically
 *   Thu Apr 09 2020 Joe Schmitt <joschmit@microsoft.com> 0.3.14-4
 -   Update Source0 with valid URL.
 -   Update License.


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details

Checklist:
1. Make PRs from either a forked repo, or a feature branch (user/feature).
2. Either use a squash merge PR, or squash your commits locally before creating the PR.
-->

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Applying a patch to fix [CVE-2020-24330](https://nvd.nist.gov/vuln/detail/CVE-2020-24330)/[24331](https://nvd.nist.gov/vuln/detail/CVE-2020-24331) in the `trousers` package. [The patch](https://seclists.org/oss-sec/2020/q2/att-135/tcsd_fixes.patch) is mentioned in both NVD links.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Applied a patch for CVE-2020-24330.
- Marked CVE-2020-24331 as `nopatch`, since the patch applies to both vulnerabilities.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
**No**.

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2020-24330
- https://nvd.nist.gov/vuln/detail/CVE-2020-24331

###### Merge Checklist  <!-- REQUIRED -->
<!-- These should all be checked before merging a PR -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
- [x] The toolchain has been rebuilt successfully if any changes were made to it
- [x] The toolchain/worker package manifests have been updated if this is a toolchain package
- [x] Updated packages have been successfully built
- [x] New source files have updated hashes in the `*.signatures.json` files
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge
