### PR TITLE
Do not build SPECs meant for other architectures

### DIFF
--- a/toolkit/tools/specreader/specreader.go
+++ b/toolkit/tools/specreader/specreader.go
@@ -160,7 +160,7 @@ func readspec(specfile, distTag, srpmDir string, wg *sync.WaitGroup, ch chan []*
 		return
 	}
 
-	if !specArchMatchesBuild(specfile, sourcedir, emptyQueryFormat, defines) {
+	if !specArchMatchesBuild(specfile, sourcedir, defines) {
 		logger.Log.Debugf(`Skipping (%s) since it cannot be built on current architecture.`, specfile)
 		return
 	}
@@ -372,7 +372,7 @@ func filterOutDynamicDependencies(pkgVers []*pkgjson.PackageVer) (filteredPkgVer
 }
 
 // specArchMatchesBuild verifies ExclusiveArch tag against the machine architecture.
-func specArchMatchesBuild(specfile, sourcedir, queryformat string, defines map[string]string) (shouldBeBuilt bool) {
+func specArchMatchesBuild(specfile, sourcedir string, defines map[string]string) (shouldBeBuilt bool) {
 	const (
 		queryExclusiveArch = "%{ARCH}\n%{EXCLUSIVEARCH}\n"
 		noExclusiveArch    = "(none)"


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details

Checklist:
1. Make PRs from either a forked repo, or a feature branch (user/feature).
2. Either use a squash merge PR, or squash your commits locally before creating the PR.
-->

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Under full end-to-end builds, `srpmpacker` skips packing SPECs that are intended for other architectures. When `DOWNLOAD_SRPMS=y` is set, this bypasses the `srpmpacker` filter and results in the build system trying to build incompatible SPECs. The fix is to apply the architecture filter to `specreader` as that runs even when SRPMs are downloaded.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Skip reading SPECs that are intended for other architectures in `specreader`.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Merge Checklist  <!-- REQUIRED -->
<!-- These should all be checked before merging a PR -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
- [x] The toolchain has been rebuilt successfully if any changes were made to it
- [x] The toolchain/worker package manifests have been updated if this is a toolchain package
- [x] Updated packages have been successfully built
- [x] New source files have updated hashes in the `*.signatures.json` files
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge
