### PR TITLE
installutils: Supply blank /etc/machine-id file

### DIFF
--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -499,24 +499,24 @@ func calculateTotalPackages(packages []string, installRoot string) (totalPackage
 	return
 }
 
+// addMachineID creates the /etc/machine-id file in the installChroot
 func addMachineID(installChroot *safechroot.Chroot) (err error) {
-	const (
-		squashErrors = false
-		setupProgram = "/bin/systemd-machine-id-setup"
-	)
+	// From https://www.freedesktop.org/software/systemd/man/machine-id.html:
+	// For operating system images which are created once and used on multiple
+	// machines, for example for containers or in the cloud, /etc/machine-id
+	// should be an empty file in the generic file system image. An ID will be
+	// generated during boot and saved to this file if possible.
 
-	// Check if systemd-machine-id-setup is present before invoking it,
-	// some images will not use systemd (such as a container)
-	exists, _ := file.PathExists(filepath.Join(installChroot.RootDir(), setupProgram))
-	if !exists {
-		logger.Log.Debugf("'%s' not found inside chroot '%s', skipping adding machine ID", setupProgram, installChroot.RootDir())
-		return
-	}
+	const (
+		squashErrors  = false
+		setupProgram  = "touch"
+		machineIDFile = "/etc/machine-id"
+	)
 
 	ReportAction("Configuring machine id")
 
 	err = installChroot.UnsafeRun(func() error {
-		return shell.ExecuteLive(squashErrors, setupProgram)
+		return shell.ExecuteLive(squashErrors, setupProgram, machineIDFile)
 	})
 	return
 }

--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -509,16 +509,15 @@ func addMachineID(installChroot *safechroot.Chroot) (err error) {
 
 	const (
 		squashErrors       = false
-		setupProgram       = "install"
 		machineIDFile      = "/etc/machine-id"
-		machineIDFilePerms = "0644"
+		machineIDFilePerms = 0644
 	)
 
 	ReportAction("Configuring machine id")
 
 	err = installChroot.UnsafeRun(func() error {
-		setupArgs := []string{"-m", machineIDFilePerms, "/dev/null", machineIDFile}
-		return shell.ExecuteLive(squashErrors, setupProgram, setupArgs...)
+		file.Create(machineIDFile, machineIDFilePerms)
+		return file.Create(machineIDFile, machineIDFilePerms)
 	})
 	return
 }

--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -508,15 +508,17 @@ func addMachineID(installChroot *safechroot.Chroot) (err error) {
 	// generated during boot and saved to this file if possible.
 
 	const (
-		squashErrors  = false
-		setupProgram  = "touch"
-		machineIDFile = "/etc/machine-id"
+		squashErrors       = false
+		setupProgram       = "install"
+		machineIDFile      = "/etc/machine-id"
+		machineIDFilePerms = "0644"
 	)
 
 	ReportAction("Configuring machine id")
 
 	err = installChroot.UnsafeRun(func() error {
-		return shell.ExecuteLive(squashErrors, setupProgram, machineIDFile)
+		setupArgs := []string{"-m", machineIDFilePerms, "/dev/null", machineIDFile}
+		return shell.ExecuteLive(squashErrors, setupProgram, setupArgs...)
 	})
 	return
 }

--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -515,7 +515,6 @@ func addMachineID(installChroot *safechroot.Chroot) (err error) {
 	ReportAction("Configuring machine id")
 
 	err = installChroot.UnsafeRun(func() error {
-		file.Create(machineIDFile, machineIDFilePerms)
 		return file.Create(machineIDFile, machineIDFilePerms)
 	})
 	return

--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -508,7 +508,6 @@ func addMachineID(installChroot *safechroot.Chroot) (err error) {
 	// generated during boot and saved to this file if possible.
 
 	const (
-		squashErrors       = false
 		machineIDFile      = "/etc/machine-id"
 		machineIDFilePerms = 0644
 	)

--- a/toolkit/tools/internal/file/file.go
+++ b/toolkit/tools/internal/file/file.go
@@ -101,11 +101,11 @@ func ReadLines(path string) (lines []string, err error) {
 	return lines, scanner.Err()
 }
 
-// Create creates a file with the provided Unix permissions
+// Create creates a new file with the provided Unix permissions
 func Create(dst string, perm os.FileMode) (err error) {
-	logger.Log.Debugf("Creating (%s) with perm (%v)", dst, perm)
+	logger.Log.Debugf("Creating (%s) with mode (%v)", dst, perm)
 
-	dstFile, err := os.OpenFile(dst, os.O_CREATE, perm)
+	dstFile, err := os.OpenFile(dst, os.O_CREATE|os.O_EXCL, perm)
 	if err != nil {
 		return
 	}

--- a/toolkit/tools/internal/file/file.go
+++ b/toolkit/tools/internal/file/file.go
@@ -101,6 +101,18 @@ func ReadLines(path string) (lines []string, err error) {
 	return lines, scanner.Err()
 }
 
+// Create creates a file with the provided Unix permissions
+func Create(dst string, perm os.FileMode) (err error) {
+	logger.Log.Debugf("Creating (%s) with perm (%v)", dst, perm)
+
+	dstFile, err := os.OpenFile(dst, os.O_CREATE, perm)
+	if err != nil {
+		return
+	}
+	defer dstFile.Close()
+	return
+}
+
 // Write writes a string to the file dst.
 func Write(data string, dst string) (err error) {
 	logger.Log.Debugf("Writing to (%s)", dst)


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Currently, the image tooling generates a random unique /etc/machine-id for our offline images. This has the side-effect where booting the same offline image on multiple devices (i.e. booting multiple copies of the same VHDx image on different VMs) will actually have the same /etc/machine-id. This machine-id is expected to be unique per device and persisted for the lifetime of the device. And having machine-id collisions like this can cause unexpected issues (i.e. same IP address assigned to different VMs)

From https://www.freedesktop.org/software/systemd/man/machine-id.html:
For operating system images which are created once and used on multiple machines, for example for containers or in the cloud, /etc/machine-id should be an empty file in the generic file system image. An ID will be generated during boot and saved to this file if possible.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Remove `systemd-machine-id-setup` call and replace with a blank /etc/machine-id file, which will be automatically populated on first boot.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
Local testing of ISO and VHD/VHDx