### PR TITLE
Skipping one `zsh` ptest testcase if ran as superuser.

### DIFF
--- a/SPECS/zsh/0001-Skipping-test-if-ran-as-superuser.patch
+++ b/SPECS/zsh/0001-Skipping-test-if-ran-as-superuser.patch
@@ -1,0 +1,37 @@
+From 0fbbbea15b38364830d7b341c86682f05575ae0b Mon Sep 17 00:00:00 2001
+From: Pawel <pawelwi@microsoft.com>
+Date: Tue, 10 Nov 2020 18:37:47 -0800
+Subject: [PATCH] Skipping test if ran as superuser.
+
+---
+ Test/D02glob.ztst | 14 +++++++++-----
+ 1 file changed, 9 insertions(+), 5 deletions(-)
+
+diff --git a/Test/D02glob.ztst b/Test/D02glob.ztst
+index b0650c8..39d97c1 100644
+--- a/Test/D02glob.ztst
++++ b/Test/D02glob.ztst
+@@ -729,11 +729,15 @@
+ >not/exist
+ >exist
+ 
+- mkdir -m 000 glob.tmp/secret-d000
+- mkdir -m 111 glob.tmp/secret-d111
+- mkdir -m 444 glob.tmp/secret-d444
+- for 1 in 000 111 444 ; do ln -s secret-d$1 glob.tmp/secret-s$1; done
+- print -rC 2 -- glob.tmp/secret-*/ glob.tmp/secret-*(-/)
++ if (( UID )); then
++   mkdir -m 000 glob.tmp/secret-d000
++   mkdir -m 111 glob.tmp/secret-d111
++   mkdir -m 444 glob.tmp/secret-d444
++   for 1 in 000 111 444 ; do ln -s secret-d$1 glob.tmp/secret-s$1; done
++   print -rC 2 -- glob.tmp/secret-*/ glob.tmp/secret-*(-/)
++ else
++   ZTST_skip="cannot test unreadable directories globbing when tests run as superuser"
++ fi
+ -f:unreadable directories can be globbed (users/24619, users/24626)
+ >glob.tmp/secret-d000/  glob.tmp/secret-d000
+ >glob.tmp/secret-d111/  glob.tmp/secret-d111
+-- 
+2.17.1
+

--- a/SPECS/zsh/zsh.spec
+++ b/SPECS/zsh/zsh.spec
@@ -1,17 +1,19 @@
 # this file is encoded in UTF-8  -*- coding: utf-8 -*-
 
-Summary:        Z shell
-Name:           zsh
-Version:        5.8
-Release:        3%{?dist}
-License:        MIT and GPLv2.0 and GPLv3.0 and GPLv2+
-URL:            http://zsh.sourceforge.net/
-Group:          System Environment/Shells
-Vendor:         Microsoft Corporation
-Distribution:   Mariner
-Source0:        https://sourceforge.net/projects/%{name}/files/%{name}/%{version}/%{name}-%{version}.tar.xz
-Source1:        zprofile.rhs
-Source2:        zshrc
+Summary:      Z shell
+Name:         zsh
+Version:      5.8
+Release:      4%{?dist}
+License:      MIT and GPLv2.0 and GPLv3.0 and GPLv2+
+URL:          http://zsh.sourceforge.net/
+Group:        System Environment/Shells
+Vendor:       Microsoft Corporation
+Distribution: Mariner
+Source0:      https://sourceforge.net/projects/%{name}/files/%{name}/%{version}/%{name}-%{version}.tar.xz
+Source1:      zprofile.rhs
+Source2:      zshrc
+
+Patch0:       0001-Skipping-test-if-ran-as-superuser.patch
 
 BuildRequires: coreutils
 BuildRequires: tar
@@ -27,7 +29,8 @@ BuildRequires: texinfo
 BuildRequires: gawk
 BuildRequires: elfutils
 Requires(post): /bin/grep
-Requires(postun): coreutils /bin/grep
+Requires(postun): /bin/grep
+Requires(postun): coreutils
 
 Provides: /bin/zsh
 
@@ -55,7 +58,7 @@ This package contains the Zsh manual in html format.
 
 %prep
 
-%setup -q
+%autosetup -p1
 
 %build
 # make loading of module's dependencies work again (#1277996)
