### PR TITLE
Fixing CVE-2020-15705 in `grub2`.

### DIFF
--- a/SPECS-SIGNED/grub2-efi-binary-signed-aarch64/grub2-efi-binary-signed-aarch64.spec
+++ b/SPECS-SIGNED/grub2-efi-binary-signed-aarch64/grub2-efi-binary-signed-aarch64.spec
@@ -3,11 +3,10 @@ Summary:        Signed GRand Unified Bootloader for aarch64 systems
 Name:           grub2-efi-binary-signed-aarch64
 Version:        2.02
 Release:        25%{?dist}
-URL:            https://www.gnu.org/software/grub
 License:        GPLv3+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
-
+URL:            https://www.gnu.org/software/grub
 # This package's "version" and "release" must reflect the unsigned version that
 # was signed.
 # An important consequence is that when making a change to this package, the
@@ -22,10 +21,8 @@ Distribution:   Mariner
 #   4. Build this spec
 Source0:        grub2-efi-unsigned-%{version}-%{release}.aarch64.rpm
 Source1:        grubaa64.efi
-
-ExclusiveArch:  aarch64
-
 Conflicts:      grub2-efi-binary
+ExclusiveArch:  aarch64
 
 %description
 This package contains the GRUB EFI image signed for secure boot. The package is
@@ -45,5 +42,6 @@ cp %{SOURCE1} %{buildroot}/boot/efi/EFI/BOOT/grubaa64.efi
 %changelog
 * Tue Nov 03 2020 Pawel Winogrodzki <pawelwi@microsoft.com> - 2.02-25
 - Updating release to be aligned with the unsigned bits.
+
 * Thu Aug 13 2020 Chris Co <chrco@microsoft.com> 2.02-24
 - Original version for CBL-Mariner.

--- a/SPECS-SIGNED/grub2-efi-binary-signed-aarch64/grub2-efi-binary-signed-aarch64.spec
+++ b/SPECS-SIGNED/grub2-efi-binary-signed-aarch64/grub2-efi-binary-signed-aarch64.spec
@@ -2,7 +2,7 @@
 Summary:        Signed GRand Unified Bootloader for aarch64 systems
 Name:           grub2-efi-binary-signed-aarch64
 Version:        2.02
-Release:        24%{?dist}
+Release:        25%{?dist}
 URL:            https://www.gnu.org/software/grub
 License:        GPLv3+
 Vendor:         Microsoft Corporation
@@ -43,5 +43,7 @@ cp %{SOURCE1} %{buildroot}/boot/efi/EFI/BOOT/grubaa64.efi
 /boot/efi/EFI/BOOT/grubaa64.efi
 
 %changelog
+* Tue Nov 03 2020 Pawel Winogrodzki <pawelwi@microsoft.com> - 2.02-25
+- Updating release to be aligned with the unsigned bits.
 * Thu Aug 13 2020 Chris Co <chrco@microsoft.com> 2.02-24
 - Original version for CBL-Mariner.

--- a/SPECS-SIGNED/grub2-efi-binary-signed-x64/grub2-efi-binary-signed-x64.spec
+++ b/SPECS-SIGNED/grub2-efi-binary-signed-x64/grub2-efi-binary-signed-x64.spec
@@ -3,11 +3,10 @@ Summary:        Signed GRand Unified Bootloader for x86_64 systems
 Name:           grub2-efi-binary-signed-x64
 Version:        2.02
 Release:        25%{?dist}
-URL:            https://www.gnu.org/software/grub
 License:        GPLv3+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
-
+URL:            https://www.gnu.org/software/grub
 # This package's "version" and "release" must reflect the unsigned version that
 # was signed.
 # An important consequence is that when making a change to this package, the
@@ -22,10 +21,8 @@ Distribution:   Mariner
 #   4. Build this spec
 Source0:        grub2-efi-unsigned-%{version}-%{release}.x86_64.rpm
 Source1:        grubx64.efi
-
-ExclusiveArch:  x86_64
-
 Conflicts:      grub2-efi-binary
+ExclusiveArch:  x86_64
 
 %description
 This package contains the GRUB EFI image signed for secure boot. The package is
@@ -45,5 +42,6 @@ cp %{SOURCE1} %{buildroot}/boot/efi/EFI/BOOT/grubx64.efi
 %changelog
 * Tue Nov 03 2020 Pawel Winogrodzki <pawelwi@microsoft.com> - 2.02-25
 - Updating release to be aligned with the unsigned bits.
+
 * Thu Aug 13 2020 Chris Co <chrco@microsoft.com> 2.02-24
 - Original version for CBL-Mariner.

--- a/SPECS-SIGNED/grub2-efi-binary-signed-x64/grub2-efi-binary-signed-x64.spec
+++ b/SPECS-SIGNED/grub2-efi-binary-signed-x64/grub2-efi-binary-signed-x64.spec
@@ -2,7 +2,7 @@
 Summary:        Signed GRand Unified Bootloader for x86_64 systems
 Name:           grub2-efi-binary-signed-x64
 Version:        2.02
-Release:        24%{?dist}
+Release:        25%{?dist}
 URL:            https://www.gnu.org/software/grub
 License:        GPLv3+
 Vendor:         Microsoft Corporation
@@ -43,5 +43,7 @@ cp %{SOURCE1} %{buildroot}/boot/efi/EFI/BOOT/grubx64.efi
 /boot/efi/EFI/BOOT/grubx64.efi
 
 %changelog
+* Tue Nov 03 2020 Pawel Winogrodzki <pawelwi@microsoft.com> - 2.02-25
+- Updating release to be aligned with the unsigned bits.
 * Thu Aug 13 2020 Chris Co <chrco@microsoft.com> 2.02-24
 - Original version for CBL-Mariner.

--- a/SPECS/grub2/CVE-2020-15705.patch
+++ b/SPECS/grub2/CVE-2020-15705.patch
@@ -1,3 +1,12 @@
+###################################### PATCH NOTICE #######################################
+
+From Pawel Winogrodzki <pawelwi@microsoft.com>:
+
+The patch below has been backported to CBL-Mariner's version of the code.
+Retained original version in terms of code changes, only affected line numbers have been
+modified in order to be able to apply the patch.
+
+############################## ORIGINAL PATCH BELOW THIS LINE ##############################
 commit 53d1b600123f4a8229a6bc43ffb27ebeaf9a4917
 Author: Dimitri John Ledkov <xnox@ubuntu.com>
 Date:   Wed Jul 22 11:31:43 2020 +0100
@@ -15,10 +24,10 @@ Date:   Wed Jul 22 11:31:43 2020 +0100
     Signed-off-by: Dimitri John Ledkov <xnox@ubuntu.com>
 
 diff --git a/grub-core/loader/arm64/linux.c b/grub-core/loader/arm64/linux.c
-index 8791b35b6..1d623ec02 100644
+index a1ac7a3..83b19b7 100644
 --- a/grub-core/loader/arm64/linux.c
 +++ b/grub-core/loader/arm64/linux.c
