### PR TITLE
Fix qemu CVE-2018-12617

### DIFF
--- a/SPECS/qemu-kvm/CVE-2018-12617.patch
+++ b/SPECS/qemu-kvm/CVE-2018-12617.patch
@@ -1,4 +1,4 @@
-From b9dc66d9eb43429900c2db5f602b2f87ff41a01a Mon Sep 17 00:00:00 2001
+From a528fc1f446cdfb2ff648d1c0bfa0348e36cdfe2 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Philippe=20Mathieu-Daud=C3=A9?= <philmd@redhat.com>
 Date: Tue, 14 Apr 2020 15:30:42 +0200
 Subject: [PATCH 1/3] qga: Extract guest_file_handle_find() to
@@ -12,6 +12,8 @@ header.
 
 Signed-off-by: Philippe Mathieu-Daudé <philmd@redhat.com>
 Signed-off-by: Michael Roth <mdroth@linux.vnet.ibm.com>
+
+Backported upstream commit 5d3586b834633c8ac462d4741b85b4036cbc0f93
 ---
  qga/commands-common.h | 18 ++++++++++++++++++
  qga/commands-posix.c  |  7 ++++---
@@ -118,7 +120,7 @@ index 55ba5b26..b0f90e34 100644
 2.17.1
 
 
-From f61a3ff124fdd28deab63f2a3f9cd887787f4858 Mon Sep 17 00:00:00 2001
+From 352427fe776b7925c481fd1febbf9c95ae4f7c50 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Philippe=20Mathieu-Daud=C3=A9?= <philmd@redhat.com>
 Date: Tue, 14 Apr 2020 15:30:43 +0200
 Subject: [PATCH 2/3] qga: Extract qmp_guest_file_read() to common commands.c
@@ -131,6 +133,7 @@ Extract the common code shared by both POSIX/Win32 implementations.
 Signed-off-by: Philippe Mathieu-Daudé <philmd@redhat.com>
 Signed-off-by: Michael Roth <mdroth@linux.vnet.ibm.com>
 
+Backported upstream commit ead83a136d54f7faa315922aff26fa11d216909f
 Modified to apply to Mariner 4.2.0 by: Daniel McIlvaney <damcilva@microsoft.com>
 ---
  qga/commands-common.h |  3 +++
@@ -282,7 +285,7 @@ index 0c7d1385..73bf92ea 100644
 2.17.1
 
 
-From 709eb802c32630d3398807021b5d0edd32b4148e Mon Sep 17 00:00:00 2001
+From 7b645bdf29f4fe0367956906b9f15b268c4cf574 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Philippe=20Mathieu-Daud=C3=A9?= <philmd@redhat.com>
 Date: Tue, 14 Apr 2020 15:30:44 +0200
 Subject: [PATCH 3/3] qga: Restrict guest-file-read count to 48 MB to avoid
@@ -317,6 +320,8 @@ Signed-off-by: Philippe Mathieu-Daudé <philmd@redhat.com>
 Reviewed-by: Daniel P. Berrangé <berrange@redhat.com>
 *update schema documentation to indicate 48MB limit instead of 10MB
 Signed-off-by: Michael Roth <mdroth@linux.vnet.ibm.com>
+
+Backported upstream commit 1329651fb4d4c5068ad12fd86aff7e52f9e18c34
 ---
  qga/commands.c       | 9 ++++++++-
  qga/qapi-schema.json | 6 ++++--

