### PR TITLE
[dev] Avoid repacking SRPMs during container builds

### DIFF
--- a/toolkit/tools/srpmpacker/srpmpacker.go
+++ b/toolkit/tools/srpmpacker/srpmpacker.go
@@ -335,10 +335,17 @@ func createChroot(workerTar, buildDir, outDir, specsDir string) (chroot *safechr
 	}()
 
 	// If this is container build then the bind mounts will not have been created.
-	// Copy in all of the SPECs so they can be packed.
 	if !buildpipeline.IsRegularBuild() {
+		// Copy in all of the SPECs so they can be packed.
 		specsInChroot := filepath.Join(chroot.RootDir(), newSpecsDir)
 		err = directory.CopyContents(specsDir, specsInChroot)
+		if err != nil {
+			return
+		}
+
+		// Copy any prepacked srpms so they will not be repacked.
+		srpmsInChroot := filepath.Join(chroot.RootDir(), newOutDir)
+		err = directory.CopyContents(outDir, srpmsInChroot)
 		if err != nil {
 			return
 		}


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
During container builds, `srpmpacker` was not copying any prepacked srpms to its output directory. This resulted in srpms being repacked.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Copy any prepacked SRPMs into the chroot's output directory at the start of `srpmpacker`

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local build.