### PR TITLE
Remove password aging customized value to set default

### DIFF
--- a/SPECS/shadow-utils/shadow-utils.spec
+++ b/SPECS/shadow-utils/shadow-utils.spec
@@ -2,11 +2,11 @@ Summary:        Programs for handling passwords in a secure way
 Name:           shadow-utils
 Version:        4.6
 Release:        9%{?dist}
-URL:            https://github.com/shadow-maint/shadow/
 License:        BSD
-Group:          Applications/System
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
+Group:          Applications/System
+URL:            https://github.com/shadow-maint/shadow/
 Source0:        https://github.com/shadow-maint/shadow/releases/download/4.6/shadow-%{version}.tar.xz
 Source1:        chage
 Source2:        chpasswd
@@ -22,8 +22,8 @@ Source11:       system-session
 Patch1:         chkname-allowcase.patch
 BuildRequires:  cracklib
 BuildRequires:  cracklib-devel
-Requires:       cracklib
 BuildRequires:  pam-devel
+Requires:       cracklib
 Requires:       pam
 
 %description
@@ -36,13 +36,13 @@ in a secure way.
 sed -i 's/groups$(EXEEXT) //' src/Makefile.in
 find man -name Makefile.in -exec sed -i 's/groups\.1 / /' {} \;
 sed -i -e 's@#ENCRYPT_METHOD DES@ENCRYPT_METHOD SHA512@' \
-    -e 's@/var/spool/mail@/var/mail@' etc/login.defs
+    -e 's@%{_var}/spool/mail@%{_var}/mail@' etc/login.defs
 
 sed -i 's@DICTPATH.*@DICTPATH\t/usr/share/cracklib/pw_dict@' \
     etc/login.defs
 
 %build
-%configure --sysconfdir=/etc --with-libpam \
+%configure --sysconfdir=%{_sysconfdir} --with-libpam \
            --with-libcrack --with-group-name-max-length=32
 make %{?_smp_mflags}
 
@@ -50,13 +50,13 @@ make %{?_smp_mflags}
 make DESTDIR=%{buildroot} install
 install -vdm 755 %{buildroot}/bin
 mv -v %{buildroot}%{_bindir}/passwd %{buildroot}/bin
-sed -i 's/yes/no/' %{buildroot}/etc/default/useradd
+sed -i 's/yes/no/' %{buildroot}%{_sysconfdir}/default/useradd
 # Use group id 100(users) by default
-sed -i 's/GROUP.*/GROUP=100/' %{buildroot}/etc/default/useradd
+sed -i 's/GROUP.*/GROUP=100/' %{buildroot}%{_sysconfdir}/default/useradd
 # Disable usergroups. Use "users" group by default (see /etc/default/useradd)
 # for all nonroot users.
-sed -i 's/USERGROUPS_ENAB.*/USERGROUPS_ENAB no/' %{buildroot}/etc/login.defs
-cp etc/{limits,login.access} %{buildroot}/etc
+sed -i 's/USERGROUPS_ENAB.*/USERGROUPS_ENAB no/' %{buildroot}%{_sysconfdir}/login.defs
+cp etc/{limits,login.access} %{buildroot}%{_sysconfdir}
 for FUNCTION in FAIL_DELAY               \
                 FAILLOG_ENAB             \
                 LASTLOG_ENAB             \
@@ -74,10 +74,10 @@ for FUNCTION in FAIL_DELAY               \
                 CHFN_AUTH ENCRYPT_METHOD \
                 ENVIRON_FILE
 do
-    sed -i "s/^${FUNCTION}/# &/" %{buildroot}/etc/login.defs
+    sed -i "s/^${FUNCTION}/# &/" %{buildroot}%{_sysconfdir}/login.defs
 done
 
-sed -i "s/^PASS_MAX_DAYS.*/PASS_MAX_DAYS    99999/" %{buildroot}/etc/login.defs
+sed -i "s/^PASS_MAX_DAYS.*/PASS_MAX_DAYS    99999/" %{buildroot}%{_sysconfdir}/login.defs
 
 install -vm644 %{SOURCE1} %{buildroot}%{_sysconfdir}/pam.d/
 install -vm644 %{SOURCE2} %{buildroot}%{_sysconfdir}/pam.d/
@@ -110,10 +110,10 @@ make %{?_smp_mflags} check
 %files -f shadow.lang
 %defattr(-,root,root)
 %license COPYING
-%config(noreplace) /etc/login.defs
-%config(noreplace) /etc/login.access
-%config(noreplace) /etc/default/useradd
-%config(noreplace) /etc/limits
+%config(noreplace) %{_sysconfdir}/login.defs
+%config(noreplace) %{_sysconfdir}/login.access
+%config(noreplace) %{_sysconfdir}/default/useradd
+%config(noreplace) %{_sysconfdir}/limits
 %{_bindir}/*
 %{_sbindir}/*
 /bin/passwd
@@ -149,64 +149,93 @@ make %{?_smp_mflags} check
 
 *   Tue Apr 28 2020 Emre Girgin <mrgirgin@microsoft.com> 4.6-7
 -   Renaming Linux-PAM to pam
+
 *   Mon Apr 14 2020 Emre Girgin <mrgirgin@microsoft.com> 4.6-6
 -   Consolidate all subpackages as one and rename it to shadow-utils.
 -   Update the URL.
+
 *   Thu Apr 09 2020 Nicolas Ontiveros <niontive@microsoft.com> 4.6-5
 -   Remove toybox and only use shadow-tools for requires.
+
 *   Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 4.6-4
 -   Initial CBL-Mariner import from Photon (license: Apache2).
+
 *   Wed Oct 24 2018 Michelle Wang <michellew@vmware.com> 4.6-3
 -   Add su and login into shadow-tool.
+
 *   Tue Oct 2 2018 Michelle Wang <michellew@vmware.com> 4.6-2
 -   Add conflict toybox for shadow-tools.
+
 *   Wed Sep 19 2018 Srinidhi Rao <srinidhir@vmware.com> 4.6-1
 -   Upgrading the version to 4.6.
+
 *   Mon Jul 30 2018 Tapas Kundu <tkundu@vmware.com> 4.2.1-16
 -   Added fix for CVE-2018-7169.
+
 *   Fri Apr 20 2018 Alexey Makhalov <amakhalov@vmware.com> 4.2.1-15
 -   Move pam.d config file to here for better tracking.
 -   Add pam_loginuid module as optional in a session.
+
 *   Tue Oct 10 2017 Alexey Makhalov <amakhalov@vmware.com> 4.2.1-14
 -   Added -tools subpackage.
 -   Main package requires -tools or toybox.
+
 *   Tue Aug 15 2017 Anish Swaminathan <anishs@vmware.com> 4.2.1-13
 -   Added fix for CVE-2017-12424, CVE-2016-6252.
+
 *   Thu Apr 27 2017 Divya Thaluru <dthaluru@vmware.com> 4.2.1-12
 -   Allow '.' in username.
+
 *   Wed Dec 07 2016 Xiaolin Li <xiaolinl@vmware.com> 4.2.1-11
 -   BuildRequires Linux-PAM-devel.
+
 *   Wed Nov 23 2016 Alexey Makhalov <amakhalov@vmware.com> 4.2.1-10
 -   Added -lang subpackage.
+
 *   Tue Oct 04 2016 ChangLee <changlee@vmware.com> 4.2.1-9
 -   Modified %check.
+
 *   Tue Jun 21 2016 Divya Thaluru <dthaluru@vmware.com> 4.2.1-8
 -   Added logic to not replace pam.d conf files in upgrade scenario.
+
 *   Fri May 27 2016 Divya Thaluru <dthaluru@vmware.com> 4.2.1-7
 -   Adding pam_cracklib module as requisite to pam password configuration.
+
 *   Wed May 25 2016 Divya Thaluru <dthaluru@vmware.com> 4.2.1-6
 -   Modifying pam_systemd module as optional in a session.
+
 *   Tue May 24 2016 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 4.2.1-5
 -   GA Bump release of all rpms.
+
 *   Mon May 2 2016 Xiaolin Li <xiaolinl@vmware.com> 4.2.1-4
 -   Enabling pam_systemd module in a session.
+
 *   Fri Apr 29 2016 Divya Thaluru <dthaluru@vmware.com> 4.2.1-3
 -   Setting password aging limits to 90 days.
+
 *   Wed Apr 27 2016 Divya Thaluru <dthaluru@vmware.com> 4.2.1-3
 -   Setting password aging limits to 365 days.
+
 *   Wed Mar 23 2016 Divya Thaluru <dthaluru@vmware.com> 4.2.1-2
 -   Enabling pam_limits module in a session.
+
 *   Tue Jan 12 2016 Anish Swaminathan <anishs@vmware.com> 4.2.1-1
 -   Update version.
+
 *   Wed Dec 2 2015 Divya Thaluru <dthaluru@vmware.com> 4.1.5.1-6
 -   Fixed PAM Configuration file for passwd.
+
 *   Mon Oct 26 2015 Sharath George <sharathg@vmware.com> 4.1.5.1-5
 -   Allow mixed case in username.
+
 *   Mon Jun 29 2015 Divya Thaluru <dthaluru@vmware.com> 4.1.5.1-4
 -   Fixed PAM Configuration file for chpasswd.
+
 *   Tue Jun 16 2015 Alexey Makhalov <amakhalov@vmware.com> 4.1.5.1-3
 -   Use group id 100(users) by default.
+
 *   Wed May 27 2015 Divya Thaluru <dthaluru@vmware.com> 4.1.5.1-2
 -   Adding PAM support.
+
 *   Wed Nov 5 2014 Divya Thaluru <dthaluru@vmware.com> 4.1.5.1-1
 -   Initial build First version.

--- a/SPECS/shadow-utils/shadow-utils.spec
+++ b/SPECS/shadow-utils/shadow-utils.spec
@@ -77,8 +77,6 @@ do
     sed -i "s/^${FUNCTION}/# &/" %{buildroot}%{_sysconfdir}/login.defs
 done
 
-sed -i "s/^PASS_MAX_DAYS.*/PASS_MAX_DAYS    99999/" %{buildroot}%{_sysconfdir}/login.defs
-
 install -vm644 %{SOURCE1} %{buildroot}%{_sysconfdir}/pam.d/
 install -vm644 %{SOURCE2} %{buildroot}%{_sysconfdir}/pam.d/
 install -vm644 %{SOURCE3} %{buildroot}%{_sysconfdir}/pam.d/
@@ -142,7 +140,7 @@ make %{?_smp_mflags} check
 
 %changelog
 * Mon Dec 14 2020 Suresh Babu Chalamalasetty <schalam@microsoft.com> - 4.6-9
-- Update PASS_MAX_DAYS to 99999
+- Remove PASS_MAX_DAYS customized value 90 to set default value
 
 * Sat May 09 00:20:53 PST 2020 Nick Samson <nisamson@microsoft.com> - 4.6-8
 - Added %%license line automatically

--- a/SPECS/shadow-utils/shadow-utils.spec
+++ b/SPECS/shadow-utils/shadow-utils.spec
@@ -1,7 +1,7 @@
 Summary:        Programs for handling passwords in a secure way
 Name:           shadow-utils
 Version:        4.6
-Release:        8%{?dist}
+Release:        9%{?dist}
 URL:            https://github.com/shadow-maint/shadow/
 License:        BSD
 Group:          Applications/System
@@ -77,7 +77,7 @@ do
     sed -i "s/^${FUNCTION}/# &/" %{buildroot}/etc/login.defs
 done
 
-sed -i "s/^PASS_MAX_DAYS.*/PASS_MAX_DAYS    90/" %{buildroot}/etc/login.defs
+sed -i "s/^PASS_MAX_DAYS.*/PASS_MAX_DAYS    99999/" %{buildroot}/etc/login.defs
 
 install -vm644 %{SOURCE1} %{buildroot}%{_sysconfdir}/pam.d/
 install -vm644 %{SOURCE2} %{buildroot}%{_sysconfdir}/pam.d/
