### PR TITLE
installutils: Remove root password expiry when no root user is specified in imageconfig file

### DIFF
--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -828,6 +828,7 @@ func addUsers(installChroot *safechroot.Chroot, users []configuration.User) (err
 
 	// If no root entry was specified in the config file, never expire the root password
 	if !rootUserAdded {
+		logger.Log.Debugf("No root user entry found in config file. Setting root password to never expire.")
 		err = installChroot.UnsafeRun(func() error {
 			return shell.ExecuteLive(squashErrors, "chage", "-M", "-1", "root")
 		})

--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -790,14 +790,17 @@ func addUsers(installChroot *safechroot.Chroot, users []configuration.User) (err
 	const (
 		squashErrors = false
 	)
-	var isRoot bool
-	var rootUserAdded bool
+
+	rootUserAdded := false
 
 	for _, user := range users {
 		logger.Log.Infof("Adding user (%s)", user.Name)
 		ReportActionf("Adding user: %s", user.Name)
 
-		var homeDir string
+		var (
+			homeDir string
+			isRoot  bool
+		)
 
 		homeDir, isRoot, err = createUserWithPassword(installChroot, user)
 		if err != nil {

--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -791,6 +791,7 @@ func addUsers(installChroot *safechroot.Chroot, users []configuration.User) (err
 		squashErrors = false
 	)
 	var isRoot bool
+	var rootUserAdded bool
 
 	for _, user := range users {
 		logger.Log.Infof("Adding user (%s)", user.Name)
@@ -801,6 +802,9 @@ func addUsers(installChroot *safechroot.Chroot, users []configuration.User) (err
 		homeDir, isRoot, err = createUserWithPassword(installChroot, user)
 		if err != nil {
 			return
+		}
+		if isRoot {
+			rootUserAdded = true
 		}
 
 		err = configureUserGroupMembership(installChroot, user)
@@ -820,7 +824,7 @@ func addUsers(installChroot *safechroot.Chroot, users []configuration.User) (err
 	}
 
 	// If no root entry was specified in the config file, never expire the root password
-	if !isRoot {
+	if !rootUserAdded {
 		err = installChroot.UnsafeRun(func() error {
 			return shell.ExecuteLive(squashErrors, "chage", "-M", "-1", "root")
 		})


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
In the current images, the root password expiry gets set to the default 90 days. If the root user was configured in the imageconfig.json, it is possible to customize this expiry date. However, if no root user is specified (which is the standard case), the default root user will get the password expiry notice after 90 days and can be locked out of the system.

This change removes the root password expiry only in the case when no root user is specified in the imageconfig file.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Remove the root password expiry only in the case when no root user is specified in the imageconfig file.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local image testing