### PR TITLE
[dev] Build without dpdk tools

### DIFF
--- a/SPECS/dpdk/dpdk.spec
+++ b/SPECS/dpdk/dpdk.spec
@@ -1,11 +1,11 @@
 # Add option to build without examples
 %bcond_without examples
 # Add option to build without tools
-%bcond_without tools
+%bcond_with tools
 
 Name:         dpdk
 Version:      18.11.2
-Release:      3%{?dist}
+Release:      4%{?dist}
 Epoch:        2
 Summary:      Set of libraries and drivers for fast packet processing
 License:      BSD and LGPLv2 and GPLv2
@@ -295,6 +295,9 @@ sed -i -e 's:-%{machine_tmpl}-:-%{machine}-:g' %{buildroot}/%{_sysconfdir}/profi
 %endif
 
 %changelog
+* Thu Nov 05 2020 Joe Schmit <pawelwi@microsoft.com> - 2:18.11.2-4
+- Build without tools subpackage and dependencies.
+
 * Wed Oct 28 2020 Pawel Winogrodzki <pawelwi@microsoft.com> - 2:18.11.2-3
 - Initial CBL-Mariner import from Fedora 31 (license: MIT).
 - Added the "Vendor" and "Distribution" tags.

--- a/SPECS/dpdk/dpdk.spec
+++ b/SPECS/dpdk/dpdk.spec
@@ -1,39 +1,8 @@
 # Add option to build without examples
+%define target %{machine_arch}-%{machine_tmpl}-linuxapp-gcc
 %bcond_without examples
 # Add option to build without tools
 %bcond_with tools
-
-Name:         dpdk
-Version:      18.11.2
-Release:      4%{?dist}
-Epoch:        2
-Summary:      Set of libraries and drivers for fast packet processing
-License:      BSD and LGPLv2 and GPLv2
-Group:        System Environment/Libraries
-Vendor:       Microsoft Corporation
-Distribution: Mariner
-URL:          https://dpdk.org
-Source0:      https://fast.%{name}.org/rel/%{name}-%{version}.tar.xz
-
-#
-# The DPDK is designed to optimize througput of network traffic using, among
-# other techniques, carefully crafted assembly instructions.  As such it
-# needs extensive work to port it to other architectures.
-#
-ExclusiveArch: x86_64 i686 aarch64 ppc64le
-
-Patch0: app-pie.patch
-Patch1: fcf-protection.patch
-Patch2: dpdk-rte-ether-align.patch
-
-BuildRequires: gcc
-BuildRequires: kernel-headers
-BuildRequires: libnuma-devel
-BuildRequires: libpcap-devel
-BuildRequires: mariner-rpm-macros
-BuildRequires: python3-sphinx
-BuildRequires: zlib-devel
-
 # machine_arch maps between rpm and dpdk arch name, often same as _target_cpu
 # machine_tmpl is the config template machine name, often "native"
 # machine is the actual machine name used in the dpdk make system
@@ -45,7 +14,7 @@ BuildRequires: zlib-devel
 %ifarch i686
 %define machine_arch i686
 %define machine_tmpl native
-%define machine default 
+%define machine default
 %endif
 %ifarch aarch64
 %define machine_arch arm64
@@ -57,33 +26,63 @@ BuildRequires: zlib-devel
 %define machine_tmpl power8
 %define machine power8
 %endif
-
-%define target %{machine_arch}-%{machine_tmpl}-linuxapp-gcc
+Summary:        Set of libraries and drivers for fast packet processing
+Name:           dpdk
+Version:        18.11.2
+Release:        4%{?dist}
+Epoch:          2
+License:        BSD AND LGPLv2 AND GPLv2
+Vendor:         Microsoft Corporation
+Distribution:   Mariner
+Group:          System Environment/Libraries
+URL:            https://dpdk.org
+Source0:        https://fast.%{name}.org/rel/%{name}-%{version}.tar.xz
+Patch0:         app-pie.patch
+Patch1:         fcf-protection.patch
+Patch2:         dpdk-rte-ether-align.patch
+BuildRequires:  gcc
+BuildRequires:  kernel-headers
+BuildRequires:  libnuma-devel
+BuildRequires:  libpcap-devel
+BuildRequires:  mariner-rpm-macros
+BuildRequires:  python3-sphinx
+BuildRequires:  zlib-devel
+#
+# The DPDK is designed to optimize througput of network traffic using, among
+# other techniques, carefully crafted assembly instructions.  As such it
+# needs extensive work to port it to other architectures.
+#
+ExclusiveArch:  x86_64 i686 aarch64 ppc64le
 
 %description
 The Data Plane Development Kit is a set of libraries and drivers for
 fast packet processing in the user space.
 
 %package devel
