### PR TITLE
Patch CVE-2020-14352 in librepo

### DIFF
--- a/SPECS/librepo/CVE-2020-14352.patch
+++ b/SPECS/librepo/CVE-2020-14352.patch
@@ -1,0 +1,48 @@
+From 7daea2a2429a54dad68b1de9b37a5f65c5cf2600 Mon Sep 17 00:00:00 2001
+From: Jaroslav Rohel <jrohel@redhat.com>
+Date: Wed, 12 Aug 2020 08:35:28 +0200
+Subject: [PATCH] Validate path read from repomd.xml (RhBug:1868639)
+
+= changelog =
+msg: Validate path read from repomd.xml
+type: security
+resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1868639
+---
+ librepo/yum.c | 17 +++++++++++++++++
+ 1 file changed, 17 insertions(+)
+
+diff --git a/librepo/yum.c b/librepo/yum.c
+index 3059188..529257b 100644
+--- a/librepo/yum.c
++++ b/librepo/yum.c
+@@ -23,6 +23,7 @@
+ #define  BITS_IN_BYTE 8
+ 
+ #include <stdio.h>
++#include <libgen.h>
+ #include <assert.h>
+ #include <stdlib.h>
+ #include <errno.h>
+@@ -770,6 +771,22 @@ prepare_repo_download_targets(LrHandle *handle,
+             continue;
+ 
+         char *location_href = record->location_href;
++
++        char *dest_dir = realpath(handle->destdir, NULL);
++        path = lr_pathconcat(handle->destdir, record->location_href, NULL);
++        char *requested_dir = realpath(dirname(path), NULL);
++        lr_free(path);
++        if (!g_str_has_prefix(requested_dir, dest_dir)) {
++            g_debug("%s: Invalid path: %s", __func__, location_href);
++            g_set_error(err, LR_YUM_ERROR, LRE_IO, "Invalid path: %s", location_href);
++            g_slist_free_full(*targets, (GDestroyNotify) lr_downloadtarget_free);
++            free(requested_dir);
++            free(dest_dir);
++            return FALSE;
++        }
++        free(requested_dir);
++        free(dest_dir);
++
+         gboolean is_zchunk = FALSE;
+         #ifdef WITH_ZCHUNK
+         if (handle->cachedir && record->header_checksum)

--- a/SPECS/librepo/CVE-2020-14352.patch
+++ b/SPECS/librepo/CVE-2020-14352.patch
@@ -23,7 +23,7 @@ index 3059188..529257b 100644
  #include <assert.h>
  #include <stdlib.h>
  #include <errno.h>
-@@ -770,6 +771,22 @@ prepare_repo_download_targets(LrHandle *handle,
+@@ -774,6 +75,22 @@ prepare_repo_download_targets(LrHandle *handle,
              continue;
  
          char *location_href = record->location_href;

--- a/SPECS/librepo/librepo.spec
+++ b/SPECS/librepo/librepo.spec
@@ -1,35 +1,33 @@
 %{!?python2_sitelib: %define python2_sitelib %(python2 -c "from distutils.sysconfig import get_python_lib;print(get_python_lib())")}
 %{!?python3_sitelib: %define python3_sitelib %(python3 -c "from distutils.sysconfig import get_python_lib;print(get_python_lib())")}
 %define _python3_sitearch %(python3 -c "from distutils.sysconfig import get_python_lib; import sys; sys.stdout.write(get_python_lib(1))")
-
 Summary:        Repodata downloading library
 Name:           librepo
 Version:        1.11.0
 Release:        3%{?dist}
 License:        LGPLv2+
-URL:            https://github.com/rpm-software-management/librepo
-Group:          Applications/System
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
+Group:          Applications/System
+URL:            https://github.com/rpm-software-management/librepo
 #Source0:       https://github.com/rpm-software-management/librepo/archive/%{version}.tar.gz
 Source0:        %{name}-%{version}.tar.gz
 # CVE-2020-14352 patch taken from upstream commit 7daea2a2429a54dad68b1de9b37a5f65c5cf2600
 Patch0:         CVE-2020-14352.patch
-
-BuildRequires:  cmake
-BuildRequires:  gcc
+BuildRequires:  attr-devel
 BuildRequires:  check
+BuildRequires:  cmake
+BuildRequires:  curl-devel
+BuildRequires:  gcc
 BuildRequires:  glib-devel
 BuildRequires:  gpgme-devel
-BuildRequires:  attr-devel
-BuildRequires:  curl-devel
 BuildRequires:  libxml2-devel
 BuildRequires:  openssl-devel
-BuildRequires:  zchunk-devel
 BuildRequires:  python-sphinx
 BuildRequires:  python2-devel
 BuildRequires:  python3-devel
 BuildRequires:  python3-sphinx
+BuildRequires:  zchunk-devel
 Requires:       curl-libs
 Requires:       gpgme
 Requires:       zchunk
@@ -40,24 +38,24 @@ metadata.
 
 %package devel
 Summary:        Repodata downloading library
-Requires:       curl-libs
-Requires:       curl-devel
 Requires:       %{name} = %{version}-%{release}
+Requires:       curl-devel
+Requires:       curl-libs
 
 %description devel
 Development files for librepo.
 
 %package -n python2-%{name}
-Summary:        Python bindings for the librepo library
 %{?python_provide:%python_provide python2-%{name}}
+Summary:        Python bindings for the librepo library
 Requires:       %{name} = %{version}-%{release}
 
 %description -n python2-%{name}
 Python 2 bindings for the librepo library.
 
 %package -n python3-%{name}
-Summary:        Python 3 bindings for the librepo library
 %{?python_provide:%python_provide python3-%{name}}
+Summary:        Python 3 bindings for the librepo library
 Requires:       %{name} = %{version}-%{release}
 
 %description -n python3-%{name}
@@ -70,12 +68,12 @@ mkdir build-py3
 
 %build
 pushd build-py2
-  %cmake -DPYTHON_DESIRED:FILEPATH=/usr/bin/python -DENABLE_PYTHON_TESTS=%{!?with_pythontests:OFF} ..
+  %cmake -DPYTHON_DESIRED:FILEPATH=%{_bindir}/python -DENABLE_PYTHON_TESTS=%{!?with_pythontests:OFF} ..
   make %{?_smp_mflags}
 popd
 
 pushd build-py3
-  %cmake -DPYTHON_DESIRED:FILEPATH=/usr/bin/python3 -DENABLE_PYTHON_TESTS=%{!?with_pythontests:OFF} ..
+  %cmake -DPYTHON_DESIRED:FILEPATH=%{_bindir}/python3 -DENABLE_PYTHON_TESTS=%{!?with_pythontests:OFF} ..
   make %{?_smp_mflags}
 popd
 
@@ -96,7 +94,6 @@ popd
 
 %files
 %license COPYING
-%doc COPYING
 %doc README.md
 %{_libdir}/%{name}.so.*
 

--- a/SPECS/librepo/librepo.spec
+++ b/SPECS/librepo/librepo.spec
@@ -5,7 +5,7 @@
 Summary:        Repodata downloading library
 Name:           librepo
 Version:        1.11.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        LGPLv2+
 URL:            https://github.com/rpm-software-management/librepo
 Group:          Applications/System
@@ -13,6 +13,8 @@ Vendor:         Microsoft Corporation
 Distribution:   Mariner
 #Source0:       https://github.com/rpm-software-management/librepo/archive/%{version}.tar.gz
 Source0:        %{name}-%{version}.tar.gz
+# CVE-2020-14352 patch taken from upstream commit 7daea2a2429a54dad68b1de9b37a5f65c5cf2600
+Patch0:         CVE-2020-14352.patch
 
 BuildRequires:  cmake
 BuildRequires:  gcc
@@ -62,7 +64,7 @@ Requires:       %{name} = %{version}-%{release}
 Python 3 bindings for the librepo library.
 
 %prep
-%setup -q
+%autosetup
 mkdir build-py2
 mkdir build-py3
 
@@ -110,14 +112,21 @@ popd
 %{_python3_sitearch}/%{name}/
 
 %changelog
-* Sat May 09 00:21:34 PST 2020 Nick Samson <nisamson@microsoft.com> - 1.11.0-2
+* Tue Nov 10 2020 Thomas Crain <thcrain@microsoft.com> - 1.11.0-3
+- Patch CVE-2020-14352
+- Lint to Mariner style
+
+* Sat May 09 2020 Nick Samson <nisamson@microsoft.com> - 1.11.0-2
 - Added %%license line automatically
 
-*   Tue May 05 2020 Pawel Winogrodzki <pawelwi@microsoft.com> 1.11.0-1
--   Update version to 1.11.0.
-*   Fri Mar 13 2020 Paul Monson <paulmon@microsoft.com> 1.10.3-1
--   Update to version 1.10.3. License verified.
-*   Wed Sep 25 2019 Saravanan Somasundaram <sarsoma@microsoft.com> 1.10.2-2
--   Initial CBL-Mariner import from Photon (license: Apache2).
-*   Wed May 15 2019 Ankit Jain <ankitja@vmware.com> 1.10.2-1
--   Initial build. First version
+* Tue May 05 2020 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.11.0-1
+- Update version to 1.11.0.
+
+* Fri Mar 13 2020 Paul Monson <paulmon@microsoft.com> - 1.10.3-1
+- Update to version 1.10.3. License verified.
+
+* Wed Sep 25 2019 Saravanan Somasundaram <sarsoma@microsoft.com> - 1.10.2-2
+- Initial CBL-Mariner import from Photon (license: Apache2).
+
+* Wed May 15 2019 Ankit Jain <ankitja@vmware.com> - 1.10.2-1
+- Initial build. First version

--- a/SPECS/librepo/librepo.spec
+++ b/SPECS/librepo/librepo.spec
@@ -62,7 +62,7 @@ Requires:       %{name} = %{version}-%{release}
 Python 3 bindings for the librepo library.
 
 %prep
-%autosetup
+%autosetup -p1
 mkdir build-py2
 mkdir build-py3
 


### PR DESCRIPTION
##### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Patches CVE-2020-14352 in librepo.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Takes upstream fix from [here](https://github.com/rpm-software-management/librepo/commit/7daea2a2429a54dad68b1de9b37a5f65c5cf2600)

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2020-14352

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local build
