### PR TITLE
Patch CVE-2020-14342 in cifs-utils

### DIFF
--- a/SPECS/cifs-utils/CVE-2020-14342-fix.patch
+++ b/SPECS/cifs-utils/CVE-2020-14342-fix.patch
@@ -1,0 +1,37 @@
+From f7e13c34bc2f820ff124f1425c5d92dbdaa2e8da Mon Sep 17 00:00:00 2001
+From: Leandro Pereira <lpereira@linux.microsoft.com>
+Date: Thu, 1 Oct 2020 15:51:32 -0700
+Subject: [PATCH] CVE-2020-13342: Do not rely on $PATH to find
+ systemd-ask-password
+
+The execlp() call will look at the $PATH environment variable to
+determine which binary to execute; if a binary naemd
+"systemd-ask-password" is present, that will be called with the same
+privileges as "mount.cifs", which could be elevated as that might be
+executed under sudo or the executable might be SUID root.  Moreover,
+this could be used to exfiltrate the password if somebody has access to
+the environment.
+
+This patch makes the call using /usr/bin/systemd-ask-password directly.
+
+Signed-off-by: Leandro Pereira <lpereira@linux.microsoft.com>
+---
+ mount.cifs.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/mount.cifs.c b/mount.cifs.c
+index 4feb397..af0a796 100644
+--- a/mount.cifs.c
++++ b/mount.cifs.c
+@@ -1669,7 +1669,8 @@ static int get_passwd_by_systemd(const char *prompt, char *input, int capacity)
+	if (pid == 0) {
+		close(fd[0]);
+		dup2(fd[1], STDOUT_FILENO);
+-		if (execlp("systemd-ask-password", "systemd-ask-password", prompt, NULL) == -1) {
++		if (execlp("/usr/bin/systemd-ask-password",
++		"/usr/bin/systemd-ask-password", prompt, NULL) == -1) {
+			fprintf(stderr, "Failed to execute systemd-ask-password: %s\n",
+			strerror(errno));
+		}
+--
+1.8.3.1

--- a/SPECS/cifs-utils/CVE-2020-14342.patch
+++ b/SPECS/cifs-utils/CVE-2020-14342.patch
@@ -1,0 +1,121 @@
+diff -Naur cifs-utils-6.8.orig/mount.cifs.c cifs-utils-6.8.mod/mount.cifs.c
+--- cifs-utils-6.8.orig/mount.cifs.c	2020-09-30 17:26:48.250924409 -0700
++++ cifs-utils-6.8.mod/mount.cifs.c	2020-09-30 17:27:19.002733900 -0700
+@@ -1646,6 +1646,73 @@
+ 	return 0;
+ }
+ 
++#ifdef ENABLE_SYSTEMD
++static int get_passwd_by_systemd(const char *prompt, char *input, int capacity)
++{
++	int fd[2];
++	pid_t pid;
++	int offs = 0;
++	int rc = 1;
++
++	if (pipe(fd) == -1) {
++		fprintf(stderr, "Failed to create pipe: %s\n", strerror(errno));
++		return 1;
++	}
++
++	pid = fork();
++	if (pid == -1) {
++		fprintf(stderr, "Unable to fork: %s\n", strerror(errno));
++		close(fd[0]);
++		close(fd[1]);
++		return 1;
++	}
++	if (pid == 0) {
++		close(fd[0]);
++		dup2(fd[1], STDOUT_FILENO);
++		if (execlp("systemd-ask-password", "systemd-ask-password", prompt, NULL) == -1) {
++			fprintf(stderr, "Failed to execute systemd-ask-password: %s\n",
++			strerror(errno));
++		}
++		exit(1);
++	}
++
++	close(fd[1]);
++	for (;;) {
++		if (offs+1 >= capacity) {
++			fprintf(stderr, "Password too long.\n");
++			kill(pid, SIGTERM);
++			rc = 1;
++			break;
++		}
++		rc = read(fd[0], input + offs, capacity - offs);
++		if (rc == -1) {
++			fprintf(stderr, "Failed to read from pipe: %s\n", strerror(errno));
++			rc = 1;
++			break;
++		}
++		if (!rc)
++			break;
++		offs += rc;
++		input[offs] = '\0';
++	}
++	if (wait(&rc) == -1) {
++		fprintf(stderr, "Failed to wait child: %s\n", strerror(errno));
++		rc = 1;
++		goto out;
++	}
++	if (!WIFEXITED(rc) || WEXITSTATUS(rc)) {
++		rc = 1;
++		goto out;
++	}
++
++		rc = 0;
++
++out:
++		close(fd[0]);
++		return rc;
++}
++#endif
++
+ /*
+  * If systemd is running and systemd-ask-password --
+  * is available, then use that else fallback on getpass(..)
+@@ -1659,35 +1726,22 @@
+ 	int is_systemd_running;
+ 	struct stat a, b;
+ 
++	memset(input, 0, capacity);
++
+ 	/* We simply test whether the systemd cgroup hierarchy is
+ 	 * mounted */
+ 	is_systemd_running = (lstat("/sys/fs/cgroup", &a) == 0)
+ 		&& (lstat("/sys/fs/cgroup/systemd", &b) == 0)
+ 		&& (a.st_dev != b.st_dev);
+ 
+-	if (is_systemd_running) {
+-		char *cmd, *ret;
+-		FILE *ask_pass_fp = NULL;
+-
+-		cmd = ret = NULL;
+-		if (asprintf(&cmd, "systemd-ask-password \"%s\"", prompt) >= 0) {
+-			ask_pass_fp = popen (cmd, "re");
+-			free (cmd);
+-		}
+-
+-		if (ask_pass_fp) {
+-			ret = fgets(input, capacity, ask_pass_fp);
+-			pclose(ask_pass_fp);
+-		}
+-
+-		if (ret) {
+-			int len = strlen(input);
+-			if (input[len - 1] == '\n')
+-				input[len - 1] = '\0';
+-			return input;
+-		}
++	if (is_systemd_running && !get_passwd_by_systemd(prompt, input, capacity)) {
++		int len = strlen(input);
++		if (input[len - 1] == '\n')
++			input[len - 1] = '\0';
++		return input;
+ 	}
+ #endif
++	memset(input, 0, capacity);
+ 
+ 	/*
+ 	 * Falling back to getpass(..)

--- a/SPECS/cifs-utils/cifs-utils.spec
+++ b/SPECS/cifs-utils/cifs-utils.spec
@@ -28,8 +28,7 @@ Requires:   cifs-utils = %{version}-%{release}
 Provides header files needed for Cifs-Utils development.
 
 %prep
-%setup -q
-%patch0 -p1
+%autosetup
 
 %build
 autoreconf -fiv &&./configure --prefix=%{_prefix}
@@ -51,9 +50,9 @@ make %{?_smp_mflags} check
 %{_includedir}/cifsidmap.h
 
 %changelog
-*   Wed Sep 30 2020 Henry Beberman <henry.beberman@microsoft.com> - 6.8-4
+*   Wed Sep 30 2020 Henry Beberman <henry.beberman@microsoft.com> 6.8-4
 -   Add patch for CVE-2020-14342
-*   Sat May 09 00:20:52 PST 2020 Nick Samson <nisamson@microsoft.com> - 6.8-3
+*   Sat May 09 2020 Nick Samson <nisamson@microsoft.com> 6.8-3
 -   Added %%license line automatically
 *   Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 6.8-2
 -   Initial CBL-Mariner import from Photon (license: Apache2).

--- a/SPECS/cifs-utils/cifs-utils.spec
+++ b/SPECS/cifs-utils/cifs-utils.spec
@@ -8,6 +8,8 @@ Group:		Applications/Nfs-utils-client
 Source0:        https://ftp.samba.org/pub/linux-cifs/cifs-utils/cifs-utils-%{version}.tar.bz2
 
 Patch0:         CVE-2020-14342.patch
+Patch1:         CVE-2020-14342-fix.patch
+
 
 Vendor:         Microsoft Corporation
 Distribution:   Mariner

--- a/SPECS/cifs-utils/cifs-utils.spec
+++ b/SPECS/cifs-utils/cifs-utils.spec
@@ -1,12 +1,14 @@
 Summary:	cifs client utils
 Name:		cifs-utils
 Version:	6.8
-Release:        3%{?dist}
+Release:	4%{?dist}
 License:	GPLv3
 URL:		http://wiki.samba.org/index.php/LinuxCIFS_utils
 Group:		Applications/Nfs-utils-client
 Source0:        https://ftp.samba.org/pub/linux-cifs/cifs-utils/cifs-utils-%{version}.tar.bz2
-%define sha1 cifs-utils=3440625e73a2e8ea58c63c61b46a61f5b7f95bac
+
+Patch0:         CVE-2020-14342.patch
+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 BuildRequires:  libcap-ng-devel
@@ -27,6 +29,7 @@ Provides header files needed for Cifs-Utils development.
 
 %prep
 %setup -q
+%patch0 -p1
 
 %build
 autoreconf -fiv &&./configure --prefix=%{_prefix}
@@ -48,9 +51,10 @@ make %{?_smp_mflags} check
 %{_includedir}/cifsidmap.h
 
 %changelog
-* Sat May 09 00:20:52 PST 2020 Nick Samson <nisamson@microsoft.com> - 6.8-3
-- Added %%license line automatically
-
+*   Wed Sep 30 2020 Henry Beberman <henry.beberman@microsoft.com> - 6.8-4
+-   Add patch for CVE-2020-14342
+*   Sat May 09 00:20:52 PST 2020 Nick Samson <nisamson@microsoft.com> - 6.8-3
+-   Added %%license line automatically
 *   Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 6.8-2
 -   Initial CBL-Mariner import from Photon (license: Apache2).
 *       Fri Sep 07 2017 Ajay Kaher <akaher@vmware.com> 6.8-1


### PR DESCRIPTION

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
This commit patches the privilege escalation CVE-2020-14342 in cifs-utils

###### Change Log  <!-- REQUIRED -->
Patch CVE-2020-14342 in cifs-utils

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2020-14342
- [Upstream patch] https://git.samba.org/cifs-utils.git/?p=cifs-utils.git;a=commitdiff;h=48a654e2e763fce24c22e1b9c695b42804bbdd4a#patch1

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local build
- Observed that running "sudo mount.cifs -o username='\`sh\`' //1 /mnt" no longer drops into a root sh session but instead prompts for a password.