### PR TITLE
Nopatch kernel CVE-2020-10757, CVE-2020-12653, CVE-2020-12657, CVE-2010-3865, CVE-2020-11668, CVE-2020-12654, CVE-2020-24394, CVE-2020-8428

### DIFF
--- a/SPECS-SIGNED/kernel-signed-aarch64/kernel-signed-aarch64.spec
+++ b/SPECS-SIGNED/kernel-signed-aarch64/kernel-signed-aarch64.spec
@@ -2,7 +2,7 @@
 Summary:        Signed Linux Kernel for aarch64 systems
 Name:           kernel-signed-aarch64
 Version:        5.4.51
-Release:        9%{?dist}
+Release:        10%{?dist}
 License:        GPLv2
 URL:            https://github.com/microsoft/WSL2-Linux-Kernel
 Group:          System Environment/Kernel
@@ -85,6 +85,8 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %config %{_localstatedir}/lib/initramfs/kernel/%{uname_r}
 
 %changelog
+*   Fri Oct 02 2020 Chris Co <chrco@microsoft.com> 5.4.51-10
+-   Update release number
 *   Fri Oct 02 2020 Chris Co <chrco@microsoft.com> 5.4.51-9
 -   Update release number
 *   Wed Sep 30 2020 Emre Girgin <mrgirgin@microsoft.com> 5.4.51-8

--- a/SPECS-SIGNED/kernel-signed-aarch64/kernel-signed-aarch64.spec
+++ b/SPECS-SIGNED/kernel-signed-aarch64/kernel-signed-aarch64.spec
@@ -86,7 +86,7 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 
 %changelog
 *   Fri Oct 02 2020 Chris Co <chrco@microsoft.com> 5.4.51-10
--   Update release number
+-   Update release number to match kernel spec
 *   Fri Oct 02 2020 Chris Co <chrco@microsoft.com> 5.4.51-9
 -   Update release number
 *   Wed Sep 30 2020 Emre Girgin <mrgirgin@microsoft.com> 5.4.51-8

--- a/SPECS-SIGNED/kernel-signed-x64/kernel-signed-x64.spec
+++ b/SPECS-SIGNED/kernel-signed-x64/kernel-signed-x64.spec
@@ -2,7 +2,7 @@
 Summary:        Signed Linux Kernel for x86_64 systems
 Name:           kernel-signed-x64
 Version:        5.4.51
-Release:        9%{?dist}
+Release:        10%{?dist}
 License:        GPLv2
 URL:            https://github.com/microsoft/WSL2-Linux-Kernel
 Group:          System Environment/Kernel
@@ -85,6 +85,8 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %config %{_localstatedir}/lib/initramfs/kernel/%{uname_r}
 
 %changelog
+*   Fri Oct 02 2020 Chris Co <chrco@microsoft.com> 5.4.51-10
+-   Update release number
 *   Fri Oct 02 2020 Chris Co <chrco@microsoft.com> 5.4.51-9
 -   Update release number
 *   Wed Sep 30 2020 Emre Girgin <mrgirgin@microsoft.com> 5.4.51-8

--- a/SPECS-SIGNED/kernel-signed-x64/kernel-signed-x64.spec
+++ b/SPECS-SIGNED/kernel-signed-x64/kernel-signed-x64.spec
@@ -86,7 +86,7 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 
 %changelog
 *   Fri Oct 02 2020 Chris Co <chrco@microsoft.com> 5.4.51-10
--   Update release number
+-   Update release number to match kernel spec
 *   Fri Oct 02 2020 Chris Co <chrco@microsoft.com> 5.4.51-9
 -   Update release number
 *   Wed Sep 30 2020 Emre Girgin <mrgirgin@microsoft.com> 5.4.51-8

--- a/SPECS/kernel/CVE-2010-3865.nopatch
+++ b/SPECS/kernel/CVE-2010-3865.nopatch
@@ -1,0 +1,3 @@
+CVE-2010-3865 - Already patched in 5.4.51 stable kernel
+Upstream commit - 1b1f693d7ad6d193862dcb1118540a030c5e761f
+Same commit id in stable branch

--- a/SPECS/kernel/CVE-2020-10757.nopatch
+++ b/SPECS/kernel/CVE-2020-10757.nopatch
@@ -1,0 +1,3 @@
+CVE-2020-10757 - Already patched in 5.4.51 stable kernel
+Upstream commit - 5bfea2d9b17f1034a68147a8b03b9789af5700f9
+Stable commit - 5a047df0b5fce377df37de75380321d1c8ca07a0

--- a/SPECS/kernel/CVE-2020-11668.nopatch
+++ b/SPECS/kernel/CVE-2020-11668.nopatch
@@ -1,0 +1,3 @@
+CVE-2020-11668 - Already patched in 5.4.51 stable kernel
+Upstream commit - a246b4d547708f33ff4d4b9a7a5dbac741dc89d8
+Stable commit - cb595cb0a1e8e07213337f063cd39a3e80fc43a0

--- a/SPECS/kernel/CVE-2020-12653.nopatch
+++ b/SPECS/kernel/CVE-2020-12653.nopatch
@@ -1,0 +1,3 @@
+CVE-2020-12653 - Already patched in 5.4.51 stable kernel
+Upstream commit - b70261a288ea4d2f4ac7cd04be08a9f0f2de4f4d
+Stable commit - 3c822e1f31186767d6b7261c3c066f01907ecfca

--- a/SPECS/kernel/CVE-2020-12654.nopatch
+++ b/SPECS/kernel/CVE-2020-12654.nopatch
@@ -1,0 +1,3 @@
+CVE-2020-12654 - Already patched in 5.4.51 stable kernel
+Upstream commit - 3a9b153c5591548612c3955c9600a98150c81875
+Stable commit - c5b071e3f44d1125694ad4dcf1234fb9a78d0be6

--- a/SPECS/kernel/CVE-2020-12657.nopatch
+++ b/SPECS/kernel/CVE-2020-12657.nopatch
@@ -1,0 +1,3 @@
+CVE-2020-12657 - Already patched in 5.4.51 stable kernel
+Upstream commit - 2f95fa5c955d0a9987ffdc3a095e2f4e62c5f2a9
+Stable commit - b2ae36d220eddd88f9a1264176e3104d988f72fe

--- a/SPECS/kernel/CVE-2020-24394.nopatch
+++ b/SPECS/kernel/CVE-2020-24394.nopatch
@@ -1,0 +1,3 @@
+CVE-2020-24394 - Already patched in 5.4.51 stable kernel
+Upstream commit - 22cf8419f1319ff87ec759d0ebdff4cbafaee832
+Stable commit - c506f985d8d151383559c0760bb1ef7466e218d4

--- a/SPECS/kernel/CVE-2020-8428.nopatch
+++ b/SPECS/kernel/CVE-2020-8428.nopatch
@@ -1,0 +1,3 @@
+CVE-2020-8428 - Already patched in 5.4.51 stable kernel
+Upstream commit - d0cb50185ae942b03c4327be322055d622dc79f6
+Stable commit - 454759886d0b463213fad0f1c733469e2c501ab9

--- a/SPECS/kernel/kernel.spec
+++ b/SPECS/kernel/kernel.spec
@@ -42,6 +42,7 @@ Patch1018:      CVE-2010-3865.nopatch
 Patch1019:      CVE-2020-11668.nopatch
 Patch1020:      CVE-2020-12654.nopatch
 Patch1021:      CVE-2020-24394.nopatch
+Patch1022:      CVE-2020-8428.nopatch
 
 BuildRequires:  bc
 BuildRequires:  diffutils
