### PR TITLE
Fix repolock removal

### DIFF
--- a/toolkit/tools/internal/packagerepo/repomanager/rpmrepomanager/rpmrepomanager.go
+++ b/toolkit/tools/internal/packagerepo/repomanager/rpmrepomanager/rpmrepomanager.go
@@ -18,13 +18,13 @@ import (
 func CreateRepo(repoDir string) (err error) {
 	const (
 		repoDataSubDir = "repodata"
-		repoLockFile   = ".repodata"
+		repoLockSubDir = ".repodata"
 	)
 
 	logger.Log.Debugf("Creating RPM repository in (%s)", repoDir)
 
 	repoDataPath := filepath.Join(repoDir, repoDataSubDir)
-	repoDataLockPath := filepath.Join(repoDir, repoLockFile)
+	repoDataLockPath := filepath.Join(repoDir, repoLockSubDir)
 
 	// Remove the repodata (and the repolock) if exists
 	err = os.RemoveAll(repoDataPath)
@@ -32,7 +32,7 @@ func CreateRepo(repoDir string) (err error) {
 		return
 	}
 
-	err = os.Remove(repoDataLockPath)
+	err = os.RemoveAll(repoDataLockPath)
 	if err != nil && !os.IsNotExist(err) {
 		return
 	}


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
The fetchers would try to remove any existing repodata before initializing a new repo. However, it was incorrectly treating the repolock directory (`.repodata`) as a file. This resulted in failures when trying to remove it.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Use `RemoveAll` to remove the `.repodata` directory if it exists.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local builds