### PR TITLE
Upgrade postgresql to 12.5

### DIFF
--- a/SPECS/postgresql/postgresql.signatures.json
+++ b/SPECS/postgresql/postgresql.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "postgresql-12.4.tar.bz2": "bee93fbe2c32f59419cb162bcc0145c58da9a8644ee154a30b9a5ce47de606cc"
+  "postgresql-12.5.tar.bz2": "bd0d25341d9578b5473c9506300022de26370879581f5fddd243a886ce79ff95"
  }
 }

--- a/SPECS/postgresql/postgresql.spec
+++ b/SPECS/postgresql/postgresql.spec
@@ -1,6 +1,6 @@
 Summary:        PostgreSQL database engine
 Name:           postgresql
-Version:        12.4
+Version:        12.5
 Release:        1%{?dist}
 License:        PostgreSQL
 Vendor:         Microsoft Corporation
@@ -165,6 +165,9 @@ rm -rf %{buildroot}/*
 %{_libdir}/libpgtypes.a
 
 %changelog
+* Mon Nov 23 2020 Henry Beberman <henry.beberman@microsoft.com> - 12.5-1
+- Upgrading to 12.5 to fix CVE-2020-25695 and CVE-2020-25694.
+
 * Tue Nov 03 2020 Pawel Winogrodzki <pawelwi@microsoft.com> - 12.4-1
 - Upgrading to 12.4 to fix CVE-2020-14349 and CVE-2020-14350.
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -4086,8 +4086,8 @@
         "type": "other",
         "other": {
           "name": "postgresql",
-          "version": "12.4",
-          "downloadUrl": "https://ftp.postgresql.org/pub/source/v12.4/postgresql-12.4.tar.bz2"
+          "version": "12.5",
+          "downloadUrl": "https://ftp.postgresql.org/pub/source/v12.5/postgresql-12.5.tar.bz2"
         }
       }
     },


### PR DESCRIPTION
postgresql v12.5 resolves CVE-2020-25695 and CVE-2020-25694

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
postgresql v12.4 is impacted by CVE-2020-25695 and CVE-2020-25694, v12.5 resolves them.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Update postgresql to v12.5 to fix CVE-2020-25695 and CVE-2020-25694

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2020-25695
- https://nvd.nist.gov/vuln/detail/CVE-2020-25694

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local Build
