### PR TITLE
Address source RPM publishing issue on packages.microsoft.com

### DIFF
--- a/SPECS/liblogging/liblogging.spec
+++ b/SPECS/liblogging/liblogging.spec
@@ -1,7 +1,7 @@
 Summary:        Logging Libraries
 Name:           liblogging
 Version:        1.0.6
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        BSD
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -11,8 +11,7 @@ Source0:        https://download.rsyslog.com/%{name}/%{name}-%{version}.tar.gz
 BuildRequires:  gcc
 
 %description
-liblogging (the upstream project) is a collection of several components.
-Namely: stdlog, journalemu, rfc3195.
+liblogging (the upstream project) is a collection of several components: stdlog, journalemu and rfc3195.
 The stdlog component of liblogging can be viewed as an enhanced version of the
 syslog(3) API. It retains the easy semantics, but makes the API more
 sophisticated "behind the scenes" with better support for multiple threads
@@ -60,6 +59,9 @@ make %{?_smp_mflags} check
 %{_includedir}/liblogging/*.h
 
 %changelog
+* Wed Oct 28 2020 Nicolas Guibourge <nicolasg@microsoft.com> - 1.0.6-4
+- Address source RPM publishing issue on packages.microsoft.com
+
 * Mon Oct 12 2020 Thomas Crain <thcrain@microsoft.com> - 1.0.6-3
 - Remove .la files
 - Lint to Mariner style


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ x] The toolchain/worker package manifests are up-to-date
- [ x] Any updated packages successfully build (or no packages were changed)
- [ x] All package sources are available
- [ x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `./.github/workflows/cgmanifest.json`)
- [ x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [ x] All source files have up-to-date hashes in the `*.signatures.json` files
- [ x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ x] Documentation has been updated to match any changes to the build system
- [ x] Ready to merge

---

###### Summary <!-- REQUIRED -->
change Description section of liblogging spec so packages.microsoft.com publishing tools can publish it
###### Change Log  <!-- REQUIRED -->
- liblogging.spec

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO
