### PR TITLE
initramfs: Regenerate initrd using host-only mode on file-based trigger

### DIFF
--- a/SPECS/initramfs/initramfs.spec
+++ b/SPECS/initramfs/initramfs.spec
@@ -1,7 +1,7 @@
 Summary:	initramfs
 Name:		initramfs
 Version:	2.0
-Release:        5%{?dist}
+Release:        6%{?dist}
 Source0:	fscks.conf
 License:	Apache License
 Group:		System Environment/Base
@@ -66,6 +66,21 @@ mkdir -p %{_localstatedir}/lib/rpm-state/initramfs \
 touch %{_localstatedir}/lib/rpm-state/initramfs/regenerate \
 echo "initramfs (re)generation" %* >&2
 
+# kdump currently uses the host system's initrd when enrolling a crash kernel
+# and initrd. There is a limitation where the kdump initrd must be generated
+# with dracut in "host-only" mode.
+#
+# The -k option forces a host-only initrd build.
+# The -q option suppresses verbose output
+#
+# If mkinitrd is called without <image> and <kernel-version> parameters, it will
+# default to calling dracut in "host-mode" mode on every kernel version it can
+# find in /boot.
+#
+# If mkinitrd is called with <image> and <kernel-version> parameters, it will
+# default to calling dracut in "generic host" mode for rebuilding the specific
+# initrd. Therefore we need to make sure to add the -k option when invoking
+# mkinitrd with an explicit <image> and <kernel version>
 %define file_trigger_action() \
 cat > /dev/null \
 if [ -f %{_localstatedir}/lib/rpm-state/initramfs/regenerate ]; then \
@@ -74,7 +89,7 @@ if [ -f %{_localstatedir}/lib/rpm-state/initramfs/regenerate ]; then \
 elif [ -d %{_localstatedir}/lib/rpm-state/initramfs/pending ]; then \
     for k in `ls %{_localstatedir}/lib/rpm-state/initramfs/pending/`; do \
         echo "(re)generate initramfs for $k," %* >&2 \
-        mkinitrd -q /boot/initrd.img-$k $k \
+        mkinitrd -q /boot/initrd.img-$k $k -k \
     done; \
 fi \
 %removal_action
@@ -111,6 +126,8 @@ echo "initramfs" %{version}-%{release} "postun" >&2
 %dir %{_localstatedir}/lib/initramfs/kernel
 
 %changelog
+*   Thu Oct 01 2020 Chris Co <chrco@microsoft.com> 2.0-6
+-   Update file-triggered initrd generation to workaround kdump initrd limitations
 *   Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 2.0-5
 -   Initial CBL-Mariner import from Photon (license: Apache2).
 *   Mon Aug 27 2018 Dheeraj Shetty <dheerajs@vmware.com> 2.0-4

--- a/SPECS/initramfs/initramfs.spec
+++ b/SPECS/initramfs/initramfs.spec
@@ -70,17 +70,18 @@ echo "initramfs (re)generation" %* >&2
 # and initrd. There is a limitation where the kdump initrd must be generated
 # with dracut in "host-only" mode.
 #
-# The -k option forces a host-only initrd build.
+# The -k option forces "host-only" initrd build for the specified kernel version.
 # The -q option suppresses verbose output
 #
 # If mkinitrd is called without <image> and <kernel-version> parameters, it will
-# default to calling dracut in "host-mode" mode on every kernel version it can
+# default to invoking dracut in "host-mode" mode on every kernel version it can
 # find in /boot.
 #
 # If mkinitrd is called with <image> and <kernel-version> parameters, it will
-# default to calling dracut in "generic host" mode for rebuilding the specific
-# initrd. Therefore we need to make sure to add the -k option when invoking
-# mkinitrd with an explicit <image> and <kernel version>
+# default to invoking dracut in "generic host" mode to create an initrd.
+#
+# So in order to be compatible with kdump, we need to make sure to add the -k
+# option when invoking mkinitrd with an explicit <image> and <kernel version>
 %define file_trigger_action() \
 cat > /dev/null \
 if [ -f %{_localstatedir}/lib/rpm-state/initramfs/regenerate ]; then \


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
This change addresses a kdump scenario regression which can occur after issuing kernel package upgrade.

Failing Behavior: After a kernel upgrade and updated crash kernel is armed, if a panic occurs, the system just hangs on the panic.

Our kdump service currently uses the host system's initrd when enrolling a crash kernel and initrd. And there is a limitation where the kdump initrd must be generated with dracut in "host-only" mode.

If mkinitrd is called without `<image>` and `<kernel-version>` parameters, it will default to calling dracut in "host-mode" mode on every kernel version it can find in /boot.

If mkinitrd is called with `<image>` and `<kernel-version>` parameters, it will default to invoking dracut in "generic host" mode to create an initrd.

During a kernel package upgrade, the initramfs's file-trigger gets called and eventually runs `mkinitrd -q <image> <kernel-version>`. This regenerates the initrd in "generic host" mode, which is now incompatible with kdump.

So this initial change adds the "-k" option when invoking mkinitrd with an explicit "image" and "kernel version" options during the file-based trigger, thereby always producing a "host-only" initrd that is compatible with kdump.

Note: The kdump service provides methods to generate a crash-kernel-specific initrd. Longer term, we should investigate doing this instead of relying on the host system's initrd.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add "-k" option to mkinitrd command in file-based initramfs regeneration trigger

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local test