--- a/SPECS/qemu-kvm/CVE-2018-12617.patch
+++ b/SPECS/qemu-kvm/CVE-2018-12617.patch
@@ -1,0 +1,381 @@
+From b9dc66d9eb43429900c2db5f602b2f87ff41a01a Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Philippe=20Mathieu-Daud=C3=A9?= <philmd@redhat.com>
+Date: Tue, 14 Apr 2020 15:30:42 +0200
+Subject: [PATCH 1/3] qga: Extract guest_file_handle_find() to
+ commands-common.h
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+As we are going to reuse this method, declare it in common
+header.
+
+Signed-off-by: Philippe Mathieu-Daudé <philmd@redhat.com>
+Signed-off-by: Michael Roth <mdroth@linux.vnet.ibm.com>
+---
+ qga/commands-common.h | 18 ++++++++++++++++++
+ qga/commands-posix.c  |  7 ++++---
+ qga/commands-win32.c  |  7 ++++---
+ 3 files changed, 26 insertions(+), 6 deletions(-)
+ create mode 100644 qga/commands-common.h
+
+diff --git a/qga/commands-common.h b/qga/commands-common.h
+new file mode 100644
+index 00000000..af90e548
+--- /dev/null
++++ b/qga/commands-common.h
+@@ -0,0 +1,18 @@
++/*
++ * QEMU Guest Agent common/cross-platform common commands
++ *
++ * Copyright (c) 2020 Red Hat, Inc.
++ *
++ * This work is licensed under the terms of the GNU GPL, version 2 or later.
++ * See the COPYING file in the top-level directory.
++ */
++#ifndef QGA_COMMANDS_COMMON_H
++#define QGA_COMMANDS_COMMON_H
++
++#include "qga-qapi-types.h"
++
++typedef struct GuestFileHandle GuestFileHandle;
++
++GuestFileHandle *guest_file_handle_find(int64_t id, Error **errp);
++
++#endif
+diff --git a/qga/commands-posix.c b/qga/commands-posix.c
+index 1c1a165d..6aa68033 100644
+--- a/qga/commands-posix.c
++++ b/qga/commands-posix.c
+@@ -26,6 +26,7 @@
+ #include "qemu/sockets.h"
+ #include "qemu/base64.h"
+ #include "qemu/cutils.h"
++#include "commands-common.h"
+ 
+ #ifdef HAVE_UTMPX
+ #include <utmpx.h>
+@@ -226,12 +227,12 @@ typedef enum {
+     RW_STATE_WRITING,
+ } RwState;
+ 
+-typedef struct GuestFileHandle {
++struct GuestFileHandle {
+     uint64_t id;
+     FILE *fh;
+     RwState state;
+     QTAILQ_ENTRY(GuestFileHandle) next;
+-} GuestFileHandle;
++};
+ 
+ static struct {
+     QTAILQ_HEAD(, GuestFileHandle) filehandles;
+@@ -257,7 +258,7 @@ static int64_t guest_file_handle_add(FILE *fh, Error **errp)
+     return handle;
+ }
+ 
+-static GuestFileHandle *guest_file_handle_find(int64_t id, Error **errp)
++GuestFileHandle *guest_file_handle_find(int64_t id, Error **errp)
+ {
+     GuestFileHandle *gfh;
+ 
+diff --git a/qga/commands-win32.c b/qga/commands-win32.c
+index 55ba5b26..b0f90e34 100644
+--- a/qga/commands-win32.c
++++ b/qga/commands-win32.c
+@@ -37,6 +37,7 @@
+ #include "qemu/queue.h"
+ #include "qemu/host-utils.h"
+ #include "qemu/base64.h"
++#include "commands-common.h"
+ 
+ #ifndef SHTDN_REASON_FLAG_PLANNED
+ #define SHTDN_REASON_FLAG_PLANNED 0x80000000
+@@ -50,11 +51,11 @@
+ 
+ #define INVALID_SET_FILE_POINTER ((DWORD)-1)
+ 
+-typedef struct GuestFileHandle {
++struct GuestFileHandle {
+     int64_t id;
+     HANDLE fh;
+     QTAILQ_ENTRY(GuestFileHandle) next;
+-} GuestFileHandle;
++};
+ 
+ static struct {
+     QTAILQ_HEAD(, GuestFileHandle) filehandles;
+@@ -126,7 +127,7 @@ static int64_t guest_file_handle_add(HANDLE fh, Error **errp)
+     return handle;
+ }
+ 
+-static GuestFileHandle *guest_file_handle_find(int64_t id, Error **errp)
++GuestFileHandle *guest_file_handle_find(int64_t id, Error **errp)
+ {
+     GuestFileHandle *gfh;
+     QTAILQ_FOREACH(gfh, &guest_file_state.filehandles, next) {
+-- 
+2.17.1
+
+
+From f61a3ff124fdd28deab63f2a3f9cd887787f4858 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Philippe=20Mathieu-Daud=C3=A9?= <philmd@redhat.com>
+Date: Tue, 14 Apr 2020 15:30:43 +0200
+Subject: [PATCH 2/3] qga: Extract qmp_guest_file_read() to common commands.c
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Extract the common code shared by both POSIX/Win32 implementations.
+
+Signed-off-by: Philippe Mathieu-Daudé <philmd@redhat.com>
+Signed-off-by: Michael Roth <mdroth@linux.vnet.ibm.com>
+
+Modified to apply to Mariner 4.2.0 by: Daniel McIlvaney <damcilva@microsoft.com>
+---
+ qga/commands-common.h |  3 +++
+ qga/commands-posix.c  | 22 +++-------------------
+ qga/commands-win32.c  | 20 +++-----------------
+ qga/commands.c        | 26 ++++++++++++++++++++++++++
+ 4 files changed, 35 insertions(+), 36 deletions(-)
+
+diff --git a/qga/commands-common.h b/qga/commands-common.h
+index af90e548..90785ed4 100644
+--- a/qga/commands-common.h
++++ b/qga/commands-common.h
+@@ -15,4 +15,7 @@ typedef struct GuestFileHandle GuestFileHandle;
+ 
+ GuestFileHandle *guest_file_handle_find(int64_t id, Error **errp);
+ 
++GuestFileRead *guest_file_read_unsafe(GuestFileHandle *gfh,
++                                      int64_t count, Error **errp);
++
+ #endif
+diff --git a/qga/commands-posix.c b/qga/commands-posix.c
+index 6aa68033..c443da08 100644
+--- a/qga/commands-posix.c
++++ b/qga/commands-posix.c
+@@ -450,29 +450,14 @@ void qmp_guest_file_close(int64_t handle, Error **errp)
+     g_free(gfh);
+ }
+ 
+-struct GuestFileRead *qmp_guest_file_read(int64_t handle, bool has_count,
+-                                          int64_t count, Error **errp)
++GuestFileRead *guest_file_read_unsafe(GuestFileHandle *gfh,
++                                      int64_t count, Error **errp)
+ {
+-    GuestFileHandle *gfh = guest_file_handle_find(handle, errp);
+     GuestFileRead *read_data = NULL;
+     guchar *buf;
+-    FILE *fh;
++    FILE *fh = gfh->fh;
+     size_t read_count;
+ 
+-    if (!gfh) {
+-        return NULL;
+-    }
+-
+-    if (!has_count) {
+-        count = QGA_READ_COUNT_DEFAULT;
+-    } else if (count < 0 || count >= UINT32_MAX) {
+-        error_setg(errp, "value '%" PRId64 "' is invalid for argument count",
+-                   count);
+-        return NULL;
+-    }
+-
+-    fh = gfh->fh;
+-
+     /* explicitly flush when switching from writing to reading */
+     if (gfh->state == RW_STATE_WRITING) {
+         int ret = fflush(fh);
+@@ -487,7 +472,6 @@ struct GuestFileRead *qmp_guest_file_read(int64_t handle, bool has_count,
+     read_count = fread(buf, 1, count, fh);
+     if (ferror(fh)) {
+         error_setg_errno(errp, errno, "failed to read file");
+-        slog("guest-file-read failed, handle: %" PRId64, handle);
+     } else {
+         buf[read_count] = 0;
+         read_data = g_new0(GuestFileRead, 1);
+diff --git a/qga/commands-win32.c b/qga/commands-win32.c
+index b0f90e34..42c3b639 100644
+--- a/qga/commands-win32.c
++++ b/qga/commands-win32.c
+@@ -321,33 +321,19 @@ void qmp_guest_shutdown(bool has_mode, const char *mode, Error **errp)
+     }
+ }
+ 
+-GuestFileRead *qmp_guest_file_read(int64_t handle, bool has_count,
+-                                   int64_t count, Error **errp)
++GuestFileRead *guest_file_read_unsafe(GuestFileHandle *gfh,
++                                      int64_t count, Error **errp)
+ {
+     GuestFileRead *read_data = NULL;
+     guchar *buf;
+-    HANDLE fh;
++    HANDLE fh = gfh->fh;
+     bool is_ok;
+     DWORD read_count;
+-    GuestFileHandle *gfh = guest_file_handle_find(handle, errp);
+-
+-    if (!gfh) {
+-        return NULL;
+-    }
+-    if (!has_count) {
+-        count = QGA_READ_COUNT_DEFAULT;
+-    } else if (count < 0 || count >= UINT32_MAX) {
+-        error_setg(errp, "value '%" PRId64
+-                   "' is invalid for argument count", count);
+-        return NULL;
+-    }
+ 
+-    fh = gfh->fh;
+     buf = g_malloc0(count+1);
+     is_ok = ReadFile(fh, buf, count, &read_count, NULL);
+     if (!is_ok) {
+         error_setg_win32(errp, GetLastError(), "failed to read file");
+-        slog("guest-file-read failed, handle %" PRId64, handle);
+     } else {
+         buf[read_count] = 0;
+         read_data = g_new0(GuestFileRead, 1);
+diff --git a/qga/commands.c b/qga/commands.c
+index 0c7d1385..73bf92ea 100644
+--- a/qga/commands.c
++++ b/qga/commands.c
+@@ -18,6 +18,7 @@
+ #include "qemu/base64.h"
+ #include "qemu/cutils.h"
+ #include "qemu/atomic.h"
++#include "commands-common.h"
+ 
+ /* Maximum captured guest-exec out_data/err_data - 16MB */
+ #define GUEST_EXEC_MAX_OUTPUT (16*1024*1024)
+@@ -542,3 +543,28 @@ error:
+     g_free(info);
+     return NULL;
+ }
++
++GuestFileRead *qmp_guest_file_read(int64_t handle, bool has_count,
++                                   int64_t count, Error **errp)
++{
++    GuestFileHandle *gfh = guest_file_handle_find(handle, errp);
++    GuestFileRead *read_data;
++
++    if (!gfh) {
++        return NULL;
++    }
++    if (!has_count) {
++        count = QGA_READ_COUNT_DEFAULT;
++    } else if (count < 0 || count >= UINT32_MAX) {
++        error_setg(errp, "value '%" PRId64 "' is invalid for argument count",
++                   count);
++        return NULL;
++    }
++
++    read_data = guest_file_read_unsafe(gfh, count, errp);
++    if (!read_data) {
++        slog("guest-file-write failed, handle: %" PRId64, handle);
++    }
++
++    return read_data;
++}
+-- 
+2.17.1
+
+
+From 709eb802c32630d3398807021b5d0edd32b4148e Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Philippe=20Mathieu-Daud=C3=A9?= <philmd@redhat.com>
+Date: Tue, 14 Apr 2020 15:30:44 +0200
+Subject: [PATCH 3/3] qga: Restrict guest-file-read count to 48 MB to avoid
+ crashes
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+On [*] Daniel Berrangé commented:
+
+  The QEMU guest agent protocol is not sensible way to access huge
+  files inside the guest. It requires the inefficient process of
+  reading the entire data into memory than duplicating it again in
+  base64 format, and then copying it again in the JSON serializer /
+  monitor code.
+
+  For arbitrary general purpose file access, especially for large
+  files, use a real file transfer program or use a network block
+  device, not the QEMU guest agent.
+
+To avoid bug reports as BZ#1594054 (CVE-2018-12617), follow his
+suggestion to put a low, hard limit on "count" in the guest agent
+QAPI schema, and don't allow count to be larger than 48 MB.
+
+[*] https://www.mail-archive.com/qemu-devel@nongnu.org/msg693176.html
+
+Fixes: CVE-2018-12617
+Buglink: https://bugzilla.redhat.com/show_bug.cgi?id=1594054
+Reported-by: Fakhri Zulkifli <mohdfakhrizulkifli@gmail.com>
+Suggested-by: Daniel P. Berrangé <berrange@redhat.com>
+Signed-off-by: Philippe Mathieu-Daudé <philmd@redhat.com>
+Reviewed-by: Daniel P. Berrangé <berrange@redhat.com>
+*update schema documentation to indicate 48MB limit instead of 10MB
+Signed-off-by: Michael Roth <mdroth@linux.vnet.ibm.com>
+---
+ qga/commands.c       | 9 ++++++++-
+ qga/qapi-schema.json | 6 ++++--
+ 2 files changed, 12 insertions(+), 3 deletions(-)
+
+diff --git a/qga/commands.c b/qga/commands.c
+index 73bf92ea..d840c3e1 100644
+--- a/qga/commands.c
++++ b/qga/commands.c
+@@ -11,6 +11,7 @@
+  */
+ 
+ #include "qemu/osdep.h"
++#include "qemu/units.h"
+ #include "guest-agent-core.h"
+ #include "qga-qapi-commands.h"
+ #include "qapi/error.h"
+@@ -24,6 +25,12 @@
+ #define GUEST_EXEC_MAX_OUTPUT (16*1024*1024)
+ /* Allocation and I/O buffer for reading guest-exec out_data/err_data - 4KB */
+ #define GUEST_EXEC_IO_SIZE (4*1024)
++/*
++ * Maximum file size to read - 48MB
++ *
++ * (48MB + Base64 3:4 overhead = JSON parser 64 MB limit)
++ */
++#define GUEST_FILE_READ_COUNT_MAX (48 * MiB)
+ 
+ /* Note: in some situations, like with the fsfreeze, logging may be
+  * temporarilly disabled. if it is necessary that a command be able
+@@ -555,7 +562,7 @@ GuestFileRead *qmp_guest_file_read(int64_t handle, bool has_count,
+     }
+     if (!has_count) {
+         count = QGA_READ_COUNT_DEFAULT;
+-    } else if (count < 0 || count >= UINT32_MAX) {
++    } else if (count < 0 || count > GUEST_FILE_READ_COUNT_MAX) {
+         error_setg(errp, "value '%" PRId64 "' is invalid for argument count",
+                    count);
+         return NULL;
+diff --git a/qga/qapi-schema.json b/qga/qapi-schema.json
+index fb4605cc..e4cecda6 100644
+--- a/qga/qapi-schema.json
++++ b/qga/qapi-schema.json
+@@ -266,11 +266,13 @@
+ ##
+ # @guest-file-read:
+ #
+-# Read from an open file in the guest. Data will be base64-encoded
++# Read from an open file in the guest. Data will be base64-encoded.
++# As this command is just for limited, ad-hoc debugging, such as log
++# file access, the number of bytes to read is limited to 48 MB.
+ #
+ # @handle: filehandle returned by guest-file-open
+ #
+-# @count: maximum number of bytes to read (default is 4KB)
++# @count: maximum number of bytes to read (default is 4KB, maximum is 48MB)
+ #
+ # Returns: @GuestFileRead on success.
+ #
+-- 
+2.17.1
+

--- a/SPECS/qemu-kvm/qemu-kvm.spec
+++ b/SPECS/qemu-kvm/qemu-kvm.spec
@@ -1,7 +1,7 @@
 Summary:        QEMU is a machine emulator and virtualizer
 Name:           qemu-kvm
 Version:        4.2.0
-Release:        20%{?dist}
+Release:        21%{?dist}
 License:        GPLv2 AND GPLv2+ AND CC-BY AND BSD
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -41,6 +41,7 @@ Patch23:        CVE-2020-15469.patch
 Patch24:        CVE-2020-24352.patch
 # CVE-2020-12820 only affects powerpc and SuperH emulation (see .nopatch file for details). Resloved fully in qemu >=5.0.0
 Patch25:        CVE-2020-12829.nopatch
+Patch26:        CVE-2018-12617.patch
 BuildRequires:  alsa-lib-devel
 BuildRequires:  glib-devel
 BuildRequires:  pixman-devel
@@ -91,6 +92,7 @@ This package provides a command line tool for manipulating disk images.
 %patch22 -p1
 %patch23 -p1
 %patch24 -p1
+%patch26 -p1
 
 %build
 
@@ -151,6 +153,9 @@ chmod 755 %{buildroot}%{_bindir}/qemu
 %{_bindir}/qemu-nbd
 
 %changelog
+* Tue Nov 17 2020 Daniel McIlvaney <damcilva@microsoft.com> - 4.2.0-21
+- Backport fix for CVE-2018-12617 from 5.0.0
+
 * Mon Nov 16 2020 Daniel McIlvaney <damcilva@microsoft.com> - 4.2.0-20
 - Noatch CVE-2020-12829, only affects SuperH and PowerPC emulation
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Backported commits from upstream `qemu` 5.0.0 to our 4.2.0 ([c1](https://github.com/qemu/qemu/commit/5d3586b834633c8ac462d4741b85b4036cbc0f93), [c2](https://github.com/qemu/qemu/commit/ead83a136d54f7faa315922aff26fa11d216909f), [c3](https://github.com/qemu/qemu/commit/1329651fb4d4c5068ad12fd86aff7e52f9e18c34)) to fix CVE-2018-12617.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Backport three commits from `qemu` 5.0.0 to our version to fully address CVE-2018-12617

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2018-12617

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local build
- Attempted self test via `make check` (test fails, but fails in the same way as prior to fix)
  - Will need to be resolved later
