### PR TITLE
Patch CVE-2020-24977 in libxml2

### DIFF
--- a/SPECS/libxml2/CVE-2020-24977.patch
+++ b/SPECS/libxml2/CVE-2020-24977.patch
@@ -1,0 +1,35 @@
+From 50f06b3efb638efb0abd95dc62dca05ae67882c2 Mon Sep 17 00:00:00 2001
+From: Nick Wellnhofer <wellnhofer@aevum.de>
+Date: Fri, 7 Aug 2020 21:54:27 +0200
+Subject: [PATCH] Fix out-of-bounds read with 'xmllint --htmlout'
+
+Make sure that truncated UTF-8 sequences don't cause an out-of-bounds
+array access.
+
+Thanks to @SuhwanSong and the Agency for Defense Development (ADD) for
+the report.
+
+Fixes #178.
+---
+ xmllint.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/xmllint.c b/xmllint.c
+index f6a8e4636..c647486f3 100644
+--- a/xmllint.c
++++ b/xmllint.c
+@@ -528,6 +528,12 @@ static void
+ xmlHTMLEncodeSend(void) {
+     char *result;
+ 
++    /*
++     * xmlEncodeEntitiesReentrant assumes valid UTF-8, but the buffer might
++     * end with a truncated UTF-8 sequence. This is a hack to at least avoid
++     * an out-of-bounds read.
++     */
++    memset(&buffer[sizeof(buffer)-4], 0, 4);
+     result = (char *) xmlEncodeEntitiesReentrant(NULL, BAD_CAST buffer);
+     if (result) {
+ 	xmlGenericError(xmlGenericErrorContext, "%s", result);
+-- 
+GitLab

--- a/SPECS/libxml2/libxml2.spec
+++ b/SPECS/libxml2/libxml2.spec
@@ -4,7 +4,7 @@
 Summary:        Libxml2
 Name:           libxml2
 Version:        2.9.10
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        MIT
 URL:            http://www.xmlsoft.org/
 Group:          System Environment/General Libraries
@@ -13,6 +13,7 @@ Distribution:   Mariner
 Source0:        ftp://xmlsoft.org/libxml2/%{name}-%{version}.tar.gz
 Patch0:         CVE-2019-20388.patch
 Patch1:         CVE-2020-7595.patch
+Patch2:         CVE-2020-24977.patch
 
 BuildRequires:  python2-devel
 BuildRequires:  python2-libs
@@ -105,6 +106,9 @@ rm -rf %{buildroot}/*
 %{_libdir}/cmake/libxml2/libxml2-config.cmake
 
 %changelog
+* Tue Oct 26 2020 Ruying Chen <v-ruyche@microsoft.com> - 2.9.10-3
+- Patch CVE-2020-24977.
+
 * Wed Sep 09 2020 Thomas Crain <thcrain@microsoft.com> - 2.9.10-2
 - Patch CVE-2019-20388 and CVE-2020-7595.
 

--- a/SPECS/libxml2/libxml2.spec
+++ b/SPECS/libxml2/libxml2.spec
@@ -1,20 +1,18 @@
 %{!?python2_sitelib: %define python2_sitelib %(python2 -c "from distutils.sysconfig import get_python_lib;print(get_python_lib())")}
 %{!?python3_sitelib: %define python3_sitelib %(python3 -c "from distutils.sysconfig import get_python_lib;print(get_python_lib())")}
-
 Summary:        Libxml2
 Name:           libxml2
 Version:        2.9.10
 Release:        3%{?dist}
 License:        MIT
-URL:            http://www.xmlsoft.org/
-Group:          System Environment/General Libraries
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
+Group:          System Environment/General Libraries
+URL:            http://www.xmlsoft.org/
 Source0:        ftp://xmlsoft.org/libxml2/%{name}-%{version}.tar.gz
 Patch0:         CVE-2019-20388.patch
 Patch1:         CVE-2020-7595.patch
 Patch2:         CVE-2020-24977.patch
-
 BuildRequires:  python2-devel
 BuildRequires:  python2-libs
 BuildRequires:  python3-devel
@@ -43,8 +41,8 @@ Requires:       python3
 Python3 libxml2.
 
 %package devel
-Summary:    Libraries and header files for libxml
-Requires:   %{name} = %{version}
+Summary:        Libraries and header files for libxml
+Requires:       %{name} = %{version}
 
 %description devel
 Static libraries and header files for the support library for libxml
@@ -61,13 +59,13 @@ make %{?_smp_mflags}
 %install
 [ %{buildroot} != "/"] && rm -rf %{buildroot}/*
 make DESTDIR=%{buildroot} install
-find %{buildroot}/%{_libdir} -name '*.la' -delete
+find %{buildroot} -type f -name "*.la" -delete -print
 %{_fixperms} %{buildroot}/*
 
 make clean
 %configure \
     --disable-static \
-    --with-python=/usr/bin/python3
+    --with-python=%{_bindir}/python3
 make %{?_smp_mflags}
 make install DESTDIR=%{buildroot}
 
@@ -76,8 +74,10 @@ make %{?_smp_mflags} check
 
 %post   -p /sbin/ldconfig
 %postun -p /sbin/ldconfig
+
 %clean
 rm -rf %{buildroot}/*
+
 %files
 %defattr(-,root,root)
 %license COPYING
@@ -88,7 +88,6 @@ rm -rf %{buildroot}/*
 %{_datadir}/aclocal/*
 %{_datadir}/gtk-doc/*
 %{_mandir}/man1/*
-
 
 %files python
 %defattr(-,root,root)
@@ -106,7 +105,7 @@ rm -rf %{buildroot}/*
 %{_libdir}/cmake/libxml2/libxml2-config.cmake
 
 %changelog
-* Tue Oct 26 2020 Ruying Chen <v-ruyche@microsoft.com> - 2.9.10-3
+* Mon Oct 26 2020 Ruying Chen <v-ruyche@microsoft.com> - 2.9.10-3
 - Patch CVE-2020-24977.
 
 * Wed Sep 09 2020 Thomas Crain <thcrain@microsoft.com> - 2.9.10-2

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -137,8 +137,8 @@ tdnf-cli-libs-2.1.0-4.cm1.aarch64.rpm
 tdnf-devel-2.1.0-4.cm1.aarch64.rpm
 tdnf-plugin-repogpgcheck-2.1.0-4.cm1.aarch64.rpm
 createrepo_c-0.11.1-6.cm1.aarch64.rpm
-libxml2-2.9.10-2.cm1.aarch64.rpm
-libxml2-devel-2.9.10-2.cm1.aarch64.rpm
+libxml2-2.9.10-3.cm1.aarch64.rpm
+libxml2-devel-2.9.10-3.cm1.aarch64.rpm
 glib-2.58.0-6.cm1.aarch64.rpm
 libltdl-2.4.6-5.cm1.aarch64.rpm
 libltdl-devel-2.4.6-5.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -137,8 +137,8 @@ tdnf-cli-libs-2.1.0-4.cm1.x86_64.rpm
 tdnf-devel-2.1.0-4.cm1.x86_64.rpm
 tdnf-plugin-repogpgcheck-2.1.0-4.cm1.x86_64.rpm
 createrepo_c-0.11.1-6.cm1.x86_64.rpm
-libxml2-2.9.10-2.cm1.x86_64.rpm
-libxml2-devel-2.9.10-2.cm1.x86_64.rpm
+libxml2-2.9.10-3.cm1.x86_64.rpm
+libxml2-devel-2.9.10-3.cm1.x86_64.rpm
 glib-2.58.0-6.cm1.x86_64.rpm
 libltdl-2.4.6-5.cm1.x86_64.rpm
 libltdl-devel-2.4.6-5.cm1.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -218,10 +218,10 @@ libtasn1-debuginfo-4.14-2.cm1.aarch64.rpm
 libtasn1-devel-4.14-2.cm1.aarch64.rpm
 libtool-2.4.6-5.cm1.aarch64.rpm
 libtool-debuginfo-2.4.6-5.cm1.aarch64.rpm
-libxml2-2.9.10-2.cm1.aarch64.rpm
-libxml2-debuginfo-2.9.10-2.cm1.aarch64.rpm
-libxml2-devel-2.9.10-2.cm1.aarch64.rpm
-libxml2-python-2.9.10-2.cm1.aarch64.rpm
+libxml2-2.9.10-3.cm1.aarch64.rpm
+libxml2-debuginfo-2.9.10-3.cm1.aarch64.rpm
+libxml2-devel-2.9.10-3.cm1.aarch64.rpm
+libxml2-python-2.9.10-3.cm1.aarch64.rpm
 libxslt-1.1.34-2.cm1.aarch64.rpm
 libxslt-debuginfo-1.1.34-2.cm1.aarch64.rpm
 libxslt-devel-1.1.34-2.cm1.aarch64.rpm
@@ -324,7 +324,7 @@ python2-test-2.7.18-4.cm1.aarch64.rpm
 python2-tools-2.7.18-4.cm1.aarch64.rpm
 python3-cracklib-2.9.7-2.cm1.aarch64.rpm
 python3-gpg-1.13.1-5.cm1.aarch64.rpm
-python3-libxml2-2.9.10-2.cm1.aarch64.rpm
+python3-libxml2-2.9.10-3.cm1.aarch64.rpm
 python3-pwquality-1.4.2-4.cm1.aarch64.rpm
 python3-rpm-4.14.2-10.cm1.aarch64.rpm
 python-curses-2.7.18-4.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -218,10 +218,10 @@ libtasn1-debuginfo-4.14-2.cm1.x86_64.rpm
 libtasn1-devel-4.14-2.cm1.x86_64.rpm
 libtool-2.4.6-5.cm1.x86_64.rpm
 libtool-debuginfo-2.4.6-5.cm1.x86_64.rpm
-libxml2-2.9.10-2.cm1.x86_64.rpm
-libxml2-debuginfo-2.9.10-2.cm1.x86_64.rpm
-libxml2-devel-2.9.10-2.cm1.x86_64.rpm
-libxml2-python-2.9.10-2.cm1.x86_64.rpm
+libxml2-2.9.10-3.cm1.x86_64.rpm
+libxml2-debuginfo-2.9.10-3.cm1.x86_64.rpm
+libxml2-devel-2.9.10-3.cm1.x86_64.rpm
+libxml2-python-2.9.10-3.cm1.x86_64.rpm
 libxslt-1.1.34-2.cm1.x86_64.rpm
 libxslt-debuginfo-1.1.34-2.cm1.x86_64.rpm
 libxslt-devel-1.1.34-2.cm1.x86_64.rpm
@@ -324,7 +324,7 @@ python2-test-2.7.18-4.cm1.x86_64.rpm
 python2-tools-2.7.18-4.cm1.x86_64.rpm
 python3-cracklib-2.9.7-2.cm1.x86_64.rpm
 python3-gpg-1.13.1-5.cm1.x86_64.rpm
-python3-libxml2-2.9.10-2.cm1.x86_64.rpm
+python3-libxml2-2.9.10-3.cm1.x86_64.rpm
 python3-pwquality-1.4.2-4.cm1.x86_64.rpm
 python3-rpm-4.14.2-10.cm1.x86_64.rpm
 python-curses-2.7.18-4.cm1.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Patch CVE-2020-24977 in libxml2.

Upstream patch:
- https://gitlab.gnome.org/GNOME/libxml2/-/commit/50f06b3efb638efb0abd95dc62dca05ae67882c2

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Patch CVE-2020-24977

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
**YES**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2020-24977

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local toolchain and package build