### PR TITLE
Revert "Update tpm2 tools to 4.2, tss to 2.4.0"

### DIFF
--- a/SPECS/tpm2-tools/tpm2-tools.signatures.json
+++ b/SPECS/tpm2-tools/tpm2-tools.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "tpm2-tools-4.2.tar.gz": "1baaccd8bd663e9dd70cf6d8f99f16897ea32b9106860967ebb259d81954f904"
+  "tpm2-tools-3.1.4.tar.gz": "2f515200e9a7958ee13015150f7958c8a332eb071c2564c33f81ebe32c4f6033"
  }
 }

--- a/SPECS/tpm2-tools/tpm2-tools.spec
+++ b/SPECS/tpm2-tools/tpm2-tools.spec
@@ -1,19 +1,15 @@
-Summary:        The source repository for the TPM (Trusted Platform Module) 2 tools
-Name:           tpm2-tools
-Version:        4.2
-Release:        1%{?dist}
-License:        BSD 2-Clause
-URL:            https://github.com/tpm2-software/tpm2-tools
-Group:          System Environment/Security
+Summary:	The source repository for the TPM (Trusted Platform Module) 2 tools
+Name:		tpm2-tools
+Version:	3.1.4
+Release:        2%{?dist}
+License:	BSD 2-Clause
+URL:		https://github.com/tpm2-software/tpm2-tools
+Group:		System Environment/Security
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
-Source0:        https://github.com/tpm2-software/tpm2-tools/releases/download/%{version}/%{name}-%{version}.tar.gz
-BuildRequires:  openssl-devel
-BuildRequires:  curl-devel
-BuildRequires:  tpm2-tss-devel >= 2.3.0
-Requires:       openssl curl
-Requires:       tpm2-tss >= 2.3.0
-Requires:       /bin/awk
+Source0:	https://github.com/tpm2-software/tpm2-tools/releases/download/%{version}/%{name}-%{version}.tar.gz
+BuildRequires:	openssl-devel curl-devel tpm2-tss-devel
+Requires:	openssl curl tpm2-tss
 %description
 The source repository for the TPM (Trusted Platform Module) 2 tools
 
@@ -30,17 +26,14 @@ make DESTDIR=%{buildroot} install
 
 %files
 %defattr(-,root,root)
-%license doc/LICENSE
+%license LICENSE
 %{_bindir}/*
 %{_mandir}/man1
-%{_datarootdir}/bash-completion/completions/tpm2_*
-%{_datarootdir}/bash-completion/completions/tss2_*
 
 %changelog
-*   Tue Aug 25 2020 Daniel McIlvaney <damcilva@microsoft.com> 4.2-1
--   Update to 4.2.
-*   Sat May 09 2020 Nick Samson <nisamson@microsoft.com> 3.1.4-2
--   Added %%license line automatically
+* Sat May 09 00:21:43 PST 2020 Nick Samson <nisamson@microsoft.com> - 3.1.4-2
+- Added %%license line automatically
+
 *   Fri Mar 13 2020 Paul Monson <paulmon@microsoft.com> 3.1.4-1
 -   Update to version 3.1.4.
 *   Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 3.1.3-2

--- a/SPECS/tpm2-tss/tpm2-tss.signatures.json
+++ b/SPECS/tpm2-tss/tpm2-tss.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "tpm2-tss-2.4.0.tar.gz": "81c548a73adf584a5ad306b5d4318140b298e724510e5883277fea4df9652e87"
+  "tpm2-tss-2.2.0.tar.gz": "c9131eaf3a22affaad58688915957e855d23608eb1c007c0f1e00681f3e32583"
  }
 }

--- a/SPECS/tpm2-tss/tpm2-tss.spec
+++ b/SPECS/tpm2-tss/tpm2-tss.spec
@@ -1,7 +1,7 @@
 Summary:          OSS implementation of the TCG TPM2 Software Stack (TSS2)
 Name:             tpm2-tss
-Version:          2.4.0
-Release:          1%{?dist}
+Version:          2.2.0
+Release:          4%{?dist}
 License:          BSD
 URL:              https://github.com/tpm2-software/tpm2-tss
 Group:            System Environment/Security
@@ -9,9 +9,7 @@ Vendor:           Microsoft Corporation
 Distribution:     Mariner
 Source0:          https://github.com/tpm2-software/tpm2-tss/releases/download/%{version}/%{name}-%{version}.tar.gz
 BuildRequires:    openssl-devel
-BuildRequires:    json-c-devel
 Requires:         openssl
-Requires:         json-c
 Requires(pre):    /usr/sbin/useradd /usr/sbin/groupadd
 Requires(postun): /usr/sbin/userdel /usr/sbin/groupdel
 %description
@@ -66,10 +64,7 @@ fi
 %defattr(-,root,root)
 %license LICENSE
 %{_sysconfdir}/udev/rules.d/tpm-udev.rules
-%{_sysconfdir}/tmpfiles.d/tpm2-tss-fapi.conf
-%{_sysconfdir}/tpm2-tss/*
 %{_libdir}/*.so.0.0.0
-%exclude %{_sysconfdir}/sysusers.d/tpm2-tss.conf
 
 %files devel
 %defattr(-,root,root)
@@ -82,10 +77,9 @@ fi
 %{_mandir}/man7
 
 %changelog
-*   Tue Aug 25 2020 Daniel McIlvaney <damcilva@microsoft.com> 2.4.0-1
--   Update to 2.4.0.
-*   Sat May 09 2020 Nick Samson <nisamson@microsoft.com> - 2.2.0-4
--   Added %%license line automatically
+* Sat May 09 00:21:09 PST 2020 Nick Samson <nisamson@microsoft.com> - 2.2.0-4
+- Added %%license line automatically
+
 *   Fri Apr 10 2020 Nick Samson <nisamson@microsoft.com> 2.2.0-3
 -   Updated Source0. Removed %%define sha1. Updated license abbreviation and validated license.
 *   Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 2.2.0-2

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -5366,8 +5366,8 @@
         "type": "other",
         "other": {
           "name": "tpm2-tools",
-          "version": "4.2",
-          "downloadUrl": "https://github.com/tpm2-software/tpm2-tools/releases/download/4.2/tpm2-tools-4.2.tar.gz"
+          "version": "3.1.4",
+          "downloadUrl": "https://github.com/tpm2-software/tpm2-tools/releases/download/3.1.4/tpm2-tools-3.1.4.tar.gz"
         }
       }
     },
@@ -5376,8 +5376,8 @@
         "type": "other",
         "other": {
           "name": "tpm2-tss",
-          "version": "2.4.0",
-          "downloadUrl": "https://github.com/tpm2-software/tpm2-tss/releases/download/2.4.0/tpm2-tss-2.4.0.tar.gz"
+          "version": "2.2.0",
+          "downloadUrl": "https://github.com/tpm2-software/tpm2-tss/releases/download/2.2.0/tpm2-tss-2.2.0.tar.gz"
         }
       }
     },


### PR DESCRIPTION
Reverts microsoft/CBL-Mariner#134
tss update is causing issues with other TPM packages, reverting until it can be root caused.