-Summary: Data Plane Development Kit development files
-Requires: %{name}%{?_isa} = %{epoch}:%{version}-%{release} python3
+Summary:        Data Plane Development Kit development files
+Requires:       %{name}%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       python3
 
 %description devel
 This package contains the headers and other files needed for developing
 applications with the Data Plane Development Kit.
 
 %package doc
-Summary: Data Plane Development Kit API documentation
-BuildArch: noarch
+Summary:        Data Plane Development Kit API documentation
+BuildArch:      noarch
 
 %description doc
 API programming documentation for the Data Plane Development Kit.
 
 %if %{with tools}
 %package tools
-Summary: Tools for setting up Data Plane Development Kit environment
-Requires: %{name} = %{epoch}:%{version}-%{release}
-Requires: kmod pciutils findutils iproute python3-pyelftools
+Summary:        Tools for setting up Data Plane Development Kit environment
+Requires:       %{name} = %{epoch}:%{version}-%{release}
+Requires:       findutils
+Requires:       iproute
+Requires:       kmod
+Requires:       pciutils
+Requires:       python3-pyelftools
 
 %description tools
 %{summary}
@@ -91,8 +90,8 @@ Requires: kmod pciutils findutils iproute python3-pyelftools
 
 %if %{with examples}
 %package examples
-Summary: Data Plane Development Kit example applications
-BuildRequires: libvirt-devel
+Summary:        Data Plane Development Kit example applications
+BuildRequires:  libvirt-devel
 
 %description examples
 Example applications utilizing the Data Plane Development Kit, such
@@ -103,17 +102,19 @@ as L2 and L3 forwarding.
 %define docdir  %{_docdir}/%{name}
 %define incdir %{_includedir}/%{name}
 %define pmddir %{_libdir}/%{name}-pmds
+Vendor:         Microsoft Corporation
+Distribution:   Mariner
 
 %prep
 %setup -q -n dpdk-stable-%{version}
-%patch0 -p1 
+%patch0 -p1
 %ifarch x86_64 i686
 %patch1 -p1
 %endif
 %patch2 -p1
 
 %build
-%set_build_flags
+%{set_build_flags}
 # set up a method for modifying the resulting .config file
 function setconf() {
 	if grep -q ^$1= %{target}/.config; then
@@ -295,7 +296,7 @@ sed -i -e 's:-%{machine_tmpl}-:-%{machine}-:g' %{buildroot}/%{_sysconfdir}/profi
 %endif
 
 %changelog
-* Thu Nov 05 2020 Joe Schmit <pawelwi@microsoft.com> - 2:18.11.2-4
+* Thu Nov 05 2020 Joe Schmit <joschmit@microsoft.com> - 2:18.11.2-4
 - Build without tools subpackage and dependencies.
 
 * Wed Oct 28 2020 Pawel Winogrodzki <pawelwi@microsoft.com> - 2:18.11.2-3
@@ -400,6 +401,7 @@ sed -i -e 's:-%{machine_tmpl}-:-%{machine}-:g' %{buildroot}/%{_sysconfdir}/profi
 - Update to 16.11
 
 * Tue Aug 02 2016 Neil Horman <nhorman@redhat.com> - 16.07-1
+
 * Update to 16.07
 
 * Thu Apr 14 2016 Panu Matilainen <pmatilai@redhat.com> - 16.04-1
@@ -515,4 +517,3 @@ sed -i -e 's:-%{machine_tmpl}-:-%{machine}-:g' %{buildroot}/%{_sysconfdir}/profi
 
 * Tue May 13 2014 - Neil Horman <nhorman@tuxdriver.com> - 1.7.0-0.6.20140603git5ebbb1728
 - Initial Build
-

--- a/SPECS/dpdk/dpdk.spec
+++ b/SPECS/dpdk/dpdk.spec
@@ -1,8 +1,5 @@
 # Add option to build without examples
 %define target %{machine_arch}-%{machine_tmpl}-linuxapp-gcc
-%bcond_without examples
-# Add option to build without tools
-%bcond_with tools
 # machine_arch maps between rpm and dpdk arch name, often same as _target_cpu
 # machine_tmpl is the config template machine name, often "native"
 # machine is the actual machine name used in the dpdk make system
@@ -26,6 +23,9 @@
 %define machine_tmpl power8
 %define machine power8
 %endif
+%bcond_without examples
+# Add option to build without tools
+%bcond_with tools
 Summary:        Set of libraries and drivers for fast packet processing
 Name:           dpdk
 Version:        18.11.2


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `./.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
The tools subpackage in dpdk created runtime dependencies on packages that do not exist in CBL-Mariner. **To unblock builds disable this build option for now.**

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Build without dpdk tools subpackage.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local builds.