### PR TITLE
Add missing requires to auoms package

### DIFF
--- a/SPECS/auoms/auoms.spec
+++ b/SPECS/auoms/auoms.spec
@@ -33,6 +33,7 @@ Requires:       audit
 Requires:       bash
 Requires:       chkconfig
 Requires:       glibc
+Requires:       initscripts
 Requires:       libstdc++
 Requires:       perl
 Requires:       procps-ng
@@ -189,6 +190,7 @@ done
 * Wed Nov 11 2020 Daniel McIlvaney <damcilva@microsoft.com> - 2.2.5-4
 - Add dependnecy on chkconfig to avoid ownership conflict with /etc/init.d directory
 - Add dependency on procps-ng so auomsctl can use pgrep
+- Add dependnecy on initscripts so auomsctl can use /usr/sbin/service
 
 * Wed Nov 11 2020 Daniel McIlvaney <damcilva@microsoft.com> - 2.2.5-3
 - Clean up spec file with feedback from linter

--- a/SPECS/auoms/auoms.spec
+++ b/SPECS/auoms/auoms.spec
@@ -1,9 +1,8 @@
 %define      debug_package %{nil}
-
 Summary:        Auditd plugin that forwards audit events to OMS Agent for Linux
 Name:           auoms
 Version:        2.2.5
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -21,7 +20,6 @@ Patch0:         auoms.patch
 BuildRequires:  audit-devel
 BuildRequires:  bash
 BuildRequires:  bash-devel
-BuildRequires:  audit-devel
 BuildRequires:  boost-devel
 BuildRequires:  cmake
 BuildRequires:  grep
@@ -33,9 +31,11 @@ BuildRequires:  unzip
 BuildRequires:  wget
 Requires:       audit
 Requires:       bash
+Requires:       chkconfig
 Requires:       glibc
 Requires:       libstdc++
 Requires:       perl
+Requires:       procps-ng
 Requires:       sed
 Requires:       sudo
 
@@ -82,7 +82,6 @@ install -m 755 intermediate/builddir/release/bin/auomsctl       %{buildroot}/opt
 
 %clean
 rm -rf %{buildroot}
-
 
 %pre
 #!/bin/sh
@@ -187,6 +186,10 @@ done
 %{_var}/opt/microsoft/auoms/data/outputs
 
 %changelog
+* Wed Nov 11 2020 Daniel McIlvaney <damcilva@microsoft.com> - 2.2.5-4
+- Add dependnecy on chkconfig to avoid ownership conflict with /etc/init.d directory
+- Add dependency on procps-ng so auomsctl can use pgrep
+
 * Wed Nov 11 2020 Daniel McIlvaney <damcilva@microsoft.com> - 2.2.5-3
 - Clean up spec file with feedback from linter
 

--- a/SPECS/auoms/auoms.spec
+++ b/SPECS/auoms/auoms.spec
@@ -3,8 +3,11 @@
 Summary:        Auditd plugin that forwards audit events to OMS Agent for Linux
 Name:           auoms
 Version:        2.2.5
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        MIT
+Vendor:         Microsoft Corporation
+Distribution:   Mariner
+Group:          Applications/System
 URL:            https://github.com/microsoft/OMS-Auditd-Plugin
 #Source0:       https://github.com/microsoft/OMS-Auditd-Plugin/archive/v2.2.5-0.tar.gz
 Source0:        %{name}-%{version}.tar.gz
@@ -15,30 +18,26 @@ Source2:        msgpack-c-cpp-2.0.0.zip
 #Source3:       https://github.com/Tencent/rapidjson/archive/v1.0.2.tar.gz
 Source3:        rapidjson-1.0.2.tar.gz
 Patch0:         auoms.patch
-Group:          Applications/System
-Vendor:         Microsoft Corporation
-Distribution:   Mariner
-
-BuildRequires:  unzip
-BuildRequires:  cmake
-BuildRequires:  wget
-BuildRequires:  sudo
-BuildRequires:  grep
-BuildRequires:  sed
+BuildRequires:  audit-devel
 BuildRequires:  bash
 BuildRequires:  bash-devel
 BuildRequires:  audit-devel
 BuildRequires:  boost-devel
