### PR TITLE
Fix missing macro in secilc

### DIFF
--- a/SPECS/secilc/secilc.spec
+++ b/SPECS/secilc/secilc.spec
@@ -1,18 +1,18 @@
+Summary:        The SELinux CIL Compiler
 Name:           secilc
 Version:        2.9
-Release:        3%{?dist}
-Summary:        The SELinux CIL Compiler
+Release:        4%{?dist}
 License:        BSD
-URL:            https://github.com/SELinuxProject/selinux
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
+URL:            https://github.com/SELinuxProject/selinux
 Source0:        %{url}/releases/download/20190315/%{name}-%{version}.tar.gz
 Patch0001:      0001-Allow-setting-arguments-to-xmlto-via-environmental-v.patch
-
-BuildRequires: gcc
-BuildRequires: libsepol-devel >= %{libsepolver}
-BuildRequires: flex
-BuildRequires: xmlto
+%global libsepolver %{version}-1
+BuildRequires:  flex
+BuildRequires:  gcc
+BuildRequires:  libsepol-devel >= %{libsepolver}
+BuildRequires:  xmlto
 
 %description
 The SELinux CIL Compiler is a compiler that converts the CIL language as
@@ -36,13 +36,17 @@ make %{?_smp_mflags} DESTDIR="%{buildroot}" SBINDIR="%{buildroot}%{_sbindir}" LI
 
 
 %files
+%license COPYING
 %{_bindir}/secilc
 %{_bindir}/secil2conf
 %{_mandir}/man8/secilc.8.gz
 %{_mandir}/man8/secil2conf.8.gz
-%license COPYING
+
 
 %changelog
+* Fri Oct 09 2020 Thomas Crain <thcrain@microsoft.com> - 2.9-4
+- Add missing %libsepolver definition
+
 * Thu Aug 27 2020 Daniel Burgener <daburgen@microsoft.com> - 2.9-3
 - Initial CBL-Mariner import from Fedora 31 (license: MIT)
 - License verified


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Fix missing %libsepolver macro in secilc.spec, which caused a build error in graphpkgfetcher

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add %libsepolver macro definition in the style of other specs from the SELinux PR (#100)
- Lint spec for style issues

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
**NO**


###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: Local build up to graphpkgfetcher step, low-risk change