### PR TITLE
Upgrade golang to 1.13.15

### DIFF
--- a/SPECS/golang/golang-1.13.signatures.json
+++ b/SPECS/golang/golang-1.13.signatures.json
@@ -1,6 +1,6 @@
 {
  "Signatures": {
-  "go1.13.11.src.tar.gz": "89ed1abce25ad003521c125d6583c93c1280de200ad221f961085200a6c00679",
+  "go1.13.15.src.tar.gz": "5fb43171046cf8784325e67913d55f88a683435071eef8e9da1aa8a1588fcf5d",
   "go1.4-bootstrap-20171003.tar.gz": "f4ff5b5eb3a3cae1c993723f3eab519c5bae18866b5e5f96fe1102f0cb5c3e52"
  }
 }

--- a/SPECS/golang/golang-1.13.spec
+++ b/SPECS/golang/golang-1.13.spec
@@ -14,7 +14,7 @@
 
 Summary:        Go
 Name:           golang
-Version:        1.13.11
+Version:        1.13.15
 Release:        1%{?dist}
 License:        BSD
 URL:            https://golang.org
@@ -124,9 +124,11 @@ rm -rf %{buildroot}/*
 %{_bindir}/*
 
 %changelog
+*   Tue Sep 08 2020 Nicolas Ontiveros <niontive@microsoft.com> 1.13.15-1
+-   Updated to version 1.13.15, which fixes CVE-2020-14039 and CVE-2020-16845.
 *   Sun May 24 2020 Mateusz Malisz <mamalisz@microsoft.com> 1.13.11-1
 -   Updated to version 1.13.11
-*   Sat May 09 2020 Nick Samson <nisamson@microsoft.com> - 1.12.5-7
+*   Sat May 09 2020 Nick Samson <nisamson@microsoft.com> 1.12.5-7
 -   Added %%license line automatically
 *   Thu Apr 30 2020 Emre Girgin <mrgirgin@microsoft.com> 1.12.5-6
 -   Renaming go to golang

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -1255,8 +1255,8 @@
         "type": "other",
         "other": {
           "name": "golang",
-          "version": "1.13.11",
-          "downloadUrl": "https://dl.google.com/go/go1.13.11.src.tar.gz"
+          "version": "1.13.15",
+          "downloadUrl": "https://dl.google.com/go/go1.13.15.src.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Upgrade golang to 1.13.15 to resolve CVE-2020-14039 and CVE-2020-16845

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
Package: "golang"
CVEs: CVE-2020-14039 and CVE-2020-16845

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
No

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
None

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2020-14039
- https://nvd.nist.gov/vuln/detail/CVE-2020-16845

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local build