### PR TITLE
[dev] Improve graphpkgfetcher logging

### DIFF
--- a/toolkit/tools/graphpkgfetcher/graphpkgfetcher.go
+++ b/toolkit/tools/graphpkgfetcher/graphpkgfetcher.go
@@ -155,7 +155,14 @@ func resolveSingleNode(cloner *rpmrepocloner.RpmRepoCloner, node *pkggraph.PkgNo
 	// Resolve nodes to exact package names so they can be referenced in the graph.
 	resolvedPackage, err := cloner.WhatProvides(node.VersionedPkg)
 	if err != nil {
-		logger.Log.Errorf("Failed to resolve '%s' to a package. Error: %s", node, err)
+		msg := fmt.Sprintf("Failed to resolve (%s) to a package. Error: %s", node.VersionedPkg, err)
+		// It is not an error if an implicit node could not be resolved as it may become available later in the build.
+		// If it does not become available, schedule will print an error at the end of the build about it.
+		if node.Implicit {
+			logger.Log.Debug(msg)
+		} else {
+			logger.Log.Error(msg)
+		}
 		return
 	}
 
@@ -176,5 +183,7 @@ func resolveSingleNode(cloner *rpmrepocloner.RpmRepoCloner, node *pkggraph.PkgNo
 	node.RpmPath = filepath.Join(outDir, rpmArch, rpmName)
 
 	node.State = pkggraph.StateCached
+
+	logger.Log.Infof("Fetched: %s", rpmName)
 	return
 }

--- a/toolkit/tools/graphpkgfetcher/graphpkgfetcher.go
+++ b/toolkit/tools/graphpkgfetcher/graphpkgfetcher.go
@@ -157,7 +157,7 @@ func resolveSingleNode(cloner *rpmrepocloner.RpmRepoCloner, node *pkggraph.PkgNo
 	if err != nil {
 		msg := fmt.Sprintf("Failed to resolve (%s) to a package. Error: %s", node.VersionedPkg, err)
 		// It is not an error if an implicit node could not be resolved as it may become available later in the build.
-		// If it does not become available, schedule will print an error at the end of the build about it.
+		// If it does not become available scheduler will print an error at the end of the build.
 		if node.Implicit {
 			logger.Log.Debug(msg)
 		} else {


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
1. Reduce error log noise generated by `graphpkgfetcher` when handling SPECs with many dynamic dependencies. Dynamic dependencies become available during the build, so it is expected that they may not be found Upstream. On SPECs with many dynamic dependencies `graphpkgfetcher` would generate hundreds of error messages.
2. Simplify error message  when a dependency could not be resolved to only contain relevant information: what package+version was trying to be cloned and what went wrong.
3. Print packages that were successfully fetched. Besides giving useful information, it also shows progress of the tool. When dealing with SPECs with many dynamic dependencies, `graphpkgfetcher` takes a significant time to run. In its current state, it either appears frozen or only generates hundreds of error messages. Generate incremental success messages to fix this.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Demote failure to fetch a dynamic dependency to `debug` log level instead of `error`.
- Simplify error message when a dependency cannot be resolved to only include the node's version information instead of the entire node structure.
- Log top level packages that are successfully fetched.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local builds.
