### PR TITLE
Use SRPM name as the working directory name to pack in

### DIFF
--- a/toolkit/tools/srpmpacker/srpmpacker.go
+++ b/toolkit/tools/srpmpacker/srpmpacker.go
@@ -387,7 +387,7 @@ func packSRPMWorker(allSpecStates chan *specState, results chan *packResult, dis
 		err = os.MkdirAll(fullOutDirPath, os.ModePerm)
 		logger.PanicOnError(err)
 
-		outputPath, err := packSingleSPEC(specState.specFile, signaturesFilePath, buildDir, fullOutDirPath, distTag, srcConfig)
+		outputPath, err := packSingleSPEC(specState.specFile, specState.srpmFile, signaturesFilePath, buildDir, fullOutDirPath, distTag, srcConfig)
 		logger.PanicOnError(err)
 
 		result.srpmFile = outputPath
@@ -440,9 +440,9 @@ func readSignatures(signaturesFilePath string) (readSignatures map[string]string
 }
 
 // packSingleSPEC will pack a given SPEC file into an SRPM.
-func packSingleSPEC(specFile, signaturesFile, buildDir, outDir, distTag string, srcConfig sourceRetrievalConfiguration) (outputPath string, err error) {
-	specName := strings.TrimSuffix(filepath.Base(specFile), filepath.Ext(specFile))
-	workingDir := filepath.Join(buildDir, specName)
+func packSingleSPEC(specFile, srpmFile, signaturesFile, buildDir, outDir, distTag string, srcConfig sourceRetrievalConfiguration) (outputPath string, err error) {
+	srpmName := filepath.Base(srpmFile)
+	workingDir := filepath.Join(buildDir, srpmName)
 
 	logger.Log.Debugf("Working directory: %s", workingDir)
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
This PR changes the working directory used by srpmpacker for each spec. Currently srpmpacker packs each spec in its own folder that lives under `{build_dir}/{spec_file_name}`. Since srpmpacker runs parallelized this working directory must be unique.

There may be specs with identical names but different versions -- e.g. a `SPECS/foo-1.7/foo.spec` and a `SPECS/foo-1.8/foo.spec`. This would cause srpmpacker to reuse the same working directory for the `foo` specs, causing a collision and corrupted SRPMs.

Switch to the spec's SRPM name as the unique folder name to avoid collisions.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Use the SRPM file name instead the spec nam as the folder name to pack inside of.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO


###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Ran `make input-srpms` and repacked all SRPMs locally