### PR TITLE
Disable debug package for nlohmann-json

### DIFF
--- a/SPECS/nlohmann-json/nlohmann-json.spec
+++ b/SPECS/nlohmann-json/nlohmann-json.spec
@@ -9,6 +9,7 @@ Group:          System Environment
 URL:            https://github.com/nlohmann/json
 #Source0:       https://github.com/nlohmann/json/archive/v%{version}.tar.gz
 Source0:        %{name}-%{version}.tar.gz
+%global debug_package %{nil}
 BuildRequires:  cmake
 BuildRequires:  gcc
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
nlohmann-json is a header-only library, we don't need to generate a debug package for it.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Disable debug package generation for nlohmann-json

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
**NO**

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local build of affected packages