### PR TITLE
Remove chrony-wait as a boot service dependency

### DIFF
--- a/SPECS/chrony/chrony.spec
+++ b/SPECS/chrony/chrony.spec
@@ -4,7 +4,7 @@
 
 Name:           chrony
 Version:        3.5.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        An NTP client/server
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -77,13 +77,17 @@ sed -e 's|^pool.*|server time.windows.com|' \
     -e 's|#\(keyfile\)|\1|' \
         < examples/chrony.conf.example2 > chrony.conf
 
+# use the example chrony-wait service, but comment out the line adding
+# chrony-wait as a boot dependency
+sed -i '/WantedBy=multi-user.target/s/^/#/g' examples/chrony-wait.service
+
 cat >> chrony.conf << EOF
 
 # Setting larger 'maxdistance' to tolerate time.windows.com delay
 maxdistance 16.0
 EOF
 
-touch -r examples/chrony.conf.example2 chrony.conf
+touch -r examples/chrony.conf.example2 examples/chrony-wait.service chrony.conf
 
 # regenerate the file from getdate.y
 rm -f getdate.c
@@ -191,6 +195,9 @@ systemctl start chronyd.service
 %dir %attr(-,chrony,chrony) %{_localstatedir}/log/chrony
 
 %changelog
+* Thu Oct 01 2020 Thomas Crain <thcrain@microsoft.com> - 3.5.1-2
+- Remove chrony-wait service as a boot dependency
+
 * Tue Sep 01 2020 Mateusz Malisz <mamalisz@microsoft.com> - 3.5.1-1
 - Update version to 3.5.1
 - Remove gpg signature check

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -444,6 +444,16 @@
       "component": {
         "type": "other",
         "other": {
+          "name": "chrony",
+          "version": "3.5.1",
+          "downloadUrl": "https://download.tuxfamily.org/chrony/chrony-3.5.1.tar.gz"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "other",
+        "other": {
           "name": "chrpath",
           "version": "0.16",
           "downloadUrl": "https://alioth-archive.debian.org/releases/chrpath/chrpath/0.16/chrpath-0.16.tar.gz"


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Example chrony-wait service definition in chrony source adds itself as a systemd boot dependency, which increases overall boot times from ~6s to ~2.75min. This patch comments out the offending line in the service definition file.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change
- Change
- Change

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
**NO**

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Rebuilt chrony locally
- Efficacy of fix was confirmed in 1.0.20200922 iso core image.