### PR TITLE
Patch CVE-2020-25613 in ruby

### DIFF
--- a/SPECS/ruby/CVE-2020-25613.patch
+++ b/SPECS/ruby/CVE-2020-25613.patch
@@ -1,0 +1,35 @@
+From 8946bb38b4d87549f0d99ed73c62c41933f97cc7 Mon Sep 17 00:00:00 2001
+From: Yusuke Endoh <mame@ruby-lang.org>
+Date: Tue, 29 Sep 2020 13:15:58 +0900
+Subject: [PATCH] Make it more strict to interpret some headers
+
+Some regexps were too tolerant.
+---
+ lib/webrick/httprequest.rb | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/lib/webrick/httprequest.rb b/lib/webrick/httprequest.rb
+index 294bd91..d34eac7 100644
+--- a/lib/webrick/httprequest.rb
++++ b/lib/webrick/httprequest.rb
+@@ -227,9 +227,9 @@ def parse(socket=nil)
+         raise HTTPStatus::BadRequest, "bad URI `#{@unparsed_uri}'."
+       end
+ 
+-      if /close/io =~ self["connection"]
++      if /\Aclose\z/io =~ self["connection"]
+         @keep_alive = false
+-      elsif /keep-alive/io =~ self["connection"]
++      elsif /\Akeep-alive\z/io =~ self["connection"]
+         @keep_alive = true
+       elsif @http_version < "1.1"
+         @keep_alive = false
+@@ -508,7 +508,7 @@ def read_body(socket, block)
+       return unless socket
+       if tc = self['transfer-encoding']
+         case tc
+-        when /chunked/io then read_chunked(socket, block)
++        when /\Achunked\z/io then read_chunked(socket, block)
+         else raise HTTPStatus::NotImplemented, "Transfer-Encoding: #{tc}."
+         end
+       elsif self['content-length'] || @remaining_size

--- a/SPECS/ruby/CVE-2020-25613.patch
+++ b/SPECS/ruby/CVE-2020-25613.patch
@@ -12,7 +12,7 @@ diff --git a/lib/webrick/httprequest.rb b/lib/webrick/httprequest.rb
 index 294bd91..d34eac7 100644
 --- a/lib/webrick/httprequest.rb
 +++ b/lib/webrick/httprequest.rb
-@@ -227,9 +227,9 @@ def parse(socket=nil)
+@@ -226,9 +226,9 @@ def parse(socket=nil)
          raise HTTPStatus::BadRequest, "bad URI `#{@unparsed_uri}'."
        end
  
@@ -24,7 +24,7 @@ index 294bd91..d34eac7 100644
          @keep_alive = true
        elsif @http_version < "1.1"
          @keep_alive = false
-@@ -508,7 +508,7 @@ def read_body(socket, block)
+@@ -503,7 +503,7 @@ def read_body(socket, block)
        return unless socket
        if tc = self['transfer-encoding']
          case tc

--- a/SPECS/ruby/ruby.spec
+++ b/SPECS/ruby/ruby.spec
@@ -1,34 +1,39 @@
 Summary:        Ruby
 Name:           ruby
 Version:        2.6.6
-Release:        1%{?dist}
-License:        (Ruby or BSD) and Public Domain and MIT and CC0 and zlib and UCD
-URL:            https://www.ruby-lang.org/en/
-Group:          System Environment/Security
+Release:        2%{?dist}
+License:        (Ruby OR BSD) AND Public Domain AND MIT AND CC0 AND zlib AND UCD
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
+Group:          System Environment/Security
+URL:            https://www.ruby-lang.org/en/
 Source0:        https://cache.ruby-lang.org/pub/ruby/2.6/%{name}-%{version}.tar.xz
+Patch0:         CVE-2020-25613.patch
 BuildRequires:  openssl-devel
-BuildRequires:  readline-devel
 BuildRequires:  readline
+BuildRequires:  readline-devel
 BuildRequires:  tzdata
-Requires:       openssl
 Requires:       gmp
+Requires:       openssl
+
 %description
 The Ruby package contains the Ruby development environment.
 This is useful for object-oriented scripting.
 
 %prep
-%setup -q
+%autosetup
+
 %build
 %configure \
         --enable-shared \
         --with-compress-debug-sections=no \
         --docdir=%{_docdir}/%{name}-%{version}
 make %{?_smp_mflags} COPY="cp -p"
+
 %install
 [ %{buildroot} != "/"] && rm -rf %{buildroot}/*
 make DESTDIR=%{buildroot} install
+
 %check
 chmod g+w . -R
 useradd test -G root -m
@@ -36,8 +41,7 @@ sudo -u test  make check TESTS="-v"
 
 %post   -p /sbin/ldconfig
 %postun -p /sbin/ldconfig
-%clean
-rm -rf %{buildroot}/*
+
 %files
 %defattr(-,root,root)
 %license COPYING
@@ -53,52 +57,78 @@ rm -rf %{buildroot}/*
 %{_mandir}/man5/*
 
 %changelog
-*   Thu Oct 15 2020 Emre Girgin <mrgirgin@microsoft.com> 2.6.6-1
--   Upgrade to 2.6.6 to resolve CVEs.
+* Thu Oct 22 2020 Thomas Crain <thcrain@microsoft.com> - 2.6.6-2
+- Patch CVE-2020-25613
+
+* Thu Oct 15 2020 Emre Girgin <mrgirgin@microsoft.com> - 2.6.6-1
+- Upgrade to 2.6.6 to resolve CVEs.
+
 *   Sat May 09 00:20:42 PST 2020 Nick Samson <nisamson@microsoft.com> - 2.6.3-3
 -   Added %%license line automatically
+
 *   Wed May 06 2020 Pawel Winogrodzki <pawelwi@microsoft.com> 2.6.3-2
 -   Removing *Requires for "ca-certificates".
+
 *   Fri Mar 13 2020 Paul Monson <paulmon@microsoft.com> 2.6.3-1
 -   Update to version 2.6.3. License verified.
+
 *   Mon Feb 3 2020 Andrew Phelps <anphel@microsoft.com> 2.5.3-3
 -   Disable compressing debug sections
+
 *   Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 2.5.3-2
 -   Initial CBL-Mariner import from Photon (license: Apache2).
+
 *   Tue Jan 01 2019 Sujay G <gsujay@vmware.com> 2.5.3-1
 -   Update to version 2.5.3, to fix CVE-2018-16395 & CVE-2018-16396
+
 *   Tue Sep 11 2018 srinidhira0 <srinidhir@vmware.com> 2.5.1-1
 -   Update to version 2.5.1
+
 *   Fri Jan 12 2018 Xiaolin Li <xiaolinl@vmware.com> 2.4.3-2
 -   Fix CVE-2017-17790
+
 *   Wed Jan 03 2018 Xiaolin Li <xiaolinl@vmware.com> 2.4.3-1
 -   Update to version 2.4.3, fix CVE-2017-17405
+
 *   Fri Sep 29 2017 Xiaolin Li <xiaolinl@vmware.com> 2.4.2-1
 -   Update to version 2.4.2
+
 *   Fri Sep 15 2017 Xiaolin Li <xiaolinl@vmware.com> 2.4.1-5
 -   [security] CVE-2017-14064
+
 *   Tue Sep 05 2017 Chang Lee <changlee@vmware.com> 2.4.1-4
 -   Built with copy preserve mode and fixed %check
+
 *   Mon Jul 24 2017 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 2.4.1-3
 -   [security] CVE-2017-9228
+
 *   Tue Jun 13 2017 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 2.4.1-2
 -   [security] CVE-2017-9224,CVE-2017-9225
 -   [security] CVE-2017-9227,CVE-2017-9229
+
 *   Thu Apr 13 2017 Siju Maliakkal <smaliakkal@vmware.com> 2.4.1-1
 -   Update to latest 2.4.1
+
 *   Wed Jan 18 2017 Anish Swaminathan <anishs@vmware.com> 2.4.0-1
 -   Update to 2.4.0 - Fixes CVE-2016-2339
+
 *   Mon Oct 10 2016 ChangLee <changlee@vmware.com> 2.3.0-4
 -   Modified %check
+
 *   Tue May 24 2016 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 2.3.0-3
 -   GA - Bump release of all rpms
+
 *   Wed Mar 09 2016 Divya Thaluru <dthaluru@vmware.com> 2.3.0-2
 -   Adding readline support
+
 *   Wed Jan 20 2016 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 2.3.0-1
 -   Updated to 2.3.0-1
+
 *   Tue Apr 28 2015 Fabio Rapposelli <fabio@vmware.com> 2.2.1-2
 -   Added SSL support
+
 *   Mon Apr 6 2015 Mahmoud Bassiouny <mbassiouny@vmware.com> 2.2.1-1
 -   Version upgrade to 2.2.1
+
 *   Fri Oct 10 2014 Divya Thaluru <dthaluru@vmware.com> 2.1.3-1
 -   Initial build.  First version

--- a/SPECS/ruby/ruby.spec
+++ b/SPECS/ruby/ruby.spec
@@ -21,7 +21,7 @@ The Ruby package contains the Ruby development environment.
 This is useful for object-oriented scripting.
 
 %prep
-%autosetup
+%autosetup -p1
 
 %build
 %configure \


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Patch CVE-2020-25613 in ruby

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Fixes CVE-2020-25613

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
**No**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2020-25613

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local build