-@@ -384,7 +384,7 @@ grub_cmd_linux (grub_command_t cmd __attribute__ ((unused)),
+@@ -328,7 +328,7 @@ grub_cmd_linux (grub_command_t cmd __attribute__ ((unused)),
    grub_dprintf ("linux", "kernel @ %p\n", kernel_addr);
  
    rc = grub_linuxefi_secure_validate (kernel_addr, kernel_size);
@@ -28,10 +37,10 @@ index 8791b35b6..1d623ec02 100644
        grub_error (GRUB_ERR_INVALID_COMMAND, N_("%s has invalid signature"), argv[0]);
        goto fail;
 diff --git a/grub-core/loader/efi/chainloader.c b/grub-core/loader/efi/chainloader.c
-index 5f7c6cfe1..2985b9f98 100644
+index 80f4492..6e741f4 100644
 --- a/grub-core/loader/efi/chainloader.c
 +++ b/grub-core/loader/efi/chainloader.c
-@@ -1082,6 +1082,7 @@ grub_cmd_chainloader (grub_command_t cmd __attribute__ ((unused)),
+@@ -1084,6 +1084,7 @@ grub_cmd_chainloader (grub_command_t cmd __attribute__ ((unused)),
  
        return 0;
      }
@@ -40,7 +49,7 @@ index 5f7c6cfe1..2985b9f98 100644
  fail:
    if (dev)
 diff --git a/grub-core/loader/efi/linux.c b/grub-core/loader/efi/linux.c
-index e09f82486..927d89a90 100644
+index 0622dfa..c42c47c 100644
 --- a/grub-core/loader/efi/linux.c
 +++ b/grub-core/loader/efi/linux.c
 @@ -33,6 +33,7 @@ struct grub_efi_shim_lock
@@ -52,11 +61,11 @@ index e09f82486..927d89a90 100644
  grub_linuxefi_secure_validate (void *data, grub_uint32_t size)
  {
 diff --git a/grub-core/loader/i386/efi/linux.c b/grub-core/loader/i386/efi/linux.c
-index e5b2736b0..0808a0d89 100644
+index ea9f513..9318fdb 100644
 --- a/grub-core/loader/i386/efi/linux.c
 +++ b/grub-core/loader/i386/efi/linux.c
-@@ -302,7 +302,7 @@ grub_cmd_linux (grub_command_t cmd __attribute__ ((unused)),
-     }
+@@ -202,7 +202,7 @@ grub_cmd_linux (grub_command_t cmd __attribute__ ((unused)),
+   grub_print_error();
  
    rc = grub_linuxefi_secure_validate (kernel, filelen);
 -  if (rc < 0)

--- a/SPECS/grub2/CVE-2020-15705.patch
+++ b/SPECS/grub2/CVE-2020-15705.patch
@@ -1,0 +1,66 @@
+commit 53d1b600123f4a8229a6bc43ffb27ebeaf9a4917
+Author: Dimitri John Ledkov <xnox@ubuntu.com>
+Date:   Wed Jul 22 11:31:43 2020 +0100
+
+    linuxefi: fail kernel validation without shim protocol.
+    
+    If certificates that signed grub are installed into db, grub can be
+    booted directly. It will then boot any kernel without signature
+    validation. The booted kernel will think it was booted in secureboot
+    mode and will implement lockdown, yet it could have been tampered.
+    
+    CVE-2020-15705
+    
+    Reported-by: Mathieu Trudel-Lapierre <cyphermox@ubuntu.com>
+    Signed-off-by: Dimitri John Ledkov <xnox@ubuntu.com>
+
+diff --git a/grub-core/loader/arm64/linux.c b/grub-core/loader/arm64/linux.c
+index 8791b35b6..1d623ec02 100644
+--- a/grub-core/loader/arm64/linux.c
++++ b/grub-core/loader/arm64/linux.c
+@@ -384,7 +384,7 @@ grub_cmd_linux (grub_command_t cmd __attribute__ ((unused)),
+   grub_dprintf ("linux", "kernel @ %p\n", kernel_addr);
+ 
+   rc = grub_linuxefi_secure_validate (kernel_addr, kernel_size);
+-  if (rc < 0)
++  if (rc <= 0)
+     {
+       grub_error (GRUB_ERR_INVALID_COMMAND, N_("%s has invalid signature"), argv[0]);
+       goto fail;
+diff --git a/grub-core/loader/efi/chainloader.c b/grub-core/loader/efi/chainloader.c
+index 5f7c6cfe1..2985b9f98 100644
+--- a/grub-core/loader/efi/chainloader.c
++++ b/grub-core/loader/efi/chainloader.c
+@@ -1082,6 +1082,7 @@ grub_cmd_chainloader (grub_command_t cmd __attribute__ ((unused)),
+ 
+       return 0;
+     }
++  // -1 fall-through to fail
+ 
+ fail:
+   if (dev)
+diff --git a/grub-core/loader/efi/linux.c b/grub-core/loader/efi/linux.c
+index e09f82486..927d89a90 100644
+--- a/grub-core/loader/efi/linux.c
++++ b/grub-core/loader/efi/linux.c
+@@ -33,6 +33,7 @@ struct grub_efi_shim_lock
+ };
+ typedef struct grub_efi_shim_lock grub_efi_shim_lock_t;
+ 
++// Returns 1 on success, -1 on error, 0 when not available
+ int
+ grub_linuxefi_secure_validate (void *data, grub_uint32_t size)
+ {
+diff --git a/grub-core/loader/i386/efi/linux.c b/grub-core/loader/i386/efi/linux.c
+index e5b2736b0..0808a0d89 100644
+--- a/grub-core/loader/i386/efi/linux.c
++++ b/grub-core/loader/i386/efi/linux.c
+@@ -302,7 +302,7 @@ grub_cmd_linux (grub_command_t cmd __attribute__ ((unused)),
+     }
+ 
+   rc = grub_linuxefi_secure_validate (kernel, filelen);
+-  if (rc < 0)
++  if (rc <= 0)
+     {
+       grub_error (GRUB_ERR_INVALID_COMMAND, N_("%s has invalid signature"),
+ 		  argv[0]);

--- a/SPECS/grub2/grub2.spec
+++ b/SPECS/grub2/grub2.spec
@@ -3,13 +3,14 @@
 Summary:        GRand Unified Bootloader
 Name:           grub2
 Version:        2.02
-Release:        24%{?dist}
+Release:        25%{?dist}
 License:        GPLv3+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Group:          Applications/System
 URL:            https://www.gnu.org/software/grub
 Source0:        ftp://ftp.gnu.org/gnu/grub/grub-2.02.tar.xz
+
 Patch0:         release-to-master.patch
 Patch1:         0001-Add-support-for-Linux-EFI-stub-loading.patch
 Patch2:         0002-Rework-linux-command.patch
@@ -41,6 +42,7 @@ Patch24:        0001-btrfs-Avoid-a-rescan-for-a-device-which-was-already-.patch
 Patch25:        0001-multiboot2-Set-min-address-for-mbi-allocation-to-0x1.patch
 Patch26:        0001-Add-missing-strtoull_test.c.patch
 Patch27:        0001-misc-Make-grub_strtol-end-pointers-have-safer-const-.patch
+
 # Start of BootHole security patches
 # CVE-2020-10713 - 0001-yylex-Make-lexer-fatal-errors-actually-be-fatal.patch
 Patch28:        CVE-2020-10713.patch
@@ -84,11 +86,17 @@ Patch53:        0026-efi-Fix-use-after-free-in-halt-reboot-path.patch
 Patch54:        0027-loader-linux-Avoid-overflow-on-initrd-size-calculati.patch
 # CVE-2020-15707 - 0028-linux-Fix-integer-overflows-in-initrd-size-handling.patch
 Patch55:        CVE-2020-15707.patch
+# CVE-2020-15705 - 0029-linuxefi-fail-kernel-validation-without-shim-protocol.patch
+Patch56:        CVE-2020-15705.patch
+
 # End of BootHole security patches
+
 Patch100:       0001-efinet-do-not-start-EFI-networking-at-module-init-ti.patch
+
 BuildRequires:  device-mapper-devel
 BuildRequires:  systemd-devel
 BuildRequires:  xz-devel
+
 Requires:       device-mapper
 Requires:       xz
 
@@ -98,6 +106,7 @@ The GRUB package contains the GRand Unified Bootloader.
 %package lang
 Summary:        Additional language files for grub
 Group:          System Environment/Programming
+
 Requires:       %{name} = %{version}
 
 %description lang
@@ -107,6 +116,7 @@ These are the additional language files of grub.
 %package pc
 Summary:        GRUB Library for BIOS
 Group:          System Environment/Programming
+
 Requires:       %{name} = %{version}
 
 %description pc
@@ -116,6 +126,7 @@ Additional library files for grub
 %package efi
 Summary:        GRUB Library for UEFI
 Group:          System Environment/Programming
+
 Requires:       %{name} = %{version}
 
 %description efi
@@ -195,6 +206,7 @@ GRUB UEFI bootloader binaries
 %patch53 -p1
 %patch54 -p1
 %patch55 -p1
+%patch56 -p1
 
 %build
 ./autogen.sh
@@ -353,6 +365,9 @@ cp $GRUB_MODULE_SOURCE $EFI_BOOT_DIR/$GRUB_MODULE_NAME
 %{_datarootdir}/locale/*
 
 %changelog
+* Fri Oct 30 2020 Pawel Winogrodzki <pawelwi@microsoft.com> - 2.02-25
+- Fix CVE-2020-15705 (BootHole cont.).
+
 * Thu Aug 13 2020 Chris Co <chrco@microsoft.com> - 2.02-24
 - Remove signed subpackage and macro
 

--- a/SPECS/grub2/grub2.spec
+++ b/SPECS/grub2/grub2.spec
@@ -5,139 +5,138 @@ Name:           grub2
 Version:        2.02
 Release:        24%{?dist}
 License:        GPLv3+
-URL:            https://www.gnu.org/software/grub
-Group:          Applications/System
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
+Group:          Applications/System
+URL:            https://www.gnu.org/software/grub
 Source0:        ftp://ftp.gnu.org/gnu/grub/grub-2.02.tar.xz
-
-Patch0:     release-to-master.patch
-Patch1:     0001-Add-support-for-Linux-EFI-stub-loading.patch
-Patch2:     0002-Rework-linux-command.patch
-Patch3:     0003-Rework-linux16-command.patch
-Patch4:     0004-Add-secureboot-support-on-efi-chainloader.patch
-Patch5:     0005-Make-any-of-the-loaders-that-link-in-efi-mode-honor-.patch
-Patch6:     0006-Handle-multi-arch-64-on-32-boot-in-linuxefi-loader.patch
-
+Patch0:         release-to-master.patch
+Patch1:         0001-Add-support-for-Linux-EFI-stub-loading.patch
+Patch2:         0002-Rework-linux-command.patch
+Patch3:         0003-Rework-linux16-command.patch
+Patch4:         0004-Add-secureboot-support-on-efi-chainloader.patch
+Patch5:         0005-Make-any-of-the-loaders-that-link-in-efi-mode-honor-.patch
+Patch6:         0006-Handle-multi-arch-64-on-32-boot-in-linuxefi-loader.patch
 # CVE-2015-8370
-Patch7:     0067-Fix-security-issue-when-reading-username-and-passwor.patch
-
-Patch8:     0127-Core-TPM-support.patch
-Patch9:     0128-Measure-kernel-initrd.patch
-Patch10:    0131-Measure-the-kernel-commandline.patch
-Patch11:    0132-Measure-commands.patch
-Patch12:    0133-Measure-multiboot-images-and-modules.patch
-Patch13:    0135-Rework-TPM-measurements.patch
-Patch14:    0136-Fix-event-log-prefix.patch
-Patch15:    0139-Make-TPM-errors-less-fatal.patch
-Patch16:    0156-TPM-Fix-hash_log_extend_event-function-prototype.patch
-Patch17:    0157-TPM-Fix-compiler-warnings.patch
-Patch18:    0216-Disable-multiboot-multiboot2-and-linux16-modules-on-.patch
-Patch19:    0224-Rework-how-the-fdt-command-builds.patch
-
+Patch7:         0067-Fix-security-issue-when-reading-username-and-passwor.patch
+Patch8:         0127-Core-TPM-support.patch
+Patch9:         0128-Measure-kernel-initrd.patch
+Patch10:        0131-Measure-the-kernel-commandline.patch
+Patch11:        0132-Measure-commands.patch
+Patch12:        0133-Measure-multiboot-images-and-modules.patch
+Patch13:        0135-Rework-TPM-measurements.patch
+Patch14:        0136-Fix-event-log-prefix.patch
+Patch15:        0139-Make-TPM-errors-less-fatal.patch
+Patch16:        0156-TPM-Fix-hash_log_extend_event-function-prototype.patch
+Patch17:        0157-TPM-Fix-compiler-warnings.patch
+Patch18:        0216-Disable-multiboot-multiboot2-and-linux16-modules-on-.patch
+Patch19:        0224-Rework-how-the-fdt-command-builds.patch
 # These patches are not required but help to apply the BootHole patches and are
 # low risk to take on (mostly just additional security or bug fixes)
-Patch20:    0001-chainloader-Fix-gcc9-error-Waddress-of-packed-member.patch
-Patch21:    0001-efi-Fix-gcc9-error-Waddress-of-packed-member.patch
-Patch22:    0001-hfsplus-Fix-gcc9-error-with-Waddress-of-packed-membe.patch
-Patch23:    0001-btrfs-Move-the-error-logging-from-find_device-to-its.patch
-Patch24:    0001-btrfs-Avoid-a-rescan-for-a-device-which-was-already-.patch
-Patch25:    0001-multiboot2-Set-min-address-for-mbi-allocation-to-0x1.patch
-Patch26:    0001-Add-missing-strtoull_test.c.patch
-Patch27:    0001-misc-Make-grub_strtol-end-pointers-have-safer-const-.patch
-
+Patch20:        0001-chainloader-Fix-gcc9-error-Waddress-of-packed-member.patch
+Patch21:        0001-efi-Fix-gcc9-error-Waddress-of-packed-member.patch
+Patch22:        0001-hfsplus-Fix-gcc9-error-with-Waddress-of-packed-membe.patch
+Patch23:        0001-btrfs-Move-the-error-logging-from-find_device-to-its.patch
+Patch24:        0001-btrfs-Avoid-a-rescan-for-a-device-which-was-already-.patch
+Patch25:        0001-multiboot2-Set-min-address-for-mbi-allocation-to-0x1.patch
+Patch26:        0001-Add-missing-strtoull_test.c.patch
+Patch27:        0001-misc-Make-grub_strtol-end-pointers-have-safer-const-.patch
 # Start of BootHole security patches
 # CVE-2020-10713 - 0001-yylex-Make-lexer-fatal-errors-actually-be-fatal.patch
-Patch28:    CVE-2020-10713.patch
-Patch29:    0002-safemath-Add-some-arithmetic-primitives-that-check-f.patch
-Patch30:    0003-calloc-Make-sure-we-always-have-an-overflow-checking.patch
+Patch28:        CVE-2020-10713.patch
+Patch29:        0002-safemath-Add-some-arithmetic-primitives-that-check-f.patch
+Patch30:        0003-calloc-Make-sure-we-always-have-an-overflow-checking.patch
 # CVE-2020-14308 - 0004-calloc-Use-calloc-at-most-places.patch
-Patch31:    CVE-2020-14308.patch
+Patch31:        CVE-2020-14308.patch
 # CVE-2020-14309 - 0005-malloc-Use-overflow-checking-primitives-where-we-do-.patch
 # CVE-2020-14310 - 0005-malloc-Use-overflow-checking-primitives-where-we-do-.patch
 # CVE-2020-14311 - 0005-malloc-Use-overflow-checking-primitives-where-we-do-.patch
-Patch32:    CVE-2020-14309.patch
-Patch33:    CVE-2020-14310.nopatch
-Patch34:    CVE-2020-14311.nopatch
-Patch35:    0006-iso9660-Don-t-leak-memory-on-realloc-failures.patch
-Patch36:    0007-font-Do-not-load-more-than-one-NAME-section.patch
-Patch37:    0008-gfxmenu-Fix-double-free-in-load_image.patch
-Patch38:    0009-xnu-Fix-double-free-in-grub_xnu_devprop_add_property.patch
+Patch32:        CVE-2020-14309.patch
+Patch33:        CVE-2020-14310.nopatch
+Patch34:        CVE-2020-14311.nopatch
+Patch35:        0006-iso9660-Don-t-leak-memory-on-realloc-failures.patch
+Patch36:        0007-font-Do-not-load-more-than-one-NAME-section.patch
+Patch37:        0008-gfxmenu-Fix-double-free-in-load_image.patch
+Patch38:        0009-xnu-Fix-double-free-in-grub_xnu_devprop_add_property.patch
 # Ignore the json double-free patch. Grub added a json library well after 2.02.
 # Revisit this if we want to enable LUKS2 encryption.
 # 0010-json-Avoid-a-double-free-when-parsing-fails.patch
-Patch39:    0011-lzma-Make-sure-we-don-t-dereference-past-array.patch
-Patch40:    0012-term-Fix-overflow-on-user-inputs.patch
-Patch41:    0013-udf-Fix-memory-leak.patch
+Patch39:        0011-lzma-Make-sure-we-don-t-dereference-past-array.patch
+Patch40:        0012-term-Fix-overflow-on-user-inputs.patch
+Patch41:        0013-udf-Fix-memory-leak.patch
 # Ignore the multiboot memleak patch. The patch is to fix a memleak that was
 # introduced with Grub's verifiers feature, which landed after 2.02.
 # Revisit this if we want to enable the verifiers feature.
 # 0014-multiboot2-Fix-memory-leak-if-grub_create_loader_cmd.patch
-Patch42:    0015-tftp-Do-not-use-priority-queue.patch
-Patch43:    0016-relocator-Protect-grub_relocator_alloc_chunk_addr-in.patch
-Patch44:    0017-relocator-Protect-grub_relocator_alloc_chunk_align-m.patch
-Patch45:    0018-script-Remove-unused-fields-from-grub_script_functio.patch
+Patch42:        0015-tftp-Do-not-use-priority-queue.patch
+Patch43:        0016-relocator-Protect-grub_relocator_alloc_chunk_addr-in.patch
+Patch44:        0017-relocator-Protect-grub_relocator_alloc_chunk_align-m.patch
+Patch45:        0018-script-Remove-unused-fields-from-grub_script_functio.patch
 # CVE-2020-15706 - 0019-script-Avoid-a-use-after-free-when-redefining-a-func.patch
-Patch46:    CVE-2020-15706.patch
-Patch47:    0020-relocator-Fix-grub_relocator_alloc_chunk_align-top-m.patch
-Patch48:    0021-hfsplus-Fix-two-more-overflows.patch
-Patch49:    0022-lvm-Fix-two-more-potential-data-dependent-alloc-over.patch
-Patch50:    0023-emu-Make-grub_free-NULL-safe.patch
-Patch51:    0024-efi-Fix-some-malformed-device-path-arithmetic-errors.patch
-Patch52:    0025-efi-chainloader-Propagate-errors-from-copy_file_path.patch
-Patch53:    0026-efi-Fix-use-after-free-in-halt-reboot-path.patch
-Patch54:    0027-loader-linux-Avoid-overflow-on-initrd-size-calculati.patch
+Patch46:        CVE-2020-15706.patch
+Patch47:        0020-relocator-Fix-grub_relocator_alloc_chunk_align-top-m.patch
+Patch48:        0021-hfsplus-Fix-two-more-overflows.patch
+Patch49:        0022-lvm-Fix-two-more-potential-data-dependent-alloc-over.patch
+Patch50:        0023-emu-Make-grub_free-NULL-safe.patch
+Patch51:        0024-efi-Fix-some-malformed-device-path-arithmetic-errors.patch
+Patch52:        0025-efi-chainloader-Propagate-errors-from-copy_file_path.patch
+Patch53:        0026-efi-Fix-use-after-free-in-halt-reboot-path.patch
+Patch54:        0027-loader-linux-Avoid-overflow-on-initrd-size-calculati.patch
 # CVE-2020-15707 - 0028-linux-Fix-integer-overflows-in-initrd-size-handling.patch
-Patch55:    CVE-2020-15707.patch
+Patch55:        CVE-2020-15707.patch
 # End of BootHole security patches
-
-Patch100:   0001-efinet-do-not-start-EFI-networking-at-module-init-ti.patch
-
+Patch100:       0001-efinet-do-not-start-EFI-networking-at-module-init-ti.patch
 BuildRequires:  device-mapper-devel
-BuildRequires:  xz-devel
 BuildRequires:  systemd-devel
-Requires:   xz
-Requires:   device-mapper
+BuildRequires:  xz-devel
+Requires:       device-mapper
+Requires:       xz
+
 %description
 The GRUB package contains the GRand Unified Bootloader.
 
 %package lang
-Summary: Additional language files for grub
-Group: System Environment/Programming
-Requires: %{name} = %{version}
+Summary:        Additional language files for grub
+Group:          System Environment/Programming
+Requires:       %{name} = %{version}
+
 %description lang
 These are the additional language files of grub.
 
 %ifarch x86_64
 %package pc
-Summary: GRUB Library for BIOS
-Group: System Environment/Programming
-Requires: %{name} = %{version}
+Summary:        GRUB Library for BIOS
+Group:          System Environment/Programming
+Requires:       %{name} = %{version}
+
 %description pc
 Additional library files for grub
 %endif
 
 %package efi
-Summary: GRUB Library for UEFI
-Group: System Environment/Programming
-Requires: %{name} = %{version}
+Summary:        GRUB Library for UEFI
+Group:          System Environment/Programming
+Requires:       %{name} = %{version}
+
 %description efi
 Additional library files for grub
 
 %package efi-unsigned
-Summary: Unsigned GRUB UEFI image
-Group: System Environment/Base
+Summary:        Unsigned GRUB UEFI image
+Group:          System Environment/Base
+
 %description efi-unsigned
 Unsigned GRUB UEFI image
 
 %package efi-binary
-Summary: GRUB UEFI image
-Group: System Environment/Base
+Summary:        GRUB UEFI image
+Group:          System Environment/Base
+
 %description efi-binary
 GRUB UEFI bootloader binaries
 
 %prep
-%setup -qn grub-%{version}
+%setup -q -n grub-%{version}
 %patch0 -p1
 %patch1 -p1
 %patch2 -p1
@@ -275,12 +274,12 @@ chmod 600 %{buildroot}/boot/%{name}/grub.cfg
 rm -rf %{buildroot}%{_infodir}
 
 # Generate grub efi image
-install -d %{buildroot}/usr/share/grub2-efi
+install -d %{buildroot}%{_datadir}/grub2-efi
 %ifarch x86_64
-./install-for-efi/usr/bin/grub2-mkimage -d ./install-for-efi/usr/lib/grub/x86_64-efi/ -o %{buildroot}/usr/share/grub2-efi/grubx64.efi -p /boot/grub2 -O x86_64-efi fat iso9660 part_gpt part_msdos normal boot linux configfile loopback chain efifwsetup efi_gop efi_uga ls search search_label search_fs_uuid search_fs_file gfxterm gfxterm_background gfxterm_menu test all_video loadenv exfat ext2 udf halt gfxmenu png tga lsefi help probe echo lvm cryptodisk luks gcry_rijndael gcry_sha512
+./install-for-efi/usr/bin/grub2-mkimage -d ./install-for-efi/usr/lib/grub/x86_64-efi/ -o %{buildroot}%{_datadir}/grub2-efi/grubx64.efi -p /boot/grub2 -O x86_64-efi fat iso9660 part_gpt part_msdos normal boot linux configfile loopback chain efifwsetup efi_gop efi_uga ls search search_label search_fs_uuid search_fs_file gfxterm gfxterm_background gfxterm_menu test all_video loadenv exfat ext2 udf halt gfxmenu png tga lsefi help probe echo lvm cryptodisk luks gcry_rijndael gcry_sha512
 %endif
 %ifarch aarch64
-./install-for-efi/usr/bin/grub2-mkimage -d ./install-for-efi/usr/lib/grub/arm64-efi/ -o %{buildroot}/usr/share/grub2-efi/grubaa64.efi -p /boot/grub2 -O arm64-efi fat iso9660 part_gpt part_msdos normal boot linux configfile loopback chain efifwsetup efi_gop ls search search_label search_fs_uuid search_fs_file gfxterm gfxterm_background gfxterm_menu test all_video loadenv exfat ext2 udf halt gfxmenu png tga lsefi help probe echo lvm cryptodisk luks gcry_rijndael gcry_sha512
+./install-for-efi/usr/bin/grub2-mkimage -d ./install-for-efi/usr/lib/grub/arm64-efi/ -o %{buildroot}%{_datadir}/grub2-efi/grubaa64.efi -p /boot/grub2 -O arm64-efi fat iso9660 part_gpt part_msdos normal boot linux configfile loopback chain efifwsetup efi_gop ls search search_label search_fs_uuid search_fs_file gfxterm gfxterm_background gfxterm_menu test all_video loadenv exfat ext2 udf halt gfxmenu png tga lsefi help probe echo lvm cryptodisk luks gcry_rijndael gcry_sha512
 %endif
 
 # Install to efi directory
@@ -292,12 +291,12 @@ install -d $EFI_BOOT_DIR
 
 %ifarch x86_64
 GRUB_MODULE_NAME=grubx64.efi
-GRUB_MODULE_SOURCE=%{buildroot}/usr/share/grub2-efi/grubx64.efi
+GRUB_MODULE_SOURCE=%{buildroot}%{_datadir}/grub2-efi/grubx64.efi
 %endif
 
 %ifarch aarch64
 GRUB_MODULE_NAME=grubaa64.efi
-GRUB_MODULE_SOURCE=%{buildroot}/usr/share/grub2-efi/grubaa64.efi
+GRUB_MODULE_SOURCE=%{buildroot}%{_datadir}/grub2-efi/grubaa64.efi
 %endif
 
 cp $GRUB_MODULE_SOURCE $EFI_BOOT_DIR/$GRUB_MODULE_NAME
@@ -328,12 +327,13 @@ cp $GRUB_MODULE_SOURCE $EFI_BOOT_DIR/$GRUB_MODULE_NAME
 %ifarch x86_64
 %files pc
 %{_libdir}/grub/i386-pc
+
 %files efi
 %{_libdir}/grub/x86_64-efi
 %endif
 
 %files efi-unsigned
-/usr/share/grub2-efi/*
+%{_datadir}/grub2-efi/*
 
 %files efi-binary
 %ifarch x86_64
@@ -353,64 +353,88 @@ cp $GRUB_MODULE_SOURCE $EFI_BOOT_DIR/$GRUB_MODULE_NAME
 %{_datarootdir}/locale/*
 
 %changelog
-*   Thu Aug 13 2020 Chris Co <chrco@microsoft.com> 2.02-24
--   Remove signed subpackage and macro
-*   Thu Jul 30 2020 Chris Co <chrco@microsoft.com> 2.02-23
--   Fix CVE-2020-10713 (BootHole)
--   Fix CVE-2020-14308
--   Fix CVE-2020-14309
--   Fix CVE-2020-14310
--   Fix CVE-2020-14311
--   Fix CVE-2020-15706
--   Fix CVE-2020-15707
-*   Wed Jul 22 2020 Joe Schmitt <joschmit@microsoft.com> 2.02-22
--   Always include Patch100, but conditionally apply it.
--   Switch URL to https.
-*   Tue Jun 30 2020 Nicolas Ontiveros <niontive@microsoft.com> 2.02-21
--   Add cryptodisk, luks, gcry_rijndael and gcry_sha512 modules to EFI files.
-*   Fri Jun 19 2020 Chris Co <chrco@microsoft.com> 2.02-20
--   Add grub2-efi-binary subpackage
--   Add grub2-efi-binary-signed subpackage and macros for adding offline signed grub binaries
-*   Mon Jun 01 2020 Henry Beberman <henry.beberman@microsoft.com> 2.02-19
--   Address compilation errors from hardened cflags.
-*   Tue May 26 2020 Emre Girgin <mrgirgin@microsoft.com> 2.02-18
--   Change /boot directory permissions to 600.
-*   Fri May 22 2020 Chris Co <chrco@microsoft.com> - 2.02-17
--   Create grubaa64.efi as part of the grub2-efi-unsigned subpackage
-*   Wed May 13 2020 Nick Samson <nisamson@microsoft.com> - 2.02-16
--   Added %%license line automatically
-*   Mon May 11 2020 Chris Co <chrco@microsoft.com> 2.02-15
--   Create new grub2-efi-unsigned subpackage containing grubx64.efi
-*   Thu Apr 30 2020 Chris Co <chrco@microsoft.com> 2.02-14
--   Add fdt rework patch to fix aarch64 build errors
--   Enable aarch64 build
-*   Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 2.02-13
--   Initial CBL-Mariner import from Photon (license: Apache2).
-*   Thu Feb 21 2019 Alexey Makhalov <amakhalov@vmware.com> 2.02-12
--   Update grub version from ~rc3 to release.
--   Enhance SB + TPM support (19 patches from grub2-2.02-70.fc30)
--   Remove i386-pc modules from grub2-efi
-*   Fri Jan 25 2019 Alexey Makhalov <amakhalov@vmware.com> 2.02-11
--   Disable efinet for aarch64 to workwround NXP ls1012a frwy PFE bug.
-*   Tue Nov 14 2017 Alexey Makhalov <amakhalov@vmware.com> 2.02-10
--   Aarch64 support
-*   Fri Jun 2  2017 Bo Gan <ganb@vmware.com> 2.02-9
--   Split grub2 to grub2 and grub2-pc, remove grub2-efi spec
-*   Fri Apr 14 2017 Alexey Makhalov <amakhalov@vmware.com>  2.02-8
--   Version update to 2.02~rc2
-*   Fri Nov 18 2016 Anish Swaminathan <anishs@vmware.com>  2.02-7
--   Add fix for CVE-2015-8370
-*   Fri Nov 18 2016 Anish Swaminathan <anishs@vmware.com>  2.02-6
--   Change systemd dependency
-*   Thu Oct 06 2016 ChangLee <changlee@vmware.com> 2.02-5
--   Modified %check
-*   Tue May 24 2016 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 2.02-4
--   GA - Bump release of all rpms
-*   Fri Oct 02 2015 Divya Thaluru <dthaluru@vmware.com> 2.02-3
--   Adding patch to boot entries with out password.
-*   Wed Jul 22 2015 Divya Thaluru <dthaluru@vmware.com> 2.02-2
--   Changing program name from grub to grub2.
-*   Mon Jun 29 2015 Divya Thaluru <dthaluru@vmware.com> 2.02-1
--   Updating grub to 2.02
-*   Wed Nov 5 2014 Divya Thaluru <dthaluru@vmware.com> 2.00-1
--   Initial build.  First version
+* Thu Aug 13 2020 Chris Co <chrco@microsoft.com> - 2.02-24
+- Remove signed subpackage and macro
+
+* Thu Jul 30 2020 Chris Co <chrco@microsoft.com> - 2.02-23
+- Fix CVE-2020-10713 (BootHole)
+- Fix CVE-2020-14308
+- Fix CVE-2020-14309
+- Fix CVE-2020-14310
+- Fix CVE-2020-14311
+- Fix CVE-2020-15706
+- Fix CVE-2020-15707
+
+* Wed Jul 22 2020 Joe Schmitt <joschmit@microsoft.com> - 2.02-22
+- Always include Patch100, but conditionally apply it.
+- Switch URL to https.
+
+* Tue Jun 30 2020 Nicolas Ontiveros <niontive@microsoft.com> - 2.02-21
+- Add cryptodisk, luks, gcry_rijndael and gcry_sha512 modules to EFI files.
+
+* Fri Jun 19 2020 Chris Co <chrco@microsoft.com> - 2.02-20
+- Add grub2-efi-binary subpackage
+- Add grub2-efi-binary-signed subpackage and macros for adding offline signed grub binaries
+
+* Mon Jun 01 2020 Henry Beberman <henry.beberman@microsoft.com> - 2.02-19
+- Address compilation errors from hardened cflags.
+
+* Tue May 26 2020 Emre Girgin <mrgirgin@microsoft.com> - 2.02-18
+- Change /boot directory permissions to 600.
+
+* Fri May 22 2020 Chris Co <chrco@microsoft.com> - 2.02-17
+- Create grubaa64.efi as part of the grub2-efi-unsigned subpackage
+
+* Wed May 13 2020 Nick Samson <nisamson@microsoft.com> - 2.02-16
+- Added %%license line automatically
+
+* Mon May 11 2020 Chris Co <chrco@microsoft.com> - 2.02-15
+- Create new grub2-efi-unsigned subpackage containing grubx64.efi
+
+* Thu Apr 30 2020 Chris Co <chrco@microsoft.com> - 2.02-14
+- Add fdt rework patch to fix aarch64 build errors
+- Enable aarch64 build
+
+* Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> - 2.02-13
+- Initial CBL-Mariner import from Photon (license: Apache2).
+
+* Thu Feb 21 2019 Alexey Makhalov <amakhalov@vmware.com> - 2.02-12
+- Update grub version from ~rc3 to release.
+- Enhance SB + TPM support (19 patches from grub2-2.02-70.fc30)
+- Remove i386-pc modules from grub2-efi
+
+* Fri Jan 25 2019 Alexey Makhalov <amakhalov@vmware.com> - 2.02-11
+- Disable efinet for aarch64 to workwround NXP ls1012a frwy PFE bug.
+
+* Tue Nov 14 2017 Alexey Makhalov <amakhalov@vmware.com> - 2.02-10
+- Aarch64 support
+
+* Fri Jun 2  2017 Bo Gan <ganb@vmware.com> - 2.02-9
+- Split grub2 to grub2 and grub2-pc, remove grub2-efi spec
+
+* Fri Apr 14 2017 Alexey Makhalov <amakhalov@vmware.com> - 2.02-8
+- Version update to 2.02~rc2
+
+* Fri Nov 18 2016 Anish Swaminathan <anishs@vmware.com> - 2.02-7
+- Add fix for CVE-2015-8370
+
+* Fri Nov 18 2016 Anish Swaminathan <anishs@vmware.com> - 2.02-6
+- Change systemd dependency
+
+* Thu Oct 06 2016 ChangLee <changlee@vmware.com> - 2.02-5
+- Modified %check
+
+* Tue May 24 2016 Priyesh Padmavilasom <ppadmavilasom@vmware.com> - 2.02-4
+- GA - Bump release of all rpms
+
+* Fri Oct 02 2015 Divya Thaluru <dthaluru@vmware.com> - 2.02-3
+- Adding patch to boot entries with out password.
+
+* Wed Jul 22 2015 Divya Thaluru <dthaluru@vmware.com> - 2.02-2
+- Changing program name from grub to grub2.
+
+* Mon Jun 29 2015 Divya Thaluru <dthaluru@vmware.com> - 2.02-1
+- Updating grub to 2.02
+
+* Wed Nov 5 2014 Divya Thaluru <dthaluru@vmware.com> - 2.00-1
+- Initial build.  First version

--- a/SPECS/grub2/grub2.spec
+++ b/SPECS/grub2/grub2.spec
@@ -85,10 +85,10 @@ Patch52:        0025-efi-chainloader-Propagate-errors-from-copy_file_path.patch
 Patch53:        0026-efi-Fix-use-after-free-in-halt-reboot-path.patch
 Patch54:        0027-loader-linux-Avoid-overflow-on-initrd-size-calculati.patch
 # CVE-2020-15707 - 0028-linux-Fix-integer-overflows-in-initrd-size-handling.patch
-# Patch adjusted to CBL-Mariner's git code. See comments inside the patch for more info.
-# Original version: https://bugzilla.suse.com/attachment.cgi?id=839944 (https://bugzilla.suse.com/show_bug.cgi?id=1174421).
 Patch55:        CVE-2020-15707.patch
 # CVE-2020-15705 - 0029-linuxefi-fail-kernel-validation-without-shim-protocol.patch
+# Patch adjusted to CBL-Mariner's git code. See comments inside the patch for more info.
+# Original version: https://bugzilla.suse.com/attachment.cgi?id=839944 (https://bugzilla.suse.com/show_bug.cgi?id=1174421).
 Patch56:        CVE-2020-15705.patch
 
 # End of BootHole security patches

--- a/SPECS/grub2/grub2.spec
+++ b/SPECS/grub2/grub2.spec
@@ -85,6 +85,8 @@ Patch52:        0025-efi-chainloader-Propagate-errors-from-copy_file_path.patch
 Patch53:        0026-efi-Fix-use-after-free-in-halt-reboot-path.patch
 Patch54:        0027-loader-linux-Avoid-overflow-on-initrd-size-calculati.patch
 # CVE-2020-15707 - 0028-linux-Fix-integer-overflows-in-initrd-size-handling.patch
+# Patch adjusted to CBL-Mariner's git code. See comments inside the patch for more info.
+# Original version: https://bugzilla.suse.com/attachment.cgi?id=839944 (https://bugzilla.suse.com/show_bug.cgi?id=1174421).
 Patch55:        CVE-2020-15707.patch
 # CVE-2020-15705 - 0029-linuxefi-fail-kernel-validation-without-shim-protocol.patch
 Patch56:        CVE-2020-15705.patch


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Fixing CVE-2020-15705 in `grub2`.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Fixed CVE-2020-15705.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
No.

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2020-15705

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
Local package build.