### PR TITLE
Fix ant to run without extra setup

### DIFF
--- a/SPECS/ant/ant.spec
+++ b/SPECS/ant/ant.spec
@@ -1,23 +1,23 @@
-Summary:        Apache Ant
-Name:           ant
-Version:        1.10.9
-Release:        1%{?dist}
-License:        ASL 2.0 and BSD and W3C
-URL:            https://ant.apache.org
-Group:          Applications/System
-Vendor:         Microsoft Corporation
-Distribution:   Mariner
-BuildArch:      noarch
-Source0:        https://archive.apache.org/dist/ant/source/apache-%{name}-%{version}-src.tar.gz
-Source1:        https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/hamcrest/hamcrest-1.3.tgz
-Source2:        https://dl.bintray.com/vmware/photon_sources/1.0/maven-ant-tasks-2.1.3.tar.gz
-
-Requires:      openjre8
-BuildRequires: openjre8
-BuildRequires: openjdk8
 %define _prefix /var/opt/apache-%{name}
 %define _bindir %{_prefix}/bin
 %define _libdir %{_prefix}/lib
+Summary:        Apache Ant
+Name:           ant
+Version:        1.10.9
+Release:        2%{?dist}
+License:        ASL 2.0 AND BSD AND W3C
+Vendor:         Microsoft Corporation
+Distribution:   Mariner
+Group:          Applications/System
+URL:            https://ant.apache.org
+Source0:        https://archive.apache.org/dist/ant/source/apache-%{name}-%{version}-src.tar.gz
+Source1:        https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/hamcrest/hamcrest-1.3.tgz
+Source2:        https://dl.bintray.com/vmware/photon_sources/1.0/maven-ant-tasks-2.1.3.tar.gz
+BuildRequires:  openjdk8
+BuildRequires:  openjre8
+Requires:       openjre8
+Requires:       which
+BuildArch:      noarch
 
 %description
 The Ant package contains binaries for a build system
@@ -118,6 +118,9 @@ bootstrap/bin/ant -v run-tests
 %{_bindir}/runant.pl
 
 %changelog
+* Wed Nov 18 2020 Joe Schmitt <joschmit@microsoft.com> - 1.10.9-2
+- Add runtime requires on which. It is used to find the java executable when ant runs.
+
 *   Wed Oct 21 2020 Henry Li <lihl@microsoft.com> - 1.10.9-1
 -   Updated to version 1.10.9 to resolve CVE-2020-11979
 *   Thu May 21 2020 Ruying Chen <v-ruyche@microsoft.com> - 1.10.8-1


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
cherry-pick of: https://github.com/microsoft/CBL-Mariner/pull/397

`ant` does not work by default after installing it on a clean system. There is an underspecified dependency on `which`. By default `ant` will check `$JAVA_HOME` for the java binary location, or fall back to calling `which java` to find it. Since on a default system `$JAVA_HOME` is not set and `which` is not installed, `ant` cannot find `java` so it will fail.

See the following ant source code: https://github.com/apache/ant/blob/81aee9ec90a14f35c54acb54299e2e23a2749423/src/script/ant#L188
 
To repro, run the following commands on a clean Core image:
```
root [ / ]# tdnf install ant
....
root [ / ]# ant
We cannot run Java, please ensure you have Java installed.
  We have tried to execute java but failed.
If you have installed Java in a unusual place you can set JAVA_HOME
to the directory containing the Java installation.
```

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add a runtime requires on `which` in `ant`

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local build.