### PR TITLE
[dev] Support epochs in spec versions

### DIFF
--- a/toolkit/tools/internal/versioncompare/versioncompare.go
+++ b/toolkit/tools/internal/versioncompare/versioncompare.go
@@ -11,7 +11,8 @@ import (
 )
 
 var (
-	componentRegex = regexp.MustCompile(`(\d+|[a-z]+)`)
+	componentRegex      = regexp.MustCompile(`(\d+|[a-z]+)`)
+	epochComponentRegex = regexp.MustCompile(`^(\d+|[a-z])\:`)
 )
 
 // TolerantVersion is a flexible version representation
@@ -135,6 +136,12 @@ func (v *TolerantVersion) parse(versionString string) {
 	}
 
 	rawComponents := componentRegex.FindAllString(versionSubstring, -1)
+
+	// If no epoch is set in the version, apply an epoch of 0 so all versions have one.
+	if epochComponentRegex.FindString(versionSubstring) == "" {
+		rawComponents = append([]string{"0"}, rawComponents...)
+	}
+
 	v.versionComponents = make([]uint64, len(rawComponents))
 	for i := range rawComponents {
 		// Base36 to support lowercase characters
@@ -149,6 +156,11 @@ func (v *TolerantVersion) parse(versionString string) {
 	// Run again if we have a release version as well
 	if releaseSubstring != "" {
 		rawComponents = componentRegex.FindAllString(releaseSubstring, -1)
+		// If no epoch is set in the version, apply an epoch of 0 so all versions have one.
+		if epochComponentRegex.FindString(releaseSubstring) == "" {
+			rawComponents = append([]string{"0"}, rawComponents...)
+		}
+
 		v.releaseComponents = make([]uint64, len(rawComponents))
 		for i := range rawComponents {
 			// Base36 to support lowercase characters

--- a/toolkit/tools/internal/versioncompare/versioncompare.go
+++ b/toolkit/tools/internal/versioncompare/versioncompare.go
@@ -156,11 +156,6 @@ func (v *TolerantVersion) parse(versionString string) {
 	// Run again if we have a release version as well
 	if releaseSubstring != "" {
 		rawComponents = componentRegex.FindAllString(releaseSubstring, -1)
-		// If no epoch is set in the version, apply an epoch of 0 so all versions have one.
-		if epochComponentRegex.FindString(releaseSubstring) == "" {
-			rawComponents = append([]string{"0"}, rawComponents...)
-		}
-
 		v.releaseComponents = make([]uint64, len(rawComponents))
 		for i := range rawComponents {
 			// Base36 to support lowercase characters

--- a/toolkit/tools/internal/versioncompare/versioncompare_test.go
+++ b/toolkit/tools/internal/versioncompare/versioncompare_test.go
@@ -16,6 +16,25 @@ const (
 	emojiMidString     = "1👌2🤣3🤢ab~52*^&%$6"
 )
 
+func TestCompareShouldProcessHigherEpochVersion(t *testing.T) {
+	highVer := New("2:1.2.1")
+	lowVer := New("4.2.2.1")
+	assert.Equal(t, 1, highVer.Compare(lowVer))
+}
+
+func TestCompareShouldProcessLowerEpochVersion(t *testing.T) {
+	highVer := New("2:1.2.1")
+	lowVer := New("4.2.2.1")
+	assert.Equal(t, 1, highVer.Compare(lowVer))
+}
+
+func TestCompareShouldProcessSameEpochVersion(t *testing.T) {
+	highVer := New("1.2.3")
+	lowVer := New("0:1.2.3")
+	assert.Equal(t, 0, lowVer.Compare(highVer))
+	assert.Equal(t, 0, highVer.Compare(lowVer))
+}
+
 func TestCompareShouldProcessHigherVersion(t *testing.T) {
 	highVer := New("1.2.3")
 	lowVer := New("1.2.2")


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

Add support for epochs to grapher and the version comparison logic. The current behavior treats epochs as simply another component of the version field. However this does not work correctly when dealing with specs that do not specify an epoch.


In the current behavior `2:1.2` is seen as a lower version than `4.2.1`, despite the epoch being higher. When a spec does not specify an epoch, it is implicitly assumed to be 0 by rpm ([reference](https://rpm-packaging-guide.github.io/#epoch)).

The fix is to prepend the implicit epoch of 0 when non is specified. This makes `4.2.1` be parsed as `0:4.2.1`, fixing the above example.


See https://rpm-packaging-guide.github.io/#epoch for more information on epochs.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Prepend an epoch of 0 if none was specified for a given version.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local builds.