### PR TITLE
Corrected URL_LIST links to preview repo

### DIFF
--- a/toolkit/Makefile
+++ b/toolkit/Makefile
@@ -96,8 +96,8 @@ SRPM_URL_LIST      += https://packages.microsoft.com/cbl-mariner/$(RELEASE_MAJOR
 endif
 
 ifeq ($(USE_PREVIEW_REPO),y)
-PACKAGE_URL_LIST   += https://packages.microsoft.com/cbl-mariner/$(RELEASE_MAJOR_ID)/prod/preview/$(build_arch)/rpms
-SRPM_URL_LIST      += https://packages.microsoft.com/cbl-mariner/$(RELEASE_MAJOR_ID)/prod/preview/srpms
+PACKAGE_URL_LIST   += https://packages.microsoft.com/cbl-mariner/$(RELEASE_MAJOR_ID)/preview/update/$(build_arch)/rpms
+SRPM_URL_LIST      += https://packages.microsoft.com/cbl-mariner/$(RELEASE_MAJOR_ID)/preview/update/srpms
 endif
 
 REPO_LIST   ?=


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x ] The toolchain/worker package manifests are up-to-date
- [ x] Any updated packages successfully build (or no packages were changed)
- [ x] All package sources are available
- [ x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `./.github/workflows/cgmanifest.json`)
- [x ] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x ] All source files have up-to-date hashes in the `*.signatures.json` files
- [x ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x ] Documentation has been updated to match any changes to the build system
- [x ] Ready to merge

---

###### Summary <!-- REQUIRED -->
A new feature that allows building mariner core from the preview repository was pointing to the wrong location on packages.microsoft.com.  This change fixes the link to point to the correct location.


###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
YES
**NO**

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
Verified by creating the input-srpms before and after the fix.