### PR TITLE
Prevent AdditionalFiles from being modified during iteration (#297)

### DIFF
--- a/toolkit/scripts/imggen.mk
+++ b/toolkit/scripts/imggen.mk
@@ -177,6 +177,7 @@ iso: $(go-isomaker) $(go-liveinstaller) $(go-imager) $(depend_CONFIG_FILE) $(CON
 		--resources $(RESOURCES_DIR) \
 		--iso-repo $(local_and_external_rpm_cache) \
 		--log-level $(LOG_LEVEL) \
+		--log-file $(LOGS_DIR)/imggen/isomaker.log \
 		$(if $(UNATTENDED_INSTALLER),--unattended-install) \
 		--output-dir $(artifact_dir) \
 		--image-tag=$(IMAGE_TAG)

--- a/toolkit/tools/imagegen/configuration/configuration.go
+++ b/toolkit/tools/imagegen/configuration/configuration.go
@@ -208,12 +208,12 @@ func convertRawBinariesPath(baseDirPath string, diskConfig *Disk) {
 }
 
 func convertAdditionalFilesPath(baseDirPath string, systemConfig *SystemConfig) {
+	absAdditionalFiles := make(map[string]string)
 	for localFilePath, targetFilePath := range systemConfig.AdditionalFiles {
-		delete(systemConfig.AdditionalFiles, localFilePath)
-
 		localFilePath = file.GetAbsPathWithBase(baseDirPath, localFilePath)
-		systemConfig.AdditionalFiles[localFilePath] = targetFilePath
+		absAdditionalFiles[localFilePath] = targetFilePath
 	}
+	systemConfig.AdditionalFiles = absAdditionalFiles
 }
 
 func convertPackageListPaths(baseDirPath string, systemConfig *SystemConfig) {

--- a/toolkit/tools/isomaker/maker.go
+++ b/toolkit/tools/isomaker/maker.go
@@ -305,12 +305,12 @@ func (im *IsoMaker) copyAndRenameAdditionalFiles(configFilesAbsDirPath string) {
 	const additionalFilesSubDirName = "additionalfiles"
 
 	for _, systemConfig := range im.config.SystemConfigs {
+		absAdditionalFiles := make(map[string]string)
 		for localAbsFilePath, installedSystemAbsFilePath := range systemConfig.AdditionalFiles {
-			delete(systemConfig.AdditionalFiles, localAbsFilePath)
 			isoRelativeFilePath := im.copyFileToConfigRoot(configFilesAbsDirPath, additionalFilesSubDirName, localAbsFilePath)
-
-			systemConfig.AdditionalFiles[isoRelativeFilePath] = installedSystemAbsFilePath
+			absAdditionalFiles[isoRelativeFilePath] = installedSystemAbsFilePath
 		}
+		systemConfig.AdditionalFiles = absAdditionalFiles
 	}
 }
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `./.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

In both `configuration` and `isomaker`, the `AdditionalFiles` map was being modified while it was being iterated. This resulted in entries added to `AdditionalFiles` sometimes being iterated in the same loop they were added. This was not the desired behavior of the functions.

Per the [golang spec on the range clause](https://golang.org/ref/spec#RangeClause):
> The iteration order over maps is not specified and is not guaranteed to be the same from one iteration to the next.
> ....
> **If a map entry is created during iteration, that entry may be produced during the iteration or may be skipped.**

This fix is to create a new map with the desired values and after iteration is complete, update `AdditionalFiles` using it.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Record `isomaker` output to a log file.
- Stop altering `AdditionalFiles` during its iteration.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local build.