### PR TITLE
Add patch for client credential support to cpprest package.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ Instructions for building CBL-Mariner may be found here: [Toolkit Documentation]
 
 This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft trademarks or logos is subject to and must follow [Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general). Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship. Any use of third-party trademarks or logos are subject to those third-party's policies.
 
+# Trademarks
+
+This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft trademarks or logos is subject to and must follow [Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general). Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship. Any use of third-party trademarks or logos are subject to those third-party's policies.
+
 # Acknowledgments 
 
 Any Linux distribution, including CBL-Mariner, benefits from contributions by the open software community. We gratefully acknowledge all contributions made from the broader open source community, in particular:

--- a/SPECS/ca-certificates/ca-certificates.spec
+++ b/SPECS/ca-certificates/ca-certificates.spec
@@ -74,7 +74,7 @@ Name:           ca-certificates
 # (but these files might have not yet been released).
 
 Version:        20200720
-Release:        10%{?dist}
+Release:        9%{?dist}
 License:        MPLv2.0
 URL:            https://hg.mozilla.org
 Group:          System Environment/Security

--- a/SPECS/cpprest/cpprest-2.10.14-Add-support-for-oauth2-using-client-credentials.patch
+++ b/SPECS/cpprest/cpprest-2.10.14-Add-support-for-oauth2-using-client-credentials.patch
@@ -1,0 +1,131 @@
+From 708a5df2bb328705622c42f84b4167ea2c7c98c9 Mon Sep 17 00:00:00 2001
+From: Ivan Cherniukh <ivan.cherniukh@gmail.com>
+Date: Wed, 9 Sep 2020 09:09:04 -0700
+Subject: [PATCH] Add support for oauth2 using only client credentials
+
+---
+ .../cpprest/details/http_constants.dat        |  1 +
+ Release/include/cpprest/oauth2.h              | 15 ++++
+ .../functional/http/client/oauth2_tests.cpp   | 68 +++++++++++++++++++
+ 3 files changed, 84 insertions(+)
+
+diff --git a/Release/include/cpprest/details/http_constants.dat b/Release/include/cpprest/details/http_constants.dat
+index c3b1a53c..3deb24a1 100644
+--- a/Release/include/cpprest/details/http_constants.dat
++++ b/Release/include/cpprest/details/http_constants.dat
+@@ -190,6 +190,7 @@ DAT(expires_in,                     "expires_in")
+ DAT(grant_type,                     "grant_type")
+ DAT(redirect_uri,                   "redirect_uri")
+ DAT(refresh_token,                  "refresh_token")
++DAT(client_credentials,             "client_credentials")
+ DAT(response_type,                  "response_type")
+ DAT(scope,                          "scope")
+ DAT(state,                          "state")
+diff --git a/Release/include/cpprest/oauth2.h b/Release/include/cpprest/oauth2.h
+index 693ebbe3..68a7c7b9 100644
+--- a/Release/include/cpprest/oauth2.h
++++ b/Release/include/cpprest/oauth2.h
+@@ -284,6 +284,21 @@ public:
+         return _request_token(ub);
+     }
+ 
++    /// <summary>
++    /// Fetches an access token from the token endpoint using client credentials grant type.
++    /// The task creates an HTTP request to the token_endpoint() using
++    /// client authentication as the authorization grant.
++    /// See: http://tools.ietf.org/html/rfc6749#section-4.4
++    /// </summary>
++    /// <returns>Task that fetches token(s) using client credentials.</returns>
++    pplx::task<void> token_from_client_credentials()
++    {
++        uri_builder ub;
++        ub.append_query(
++        details::oauth2_strings::grant_type, details::oauth2_strings::client_credentials, false);
++        return _request_token(ub);
++    }
++
+     /// <summary>
+     /// Returns enabled state of the configuration.
+     /// The oauth2_handler will perform OAuth 2.0 authentication only if
+diff --git a/Release/tests/functional/http/client/oauth2_tests.cpp b/Release/tests/functional/http/client/oauth2_tests.cpp
+index e1f54085..08bb12a6 100644
+--- a/Release/tests/functional/http/client/oauth2_tests.cpp
++++ b/Release/tests/functional/http/client/oauth2_tests.cpp
+@@ -291,6 +291,74 @@ SUITE(oauth2_tests)
+         VERIFY_ARE_EQUAL(U("done"), m_oauth2_config.token().access_token());
+     }
+ 
++    TEST_FIXTURE(oauth2_test_setup, oauth2_token_from_client_credentials)
++    {
++        VERIFY_IS_FALSE(m_oauth2_config.is_enabled());
++
++        m_oauth2_config.set_user_agent(U("test_user_agent"));
++
++        // Fetch using HTTP Basic authentication.
++        {
++            m_scoped.server()->next_request().then([](test_request* request) {
++                VERIFY_ARE_EQUAL(request->m_method, methods::POST);
++
++                VERIFY_IS_TRUE(is_application_x_www_form_urlencoded(request));
++
++                VERIFY_ARE_EQUAL(
++                    U("Basic MTIzQUJDOjQ1NkRFRg=="),
++                    request->m_headers[header_names::authorization]);
++
++                VERIFY_ARE_EQUAL(
++                    to_body_data(U("grant_type=client_credentials")),
++                    request->m_body);
++
++                VERIFY_ARE_EQUAL(
++                    U("test_user_agent"),
++                    get_request_user_agent(request));
++
++                std::map<utility::string_t, utility::string_t> headers;
++                headers[header_names::content_type] = mime_types::application_json;
++                request->reply(
++                    status_codes::OK, U(""), headers, "{\"access_token\":\"xyzzy123\",\"token_type\":\"bearer\"}");
++            });
++
++            m_oauth2_config.token_from_client_credentials().wait();
++            VERIFY_ARE_EQUAL(U("xyzzy123"), m_oauth2_config.token().access_token());
++            VERIFY_IS_TRUE(m_oauth2_config.is_enabled());
++        }
++
++        // Fetch using client key & secret in request body (x-www-form-urlencoded).
++        {
++            m_scoped.server()->next_request().then([](test_request* request) {
++                VERIFY_IS_TRUE(is_application_x_www_form_urlencoded(request));
++
++                VERIFY_ARE_EQUAL(U(""), request->m_headers[header_names::authorization]);
++
++                VERIFY_ARE_EQUAL(
++                    to_body_data(U("grant_type=client_credentials&client_id=123ABC&client_secret=456DEF")),
++                    request->m_body);
++
++                VERIFY_ARE_EQUAL(U("test_user_agent"), get_request_user_agent(request));
++
++                std::map<utility::string_t, utility::string_t> headers;
++                headers[header_names::content_type] = mime_types::application_json;
++                request->reply(
++                    status_codes::OK, U(""), headers, "{\"access_token\":\"xyzzy123\",\"token_type\":\"bearer\"}");
++            });
++
++            m_oauth2_config.set_token(oauth2_token()); // Clear token.
++            VERIFY_IS_FALSE(m_oauth2_config.is_enabled());
++
++            m_oauth2_config.set_http_basic_auth(false);
++            m_oauth2_config.token_from_client_credentials().wait();
++
++            VERIFY_ARE_EQUAL(
++                U("xyzzy123"),
++                m_oauth2_config.token().access_token());
++            VERIFY_IS_TRUE(m_oauth2_config.is_enabled());
++        }
++    }
++
+     TEST_FIXTURE(oauth2_test_setup, oauth2_bearer_token)
+     {
+         m_oauth2_config.set_token(oauth2_token(U("12345678")));
+-- 
+2.23.3
+

--- a/SPECS/cpprest/cpprest.spec
+++ b/SPECS/cpprest/cpprest.spec
@@ -1,13 +1,14 @@
 %define major 2
 %define minor 10
-
+Summary:        C++ REST library
 Name:           cpprest
 Version:        2.10.14
 Release:        5%{?dist}
-Summary:        C++ REST library
-Group:          Applications/File
 License:        MIT
-Url:            https://github.com/Microsoft/cpprestsdk
+Vendor:         Microsoft Corporation
+Distribution:   Mariner
+Group:          Applications/File
+URL:            https://github.com/Microsoft/cpprestsdk
 #Source0:       https://github.com/Microsoft/cpprestsdk/archive/v%{version}.tar.gz
 Source0:        %{name}-%{version}.tar.gz
 # Disable outside, failing and sometimes failing tests
@@ -18,13 +19,11 @@ Patch2:         cpprest-2.10.9-disable-tests-long-timeouts.patch
 Patch3:         cpprest-2.10.9-disable-test-extract_floating_point.patch
 # Add support for oauth2 'client_credentials' grant type.
 Patch4:         cpprest-2.10.14-Add-support-for-oauth2-using-client-credentials.patch
-Vendor:         Microsoft Corporation
-Distribution:   Mariner
 BuildRequires:  boost-devel >= 1.55
-BuildRequires:  cmake >= 3.1
-BuildRequires:  websocketpp-devel
 BuildRequires:  brotli-devel
+BuildRequires:  cmake >= 3.1
 BuildRequires:  openssl >= 1.0
+BuildRequires:  websocketpp-devel
 BuildRequires:  zlib
 
 %description
@@ -48,7 +47,7 @@ project aims to help C++ developers connect to and interact with services.
 Development files.
 
 %prep
-%setup -n cpprestsdk-%{version}
+%setup -q -n cpprestsdk-%{version}
 %patch1 -p1
 %patch2 -p1
 %patch3 -p1
@@ -77,7 +76,6 @@ cd Release/build.release/Binaries
 ./test_runner *_test.so ||:
 
 %post -p /sbin/ldconfig
-
 %postun -p /sbin/ldconfig
 
 %files
@@ -91,7 +89,6 @@ cd Release/build.release/Binaries
 %{_includedir}/pplx
 %{_libdir}/libcpprest.so
 %{_libdir}/cmake/cpprestsdk
-
 
 %changelog
 * Mon Dec 07 2020 Andrew Beltrano <anbeltra@microsoft.com> - 2.10.14-6

--- a/SPECS/cpprest/cpprest.spec
+++ b/SPECS/cpprest/cpprest.spec
@@ -16,6 +16,8 @@ Patch1:         cpprest-2.10.9-disable-outside-and-failing-tests.patch
 Patch2:         cpprest-2.10.9-disable-tests-long-timeouts.patch
 # Disable test extract_floating_point, which fails on ppc64le and aarch64
 Patch3:         cpprest-2.10.9-disable-test-extract_floating_point.patch
+# Add support for oauth2 'client_credentials' grant type.
+Patch4:         cpprest-2.10.14-Add-support-for-oauth2-using-client-credentials.patch
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 BuildRequires:  boost-devel >= 1.55
@@ -50,6 +52,7 @@ Development files.
 %patch1 -p1
 %patch2 -p1
 %patch3 -p1
+%patch4 -p1
 # Remove bundled sources of websocketpp
 rm -r Release/libs
 # Remove file ThirdPartyNotices.txt, which is associated to websocketpp
@@ -91,6 +94,9 @@ cd Release/build.release/Binaries
 
 
 %changelog
+* Mon Dec 7 2020 Andrew Beltrano <anbeltra@microsoft.com> 2.10.14-6
+- Add cpprest-2.10.14-Add-support-for-oauth2-using-client-credentials.patch.
+
 * Sat Nov 21 2020 Thomas Crain <thcrain@microsoft.com> - 2.10.14-5
 - Replace %%ldconfig_scriptlets with actual post/postun sections
 

--- a/SPECS/cpprest/cpprest.spec
+++ b/SPECS/cpprest/cpprest.spec
@@ -94,7 +94,7 @@ cd Release/build.release/Binaries
 
 
 %changelog
-* Mon Dec 7 2020 Andrew Beltrano <anbeltra@microsoft.com> 2.10.14-6
+* Mon Dec 07 2020 Andrew Beltrano <anbeltra@microsoft.com> - 2.10.14-6
 - Add cpprest-2.10.14-Add-support-for-oauth2-using-client-credentials.patch.
 
 * Sat Nov 21 2020 Thomas Crain <thcrain@microsoft.com> - 2.10.14-5

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -161,6 +161,6 @@ libffi-3.2.1-12.cm1.aarch64.rpm
 libtasn1-4.14-2.cm1.aarch64.rpm
 p11-kit-0.23.16.1-2.cm1.aarch64.rpm
 p11-kit-trust-0.23.16.1-2.cm1.aarch64.rpm
-ca-certificates-shared-20200720-10.cm1.noarch.rpm
-ca-certificates-tools-20200720-10.cm1.noarch.rpm
-ca-certificates-base-20200720-10.cm1.noarch.rpm
+ca-certificates-shared-20200720-9.cm1.noarch.rpm
+ca-certificates-tools-20200720-9.cm1.noarch.rpm
+ca-certificates-base-20200720-9.cm1.noarch.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -161,6 +161,6 @@ libffi-3.2.1-12.cm1.x86_64.rpm
 libtasn1-4.14-2.cm1.x86_64.rpm
 p11-kit-0.23.16.1-2.cm1.x86_64.rpm
 p11-kit-trust-0.23.16.1-2.cm1.x86_64.rpm
-ca-certificates-shared-20200720-10.cm1.noarch.rpm
-ca-certificates-tools-20200720-10.cm1.noarch.rpm
-ca-certificates-base-20200720-10.cm1.noarch.rpm
+ca-certificates-shared-20200720-9.cm1.noarch.rpm
+ca-certificates-tools-20200720-9.cm1.noarch.rpm
+ca-certificates-base-20200720-9.cm1.noarch.rpm


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
This adds support to use [OAuth2 client credentials](https://oauth.net/2/grant-types/client-credentials/) grant type to the cpprest package. This grant type is commonly used in the absence of a user, so is useful for applications involving IoT devices.

###### Change Log  <!-- REQUIRED -->
- Add cpprest-2.10.14-Add-support-for-oauth2-using-client-credentials.patch, enabling grant type 'client_credentials'.

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Associated issues  <!-- optional -->
- microsoft/cpprestsdk#1496

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local package build of cpprestsdk package.
- This patch has been used successfully since 09/15/2020 in a Mariner-derivative at Microsoft for an Azure project, using the same base version of cppresksdk (2.10.14). The package is used by two other packages in the derivative.