### PR TITLE
Nopatch groff CVE-2000-0803

### DIFF
--- a/SPECS/groff/CVE-2000-0803.nopatch
+++ b/SPECS/groff/CVE-2000-0803.nopatch
@@ -1,0 +1,1 @@
+# No patch has been made available for CVE-2000-0803

--- a/SPECS/groff/groff.spec
+++ b/SPECS/groff/groff.spec
@@ -48,9 +48,9 @@ rm -rf %{buildroot}%{_infodir}
 %{_mandir}/*/*
 
 %changelog
-*   Mon Sep 28 2020 Daniel McIlvaney <damcilva@microsoft.com> - 1.22.3-5
+*   Mon Sep 28 2020 Daniel McIlvaney <damcilva@microsoft.com> 1.22.3-5
 -   Nopatch CVE-2000-0803.nopatch
-*   Sat May 09 2020 Nick Samson <nisamson@microsoft.com> - 1.22.3-4
+*   Sat May 09 2020 Nick Samson <nisamson@microsoft.com> 1.22.3-4
 -   Added %%license line automatically
 *   Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 1.22.3-3
 -   Initial CBL-Mariner import from Photon (license: Apache2).

--- a/SPECS/groff/groff.spec
+++ b/SPECS/groff/groff.spec
@@ -1,23 +1,27 @@
-Summary:	Programs for processing and formatting text
-Name:		groff
-Version:	1.22.3
-Release:        4%{?dist}
-License:	GPLv3+
-URL:		http://www.gnu.org/software/groff
-Group:		Applications/Text
+Summary:        Programs for processing and formatting text
+Name:           groff
+Version:        1.22.3
+Release:        5%{?dist}
+License:        GPLv3+
+URL:            http://www.gnu.org/software/groff
+Group:          Applications/Text
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
-Source0:	http://ftp.gnu.org/gnu/groff/%{name}-%{version}.tar.gz
-%define sha1 groff=61a6808ea1ef715df9fa8e9b424e1f6b9fa8c091
-Provides:	perl(oop_fh.pl)
-Provides:	perl(main_subs.pl)
-Provides:   perl(man.pl)
-Provides:   perl(subs.pl)
-Requires: perl
-Requires: perl-DBI
-Requires: perl-DBIx-Simple
-Requires: perl-DBD-SQLite
-Requires: perl-File-HomeDir
+Source0:        http://ftp.gnu.org/gnu/groff/%{name}-%{version}.tar.gz
+# No patch has been made available for CVE-2000-0803
+Patch0:         CVE-2000-0803.nopatch
+
+Provides:       perl(oop_fh.pl)
+Provides:       perl(main_subs.pl)
+Provides:       perl(man.pl)
+Provides:       perl(subs.pl)
+
+Requires:       perl
+Requires:       perl-DBI
+Requires:       perl-DBIx-Simple
+Requires:       perl-DBD-SQLite
+Requires:       perl-File-HomeDir
+
 %description
 The Groff package contains programs for processing
 and formatting text.
@@ -25,8 +29,8 @@ and formatting text.
 %setup -q
 %build
 PAGE=letter ./configure \
-	--prefix=%{_prefix} \
-	--with-grofferdir=%{_datadir}/%{name}/%{version}/groffer
+    --prefix=%{_prefix} \
+    --with-grofferdir=%{_datadir}/%{name}/%{version}/groffer
 make
 %install
 install -vdm 755 %{_defaultdocdir}/%{name}-1.22/pdf
@@ -42,15 +46,17 @@ rm -rf %{buildroot}%{_infodir}
 %{_defaultdocdir}/%{name}-%{version}/*
 %{_datarootdir}/%{name}/*
 %{_mandir}/*/*
-%changelog
-* Sat May 09 00:21:28 PST 2020 Nick Samson <nisamson@microsoft.com> - 1.22.3-4
-- Added %%license line automatically
 
+%changelog
+*   Mon Sep 28 2020 Daniel McIlvaney <damcilva@microsoft.com> - 1.22.3-5
+-   Nopatch CVE-2000-0803.nopatch
+*   Sat May 09 2020 Nick Samson <nisamson@microsoft.com> - 1.22.3-4
+-   Added %%license line automatically
 *   Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 1.22.3-3
 -   Initial CBL-Mariner import from Photon (license: Apache2).
-*	Tue May 24 2016 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 1.22.3-2
--	GA - Bump release of all rpms
+*   Tue May 24 2016 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 1.22.3-2
+-   GA - Bump release of all rpms
 *   Tue Feb 23 2016 Xiaolin Li <xiaolinl@vmware.com> 1.22.3-1
 -   Updated to version 1.22.3
-*	Wed Nov 5 2014 Divya Thaluru <dthaluru@vmware.com> 1.22.2-1
--	Initial build. First version
+*   Wed Nov 5 2014 Divya Thaluru <dthaluru@vmware.com> 1.22.2-1
+-   Initial build. First version


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
`groff` CVE-2000-0803 is unpatched. Centos & Fedora do not appear to address this CVE either.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Nopatch `groff` CVE-2000-0803
- Unify changelog format for `groff.spec`

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2000-0803

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- make 'input-srpms' to validate spec file format.