### PR TITLE
No patch for mySQL and CVE-2012-5627

### DIFF
--- a/SPECS/mysql/mysql.spec
+++ b/SPECS/mysql/mysql.spec
@@ -76,8 +76,8 @@ make test
 %{_libdir}/pkgconfig/mysqlclient.pc
 
 %changelog
-* Thu Nov 05 2020 Rachel Menge <rachelmenge@microsoft.com> - 8.0.22-2
-- Added no patch for CVE-2012-5627
+*   Thu Nov 05 2020 Rachel Menge <rachelmenge@microsoft.com> - 8.0.22-2
+-   Added no patch for CVE-2012-5627
 
 *   Tue Nov 03 2020 Rachel Menge <rachelmenge@microsoft.com> - 8.0.22-1
 -   Upgrade to 8.0.22. Fixes 40 CVES.

--- a/SPECS/mysql/mysql.spec
+++ b/SPECS/mysql/mysql.spec
@@ -77,7 +77,7 @@ make test
 
 %changelog
 * Thu Nov 05 2020 Rachel Menge <rachelmenge@microsoft.com> - 8.0.22-2
-- No patch
+- Added no patch for CVE-2012-5627
 
 *   Tue Nov 03 2020 Rachel Menge <rachelmenge@microsoft.com> - 8.0.22-1
 -   Upgrade to 8.0.22. Fixes 40 CVES.

--- a/SPECS/mysql/mysql.spec
+++ b/SPECS/mysql/mysql.spec
@@ -1,13 +1,14 @@
 Summary:        MySQL.
 Name:           mysql
 Version:        8.0.22
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2 with exceptions AND LGPLv2 AND BSD
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Group:          Applications/Databases
 URL:            https://www.mysql.com
 Source0:        https://cdn.mysql.com/Downloads/MySQL-8.0/%{name}-boost-%{version}.tar.gz
+Patch0:         CVE-2012-5627.nopatch
 BuildRequires:  cmake
 BuildRequires:  libtirpc-devel
 BuildRequires:  openssl-devel
@@ -25,7 +26,7 @@ Requires:       %{name} = %{version}-%{release}
 Development headers for developing applications linking to maridb
 
 %prep
-%setup -q %{name}-boost-%{version}
+%autosetup -p1
 
 %build
 cmake . \
@@ -75,9 +76,12 @@ make test
 %{_libdir}/pkgconfig/mysqlclient.pc
 
 %changelog
-* Tue Nov 03 2020 Rachel Menge <rachelmenge@microsoft.com> - 8.0.22-1
-- Upgrade to 8.0.22. Fixes 40 CVES.
-- Lint spec
+* Thu Nov 05 2020 Rachel Menge <rachelmenge@microsoft.com> - 8.0.22-2
+- No patch
+
+*   Tue Nov 03 2020 Rachel Menge <rachelmenge@microsoft.com> - 8.0.22-1
+-   Upgrade to 8.0.22. Fixes 40 CVES.
+-   Lint spec
 
 *   Tue Aug 18 2020 Henry Beberman <henry.beberman@microsoft.com> - 8.0.21-1
 -   Upgrade to 8.0.21. Fixes 32 CVEs.


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `./.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Nopatch to address CVE-2012-5627.  NIST description is misleading and vendors only fixed MariaDB, but not MySQL. However, Bugzilla decided to not fix this particular CVE for MySQL: https://bugzilla.redhat.com/show_bug.cgi?id=883719 

###### Change Log  <!-- REQUIRED -->
Nopatch to address CVE-2012-5627.

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2012-5627

###### Test Methodology
- local package build 