### PR TITLE
Remove implicit git repository dependency from toolkit

### DIFF
--- a/toolkit/Makefile
+++ b/toolkit/Makefile
@@ -97,7 +97,12 @@ TLS_KEY     ?=
 
 # Build defines
 DIST_TAG           ?= .cm1
-BUILD_NUMBER       ?= $(shell git rev-parse --short HEAD)
+GIT_REV            ?= $(shell git rev-parse --short HEAD)
+ifeq ($(GIT_REV),)
+	BUILD_NUMBER ?= non-git
+else
+	BUILD_NUBMER ?= $(GIT_REV)
+endif
 RELEASE_MAJOR_ID   ?= 1.0
 # use minor ID defined in file (if exist) otherwise define it
 # note this file must be single line

--- a/toolkit/Makefile
+++ b/toolkit/Makefile
@@ -97,11 +97,10 @@ TLS_KEY     ?=
 
 # Build defines
 DIST_TAG           ?= .cm1
-GIT_REV            ?= $(shell git rev-parse --short HEAD)
-ifeq ($(GIT_REV),)
-	BUILD_NUMBER ?= non-git
-else
-	BUILD_NUBMER ?= $(GIT_REV)
+BUILD_NUMBER       ?= $(shell git rev-parse --short HEAD)
+# an empty BUILD_NUMBER breaks the build later on
+ifeq ($(BUILD_NUMBER),)
+        BUILD_NUMBER = non-git
 endif
 RELEASE_MAJOR_ID   ?= 1.0
 # use minor ID defined in file (if exist) otherwise define it


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
The toolkit is required to be run under a git repository to populate a non-empty `BUILD_NUMBER` variable. Later on, when `BUILD_NUMBER` is passed on to the go tools, i.e. `unravel`, the tools rejects the command as it expects a non-empty string.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- If the git does not return a revision, use a simple string to avoid `BUILD_NUMBER` being empty.
###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
YES
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/...

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: xxxx