### PR TITLE
Add status badge, update quickstart workflow

### DIFF
--- a/.github/workflows/quickstart_1.0.yml
+++ b/.github/workflows/quickstart_1.0.yml
@@ -3,7 +3,7 @@
 #
 # Workflow to automatedly verify the quickstart instructions
 
-name: Verify Quickstart
+name: Verify Quickstart 1.0
 
 on:
   workflow_dispatch:
@@ -11,7 +11,7 @@ on:
     - cron: "0 15 * * *"
 
 jobs:
-  iso_quickstart:
+  get_input-srpms:
     runs-on: ubuntu-18.04
 
     steps:
@@ -32,12 +32,33 @@ jobs:
         sudo apt-get update
         sudo apt -y install make tar wget curl rpm qemu-utils genisoimage pigz
 
-    - name: Configure the Environment
+    - name: Download SRPMS
       run: |
         pushd toolkit
         sudo make go-tools REBUILD_TOOLS=y
         sudo make input-srpms DOWNLOAD_SRPMS=y
         popd
+
+  iso_quickstart:
+    runs-on: ubuntu-18.04
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2.3.2
+      with:
+        ref: '1.0-stable'
+
+    - name: Set up Go 1.13
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.13
+      id: go
+
+    - name: Install Remaining Prerequisites
+      run: |
+        # Golang and docker are already installed on the agent
+        sudo apt-get update
+        sudo apt -y install make tar wget curl rpm qemu-utils genisoimage pigz
 
     - name: ISO Quick Start
       run: |
@@ -65,13 +86,6 @@ jobs:
         # Golang and docker are already installed on the agent
         sudo apt-get update
         sudo apt -y install make tar wget curl rpm qemu-utils genisoimage pigz
-
-    - name: Configure Environment
-      run: |
-        pushd toolkit
-        sudo make go-tools REBUILD_TOOLS=y
-        sudo make input-srpms DOWNLOAD_SRPMS=y
-        popd
 
     - name: VHDX Quick Start
       run: |

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # CBL-Mariner
 
+| Release Branch | Status                                                                                                                                                                                                 |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 1.0            | [![1.0 Status](https://github.com/microsoft/CBL-Mariner/workflows/Verify%20Quickstart%201.0/badge.svg)](https://github.com/microsoft/CBL-Mariner/actions?query=workflow%3A%22Verify+Quickstart+1.0%22) |
+
 CBL-Mariner is an internal Linux distribution for Microsoft’s cloud infrastructure and edge products and services. CBL-Mariner is designed to provide a consistent platform for these devices and services and will enhance Microsoft’s ability to stay current on Linux updates. This initiative is part of Microsoft’s increasing investment in a wide range of Linux technologies, such as [SONiC](https://azure.microsoft.com/en-us/blog/sonic-the-networking-switch-software-that-powers-the-microsoft-global-cloud/), [Azure Sphere OS](https://docs.microsoft.com/en-us/azure-sphere/product-overview/what-is-azure-sphere) and [Windows Subsystem for Linux (WSL)](https://docs.microsoft.com/en-us/windows/wsl/about). CBL-Mariner is being shared publicly as part of Microsoft’s commitment to Open Source and to contribute back to the Linux community. CBL-Mariner does not change our approach or commitment to any existing third-party Linux distribution offerings. 
 
 CBL-Mariner has been engineered with the notion that a small common core set of packages can address the universal needs of first party cloud and edge services while allowing individual teams to layer additional packages on top of the common core to produce images for their workloads. This is made possible by a simple build system that enables:


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
1.0 is now our default branch, we should display a set of status badges for the current state of the *-stable tags. While doing a full build from sources is too slow to do with a github action we can at least validate the `REBUILD_PACKAGES=n` case. 

Each time we snap a new stable branch (2.0-stable, 3.0-stable, etc.) we will need to create a new workflow and badge to target that tag. As releases drop out of support we can remove the workflows. Scheduled workflows (like the quickstart workflow) will only run if they are part of the default branch, so we only need to maintain these badges and workflow definitions on the current leading edge stable branch (1.0 right now).

**NOTE:** This will display a failed build badge until it reaches the `dev` branch, AND a nightly build runs (I renamed the workflow to include "1.0").  The workflow has been running however, and can be seen [here](https://github.com/microsoft/CBL-Mariner/actions?query=workflow%3A%22Verify+Quickstart%22)

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add status badges to the readme
- Split the `make input-srpms` and `make go-tools` steps into their own task in the workflow

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Validated on a fork [here](https://github.com/dmcilvaney/CBL-Mariner/blob/1.0/README.md)
