### PR TITLE
[dev] Remove "::set-env" commands in GitHub Actions for CVE-2020-15228

### DIFF
--- a/.github/workflows/check-package-cgmanifest.yml
+++ b/.github/workflows/check-package-cgmanifest.yml
@@ -20,14 +20,14 @@ jobs:
       if: ${{ github.event_name == 'pull_request' }}
       run: |
         git fetch origin ${{ github.base_ref }}
-        echo "::set-env name=base_sha::$(git rev-parse origin/${{ github.base_ref }})"
+        echo "base_sha=$(git rev-parse origin/${{ github.base_ref }})" >> $GITHUB_ENV 
         echo "Merging ${{ github.sha }} into ${{ github.base_ref }}"
 
     - name: Get base commit for Pushes
       if: ${{ github.event_name == 'push' }}
       run: |
         git fetch origin ${{ github.event.before }}
-        echo "::set-env name=base_sha::${{ github.event.before }}"
+        echo "base_sha=${{ github.event.before }}" >> $GITHUB_ENV 
         echo "Merging ${{ github.sha }} into ${{ github.event.before }}"
 
     - name: Get the changed files
@@ -35,7 +35,7 @@ jobs:
         echo "Files changed: '$(git diff-tree --no-commit-id --name-only -r ${{ env.base_sha }} ${{ github.sha }})'"
         changed_specs=$(git diff-tree --no-commit-id --name-only -r ${{ env.base_sha }} ${{ github.sha }} | { grep "\.spec$" || test $? = 1; })
         echo "Files to validate: '${changed_specs}'"
-        echo "::set-env name=updated-specs::$(echo ${changed_specs})"
+        echo "updated-specs=$(echo ${changed_specs})" >> $GITHUB_ENV
 
     - name: Check each spec
       run: |


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Patches CVE-2020-15228 in our GitHub Actions scripts using the "::set-env" command (corresponds to PR against 1.0-dev branch microsoft/CBL-Mariner#178)

###### Change Log  <!-- REQUIRED -->
- Address [deprecation of "::set-env"" command](https://github.com/actions/toolkit/security/advisories/GHSA-mfwh-5m23-j46w) due to CVE-2020-15228
- Replace deprecated command with ["Environment File Syntax"](https://github.com/actions/toolkit/blob/main/docs/commands.md#environment-files)

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2020-15228

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Tested push functionality in thcrain/test-workflow-set-env branch, tested PR functionality in thcrain/test-workflow-set-env-fix branch
- Both functioned as expected post-change