@@ -342,7 +343,7 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %changelog
 *   Fri Oct 02 2020 Chris Co <chrco@microsoft.com> 5.4.51-10
 -   Address CVE-2020-10757, CVE-2020-12653, CVE-2020-12657, CVE-2010-3865,
--   CVE-2020-11668, CVE-2020-12654, CVE-2020-24394
+-   CVE-2020-11668, CVE-2020-12654, CVE-2020-24394, CVE-2020-8428
 *   Fri Oct 02 2020 Chris Co <chrco@microsoft.com> 5.4.51-9
 -   Fix aarch64 build error
 *   Wed Sep 30 2020 Emre Girgin <mrgirgin@microsoft.com> 5.4.51-8

--- a/SPECS/kernel/kernel.spec
+++ b/SPECS/kernel/kernel.spec
@@ -38,6 +38,7 @@ Patch1014:      CVE-2020-11725.nopatch
 Patch1015:      CVE-2020-10757.nopatch
 Patch1016:      CVE-2020-12653.nopatch
 Patch1017:      CVE-2020-12657.nopatch
+Patch1018:      CVE-2010-3865.nopatch
 
 BuildRequires:  bc
 BuildRequires:  diffutils
@@ -337,7 +338,7 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 
 %changelog
 *   Fri Oct 02 2020 Chris Co <chrco@microsoft.com> 5.4.51-10
--   Address CVE-2020-10757, CVE-2020-12653, CVE-2020-12657
+-   Address CVE-2020-10757, CVE-2020-12653, CVE-2020-12657, CVE-2010-3865
 *   Fri Oct 02 2020 Chris Co <chrco@microsoft.com> 5.4.51-9
 -   Fix aarch64 build error
 *   Wed Sep 30 2020 Emre Girgin <mrgirgin@microsoft.com> 5.4.51-8

--- a/SPECS/kernel/kernel.spec
+++ b/SPECS/kernel/kernel.spec
@@ -41,6 +41,7 @@ Patch1017:      CVE-2020-12657.nopatch
 Patch1018:      CVE-2010-3865.nopatch
 Patch1019:      CVE-2020-11668.nopatch
 Patch1020:      CVE-2020-12654.nopatch
+Patch1021:      CVE-2020-24394.nopatch
 
 BuildRequires:  bc
 BuildRequires:  diffutils
@@ -341,7 +342,7 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %changelog
 *   Fri Oct 02 2020 Chris Co <chrco@microsoft.com> 5.4.51-10
 -   Address CVE-2020-10757, CVE-2020-12653, CVE-2020-12657, CVE-2010-3865,
--   CVE-2020-11668, CVE-2020-12654
+-   CVE-2020-11668, CVE-2020-12654, CVE-2020-24394
 *   Fri Oct 02 2020 Chris Co <chrco@microsoft.com> 5.4.51-9
 -   Fix aarch64 build error
 *   Wed Sep 30 2020 Emre Girgin <mrgirgin@microsoft.com> 5.4.51-8

--- a/SPECS/kernel/kernel.spec
+++ b/SPECS/kernel/kernel.spec
@@ -39,6 +39,7 @@ Patch1015:      CVE-2020-10757.nopatch
 Patch1016:      CVE-2020-12653.nopatch
 Patch1017:      CVE-2020-12657.nopatch
 Patch1018:      CVE-2010-3865.nopatch
+Patch1019:      CVE-2020-11668.nopatch
 
 BuildRequires:  bc
 BuildRequires:  diffutils
@@ -338,7 +339,8 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 
 %changelog
 *   Fri Oct 02 2020 Chris Co <chrco@microsoft.com> 5.4.51-10
--   Address CVE-2020-10757, CVE-2020-12653, CVE-2020-12657, CVE-2010-3865
+-   Address CVE-2020-10757, CVE-2020-12653, CVE-2020-12657, CVE-2010-3865,
+-   CVE-2020-11668
 *   Fri Oct 02 2020 Chris Co <chrco@microsoft.com> 5.4.51-9
 -   Fix aarch64 build error
 *   Wed Sep 30 2020 Emre Girgin <mrgirgin@microsoft.com> 5.4.51-8

