### PR TITLE
Nopatch httpd CVE-1999-0236, CVE-1999-1412

### DIFF
--- a/SPECS/httpd/CVE-1999-0236.nopatch
+++ b/SPECS/httpd/CVE-1999-0236.nopatch
@@ -1,0 +1,1 @@
+# CVE-1999-0236 must be mitigated by the user. See "Server Side Includes" on https://httpd.apache.org/docs/2.4/misc/security_tips.html

--- a/SPECS/httpd/CVE-1999-1412.nopatch
+++ b/SPECS/httpd/CVE-1999-1412.nopatch
@@ -1,0 +1,1 @@
+# CVE-1999-1412 applies only to MacOS X

--- a/SPECS/httpd/httpd.spec
+++ b/SPECS/httpd/httpd.spec
@@ -198,7 +198,7 @@ fi
 -   Updated to 2.4.43 to resolve the following CVEs
 -   CVE-2019-10081, CVE-2019-10082, CVE-2019-10092, CVE-2019-10097
 -   CVE-2019-10098, CVE-2020-1927, CVE-2020-1934
-*   Sat May 09 2020 Nick Samson <nisamson@microsoft.com> - 2.4.39-4
+*   Sat May 09 2020 Nick Samson <nisamson@microsoft.com> 2.4.39-4
 -   Added %%license line automatically
 *   Tue Apr 07 2020 Pawel Winogrodzki <pawelwi@microsoft.com> 2.4.39-3
 -   Updated and verified 'Source0', 'Patch0' and 'URL' tags.

--- a/SPECS/httpd/httpd.spec
+++ b/SPECS/httpd/httpd.spec
@@ -1,7 +1,7 @@
 Summary:        The Apache HTTP Server
 Name:           httpd
 Version:        2.4.46
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        ASL 2.0
 URL:            https://httpd.apache.org/
 Group:          Applications/System
@@ -10,6 +10,11 @@ Distribution:   Mariner
 Source0:        https://archive.apache.org/dist/%{name}/%{name}-%{version}.tar.bz2
 Patch0:         httpd-blfs_layout-1.patch
 Patch1:         httpd-uncomment-ServerName.patch
+
+# CVE-1999-0236 must be mitigated by the user. See "Server Side Includes" at https://httpd.apache.org/docs/2.4/misc/security_tips.html
+Patch100: CVE-1999-0236.nopatch
+# CVE-1999-1412 applies only to MacOS X
+Patch101: CVE-1999-1412.nopatch
 
 BuildRequires:  openssl
 BuildRequires:  openssl-devel
@@ -185,17 +190,16 @@ fi
 %{_bindir}/dbmmanage
 
 %changelog
-* Tue Aug 18 2020 Pawel Winogrodzki <pawelwi@microsoft.com> 2.4.46-1
-- Updated to 2.4.46 to resolve CVE-2020-11984.
-
-* Tue May 19 2020 Ruying Chen <v-ruyche@microsoft.com> 2.4.43-1
-- Updated to 2.4.43 to resolve the following CVEs
-- CVE-2019-10081, CVE-2019-10082, CVE-2019-10092, CVE-2019-10097
-- CVE-2019-10098, CVE-2020-1927, CVE-2020-1934
-
-* Sat May 09 00:20:57 PST 2020 Nick Samson <nisamson@microsoft.com> - 2.4.39-4
-- Added %%license line automatically
-
+*   Mon Sep 28 2020 Daniel McIlvaney <damcilva@microsoft.com> 2.4.46-2
+-   Mark CVE-1999-0236 CVE-1999-1412 as nopatch
+*   Tue Aug 18 2020 Pawel Winogrodzki <pawelwi@microsoft.com> 2.4.46-1
+-   Updated to 2.4.46 to resolve CVE-2020-11984.
+*   Tue May 19 2020 Ruying Chen <v-ruyche@microsoft.com> 2.4.43-1
+-   Updated to 2.4.43 to resolve the following CVEs
+-   CVE-2019-10081, CVE-2019-10082, CVE-2019-10092, CVE-2019-10097
+-   CVE-2019-10098, CVE-2020-1927, CVE-2020-1934
+*   Sat May 09 2020 Nick Samson <nisamson@microsoft.com> - 2.4.39-4
+-   Added %%license line automatically
 *   Tue Apr 07 2020 Pawel Winogrodzki <pawelwi@microsoft.com> 2.4.39-3
 -   Updated and verified 'Source0', 'Patch0' and 'URL' tags.
 -   License verified.

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -1466,8 +1466,8 @@
         "type": "other",
         "other": {
           "name": "httpd",
-          "version": "2.4.43",
-          "downloadUrl": "https://archive.apache.org/dist/httpd/httpd-2.4.43.tar.bz2"
+          "version": "2.4.46",
+          "downloadUrl": "https://archive.apache.org/dist/httpd/httpd-2.4.46.tar.bz2"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
`httpd` CVE-1999-0236 is unpatched, and appears to require the user to provide the mitigations through configuration (see "Server Side Includes" [docs](https://httpd.apache.org/docs/2.4/misc/security_tips.html)

`httpd` CVE-1999-1412 applies only to MacOS X.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Nopatch `httpd` CVE-1999-0236
- Nopatch `httpd` CVE-1999-1412 
- Unify changelog format for `httpd.spec`

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-1999-0236
- https://nvd.nist.gov/vuln/detail/CVE-1999-1412

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- make 'input-srpms' to validate spec file format.