### PR TITLE
[dev] Guard scheduler's graph to prevent concurrent reads and writes

### DIFF
--- a/toolkit/tools/scheduler/scheduler.go
+++ b/toolkit/tools/scheduler/scheduler.go
@@ -330,6 +330,7 @@ func buildAllNodes(stopOnFailure, isGraphOptimized, canUseCache bool, packagesTo
 // updateGraphWithImplicitProvides will update the graph with new implicit provides if available.
 // It will also attempt to subgraph the graph if it becomes solvable with the new implicit provides.
 func updateGraphWithImplicitProvides(res *schedulerutils.BuildResult, pkgGraph *pkggraph.PkgGraph, graphMutex sync.RWMutex, useCachedImplicit bool) (didOptimize bool, newGraph *pkggraph.PkgGraph, newGoalNode *pkggraph.PkgNode) {
+	// acquire a writer lock since this routine will collapse nodes
 	graphMutex.Lock()
 	defer graphMutex.Unlock()
 

--- a/toolkit/tools/scheduler/scheduler.go
+++ b/toolkit/tools/scheduler/scheduler.go
@@ -183,7 +183,7 @@ func buildGraph(inputFile, outputFile string, agent buildagents.BuildAgent, work
 	channels := startWorkerPool(agent, workers, buildAttempts, numberOfNodes, graphMutex)
 	logger.Log.Infof("Building %d nodes with %d workers", numberOfNodes, workers)
 
-	// After this call pkgGraph will be given to multiple routines and accessing it requires a mutex.
+	// After this call pkgGraph will be given to multiple routines and accessing it requires acquiring the mutex.
 	builtGraph, err := buildAllNodes(stopOnFailure, isGraphOptimized, canUseCache, packagesNamesToRebuild, pkgGraph, graphMutex, goalNode, channels)
 
 	if builtGraph != nil {

--- a/toolkit/tools/scheduler/scheduler.go
+++ b/toolkit/tools/scheduler/scheduler.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"runtime"
+	"sync"
 
 	"golang.org/x/sys/unix"
 	"gopkg.in/alecthomas/kingpin.v2"
@@ -168,6 +169,9 @@ func cancelBuildsOnSignal(signals chan os.Signal, agent buildagents.BuildAgent) 
 // buildGraph builds all packages in the dependency graph requested.
 // It will save the resulting graph to outputFile.
 func buildGraph(inputFile, outputFile string, agent buildagents.BuildAgent, workers, buildAttempts int, stopOnFailure, canUseCache bool, packagesToBuild []*pkgjson.PackageVer, packagesNamesToRebuild []string) (err error) {
+	// graphMutex guards pkgGraph from concurrent reads and writes during build.
+	var graphMutex sync.RWMutex
+
 	isGraphOptimized, pkgGraph, goalNode, err := schedulerutils.InitializeGraph(inputFile, packagesToBuild)
 	if err != nil {
 		return
@@ -175,14 +179,20 @@ func buildGraph(inputFile, outputFile string, agent buildagents.BuildAgent, work
 
 	// Setup and start the worker pool and scheduler routine.
 	numberOfNodes := pkgGraph.Nodes().Len()
-	channels := startWorkerPool(agent, workers, buildAttempts, numberOfNodes)
+
+	channels := startWorkerPool(agent, workers, buildAttempts, numberOfNodes, graphMutex)
 	logger.Log.Infof("Building %d nodes with %d workers", numberOfNodes, workers)
 
-	builtGraph, err := buildAllNodes(stopOnFailure, isGraphOptimized, canUseCache, packagesNamesToRebuild, pkgGraph, goalNode, channels)
+	// After this call pkgGraph will be given to multiple routines and accessing it requires a mutex.
+	builtGraph, err := buildAllNodes(stopOnFailure, isGraphOptimized, canUseCache, packagesNamesToRebuild, pkgGraph, graphMutex, goalNode, channels)
+
 	if builtGraph != nil {
+		graphMutex.RLock()
+		defer graphMutex.RUnlock()
+
 		saveErr := pkggraph.WriteDOTGraphFile(builtGraph, outputFile)
 		if saveErr != nil {
-			logger.Log.Errorf("Failed to save built graph, erorr: %s", saveErr)
+			logger.Log.Errorf("Failed to save built graph, error: %s", saveErr)
 		}
 	}
 
@@ -191,7 +201,7 @@ func buildGraph(inputFile, outputFile string, agent buildagents.BuildAgent, work
 
 // startWorkerPool starts the worker pool and returns the communication channels between the workers and the scheduler.
 // channelBufferSize controls how many entries in the channels can be buffered before blocking writes to them.
-func startWorkerPool(agent buildagents.BuildAgent, workers, buildAttempts, channelBufferSize int) (channels *schedulerChannels) {
+func startWorkerPool(agent buildagents.BuildAgent, workers, buildAttempts, channelBufferSize int, graphMutex sync.RWMutex) (channels *schedulerChannels) {
 	channels = &schedulerChannels{
 		Requests: make(chan *schedulerutils.BuildRequest, channelBufferSize),
 		Results:  make(chan *schedulerutils.BuildResult, channelBufferSize),
@@ -208,7 +218,7 @@ func startWorkerPool(agent buildagents.BuildAgent, workers, buildAttempts, chann
 	// Start the workers now so they begin working as soon as a new job is queued.
 	for i := 0; i < workers; i++ {
 		logger.Log.Debugf("Starting worker #%d", i)
-		go schedulerutils.BuildNodeWorker(directionalChannels, agent, buildAttempts)
+		go schedulerutils.BuildNodeWorker(directionalChannels, agent, graphMutex, buildAttempts)
 	}
 
 	return
@@ -223,7 +233,7 @@ func startWorkerPool(agent buildagents.BuildAgent, workers, buildAttempts, chann
 // - Attempts to satisfy any unresolved dynamic dependencies with new implicit provides from the build result.
 // - Attempts to subgraph the graph to only contain the requested packages if possible.
 // - Repeat.
-func buildAllNodes(stopOnFailure, isGraphOptimized, canUseCache bool, packagesToRebuild []string, pkgGraph *pkggraph.PkgGraph, goalNode *pkggraph.PkgNode, channels *schedulerChannels) (builtGraph *pkggraph.PkgGraph, err error) {
+func buildAllNodes(stopOnFailure, isGraphOptimized, canUseCache bool, packagesToRebuild []string, pkgGraph *pkggraph.PkgGraph, graphMutex sync.RWMutex, goalNode *pkggraph.PkgNode, channels *schedulerChannels) (builtGraph *pkggraph.PkgGraph, err error) {
 	var (
 		// stopBuilding tracks if the build has entered a failed state and this routine should stop as soon as possible.
 		stopBuilding bool
@@ -237,13 +247,13 @@ func buildAllNodes(stopOnFailure, isGraphOptimized, canUseCache bool, packagesTo
 	// Start the build at the leaf nodes.
 	// The build will bubble up through the graph as it processes nodes.
 	buildState := schedulerutils.NewGraphBuildState()
-	nodesToBuild := schedulerutils.LeafNodes(pkgGraph, goalNode, buildState, useCachedImplicit)
+	nodesToBuild := schedulerutils.LeafNodes(pkgGraph, graphMutex, goalNode, buildState, useCachedImplicit)
 
 	for {
 		logger.Log.Debugf("Found %d unblocked nodes", len(nodesToBuild))
 
 		// Each node that is ready to build must be converted into a build request and submitted to the worker pool.
-		newRequests := schedulerutils.ConvertNodesToRequests(pkgGraph, nodesToBuild, packagesToRebuild, buildState, canUseCache)
+		newRequests := schedulerutils.ConvertNodesToRequests(pkgGraph, graphMutex, nodesToBuild, packagesToRebuild, buildState, canUseCache)
 		for _, req := range newRequests {
 			buildState.RecordBuildRequest(req)
 			channels.Requests <- req
@@ -259,7 +269,7 @@ func buildAllNodes(stopOnFailure, isGraphOptimized, canUseCache bool, packagesTo
 			} else {
 				logger.Log.Warn("Enabling cached packages to satisfy unresolved dynamic dependencies.")
 				useCachedImplicit = true
-				nodesToBuild = schedulerutils.LeafNodes(pkgGraph, goalNode, buildState, useCachedImplicit)
+				nodesToBuild = schedulerutils.LeafNodes(pkgGraph, graphMutex, goalNode, buildState, useCachedImplicit)
 				continue
 			}
 		}
@@ -274,7 +284,7 @@ func buildAllNodes(stopOnFailure, isGraphOptimized, canUseCache bool, packagesTo
 				// If the graph has already been optimized and is now solvable without any additional information
 				// then skip processing any new implicit provides.
 				if !isGraphOptimized {
-					didOptimize, newGraph, newGoalNode := updateGraphWithImplicitProvides(res, pkgGraph, useCachedImplicit)
+					didOptimize, newGraph, newGoalNode := updateGraphWithImplicitProvides(res, pkgGraph, graphMutex, useCachedImplicit)
 					if didOptimize {
 						isGraphOptimized = true
 						// Replace the graph and goal node pointers.
@@ -285,7 +295,7 @@ func buildAllNodes(stopOnFailure, isGraphOptimized, canUseCache bool, packagesTo
 					}
 				}
 
-				nodesToBuild = schedulerutils.FindUnblockedNodesFromResult(res, pkgGraph, buildState)
+				nodesToBuild = schedulerutils.FindUnblockedNodesFromResult(res, pkgGraph, graphMutex, buildState)
 			} else if stopOnFailure {
 				stopBuilding = true
 				err = res.Err
@@ -312,14 +322,17 @@ func buildAllNodes(stopOnFailure, isGraphOptimized, canUseCache bool, packagesTo
 	}
 
 	builtGraph = pkgGraph
-	schedulerutils.PrintBuildSummary(builtGraph, buildState)
+	schedulerutils.PrintBuildSummary(builtGraph, graphMutex, buildState)
 
 	return
 }
 
 // updateGraphWithImplicitProvides will update the graph with new implicit provides if available.
 // It will also attempt to subgraph the graph if it becomes solvable with the new implicit provides.
-func updateGraphWithImplicitProvides(res *schedulerutils.BuildResult, pkgGraph *pkggraph.PkgGraph, useCachedImplicit bool) (didOptimize bool, newGraph *pkggraph.PkgGraph, newGoalNode *pkggraph.PkgNode) {
+func updateGraphWithImplicitProvides(res *schedulerutils.BuildResult, pkgGraph *pkggraph.PkgGraph, graphMutex sync.RWMutex, useCachedImplicit bool) (didOptimize bool, newGraph *pkggraph.PkgGraph, newGoalNode *pkggraph.PkgNode) {
+	graphMutex.Lock()
+	defer graphMutex.Unlock()
+
 	didInjectAny, err := schedulerutils.InjectMissingImplicitProvides(res, pkgGraph, useCachedImplicit)
 	if err != nil {
 		logger.Log.Warnf("Failed to inject any missing implicit provides for (%s). Error: %s", res.Node.FriendlyName(), err)

--- a/toolkit/tools/scheduler/schedulerutils/preparerequest.go
+++ b/toolkit/tools/scheduler/schedulerutils/preparerequest.go
@@ -6,6 +6,7 @@ package schedulerutils
 import (
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"microsoft.com/pkggen/internal/logger"
 	"microsoft.com/pkggen/internal/pkggraph"
@@ -15,7 +16,10 @@ import (
 // ConvertNodesToRequests converts a slice of nodes into a slice of build requests.
 // - It will determine if the cache can be used for prebuilt nodes.
 // - It will group similair build nodes together into AncillaryNodes.
-func ConvertNodesToRequests(pkgGraph *pkggraph.PkgGraph, nodesToBuild []*pkggraph.PkgNode, packagesToRebuild []string, buildState *GraphBuildState, isCacheAllowed bool) (requests []*BuildRequest) {
+func ConvertNodesToRequests(pkgGraph *pkggraph.PkgGraph, graphMutex sync.RWMutex, nodesToBuild []*pkggraph.PkgNode, packagesToRebuild []string, buildState *GraphBuildState, isCacheAllowed bool) (requests []*BuildRequest) {
+	graphMutex.RLock()
+	defer graphMutex.RUnlock()
+
 	// Group build nodes together as they will be unblocked all at once for any given SRPM,
 	// and building a single build node will result in all of them becoming available.
 	buildNodes := make(map[string][]*pkggraph.PkgNode)

--- a/toolkit/tools/scheduler/schedulerutils/printresults.go
+++ b/toolkit/tools/scheduler/schedulerutils/printresults.go
@@ -5,6 +5,7 @@ package schedulerutils
 
 import (
 	"path/filepath"
+	"sync"
 
 	"microsoft.com/pkggen/internal/logger"
 	"microsoft.com/pkggen/internal/pkggraph"
@@ -30,7 +31,10 @@ func PrintBuildResult(res *BuildResult) {
 }
 
 // PrintBuildSummary prints the summary of the entire build to the logger.
-func PrintBuildSummary(pkgGraph *pkggraph.PkgGraph, buildState *GraphBuildState) {
+func PrintBuildSummary(pkgGraph *pkggraph.PkgGraph, graphMutex sync.RWMutex, buildState *GraphBuildState) {
+	graphMutex.RLock()
+	defer graphMutex.RUnlock()
+
 	failedSRPMs := make(map[string]bool)
 	failures := buildState.BuildFailures()
 	for _, failure := range failures {


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
When scheduler runs, multiple routines have access to the dependency graph for reading. However, when injecting implicit provides or sub-graphing, the graph and its edges are altered. It is possible for other routines to be traversing the graph when this happens, resulting in concurrent reads and writes to a non-thread-safe object. Implement a reader-writer mutex around the graph to prevent this.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Implement a reader-writer mutex for graph access in scheduler.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local builds.
