### PR TITLE
Use time.windows.com for systemd-timesyncd by default

### DIFF
--- a/SPECS/systemd/systemd.spec
+++ b/SPECS/systemd/systemd.spec
@@ -1,7 +1,7 @@
 Summary:          Systemd-239
 Name:             systemd
 Version:          239
-Release:          30%{?dist}
+Release:          31%{?dist}
 License:          LGPLv2+ and GPLv2+ and MIT
 URL:              https://www.freedesktop.org/wiki/Software/systemd/
 Group:            System Environment/Security
@@ -153,6 +153,7 @@ sed -i '/srv/d' %{buildroot}/usr/lib/tmpfiles.d/home.conf
 sed -i "s:0775 root lock:0755 root root:g" %{buildroot}/usr/lib/tmpfiles.d/legacy.conf
 sed -i "s:NamePolicy=kernel database onboard slot path:NamePolicy=kernel database:g" %{buildroot}/lib/systemd/network/99-default.link
 sed -i "s:#LLMNR=yes:LLMNR=false:g" %{buildroot}/etc/systemd/resolved.conf
+sed -i "s:#NTP=:NTP=time.windows.com:g" %{buildroot}/etc/systemd/timesyncd.conf
 rm -f %{buildroot}%{_var}/log/README
 mkdir -p %{buildroot}%{_localstatedir}/opt/journal/log
 mkdir -p %{buildroot}%{_localstatedir}/log
@@ -270,6 +271,8 @@ rm -rf %{buildroot}/*
 %files lang -f %{name}.lang
 
 %changelog
+*  Mon Aug 24 2020 Leandro Pereira <leperei@microsoft.com> 239-31
+-  Use time.windows.com as the default NTP server in timesyncd.
 *  Tue Aug 11 2020 Mateusz Malisz <mamalisz@microsoft.com> 239-30
 -  Reduce kptr_restrict to 1
 *  Fri May 29 2020 Nicolas Ontiveros <niontive@microsoft.com> 239-29

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -350,13 +350,13 @@ sqlite-devel-3.32.3-1.cm1.aarch64.rpm
 sqlite-libs-3.32.3-1.cm1.aarch64.rpm
 swig-3.0.12-4.cm1.aarch64.rpm
 swig-debuginfo-3.0.12-4.cm1.aarch64.rpm
-systemd-239-30.cm1.aarch64.rpm
+systemd-239-31.cm1.aarch64.rpm
 systemd-bootstrap-239-29.cm1.aarch64.rpm
 systemd-bootstrap-debuginfo-239-29.cm1.aarch64.rpm
 systemd-bootstrap-devel-239-29.cm1.aarch64.rpm
-systemd-debuginfo-239-30.cm1.aarch64.rpm
-systemd-devel-239-30.cm1.aarch64.rpm
-systemd-lang-239-30.cm1.aarch64.rpm
+systemd-debuginfo-239-31.cm1.aarch64.rpm
+systemd-devel-239-31.cm1.aarch64.rpm
+systemd-lang-239-31.cm1.aarch64.rpm
 tar-1.32-2.cm1.aarch64.rpm
 tar-debuginfo-1.32-2.cm1.aarch64.rpm
 tdnf-2.1.0-4.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -350,13 +350,13 @@ sqlite-devel-3.32.3-1.cm1.x86_64.rpm
 sqlite-libs-3.32.3-1.cm1.x86_64.rpm
 swig-3.0.12-4.cm1.x86_64.rpm
 swig-debuginfo-3.0.12-4.cm1.x86_64.rpm
-systemd-239-30.cm1.x86_64.rpm
+systemd-239-31.cm1.x86_64.rpm
 systemd-bootstrap-239-29.cm1.x86_64.rpm
 systemd-bootstrap-debuginfo-239-29.cm1.x86_64.rpm
 systemd-bootstrap-devel-239-29.cm1.x86_64.rpm
-systemd-debuginfo-239-30.cm1.x86_64.rpm
-systemd-devel-239-30.cm1.x86_64.rpm
-systemd-lang-239-30.cm1.x86_64.rpm
+systemd-debuginfo-239-31.cm1.x86_64.rpm
+systemd-devel-239-31.cm1.x86_64.rpm
+systemd-lang-239-31.cm1.x86_64.rpm
 tar-1.32-2.cm1.x86_64.rpm
 tar-debuginfo-1.32-2.cm1.x86_64.rpm
 tdnf-2.1.0-4.cm1.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details

Checklist:
1. Make PRs from either a forked repo, or a feature branch (user/feature).
2. Either use a squash merge PR, or squash your commits locally before creating the PR.
-->

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
This changes the default configuration for `systemd-timesyncd` to use the Windows NTP servers by default.  (This can be still overridden by the user either on a system- or on per network interface level.)

###### Change Log  <!-- REQUIRED -->
- Change the default `timesyncd.conf` file to use `time.windows.com` as the only NTP server. No fallback servers are provided.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
**YES**

###### Merge Checklist  <!-- REQUIRED -->
<!-- These should all be checked before merging a PR -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
- [ ] The toolchain has been rebuilt successfully if any changes were made to it
- [x] The toolchain/worker package manifests have been updated if this is a toolchain package
- [ ] Updated packages have been successfully built
- [ ] New source files have updated hashes in the `*.signatures.json` files
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge
