### PR TITLE
Remove instances of %ldconfig_scriptlets in specs

### DIFF
--- a/SPECS/cpprest/cpprest.spec
+++ b/SPECS/cpprest/cpprest.spec
@@ -3,7 +3,7 @@
 
 Name:           cpprest
 Version:        2.10.14
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        C++ REST library
 Group:          Applications/File
 License:        MIT
@@ -73,7 +73,9 @@ cd Release/build.release
 cd Release/build.release/Binaries
 ./test_runner *_test.so ||:
 
-%ldconfig_scriptlets
+%post -p /sbin/ldconfig
+
+%postun -p /sbin/ldconfig
 
 %files
 %doc CONTRIBUTORS.txt
@@ -89,6 +91,9 @@ cd Release/build.release/Binaries
 
 
 %changelog
+* Sat Nov 21 2020 Thomas Crain <thcrain@microsoft.com> - 2.10.14-5
+- Replace %%ldconfig_scriptlets with actual post/postun sections
+
 * Tue Mar 31 2020 Paul Monson <paulmon@microsoft.com> 2.10.14-4
 - Fix Source0 URL. License verified.
 

--- a/SPECS/libpwquality/libpwquality.spec
+++ b/SPECS/libpwquality/libpwquality.spec
@@ -3,7 +3,7 @@
 Summary:       A library for password generation and password quality checking
 Name:          libpwquality
 Version:       1.4.2
-Release:       5%{?dist}
+Release:       6%{?dist}
 Vendor:        Microsoft Corporation
 Distribution:  Mariner
 URL:           https://github.com/libpwquality/libpwquality/
@@ -84,7 +84,9 @@ mkdir $RPM_BUILD_ROOT%{_secconfdir}/pwquality.conf.d
 
 %find_lang libpwquality
 
-%ldconfig_scriptlets
+%post -p /sbin/ldconfig
+
+%postun -p /sbin/ldconfig
 
 %files -f libpwquality.lang
 %{!?_licensedir:%global license %%doc}
