### PR TITLE
Fix bash script issue in spec lint action

### DIFF
--- a/.github/workflows/lint-specs.yml
+++ b/.github/workflows/lint-specs.yml
@@ -82,9 +82,9 @@ jobs:
           spec-cleaner -o linted_specs ${{ env.updated-specs }}
           [ -n "$(ls -A linted_specs)" ] \
           && echo "Specs are not correctly formatted." \
-          && echo "Linting output is available in the linted_specs artifact."
+          && echo "Linting output is available in the linted_specs artifact." \
           && echo "Please properly format your specs according to that output before merging." \
-          && echo "A diff of the changes required is printed below:"
+          && echo "A diff of the changes required is printed below:" \
           && spec-cleaner -d --diff-prog="git --no-pager diff" ${{ env.updated-specs }} \
           && exit 1
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Forgot a commit in the last push that breaks lint-specs: add that back in (cherry pick of #284 )
###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Correct lint-specs.yml bash syntax
###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO
