### PR TITLE
Upgrade python-markupsafe and python-zope-interface for setuptools compatibility

### DIFF
--- a/.github/workflows/validate-cg-manifest.sh
+++ b/.github/workflows/validate-cg-manifest.sh
@@ -19,6 +19,8 @@ ignore_list=" \
   mariner-rpm-macros \
   moby-buildx \
   moby-containerd \
+  python-markupsafe \
+  python-zope-interface \
   qt5-rpm-macros \
   runc \
   grub2-efi-binary-signed-aarch64 \

--- a/SPECS/python-markupsafe/python-markupsafe.signatures.json
+++ b/SPECS/python-markupsafe/python-markupsafe.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "MarkupSafe-1.0.tar.gz": "a6be69091dac236ea9c6bc7d012beab42010fa914c459791d627dad4910eb665"
+  "MarkupSafe-1.1.1.tar.gz": "29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b"
  }
 }

--- a/SPECS/python-markupsafe/python-markupsafe.spec
+++ b/SPECS/python-markupsafe/python-markupsafe.spec
@@ -1,17 +1,17 @@
 %{!?python2_sitelib: %define python2_sitelib %(python2 -c "from distutils.sysconfig import get_python_lib;print(get_python_lib())")}
 %{!?python3_sitelib: %define python3_sitelib %(python3 -c "from distutils.sysconfig import get_python_lib;print(get_python_lib())")}
+%define pypi_name MarkupSafe
 
 Summary:        A XML/HTML/XHTML Markup safe string for Python.
 Name:           python-markupsafe
-Version:        1.0
-Release:        5%{?dist}
+Version:        1.1.1
+Release:        1%{?dist}
 License:        BSD
 Group:          Development/Languages/Python
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
-Url:            https://pypi.python.org/pypi/MarkupSafe
-Source0:        https://pypi.python.org/packages/4d/de/32d741db316d8fdb7680822dd37001ef7a448255de9699ab4bfcbdf4172b/MarkupSafe-%{version}.tar.gz
-%define sha1    MarkupSafe=9072e80a7faa0f49805737a48f3d871eb1c48728
+URL:            https://pypi.python.org/pypi/MarkupSafe
+Source0:        http://pypi.python.org/packages/source/M/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
 
 BuildRequires:  python2
 BuildRequires:  python2-libs
@@ -37,7 +37,7 @@ Requires:       python3-libs
 Python 3 version.
 
 %prep
-%setup -q -n MarkupSafe-%{version}
+%setup -q -n %{pypi_name}-%{version}
 
 %build
 python2 setup.py build
@@ -62,16 +62,26 @@ python3 setup.py test
 %{python3_sitelib}/*
 
 %changelog
+* Wed Nov 11 2020 Thomas Crain <thcrain@microsoft.com> - 1.1.1-1
+- Upgrade to 1.1.1 to fix setuptools compatibility issues
+- Change Source0
+- Remove inline sha1
+- Lint to Mariner style
+
 * Sat May 09 00:21:01 PST 2020 Nick Samson <nisamson@microsoft.com> - 1.0-5
 - Added %%license line automatically
 
-*   Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 1.0-4
--   Initial CBL-Mariner import from Photon (license: Apache2).
-*   Wed Jun 07 2017 Xiaolin Li <xiaolinl@vmware.com> 1.0-3
--   Add python3-setuptools and python3-xml to python3 sub package Buildrequires.
-*   Thu Jun 01 2017 Dheeraj Shetty <dheerajs@vmware.com> 1.0-2
--   Removed erroneous version line
-*   Thu Mar 30 2017 Sarah Choi <sarahc@vmware.com> 1.0-1
--   Upgrade version to 1.0
-*   Thu Mar 02 2017 Xiaolin Li <xiaolinl@vmware.com> 0.23-1
--   Initial packaging for Photon
+* Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> - 1.0-4
+- Initial CBL-Mariner import from Photon (license: Apache2).
+
+* Wed Jun 07 2017 Xiaolin Li <xiaolinl@vmware.com> - 1.0-3
+- Add python3-setuptools and python3-xml to python3 sub package Buildrequires.
+
+* Thu Jun 01 2017 Dheeraj Shetty <dheerajs@vmware.com> - 1.0-2
+- Removed erroneous version line
+
+* Thu Mar 30 2017 Sarah Choi <sarahc@vmware.com> - 1.0-1
+- Upgrade version to 1.0
+
+* Thu Mar 02 2017 Xiaolin Li <xiaolinl@vmware.com> - 0.23-1
+- Initial packaging for Photon

--- a/SPECS/python-markupsafe/python-markupsafe.spec
+++ b/SPECS/python-markupsafe/python-markupsafe.spec
@@ -51,7 +51,7 @@ python3 setup.py test
 
 %files
 %defattr(-,root,root,-)
-%license LICENSE
+%license LICENSE.rst
 %{python2_sitelib}/*
 
 %files -n python3-markupsafe
@@ -62,6 +62,7 @@ python3 setup.py test
 * Wed Nov 11 2020 Thomas Crain <thcrain@microsoft.com> - 1.1.1-1
 - Upgrade to 1.1.1 to fix setuptools compatibility issues
 - Change Source0
+- Correct license location
 - Remove inline sha1
 - Lint to Mariner style
 

--- a/SPECS/python-markupsafe/python-markupsafe.spec
+++ b/SPECS/python-markupsafe/python-markupsafe.spec
@@ -1,22 +1,19 @@
 %{!?python2_sitelib: %define python2_sitelib %(python2 -c "from distutils.sysconfig import get_python_lib;print(get_python_lib())")}
 %{!?python3_sitelib: %define python3_sitelib %(python3 -c "from distutils.sysconfig import get_python_lib;print(get_python_lib())")}
 %define pypi_name MarkupSafe
-
 Summary:        A XML/HTML/XHTML Markup safe string for Python.
 Name:           python-markupsafe
 Version:        1.1.1
 Release:        1%{?dist}
 License:        BSD
-Group:          Development/Languages/Python
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
+Group:          Development/Languages/Python
 URL:            https://pypi.python.org/pypi/MarkupSafe
-Source0:        http://pypi.python.org/packages/source/M/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
-
+Source0:        https://pypi.python.org/packages/source/M/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+BuildRequires:  python-setuptools
 BuildRequires:  python2
 BuildRequires:  python2-libs
-BuildRequires:  python-setuptools
-
 Requires:       python2
 Requires:       python2-libs
 

--- a/SPECS/python-zope-interface/python-zope-interface.signatures.json
+++ b/SPECS/python-zope-interface/python-zope-interface.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "zope.interface-4.6.0.tar.gz": "1b3d0dcabc7c90b470e59e38a9acaa361be43b3a6ea644c0063951964717f0e5"
+  "zope.interface-4.7.2.tar.gz": "fd1101bd3fcb4f4cf3485bb20d6cb0b56909b94d3bd2a53a6cb9d381c3da3365"
  }
 }

--- a/SPECS/python-zope-interface/python-zope-interface.spec
+++ b/SPECS/python-zope-interface/python-zope-interface.spec
@@ -1,14 +1,16 @@
 %{!?python2_sitelib: %define python2_sitelib %(python2 -c "from distutils.sysconfig import get_python_lib;print(get_python_lib())")}
 %{!?python3_sitelib: %define python3_sitelib %(python3 -c "from distutils.sysconfig import get_python_lib;print(get_python_lib())")}
-
+%define pypi_name zope.interface
 Name:           python-zope-interface
-Version:        4.6.0
-Release:        3%{?dist}
-Url:            https://github.com/zopefoundation/zope.interface
+Version:        4.7.2
+Release:        1%{?dist}
+URL:            https://github.com/zopefoundation/zope.interface
 Summary:        Interfaces for Python
 License:        ZPLv2.1
 Group:          Development/Languages/Python
-Source0:        https://files.pythonhosted.org/packages/4e/d0/c9d16bd5b38de44a20c6dc5d5ed80a49626fafcb3db9f9efdc2a19026db6/zope.interface-%{version}.tar.gz
+Vendor:         Microsoft Corporation
+Distribution:   Mariner
+Source0:        https://pypi.python.org/packages/source/z/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
 
 BuildRequires:  python2-devel
 BuildRequires:  python2-libs
@@ -38,7 +40,7 @@ Requires:       python3-libs
 
 Python 3 version.
 %prep
-%setup -q -n zope.interface-%{version}
+%setup -q -n %{pypi_name}-%{version}
 rm -rf ../p3dir
 cp -a . ../p3dir
 
@@ -71,22 +73,35 @@ popd
 %{python3_sitelib}/*
 
 %changelog
-*   Sat May 09 2020 Nick Samson <nisamson@microsoft.com> 4.6.0-3
--   Added %%license line automatically
-*   Wed Apr 29 2020 Emre Girgin <mrgirgin@microsoft.com> 4.6.0-2
--   Renaming python-zope.interface to python-zope-interface
-*   Wed Mar 18 2020 Henry Beberman <henry.beberman@microsoft.com> 4.6.0-1
--   Initial CBL-Mariner import from Photon (license: Apache2).
--   Update to 4.6.0. Source0 URL fixed. License verified.
-*   Fri Sep 14 2018 Tapas Kundu <tkundu@vmware.com> 4.5.0-1
--   Updated to release 4.5.0
-*   Wed Jun 07 2017 Xiaolin Li <xiaolinl@vmware.com> 4.3.3-2
--   Add python3-setuptools and python3-xml to python3 sub package Buildrequires.
-*   Mon Mar 13 2017 Xiaolin Li <xiaolinl@vmware.com> 4.3.3-1
--   Updated to version 4.3.3.
-*   Mon Oct 04 2016 ChangLee <changlee@vmware.com> 4.1.3-3
--   Modified %check
-*   Tue May 24 2016 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 4.1.3-2
--   GA - Bump release of all rpms
-*   Tue Oct 27 2015 Mahmoud Bassiouny <mbassiouny@vmware.com>
--   Initial packaging for Photon
+* Wed Nov 11 2020 Thomas Crain <thcrain@microsoft.com> - 4.7.2-1
+- Update to 4.7.2 to fix setuptools compatibility issues
+- Update Source0
+- Lint to Mariner style
+
+* Sat May 09 2020 Nick Samson <nisamson@microsoft.com> - 4.6.0-3
+- Added %%license line automatically
+
+* Wed Apr 29 2020 Emre Girgin <mrgirgin@microsoft.com> - 4.6.0-2
+- Renaming python-zope.interface to python-zope-interface
+
+* Wed Mar 18 2020 Henry Beberman <henry.beberman@microsoft.com> - 4.6.0-1
+- Initial CBL-Mariner import from Photon (license: Apache2).
+- Update to 4.6.0. Source0 URL fixed. License verified.
+
+* Fri Sep 14 2018 Tapas Kundu <tkundu@vmware.com> - 4.5.0-1
+- Updated to release 4.5.0
+
+* Wed Jun 07 2017 Xiaolin Li <xiaolinl@vmware.com> - 4.3.3-2
+- Add python3-setuptools and python3-xml to python3 sub package Buildrequires.
+
+* Mon Mar 13 2017 Xiaolin Li <xiaolinl@vmware.com> - 4.3.3-1
+- Updated to version 4.3.3.
+
+* Mon Oct 04 2016 ChangLee <changlee@vmware.com> - 4.1.3-3
+- Modified %check
+
+* Tue May 24 2016 Priyesh Padmavilasom <ppadmavilasom@vmware.com> - 4.1.3-2
+- GA - Bump release of all rpms
+
+* Tue Oct 27 2015 Mahmoud Bassiouny <mbassiouny@vmware.com> - 4.1.3-1
+- Initial packaging for Photon

--- a/SPECS/python-zope-interface/python-zope-interface.spec
+++ b/SPECS/python-zope-interface/python-zope-interface.spec
@@ -1,21 +1,19 @@
 %{!?python2_sitelib: %define python2_sitelib %(python2 -c "from distutils.sysconfig import get_python_lib;print(get_python_lib())")}
 %{!?python3_sitelib: %define python3_sitelib %(python3 -c "from distutils.sysconfig import get_python_lib;print(get_python_lib())")}
 %define pypi_name zope.interface
+Summary:        Interfaces for Python
 Name:           python-zope-interface
 Version:        4.7.2
 Release:        1%{?dist}
-URL:            https://github.com/zopefoundation/zope.interface
-Summary:        Interfaces for Python
 License:        ZPLv2.1
-Group:          Development/Languages/Python
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
+Group:          Development/Languages/Python
+URL:            https://github.com/zopefoundation/zope.interface
 Source0:        https://pypi.python.org/packages/source/z/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
-
+BuildRequires:  python-setuptools
 BuildRequires:  python2-devel
 BuildRequires:  python2-libs
-BuildRequires:  python-setuptools
-
 Requires:       python2
 Requires:       python2-libs
 
@@ -39,6 +37,7 @@ Requires:       python3-libs
 %description -n python3-zope-interface
 
 Python 3 version.
+
 %prep
 %setup -q -n %{pypi_name}-%{version}
 rm -rf ../p3dir

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -4666,8 +4666,8 @@
         "type": "other",
         "other": {
           "name": "python-markupsafe",
-          "version": "1.0",
-          "downloadUrl": "https://pypi.python.org/packages/4d/de/32d741db316d8fdb7680822dd37001ef7a448255de9699ab4bfcbdf4172b/MarkupSafe-1.0.tar.gz"
+          "version": "1.1.1",
+          "downloadUrl": "https://pypi.python.org/packages/source/M/MarkupSafe/MarkupSafe-1.1.1.tar.gz"
         }
       }
     },

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -5076,8 +5076,8 @@
         "type": "other",
         "other": {
           "name": "python-zope-interface",
-          "version": "4.6.0",
-          "downloadUrl": "https://files.pythonhosted.org/packages/4e/d0/c9d16bd5b38de44a20c6dc5d5ed80a49626fafcb3db9f9efdc2a19026db6/zope.interface-4.6.0.tar.gz"
+          "version": "4.7.2",
+          "downloadUrl": "https://pypi.python.org/packages/source/z/zope.interface/zope.interface-4.7.2.tar.gz"
         }
       }
     },


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
The upgrade to Python 3.7.9 from Python 3.7.7 included an upgrade to python3-setuptools. This new version of setuptools finally removed a long deprecated feature (~6 years), which was still in use by two of our packages. These two packages are upgraded to versions which no longer use this feature. Since the Python 3.7.9 upgrade fixes many CVEs, I opted to upgrade these two packages rather than rollback the 3.7.9 upgrade.

The python-markupsafe developers say that this upgrade should contain no breaking changes. Package rebuilds of dependent packages were done anyways.

The python-zope-interface upgrade has one small breaking change, and all packages depending on it have been confirmed to build with the new version.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Upgrade python-markupsafe to 1.1.1
- Upgrade python-zope-interface to 4.7.2

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local build of packages, as well as those that depend on the changed packages either directly or indirectly
