### PR TITLE
Update mysql to version 8.0.21 to fix 32 CVEs

### DIFF
--- a/SPECS/mysql/mysql.signatures.json
+++ b/SPECS/mysql/mysql.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "mysql-boost-8.0.20.tar.gz": "b6ad1a09eb146fa913f1afc257bbed8ffab688e2d504fb8ddb652f69f551a9c1"
+  "mysql-boost-8.0.21.tar.gz": "37231a123372a95f409857364dc1deb196b6f2c0b1fe60cc8382c7686b487f11"
  }
 }

--- a/SPECS/mysql/mysql.spec
+++ b/SPECS/mysql/mysql.spec
@@ -1,7 +1,7 @@
 Summary:        MySQL.
 Name:           mysql
-Version:        8.0.20
-Release:        2%{?dist}
+Version:        8.0.21
+Release:        1%{?dist}
 License:        GPLv2 with exceptions and LGPLv2 and BSD
 Group:          Applications/Databases
 Vendor:         Microsoft Corporation
@@ -32,7 +32,7 @@ Development headers for developing applications linking to maridb
 %build
 cmake . \
       -DCMAKE_INSTALL_PREFIX=/usr   \
-      -DWITH_BOOST=boost/boost_1_70_0 \
+      -DWITH_BOOST=boost/boost_1_72_0 \
       -DINSTALL_MANDIR=share/man \
       -DINSTALL_DOCDIR=share/doc \
       -DINSTALL_DOCREADMEDIR=share/doc \
@@ -76,9 +76,10 @@ make test
 %{_libdir}/pkgconfig/mysqlclient.pc
 
 %changelog
-* Sat May 09 00:21:19 PST 2020 Nick Samson <nisamson@microsoft.com> - 8.0.20-2
-- Added %%license line automatically
-
+*   Tue Aug 18 2020 Henry Beberman <henry.beberman@microsoft.com> - 8.0.21-1
+-   Upgrade to 8.0.21. Fixes 32 CVEs.
+*   Sat May 09 2020 Nick Samson <nisamson@microsoft.com> - 8.0.20-2
+-   Added %%license line automatically
 *   Mon Apr 27 2020 Emre Girgin <mrgirgin@microsoft.com> 8.0.20-1
 -   Upgrade to 8.0.20. Fixes 70 CVEs.
 -   Update URL.


### PR DESCRIPTION
###### Summary <!-- REQUIRED -->
Update mysql to 8.0.21 to fix 32 CVEs

###### Change Log  <!-- REQUIRED -->
- Update mysql to 8.0.21

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2020-14539
- https://nvd.nist.gov/vuln/detail/CVE-2020-14540
- https://nvd.nist.gov/vuln/detail/CVE-2020-14547
- https://nvd.nist.gov/vuln/detail/CVE-2020-14550
- https://nvd.nist.gov/vuln/detail/CVE-2020-14553
- https://nvd.nist.gov/vuln/detail/CVE-2020-14559
- https://nvd.nist.gov/vuln/detail/CVE-2020-14568
- https://nvd.nist.gov/vuln/detail/CVE-2020-14575
- https://nvd.nist.gov/vuln/detail/CVE-2020-14576
- https://nvd.nist.gov/vuln/detail/CVE-2020-14586
- https://nvd.nist.gov/vuln/detail/CVE-2020-14591
- https://nvd.nist.gov/vuln/detail/CVE-2020-14597
- https://nvd.nist.gov/vuln/detail/CVE-2020-14614
- https://nvd.nist.gov/vuln/detail/CVE-2020-14619
- https://nvd.nist.gov/vuln/detail/CVE-2020-14620
- https://nvd.nist.gov/vuln/detail/CVE-2020-14623
- https://nvd.nist.gov/vuln/detail/CVE-2020-14624
- https://nvd.nist.gov/vuln/detail/CVE-2020-14631
- https://nvd.nist.gov/vuln/detail/CVE-2020-14632
- https://nvd.nist.gov/vuln/detail/CVE-2020-14633
- https://nvd.nist.gov/vuln/detail/CVE-2020-14634
- https://nvd.nist.gov/vuln/detail/CVE-2020-14641
- https://nvd.nist.gov/vuln/detail/CVE-2020-14643
- https://nvd.nist.gov/vuln/detail/CVE-2020-14651
- https://nvd.nist.gov/vuln/detail/CVE-2020-14654
- https://nvd.nist.gov/vuln/detail/CVE-2020-14656
- https://nvd.nist.gov/vuln/detail/CVE-2020-14663
- https://nvd.nist.gov/vuln/detail/CVE-2020-14678
- https://nvd.nist.gov/vuln/detail/CVE-2020-14680
- https://nvd.nist.gov/vuln/detail/CVE-2020-14697
- https://nvd.nist.gov/vuln/detail/CVE-2020-14702
- https://nvd.nist.gov/vuln/detail/CVE-2020-14725

###### Merge Checklist  <!-- REQUIRED -->
<!-- These should all be checked before merging a PR -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
- [x] The toolchain has been rebuilt successfully if any changes were made to it
- [x] The toolchain/worker package manifests have been updated if this is a toolchain package
- [x] Updated packages have been successfully built
- [x] New source files have updated hashes in the `*.signatures.json` files
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge
