### PR TITLE
[dev] Ensure the graph is acyclic after injecting implicit provides

### DIFF
--- a/toolkit/tools/internal/pkggraph/pkggraph.go
+++ b/toolkit/tools/internal/pkggraph/pkggraph.go
@@ -12,12 +12,14 @@ import (
 	"io/ioutil"
 	"os"
 	"sort"
+	"strings"
 	"sync"
 
 	"gonum.org/v1/gonum/graph"
 	"gonum.org/v1/gonum/graph/encoding"
 	"gonum.org/v1/gonum/graph/encoding/dot"
 	"gonum.org/v1/gonum/graph/simple"
+	"gonum.org/v1/gonum/graph/topo"
 	"gonum.org/v1/gonum/graph/traverse"
 
 	"microsoft.com/pkggen/internal/logger"
@@ -1118,6 +1120,87 @@ func (g *PkgGraph) DeepCopy() (deepCopy *PkgGraph, err error) {
 	}
 	deepCopy = NewPkgGraph()
 	err = ReadDOTGraph(deepCopy, &buf)
+	return
+}
+
+// MakeDAG ensures the graph is a directed acyclic graph (DAG).
+// If the graph is not a DAG, this routine will attempt to resolve any cycles to make the graph a DAG.
+func (g *PkgGraph) MakeDAG() (err error) {
+	cycles := topo.DirectedCyclesIn(g)
+
+	// Try to fix the cycles if we can before reporting them
+	// Keep track of which cycles we've failed to fix
+	unfixableCycleCount := 0
+	for len(cycles) > 0 {
+		cycle := cycles[0]
+		// Convert our list to pkggraph.PkgNodes
+		pkgCycle := make([]*PkgNode, 0, len(cycle))
+		for _, node := range cycle {
+			pkgCycle = append(pkgCycle, node.(*PkgNode).This)
+		}
+
+		err = g.fixCycle(pkgCycle)
+		if err != nil {
+			var cycleStringBuilder strings.Builder
+			fmt.Fprintf(&cycleStringBuilder, "{%s}", pkgCycle[0].FriendlyName())
+			for _, node := range pkgCycle[1:] {
+				fmt.Fprintf(&cycleStringBuilder, " --> {%s}", node.FriendlyName())
+			}
+			logger.Log.Errorf("Unfixable circular dependency found %d:\t%s\terror: %s", unfixableCycleCount, cycleStringBuilder.String(), err)
+			unfixableCycleCount++
+		}
+
+		if unfixableCycleCount > 0 {
+			err = fmt.Errorf("cycles detected in dependency graph")
+			return err
+		}
+
+		// Recalculate the list of cycles
+		cycles = topo.DirectedCyclesIn(g)
+	}
+	return
+}
+
+// fixCycle attempts to fix a cycle. Cycles may be acceptable if all nodes are from the same spec file.
+// If a cycle can be fixed an additional meta node will be added to represent the interdependencies of the cycle.
+func (g *PkgGraph) fixCycle(cycle []*PkgNode) (err error) {
+	srpmPath := cycle[0].SrpmPath
+	// Omit the first element of the cycle, since it is repeated as the last element
+	trimmedCycle := cycle[1:]
+	logger.Log.Debugf("Found cycle starting at %s", cycle[0].FriendlyName())
+
+	// For each node, remove any edges which point to other nodes in the cycle, and move any remaining dependencies to a new
+	// meta node, then have everything in the cycle depend on the new meta node.
+	groupedDependencies := make(map[int64]bool)
+	for _, currentNode := range trimmedCycle {
+		logger.Log.Tracef("\tCycle node: %s", currentNode.FriendlyName())
+		if currentNode.Type == TypeBuild {
+			return fmt.Errorf("cycle contains build dependencies, unresolvable")
+		}
+		// Remove all links to other members of the cycle
+		for _, nodeInCycle := range trimmedCycle {
+			g.RemoveEdge(currentNode.ID(), nodeInCycle.ID())
+		}
+
+		// Record any other dependencies the nodes have (ie, where can we get to from here), then remove them
+		fromNodes := graph.NodesOf(g.From(currentNode.ID()))
+		for _, from := range fromNodes {
+			groupedDependencies[from.ID()] = true
+			g.RemoveEdge(currentNode.ID(), from.ID())
+		}
+	}
+
+	// Convert the IDs back into actual nodes
+	dependencyNodes := make([]*PkgNode, 0, len(groupedDependencies))
+	for id := range groupedDependencies {
+		dependencyNodes = append(dependencyNodes, g.Node(id).(*PkgNode).This)
+	}
+
+	metaNode := g.AddMetaNode(trimmedCycle, dependencyNodes)
+
+	// Enable cycle detection between meta nodes within the same srpm file
+	metaNode.SrpmPath = srpmPath
+
 	return
 }
 

--- a/toolkit/tools/scheduler/scheduler.go
+++ b/toolkit/tools/scheduler/scheduler.go
@@ -284,8 +284,18 @@ func buildAllNodes(stopOnFailure, isGraphOptimized, canUseCache bool, packagesTo
 				// If the graph has already been optimized and is now solvable without any additional information
 				// then skip processing any new implicit provides.
 				if !isGraphOptimized {
-					didOptimize, newGraph, newGoalNode := updateGraphWithImplicitProvides(res, pkgGraph, graphMutex, useCachedImplicit)
-					if didOptimize {
+					var (
+						didOptimize bool
+						newGraph    *pkggraph.PkgGraph
+						newGoalNode *pkggraph.PkgNode
+					)
+					didOptimize, newGraph, newGoalNode, err = updateGraphWithImplicitProvides(res, pkgGraph, graphMutex, useCachedImplicit)
+					if err != nil {
+						// Failures to manipulate the graph are fatal.
+						// There is no guarantee the graph is still a directed acyclic graph and is solvable.
+						stopBuilding = true
+						stopBuild(channels, buildState)
+					} else if didOptimize {
 						isGraphOptimized = true
 						// Replace the graph and goal node pointers.
 						// Any outstanding builds of nodes that are no longer in the graph will gracefully handle this.
@@ -329,14 +339,14 @@ func buildAllNodes(stopOnFailure, isGraphOptimized, canUseCache bool, packagesTo
 
 // updateGraphWithImplicitProvides will update the graph with new implicit provides if available.
 // It will also attempt to subgraph the graph if it becomes solvable with the new implicit provides.
-func updateGraphWithImplicitProvides(res *schedulerutils.BuildResult, pkgGraph *pkggraph.PkgGraph, graphMutex sync.RWMutex, useCachedImplicit bool) (didOptimize bool, newGraph *pkggraph.PkgGraph, newGoalNode *pkggraph.PkgNode) {
+func updateGraphWithImplicitProvides(res *schedulerutils.BuildResult, pkgGraph *pkggraph.PkgGraph, graphMutex sync.RWMutex, useCachedImplicit bool) (didOptimize bool, newGraph *pkggraph.PkgGraph, newGoalNode *pkggraph.PkgNode, err error) {
 	// acquire a writer lock since this routine will collapse nodes
 	graphMutex.Lock()
 	defer graphMutex.Unlock()
 
 	didInjectAny, err := schedulerutils.InjectMissingImplicitProvides(res, pkgGraph, useCachedImplicit)
 	if err != nil {
-		logger.Log.Warnf("Failed to inject any missing implicit provides for (%s). Error: %s", res.Node.FriendlyName(), err)
+		logger.Log.Errorf("Failed to add implicit provides for (%s). Error: %s", res.Node.FriendlyName(), err)
 	} else if didInjectAny {
 		newGraph, newGoalNode, err = schedulerutils.OptimizeGraph(pkgGraph, useCachedImplicit)
 		if err == nil {

--- a/toolkit/tools/scheduler/scheduler.go
+++ b/toolkit/tools/scheduler/scheduler.go
@@ -348,8 +348,10 @@ func updateGraphWithImplicitProvides(res *schedulerutils.BuildResult, pkgGraph *
 	if err != nil {
 		logger.Log.Errorf("Failed to add implicit provides for (%s). Error: %s", res.Node.FriendlyName(), err)
 	} else if didInjectAny {
-		newGraph, newGoalNode, err = schedulerutils.OptimizeGraph(pkgGraph, useCachedImplicit)
-		if err == nil {
+		// Failure to optimize the graph is non fatal as there may simply be unresolved dynamic dependencies
+		var subgraphErr error
+		newGraph, newGoalNode, subgraphErr = schedulerutils.OptimizeGraph(pkgGraph, useCachedImplicit)
+		if subgraphErr == nil {
 			logger.Log.Infof("Created solvable subgraph with new implicit provide information")
 			didOptimize = true
 		}

--- a/toolkit/tools/scheduler/schedulerutils/implicitprovides.go
+++ b/toolkit/tools/scheduler/schedulerutils/implicitprovides.go
@@ -43,6 +43,8 @@ func InjectMissingImplicitProvides(res *BuildResult, pkgGraph *pkggraph.PkgGraph
 		}
 	}
 
+	// Make sure the graph is still a directed acyclic graph (DAG) after manipulating it.
+	err = pkgGraph.MakeDAG()
 	return
 }
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
During package building the graph is manipulated when injecting implicit provide information. New nodes are added and edges are altered. During this process it is possible for a directed cycle to be created. In its current state cycles are never checked for and some nodes become unsolvable, leading to blocked SRPMs.

The fix is to scan the graph for cycles each time after manipulating it during a package build. If a cycle is found, it should be fixed if possible to keep the graph acyclic. If this is not possible, it should constitute a failed build as the graph is longer solvable.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Create a common `g.MakeDAG()` call that `grapher` and `scheduler` can use.
- Ensure the graph is a DAG after manipulating the graph with implicit provides.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local builds.
