### PR TITLE
Don't warn about StreamOutput log buffer overflow

### DIFF
--- a/toolkit/tools/internal/logger/log.go
+++ b/toolkit/tools/internal/logger/log.go
@@ -145,8 +145,7 @@ func StreamOutput(pipe io.Reader, logFunction func(...interface{}), wg *sync.Wai
 			select {
 			case outputChan <- line:
 			default:
-				// In the event the buffer is full, just print to console
-				Log.Warnf("Output buffer full: dropping: \"%s\"", line)
+				// In the event the buffer is full, drop the line
 			}
 		}
 	}


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Some commands which are run via `ExecuteLiveWithCallback()` (especially in the dev branch) output significantly more than is reasonable to store in the output buffer (1500 lines currently). We already log every line at trace level so there isn't much value in also printing the unbufferable lines at warn level. Just silently drop the unbufferable lines.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Remove warning about dropping unbufferable stdout/stderr output from `StreamOutput()` when using `printOutputOnError = true`

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local go build, validated with Joe
