### PR TITLE
Remove private ADO reference in docs

### DIFF
--- a/toolkit/docs/security/ca-certificates.md
+++ b/toolkit/docs/security/ca-certificates.md
@@ -11,7 +11,7 @@
 This package contains the basic SSL CA certificates available to use on all images. The certificates are split into two sub packages:
 
 - `ca-certificates-base` - package containing the minimal set of certificates required by the package management tools to authenticate the package repositories.
-- `ca-certificates` - package containig a collection of Mozilla certificates listed in [Mozzila's certdata.txt file](https://hg.mozilla.org/releases/mozilla-release/file/tip/security/nss/lib/ckfw/builtins/certdata.txt). For exact version information please consult the [`ca-certificates.spec`](https://dev.azure.com/mariner-org/_git/mariner?path=%2FSPECS%2Fca-certificates%2Fca-certificates.spec). Installing this package will automatically pull in `ca-certificates-base`.
+- `ca-certificates` - package containig a collection of Mozilla certificates listed in [Mozzila's certdata.txt file](https://hg.mozilla.org/releases/mozilla-release/file/tip/security/nss/lib/ckfw/builtins/certdata.txt). For exact version information please consult the [`ca-certificates.spec`](../../../SPECS/ca-certificates/ca-certificates.spec). Installing this package will automatically pull in `ca-certificates-base`.
 
 In addition to the certificates, the `ca-certificates-tools` package provides tooling for [installation of custom certificates](#custom-configuration-of-the-ca-certificates).
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
`ca-certificates.md` contains a link to a private ADO instance- replace that with a relative link to the spec the text refers to.

###### Change Log  <!-- REQUIRED -->
- Link change in ca-certificates.md

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Checked that link works in this branch
