### PR TITLE
Update libarchive source URL to GitHub

### DIFF
--- a/SPECS/libarchive/libarchive.spec
+++ b/SPECS/libarchive/libarchive.spec
@@ -8,7 +8,7 @@ URL:            https://www.libarchive.org/
 Group:          System Environment/Development
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
-Source0:        https://www.libarchive.org/downloads/%{name}-%{version}.tar.gz
+Source0:        https://github.com/libarchive/libarchive/releases/download/v%{version}/%{name}-%{version}.tar.gz
 
 BuildRequires:  xz-libs
 BuildRequires:  xz-devel

--- a/SPECS/libarchive/libarchive.spec
+++ b/SPECS/libarchive/libarchive.spec
@@ -1,26 +1,24 @@
 Summary:        Multi-format archive and compression library
 Name:           libarchive
 Version:        3.4.2
-Release:        2%{?dist}
+Release:        3%{?dist}
 # Certain files have individual licenses. For more details see contents of "COPYING".
-License:        BSD and Public Domain and (ASL 2.0 or CC0 1.0 or OpenSSL)
-URL:            https://www.libarchive.org/
-Group:          System Environment/Development
+License:        BSD AND Public Domain AND (ASL 2.0 OR CC0 1.0 OR OpenSSL)
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
+Group:          System Environment/Development
+URL:            https://www.libarchive.org/
 Source0:        https://github.com/libarchive/libarchive/releases/download/v%{version}/%{name}-%{version}.tar.gz
-
-BuildRequires:  xz-libs
 BuildRequires:  xz-devel
-
+BuildRequires:  xz-libs
 Requires:       xz-libs
 
 %description
 Multi-format archive and compression library
 
 %package	devel
-Summary:	Header and development files
-Requires:	%{name} = %{version}
+Summary:        Header and development files
+Requires:       %{name} = %{version}
 
 %description	devel
 It contains the libraries and header files to create applications
@@ -37,7 +35,7 @@ make %{?_smp_mflags}
 %install
 rm -rf %{buildroot}%{_infodir}
 make DESTDIR=%{buildroot} install
-find %{buildroot}%{_libdir} -name '*.la' -delete
+find %{buildroot} -type f -name "*.la" -delete -print
 
 %check
 make %{?_smp_mflags} check
@@ -60,7 +58,10 @@ make %{?_smp_mflags} check
 %{_libdir}/pkgconfig/*.pc
 
 %changelog
-* Sat May 09 00:21:07 PST 2020 Nick Samson <nisamson@microsoft.com> - 3.4.2-2
+* Tue Nov 24 2020 Henry Beberman <henry.beberman@microsoft.com> - 3.4.2-3
+- Update Source URL to GitHub instead of libarchive.org
+
+* Sat May 09 2020 Nick Samson <nisamson@microsoft.com> - 3.4.2-2
 - Added %%license line automatically
 
 *   Fri May 01 2020 Pawel Winogrodzki <pawelwi@microsoft.com> 3.4.2-1
@@ -75,27 +76,39 @@ make %{?_smp_mflags} check
 -       CVE-2020-9308.
 -   Fixed "Source0" and "URL" tags.
 -   License verified.
+
 *   Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 3.3.3-2
 -   Initial CBL-Mariner import from Photon (license: Apache2).
+
 *   Thu Sep 13 2018 Siju Maliakkal <smaliakkal@vmware.com> 3.3.3-1
 -   Updated to latest version
+
 *   Fri Sep 15 2017 Dheeraj Shetty <dheerajs@vmware.com> 3.3.1-2
 -   Add xz-libs and xz-devel to BuildRequires and Requires
+
 *   Mon Apr 03 2017 Divya Thaluru <dthaluru@vmware.com> 3.3.1-1
 -   Upgrade version to 3.3.1
+
 *   Tue Sep 27 2016 Alexey Makhalov <amakhalov@vmware.com> 3.2.1-1
 -   Update version to 3.2.1
+
 *   Thu Sep 22 2016 Anish Swaminathan <anishs@vmware.com> 3.1.2-7
 -   Adding patch for security fix CVE-2016-6250
+
 *   Tue May 24 2016 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 3.1.2-6
 -   GA - Bump release of all rpms
+
 *   Mon Oct 12 2015 Xiaolin Li <xiaolinl@vmware.com> 3.1.2-5
 -   Moving static lib files to devel package.
+
 *   Fri Oct 9 2015 Xiaolin Li <xiaolinl@vmware.com> 3.1.2-4
 -   Removing la files from packages.
+
 *   Fri Aug 14 2015 Alexey Makhalov <amakhalov@vmware.com> 3.1.2-3
 -   Adding patches for security fixes CVE-2013-2011 and CVE-2015-2304.
+
 *   Wed Jul 8 2015 Alexey Makhalov <amakhalov@vmware.com> 3.1.2-2
 -   Added devel package, dist tag. Use macroses part.
+
 *   Fri Jun 5 2015 Touseef Liaqat <tliaqat@vmware.com> 3.1.2-1
 -   Initial build.  First version

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -2057,7 +2057,7 @@
         "other": {
           "name": "libarchive",
           "version": "3.4.2",
-          "downloadUrl": "https://www.libarchive.org/downloads/libarchive-3.4.2.tar.gz"
+          "downloadUrl": "https://github.com/libarchive/libarchive/releases/download/v3.4.2/libarchive-3.4.2.tar.gz"
         }
       }
     },

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -156,9 +156,9 @@ krb5-lang-1.17-4.cm1.aarch64.rpm
 libaio-0.3.112-2.cm1.aarch64.rpm
 libaio-debuginfo-0.3.112-2.cm1.aarch64.rpm
 libaio-devel-0.3.112-2.cm1.aarch64.rpm
-libarchive-3.4.2-2.cm1.aarch64.rpm
-libarchive-debuginfo-3.4.2-2.cm1.aarch64.rpm
-libarchive-devel-3.4.2-2.cm1.aarch64.rpm
+libarchive-3.4.2-3.cm1.aarch64.rpm
+libarchive-debuginfo-3.4.2-3.cm1.aarch64.rpm
+libarchive-devel-3.4.2-3.cm1.aarch64.rpm
 libassuan-2.5.1-3.cm1.aarch64.rpm
 libassuan-debuginfo-2.5.1-3.cm1.aarch64.rpm
 libcap-2.26-2.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -156,9 +156,9 @@ krb5-lang-1.17-4.cm1.x86_64.rpm
 libaio-0.3.112-2.cm1.x86_64.rpm
 libaio-debuginfo-0.3.112-2.cm1.x86_64.rpm
 libaio-devel-0.3.112-2.cm1.x86_64.rpm
-libarchive-3.4.2-2.cm1.x86_64.rpm
-libarchive-debuginfo-3.4.2-2.cm1.x86_64.rpm
-libarchive-devel-3.4.2-2.cm1.x86_64.rpm
+libarchive-3.4.2-3.cm1.x86_64.rpm
+libarchive-debuginfo-3.4.2-3.cm1.x86_64.rpm
+libarchive-devel-3.4.2-3.cm1.x86_64.rpm
 libassuan-2.5.1-3.cm1.x86_64.rpm
 libassuan-debuginfo-2.5.1-3.cm1.x86_64.rpm
 libcap-2.26-2.cm1.x86_64.rpm

--- a/toolkit/scripts/toolchain/container/toolchain-remote-wget-list
+++ b/toolkit/scripts/toolchain/container/toolchain-remote-wget-list
@@ -27,7 +27,7 @@ https://tukaani.org/xz/xz-5.2.4.tar.xz
 https://zlib.net/zlib-1.2.11.tar.xz
 https://ftp.gnu.org/gnu/cpio/cpio-2.13.tar.bz2
 http://anduin.linuxfromscratch.org/BLFS/bdb/db-5.3.28.tar.gz
-https://www.libarchive.org/downloads/libarchive-3.4.2.tar.gz
+https://github.com/libarchive/libarchive/releases/download/v3.4.2/libarchive-3.4.2.tar.gz
 http://www.lua.org/ftp/lua-5.3.5.tar.gz
 ftp://anduin.linuxfromscratch.org/BLFS/popt/popt-1.16.tar.gz
 http://ftp.rpm.org/releases/rpm-4.14.x/rpm-4.14.2.tar.bz2


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
libarchive.org/downloads page is returning a 502 error, causing the toolchain build to fail when pulling sources. Updating the source URL for libarchive to GitHub, which will be more reliable. Hash of the source tar is unchanged.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Update libarchive source URL to pull from GitHub instead of libarchive.org. The hash of the source tar is unchanged.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
**YES**

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local build was able to pull libarchive source from GitHub and the md5sum hash checking section of the toolchain build approved it.