--- a/SPECS/kernel/kernel.spec
+++ b/SPECS/kernel/kernel.spec
@@ -2,7 +2,7 @@
 Summary:        Linux Kernel
 Name:           kernel
 Version:        5.4.51
-Release:        9%{?dist}
+Release:        10%{?dist}
 License:        GPLv2
 URL:            https://github.com/microsoft/WSL2-Linux-Kernel
 Group:          System Environment/Kernel
@@ -35,6 +35,9 @@ Patch1011:      CVE-2020-8648.nopatch
 Patch1012:      CVE-2020-8649.nopatch
 Patch1013:      CVE-2020-9383.nopatch
 Patch1014:      CVE-2020-11725.nopatch
+Patch1015:      CVE-2020-10757.nopatch
+Patch1016:      CVE-2020-12653.nopatch
+Patch1017:      CVE-2020-12657.nopatch
 
 BuildRequires:  bc
 BuildRequires:  diffutils
@@ -333,6 +336,8 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %{_libdir}/perf/include/bpf/*
 
 %changelog
+*   Fri Oct 02 2020 Chris Co <chrco@microsoft.com> 5.4.51-10
+-   Address CVE-2020-10757, CVE-2020-12653, CVE-2020-12657
 *   Fri Oct 02 2020 Chris Co <chrco@microsoft.com> 5.4.51-9
 -   Fix aarch64 build error
 *   Wed Sep 30 2020 Emre Girgin <mrgirgin@microsoft.com> 5.4.51-8

--- a/SPECS/kernel/kernel.spec
+++ b/SPECS/kernel/kernel.spec
@@ -40,6 +40,7 @@ Patch1016:      CVE-2020-12653.nopatch
 Patch1017:      CVE-2020-12657.nopatch
 Patch1018:      CVE-2010-3865.nopatch
 Patch1019:      CVE-2020-11668.nopatch
+Patch1020:      CVE-2020-12654.nopatch
 
 BuildRequires:  bc
 BuildRequires:  diffutils
@@ -340,7 +341,7 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %changelog
 *   Fri Oct 02 2020 Chris Co <chrco@microsoft.com> 5.4.51-10
 -   Address CVE-2020-10757, CVE-2020-12653, CVE-2020-12657, CVE-2010-3865,
--   CVE-2020-11668
+-   CVE-2020-11668, CVE-2020-12654
 *   Fri Oct 02 2020 Chris Co <chrco@microsoft.com> 5.4.51-9
 -   Fix aarch64 build error
 *   Wed Sep 30 2020 Emre Girgin <mrgirgin@microsoft.com> 5.4.51-8


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
`kernel` CVE-2020-10757, CVE-2020-12653, CVE-2020-12657, CVE-2010-3865, CVE-2020-11668, CVE-2020-12654, CVE-2020-24394, CVE-2020-8428 upstream fixes are already present in our 5.4.51 stable kernel source.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add nopatch files for `kernel` CVE-2020-10757, CVE-2020-12653, CVE-2020-12657, CVE-2010-3865, CVE-2020-11668, CVE-2020-12654, CVE-2020-24394, CVE-2020-8428. Includes commit ID mapping between upstream kernel commit ID to our stable kernel commit ID.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2020-10757
- https://nvd.nist.gov/vuln/detail/CVE-2020-12653
- https://nvd.nist.gov/vuln/detail/CVE-2020-12657
- https://nvd.nist.gov/vuln/detail/CVE-2010-3865
- https://nvd.nist.gov/vuln/detail/CVE-2020-11668
- https://nvd.nist.gov/vuln/detail/CVE-2020-12654
- https://nvd.nist.gov/vuln/detail/CVE-2020-24394
- https://nvd.nist.gov/vuln/detail/CVE-2020-8428

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local build