### PR TITLE
Nopatch qemu CVE-2016-7161

### DIFF
--- a/SPECS/qemu-kvm/CVE-2016-7161.nopatch
+++ b/SPECS/qemu-kvm/CVE-2016-7161.nopatch
@@ -1,0 +1,1 @@
+# CVE-2016-7161 was fixed in 2.7.0, but the CVE database was not updated.

--- a/SPECS/qemu-kvm/qemu-kvm.spec
+++ b/SPECS/qemu-kvm/qemu-kvm.spec
@@ -1,7 +1,7 @@
-Summary:	QEMU is a machine emulator and virtualizer
-Name:		qemu-kvm
-Version:	4.2.0
-Release:    11%{?dist}
+Summary:    QEMU is a machine emulator and virtualizer
+Name:       qemu-kvm
+Version:    4.2.0
+Release:    12%{?dist}
 License:    GPLv2 and GPLv2+ and CC-BY and BSD
 Group:      Development/Tools
 URL:        https://www.qemu.org/
@@ -18,6 +18,8 @@ Patch4:      CVE-2019-20175.patch
 Patch5:      CVE-2020-13659.patch
 Patch6:      CVE-2020-16092.patch
 Patch7:      CVE-2020-15863.patch
+# CVE-2016-7161 was fixed in 2.7.0, but the CVE database was not updated.
+Patch8:      CVE-2016-7161.nopatch
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 
@@ -114,6 +116,8 @@ chmod 755 %{buildroot}%{_bindir}/qemu
 %{_bindir}/qemu-nbd
 
 %changelog
+*   Mon Sep 28 2020 Daniel McIlvaney <damcilva@microsoft.com> 4.2.0-12
+-   Nopatch CVE-2016-7161, it was fixed in 2.7
 *   Mon Sep 14 2020 Nicolas Guibourge <nicolasg@microsoft.com> 4.2.0-11
 -   Add patch for CVE-2020-15863
 *   Wed Sep 02 2020 Nicolas Ontiveros <niontive@microsoft.com> 4.2.0-10

--- a/SPECS/qemu-kvm/qemu-kvm.spec
+++ b/SPECS/qemu-kvm/qemu-kvm.spec
@@ -1,27 +1,27 @@
-Summary:    QEMU is a machine emulator and virtualizer
-Name:       qemu-kvm
-Version:    4.2.0
-Release:    12%{?dist}
-License:    GPLv2 and GPLv2+ and CC-BY and BSD
-Group:      Development/Tools
-URL:        https://www.qemu.org/
-Source0:    https://download.qemu.org/qemu-%{version}.tar.xz
-Source1:    65-kvm.rules
+Summary:       QEMU is a machine emulator and virtualizer
+Name:          qemu-kvm
+Version:       4.2.0
+Release:       12%{?dist}
+License:       GPLv2 and GPLv2+ and CC-BY and BSD
+Group:         Development/Tools
+URL:           https://www.qemu.org/
+Vendor:        Microsoft Corporation
+Distribution:  Mariner
+Source0:       https://download.qemu.org/qemu-%{version}.tar.xz
+Source1:       65-kvm.rules
 # https://git.qemu.org/?p=qemu.git;a=commit;h=8ffb7265af64ec81748335ec8f20e7ab542c3850
-Patch0:      CVE-2020-11102.patch
+Patch0:        CVE-2020-11102.patch
 # This vulnerability is in libslirp source code. And qemu is exposed to it when configured with libslirp.
 # Since Mariner does not have libslirp, it is not applicable.
-Patch1:      CVE-2020-7039.nopatch
-Patch2:      CVE-2020-1711.patch
-Patch3:      CVE-2020-7211.patch
-Patch4:      CVE-2019-20175.patch
-Patch5:      CVE-2020-13659.patch
-Patch6:      CVE-2020-16092.patch
-Patch7:      CVE-2020-15863.patch
+Patch1:        CVE-2020-7039.nopatch
+Patch2:        CVE-2020-1711.patch
+Patch3:        CVE-2020-7211.patch
+Patch4:        CVE-2019-20175.patch
+Patch5:        CVE-2020-13659.patch
+Patch6:        CVE-2020-16092.patch
+Patch7:        CVE-2020-15863.patch
 # CVE-2016-7161 was fixed in 2.7.0, but the CVE database was not updated.
-Patch8:      CVE-2016-7161.nopatch
-Vendor:         Microsoft Corporation
-Distribution:   Mariner
+Patch8:        CVE-2016-7161.nopatch
 
 BuildRequires: python3-devel
 BuildRequires: glib-devel


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
`qemu-kvm`CVE-2016-7161 is already patched. It was fixed in version 2.7 but NVD was not updated.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Nopatch`qemu-kvm`CVE-2016-7161
- Unify formatting in `qemu-kvm.spec`

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2016-7161

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- make 'input-srpms' to validate spec file format.