### PR TITLE
cherry-pick: Install cracklib before building pam

### DIFF
--- a/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
+++ b/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
@@ -352,6 +352,9 @@ build_rpm_in_chroot_no_install libxml2
 chroot_and_install_rpms python-setuptools
 build_rpm_in_chroot_no_install cracklib
 
+# pam needs cracklib
+chroot_and_install_rpms cracklib
+
 build_rpm_in_chroot_no_install cmake
 build_rpm_in_chroot_no_install pam
 build_rpm_in_chroot_no_install docbook-dtd-xml
@@ -439,8 +442,6 @@ chroot_and_install_rpms ninja-build
 chroot_and_install_rpms gettext
 build_rpm_in_chroot_no_install meson
 
-# libpwquality requires cracklib
-chroot_and_install_rpms cracklib
 build_rpm_in_chroot_no_install libpwquality
 build_rpm_in_chroot_no_install json-c
 build_rpm_in_chroot_no_install libsepol


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

Cherry-pick of: https://github.com/microsoft/CBL-Mariner/pull/375

When pam is built in the toolchain environment, cracklib-devel is not installed. This results in pam's auto configure skipping cracklib integration. However pam's cracklib integration is needed by other packages such as shadowutils.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Install cracklib before pam is built in the toolchain.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
**YES**

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local end to end build.
