### PR TITLE
Fix kernel specs' %postun scripts

### DIFF
--- a/SPECS-SIGNED/kernel-signed-aarch64/kernel-signed-aarch64.spec
+++ b/SPECS-SIGNED/kernel-signed-aarch64/kernel-signed-aarch64.spec
@@ -2,7 +2,7 @@
 Summary:        Signed Linux Kernel for aarch64 systems
 Name:           kernel-signed-aarch64
 Version:        5.4.51
-Release:        7%{?dist}
+Release:        8%{?dist}
 License:        GPLv2
 URL:            https://github.com/microsoft/WSL2-Linux-Kernel
 Group:          System Environment/Kernel
@@ -67,7 +67,8 @@ echo "initrd of kernel %{uname_r} removed" >&2
 %postun
 if [ ! -e /boot/mariner.cfg ]
 then
-     if [ `ls /boot/linux-*.cfg 1> /dev/null 2>&1` ]
+     ls /boot/linux-*.cfg 1> /dev/null 2>&1
+     if [ $? -eq 0 ]
      then
           list=`ls -tu /boot/linux-*.cfg | head -n1`
           test -n "$list" && ln -sf "$list" /boot/mariner.cfg
@@ -84,6 +85,8 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %config %{_localstatedir}/lib/initramfs/kernel/%{uname_r}
 
 %changelog
+*   Wed Sep 30 2020 Emre Girgin <mrgirgin@microsoft.com> 5.4.51-8
+-   Update postun script to deal with removal in case of another installed kernel.
 *   Fri Sep 25 2020 Suresh Babu Chalamalasetty <schalam@microsoft.com> 5.4.51-7
 -   Update release number
 *   Wed Sep 23 2020 Daniel McIlvaney <damcilva@microsoft.com> 5.4.51-6

--- a/SPECS-SIGNED/kernel-signed-x64/kernel-signed-x64.spec
+++ b/SPECS-SIGNED/kernel-signed-x64/kernel-signed-x64.spec
@@ -2,7 +2,7 @@
 Summary:        Signed Linux Kernel for x86_64 systems
 Name:           kernel-signed-x64
 Version:        5.4.51
-Release:        7%{?dist}
+Release:        8%{?dist}
 License:        GPLv2
 URL:            https://github.com/microsoft/WSL2-Linux-Kernel
 Group:          System Environment/Kernel
@@ -67,7 +67,8 @@ echo "initrd of kernel %{uname_r} removed" >&2
 %postun
 if [ ! -e /boot/mariner.cfg ]
 then
-     if [ `ls /boot/linux-*.cfg 1> /dev/null 2>&1` ]
+     ls /boot/linux-*.cfg 1> /dev/null 2>&1
+     if [ $? -eq 0 ]
      then
           list=`ls -tu /boot/linux-*.cfg | head -n1`
           test -n "$list" && ln -sf "$list" /boot/mariner.cfg
@@ -84,6 +85,8 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %config %{_localstatedir}/lib/initramfs/kernel/%{uname_r}
 
 %changelog
+*   Wed Sep 30 2020 Emre Girgin <mrgirgin@microsoft.com> 5.4.51-8
+-   Update postun script to deal with removal in case of another installed kernel.
 *   Fri Sep 25 2020 Suresh Babu Chalamalasetty <schalam@microsoft.com> 5.4.51-7
 -   Update release number
 *   Wed Sep 23 2020 Daniel McIlvaney <damcilva@microsoft.com> 5.4.51-6

--- a/SPECS/kernel-hyperv/kernel-hyperv.spec
+++ b/SPECS/kernel-hyperv/kernel-hyperv.spec
@@ -2,7 +2,7 @@
 Summary:        Linux Kernel optimized for Hyper-V
 Name:           kernel-hyperv
 Version:        5.4.51
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        GPLv2
 URL:            https://github.com/microsoft/WSL2-Linux-Kernel
 Group:          System Environment/Kernel
@@ -202,7 +202,8 @@ echo "initrd of kernel %{uname_r} removed" >&2
 %postun
 if [ ! -e /boot/mariner.cfg ]
 then
-     if [ `ls /boot/linux-*.cfg 1> /dev/null 2>&1` ]
+     ls /boot/linux-*.cfg 1> /dev/null 2>&1
+     if [ $? -eq 0 ]
      then
           list=`ls -tu /boot/linux-*.cfg | head -n1`
           test -n "$list" && ln -sf "$list" /boot/mariner.cfg
@@ -257,6 +258,8 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %{_libdir}/perf/include/bpf/*
 
 %changelog
+*   Wed Sep 30 2020 Emre Girgin <mrgirgin@microsoft.com> 5.4.51-4
+-   Update postun script to deal with removal in case of another installed kernel.
 *   Thu Sep 03 2020 Daniel McIlvaney <damcilva@microsoft.com> 5.4.51-3
 -   Add code to check for missing config flags in the checked in configs
 *   Tue Sep 01 2020 Chris Co <chrco@microsoft.com> 5.4.51-2

--- a/SPECS/kernel/kernel.spec
+++ b/SPECS/kernel/kernel.spec
@@ -2,7 +2,7 @@
 Summary:        Linux Kernel
 Name:           kernel
 Version:        5.4.51
-Release:        7%{?dist}
+Release:        8%{?dist}
 License:        GPLv2
 URL:            https://github.com/microsoft/WSL2-Linux-Kernel
 Group:          System Environment/Kernel
@@ -259,7 +259,8 @@ echo "initrd of kernel %{uname_r} removed" >&2
 %postun
 if [ ! -e /boot/mariner.cfg ]
 then
-     if [ `ls /boot/linux-*.cfg 1> /dev/null 2>&1` ]
+     ls /boot/linux-*.cfg 1> /dev/null 2>&1
+     if [ $? -eq 0 ]
      then
           list=`ls -tu /boot/linux-*.cfg | head -n1`
           test -n "$list" && ln -sf "$list" /boot/mariner.cfg
@@ -332,6 +333,8 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %{_libdir}/perf/include/bpf/*
 
 %changelog
+*   Wed Sep 30 2020 Emre Girgin <mrgirgin@microsoft.com> 5.4.51-8
+-   Update postun script to deal with removal in case of another installed kernel.
 *   Fri Sep 25 2020 Suresh Babu Chalamalasetty <schalam@microsoft.com> 5.4.51-7
 -   Enable Mellanox kernel configs
 *   Wed Sep 23 2020 Daniel McIlvaney <damcilva@microsoft.com> 5.4.51-6


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
The `%postun` script was testing the the outcome of a statement that always returns empty string. As a consequence, `mariner.cfg` was not pointing to the next available `kernel` after an uninstall.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change the `%postun` script in `kernel.spec` to test whether any other `kernel` configurations are around.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
YES
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/...

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: xxxx