### PR TITLE
[dev] Skip refetching synonymous provides

### DIFF
--- a/toolkit/tools/graphpkgfetcher/graphpkgfetcher.go
+++ b/toolkit/tools/graphpkgfetcher/graphpkgfetcher.go
@@ -104,9 +104,10 @@ func resolveGraphNodes(dependencyGraph *pkggraph.PkgGraph, inputSummaryFile, out
 
 	if strings.TrimSpace(inputSummaryFile) == "" {
 		// Cache an RPM for each unresolved node in the graph.
+		fetchedPackages := make(map[string]bool)
 		for _, n := range dependencyGraph.AllRunNodes() {
 			if n.State == pkggraph.StateUnresolved {
-				resolveErr := resolveSingleNode(cloner, n, *outDir)
+				resolveErr := resolveSingleNode(cloner, n, fetchedPackages, *outDir)
 				// Failing to clone a dependency should not halt a build.
 				// The build should continue and attempt best effort to build as many packages as possible.
 				if resolveErr != nil {
@@ -146,8 +147,9 @@ func resolveGraphNodes(dependencyGraph *pkggraph.PkgGraph, inputSummaryFile, out
 	return
 }
 
-// resolveSingleNode caches the RPM for a single node
-func resolveSingleNode(cloner *rpmrepocloner.RpmRepoCloner, node *pkggraph.PkgNode, outDir string) (err error) {
+// resolveSingleNode caches the RPM for a single node.
+// It will modify fetchedPackages on a successful package clone.
+func resolveSingleNode(cloner *rpmrepocloner.RpmRepoCloner, node *pkggraph.PkgNode, fetchedPackages map[string]bool, outDir string) (err error) {
 	const cloneDeps = true
 	logger.Log.Debugf("Adding node %s to the cache", node.FriendlyName())
 
@@ -166,6 +168,11 @@ func resolveSingleNode(cloner *rpmrepocloner.RpmRepoCloner, node *pkggraph.PkgNo
 		return
 	}
 
+	// Skip fetching packages that have already been fetched.
+	if fetchedPackages[resolvedPackage] {
+		return
+	}
+
 	desiredPackage := &pkgjson.PackageVer{
 		Name: resolvedPackage,
 	}
@@ -175,6 +182,7 @@ func resolveSingleNode(cloner *rpmrepocloner.RpmRepoCloner, node *pkggraph.PkgNo
 		logger.Log.Errorf("Failed to clone '%s' from RPM repo. Error: %s", resolvedPackage, err)
 		return
 	}
+	fetchedPackages[resolvedPackage] = true
 
 	// Construct the rpm path of the cloned package.
 	rpmName := fmt.Sprintf("%s.rpm", resolvedPackage)


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
`graphpkgfetcher` may attempt to fetch the same package multiple times, incurring a non trivial time penalty during builds. This penalty is especially prominent when dealing with specs with multiple dynamic dependencies on external packages.

For example an external package `foo` may provide `foo(a)`, `foo(b)`, .... `foo(z)`. Every one of these provides is backed by the same rpm, but local specs may take a dependency on any one of them. Each one is treated as a different unresolved node in the dependency graph.  For each of these unresolved nodes, `graphpkgfetcher` currently resolves the dependency to an exact rpm and then fetches it using `tdnf download`. In its current form, `tdnf download` would be invoked for each one of the `foo(*)` provides even if the `foo` package has already been fetched.

The fix is to store a list of fetched packages and check the list each time after resolving a dependency but before fetching it.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Maintain a lookup of all fetched packages during node resolution. Skip refetching any packages that have already been fetched in the same run. 

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local builds.
