### PR TITLE
Change systemConfig test to copy rather than reference valid users

### DIFF
--- a/toolkit/tools/imagegen/configuration/systemconfig_test.go
+++ b/toolkit/tools/imagegen/configuration/systemconfig_test.go
@@ -123,9 +123,12 @@ func TestShouldFailParsingBadKernelCommandLine_SystemConfig(t *testing.T) {
 
 func TestShouldFailParsingBadUserUID_SystemConfig(t *testing.T) {
 	var checkedSystemConfig SystemConfig
-
 	badUserConfig := validSystemConfig
-	badUserConfig.Users[1].UID = "-2"
+
+	// Copy the current users (via append to get a copy), then mangle one
+	badUsers := append([]User{}, validSystemConfig.Users...)
+	badUsers[1].UID = "-2"
+	badUserConfig.Users = badUsers
 
 	err := badUserConfig.IsValid()
 	assert.Error(t, err)

--- a/toolkit/tools/imagegen/configuration/systemconfig_test.go
+++ b/toolkit/tools/imagegen/configuration/systemconfig_test.go
@@ -123,7 +123,7 @@ func TestShouldFailParsingBadKernelCommandLine_SystemConfig(t *testing.T) {
 
 func TestShouldFailParsingBadUserUID_SystemConfig(t *testing.T) {
 	var checkedSystemConfig SystemConfig
-	
+
 	badUserConfig := validSystemConfig
 	// Copy the current users (via append to get a copy), then mangle one
 	badUsers := append([]User{}, validSystemConfig.Users...)

--- a/toolkit/tools/imagegen/configuration/systemconfig_test.go
+++ b/toolkit/tools/imagegen/configuration/systemconfig_test.go
@@ -123,8 +123,8 @@ func TestShouldFailParsingBadKernelCommandLine_SystemConfig(t *testing.T) {
 
 func TestShouldFailParsingBadUserUID_SystemConfig(t *testing.T) {
 	var checkedSystemConfig SystemConfig
+	
 	badUserConfig := validSystemConfig
-
 	// Copy the current users (via append to get a copy), then mangle one
 	badUsers := append([]User{}, validSystemConfig.Users...)
 	badUsers[1].UID = "-2"


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Test fails in system config tests if other tests use "validSytemConfig" after the User test. The changes made in the user test persisted and changed expected output.  

###### Change Log  <!-- REQUIRED -->
- Change badUsers to use a copy of validSystemConfig's users rather than reference.

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Test Methodology
- local build of go-tools