@@ -111,6 +113,9 @@ mkdir $RPM_BUILD_ROOT%{_secconfdir}/pwquality.conf.d
 %{python3_sitearch}/*.egg-info
 
 %changelog
+* Sat Nov 21 2020 Thomas Crain <thcrain@microsoft.com> - 1.4.2-6
+- Replace %%ldconfig_scriptlets with actual post/postun sections
+
 * Thu Nov 19 2020 Andrew Phelps <anphel@microsoft.com> 1.4.2-5
 - Remove empty check section.
 

--- a/SPECS/libxcrypt/libxcrypt.spec
+++ b/SPECS/libxcrypt/libxcrypt.spec
@@ -102,7 +102,7 @@
 Summary:        Extended crypt library for descrypt, md5crypt, bcrypt, and others
 Name:           libxcrypt
 Version:        4.4.17
-Release:        2%{?dist}
+Release:        3%{?dist}
 # For explicit license breakdown, see the
 # LICENSING file in the source tarball.
 License:        LGPLv2+ AND BSD AND Public Domain
@@ -344,10 +344,13 @@ for dir in ${build_dirs}; do
     }
 done
 
+%post -p /sbin/ldconfig
 
-%ldconfig_scriptlets
+%postun -p /sbin/ldconfig
+
 %if %{with compat_pkg}
-%ldconfig_scriptlets compat
+%post -n compat -p /sbin/ldconfig
+%postun -n compat -p /sbin/ldconfig
 %endif
 
 
@@ -447,6 +450,9 @@ ln -s %{_libdir}/libcrypt-%{glibcversion}.so %{_libdir}/libcrypt.so.1
 
 
 %changelog
+* Sat Nov 21 2020 Thomas Crain <thcrain@microsoft.com> - 4.4.17-3
+- Replace %%ldconfig_scriptlets with actual post/postun sections
+
 * Wed Oct 21 2020 Henry Beberman <henry.beberman@microsoft.com> - 4.4.17-2
 - Initial CBL-Mariner import from Fedora 31 (license: MIT).
 - Remove dependency on fipscheck

--- a/SPECS/libxcrypt/libxcrypt.spec
+++ b/SPECS/libxcrypt/libxcrypt.spec
@@ -344,9 +344,24 @@ for dir in ${build_dirs}; do
     }
 done
 
+%if %{with override_glibc}
+# This posttrans section is a stopgap to allow installing
+# libxcrypt on a system that already has libcrypt from glibc.
+# In a future release these will be removed and libxcrypt will be default.
+%posttrans
+rm %{_libdir}/libcrypt.so.1
+ln -s %{_libdir}/libxcrypt.so.%{sov} %{_libdir}/libcrypt.so.1
+%endif
+
 %post -p /sbin/ldconfig
 
-%postun -p /sbin/ldconfig
+%postun
+# See above comments about the %%posttrans section
+%if %{with override_glibc}
+rm %{_libdir}/libcrypt.so.1
+ln -s %{_libdir}/libcrypt-%{glibcversion}.so %{_libdir}/libcrypt.so.1
+%endif
+/sbin/ldconfig
 
 %if %{with compat_pkg}
 %post -n compat -p /sbin/ldconfig
@@ -379,19 +394,6 @@ done
 %endif
 
 %{_mandir}/man5/crypt.5*
-
-%if %{with override_glibc}
-# These posttrans and postun sections are stopgaps to allow installing
-# libxcrypt on a system that already has libcrypt from glibc.
-# In a future release these will be removed and libxcrypt will be default.
-%posttrans
-rm %{_libdir}/libcrypt.so.1
-ln -s %{_libdir}/libxcrypt.so.%{sov} %{_libdir}/libcrypt.so.1
-
-%postun
-rm %{_libdir}/libcrypt.so.1
-ln -s %{_libdir}/libcrypt-%{glibcversion}.so %{_libdir}/libcrypt.so.1
-%endif
 
 %if %{with compat_pkg}
 %files compat

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -192,9 +192,9 @@ libmpc-debuginfo-1.1.0-5.cm1.aarch64.rpm
 libpipeline-1.5.0-3.cm1.aarch64.rpm
 libpipeline-debuginfo-1.5.0-3.cm1.aarch64.rpm
 libpipeline-devel-1.5.0-3.cm1.aarch64.rpm
-libpwquality-1.4.2-5.cm1.aarch64.rpm
-libpwquality-debuginfo-1.4.2-5.cm1.aarch64.rpm
-libpwquality-devel-1.4.2-5.cm1.aarch64.rpm
+libpwquality-1.4.2-6.cm1.aarch64.rpm
+libpwquality-debuginfo-1.4.2-6.cm1.aarch64.rpm
+libpwquality-devel-1.4.2-6.cm1.aarch64.rpm
 libselinux-2.9-3.cm1.aarch64.rpm
 libselinux-debuginfo-2.9-3.cm1.aarch64.rpm
 libselinux-devel-2.9-3.cm1.aarch64.rpm
@@ -325,7 +325,7 @@ python2-tools-2.7.18-5.cm1.aarch64.rpm
 python3-cracklib-2.9.7-2.cm1.aarch64.rpm
 python3-gpg-1.13.1-6.cm1.aarch64.rpm
 python3-libxml2-2.9.10-3.cm1.aarch64.rpm
-python3-pwquality-1.4.2-5.cm1.aarch64.rpm
+python3-pwquality-1.4.2-6.cm1.aarch64.rpm
 python3-rpm-4.14.2-10.cm1.aarch64.rpm
 python-curses-2.7.18-5.cm1.aarch64.rpm
 python-gpg-1.13.1-6.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -325,7 +325,7 @@ python2-tools-2.7.18-5.cm1.x86_64.rpm
 python3-cracklib-2.9.7-2.cm1.x86_64.rpm
 python3-gpg-1.13.1-6.cm1.x86_64.rpm
 python3-libxml2-2.9.10-3.cm1.x86_64.rpm
-python3-pwquality-1.4.2-5.cm1.x86_64.rpm
+python3-pwquality-1.4.2-6.cm1.x86_64.rpm
 python3-rpm-4.14.2-10.cm1.x86_64.rpm
 python-curses-2.7.18-5.cm1.x86_64.rpm
 python-gpg-1.13.1-6.cm1.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -192,9 +192,9 @@ libmpc-debuginfo-1.1.0-5.cm1.x86_64.rpm
 libpipeline-1.5.0-3.cm1.x86_64.rpm
 libpipeline-debuginfo-1.5.0-3.cm1.x86_64.rpm
 libpipeline-devel-1.5.0-3.cm1.x86_64.rpm
-libpwquality-1.4.2-5.cm1.x86_64.rpm
-libpwquality-debuginfo-1.4.2-5.cm1.x86_64.rpm
-libpwquality-devel-1.4.2-5.cm1.x86_64.rpm
+libpwquality-1.4.2-6.cm1.x86_64.rpm
+libpwquality-debuginfo-1.4.2-6.cm1.x86_64.rpm
+libpwquality-devel-1.4.2-6.cm1.x86_64.rpm
 libselinux-2.9-3.cm1.x86_64.rpm
 libselinux-debuginfo-2.9-3.cm1.x86_64.rpm
 libselinux-devel-2.9-3.cm1.x86_64.rpm


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
We don't define `%ldconfig_scriptlets` as part of our standard RPM macros. So, let's remove the ones that remain in our specs.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Replace `%ldconfig_scriptlets` with actual `%post`/`%postun` calls to `ldconfig` in libpwquality, cpprest, and libxcrypt.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
**YES**

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Running a pipeline build currently
