### PR TITLE
[dev] Include all sources in bond regardless of arch

### DIFF
--- a/SPECS/bond/bond.signatures.json
+++ b/SPECS/bond/bond.signatures.json
@@ -1,7 +1,7 @@
 {
- "Signatures": {
-  "bond-8.0.1.tar.gz": "d22428a40ab158813c6b0d6548a9a4c1304c1873bd4f2f62a0f36c0ba2855a8b",
-  "gbc-0.11.0.3-aarch64" : "2fa232b3ceb79ff2e002ad06f8da93bd59f81599102f95258b4dadb84d6b847d",
-  "gbc-0.11.0.3-x86_64": "c64f9db841b8cccad4c8ec0bd724e52d28b51a15af145fe40223cd92d7356d71"
+  "Signatures": {
+   "bond-8.0.1.tar.gz": "d22428a40ab158813c6b0d6548a9a4c1304c1873bd4f2f62a0f36c0ba2855a8b",
+   "gbc-0.11.0.3-aarch64": "2fa232b3ceb79ff2e002ad06f8da93bd59f81599102f95258b4dadb84d6b847d",
+   "gbc-0.11.0.3-x86_64": "c64f9db841b8cccad4c8ec0bd724e52d28b51a15af145fe40223cd92d7356d71"
+  }
  }
-}

--- a/SPECS/bond/bond.spec
+++ b/SPECS/bond/bond.spec
@@ -1,22 +1,22 @@
-Name:           bond
 Summary:        Microsoft Bond Library
+Name:           bond
 Version:        8.0.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 URL:            https://github.com/microsoft/bond
 #Source0:       %{url}/archive/%{version}.tar.gz
 Source0:        %{name}-%{version}.tar.gz
-Source1:        gbc-0.11.0.3-%{_arch}
-
+Source1:        gbc-0.11.0.3-aarch64
+Source2:        gbc-0.11.0.3-x86_64
+BuildRequires:  boost-devel
 BuildRequires:  clang
 BuildRequires:  cmake
-BuildRequires:  zlib-devel
-BuildRequires:  boost-devel
+BuildRequires:  gmp-devel
 BuildRequires:  ncurses-devel
 BuildRequires:  rapidjson-devel
-BuildRequires:  gmp-devel
+BuildRequires:  zlib-devel
 
 %description
 Bond is an open-source, cross-platform framework for working with schematized data.
@@ -39,7 +39,11 @@ CMAKE_OPTS="\
     -DBOND_FIND_RAPIDJSON=TRUE \
     -DBOND_SKIP_CORE_TESTS=TRUE \
     -DBOND_SKIP_GBC_TESTS=TRUE \
+%ifarch aarch64
     -DBOND_GBC_PATH=%{SOURCE1} \
+%else
+    -DBOND_GBC_PATH=%{SOURCE2} \
+%endif
     -DCMAKE_INSTALL_PREFIX=%{_prefix} \
 "
 
@@ -63,11 +67,16 @@ chmod 0755 %{buildroot}%{_bindir}/gbc
 %{_libdir}/%{name}/*
 
 %changelog
+* Tue Oct 27 2020 Joe Schmitt <joschmit@microsoft.com> - 8.0.1-4
+- Include all sources regardless of architecture.
+
 *   Mon Oct 19 2020 Pawel Winogrodzki <pawelwi@microsoft.com> 8.0.1-3
 -   License verified.
 -   Added source URL.
 -   Added 'Vendor' and 'Distribution' tags.
+
 *   Tue May 19 2020 Jonathan Chiu <jochi@microsoft.com> 8.0.1-2
 -   Add aarch64 support
+
 *   Mon Apr 06 2020 Jonathan Chiu <jochi@microsoft.com> 8.0.1-1
 -   Original version for CBL-Mariner.


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

Cherrypick: https://github.com/microsoft/CBL-Mariner/pull/280

bond's `SOURCE1` changed depending on which architecture it was being processed on. This resulted in an architecture-specific SRPM being produced for it. SRPMs should contain all the needed sources for every supported architecture it can build on.

Change bond to always list both `aarch64` and `x86_64` specific sources, but selectively choose which one to use.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Include both `aarch64` and `x86_64` sources in bond.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local builds.