### PR TITLE
HyperV IP injection support

### DIFF
--- a/SPECS/hyperv-daemons/hv_set_ifconfig
+++ b/SPECS/hyperv-daemons/hv_set_ifconfig
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# Script to configure the network interface based
+# on the setting passed by hypervkvpd daemon
+#
+# This script works based on the kvp values supplied by the host.
+# Network setting supplied by host is described in the below link.
+# https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/tree/tools/hv/hv_set_ifconfig.sh
+#
+# Usage: hv_set_ifconfig <ifcfg-eth*>
+#
+
+BKDIR=$(mktemp -td .netconfig.XXXXXX)
+trap 'rm -rf ${BKDIR}' EXIT
+
+# Network configuration entries
+NETDIR="/etc/systemd/network"
+NETCONFFILE="" # populated during execution
+
+# Restart the network service
+restart_net_service() {
+    systemctl restart systemd-networkd
+}
+
+# Revert the network setting
+restore_net_settings() {
+    [[ -d ${BKDIR} ]] && {
+        find "${BKDIR}" -maxdepth 1 -type f -exec cp {} "${NETDIR}" \;
+    } || return 1
+
+    [[ -f "${NETCONFFILE}" ]] && rm -f "${NETCONFFILE}"
+    restart_net_service
+}
+
+# Backup the network setting to revert in case of failure
+backup_net_settings() {
+    find "${NETDIR}" -maxdepth 1 -type f -exec mv {} "${BKDIR}" >/dev/null 2>&1 \;
+}
+
+# Update IPv6 setting in network configuration
+update_ipv6_conf() {
+
+    local cfgfile="" ipaddr="" ipv6pfx="" gateway=""
+    cfgfile=${1}
+
+    # Update IPv6 address and netmask
+    ipaddr_cnt=$(grep -c IPV6ADDR "${cfgfile}")
+    for ((i=0; i<ipaddr_cnt; i++)); do
+        ipaddr=$(grep -w "IPV6ADDR$i" "${cfgfile}" | cut -d'=' -f2)
+        ipv6pfx=$(grep -w "IPV6NETMASK$i" "${cfgfile}" | cut -d'=' -f2)
+        [[ -z ${ipv6pfx} ]] && ipv6pfx=64
+        [[ ! -z ${ipaddr} ]] && {
+            echo "Address=${ipaddr}/${ipv6pfx}" >> "${NETCONFFILE}"
+        }
+    done
+
+    # Update GATEWAY
+    gateway=$(awk -F "=" '/IPV6_DEFAULTGW/ {print $2}' "${cfgfile}")
+    [[ ! -z "${gateway}" ]] && {
+        echo "Gateway=${gateway}" >> "${NETCONFFILE}"
+    }
+}
+
+# Update IPv4 setting in network configuration
+update_ipv4_conf() {
+
+    local cfgfile="" gateway="" ipaddr="" netmask=""
+    local ipaddr_cnt=0 gateway_cnt=0
+    cfgfile="${1}"
+
+    # Update IPv4 address and netmask
+    ipaddr_cnt=$(grep -c IPADDR "${cfgfile}")
+    for ((i=0; i<ipaddr_cnt; i++)); do
+        local pfx=24
+        ipaddr=$(grep -w "IPADDR$i" "${cfgfile}" | cut -d'=' -f2)
+        netmask=$(grep -w "NETMASK$i" "${cfgfile}" | cut -d'=' -f2)
+        [[ ! -z "${netmask}" ]] && {
+            pfx=0
+            for num in ${netmask//\./ }; do
+                local brep=0
+                [[ "${num}" -eq 0 ]] && continue
+                brep=$(bc <<< "obase=2; ${num}")
+                brep=${brep//0/}
+                pfx=$((pfx + ${#brep}))
+            done
+        }
+        [[ ! -z "${ipaddr}" ]] && {
+            echo "Address=${ipaddr}/${pfx}" >> "${NETCONFFILE}"
+        }
+    done
+
+    # Update GATEWAY
+    gateway_cnt=$(grep -c GATEWAY "${cfgfile}")
+    gateway=$(awk -F "=" '/GATEWAY/ {print $2}' "${cfgfile}")
+    [[ ! -z "${gateway}" ]] && {
+        echo "Gateway=${gateway}" >> "${NETCONFFILE}"
+    }
+
+    for ((i=1; i<gateway_cnt; i++)); do
+        gateway=$(grep -w "GATEWAY$i" "${cfgfile}" | cut -d'=' -f2)
+        [[ ! -z "${gateway}" ]] && {
+            echo "Gateway=${gateway}" >> "${NETCONFFILE}"
+        }
+    done
+
+    return 0
+}
+
+# Generate the config file for updating the new configuration
+generate_net_config() {
+
+    # Network configuration
+    #
+    local cfgfile="" netifc="" hwaddr="" bootproto="" dns=""
+    local dns_cnt=0
+
+    cfgfile=${1}
+    netifc=$(cut -d- -f2 <<< "${cfgfile}")
+    hwaddr=$(awk -F "=" '/HWADDR/ {print $2}' "${cfgfile}")
+
+    NETCONFFILE="${NETDIR}/98-static-${netifc}.network"
+
+    # Generate the network configuration file
+    {
+        echo "[Match]"
+        echo "Name=${netifc}"
+        echo "MACAddress=${hwaddr}"
+        echo ""
+        echo "[Network]"
+    } > "${NETCONFFILE}"
+
+    bootproto=$(awk -F "=" '/BOOTPROTO/ {print $2}' "${cfgfile}")
+    [[ ! -z "${bootproto}" && (${bootproto} == "DHCP") ]] && {
+        echo "DHCP=yes" >> "${NETCONFFILE}"
+    }
+
+    # Update IPv4 configuration
+    update_ipv4_conf "${cfgfile}"
+
+    # Update IPv6 configuration
+    update_ipv6_conf "${cfgfile}"
+
+    # Update DNS
+    dns_cnt=$(grep -c DNS "${cfgfile}")
+    for ((i=1; i<=dns_cnt; i++)); do
+        dns=$(grep "DNS$i" "${cfgfile}" | cut -d'=' -f2)
+        [[ ! -z ${dns} ]] && {
+            echo "DNS=${dns}" >> "${NETCONFFILE}"
+        }
+    done
+
+    echo "" >> "${NETCONFFILE}"
+
+    chmod 0644 "${NETCONFFILE}"
+    return 0
+}
+
+# Entry point
+
+# Check parameters
+[[ -z "$1" || ! -f "$1" ]] && {
+    echo "Usage: hv_set_ifconfig hv_config"
+    exit 1
+}
+
+# Backup current setting to recover in case of failure
+backup_net_settings
+
+# Generate net config based on hv_config settings
+generate_net_config "$1"
+
+# Restart network service
+restart_net_service || restore_net_settings
+
+exit 0

--- a/SPECS/hyperv-daemons/hyperv-daemons.signatures.json
+++ b/SPECS/hyperv-daemons/hyperv-daemons.signatures.json
@@ -6,6 +6,7 @@
   "hypervkvpd.service": "25339871302f7a47e1aecfa9fc2586c78bc37edb98773752f0a5dec30f0ed3a1",
   "hypervvss.rules": "94cead44245ef6553ab79c0bbac8419e3ff4b241f01bcec66e6f508098cbedd1",
   "hypervvssd.service": "22270d9f0f23af4ea7905f19c1d5d5495e40c1f782cbb87a99f8aec5a011078d",
+  "hv_set_ifconfig": "0865f76b18f8f04cb54b7779c2d5d400dab68b132210e17db98117012d177c90",
   "linux-msft-5.4.72.tar.gz": "3407ccf8505595ae3e7a7b30c206190a0762f3e202f21f9de88a8d59e182ddef"
  }
 }

--- a/SPECS/hyperv-daemons/hyperv-daemons.spec
+++ b/SPECS/hyperv-daemons/hyperv-daemons.spec
@@ -9,7 +9,7 @@
 Summary:        Hyper-V daemons suite
 Name:           hyperv-daemons
 Version:        5.4.72
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        GPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -19,6 +19,7 @@ Source0:        https://github.com/microsoft/WSL2-Linux-Kernel/archive/linux-msf
 # HYPERV KVP DAEMON
 Source1:        hypervkvpd.service
 Source2:        hypervkvp.rules
+Source3:        hv_set_ifconfig
 # HYPERV VSS DAEMON
 Source101:      hypervvssd.service
 Source102:      hypervvss.rules
@@ -140,7 +141,7 @@ install -p -m 0644 %{SOURCE202} %{buildroot}%{_udevrulesdir}/%{udev_prefix}-hype
 mkdir -p %{buildroot}%{_libexecdir}/%{hv_kvp_daemon}
 install -p -m 0755 tools/hv/hv_get_dhcp_info.sh %{buildroot}%{_libexecdir}/%{hv_kvp_daemon}/hv_get_dhcp_info
 install -p -m 0755 tools/hv/hv_get_dns_info.sh %{buildroot}%{_libexecdir}/%{hv_kvp_daemon}/hv_get_dns_info
-install -p -m 0755 tools/hv/hv_set_ifconfig.sh %{buildroot}%{_libexecdir}/%{hv_kvp_daemon}/hv_set_ifconfig
+install -p -m 0755 %{SOURCE3} %{buildroot}%{_libexecdir}/%{hv_kvp_daemon}/hv_set_ifconfig
 # Directory for pool files
 mkdir -p %{buildroot}%{_sharedstatedir}/hyperv
 
@@ -217,6 +218,9 @@ fi
 %{_sbindir}/lsvmbus
 
 %changelog
+* Fri Nov 20 2020 Johnson George <johgeorg@microsoft.com> - 5.4.72-3
+- Added network configure script to support ip injection
+
 * Wed Nov 11 2020 Suresh Babu Chalamalasetty <schalam@microsoft.com> - 5.4.72-2
 - Enable Hyper-V daemons package building for Arm64 arch
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Support IP injection.
The current hv_set_ifconfig script from kernel source is used in Mariner. That is a sample script and based on RHEL, this script should be updated or customized based on the network manager used by distribution. Created a new hv_set_ifconfig script to configure the network settings for Mariner.

###### Change Log  <!-- REQUIRED -->
Added a new script hv_set_ifconfig
``` Package: hypervkvpd```


###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Test Methodology
```
1. Tested locally by copying the script in Deployed VM
2. Tested using the newly created hypervkvpd package. 
    a. Build a new package(hypervkvpd)
    b. Deploy a VM in HyperV Manager
    c. Boot the VM & Deploy package
    d. Run **NET-IP-INJECTION** from LISA test
    e. Test completed successfully.
```