### PR TITLE
Jslobodzian/off cycle merge to fix cves and community build issues

### DIFF
--- a/.github/workflows/validate-cg-manifest.sh
+++ b/.github/workflows/validate-cg-manifest.sh
@@ -19,6 +19,8 @@ ignore_list=" \
   mariner-rpm-macros \
   moby-buildx \
   moby-containerd \
+  python-markupsafe \
+  python-zope-interface \
   qt5-rpm-macros \
   runc \
   grub2-efi-binary-signed-aarch64 \

--- a/SPECS/bond/bond.signatures.json
+++ b/SPECS/bond/bond.signatures.json
@@ -1,7 +1,7 @@
 {
-    "Signatures": {
-        "bond-8.0.1.tar.gz" : "d22428a40ab158813c6b0d6548a9a4c1304c1873bd4f2f62a0f36c0ba2855a8b",
-        "gbc-0.11.0.3-aarch64" : "2fa232b3ceb79ff2e002ad06f8da93bd59f81599102f95258b4dadb84d6b847d",
-        "gbc-0.11.0.3-x86_64" : "c64f9db841b8cccad4c8ec0bd724e52d28b51a15af145fe40223cd92d7356d71"
-    }
+ "Signatures": {
+  "bond-8.0.1.tar.gz": "d22428a40ab158813c6b0d6548a9a4c1304c1873bd4f2f62a0f36c0ba2855a8b",
+  "gbc-0.11.0.3-aarch64": "2fa232b3ceb79ff2e002ad06f8da93bd59f81599102f95258b4dadb84d6b847d",
+  "gbc-0.11.0.3-x86_64": "c64f9db841b8cccad4c8ec0bd724e52d28b51a15af145fe40223cd92d7356d71"
+ }
 }

--- a/SPECS/bond/bond.spec
+++ b/SPECS/bond/bond.spec
@@ -1,22 +1,22 @@
-Name:           bond
 Summary:        Microsoft Bond Library
+Name:           bond
 Version:        8.0.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 URL:            https://github.com/microsoft/bond
 #Source0:       %{url}/archive/%{version}.tar.gz
 Source0:        %{name}-%{version}.tar.gz
-Source1:        gbc-0.11.0.3-%{_arch}
-
+Source1:        gbc-0.11.0.3-aarch64
+Source2:        gbc-0.11.0.3-x86_64
+BuildRequires:  boost-devel
 BuildRequires:  clang
 BuildRequires:  cmake
-BuildRequires:  zlib-devel
-BuildRequires:  boost-devel
+BuildRequires:  gmp-devel
 BuildRequires:  ncurses-devel
 BuildRequires:  rapidjson-devel
-BuildRequires:  gmp-devel
+BuildRequires:  zlib-devel
 
 %description
 Bond is an open-source, cross-platform framework for working with schematized data.
@@ -39,7 +39,11 @@ CMAKE_OPTS="\
     -DBOND_FIND_RAPIDJSON=TRUE \
     -DBOND_SKIP_CORE_TESTS=TRUE \
     -DBOND_SKIP_GBC_TESTS=TRUE \
+%ifarch aarch64
     -DBOND_GBC_PATH=%{SOURCE1} \
+%else
+    -DBOND_GBC_PATH=%{SOURCE2} \
+%endif
     -DCMAKE_INSTALL_PREFIX=%{_prefix} \
 "
 