@@ -143,30 +146,43 @@ fi
 %doc Doc/*.html
 
 %changelog
+* Tue Nov 10 2020 Pawel Winogrodzki <pawelwi@microsoft.com> - 5.8-4
+- Adding a patch to skip globbing test if ran as root.
+
 * Sat May 09 00:20:44 PST 2020 Nick Samson <nisamson@microsoft.com> - 5.8-3
 - Added %%license line automatically
 
-*   Thu Apr 30 2020 Emre Girgin <mrgirgin@microsoft.com> 5.8-2
--   Renaming linux-api-headers to kernel-headers
-*   Fri Apr 10 2020 Jon Slobodzian <joslobo@microsoft.com> 5.8-1
--   Updated to latest version to fix CVE CVE-2019-20044.
--   Fixed Source0 download link
--   Verified license.
-*   Thu Apr 09 2020 Nicolas Ontiveros <niontive@microsoft.com> 5.6.1-3
--   Remove coreutils and only use toybox in requires.
-*   Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 5.6.1-2
--   Initial CBL-Mariner import from Photon (license: Apache2).
-*   Thu Sep 13 2018 Siju Maliakkal <smaliakkal@vmware.com> 5.6.1-1
--   Upgrading to latest
-*   Mon Mar 19 2018 Xiaolin Li <xiaolinl@vmware.com> 5.3.1-5
--   Fix CVE-2018-7548
-*   Mon Sep 18 2017 Alexey Makhalov <amakhalov@vmware.com> 5.3.1-4
--   Requires coreutils or toybox and /bin/grep
-*   Fri Sep 15 2017 Bo Gan <ganb@vmware.com> 5.3.1-3
--   Clean up check
-*   Wed Aug 02 2017 Chang Lee <changlee@vmware.com> 5.3.1-2
--   Skip a test case that is not supported from photon OS chroot
-*   Wed Apr 05 2017 Xiaolin Li <xiaolinl@vmware.com> 5.3.1-1
--   Updated to version 5.3.1.
-*   Sun Jul 24 2016 Ivan Porto Carrero <icarrero@vmware.com> - 5.2-1
--   Initial zsh for photon os
+* Thu Apr 30 2020 Emre Girgin <mrgirgin@microsoft.com> - 5.8-2
+- Renaming linux-api-headers to kernel-headers
+
+* Fri Apr 10 2020 Jon Slobodzian <joslobo@microsoft.com> - 5.8-1
+- Updated to latest version to fix CVE CVE-2019-20044.
+- Fixed Source0 download link
+- Verified license.
+
+* Thu Apr 09 2020 Nicolas Ontiveros <niontive@microsoft.com> - 5.6.1-3
+- Remove coreutils and only use toybox in requires.
+
+* Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> - 5.6.1-2
+- Initial CBL-Mariner import from Photon (license: Apache2).
+
+* Thu Sep 13 2018 Siju Maliakkal <smaliakkal@vmware.com> - 5.6.1-1
+- Upgrading to latest
+
+* Mon Mar 19 2018 Xiaolin Li <xiaolinl@vmware.com> - 5.3.1-5
+- Fix CVE-2018-7548
+
+* Mon Sep 18 2017 Alexey Makhalov <amakhalov@vmware.com> - 5.3.1-4
+- Requires coreutils or toybox and /bin/grep
+
+* Fri Sep 15 2017 Bo Gan <ganb@vmware.com> - 5.3.1-3
+- Clean up check
+
+* Wed Aug 02 2017 Chang Lee <changlee@vmware.com> - 5.3.1-2
+- Skip a test case that is not supported from photon OS chroot
+
+* Wed Apr 05 2017 Xiaolin Li <xiaolinl@vmware.com> - 5.3.1-1
+- Updated to version 5.3.1.
+
+* Sun Jul 24 2016 Ivan Porto Carrero <icarrero@vmware.com> - 5.2-1
+- Initial zsh for photon os

--- a/SPECS/zsh/zsh.spec
+++ b/SPECS/zsh/zsh.spec
@@ -93,15 +93,6 @@ done
 mkdir -p %{buildroot}%{_sysconfdir}/skel
 install -m 644 %{SOURCE2} %{buildroot}%{_sysconfdir}/skel/.zshrc
 
-# This is just here to shut up rpmlint, and is very annoying.
-# Note that we can't chmod everything as then rpmlint will complain about
-# those without a she-bang line.
-for i in checkmail harden run-help zcalc zkbd; do
-    sed -i -e 's!/usr/local/bin/zsh!%{_bindir}/zsh!' \
-    %{buildroot}%{_datadir}/zsh/%{version}/functions/$i
-    chmod +x %{buildroot}%{_datadir}/zsh/%{version}/functions/$i
-done
-
 sed -i "s!%{buildroot}%{_datadir}/%{name}/%{version}/help!%{_datadir}/%{name}/%{version}/help!" \
     %{buildroot}%{_datadir}/zsh/%{version}/functions/{run-help,_run-help}
 
@@ -147,6 +138,7 @@ fi
 %changelog
 * Tue Nov 10 2020 Pawel Winogrodzki <pawelwi@microsoft.com> - 5.8-4
 - Adding a patch to skip globbing test if ran as root.
+- Removing redundant 'sed' and 'chmod' commands in %%install.
 
 * Sat May 09 00:20:44 PST 2020 Nick Samson <nisamson@microsoft.com> - 5.8-3
 - Added %%license line automatically

--- a/SPECS/zsh/zsh.spec
+++ b/SPECS/zsh/zsh.spec
@@ -1,38 +1,39 @@
 # this file is encoded in UTF-8  -*- coding: utf-8 -*-
 
-Summary:      Z shell
-Name:         zsh
-Version:      5.8
-Release:      4%{?dist}
-License:      MIT and GPLv2.0 and GPLv3.0 and GPLv2+
-URL:          http://zsh.sourceforge.net/
-Group:        System Environment/Shells
-Vendor:       Microsoft Corporation
-Distribution: Mariner
-Source0:      https://sourceforge.net/projects/%{name}/files/%{name}/%{version}/%{name}-%{version}.tar.xz
-Source1:      zprofile.rhs
-Source2:      zshrc
+Summary:        Z shell
+Name:           zsh
+Version:        5.8
+Release:        4%{?dist}
+License:        MIT AND GPLv2.0 AND GPLv3.0 AND GPLv2+
+Vendor:         Microsoft Corporation
+Distribution:   Mariner
+Group:          System Environment/Shells
+URL:            http://zsh.sourceforge.net/
+Source0:        https://sourceforge.net/projects/%{name}/files/%{name}/%{version}/%{name}-%{version}.tar.xz
+Source1:        zprofile.rhs
+Source2:        zshrc
 
-Patch0:       0001-Skipping-test-if-ran-as-superuser.patch
+Patch0:         0001-Skipping-test-if-ran-as-superuser.patch
 
-BuildRequires: coreutils
-BuildRequires: tar
-BuildRequires: diffutils
-BuildRequires: make
-BuildRequires: gcc
-BuildRequires: binutils
-BuildRequires: kernel-headers
-BuildRequires: sed
-BuildRequires: ncurses-devel
-BuildRequires: libcap-devel
-BuildRequires: texinfo
-BuildRequires: gawk
-BuildRequires: elfutils
+BuildRequires:  binutils
+BuildRequires:  coreutils
+BuildRequires:  diffutils
+BuildRequires:  elfutils
+BuildRequires:  gawk
+BuildRequires:  gcc
+BuildRequires:  kernel-headers
+BuildRequires:  libcap-devel
+BuildRequires:  make
+BuildRequires:  ncurses-devel
+BuildRequires:  sed
+BuildRequires:  tar
+BuildRequires:  texinfo
+
 Requires(post): /bin/grep
 Requires(postun): /bin/grep
 Requires(postun): coreutils
 
-Provides: /bin/zsh
+Provides:       /bin/zsh
 
 %description
 The zsh shell is a command interpreter usable as an interactive login
@@ -43,8 +44,8 @@ command completion, shell functions (with autoloading), a history
 mechanism, and more.
 
 %package html
-Summary: Zsh shell manual in html format
-Group: System Environment/Shells
+Summary:        Zsh shell manual in html format
+Group:          System Environment/Shells
 
 %description html
 The zsh shell is a command interpreter usable as an interactive login
@@ -71,42 +72,42 @@ make all html
 %check
 rm -f Test/C02cond.ztst
 make check
+
 %install
-rm -rf $RPM_BUILD_ROOT
 
 %makeinstall install.info \
-  fndir=$RPM_BUILD_ROOT%{_datadir}/%{name}/%{version}/functions \
-  sitefndir=$RPM_BUILD_ROOT%{_datadir}/%{name}/site-functions \
-  scriptdir=$RPM_BUILD_ROOT%{_datadir}/%{name}/%{version}/scripts \
-  sitescriptdir=$RPM_BUILD_ROOT%{_datadir}/%{name}/scripts \
-  runhelpdir=$RPM_BUILD_ROOT%{_datadir}/%{name}/%{version}/help
+  fndir=%{buildroot}%{_datadir}/%{name}/%{version}/functions \
+  sitefndir=%{buildroot}%{_datadir}/%{name}/site-functions \
+  scriptdir=%{buildroot}%{_datadir}/%{name}/%{version}/scripts \
+  sitescriptdir=%{buildroot}%{_datadir}/%{name}/scripts \
+  runhelpdir=%{buildroot}%{_datadir}/%{name}/%{version}/help
 
-rm -f ${RPM_BUILD_ROOT}%{_bindir}/zsh-%{version}
-rm -f $RPM_BUILD_ROOT%{_infodir}/dir
+rm -f %{buildroot}%{_bindir}/zsh-%{version}
+rm -f %{buildroot}%{_infodir}/dir
 
-mkdir -p ${RPM_BUILD_ROOT}%{_sysconfdir}
+mkdir -p %{buildroot}%{_sysconfdir}
 for i in %{SOURCE1}; do
-    install -m 644 $i $RPM_BUILD_ROOT%{_sysconfdir}/"$(basename $i .rhs)"
+    install -m 644 $i %{buildroot}%{_sysconfdir}/"$(basename $i .rhs)"
 done
 
-mkdir -p $RPM_BUILD_ROOT%{_sysconfdir}/skel
-install -m 644 %{SOURCE2} $RPM_BUILD_ROOT%{_sysconfdir}/skel/.zshrc
+mkdir -p %{buildroot}%{_sysconfdir}/skel
+install -m 644 %{SOURCE2} %{buildroot}%{_sysconfdir}/skel/.zshrc
 
 # This is just here to shut up rpmlint, and is very annoying.
 # Note that we can't chmod everything as then rpmlint will complain about
 # those without a she-bang line.
 for i in checkmail harden run-help zcalc zkbd; do
     sed -i -e 's!/usr/local/bin/zsh!%{_bindir}/zsh!' \
-    $RPM_BUILD_ROOT%{_datadir}/zsh/%{version}/functions/$i
-    chmod +x $RPM_BUILD_ROOT%{_datadir}/zsh/%{version}/functions/$i
+    %{buildroot}%{_datadir}/zsh/%{version}/functions/$i
+    chmod +x %{buildroot}%{_datadir}/zsh/%{version}/functions/$i
 done
 
-sed -i "s!$RPM_BUILD_ROOT%{_datadir}/%{name}/%{version}/help!%{_datadir}/%{name}/%{version}/help!" \
-    $RPM_BUILD_ROOT%{_datadir}/zsh/%{version}/functions/{run-help,_run-help}
+sed -i "s!%{buildroot}%{_datadir}/%{name}/%{version}/help!%{_datadir}/%{name}/%{version}/help!" \
+    %{buildroot}%{_datadir}/zsh/%{version}/functions/{run-help,_run-help}
 
 
 %clean
-rm -rf $RPM_BUILD_ROOT
+rm -rf %{buildroot}
 
 %post
 if [ "$1" = 1 ]; then
@@ -120,18 +121,16 @@ if [ "$1" = 1 ]; then
 fi
 
 %preun
-
 %postun
 if [ "$1" = 0 ] && [ -f %{_sysconfdir}/shells ] ; then
   sed -i '\!^%{_bindir}/%{name}$!d' %{_sysconfdir}/shells
   sed -i '\!^/bin/%{name}$!d' %{_sysconfdir}/shells
 fi
 
-
 %files
 %defattr(-,root,root)
 %license LICENCE
-%doc README LICENCE Etc/BUGS Etc/CONTRIBUTORS Etc/FAQ FEATURES MACHINES
+%doc README Etc/BUGS Etc/CONTRIBUTORS Etc/FAQ FEATURES MACHINES
 %doc NEWS Etc/zsh-development-guide Etc/completion-style-guide
 %attr(755,root,root) %{_bindir}/zsh
 %{_mandir}/*/*


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
The directories globbing test is supposed to fail but it doesn't since we're building everything as root.
It looks like `zsh` is solving similar cases by skipping single testcases when the test runs as root.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Skipped one testcase when `rpmbuild` is run by the root user.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
No.

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local package build.
