### PR TITLE
Fix CVE-2020-26159 in oniguruma

### DIFF
--- a/SPECS/oniguruma/CVE-2020-26159.patch
+++ b/SPECS/oniguruma/CVE-2020-26159.patch
@@ -1,0 +1,22 @@
+From cbe9f8bd9cfc6c3c87a60fbae58fa1a85db59df0 Mon Sep 17 00:00:00 2001
+From: "K.Kosako" <kkosako0@gmail.com>
+Date: Mon, 21 Sep 2020 12:58:29 +0900
+Subject: [PATCH] #207: Out-of-bounds write
+
+---
+ src/regcomp.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/regcomp.c b/src/regcomp.c
+index f6494b6d..a0a68561 100644
+--- a/src/regcomp.c
++++ b/src/regcomp.c
+@@ -6257,7 +6257,7 @@ concat_opt_exact_str(OptStr* to, UChar* s, UChar* end, OnigEncoding enc)
+ 
+   for (i = to->len, p = s; p < end && i < OPT_EXACT_MAXLEN; ) {
+     len = enclen(enc, p);
+-    if (i + len > OPT_EXACT_MAXLEN) break;
++    if (i + len >= OPT_EXACT_MAXLEN) break;
+     for (j = 0; j < len && p < end; j++)
+       to->s[i++] = *p++;
+   }

--- a/SPECS/oniguruma/oniguruma.spec
+++ b/SPECS/oniguruma/oniguruma.spec
@@ -1,6 +1,6 @@
 Name:           oniguruma
 Version:        6.9.5
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        BSD
 Summary:        Regular expressions library
 Group:          System Environment/Libraries
@@ -26,7 +26,7 @@ Requires:       oniguruma = %{version}-%{release}
 Development files for libonig
 
 %prep
-%autosetup -n onig-%{version}
+%autosetup -n onig-%{version} -p1
 
 
 %build
@@ -65,6 +65,8 @@ make  check
 %{_libdir}/pkgconfig/%{name}.pc
 
 %changelog
+* Thu Oct 15 2020 Emre Girgin <mrgirgin@microsoft.com> 6.9.5-2
+- Fix CVE-2020-26159. 
 * Tue May 19 2020 Andrew Phelps <anphel@microsoft.com> 6.9.5-1
 - Upgrade to 6.9.5.
 * Wed Apr 22 2020 Emre Girgin <mrgirgin@microsoft.com> 6.9.0-4

--- a/SPECS/oniguruma/oniguruma.spec
+++ b/SPECS/oniguruma/oniguruma.spec
@@ -8,6 +8,8 @@ Vendor:         Microsoft Corporation
 Distribution:   Mariner
 URL:            https://github.com/kkos/oniguruma/
 Source0:        https://github.com/kkos/oniguruma/releases/download/v%{version}/onig-%{version}.tar.gz
+# https://github.com/kkos/oniguruma/commit/cbe9f8bd9cfc6c3c87a60fbae58fa1a85db59df0.patch
+Patch0:         CVE-2020-26159.patch
 
 %description
 Oniguruma is a regular expressions library.
@@ -24,7 +26,8 @@ Requires:       oniguruma = %{version}-%{release}
 Development files for libonig
 
 %prep
-%setup -q -n onig-%{version}
+%autosetup -n onig-%{version}
+
 
 %build
 %configure                     \


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Fixes CVE-2020-26159.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Use the patch from upstream. 
###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
YES
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/...

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: xxxx
- Local build