### PR TITLE
Nopatch CVE-2013-0170

### DIFF
--- a/SPECS/libvirt/CVE-2013-0170.nopatch
+++ b/SPECS/libvirt/CVE-2013-0170.nopatch
@@ -1,0 +1,1 @@
+# This CVE only affects libvirt older than 1.0.2

--- a/SPECS/libvirt/libvirt.spec
+++ b/SPECS/libvirt/libvirt.spec
@@ -1,7 +1,7 @@
 Summary:        Virtualization API library that supports KVM, QEMU, Xen, ESX etc
 Name:           libvirt
 Version:        6.1.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        LGPL
 URL:            https://libvirt.org/
 Source0:        https://libvirt.org/sources/%{name}-%{version}.tar.xz
@@ -9,6 +9,8 @@ Source0:        https://libvirt.org/sources/%{name}-%{version}.tar.xz
 Patch0:         CVE-2019-3886.nopatch
 # The fix for this CVE is already in 6.1.0.
 Patch1:         CVE-2017-1000256.nopatch
+# This CVE only affects libvirt older than 1.0.2
+Patch2:         CVE-2013-0170.nopatch
 Group:          Virtualization/Libraries
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -127,9 +129,11 @@ make check
 %{_mandir}/*
 
 %changelog
+*   Tue Sep 29 2020 Mateusz Malisz <mamalisz@microsoft.com> 6.1.0-2
+-   Add nopatch for CVE-2013-0170
 *   Fri May 29 2020 Emre Girgin <mrgirgin@microsoft.com> 6.1.0-1
 -   Upgrade to 6.1.0.
-*   Sat May 09 00:21:42 PST 2020 Nick Samson <nisamson@microsoft.com> - 4.7.0-5
+*   Sat May 09 2020 Nick Samson <nisamson@microsoft.com> 4.7.0-5
 -   Added %%license line automatically
 *   Fri Apr 17 2020 Nicolas Ontiveros <niontive@microsoft.com> 4.7.0-4
 -   Rename libnl to libnl3.


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Add nopatch file for CVE-2013-0170 which affects libvirt < 1.0.2

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add nopatch for CVE-2013-0170

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2013-0170

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local `make input-srpms` build to verify SPEC format.