### PR TITLE
Update mariner release vers

### DIFF
--- a/SPECS/mariner-release/mariner-release.spec
+++ b/SPECS/mariner-release/mariner-release.spec
@@ -1,7 +1,7 @@
 Summary:       CBL-Mariner release files
 Name:          mariner-release
 Version:       1.0
-Release:       9%{?dist}
+Release:       10%{?dist}
 License:       MIT
 Group:         System Environment/Base
 URL:           https://aka.ms/cbl-mariner
@@ -67,6 +67,8 @@ rm -rf $RPM_BUILD_ROOT
 %config(noreplace) /etc/issue.net
 
 %changelog
+*   Sat Oct 24 2020 Jon Slobodzian <joslobo@microsoft.com> - 1.0-10
+-   Updating version for October update
 *   Fri Sep 04 2020 Mateusz Malisz <mamalisz@microsoft.com> - 1.0-9
 -   Remove empty %%post section, dropping dependency on /bin/sh
 *   Tue Aug 24 2020 Jon Slobodzian <joslobo@microsoft.com> - 1.0-8

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -58,7 +58,7 @@ findutils-lang-4.6.0-7.cm1.aarch64.rpm
 gettext-0.19.8.1-3.cm1.aarch64.rpm
 gzip-1.9-5.cm1.aarch64.rpm
 make-4.2.1-5.cm1.aarch64.rpm
-mariner-release-1.0-9.cm1.noarch.rpm
+mariner-release-1.0-10.cm1.noarch.rpm
 patch-2.7.6-7.cm1.aarch64.rpm
 util-linux-2.32.1-3.cm1.aarch64.rpm
 util-linux-devel-2.32.1-3.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -58,7 +58,7 @@ findutils-lang-4.6.0-7.cm1.x86_64.rpm
 gettext-0.19.8.1-3.cm1.x86_64.rpm
 gzip-1.9-5.cm1.x86_64.rpm
 make-4.2.1-5.cm1.x86_64.rpm
-mariner-release-1.0-9.cm1.noarch.rpm
+mariner-release-1.0-10.cm1.noarch.rpm
 patch-2.7.6-7.cm1.x86_64.rpm
 util-linux-2.32.1-3.cm1.x86_64.rpm
 util-linux-devel-2.32.1-3.cm1.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -238,7 +238,7 @@ m4-debuginfo-1.4.18-4.cm1.aarch64.rpm
 make-4.2.1-5.cm1.aarch64.rpm
 make-debuginfo-4.2.1-5.cm1.aarch64.rpm
 mariner-check-macros-1.0-3.cm1.noarch.rpm
-mariner-release-1.0-9.cm1.noarch.rpm
+mariner-release-1.0-10.cm1.noarch.rpm
 mariner-repos-1.0-11.cm1.noarch.rpm
 mariner-repos-preview-1.0-11.cm1.noarch.rpm
 mariner-rpm-macros-1.0-3.cm1.noarch.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -238,7 +238,7 @@ m4-debuginfo-1.4.18-4.cm1.x86_64.rpm
 make-4.2.1-5.cm1.x86_64.rpm
 make-debuginfo-4.2.1-5.cm1.x86_64.rpm
 mariner-check-macros-1.0-3.cm1.noarch.rpm
-mariner-release-1.0-9.cm1.noarch.rpm
+mariner-release-1.0-10.cm1.noarch.rpm
 mariner-repos-1.0-11.cm1.noarch.rpm
 mariner-repos-preview-1.0-11.cm1.noarch.rpm
 mariner-rpm-macros-1.0-3.cm1.noarch.rpm


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?

###### Change Log  <!-- REQUIRED -->
Each time a build is made, a new build version number is created (e.g. 1.0.20201023 or 1.0.20201024).  That build number gets embedded in the mariner-release package with every daily build, but the package version itself does not change.  Currently the last officially released mariner-release package number was 1.0-9 and contains the 1.0.20201003 version number stamped within.   This change ensures that a new mariner-release.1.0-10 package will be created, and the new package version will be stamped with 1.0.20201024 (or whatever version is ultimately built from the 1.0 branch).  

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
**YES**
NO
