### PR TITLE
Replace the misuse of `archdir` shell variable

### DIFF
--- a/SPECS/kernel/kernel.spec
+++ b/SPECS/kernel/kernel.spec
@@ -135,12 +135,9 @@ cp %{SOURCE1} .config
 cp %{SOURCE2} .config
 %endif
 
-arch=%{arch}
-archdir=%{archdir}
-
 cp .config current_config
 sed -i 's/CONFIG_LOCALVERSION=""/CONFIG_LOCALVERSION="-%{release}"/' .config
-make LC_ALL=  ARCH=${arch} oldconfig
+make LC_ALL=  ARCH=%{arch} oldconfig
 
 # Verify the config files match
 cp .config new_config
@@ -157,7 +154,7 @@ if [ -s config_diff ]; then
     exit 1
 fi
 
-make VERBOSE=1 KBUILD_BUILD_VERSION="1" KBUILD_BUILD_HOST="CBL-Mariner" ARCH=${arch} %{?_smp_mflags}
+make VERBOSE=1 KBUILD_BUILD_VERSION="1" KBUILD_BUILD_HOST="CBL-Mariner" ARCH=%{arch} %{?_smp_mflags}
 make -C tools perf
 
 %define __modules_install_post \

--- a/SPECS/kernel/kernel.spec
+++ b/SPECS/kernel/kernel.spec
@@ -2,7 +2,7 @@
 Summary:        Linux Kernel
 Name:           kernel
 Version:        5.4.51
-Release:        5%{?dist}
+Release:        6%{?dist}
 License:        GPLv2
 URL:            https://github.com/microsoft/WSL2-Linux-Kernel
 Group:          System Environment/Kernel
@@ -52,6 +52,15 @@ Requires:       filesystem kmod
 Requires(post): coreutils
 Requires(postun): coreutils
 %define uname_r %{version}-%{release}
+%ifarch x86_64
+%define arch x86_64
+%define archdir x86
+%endif
+
+%ifarch aarch64
+%define arch arm64
+%define archdir arm64
+%endif
 
 # When updating the config files it is important to sanitize them.
 # Steps for updating a config file:
@@ -120,15 +129,14 @@ make mrproper
 
 %ifarch x86_64
 cp %{SOURCE1} .config
-arch="x86_64"
-archdir="x86"
 %endif
 
 %ifarch aarch64
 cp %{SOURCE2} .config
-arch="arm64"
-archdir="arm64"
 %endif
+
+arch=%{arch}
+archdir=%{archdir}
 
 cp .config current_config
 sed -i 's/CONFIG_LOCALVERSION=""/CONFIG_LOCALVERSION="-%{release}"/' .config
@@ -224,9 +232,9 @@ rm -rf %{buildroot}/lib/modules/%{uname_r}/source
 rm -rf %{buildroot}/lib/modules/%{uname_r}/build
 
 find . -name Makefile* -o -name Kconfig* -o -name *.pl | xargs  sh -c 'cp --parents "$@" %{buildroot}/usr/src/linux-headers-%{uname_r}' copy
-find arch/${archdir}/include include scripts -type f | xargs  sh -c 'cp --parents "$@" %{buildroot}/usr/src/linux-headers-%{uname_r}' copy
-find $(find arch/${archdir} -name include -o -name scripts -type d) -type f | xargs  sh -c 'cp --parents "$@" %{buildroot}/usr/src/linux-headers-%{uname_r}' copy
-find arch/${archdir}/include Module.symvers include scripts -type f | xargs  sh -c 'cp --parents "$@" %{buildroot}/usr/src/linux-headers-%{uname_r}' copy
+find arch/%{archdir}/include include scripts -type f | xargs  sh -c 'cp --parents "$@" %{buildroot}/usr/src/linux-headers-%{uname_r}' copy
+find $(find arch/%{archdir} -name include -o -name scripts -type d) -type f | xargs  sh -c 'cp --parents "$@" %{buildroot}/usr/src/linux-headers-%{uname_r}' copy
+find arch/%{archdir}/include Module.symvers include scripts -type f | xargs  sh -c 'cp --parents "$@" %{buildroot}/usr/src/linux-headers-%{uname_r}' copy
 %ifarch x86_64
 # CONFIG_STACK_VALIDATION=y requires objtool to build external modules
 install -vsm 755 tools/objtool/objtool %{buildroot}/usr/src/linux-headers-%{uname_r}/tools/objtool/
@@ -332,6 +340,8 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %{_libdir}/perf/include/bpf/*
 
 %changelog
+*   Thu Sep 24 2020 Emre Girgin <mrgirgin@microsoft.cpm> 5.4.51-6
+-   Replace the misuse of the 'archdir' shell variable.
 *   Thu Sep 03 2020 Daniel McIlvaney <damcilva@microsoft.com> 5.4.51-5
 -   Add code to check for missing config flags in the checked in configs
 *   Thu Sep 03 2020 Chris Co <chrco@microsoft.com> 5.4.51-4

--- a/SPECS/kernel/kernel.spec
+++ b/SPECS/kernel/kernel.spec
@@ -338,7 +338,7 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 
 %changelog
 *   Thu Sep 24 2020 Emre Girgin <mrgirgin@microsoft.cpm> 5.4.51-6
--   Replace the misuse of the 'archdir' shell variable.
+-   Replace the misuse of the 'archdir' and `arch` shell variables.
 *   Thu Sep 03 2020 Daniel McIlvaney <damcilva@microsoft.com> 5.4.51-5
 -   Add code to check for missing config flags in the checked in configs
 *   Thu Sep 03 2020 Chris Co <chrco@microsoft.com> 5.4.51-4


### PR DESCRIPTION
- The `archdir` shell variable is defined in the `%build` section of `kernel.spec`, but it is later referenced in the `%install` section.
- As those two scriptlets have been run separately, `${archdir}` reference in `%install` returns an empty string.
- Address this problem by defining it as a spec variable.

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
- The `archdir` shell variable is defined in the `%build` section of `kernel.spec`, but it is later referenced in the `%install` section.
- As those two scriptlets have been run separately, `${archdir}` reference in `%install` returns an empty string.
- Address this problem by defining it as a spec variable.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Define `arch` and `archdir` as spec variables instead of shell variables, depending on the build architecture.
- Replace mentions of `archdir` and `arch` as a shell variable with spec variable mentions.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
YES
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/...

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: xxxx