### PR TITLE
Enabling network access for package builds running with `%check`.

### DIFF
--- a/toolkit/tools/pkgworker/pkgworker.go
+++ b/toolkit/tools/pkgworker/pkgworker.go
@@ -135,7 +135,7 @@ func buildSRPMInChroot(chrootDir, rpmDirPath, workerTar, srpmFile, repoFile, rpm
 	defer chroot.Close(noCleanup)
 
 	// Place extra files that will be needed to build into the chroot
-	srpmFileInChroot, err := copyFilesIntoChroot(chroot, srpmFile, repoFile, rpmmacrosFile)
+	srpmFileInChroot, err := copyFilesIntoChroot(chroot, srpmFile, repoFile, rpmmacrosFile, runCheck)
 	if err != nil {
 		return
 	}
@@ -356,10 +356,11 @@ func removeLibArchivesFromSystem() (err error) {
 }
 
 // copyFilesIntoChroot copies several required build specific files into the chroot.
-func copyFilesIntoChroot(chroot *safechroot.Chroot, srpmFile, repoFile, rpmmacrosFile string) (srpmFileInChroot string, err error) {
+func copyFilesIntoChroot(chroot *safechroot.Chroot, srpmFile, repoFile, rpmmacrosFile string, runCheck bool) (srpmFileInChroot string, err error) {
 	const (
 		chrootRepoDestDir = "/etc/yum.repos.d"
 		chrootSrpmDestDir = "/root/SRPMS"
+		resolvFilePath    = "/etc/resolv.conf"
 		rpmmacrosDest     = "/usr/lib/rpm/macros.d/macros.override"
 	)
 
@@ -383,6 +384,14 @@ func copyFilesIntoChroot(chroot *safechroot.Chroot, srpmFile, repoFile, rpmmacro
 			Dest: rpmmacrosDest,
 		}
 		filesToCopy = append(filesToCopy, rpmmacrosCopy)
+	}
+
+	if runCheck {
+		resolvFileCopy := safechroot.FileToCopy{
+			Src:  resolvFilePath,
+			Dest: resolvFilePath,
+		}
+		filesToCopy = append(filesToCopy, resolvFileCopy)
 	}
 
 	err = chroot.AddFiles(filesToCopy...)

--- a/toolkit/tools/pkgworker/pkgworker.go
+++ b/toolkit/tools/pkgworker/pkgworker.go
@@ -387,6 +387,8 @@ func copyFilesIntoChroot(chroot *safechroot.Chroot, srpmFile, repoFile, rpmmacro
 	}
 
 	if runCheck {
+		logger.Log.Warn("Enabling network access because we're running package tests (make argument 'RUN_CHECK' set to 'y').")
+
 		resolvFileCopy := safechroot.FileToCopy{
 			Src:  resolvFilePath,
 			Dest: resolvFilePath,


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Many of the package tests run in the `%check` section install additional libraries (through `cpan` for instance) and we need network access from the worker chroot for that. This change still keeps the regular, non-test builds offline.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Enabled network access for the worker chroot during package test runs.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
No.

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local `make go-tool REBUILD_TOOLS=y` run succeeded.