@@ -63,11 +67,16 @@ chmod 0755 %{buildroot}%{_bindir}/gbc
 %{_libdir}/%{name}/*
 
 %changelog
+* Tue Oct 27 2020 Joe Schmitt <joschmit@microsoft.com> - 8.0.1-4
+- Include all sources regardless of architecture.
+
 *   Mon Oct 19 2020 Pawel Winogrodzki <pawelwi@microsoft.com> 8.0.1-3
 -   License verified.
 -   Added source URL.
 -   Added 'Vendor' and 'Distribution' tags.
+
 *   Tue May 19 2020 Jonathan Chiu <jochi@microsoft.com> 8.0.1-2
 -   Add aarch64 support
+
 *   Mon Apr 06 2020 Jonathan Chiu <jochi@microsoft.com> 8.0.1-1
 -   Original version for CBL-Mariner.

--- a/SPECS/python-markupsafe/python-markupsafe.signatures.json
+++ b/SPECS/python-markupsafe/python-markupsafe.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "MarkupSafe-1.0.tar.gz": "a6be69091dac236ea9c6bc7d012beab42010fa914c459791d627dad4910eb665"
+  "MarkupSafe-1.1.1.tar.gz": "29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b"
  }
 }

--- a/SPECS/python-markupsafe/python-markupsafe.spec
+++ b/SPECS/python-markupsafe/python-markupsafe.spec
@@ -1,22 +1,19 @@
 %{!?python2_sitelib: %define python2_sitelib %(python2 -c "from distutils.sysconfig import get_python_lib;print(get_python_lib())")}
 %{!?python3_sitelib: %define python3_sitelib %(python3 -c "from distutils.sysconfig import get_python_lib;print(get_python_lib())")}
-
+%define pypi_name MarkupSafe
 Summary:        A XML/HTML/XHTML Markup safe string for Python.
 Name:           python-markupsafe
-Version:        1.0
-Release:        5%{?dist}
+Version:        1.1.1
+Release:        1%{?dist}
 License:        BSD
-Group:          Development/Languages/Python
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
-Url:            https://pypi.python.org/pypi/MarkupSafe
-Source0:        https://pypi.python.org/packages/4d/de/32d741db316d8fdb7680822dd37001ef7a448255de9699ab4bfcbdf4172b/MarkupSafe-%{version}.tar.gz
-%define sha1    MarkupSafe=9072e80a7faa0f49805737a48f3d871eb1c48728
-
+Group:          Development/Languages/Python
+URL:            https://pypi.python.org/pypi/MarkupSafe
+Source0:        https://pypi.python.org/packages/source/M/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+BuildRequires:  python-setuptools
 BuildRequires:  python2
 BuildRequires:  python2-libs
-BuildRequires:  python-setuptools
-
 Requires:       python2
 Requires:       python2-libs
 
@@ -37,7 +34,7 @@ Requires:       python3-libs
 Python 3 version.
 
 %prep
-%setup -q -n MarkupSafe-%{version}
+%setup -q -n %{pypi_name}-%{version}
 
 %build
 python2 setup.py build
@@ -54,7 +51,7 @@ python3 setup.py test
 
 %files
 %defattr(-,root,root,-)
-%license LICENSE
+%license LICENSE.rst
 %{python2_sitelib}/*
 
 %files -n python3-markupsafe
@@ -62,16 +59,27 @@ python3 setup.py test
 %{python3_sitelib}/*
 
 %changelog
+* Wed Nov 11 2020 Thomas Crain <thcrain@microsoft.com> - 1.1.1-1
+- Upgrade to 1.1.1 to fix setuptools compatibility issues
+- Change Source0
+- Correct license location
+- Remove inline sha1
+- Lint to Mariner style
+
 * Sat May 09 00:21:01 PST 2020 Nick Samson <nisamson@microsoft.com> - 1.0-5
 - Added %%license line automatically
 
-*   Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 1.0-4
--   Initial CBL-Mariner import from Photon (license: Apache2).
-*   Wed Jun 07 2017 Xiaolin Li <xiaolinl@vmware.com> 1.0-3
--   Add python3-setuptools and python3-xml to python3 sub package Buildrequires.
-*   Thu Jun 01 2017 Dheeraj Shetty <dheerajs@vmware.com> 1.0-2
--   Removed erroneous version line
-*   Thu Mar 30 2017 Sarah Choi <sarahc@vmware.com> 1.0-1
--   Upgrade version to 1.0
-*   Thu Mar 02 2017 Xiaolin Li <xiaolinl@vmware.com> 0.23-1
--   Initial packaging for Photon
+* Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> - 1.0-4
+- Initial CBL-Mariner import from Photon (license: Apache2).
+
+* Wed Jun 07 2017 Xiaolin Li <xiaolinl@vmware.com> - 1.0-3
+- Add python3-setuptools and python3-xml to python3 sub package Buildrequires.
+
+* Thu Jun 01 2017 Dheeraj Shetty <dheerajs@vmware.com> - 1.0-2
+- Removed erroneous version line
+
+* Thu Mar 30 2017 Sarah Choi <sarahc@vmware.com> - 1.0-1
+- Upgrade version to 1.0
+
+* Thu Mar 02 2017 Xiaolin Li <xiaolinl@vmware.com> - 0.23-1
+- Initial packaging for Photon

--- a/SPECS/python-zope-interface/python-zope-interface.signatures.json
+++ b/SPECS/python-zope-interface/python-zope-interface.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "zope.interface-4.6.0.tar.gz": "1b3d0dcabc7c90b470e59e38a9acaa361be43b3a6ea644c0063951964717f0e5"
+  "zope.interface-4.7.2.tar.gz": "fd1101bd3fcb4f4cf3485bb20d6cb0b56909b94d3bd2a53a6cb9d381c3da3365"
  }
 }

--- a/SPECS/python-zope-interface/python-zope-interface.spec
+++ b/SPECS/python-zope-interface/python-zope-interface.spec
@@ -1,19 +1,19 @@
 %{!?python2_sitelib: %define python2_sitelib %(python2 -c "from distutils.sysconfig import get_python_lib;print(get_python_lib())")}
 %{!?python3_sitelib: %define python3_sitelib %(python3 -c "from distutils.sysconfig import get_python_lib;print(get_python_lib())")}
-
-Name:           python-zope-interface
-Version:        4.6.0
-Release:        3%{?dist}
-Url:            https://github.com/zopefoundation/zope.interface
+%define pypi_name zope.interface
 Summary:        Interfaces for Python
+Name:           python-zope-interface
+Version:        4.7.2
+Release:        1%{?dist}
 License:        ZPLv2.1
+Vendor:         Microsoft Corporation
+Distribution:   Mariner
 Group:          Development/Languages/Python
-Source0:        https://files.pythonhosted.org/packages/4e/d0/c9d16bd5b38de44a20c6dc5d5ed80a49626fafcb3db9f9efdc2a19026db6/zope.interface-%{version}.tar.gz
-
+URL:            https://github.com/zopefoundation/zope.interface
+Source0:        https://pypi.python.org/packages/source/z/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+BuildRequires:  python-setuptools
 BuildRequires:  python2-devel
 BuildRequires:  python2-libs
-BuildRequires:  python-setuptools
-
 Requires:       python2
 Requires:       python2-libs
 
@@ -37,8 +37,9 @@ Requires:       python3-libs
 %description -n python3-zope-interface
 
 Python 3 version.
+
 %prep
-%setup -q -n zope.interface-%{version}
+%setup -q -n %{pypi_name}-%{version}
 rm -rf ../p3dir
 cp -a . ../p3dir
 
@@ -71,22 +72,35 @@ popd
 %{python3_sitelib}/*
 
 %changelog
-*   Sat May 09 2020 Nick Samson <nisamson@microsoft.com> 4.6.0-3
--   Added %%license line automatically
-*   Wed Apr 29 2020 Emre Girgin <mrgirgin@microsoft.com> 4.6.0-2
--   Renaming python-zope.interface to python-zope-interface
-*   Wed Mar 18 2020 Henry Beberman <henry.beberman@microsoft.com> 4.6.0-1
--   Initial CBL-Mariner import from Photon (license: Apache2).
--   Update to 4.6.0. Source0 URL fixed. License verified.
-*   Fri Sep 14 2018 Tapas Kundu <tkundu@vmware.com> 4.5.0-1
--   Updated to release 4.5.0
-*   Wed Jun 07 2017 Xiaolin Li <xiaolinl@vmware.com> 4.3.3-2
--   Add python3-setuptools and python3-xml to python3 sub package Buildrequires.
-*   Mon Mar 13 2017 Xiaolin Li <xiaolinl@vmware.com> 4.3.3-1
--   Updated to version 4.3.3.
-*   Mon Oct 04 2016 ChangLee <changlee@vmware.com> 4.1.3-3
--   Modified %check
-*   Tue May 24 2016 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 4.1.3-2
--   GA - Bump release of all rpms
-*   Tue Oct 27 2015 Mahmoud Bassiouny <mbassiouny@vmware.com>
--   Initial packaging for Photon
+* Wed Nov 11 2020 Thomas Crain <thcrain@microsoft.com> - 4.7.2-1
+- Update to 4.7.2 to fix setuptools compatibility issues
+- Update Source0
+- Lint to Mariner style
+
+* Sat May 09 2020 Nick Samson <nisamson@microsoft.com> - 4.6.0-3
+- Added %%license line automatically
+
+* Wed Apr 29 2020 Emre Girgin <mrgirgin@microsoft.com> - 4.6.0-2
+- Renaming python-zope.interface to python-zope-interface
+
+* Wed Mar 18 2020 Henry Beberman <henry.beberman@microsoft.com> - 4.6.0-1
+- Initial CBL-Mariner import from Photon (license: Apache2).
+- Update to 4.6.0. Source0 URL fixed. License verified.
+
+* Fri Sep 14 2018 Tapas Kundu <tkundu@vmware.com> - 4.5.0-1
+- Updated to release 4.5.0
+
+* Wed Jun 07 2017 Xiaolin Li <xiaolinl@vmware.com> - 4.3.3-2
+- Add python3-setuptools and python3-xml to python3 sub package Buildrequires.
+
+* Mon Mar 13 2017 Xiaolin Li <xiaolinl@vmware.com> - 4.3.3-1
+- Updated to version 4.3.3.
+
+* Mon Oct 04 2016 ChangLee <changlee@vmware.com> - 4.1.3-3
+- Modified %check
+
+* Tue May 24 2016 Priyesh Padmavilasom <ppadmavilasom@vmware.com> - 4.1.3-2
+- GA - Bump release of all rpms
+
+* Tue Oct 27 2015 Mahmoud Bassiouny <mbassiouny@vmware.com> - 4.1.3-1
+- Initial packaging for Photon

--- a/SPECS/python3/CVE-2020-27619.patch
+++ b/SPECS/python3/CVE-2020-27619.patch
@@ -1,0 +1,64 @@
+From 43e523103886af66d6c27cd72431b5d9d14cd2a9 Mon Sep 17 00:00:00 2001
+From: "Miss Skeleton (bot)" <31488909+miss-islington@users.noreply.github.com>
+Date: Mon, 19 Oct 2020 19:38:40 -0700
+Subject: [PATCH] bpo-41944: No longer call eval() on content received via HTTP
+ in the CJK codec tests (GH-22566) (GH-22578)
+
+(cherry picked from commit 2ef5caa58febc8968e670e39e3d37cf8eef3cab8)
+
+Co-authored-by: Serhiy Storchaka <storchaka@gmail.com>
+---
+ Lib/test/multibytecodec_support.py            | 22 +++++++------------
+ .../2020-10-05-17-43-46.bpo-41944.rf1dYb.rst  |  1 +
+ 2 files changed, 9 insertions(+), 14 deletions(-)
+ create mode 100644 Misc/NEWS.d/next/Tests/2020-10-05-17-43-46.bpo-41944.rf1dYb.rst
+
+diff --git a/Lib/test/multibytecodec_support.py b/Lib/test/multibytecodec_support.py
+index cca8af67d6d1d..f76c0153f5ecf 100644
+--- a/Lib/test/multibytecodec_support.py
++++ b/Lib/test/multibytecodec_support.py
+@@ -305,29 +305,23 @@ def test_mapping_file(self):
+             self._test_mapping_file_plain()
+ 
+     def _test_mapping_file_plain(self):
+-        unichrs = lambda s: ''.join(map(chr, map(eval, s.split('+'))))
++        def unichrs(s):
++            return ''.join(chr(int(x, 16)) for x in s.split('+'))
++
+         urt_wa = {}
+ 
+         with self.open_mapping_file() as f:
+             for line in f:
+                 if not line:
+                     break
+-                data = line.split('#')[0].strip().split()
++                data = line.split('#')[0].split()
+                 if len(data) != 2:
+                     continue
+ 
+-                csetval = eval(data[0])
+-                if csetval <= 0x7F:
+-                    csetch = bytes([csetval & 0xff])
+-                elif csetval >= 0x1000000:
+-                    csetch = bytes([(csetval >> 24), ((csetval >> 16) & 0xff),
+-                                    ((csetval >> 8) & 0xff), (csetval & 0xff)])
+-                elif csetval >= 0x10000:
+-                    csetch = bytes([(csetval >> 16), ((csetval >> 8) & 0xff),
+-                                    (csetval & 0xff)])
+-                elif csetval >= 0x100:
+-                    csetch = bytes([(csetval >> 8), (csetval & 0xff)])
+-                else:
++                if data[0][:2] != '0x':
++                    self.fail(f"Invalid line: {line!r}")
++                csetch = bytes.fromhex(data[0][2:])
++                if len(csetch) == 1 and 0x80 <= csetch[0]:
+                     continue
+ 
+                 unich = unichrs(data[1])
+diff --git a/Misc/NEWS.d/next/Tests/2020-10-05-17-43-46.bpo-41944.rf1dYb.rst b/Misc/NEWS.d/next/Tests/2020-10-05-17-43-46.bpo-41944.rf1dYb.rst
+new file mode 100644
+index 0000000000000..4f9782f1c85af
+--- /dev/null
++++ b/Misc/NEWS.d/next/Tests/2020-10-05-17-43-46.bpo-41944.rf1dYb.rst
+@@ -0,0 +1 @@
++Tests for CJK codecs no longer call ``eval()`` on content received via HTTP.

--- a/SPECS/python3/python3.signatures.json
+++ b/SPECS/python3/python3.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "Python-3.7.7.tar.xz": "06a0a9f1bf0d8cd1e4121194d666c4e28ddae4dd54346de6c343206599f02136"
+  "Python-3.7.9.tar.xz": "91923007b05005b5f9bd46f3b9172248aea5abc1543e8a636d59e629c3331b01"
  }
 }

--- a/SPECS/python3/python3.spec
+++ b/SPECS/python3/python3.spec
@@ -1,27 +1,28 @@
 %global openssl_flags -DOPENSSL_NO_SSL3 -DOPENSSL_NO_SSL2
-
 Summary:        A high-level scripting language
 Name:           python3
-Version:        3.7.7
+Version:        3.7.9
 Release:        2%{?dist}
 License:        PSF
-URL:            http://www.python.org/
-Group:          System Environment/Programming
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
+Group:          System Environment/Programming
+URL:            https://www.python.org/
 Source0:        https://www.python.org/ftp/python/%{version}/Python-%{version}.tar.xz
 Patch0:         cgi3.patch
 Patch1:         python3-support-mariner-platform.patch
 Patch2:         Replace-unsupported-TLS-methods.patch
-BuildRequires:  pkg-config >= 0.28
+# CVE-2020-27619 patch is pulled from upstream commit
+Patch3:         CVE-2020-27619.patch
 BuildRequires:  bzip2-devel
-BuildRequires:  ncurses-devel
-BuildRequires:  openssl-devel
-BuildRequires:  readline-devel
-BuildRequires:  xz-devel
 BuildRequires:  expat-devel >= 2.1.0
 BuildRequires:  libffi-devel >= 3.0.13
+BuildRequires:  ncurses-devel
+BuildRequires:  openssl-devel
+BuildRequires:  pkg-config >= 0.28
+BuildRequires:  readline-devel
 BuildRequires:  sqlite-devel
+BuildRequires:  xz-devel
 Requires:       ncurses
 Requires:       openssl
 Requires:       python3-libs = %{version}-%{release}
@@ -29,10 +30,9 @@ Requires:       readline
 Requires:       xz
 Provides:       python-sqlite
 Provides:       python(abi)
-Provides:       /usr/bin/python
+Provides:       %{_bindir}/python
 Provides:       /bin/python
 Provides:       /bin/python3
-
 %if %{with_check}
 BuildRequires:  iana-etc
 BuildRequires:  tzdata
@@ -45,15 +45,14 @@ strings support, easier and more intuitive syntax, and removes the deprecated
 code. It is incompatible with Python 2.x releases.
 
 %package libs
-Summary: The libraries for python runtime
-Group: Applications/System
+Summary:        The libraries for python runtime
+Group:          Applications/System
+Requires:       bzip2-libs
 Requires:       coreutils
 Requires:       expat >= 2.1.0
 Requires:       libffi >= 3.0.13
 Requires:       ncurses
 Requires:       sqlite-libs
-Requires:       bzip2-libs
-
 
 %description    libs
 The python interpreter can be embedded into applications wanting to
@@ -63,8 +62,8 @@ provides the libraries needed for python 3 applications.
 %package        xml
 Summary:        XML libraries for python3 runtime
 Group:          Applications/System
-Requires:       python3-libs = %{version}-%{release}
 Requires:       python3 = %{version}-%{release}
+Requires:       python3-libs = %{version}-%{release}
 
 %description    xml
 The python3-xml package provides the libraries needed for XML manipulation.
@@ -72,20 +71,20 @@ The python3-xml package provides the libraries needed for XML manipulation.
 %package        curses
 Summary:        Python module interface for NCurses Library
 Group:          Applications/System
-Requires:       python3-libs = %{version}-%{release}
 Requires:       ncurses
+Requires:       python3-libs = %{version}-%{release}
 
 %description    curses
 The python3-curses package provides interface for ncurses library.
 
 %package        devel
-Summary: The libraries and header files needed for Python development.
+Summary:        The libraries and header files needed for Python development.
 Group:          Development/Libraries
-Requires:       python3 = %{version}-%{release}
 Requires:       expat-devel >= 2.1.0
+Requires:       python3 = %{version}-%{release}
 # Needed here because of the migration of Makefile from -devel to the main
 # package
-Conflicts: python3 < %{version}-%{release}
+Conflicts:      python3 < %{version}-%{release}
 
 %description    devel
 The Python programming language's interpreter can be extended with
@@ -110,9 +109,9 @@ to build python programs.
 %package        pip
 Summary:        The PyPA recommended tool for installing Python packages.
 Group:          Development/Tools
-BuildArch:      noarch
 Requires:       python3 = %{version}-%{release}
 Requires:       python3-xml = %{version}-%{release}
+BuildArch:      noarch
 
 %description    pip
 The PyPA recommended tool for installing Python packages.
@@ -120,16 +119,16 @@ The PyPA recommended tool for installing Python packages.
 %package        setuptools
 Summary:        Download, build, install, upgrade, and uninstall Python packages.
 Group:          Development/Tools
-BuildArch:      noarch
 Requires:       python3 = %{version}-%{release}
+BuildArch:      noarch
 
 %description    setuptools
 setuptools is a collection of enhancements to the Python distutils that allow you to more easily build and distribute Python packages, especially ones that have dependencies on other packages.
 
 %package test
-Summary: Regression tests package for Python.
-Group: Development/Tools
-Requires: python3 = %{version}-%{release}
+Summary:        Regression tests package for Python.
+Group:          Development/Tools
+Requires:       python3 = %{version}-%{release}
 
 %description test
 The test package contains all regression tests for Python as well as the modules test.support and test.regrtest. test.support is used to enhance your tests while test.regrtest drives the testing suite.
@@ -139,6 +138,7 @@ The test package contains all regression tests for Python as well as the modules
 %patch0 -p1
 %patch1 -p1
 %patch2 -p1
+%patch3 -p1
 
 %build
 export OPT="%{optflags} %{openssl_flags}"
@@ -173,10 +173,10 @@ make  %{?_smp_mflags} test
 %clean
 rm -rf %{buildroot}/*
 
+
 %files
 %defattr(-, root, root)
 %license LICENSE
-%doc LICENSE README.rst
 %{_bindir}/pydoc*
 %{_bindir}/pyvenv*
 %{_bindir}/python3
@@ -191,7 +191,6 @@ rm -rf %{buildroot}/*
 %{_libdir}/libpython3.7.so
 %{_libdir}/libpython3.7m.so.1.0
 
-
 %exclude %{_libdir}/python3.7/ctypes/test
 %exclude %{_libdir}/python3.7/distutils/tests
 %exclude %{_libdir}/python3.7/sqlite3/test
@@ -201,7 +200,6 @@ rm -rf %{buildroot}/*
 
 %files libs
 %defattr(-,root,root)
-%doc LICENSE README.rst
 %{_libdir}/python3.7
 %{_libdir}/python3.7/site-packages/easy_install.py
 %{_libdir}/python3.7/site-packages/README.txt
@@ -218,11 +216,11 @@ rm -rf %{buildroot}/*
 %exclude %{_libdir}/python3.7/lib-dynload/_curses*.so
 %exclude %{_libdir}/python3.7/distutils/command/wininst-*.exe
 
-%files  xml
+%files xml
 %{_libdir}/python3.7/xml/*
 %{_libdir}/python3.7/lib-dynload/pyexpat*.so
 
-%files  curses
+%files curses
 %{_libdir}/python3.7/curses/*
 %{_libdir}/python3.7/lib-dynload/_curses*.so
 
@@ -251,105 +249,153 @@ rm -rf %{buildroot}/*
 %files pip
 %defattr(-,root,root,755)
 %{_libdir}/python3.7/site-packages/pip/*
-%{_libdir}/python3.7/site-packages/pip-19.2.3.dist-info/*
+%{_libdir}/python3.7/site-packages/pip-20.1.1.dist-info/*
 %{_bindir}/pip*
 
 %files setuptools
 %defattr(-,root,root,755)
 %{_libdir}/python3.7/site-packages/pkg_resources/*
 %{_libdir}/python3.7/site-packages/setuptools/*
-%{_libdir}/python3.7/site-packages/setuptools-41.2.0.dist-info/*
+%{_libdir}/python3.7/site-packages/setuptools-47.1.0.dist-info/*
 %{_bindir}/easy_install-3.7
 
 %files test
 %{_libdir}/python3.7/test/*
 
 %changelog
-*   Mon Jul 06 2020 Henry Beberman <henry.beberman@microsoft.com> 3.7.7-2
--   Add BuildRequires for iana-etc and tzdata for check section.
-*   Wed Jun 10 2020 Paul Monson <paulmon@microsoft.com> 3.7.7-1
--   Update to Python 3.7.7 to fix CVEs
-*   Thu May 21 2020 Suresh Babu Chalamalasetty <schalam@microsoft.com> 3.7.3-10
--   Fix CVE-2019-16056.
-*   Wed May 20 2020 Nicolas Ontiveros <niontive@microsoft.com> 3.7.3-9
--   Fix CVE-2020-8492.
-*   Wed May 20 2020 Paul Monson <paulmon@microsoft.com> 3.7.3-8
--   Fix variable use.
-*   Sat May 09 00:20:54 PST 2020 Nick Samson <nisamson@microsoft.com> - 3.7.3-7
--   Added %%license line automatically
-*   Wed May 06 2020 Paul Monson <paulmon@microsoft.com> 3.7.3-6
--   Replace unsupported TLS methods with a patch.
-*   Thu Apr 09 2020 Nicolas Ontiveros <niontive@microsoft.com> 3.7.3-5
--   Remove toybox and only use coreutils for requires.
-*   Mon Nov 25 2019 Andrew Phelps <anphel@microsoft.com> 3.7.3-4
--   Remove duplicate libpython3.so from devel package
-*   Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 3.7.3-3
--   Initial CBL-Mariner import from Photon (license: Apache2).
-*   Mon Jun 17 2019 Tapas Kundu <tkundu@vmware.com> 3.7.3-2
--   Fix for CVE-2019-10160
-*   Mon Jun 10 2019 Tapas Kundu <tkundu@vmware.com> 3.7.3-1
--   Update to Python 3.7.3 release
-*   Thu May 23 2019 Tapas Kundu <tkundu@vmware.com> 3.7.0-6
--   Fix for CVE-2019-5010
--   Fix for CVE-2019-9740
-*   Tue Mar 12 2019 Tapas Kundu <tkundu@vmware.com> 3.7.0-5
--   Fix for CVE-2019-9636
-*   Mon Feb 11 2019 Taps Kundu <tkundu@vmware.com> 3.7.0-4
--   Fix for CVE-2018-20406
-*   Fri Dec 21 2018 Tapas Kundu <tkundu@vmware.com> 3.7.0-3
--   Fix for CVE-2018-14647
-*   Tue Dec 04 2018 Tapas Kundu <tkundu@vmware.com> 3.7.0-2
--   Excluded windows installer from python3 libs packaging.
-*   Wed Sep 26 2018 Tapas Kundu <tkundu@vmware.com> 3.7.0-1
--   Updated to version 3.7.0
-*   Mon Sep 18 2017 Alexey Makhalov <amakhalov@vmware.com> 3.6.1-9
--   Requires coreutils or toybox
--   Requires bzip2-libs
-*   Fri Sep 15 2017 Bo Gan <ganb@vmware.com> 3.6.1-8
--   Remove devpts mount in check
-*   Mon Aug 28 2017 Dheeraj Shetty <dheerajs@vmware.com> 3.6.1-7
--   Add pty for tests to pass
-*   Wed Jul 12 2017 Xiaolin Li <xiaolinl@vmware.com> 3.6.1-6
--   Add python3-test package.
-*   Fri Jun 30 2017 Dheeraj Shetty <dheerajs@vmware.com> 3.6.1-5
--   Remove the imaplib tests.
-*   Mon Jun 05 2017 Xiaolin Li <xiaolinl@vmware.com> 3.6.1-4
--   Added pip, setuptools, xml, and curses sub packages.
-*   Sun Jun 04 2017 Bo Gan <ganb@vmware.com> 3.6.1-3
--   Fix symlink and script
-*   Wed May 10 2017 Harish Udaiya Kumar <hudaiyakumar@vmware.com> 3.6.1-2
--   Exclude idle3.
-*   Wed Apr 26 2017 Siju Maliakkal <smaliakkal@vmware.com> 3.6.1-1
--   Updating to latest
-*   Fri Apr 14 2017 Alexey Makhalov <amakhalov@vmware.com> 3.5.3-3
--   Python3-devel requires expat-devel.
-*   Thu Mar 23 2017 Xiaolin Li <xiaolinl@vmware.com> 3.5.3-2
--   Provides /bin/python3.
-*   Tue Feb 28 2017 Xiaolin Li <xiaolinl@vmware.com> 3.5.3-1
--   Updated to version 3.5.3.
-*   Fri Jan 20 2017 Dheeraj Shetty <dheerajs@vmware.com> 3.5.1-10
--   Added patch to support Photon OS
-*   Tue Dec 20 2016 Xiaolin Li <xiaolinl@vmware.com> 3.5.1-9
--   Move easy_install-3.5 to devel subpackage.
-*   Wed Nov 16 2016 Alexey Makhalov <ppadmavilasom@vmware.com> 3.5.1-8
--   Use sqlite-{devel,libs}
-*   Thu Oct 27 2016 Anish Swaminathan <anishs@vmware.com> 3.5.1-7
--   Patch for CVE-2016-5636
-*   Mon Oct 10 2016 ChangLee <changlee@vmware.com> 3.5.1-6
--   Modified %check
-*   Tue May 24 2016 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 3.5.1-5
--   GA - Bump release of all rpms
-*   Wed May 04 2016 Anish Swaminathan <anishs@vmware.com> 3.5.1-4
--   Edit scriptlets.
-*   Wed Apr 13 2016 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 3.5.1-3
--   update python to require python-libs
-*   Thu Apr 07 2016 Mahmoud Bassiouny <mbassiouny@vmware.com> 3.5.1-2
--   Providing python3 binaries instead of the minor versions.
-*   Tue Feb 23 2016 Harish Udaiya Kumar <hudaiyakumar@vmware.com> 3.5.1-1
--   Updated to version 3.5.1
-*   Wed Dec 09 2015 Anish Swaminathan <anishs@vmware.com> 3.4.3-3
--   Edit post script.
-*   Mon Aug 17 2015 Vinay Kulkarni <kulkarniv@vmware.com> 3.4.3-2
--   Remove python.o file, and minor cleanups.
-*   Wed Jul 1 2015 Vinay Kulkarni <kulkarniv@vmware.com> 3.4.3
--   Add Python3 package to Photon.
+* Fri Nov 06 2020 Thomas Crain <thcrain@microsoft.com> - 3.7.9-2
+- Patch CVE-2020-27619
+
+* Fri Nov 06 2020 Thomas Crain <thcrain@microsoft.com> - 3.7.9-1
+- Update to 3.7.9, the latest security release for 3.7
+
+* Mon Jul 06 2020 Henry Beberman <henry.beberman@microsoft.com> - 3.7.7-2
+- Add BuildRequires for iana-etc and tzdata for check section.
+
+* Wed Jun 10 2020 Paul Monson <paulmon@microsoft.com> - 3.7.7-1
+- Update to Python 3.7.7 to fix CVEs
+
+* Thu May 21 2020 Suresh Babu Chalamalasetty <schalam@microsoft.com> - 3.7.3-10
+- Fix CVE-2019-16056.
+
+* Wed May 20 2020 Nicolas Ontiveros <niontive@microsoft.com> - 3.7.3-9
+- Fix CVE-2020-8492.
+
+* Wed May 20 2020 Paul Monson <paulmon@microsoft.com> - 3.7.3-8
+- Fix variable use.
+
+* Sat May 09 00:20:54 PST 2020 Nick Samson <nisamson@microsoft.com> - 3.7.3-7
+- Added %%license line automatically
+
+* Wed May 06 2020 Paul Monson <paulmon@microsoft.com> - 3.7.3-6
+- Replace unsupported TLS methods with a patch.
+
+* Thu Apr 09 2020 Nicolas Ontiveros <niontive@microsoft.com> - 3.7.3-5
+- Remove toybox and only use coreutils for requires.
+
+* Mon Nov 25 2019 Andrew Phelps <anphel@microsoft.com> - 3.7.3-4
+- Remove duplicate libpython3.so from devel package
+
+* Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> - 3.7.3-3
+- Initial CBL-Mariner import from Photon (license: Apache2).
+
+* Mon Jun 17 2019 Tapas Kundu <tkundu@vmware.com> - 3.7.3-2
+- Fix for CVE-2019-10160
+
+* Mon Jun 10 2019 Tapas Kundu <tkundu@vmware.com> - 3.7.3-1
+- Update to Python 3.7.3 release
+
+* Thu May 23 2019 Tapas Kundu <tkundu@vmware.com> - 3.7.0-6
+- Fix for CVE-2019-5010
+- Fix for CVE-2019-9740
+
+* Tue Mar 12 2019 Tapas Kundu <tkundu@vmware.com> - 3.7.0-5
+- Fix for CVE-2019-9636
+
+* Mon Feb 11 2019 Taps Kundu <tkundu@vmware.com> - 3.7.0-4
+- Fix for CVE-2018-20406
+
+* Fri Dec 21 2018 Tapas Kundu <tkundu@vmware.com> - 3.7.0-3
+- Fix for CVE-2018-14647
+
+* Tue Dec 04 2018 Tapas Kundu <tkundu@vmware.com> - 3.7.0-2
+- Excluded windows installer from python3 libs packaging.
+
+* Wed Sep 26 2018 Tapas Kundu <tkundu@vmware.com> - 3.7.0-1
+- Updated to version 3.7.0
+
+* Mon Sep 18 2017 Alexey Makhalov <amakhalov@vmware.com> - 3.6.1-9
+- Requires coreutils or toybox
+- Requires bzip2-libs
+
+* Fri Sep 15 2017 Bo Gan <ganb@vmware.com> - 3.6.1-8
+- Remove devpts mount in check
+
+* Mon Aug 28 2017 Dheeraj Shetty <dheerajs@vmware.com> - 3.6.1-7
+- Add pty for tests to pass
+
+* Wed Jul 12 2017 Xiaolin Li <xiaolinl@vmware.com> - 3.6.1-6
+- Add python3-test package.
+
+* Fri Jun 30 2017 Dheeraj Shetty <dheerajs@vmware.com> - 3.6.1-5
+- Remove the imaplib tests.
+
+* Mon Jun 05 2017 Xiaolin Li <xiaolinl@vmware.com> - 3.6.1-4
+- Added pip, setuptools, xml, and curses sub packages.
+
+* Sun Jun 04 2017 Bo Gan <ganb@vmware.com> - 3.6.1-3
+- Fix symlink and script
+
+* Wed May 10 2017 Harish Udaiya Kumar <hudaiyakumar@vmware.com> - 3.6.1-2
+- Exclude idle3.
+
+* Wed Apr 26 2017 Siju Maliakkal <smaliakkal@vmware.com> - 3.6.1-1
+- Updating to latest
+
+* Fri Apr 14 2017 Alexey Makhalov <amakhalov@vmware.com> - 3.5.3-3
+- Python3-devel requires expat-devel.
+
+* Thu Mar 23 2017 Xiaolin Li <xiaolinl@vmware.com> - 3.5.3-2
+- Provides /bin/python3.
+
+* Tue Feb 28 2017 Xiaolin Li <xiaolinl@vmware.com> - 3.5.3-1
+- Updated to version 3.5.3.
+
+* Fri Jan 20 2017 Dheeraj Shetty <dheerajs@vmware.com> - 3.5.1-10
+- Added patch to support Photon OS
+
+* Tue Dec 20 2016 Xiaolin Li <xiaolinl@vmware.com> - 3.5.1-9
+- Move easy_install-3.5 to devel subpackage.
+
+* Wed Nov 16 2016 Alexey Makhalov <ppadmavilasom@vmware.com> - 3.5.1-8
+- Use sqlite-{devel,libs}
+
+* Thu Oct 27 2016 Anish Swaminathan <anishs@vmware.com> - 3.5.1-7
+- Patch for CVE-2016-5636
+
+* Mon Oct 10 2016 ChangLee <changlee@vmware.com> - 3.5.1-6
+- Modified %check
+
+* Tue May 24 2016 Priyesh Padmavilasom <ppadmavilasom@vmware.com> - 3.5.1-5
+- GA - Bump release of all rpms
+
+* Wed May 04 2016 Anish Swaminathan <anishs@vmware.com> - 3.5.1-4
+- Edit scriptlets.
+
+* Wed Apr 13 2016 Priyesh Padmavilasom <ppadmavilasom@vmware.com> - 3.5.1-3
+- update python to require python-libs
+
+* Thu Apr 07 2016 Mahmoud Bassiouny <mbassiouny@vmware.com> - 3.5.1-2
+- Providing python3 binaries instead of the minor versions.
+
+* Tue Feb 23 2016 Harish Udaiya Kumar <hudaiyakumar@vmware.com> - 3.5.1-1
+- Updated to version 3.5.1
+
+* Wed Dec 09 2015 Anish Swaminathan <anishs@vmware.com> - 3.4.3-3
+- Edit post script.
+
+* Mon Aug 17 2015 Vinay Kulkarni <kulkarniv@vmware.com> - 3.4.3-2
+- Remove python.o file, and minor cleanups.
+
+* Wed Jul 1 2015 Vinay Kulkarni <kulkarniv@vmware.com> - 3.4.3
+- Add Python3 package to Photon.

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -4186,8 +4186,8 @@
         "type": "other",
         "other": {
           "name": "python3",
-          "version": "3.7.7",
-          "downloadUrl": "https://www.python.org/ftp/python/3.7.7/Python-3.7.7.tar.xz"
+          "version": "3.7.9",
+          "downloadUrl": "https://www.python.org/ftp/python/3.7.9/Python-3.7.9.tar.xz"
         }
       }
     },
@@ -4626,8 +4626,8 @@
         "type": "other",
         "other": {
           "name": "python-markupsafe",
-          "version": "1.0",
-          "downloadUrl": "https://pypi.python.org/packages/4d/de/32d741db316d8fdb7680822dd37001ef7a448255de9699ab4bfcbdf4172b/MarkupSafe-1.0.tar.gz"
+          "version": "1.1.1",
+          "downloadUrl": "https://pypi.python.org/packages/source/M/MarkupSafe/MarkupSafe-1.1.1.tar.gz"
         }
       }
     },
@@ -5036,8 +5036,8 @@
         "type": "other",
         "other": {
           "name": "python-zope-interface",
-          "version": "4.6.0",
-          "downloadUrl": "https://files.pythonhosted.org/packages/4e/d0/c9d16bd5b38de44a20c6dc5d5ed80a49626fafcb3db9f9efdc2a19026db6/zope.interface-4.6.0.tar.gz"
+          "version": "4.7.2",
+          "downloadUrl": "https://pypi.python.org/packages/source/z/zope.interface/zope.interface-4.7.2.tar.gz"
         }
       }
     },

--- a/toolkit/scripts/imggen.mk
+++ b/toolkit/scripts/imggen.mk
@@ -152,8 +152,7 @@ $(image_external_package_cache_summary): $(cached_file) $(go-imagepkgfetcher) $(
 		--tls-cert=$(TLS_CERT) \
 		--tls-key=$(TLS_KEY) \
 		$(foreach repo, $(imagefetcher_local_repo) $(imagefetcher_cloned_repo) $(REPO_LIST),--repo-file="$(repo)" ) \
-		$(imagepkgfetcher_update_repo_flag) \
-		$(imagepkgfetcher_disable_upstream_repos_flag) \
+		$(imagepkgfetcher_extra_flags) \
 		--input-summary-file=$(IMAGE_CACHE_SUMMARY) \
 		--output-summary-file=$@ \
 		--output-dir=$(external_rpm_cache)

--- a/toolkit/scripts/toolchain/container/toolchain-remote-wget-list
+++ b/toolkit/scripts/toolchain/container/toolchain-remote-wget-list
@@ -14,7 +14,7 @@ https://gcc.gnu.org/pub/libffi/libffi-3.2.1.tar.gz
 http://ftp.gnu.org/gnu/libtool/libtool-2.4.6.tar.xz
 http://ftp.gnu.org/gnu/m4/m4-1.4.18.tar.xz
 http://ftp.gnu.org/gnu/make/make-4.2.1.tar.gz
-https://www.kernel.org/pub/linux/docs/man-pages/man-pages-5.02.tar.xz
+https://www.kernel.org/pub/linux/docs/man-pages/Archive/man-pages-5.02.tar.xz
 https://ftp.gnu.org/gnu/mpc/mpc-1.1.0.tar.gz
 http://www.mpfr.org/mpfr-4.0.1/mpfr-4.0.1.tar.xz
 ftp://ftp.invisible-island.net/ncurses/ncurses-6.2.tar.gz


### PR DESCRIPTION

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
This PR is a merge of select fixes from the 1.0-dev branch to:
1) Fix a critical CVE in Python
2) Fix a community build issue where the bootstrap toolchain phase fails.
3) Fix a community build issue where the SRPM for bond is ARM64 specific and not platform generic
4) Fix an image build flag issue.


###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**