+BuildRequires:  cmake
+BuildRequires:  grep
 BuildRequires:  python2
 BuildRequires:  python2-devel
-
+BuildRequires:  sed
+BuildRequires:  sudo
+BuildRequires:  unzip
+BuildRequires:  wget
 Requires:       audit
-Requires:       sudo
 Requires:       bash
-Requires:       sed
+Requires:       glibc
 Requires:       libstdc++
 Requires:       perl
-Requires:       glibc
+Requires:       sed
+Requires:       sudo
 
 %description
 OMS Audit data collection daemon
@@ -53,8 +52,8 @@ cp %{SOURCE3} ./
 %build
 grep AUOMS_BUILDVERSION auoms.version | head -n 4 | cut -d'=' -f2 | tr '\n' '.' | sed 's/.$//' | sed 's/^/#define AUOMS_VERSION "/' > auoms_version.h
 sed -i 's/$/"/' auoms_version.h
-cp -R /usr/include/boost /usr/local/include/boost
-mv /usr/include/boost /usr/include/boost148
+cp -R %{_includedir}/boost %{_prefix}/local/include/boost
+mv %{_includedir}/boost %{_includedir}/boost148
 cd build
 ./configure --enable-ulinux && make clean && make
 
@@ -65,11 +64,11 @@ install -vdm 755 %{buildroot}%{_sysconfdir}/opt/microsoft/auoms/outconf.d
 install -vdm 755 %{buildroot}%{_sysconfdir}/opt/microsoft/auoms/rules.d
 install -vdm 755 %{buildroot}/opt/microsoft/auoms
 install -vdm 755 %{buildroot}/opt/microsoft/auoms/bin
-install -vdm 755 %{buildroot}/usr/share/selinux/packages/auoms
-install -vdm 750 %{buildroot}/var/opt/microsoft/auoms/data
-install -vdm 750 %{buildroot}/var/opt/microsoft/auoms/data/outputs
+install -vdm 755 %{buildroot}%{_datadir}/selinux/packages/auoms
+install -vdm 750 %{buildroot}%{_var}/opt/microsoft/auoms/data
+install -vdm 750 %{buildroot}%{_var}/opt/microsoft/auoms/data/outputs
 
