### PR TITLE
Updating cert bundle paths.

### DIFF
--- a/SPECS/curl/curl.spec
+++ b/SPECS/curl/curl.spec
@@ -1,7 +1,7 @@
 Summary:        An URL retrieval utility and library
 Name:           curl
 Version:        7.68.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        MIT
 URL:            http://curl.haxx.se
 Group:          System Environment/NetworkingLibraries
@@ -47,7 +47,7 @@ This package contains minimal set of shared curl libraries.
     --with-ssl \
     --with-gssapi \
     --with-libssh2 \
-    --with-ca-bundle=/etc/pki/tls/certs/ca-bundle.crt \
+    --with-ca-bundle=/etc/pki/tls/certs/ca-bundle.trust.crt \
     --with-ca-path=/etc/ssl/certs
 make %{?_smp_mflags}
 
@@ -87,6 +87,8 @@ rm -rf %{buildroot}/*
 %{_libdir}/libcurl.so.*
 
 %changelog
+*   Wed Oct 07 2020 Pawel Winogrodzki <joschmit@microsoft.com> 7.68.0-2
+-   Updating certificate bundle path to include full set of trust information.
 *   Tue Aug 11 2020 Pawel Winogrodzki <pawelwi@microsoft.com> 7.68.0-1
 -   Upgrading to 7.68.0 to enable verification against a partial cert chain.
 *   Thu May 14 2020 Nicolas Ontiveros <niontive@microsoft.com> 7.66.0-1

--- a/SPECS/curl/curl.spec
+++ b/SPECS/curl/curl.spec
@@ -87,7 +87,7 @@ rm -rf %{buildroot}/*
 %{_libdir}/libcurl.so.*
 
 %changelog
-*   Wed Oct 07 2020 Pawel Winogrodzki <joschmit@microsoft.com> 7.68.0-2
+*   Wed Oct 07 2020 Pawel Winogrodzki <pawelwi@microsoft.com> 7.68.0-2
 -   Updating certificate bundle path to include full set of trust information.
 *   Tue Aug 11 2020 Pawel Winogrodzki <pawelwi@microsoft.com> 7.68.0-1
 -   Upgrading to 7.68.0 to enable verification against a partial cert chain.

--- a/SPECS/gnutls/gnutls.spec
+++ b/SPECS/gnutls/gnutls.spec
@@ -1,7 +1,7 @@
 Summary:        The GnuTLS Transport Layer Security Library
 Name:           gnutls
 Version:        3.6.14
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv3+ and LGPLv2+
 URL:            https://www.gnutls.org
 Source0:        ftp://ftp.gnutls.org/gcrypt/gnutls/v3.6/%{name}-%{version}.tar.xz
@@ -44,7 +44,7 @@ developing applications that use gnutls.
     --disable-openssl-compatibility \
     --with-included-unistring \
     --with-system-priority-file=%{_sysconfdir}/gnutls/default-priorities \
-    --with-default-trust-store-file=%{_sysconfdir}/pki/tls/certs/ca-bundle.crt \
+    --with-default-trust-store-file=%{_sysconfdir}/pki/tls/certs/ca-bundle.trust.crt \
     --with-default-trust-store-dir=%{_sysconfdir}/ssl/certs
 make %{?_smp_mflags}
 
@@ -88,6 +88,8 @@ make %{?_smp_mflags} check
 %{_mandir}/man3/*
 
 %changelog
+*   Wed Oct 07 2020 Pawel Winogrodzki <joschmit@microsoft.com> 3.6.14-2
+-   Updating certificate bundle path to include full set of trust information.
 *   Fri Aug 21 2020 Andrew Phelps <anphel@microsoft.com> 3.6.14-1
 -   Update to version 3.6.14 for CVE-2020-13777
 *   Sat May 09 2020 Nick Samson <nisamson@microsoft.com> 3.6.8-3

--- a/SPECS/gnutls/gnutls.spec
+++ b/SPECS/gnutls/gnutls.spec
@@ -88,7 +88,7 @@ make %{?_smp_mflags} check
 %{_mandir}/man3/*
 
 %changelog
-*   Wed Oct 07 2020 Pawel Winogrodzki <joschmit@microsoft.com> 3.6.14-2
+*   Wed Oct 07 2020 Pawel Winogrodzki <pawelwi@microsoft.com> 3.6.14-2
 -   Updating certificate bundle path to include full set of trust information.
 *   Fri Aug 21 2020 Andrew Phelps <anphel@microsoft.com> 3.6.14-1
 -   Update to version 3.6.14 for CVE-2020-13777

--- a/SPECS/wget/wget.spec
+++ b/SPECS/wget/wget.spec
@@ -62,7 +62,7 @@ rm -rf %{buildroot}/*
 %{_mandir}/man1/*
 
 %changelog
-*   Wed Oct 07 2020 Pawel Winogrodzki <joschmit@microsoft.com> 1.20.3-2
+*   Wed Oct 07 2020 Pawel Winogrodzki <pawelwi@microsoft.com> 1.20.3-2
 -   Updating certificate bundle path to include full set of trust information.
 *   Mon Jun 08 2020 Joe Schmitt <joschmit@microsoft.com> 1.20.3-1
 -   Update to version 1.20.3 to resolve CVE-2019-5953.

--- a/SPECS/wget/wget.spec
+++ b/SPECS/wget/wget.spec
@@ -1,7 +1,7 @@
 Summary:        A network utility to retrieve files from the Web
 Name:           wget
 Version:        1.20.3
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv3+
 URL:            https://www.gnu.org/software/wget/wget.html
 Group:          System Environment/NetworkingPrograms
@@ -40,7 +40,7 @@ make DESTDIR=%{buildroot} install
 install -vdm 755 %{buildroot}/etc
 cat >> %{buildroot}/etc/wgetrc <<-EOF
 #   default root certs location
-    ca_certificate=/etc/pki/tls/certs/ca-bundle.crt
+    ca_certificate=/etc/pki/tls/certs/ca-bundle.trust.crt
     ca_directory = /etc/ssl/certs
 EOF
 rm -rf %{buildroot}/%{_infodir}
@@ -62,6 +62,8 @@ rm -rf %{buildroot}/*
 %{_mandir}/man1/*
 
 %changelog
+*   Wed Oct 07 2020 Pawel Winogrodzki <joschmit@microsoft.com> 1.20.3-2
+-   Updating certificate bundle path to include full set of trust information.
 *   Mon Jun 08 2020 Joe Schmitt <joschmit@microsoft.com> 1.20.3-1
 -   Update to version 1.20.3 to resolve CVE-2019-5953.
 -   Use https for URL.

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -666,8 +666,8 @@
         "type": "other",
         "other": {
           "name": "curl",
-          "version": "7.66.0",
-          "downloadUrl": "http://curl.haxx.se/download/curl-7.66.0.tar.gz"
+          "version": "7.68.0",
+          "downloadUrl": "http://curl.haxx.se/download/curl-7.68.0.tar.gz"
         }
       }
     },
@@ -1266,8 +1266,8 @@
         "type": "other",
         "other": {
           "name": "gnutls",
-          "version": "3.6.8",
-          "downloadUrl": "ftp://ftp.gnutls.org/gcrypt/gnutls/v3.6/gnutls-3.6.8.tar.xz"
+          "version": "3.6.14",
+          "downloadUrl": "ftp://ftp.gnutls.org/gcrypt/gnutls/v3.6/gnutls-3.6.14.tar.xz"
         }
       }
     },

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -129,9 +129,9 @@ libsolv-0.7.7-4.cm1.aarch64.rpm
 libsolv-devel-0.7.7-4.cm1.aarch64.rpm
 libssh2-1.9.0-1.cm1.aarch64.rpm
 libssh2-devel-1.9.0-1.cm1.aarch64.rpm
-curl-7.68.0-1.cm1.aarch64.rpm
-curl-devel-7.68.0-1.cm1.aarch64.rpm
-curl-libs-7.68.0-1.cm1.aarch64.rpm
+curl-7.68.0-2.cm1.aarch64.rpm
+curl-devel-7.68.0-2.cm1.aarch64.rpm
+curl-libs-7.68.0-2.cm1.aarch64.rpm
 tdnf-2.1.0-4.cm1.aarch64.rpm
 tdnf-cli-libs-2.1.0-4.cm1.aarch64.rpm
 tdnf-devel-2.1.0-4.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -129,9 +129,9 @@ libsolv-0.7.7-4.cm1.x86_64.rpm
 libsolv-devel-0.7.7-4.cm1.x86_64.rpm
 libssh2-1.9.0-1.cm1.x86_64.rpm
 libssh2-devel-1.9.0-1.cm1.x86_64.rpm
-curl-7.68.0-1.cm1.x86_64.rpm
-curl-devel-7.68.0-1.cm1.x86_64.rpm
-curl-libs-7.68.0-1.cm1.x86_64.rpm
+curl-7.68.0-2.cm1.x86_64.rpm
+curl-devel-7.68.0-2.cm1.x86_64.rpm
+curl-libs-7.68.0-2.cm1.x86_64.rpm
 tdnf-2.1.0-4.cm1.x86_64.rpm
 tdnf-cli-libs-2.1.0-4.cm1.x86_64.rpm
 tdnf-devel-2.1.0-4.cm1.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -47,10 +47,10 @@ cryptsetup-debuginfo-2.3.3-2.cm1.aarch64.rpm
 cryptsetup-devel-2.3.3-2.cm1.aarch64.rpm
 cryptsetup-libs-2.3.3-2.cm1.aarch64.rpm
 cryptsetup-reencrypt-2.3.3-2.cm1.aarch64.rpm
-curl-7.68.0-1.cm1.aarch64.rpm
-curl-debuginfo-7.68.0-1.cm1.aarch64.rpm
-curl-devel-7.68.0-1.cm1.aarch64.rpm
-curl-libs-7.68.0-1.cm1.aarch64.rpm
+curl-7.68.0-2.cm1.aarch64.rpm
+curl-debuginfo-7.68.0-2.cm1.aarch64.rpm
+curl-devel-7.68.0-2.cm1.aarch64.rpm
+curl-libs-7.68.0-2.cm1.aarch64.rpm
 device-mapper-2.03.05-5.cm1.aarch64.rpm
 device-mapper-devel-2.03.05-5.cm1.aarch64.rpm
 device-mapper-event-2.03.05-5.cm1.aarch64.rpm
@@ -378,8 +378,8 @@ util-linux-devel-2.32.1-3.cm1.aarch64.rpm
 util-linux-lang-2.32.1-3.cm1.aarch64.rpm
 util-linux-libs-2.32.1-3.cm1.aarch64.rpm
 veritysetup-2.3.3-2.cm1.aarch64.rpm
-wget-1.20.3-1.cm1.aarch64.rpm
-wget-debuginfo-1.20.3-1.cm1.aarch64.rpm
+wget-1.20.3-2.cm1.aarch64.rpm
+wget-debuginfo-1.20.3-2.cm1.aarch64.rpm
 which-2.21-7.cm1.aarch64.rpm
 which-debuginfo-2.21-7.cm1.aarch64.rpm
 xz-5.2.4-3.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -47,10 +47,10 @@ cryptsetup-debuginfo-2.3.3-2.cm1.x86_64.rpm
 cryptsetup-devel-2.3.3-2.cm1.x86_64.rpm
 cryptsetup-libs-2.3.3-2.cm1.x86_64.rpm
 cryptsetup-reencrypt-2.3.3-2.cm1.x86_64.rpm
-curl-7.68.0-1.cm1.x86_64.rpm
-curl-debuginfo-7.68.0-1.cm1.x86_64.rpm
-curl-devel-7.68.0-1.cm1.x86_64.rpm
-curl-libs-7.68.0-1.cm1.x86_64.rpm
+curl-7.68.0-2.cm1.x86_64.rpm
+curl-debuginfo-7.68.0-2.cm1.x86_64.rpm
+curl-devel-7.68.0-2.cm1.x86_64.rpm
+curl-libs-7.68.0-2.cm1.x86_64.rpm
 device-mapper-2.03.05-5.cm1.x86_64.rpm
 device-mapper-devel-2.03.05-5.cm1.x86_64.rpm
 device-mapper-event-2.03.05-5.cm1.x86_64.rpm
@@ -378,8 +378,8 @@ util-linux-devel-2.32.1-3.cm1.x86_64.rpm
 util-linux-lang-2.32.1-3.cm1.x86_64.rpm
 util-linux-libs-2.32.1-3.cm1.x86_64.rpm
 veritysetup-2.3.3-2.cm1.x86_64.rpm
-wget-1.20.3-1.cm1.x86_64.rpm
-wget-debuginfo-1.20.3-1.cm1.x86_64.rpm
+wget-1.20.3-2.cm1.x86_64.rpm
+wget-debuginfo-1.20.3-2.cm1.x86_64.rpm
 which-2.21-7.cm1.x86_64.rpm
 which-debuginfo-2.21-7.cm1.x86_64.rpm
 xz-5.2.4-3.cm1.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Before the change `curl`, `gnutls`, and `wget` were using a legacy certificate bundle, which only contains certificates of trusted 
CAs, so blacklisting any **intermediate** CA was being ignored by these tools (**root** CAs were still blacklisted, as they were just removed from the bundle after being blacklisted). Right next to that bundle sits an extended version containing distrust/blacklist information, which is the one that should actually be used to make sure we properly handle blacklisting any interemediate CAs.
###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Changed the cert bundle file used by `curl`, `gnutls` and `wget` to include distrust information about any (root **and** intermediate) CAs.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
No.

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Rebuilt the packages locally.
- Built an image containing the updated packages and tested that we're still being able to properly authenticate HTTPS servers, while now also blocking the blacklisted ones. 