### PR TITLE
Add validatechroot tool to check worker chroot dependencies

### DIFF
--- a/toolkit/docs/how_it_works/1_initial_prep.md
+++ b/toolkit/docs/how_it_works/1_initial_prep.md
@@ -24,6 +24,7 @@ Prepping the Build Environment
         - [specreader](#specreader)
         - [srpmpacker](#srpmpacker)
         - [unravel](#unravel)
+        - [validatechroot](#validatechroot)
 
 ## The Makefile
 
@@ -93,5 +94,7 @@ The `specreader` tool scans all the `*.spec` files in a directory and generates 
 The `srpmpacker` tool creates `.src.rpm` files from local specs and sources. The sources can be found locally, or downloaded from a source server. It is responsible for enforcing a matching hash for every source file.
 #### unravel
 The `unravel` tool converts a dependency graph into a set of build instructions which can be used to successfully build all local packages.
+#### validatechroot
+A tool which double checks the worker chroot has all its dependencies correctly installed.
 
 ## Prev: [Intro](0_intro.md), Next: [Local Packages](2_local_packages.md)

--- a/toolkit/scripts/tools.mk
+++ b/toolkit/scripts/tools.mk
@@ -29,6 +29,7 @@ go_tool_list = \
 	specreader \
 	srpmpacker \
 	unravel \
+	validatechroot \
 
 # For each utility "util", create a "out/tools/util" target which references code in "tools/util/"
 go_tool_targets = $(foreach target,$(go_tool_list),$(TOOL_BINS_DIR)/$(target))
@@ -112,7 +113,7 @@ go-test-coverage: $(test_coverage_report)
 
 chroot_worker = $(BUILD_DIR)/worker/worker_chroot.tar.gz
 
-.PHONY: chroot-tools clean-chroot-tools
+.PHONY: chroot-tools clean-chroot-tools validate-chroot
 chroot-tools: $(chroot_worker)
 
 clean: clean-chroot-tools
@@ -120,7 +121,9 @@ clean-chroot-tools:
 	rm -f $(chroot_worker)
 	@echo Verifying no mountpoints present in $(BUILD_DIR)/worker/
 	$(SCRIPTS_DIR)/safeunmount.sh "$(BUILD_DIR)/worker/" && \
-	rm -rf $(BUILD_DIR)/worker
+	$(SCRIPTS_DIR)/safeunmount.sh "$(BUILD_DIR)/validatechroot/" && \
+	rm -rf $(BUILD_DIR)/worker && \
+	rm -rf $(BUILD_DIR)/validatechroot
 
 worker_chroot_manifest = $(TOOLCHAIN_MANIFESTS_DIR)/pkggen_core_$(build_arch).txt
 # Find the *.rpm corresponding to each of the entries in the manifest
@@ -139,6 +142,15 @@ worker_chroot_deps := \
 
 $(chroot_worker): $(worker_chroot_deps)
 	$(PKGGEN_DIR)/worker/create_worker_chroot.sh $(BUILD_DIR)/worker $(worker_chroot_manifest) $(toolchain_rpms_dir) $(LOGS_DIR)
+
+validate-chroot: $(go-validatechroot) $(chroot_worker)
+	$(go-validatechroot) \
+	--rpm-dir="$(toolchain_rpms_dir)" \
+	--tmp-dir="$(BUILD_DIR)/validatechroot" \
+	--worker-chroot="$(chroot_worker)" \
+	--worker-manifest="$(worker_chroot_manifest)" \
+	--log-file="$(LOGS_DIR)/worker/validate.log" \
+	--log-level="$(LOG_LEVEL)"
 
 ######## MACRO TOOLS ########
 

--- a/toolkit/tools/validatechroot/validatechroot.go
+++ b/toolkit/tools/validatechroot/validatechroot.go
@@ -1,0 +1,122 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"regexp"
+	"strings"
+
+	"gopkg.in/alecthomas/kingpin.v2"
+	"microsoft.com/pkggen/internal/exe"
+	"microsoft.com/pkggen/internal/file"
+	"microsoft.com/pkggen/internal/logger"
+	"microsoft.com/pkggen/internal/safechroot"
+	"microsoft.com/pkggen/internal/shell"
+)
+
+var (
+	app = kingpin.New("validatechroot", "A tool to validate that the worker chroot is well configured and all dependencies are satisfied.")
+
+	toolchainRpmsDir = app.Flag("rpm-dir", "Directory that contains already built toolchain RPMs. Should contain top level directories for architecture.").Required().ExistingDir()
+	tmpDir           = app.Flag("tmp-dir", "Temporary chroot directory.").String()
+
+	workerTar      = app.Flag("worker-chroot", "Full path to worker_chroot.tar.gz").Required().ExistingFile()
+	workerManifest = app.Flag("worker-manifest", "Full path to the worker manifest file").Required().ExistingFile()
+
+	logFile  = exe.LogFileFlag(app)
+	logLevel = exe.LogLevelFlag(app)
+
+	leaveChrootFilesOnDisk = false
+)
+
+func main() {
+	app.Version(exe.ToolkitVersion)
+	kingpin.MustParse(app.Parse(os.Args[1:]))
+	logger.InitBestEffort(*logFile, *logLevel)
+
+	err := validateWorker()
+
+	if err != nil {
+		logger.Log.Fatalf("Failed to validate worker. Error: %s", err)
+	}
+}
+
+func validateWorker() (err error) {
+	const (
+		chrootToolchainRpmsDir = "/toolchainrpms"
+		isExistingDir          = false
+	)
+
+	var (
+		chroot *safechroot.Chroot
+		// Every valid line will be of the form: <package>-<version>.<arch>.rpm
+		packageArchLookupRegex = regexp.MustCompile(`^.+(?P<arch>x86_64|aarch64|noarch)\.rpm$`)
+	)
+
+	// Ensure that if initialization fails, the chroot is closed
+	defer func() {
+		if chroot != nil {
+			closeErr := chroot.Close(leaveChrootFilesOnDisk)
+			if closeErr != nil {
+				logger.Log.Panicf("Unable to close chroot on failed initialization. Error: %s", closeErr)
+			}
+		}
+	}()
+
+	logger.Log.Infof("Creating chroot environment to validate '%s' against '%s'", *workerTar, *workerManifest)
+
+	chroot = safechroot.NewChroot(*tmpDir, isExistingDir)
+	rpmMount := safechroot.NewMountPoint(*toolchainRpmsDir, chrootToolchainRpmsDir, "", safechroot.BindMountPointFlags, "")
+	extraDirectories := []string{chrootToolchainRpmsDir}
+	rpmMounts := []*safechroot.MountPoint{rpmMount}
+	err = chroot.Initialize(*workerTar, extraDirectories, rpmMounts)
+	if err != nil {
+		chroot = nil
+		return
+	}
+
+	manifestEntires, err := file.ReadLines(*workerManifest)
+	badEntries := make(map[string]string)
+
+	err = chroot.Run(func() (err error) {
+		for _, rpm := range manifestEntires {
+			archMatches := packageArchLookupRegex.FindStringSubmatch(rpm)
+			if len(archMatches) != 2 {
+				logger.Log.Errorf("%v", archMatches)
+				return fmt.Errorf("'%s' is an invalid rpm file path", rpm)
+			}
+			arch := archMatches[1]
+			rpmPath := path.Join(chrootToolchainRpmsDir, arch, rpm)
+
+			// --replacepkgs instructs RPM to gracefully re-install a package, including checking dependencies
+			args := []string{
+				"-ihv",
+				"--replacepkgs",
+				"--nosignature",
+				rpmPath,
+			}
+			logger.Log.Infof("Running rpm %s", strings.Join(args, " "))
+			stdout, stderr, err := shell.Execute("rpm", args...)
+
+			logger.Log.Debug(stdout)
+
+			if err != nil || len(stderr) > 0 {
+				logger.Log.Warn(stderr)
+				badEntries[rpm] = stderr
+			}
+		}
+		return
+	})
+
+	if len(badEntries) > 0 {
+		for rpm, stderr := range badEntries {
+			logger.Log.Errorf("%s:\n %s", rpm, stderr)
+		}
+		err = fmt.Errorf("found invalid packages in the worker chroot")
+	}
+	return
+}

--- a/toolkit/tools/validatechroot/validatechroot.go
+++ b/toolkit/tools/validatechroot/validatechroot.go
@@ -122,8 +122,8 @@ func validateWorker(rpmsDir, chrootDir, workerTarPath, manifestPath string) (err
 	})
 
 	if len(badEntries) > 0 {
-		for rpm, stderr := range badEntries {
-			logger.Log.Errorf("%s:\n %s", rpm, stderr)
+		for rpm, errMsg := range badEntries {
+			logger.Log.Errorf("%s:\n %s", rpm, errMsg)
 		}
 		err = fmt.Errorf("found invalid packages in the worker chroot")
 	}


### PR DESCRIPTION
Signed-off-by: Daniel McIlvaney <damcilva@microsoft.com>

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
There have been a few times when changes to package dependencies are not properly propagated back to the toolchain. This can at best cause unexpected package rebuilds, or at worst cause correctness issues since expected features may not be available in the chroot worker.

Add the make target `validate-chroot` which will run through the chroot worker and double check every RPM is correctly installed. The target will automatically rebuild the toolchain if needed. For checking a stable tag upstream packages can be used: `sudo make validate-chroot REBUILD_TOOLS=y REBUILD_TOOLCHAIN=n  -j10 2>&1 | tee ./validate.log`.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add `validatechroot.go` tool
  - Creates a chroot, and force reinstalls each worker RPM into the environment, summarizing any errors at the end.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Ran against SELinux and 1.0-stable branches with reasonable results.