-install -m 644 intermediate/selinux/*                           %{buildroot}/usr/share/selinux/packages/auoms
+install -m 644 intermediate/selinux/*                           %{buildroot}%{_datadir}/selinux/packages/auoms
 install -m 555 installer/auoms.init                             %{buildroot}%{_sysconfdir}/init.d/auoms
 install -m 644 installer/conf/auoms.conf                        %{buildroot}%{_sysconfdir}/opt/microsoft/auoms
 install -m 644 installer/conf/auomscollect.conf                 %{buildroot}%{_sysconfdir}/opt/microsoft/auoms
@@ -82,25 +81,26 @@ install -m 755 intermediate/builddir/release/bin/auoms          %{buildroot}/opt
 install -m 755 intermediate/builddir/release/bin/auomsctl       %{buildroot}/opt/microsoft/auoms/bin
 
 %clean
-rm -rf $RPM_BUILD_ROOT
+rm -rf %{buildroot}
+
 
 %pre
 #!/bin/sh
 
 if [ $1 -gt 1 ] ; then
-    if [ -e /etc/audisp/plugins.d/auoms.conf ]; then
+    if [ -e %{_sysconfdir}/audisp/plugins.d/auoms.conf ]; then
         echo "Pre: found etc/audisp/plugins.d/auoms.conf"
-        if [ -e /etc/audisp/plugins.d/auoms.conf.auomssave ]; then
-            rm /etc/audisp/plugins.d/auoms.conf.auomssave
+        if [ -e %{_sysconfdir}/audisp/plugins.d/auoms.conf.auomssave ]; then
+            rm %{_sysconfdir}/audisp/plugins.d/auoms.conf.auomssave
         fi
-        cp -p /etc/audisp/plugins.d/auoms.conf /etc/audisp/plugins.d/auoms.conf.auomssave
+        cp -p %{_sysconfdir}/audisp/plugins.d/auoms.conf %{_sysconfdir}/audisp/plugins.d/auoms.conf.auomssave
     fi
-    if [ -e /etc/audit/plugins.d/auoms.conf ]; then
+    if [ -e %{_sysconfdir}/audit/plugins.d/auoms.conf ]; then
         echo "Pre: found etc/audit/plugins.d/auoms.conf"
-        if [ -e /etc/audit/plugins.d/auoms.conf.auomssave ]; then
-            rm /etc/audit/plugins.d/auoms.conf.auomssave
+        if [ -e %{_sysconfdir}/audit/plugins.d/auoms.conf.auomssave ]; then
+            rm %{_sysconfdir}/audit/plugins.d/auoms.conf.auomssave
         fi
-        cp -p /etc/audit/plugins.d/auoms.conf /etc/audit/plugins.d/auoms.conf.auomssave
+        cp -p %{_sysconfdir}/audit/plugins.d/auoms.conf %{_sysconfdir}/audit/plugins.d/auoms.conf.auomssave
     fi
 fi
 
@@ -117,24 +117,24 @@ fi
 SERVICEDIR=/opt/microsoft/auoms
 
 if [ $1 -gt 1 ] ; then
-    if [ -e /etc/audisp/plugins.d/auoms.conf.auomssave ]; then
-        echo "Post: found /etc/audisp/plugins.d/auoms.conf"
-        if [ -e /etc/audisp/plugins.d/auoms.conf ]; then
-            rm /etc/audisp/plugins.d/auoms.conf
+    if [ -e %{_sysconfdir}/audisp/plugins.d/auoms.conf.auomssave ]; then
+        echo "Post: found %{_sysconfdir}/audisp/plugins.d/auoms.conf"
+        if [ -e %{_sysconfdir}/audisp/plugins.d/auoms.conf ]; then
+            rm %{_sysconfdir}/audisp/plugins.d/auoms.conf
         fi
-        cp -p /etc/audisp/plugins.d/auoms.conf.auomssave /etc/audisp/plugins.d/auoms.conf
+        cp -p %{_sysconfdir}/audisp/plugins.d/auoms.conf.auomssave %{_sysconfdir}/audisp/plugins.d/auoms.conf
     fi
-    if [ -e /etc/audit/plugins.d/auoms.conf.auomssave ]; then
-        echo "Post: found /etc/audit/plugins.d/auoms.conf"
-        if [ -e /etc/audit/plugins.d/auoms.conf ]; then
-            rm /etc/audit/plugins.d/auoms.conf
+    if [ -e %{_sysconfdir}/audit/plugins.d/auoms.conf.auomssave ]; then
+        echo "Post: found %{_sysconfdir}/audit/plugins.d/auoms.conf"
+        if [ -e %{_sysconfdir}/audit/plugins.d/auoms.conf ]; then
+            rm %{_sysconfdir}/audit/plugins.d/auoms.conf
         fi
-        cp -p /etc/audit/plugins.d/auoms.conf.auomssave /etc/audit/plugins.d/auoms.conf
+        cp -p %{_sysconfdir}/audit/plugins.d/auoms.conf.auomssave %{_sysconfdir}/audit/plugins.d/auoms.conf
     fi
     echo "Post: executing upgrade"
     /opt/microsoft/auoms/bin/auomsctl upgrade
 fi
-for dir in /usr/lib/systemd/system /lib/systemd/system; do
+for dir in %{_lib}/systemd/system /lib/systemd/system; do
     if [ -e $dir ]; then
         install -m 644 ${SERVICEDIR}/auoms.service $dir
         systemctl enable auoms.service
@@ -142,20 +142,20 @@ for dir in /usr/lib/systemd/system /lib/systemd/system; do
     fi
 done
 sudo /opt/microsoft/auoms/bin/auomsctl enable
-rm -f /etc/audisp/plugins.d/auoms.conf.*
-rm -f /etc/audit/plugins.d/auoms.conf.*
+rm -f %{_sysconfdir}/audisp/plugins.d/auoms.conf.*
+rm -f %{_sysconfdir}/audit/plugins.d/auoms.conf.*
 
 %postun
 #!/bin/sh
 
 if [ $1 -eq 0 ]; then
-    rm -f /etc/audisp/plugins.d/auoms.conf*
-    rm -f /etc/audit/plugins.d/auoms.conf*
+    rm -f %{_sysconfdir}/audisp/plugins.d/auoms.conf*
+    rm -f %{_sysconfdir}/audit/plugins.d/auoms.conf*
 
-    rm -rf -v /etc/opt/microsoft/auoms
-    rm -rf -v /var/opt/microsoft/auoms
+    rm -rf -v %{_sysconfdir}/opt/microsoft/auoms
+    rm -rf -v %{_var}/opt/microsoft/auoms
 fi
-for dir in /usr/lib/systemd/system /lib/systemd/system; do
+for dir in %{_lib}/systemd/system /lib/systemd/system; do
     if [ -e ${dir}/auoms.service ]; then
         systemctl disable auoms.service
         rm -f ${dir}/auoms.service
@@ -165,8 +165,8 @@ done
 
 %files
 %defattr(-,root,root)
-/usr/share/selinux/packages/auoms
-/usr/share/selinux/packages/auoms/*
+%{_datadir}/selinux/packages/auoms
+%{_datadir}/selinux/packages/auoms/*
 %{_sysconfdir}/init.d/auoms
 %{_sysconfdir}/opt/microsoft/auoms
 %{_sysconfdir}/opt/microsoft/auoms/auoms.conf
@@ -182,12 +182,16 @@ done
 /opt/microsoft/auoms/bin/auomscollect
 /opt/microsoft/auoms/bin/auoms
 /opt/microsoft/auoms/bin/auomsctl
-/var/opt/microsoft/auoms
-/var/opt/microsoft/auoms/data
-/var/opt/microsoft/auoms/data/outputs
+%{_var}/opt/microsoft/auoms
+%{_var}/opt/microsoft/auoms/data
+%{_var}/opt/microsoft/auoms/data/outputs
 
 %changelog
+* Wed Nov 11 2020 Daniel McIlvaney <damcilva@microsoft.com> - 2.2.5-3
+- Clean up spec file with feedback from linter
+
 * Sat Oct 24 2020 Andrew Phelps <anphel@microsoft.com> 2.2.5-2
 - Fix setup macro
+
 * Thu Oct 22 2020 Andrew Phelps <anphel@microsoft.com> 2.2.5-1
 - Initial CBL-Mariner version.

--- a/SPECS/auoms/auoms.spec
+++ b/SPECS/auoms/auoms.spec
@@ -53,8 +53,8 @@ cp %{SOURCE3} ./
 %build
 grep AUOMS_BUILDVERSION auoms.version | head -n 4 | cut -d'=' -f2 | tr '\n' '.' | sed 's/.$//' | sed 's/^/#define AUOMS_VERSION "/' > auoms_version.h
 sed -i 's/$/"/' auoms_version.h
-cp -R %{_includedir}/boost %{_prefix}/local/include/boost
-mv %{_includedir}/boost %{_includedir}/boost148
+cp -R %{_includedir}/boost /usr/local/include/boost
+mv %{_includedir}/boost /usr/include/boost148
 cd build
 ./configure --enable-ulinux && make clean && make
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
The `auoms` package creates the file `/etc/init.d/auoms`, however the `chkconfig` package explictly claims ownership of the `/etc/init.d` directory. If `chkconfig` is installed after `auoms` it will find that directory already present and will fail to install (this ordering is common since package lists are alphabetical). Claim `chkconfig` as a runtime requirement for `auoms` so that the `chkconfig` package can create the directory as expected. Also add `procps-ng` and `initscripts` packages since post and preun stpeps call into 
`auomsctl` which relies on `pgrep` and `service`.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add `chkconfig` as a runtime requirement for `auoms`
- Add `procps-ng` as runtime requirement for `auoms`
- Add `initscripts` as runtime requirement for `auoms`

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local builds
- Manual install/uninstall on VMs