@@ -141,6 +141,9 @@ make %{?_smp_mflags} check
 %config(noreplace) %{_sysconfdir}/pam.d/*
 
 %changelog
+* Mon Dec 14 2020 Suresh Babu Chalamalasetty <schalam@microsoft.com> - 4.6-9
+- Update PASS_MAX_DAYS to 99999
+
 * Sat May 09 00:20:53 PST 2020 Nick Samson <nisamson@microsoft.com> - 4.6-8
 - Added %%license line automatically
 

--- a/SPECS/shadow-utils/shadow-utils.spec
+++ b/SPECS/shadow-utils/shadow-utils.spec
@@ -36,7 +36,7 @@ in a secure way.
 sed -i 's/groups$(EXEEXT) //' src/Makefile.in
 find man -name Makefile.in -exec sed -i 's/groups\.1 / /' {} \;
 sed -i -e 's@#ENCRYPT_METHOD DES@ENCRYPT_METHOD SHA512@' \
-    -e 's@%{_var}/spool/mail@%{_var}/mail@' etc/login.defs
+    -e 's@/var/spool/mail@/var/mail@' etc/login.defs
 
 sed -i 's@DICTPATH.*@DICTPATH\t/usr/share/cracklib/pw_dict@' \
     etc/login.defs

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -345,8 +345,8 @@ rpm-libs-4.14.2-10.cm1.aarch64.rpm
 sed-4.5-3.cm1.aarch64.rpm
 sed-debuginfo-4.5-3.cm1.aarch64.rpm
 sed-lang-4.5-3.cm1.aarch64.rpm
-shadow-utils-4.6-8.cm1.aarch64.rpm
-shadow-utils-debuginfo-4.6-8.cm1.aarch64.rpm
+shadow-utils-4.6-9.cm1.aarch64.rpm
+shadow-utils-debuginfo-4.6-9.cm1.aarch64.rpm
 sqlite-3.32.3-2.cm1.aarch64.rpm
 sqlite-debuginfo-3.32.3-2.cm1.aarch64.rpm
 sqlite-devel-3.32.3-2.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -345,8 +345,8 @@ rpm-libs-4.14.2-10.cm1.x86_64.rpm
 sed-4.5-3.cm1.x86_64.rpm
 sed-debuginfo-4.5-3.cm1.x86_64.rpm
 sed-lang-4.5-3.cm1.x86_64.rpm
-shadow-utils-4.6-8.cm1.x86_64.rpm
-shadow-utils-debuginfo-4.6-8.cm1.x86_64.rpm
+shadow-utils-4.6-9.cm1.x86_64.rpm
+shadow-utils-debuginfo-4.6-9.cm1.x86_64.rpm
 sqlite-3.32.3-2.cm1.x86_64.rpm
 sqlite-debuginfo-3.32.3-2.cm1.x86_64.rpm
 sqlite-devel-3.32.3-2.cm1.x86_64.rpm


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x ] The toolchain/worker package manifests are up-to-date
- [x ] Any updated packages successfully build (or no packages were changed)
- [x ] All package sources are available
- [x ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x ] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [ x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
 Currently 90 days older Mariner VHD images are failing with provisioning due to PAM complaining about authentication token no longer valid and password aging. Increasing maximum number of days a password can be used to 99999 which is default by removing customized value. Most of Linux distros have default value 99999 used for password aging. 

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change 
-   Remove password aging customized value to set default.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
**YES**
NO

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/...

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Built changes locally and verified the fix to confirm password aging set to default.  