### PR TITLE
Add cloud-init-vmware-guestinfo package

### DIFF
--- a/SPECS/cloud-init-vmware-guestinfo/cloud-init-vmware-guestinfo.signatures.json
+++ b/SPECS/cloud-init-vmware-guestinfo/cloud-init-vmware-guestinfo.signatures.json
@@ -1,0 +1,5 @@
+{
+ "Signatures": {
+  "cloud-init-vmware-guestinfo-1.3.1.tar.gz": "1f6c74b75d3697d62f0b5b8613e0d66bc06b2fd962f9b7c827c459d8c72505b9"
+ }
+}

--- a/SPECS/cloud-init-vmware-guestinfo/cloud-init-vmware-guestinfo.spec
+++ b/SPECS/cloud-init-vmware-guestinfo/cloud-init-vmware-guestinfo.spec
@@ -31,6 +31,7 @@ install -dm 0755 %{buildroot}%{python3_sitelib}/cloudinit/sources/
 install -m 0644 DataSourceVMwareGuestInfo.py %{buildroot}%{python3_sitelib}/cloudinit/sources/DataSourceVMwareGuestInfo.py
 
 %files
+%license LICENSE
 %config %{_sysconfdir}/cloud/cloud.cfg.d/99-DataSourceVMwareGuestInfo.cfg
 %{python3_sitelib}/cloudinit/sources/DataSourceVMwareGuestInfo.py
 

--- a/SPECS/cloud-init-vmware-guestinfo/cloud-init-vmware-guestinfo.spec
+++ b/SPECS/cloud-init-vmware-guestinfo/cloud-init-vmware-guestinfo.spec
@@ -4,10 +4,10 @@ Version:        1.3.1
 Release:        1
 Summary:        A cloud-init datasource for VMware
 Group:          System/Management
-License:        Apache-2.0
+License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
-Url:            https://github.com/vmware/cloud-init-vmware-guestinfo
+URL:            https://github.com/vmware/cloud-init-vmware-guestinfo
 BuildArch:      noarch
 
 #Source0:  https://github.com/vmware/%{name}/archive/v%{version}.tar.gz

--- a/SPECS/cloud-init-vmware-guestinfo/cloud-init-vmware-guestinfo.spec
+++ b/SPECS/cloud-init-vmware-guestinfo/cloud-init-vmware-guestinfo.spec
@@ -8,12 +8,12 @@ License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 URL:            https://github.com/vmware/cloud-init-vmware-guestinfo
-BuildArch:      noarch
 
-#Source0:  https://github.com/vmware/%{name}/archive/v%{version}.tar.gz
+#Source0:      https://github.com/vmware/%{name}/archive/v%{version}.tar.gz
 Source0:       %{name}-%{version}.tar.gz
 BuildRequires: python3
 Requires:      cloud-init
+BuildArch:     noarch
 
 %description
 Provides a cloud-init datasource for pulling meta, user,
@@ -37,5 +37,5 @@ install -m 0644 DataSourceVMwareGuestInfo.py %{buildroot}%{python3_sitelib}/clou
 
 %changelog
 * Thu Sep 17 2020 Mateusz Malisz <mamalisz@microsoft.com> 1.3.1-1
-- Initial CBL-Mariner packaging.
+- Original version for CBL-Mariner.
 - License Verified

--- a/SPECS/cloud-init-vmware-guestinfo/cloud-init-vmware-guestinfo.spec
+++ b/SPECS/cloud-init-vmware-guestinfo/cloud-init-vmware-guestinfo.spec
@@ -1,0 +1,40 @@
+%{!?python3_sitelib: %define python3_sitelib %(python3 -c "from distutils.sysconfig import get_python_lib;print(get_python_lib())")}
+Name:           cloud-init-vmware-guestinfo
+Version:        1.3.1
+Release:        1
+Summary:        A cloud-init datasource for VMware
+Group:          System/Management
+License:        Apache-2.0
+Vendor:         Microsoft Corporation
+Distribution:   Mariner
+Url:            https://github.com/vmware/cloud-init-vmware-guestinfo
+BuildArch:      noarch
+
+#Source0:  https://github.com/vmware/%{name}/archive/v%{version}.tar.gz
+Source0:       %{name}-%{version}.tar.gz
+BuildRequires: python3
+Requires:      cloud-init
+
+%description
+Provides a cloud-init datasource for pulling meta, user,
+and vendor data from VMware vSphere's GuestInfo interface.
+
+%prep
+%setup -q
+
+%build
+
+%install
+install -dm 0755 %{buildroot}%{_sysconfdir}/cloud/cloud.cfg.d
+install -m 0644 99-DataSourceVMwareGuestInfo.cfg %{buildroot}%{_sysconfdir}/cloud/cloud.cfg.d/99-DataSourceVMwareGuestInfo.cfg
+install -dm 0755 %{buildroot}%{python3_sitelib}/cloudinit/sources/
+install -m 0644 DataSourceVMwareGuestInfo.py %{buildroot}%{python3_sitelib}/cloudinit/sources/DataSourceVMwareGuestInfo.py
+
+%files
+%config %{_sysconfdir}/cloud/cloud.cfg.d/99-DataSourceVMwareGuestInfo.cfg
+%{python3_sitelib}/cloudinit/sources/DataSourceVMwareGuestInfo.py
+
+%changelog
+* Thu Sep 17 2020 Mateusz Malisz <mamalisz@microsoft.com> 1.3.1-1
+- Initial CBL-Mariner packaging.
+- License Verified

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -496,7 +496,7 @@
       "other": {
         "name": "cloud-init-vmware-guestinfo",
         "version": "1.3.1",
-        "downloadUrl": "https://launchpad.net/cloud-init/trunk/19.1/+download/cloud-init-19.1.tar.gz"
+        "downloadUrl": "https://github.com/vmware/cloud-init-vmware-guestinfo/archive/v1.3.1.tar.gz"
         }
       }
     },

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -492,6 +492,17 @@
     },
     {
       "component": {
+      "type": "other",
+      "other": {
+        "name": "cloud-init-vmware-guestinfo",
+        "version": "1.3.1",
+        "downloadUrl": "https://launchpad.net/cloud-init/trunk/19.1/+download/cloud-init-19.1.tar.gz"
+        }
+      }
+    },
+
+    {
+      "component": {
         "type": "other",
         "other": {
           "name": "cloud-utils-growpart",


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

This PR adds cloud-init-vmware-guestinfo package, which is required for the cloud-init to work in the VMWare cloud environment. The package supplies cloud-init datasource for the vSphere's GuestInfo interface.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Added cloud-init-vmware-guestinfo package.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local build succeeded.