### PR TITLE
Fix word wrapping in qemu-kvm CVE-2018-19665 patch

### DIFF
--- a/SPECS/qemu-kvm/CVE-2018-19665.patch
+++ b/SPECS/qemu-kvm/CVE-2018-19665.patch
@@ -99,8 +99,7 @@ diff --git a/hw/bt/core.c b/hw/bt/core.c
 index 78370e64f5..62720d1663 100644
 --- a/hw/bt/core.c
 +++ b/hw/bt/core.c
-@@ -45,7 +45,7 @@ static void bt_dummy_lmp_disconnect_master(struct bt_link_s 
-*link)
+@@ -45,7 +45,7 @@ static void bt_dummy_lmp_disconnect_master(struct bt_link_s *link)
  }
  
  static void bt_dummy_lmp_acl_resp(struct bt_link_s *link,
@@ -122,8 +121,7 @@ index 0341ded50c..26bd516d31 100644
  {
      int off = s->out_start + s->out_len;
  
-@@ -112,14 +112,14 @@ static uint8_t *csrhci_out_packet(struct csrhci_s *s, int 
-len)
+@@ -112,14 +112,14 @@ static uint8_t *csrhci_out_packet(struct csrhci_s *s, int len)
  
      if (off < FIFO_LEN) {
          if (off + len > FIFO_LEN && (s->out_size = off + len) > FIFO_LEN * 2) {
@@ -140,8 +138,7 @@ len)
          exit(-1);
      }
  
-@@ -127,7 +127,7 @@ static uint8_t *csrhci_out_packet(struct csrhci_s *s, int 
-len)
+@@ -127,7 +127,7 @@ static uint8_t *csrhci_out_packet(struct csrhci_s *s, int len)
  }
  
  static inline uint8_t *csrhci_out_packet_csr(struct csrhci_s *s,
@@ -150,8 +147,7 @@ len)
  {
      uint8_t *ret = csrhci_out_packetz(s, len + 2);
  
-@@ -138,7 +138,7 @@ static inline uint8_t *csrhci_out_packet_csr(struct 
-csrhci_s *s,
+@@ -138,7 +138,7 @@ static inline uint8_t *csrhci_out_packet_csr(struct csrhci_s *s,
  }
  
  static inline uint8_t *csrhci_out_packet_event(struct csrhci_s *s,
@@ -160,8 +156,7 @@ csrhci_s *s,
  {
      uint8_t *ret = csrhci_out_packetz(s,
                      len + 1 + sizeof(struct hci_event_hdr));
-@@ -151,7 +151,7 @@ static inline uint8_t *csrhci_out_packet_event(struct 
-csrhci_s *s,
+@@ -151,7 +151,7 @@ static inline uint8_t *csrhci_out_packet_event(struct csrhci_s *s,
  }
  
  static void csrhci_in_packet_vendor(struct csrhci_s *s, int ocf,
@@ -262,8 +257,7 @@ index c6b2cc1d48..c59ccc55b9 100644
          exit(-1);
      }
  
-@@ -475,7 +475,7 @@ static inline uint8_t *bt_hci_event_start(struct bt_hci_s 
-*hci,
+@@ -475,7 +475,7 @@ static inline uint8_t *bt_hci_event_start(struct bt_hci_s *hci,
  }
  
  static inline void bt_hci_event(struct bt_hci_s *hci, int evt,
@@ -272,8 +266,7 @@ index c6b2cc1d48..c59ccc55b9 100644
  {
      uint8_t *packet = bt_hci_event_start(hci, evt, len);
  
-@@ -500,7 +500,7 @@ static inline void bt_hci_event_status(struct bt_hci_s 
-*hci, int status)
+@@ -500,7 +500,7 @@ static inline void bt_hci_event_status(struct bt_hci_s *hci, int status)
  }
  
  static inline void bt_hci_event_complete(struct bt_hci_s *hci,
@@ -282,8 +275,7 @@ index c6b2cc1d48..c59ccc55b9 100644
  {
      uint8_t *packet = bt_hci_event_start(hci, EVT_CMD_COMPLETE,
                      len + EVT_CMD_COMPLETE_SIZE);
-@@ -1477,7 +1477,7 @@ static inline void bt_hci_event_num_comp_pkts(struct 
-bt_hci_s *hci,
+@@ -1477,7 +1477,7 @@ static inline void bt_hci_event_num_comp_pkts(struct bt_hci_s *hci,
  }
  
  static void bt_submit_hci(struct HCIInfo *info,
@@ -310,8 +302,7 @@ bt_hci_s *hci,
  {
      struct hci_acl_hdr *pkt = (void *) hci->acl_buf;
  
-@@ -1990,7 +1990,7 @@ static inline void bt_hci_lmp_acl_data(struct bt_hci_s 
-*hci, uint16_t handle,
+@@ -1990,7 +1990,7 @@ static inline void bt_hci_lmp_acl_data(struct bt_hci_s *hci, uint16_t handle,
      /* TODO: avoid memcpy'ing */
  
      if (len + HCI_ACL_HDR_SIZE > sizeof(hci->acl_buf)) {
@@ -320,8 +311,7 @@ bt_hci_s *hci,
                       __func__, len);
          return;
      }
-@@ -2004,7 +2004,7 @@ static inline void bt_hci_lmp_acl_data(struct bt_hci_s 
-*hci, uint16_t handle,
+@@ -2004,7 +2004,7 @@ static inline void bt_hci_lmp_acl_data(struct bt_hci_s *hci, uint16_t handle,
  }
  
  static void bt_hci_lmp_acl_data_slave(struct bt_link_s *btlink,
@@ -330,8 +320,7 @@ bt_hci_s *hci,
  {
      struct bt_hci_link_s *link = (struct bt_hci_link_s *) btlink;
  
-@@ -2013,14 +2013,14 @@ static void bt_hci_lmp_acl_data_slave(struct bt_link_s 
-*btlink,
+@@ -2013,14 +2013,14 @@ static void bt_hci_lmp_acl_data_slave(struct bt_link_s *btlink,
  }
  
  static void bt_hci_lmp_acl_data_host(struct bt_link_s *link,
@@ -415,8 +404,7 @@ index 056291f9b5..c5ecc8bdcd 100644
  {
      uint8_t *pkt, hdr = (BT_DATA << 4) | type;
      int plen;
-@@ -190,7 +190,7 @@ static void bt_hid_send_data(struct bt_l2cap_conn_params_s 
-*ch, int type,
+@@ -190,7 +190,7 @@ static void bt_hid_send_data(struct bt_l2cap_conn_params_s *ch, int type,
  }
  
  static void bt_hid_control_transaction(struct bt_hid_device_s *s,
@@ -425,8 +413,7 @@ index 056291f9b5..c5ecc8bdcd 100644
  {
      uint8_t type, parameter;
      int rlen, ret = -1;
-@@ -362,7 +362,7 @@ static void bt_hid_control_transaction(struct 
-bt_hid_device_s *s,
+@@ -362,7 +362,7 @@ static void bt_hid_control_transaction(struct bt_hid_device_s *s,
          bt_hid_send_handshake(s, ret);
  }
  
@@ -488,8 +475,7 @@ index 9cf27f0df6..efd9a4b66a 100644
  {
      uint16_t fcs = 0x0000;
  
-@@ -186,7 +186,7 @@ static void l2cap_monitor_timer_update(struct l2cap_chan_s 
-*ch)
+@@ -186,7 +186,7 @@ static void l2cap_monitor_timer_update(struct l2cap_chan_s *ch)
  }
  
  static void l2cap_command_reject(struct l2cap_instance_s *l2cap, int id,
@@ -498,8 +484,7 @@ index 9cf27f0df6..efd9a4b66a 100644
  {
      uint8_t *pkt;
      l2cap_cmd_hdr *hdr;
-@@ -247,7 +247,7 @@ static void l2cap_connection_response(struct 
-l2cap_instance_s *l2cap,
+@@ -247,7 +247,7 @@ static void l2cap_connection_response(struct l2cap_instance_s *l2cap,
  }
  
  static void l2cap_configuration_request(struct l2cap_instance_s *l2cap,
@@ -508,8 +493,7 @@ l2cap_instance_s *l2cap,
  {
      uint8_t *pkt;
      l2cap_cmd_hdr *hdr;
-@@ -275,7 +275,7 @@ static void l2cap_configuration_request(struct 
-l2cap_instance_s *l2cap,
+@@ -275,7 +275,7 @@ static void l2cap_configuration_request(struct l2cap_instance_s *l2cap,
  }
  
  static void l2cap_configuration_response(struct l2cap_instance_s *l2cap,
@@ -519,8 +503,7 @@ len)
  {
      uint8_t *pkt;
      l2cap_cmd_hdr *hdr;
-@@ -322,7 +322,7 @@ static void l2cap_disconnection_response(struct 
-l2cap_instance_s *l2cap,
+@@ -322,7 +322,7 @@ static void l2cap_disconnection_response(struct l2cap_instance_s *l2cap,
  }
  
  static void l2cap_echo_response(struct l2cap_instance_s *l2cap,
@@ -529,8 +512,7 @@ l2cap_instance_s *l2cap,
  {
      uint8_t *pkt;
      l2cap_cmd_hdr *hdr;
-@@ -343,7 +343,7 @@ static void l2cap_echo_response(struct l2cap_instance_s 
-*l2cap,
+@@ -343,7 +343,7 @@ static void l2cap_echo_response(struct l2cap_instance_s *l2cap,
  }
  
  static void l2cap_info_response(struct l2cap_instance_s *l2cap, int type,
@@ -539,8 +521,7 @@ l2cap_instance_s *l2cap,
  {
      uint8_t *pkt;
      l2cap_cmd_hdr *hdr;
-@@ -366,16 +366,18 @@ static void l2cap_info_response(struct l2cap_instance_s 
-*l2cap, int type,
+@@ -366,16 +366,18 @@ static void l2cap_info_response(struct l2cap_instance_s *l2cap, int type,
      l2cap->signalling_ch.params.sdu_submit(&l2cap->signalling_ch.params);
  }
  
@@ -563,8 +544,7 @@ l2cap_instance_s *l2cap,
  
  static int l2cap_cid_new(struct l2cap_instance_s *l2cap)
  {
-@@ -499,7 +501,7 @@ static void l2cap_channel_config_req_event(struct 
-l2cap_instance_s *l2cap,
+@@ -499,7 +501,7 @@ static void l2cap_channel_config_req_event(struct l2cap_instance_s *l2cap,
  
  static int l2cap_channel_config(struct l2cap_instance_s *l2cap,
                  struct l2cap_chan_s *ch, int flag,
@@ -573,8 +553,7 @@ l2cap_instance_s *l2cap,
  {
      l2cap_conf_opt *opt;
      l2cap_conf_opt_qos *qos;
-@@ -684,7 +686,7 @@ static int l2cap_channel_config(struct l2cap_instance_s 
-*l2cap,
+@@ -684,7 +686,7 @@ static int l2cap_channel_config(struct l2cap_instance_s *l2cap,
  }
  
  static void l2cap_channel_config_req_msg(struct l2cap_instance_s *l2cap,
@@ -583,8 +562,7 @@ l2cap_instance_s *l2cap,
  {
      struct l2cap_chan_s *ch;
  
-@@ -716,7 +718,7 @@ static void l2cap_channel_config_req_msg(struct 
-l2cap_instance_s *l2cap,
+@@ -716,7 +718,7 @@ static void l2cap_channel_config_req_msg(struct l2cap_instance_s *l2cap,
  }
  
  static int l2cap_channel_config_rsp_msg(struct l2cap_instance_s *l2cap,
@@ -593,8 +571,7 @@ l2cap_instance_s *l2cap,
  {
      struct l2cap_chan_s *ch;
  
-@@ -784,7 +786,7 @@ static void l2cap_info(struct l2cap_instance_s *l2cap, int 
-type)
+@@ -784,7 +786,7 @@ static void l2cap_info(struct l2cap_instance_s *l2cap, int type)
  }
  
  static void l2cap_command(struct l2cap_instance_s *l2cap, int code, int id,
@@ -603,8 +580,7 @@ type)
  {
      int err;
  
-@@ -939,7 +941,7 @@ static void l2cap_rexmit_enable(struct l2cap_chan_s *ch, 
-int enable)
+@@ -939,7 +941,7 @@ static void l2cap_rexmit_enable(struct l2cap_chan_s *ch, int enable)
  }
  
  /* Command frame SDU */
@@ -613,8 +589,7 @@ int enable)
  {
      struct l2cap_instance_s *l2cap = opaque;
      const l2cap_cmd_hdr *hdr;
-@@ -967,7 +969,7 @@ static void l2cap_cframe_in(void *opaque, const uint8_t 
-*data, int len)
+@@ -967,7 +969,7 @@ static void l2cap_cframe_in(void *opaque, const uint8_t *data, int len)
  }
  
  /* Group frame SDU */
@@ -623,8 +598,7 @@ int enable)
  {
  }
  
-@@ -978,7 +980,7 @@ static void l2cap_sframe_in(struct l2cap_chan_s *ch, 
-uint16_t ctrl)
+@@ -978,7 +980,7 @@ static void l2cap_sframe_in(struct l2cap_chan_s *ch, uint16_t ctrl)
  
  /* Basic L2CAP mode Information frame */
  static void l2cap_bframe_in(struct l2cap_chan_s *ch, uint16_t cid,
@@ -633,8 +607,7 @@ uint16_t ctrl)
  {
      /* We have a full SDU, no further processing */
      ch->params.sdu_in(ch->params.opaque, hdr->data, len);
-@@ -986,7 +988,7 @@ static void l2cap_bframe_in(struct l2cap_chan_s *ch, 
-uint16_t cid,
+@@ -986,7 +988,7 @@ static void l2cap_bframe_in(struct l2cap_chan_s *ch, uint16_t cid,
  
  /* Flow Control and Retransmission mode frame */
  static void l2cap_iframe_in(struct l2cap_chan_s *ch, uint16_t cid,
@@ -652,8 +625,7 @@ uint16_t cid,
  {
      const l2cap_hdr *hdr = (void *) l2cap->frame_in;
  
-@@ -1124,7 +1126,7 @@ static inline void l2cap_pdu_submit(struct 
-l2cap_instance_s *l2cap)
+@@ -1124,7 +1126,7 @@ static inline void l2cap_pdu_submit(struct l2cap_instance_s *l2cap)
              (l2cap->link, l2cap->frame_out, 1, l2cap->frame_out_len);
  }
  
@@ -663,8 +635,7 @@ len)
  {
      struct l2cap_chan_s *chan = (struct l2cap_chan_s *) parm;
  
-@@ -1147,7 +1149,7 @@ static void l2cap_bframe_submit(struct 
-bt_l2cap_conn_params_s *parms)
+@@ -1147,7 +1149,7 @@ static void l2cap_bframe_submit(struct bt_l2cap_conn_params_s *parms)
  
  #if 0
  /* Stub: Only used if an emulated device requests outgoing flow control */
@@ -674,8 +645,7 @@ len)
  {
      struct l2cap_chan_s *chan = (struct l2cap_chan_s *) parm;
  
-@@ -1292,7 +1294,7 @@ static void l2cap_lmp_disconnect_slave(struct bt_link_s 
-*link)
+@@ -1292,7 +1294,7 @@ static void l2cap_lmp_disconnect_slave(struct bt_link_s *link)
  }
  
  static void l2cap_lmp_acl_data_slave(struct bt_link_s *link,
@@ -684,8 +654,7 @@ len)
  {
      struct slave_l2cap_instance_s *l2cap =
              (struct slave_l2cap_instance_s *) link;
-@@ -1305,7 +1307,7 @@ static void l2cap_lmp_acl_data_slave(struct bt_link_s 
-*link,
+@@ -1305,7 +1307,7 @@ static void l2cap_lmp_acl_data_slave(struct bt_link_s *link,
  
  /* Stub */
  static void l2cap_lmp_acl_data_host(struct bt_link_s *link,
@@ -698,8 +667,7 @@ diff --git a/hw/bt/sdp.c b/hw/bt/sdp.c
 index f4aba9d74f..163d315874 100644
 --- a/hw/bt/sdp.c
 +++ b/hw/bt/sdp.c
-@@ -497,7 +497,7 @@ static ssize_t sdp_svc_search_attr_get(struct 
-bt_l2cap_sdp_state_s *sdp,
+@@ -497,7 +497,7 @@ static ssize_t sdp_svc_search_attr_get(struct bt_l2cap_sdp_state_s *sdp,
      return end + 2;
  }
  
@@ -708,8 +676,7 @@ bt_l2cap_sdp_state_s *sdp,
  {
      struct bt_l2cap_sdp_state_s *sdp = opaque;
      enum bt_sdp_cmd pdu_id;
-@@ -507,7 +507,7 @@ static void bt_l2cap_sdp_sdu_in(void *opaque, const uint8_t 
-*data, int len)
+@@ -507,7 +507,7 @@ static void bt_l2cap_sdp_sdu_in(void *opaque, const uint8_t *data, int len)
      int rsp_len = 0;
  
      if (len < 5) {
@@ -718,8 +685,7 @@ bt_l2cap_sdp_state_s *sdp,
          return;
      }
  
-@@ -518,7 +518,7 @@ static void bt_l2cap_sdp_sdu_in(void *opaque, const uint8_t 
-*data, int len)
+@@ -518,7 +518,7 @@ static void bt_l2cap_sdp_sdu_in(void *opaque, const uint8_t *data, int len)
      len -= 5;
  
      if (len != plen) {
@@ -732,8 +698,7 @@ diff --git a/hw/usb/dev-bluetooth.c b/hw/usb/dev-bluetooth.c
 index eac7365b0a..cf46ba06c6 100644
 --- a/hw/usb/dev-bluetooth.c
 +++ b/hw/usb/dev-bluetooth.c
-@@ -265,7 +265,7 @@ static void usb_bt_fifo_reset(struct usb_hci_in_fifo_s 
-*fifo)
+@@ -265,7 +265,7 @@ static void usb_bt_fifo_reset(struct usb_hci_in_fifo_s *fifo)
  }
  
  static void usb_bt_fifo_enqueue(struct usb_hci_in_fifo_s *fifo,
@@ -742,8 +707,7 @@ index eac7365b0a..cf46ba06c6 100644
  {
      int off = fifo->dstart + fifo->dlen;
      uint8_t *buf;
-@@ -274,13 +274,13 @@ static void usb_bt_fifo_enqueue(struct usb_hci_in_fifo_s 
-*fifo,
+@@ -274,13 +274,13 @@ static void usb_bt_fifo_enqueue(struct usb_hci_in_fifo_s *fifo,
      if (off <= DFIFO_LEN_MASK) {
          if (off + len > DFIFO_LEN_MASK + 1 &&
                          (fifo->dsize = off + len) > (DFIFO_LEN_MASK + 1) * 2) {
@@ -759,8 +723,7 @@ index eac7365b0a..cf46ba06c6 100644
              exit(-1);
          }
          buf = fifo->data + off - fifo->dsize;
-@@ -319,7 +319,7 @@ static inline void usb_bt_fifo_dequeue(struct 
-usb_hci_in_fifo_s *fifo,
+@@ -319,7 +319,7 @@ static inline void usb_bt_fifo_dequeue(struct usb_hci_in_fifo_s *fifo,
  
  static inline void usb_bt_fifo_out_enqueue(struct USBBtState *s,
                  struct usb_hci_out_fifo_s *fifo,

--- a/SPECS/qemu-kvm/CVE-2018-19665.patch
+++ b/SPECS/qemu-kvm/CVE-2018-19665.patch
@@ -498,8 +498,7 @@ index 9cf27f0df6..efd9a4b66a 100644
  
  static void l2cap_configuration_response(struct l2cap_instance_s *l2cap,
 -                int scid, int flag, int result, const uint8_t *data, int len)
-+                int scid, int flag, int result, const uint8_t *data, size_t 
-len)
++                int scid, int flag, int result, const uint8_t *data, size_t len)
  {
      uint8_t *pkt;
      l2cap_cmd_hdr *hdr;
@@ -630,8 +629,7 @@ len)
  }
  
 -static uint8_t *l2cap_bframe_out(struct bt_l2cap_conn_params_s *parm, int len)
-+static uint8_t *l2cap_bframe_out(struct bt_l2cap_conn_params_s *parm, size_t 
-len)
++static uint8_t *l2cap_bframe_out(struct bt_l2cap_conn_params_s *parm, size_t len)
  {
      struct l2cap_chan_s *chan = (struct l2cap_chan_s *) parm;
  
@@ -640,8 +638,7 @@ len)
  #if 0
  /* Stub: Only used if an emulated device requests outgoing flow control */
 -static uint8_t *l2cap_iframe_out(struct bt_l2cap_conn_params_s *parm, int len)
-+static uint8_t *l2cap_iframe_out(struct bt_l2cap_conn_params_s *parm, size_t 
-len)
++static uint8_t *l2cap_iframe_out(struct bt_l2cap_conn_params_s *parm, size_t len)
  {
      struct l2cap_chan_s *chan = (struct l2cap_chan_s *) parm;
  


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Fix a word-wrapping issue with CVE-2018-19665's patch. This issue was caught in testing, but the fix was not pushed to the merged PR #324.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Fix word wrapping in CVE-2018-19665 patch
- Does not bump qemu-kvm release number, as the latest release has not been built

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: Locally building
