### PR TITLE
Update kernel to 4.5.83, Address 7 kernel CVEs 

### DIFF
--- a/SPECS-SIGNED/kernel-signed-aarch64/kernel-signed-aarch64.spec
+++ b/SPECS-SIGNED/kernel-signed-aarch64/kernel-signed-aarch64.spec
@@ -2,7 +2,7 @@
 %define uname_r %{version}-%{release}
 Summary:        Signed Linux Kernel for aarch64 systems
 Name:           kernel-signed-aarch64
-Version:        5.4.81
+Version:        5.4.83
 Release:        1%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
@@ -80,6 +80,9 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %config %{_localstatedir}/lib/initramfs/kernel/%{uname_r}
 
 %changelog
+* Tue Dec 15 2020 Henry Beberman <henry.beberman@microsoft.com> - 5.4.83-1
+- Update source to 5.4.83
+
 * Fri Dec 04 2020 Chris Co <chrco@microsoft.com> - 5.4.81-1
 - Update source to 5.4.81
 

--- a/SPECS-SIGNED/kernel-signed-x64/kernel-signed-x64.spec
+++ b/SPECS-SIGNED/kernel-signed-x64/kernel-signed-x64.spec
@@ -80,6 +80,9 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %config %{_localstatedir}/lib/initramfs/kernel/%{uname_r}
 
 %changelog
+* Tue Dec 15 2020 Henry Beberman <henry.beberman@microsoft.com> - 5.4.83-1
+- Update source to 5.4.83
+
 * Fri Dec 04 2020 Chris Co <chrco@microsoft.com> - 5.4.81-1
 - Update source to 5.4.81
 

--- a/SPECS/hyperv-daemons/hyperv-daemons.signatures.json
+++ b/SPECS/hyperv-daemons/hyperv-daemons.signatures.json
@@ -7,6 +7,6 @@
   "hypervvss.rules": "94cead44245ef6553ab79c0bbac8419e3ff4b241f01bcec66e6f508098cbedd1",
   "hypervvssd.service": "22270d9f0f23af4ea7905f19c1d5d5495e40c1f782cbb87a99f8aec5a011078d",
   "hv_set_ifconfig": "0865f76b18f8f04cb54b7779c2d5d400dab68b132210e17db98117012d177c90",
-  "linux-msft-5.4.81.tar.gz": "2d6af30b7472b7693c428900fcc90eb9cec9f54c8578d1867ebff02f675e7a1d"
+  "linux-msft-5.4.83.tar.gz": "aee2d028c87565ae41b6c8d9de0770e80e614fdeb8cfafe42ae64e280b8f10be"
  }
 }

--- a/SPECS/hyperv-daemons/hyperv-daemons.spec
+++ b/SPECS/hyperv-daemons/hyperv-daemons.spec
@@ -8,7 +8,7 @@
 %global udev_prefix 70
 Summary:        Hyper-V daemons suite
 Name:           hyperv-daemons
-Version:        5.4.81
+Version:        5.4.83
 Release:        1%{?dist}
 License:        GPLv2+
 Vendor:         Microsoft Corporation
@@ -218,6 +218,9 @@ fi
 %{_sbindir}/lsvmbus
 
 %changelog
+* Tue Dec 15 2020 Henry Beberman <henry.beberman@microsoft.com> - 5.4.83-1
+- Update source to 5.4.83
+
 * Fri Dec 04 2020 Chris Co <chrco@microsoft.com> - 5.4.81-1
 - Update source to 5.4.81
 

--- a/SPECS/kernel-headers/kernel-headers.signatures.json
+++ b/SPECS/kernel-headers/kernel-headers.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "linux-msft-5.4.81.tar.gz": "2d6af30b7472b7693c428900fcc90eb9cec9f54c8578d1867ebff02f675e7a1d"
+  "linux-msft-5.4.83.tar.gz": "aee2d028c87565ae41b6c8d9de0770e80e614fdeb8cfafe42ae64e280b8f10be"
  }
 }

--- a/SPECS/kernel-headers/kernel-headers.spec
+++ b/SPECS/kernel-headers/kernel-headers.spec
@@ -1,6 +1,6 @@
 Summary:        Linux API header files
 Name:           kernel-headers
-Version:        5.4.81
+Version:        5.4.83
 Release:        1%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
@@ -34,6 +34,9 @@ cp -rv usr/include/* /%{buildroot}%{_includedir}
 %{_includedir}/*
 
 %changelog
+* Tue Dec 15 2020 Henry Beberman <henry.beberman@microsoft.com> - 5.4.83-1
+- Update source to 5.4.83
+
 * Fri Dec 04 2020 Chris Co <chrco@microsoft.com> - 5.4.81-1
 - Update source to 5.4.81
 

--- a/SPECS/kernel-hyperv/config
+++ b/SPECS/kernel-hyperv/config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86_64 5.4.81 Kernel Configuration
+# Linux/x86_64 5.4.83 Kernel Configuration
 #
 
 #

--- a/SPECS/kernel-hyperv/kernel-hyperv.signatures.json
+++ b/SPECS/kernel-hyperv/kernel-hyperv.signatures.json
@@ -1,6 +1,6 @@
 {
  "Signatures": {
   "config": "aaf458ca2441528693b66b001ae5635ea4f671eed69f675fb29426e5025e0cd7",
-  "linux-msft-5.4.81.tar.gz": "2d6af30b7472b7693c428900fcc90eb9cec9f54c8578d1867ebff02f675e7a1d"
+  "linux-msft-5.4.83.tar.gz": "aee2d028c87565ae41b6c8d9de0770e80e614fdeb8cfafe42ae64e280b8f10be"
  }
 }

--- a/SPECS/kernel-hyperv/kernel-hyperv.signatures.json
+++ b/SPECS/kernel-hyperv/kernel-hyperv.signatures.json
@@ -1,6 +1,6 @@
 {
  "Signatures": {
-  "config": "aaf458ca2441528693b66b001ae5635ea4f671eed69f675fb29426e5025e0cd7",
+  "config": "3ec945438671dcd635aed408127a876691da9fd5f999eee7f2f0d3f214fb46cb",
   "linux-msft-5.4.83.tar.gz": "aee2d028c87565ae41b6c8d9de0770e80e614fdeb8cfafe42ae64e280b8f10be"
  }
 }

--- a/SPECS/kernel-hyperv/kernel-hyperv.spec
+++ b/SPECS/kernel-hyperv/kernel-hyperv.spec
@@ -262,7 +262,7 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %{_libdir}/perf/include/bpf/*
 
 %changelog
-* Fri Dec 04 2020 Chris Co <chrco@microsoft.com> - 5.4.83-1
+* Tue Dec 15 2020 Henry Beberman <henry.beberman@microsoft.com> - 5.4.83-1
 - Update source to 5.4.83
 
 * Fri Dec 04 2020 Chris Co <chrco@microsoft.com> - 5.4.81-1

--- a/SPECS/kernel-hyperv/kernel-hyperv.spec
+++ b/SPECS/kernel-hyperv/kernel-hyperv.spec
@@ -2,7 +2,7 @@
 %define uname_r %{version}-%{release}
 Summary:        Linux Kernel optimized for Hyper-V
 Name:           kernel-hyperv
-Version:        5.4.81
+Version:        5.4.83
 Release:        1%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
@@ -262,6 +262,9 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %{_libdir}/perf/include/bpf/*
 
 %changelog
+* Fri Dec 04 2020 Chris Co <chrco@microsoft.com> - 5.4.83-1
+- Update source to 5.4.83
+
 * Fri Dec 04 2020 Chris Co <chrco@microsoft.com> - 5.4.81-1
 - Update source to 5.4.81
 

--- a/SPECS/kernel/CVE-2020-14351.nopatch
+++ b/SPECS/kernel/CVE-2020-14351.nopatch
@@ -1,1 +1,1 @@
-CVE-2020-12826 - already patched in linux-msft-5.4.78 stable kernel
+CVE-2020-14351 - already patched in linux-msft-5.4.78 stable kernel

--- a/SPECS/kernel/CVE-2020-14351.nopatch
+++ b/SPECS/kernel/CVE-2020-14351.nopatch
@@ -1,0 +1,1 @@
+CVE-2020-12826 - already patched in linux-msft-5.4.78 stable kernel

--- a/SPECS/kernel/CVE-2020-14381.nopatch
+++ b/SPECS/kernel/CVE-2020-14381.nopatch
@@ -1,0 +1,1 @@
+CVE-2020-14381 - already patched in linux-msft-5.4.81 stable kernel

--- a/SPECS/kernel/CVE-2020-25656.nopatch
+++ b/SPECS/kernel/CVE-2020-25656.nopatch
@@ -1,0 +1,1 @@
+CVE-2020-25656 - already patched in linux-msft-5.4.81 stable kernel

--- a/SPECS/kernel/CVE-2020-25704.nopatch
+++ b/SPECS/kernel/CVE-2020-25704.nopatch
@@ -1,0 +1,1 @@
+CVE-2020-25704 - already patched in linux-msft-5.4.81 stable kernel

--- a/SPECS/kernel/CVE-2020-29534.nopatch
+++ b/SPECS/kernel/CVE-2020-29534.nopatch
@@ -1,0 +1,1 @@
+CVE-2020-29534 - Not applicable for 5.4 kernel  (io_uring v5.5+)

--- a/SPECS/kernel/CVE-2020-29660.nopatch
+++ b/SPECS/kernel/CVE-2020-29660.nopatch
@@ -1,0 +1,1 @@
+CVE-2020-29660 - already patched in linux-msft-5.4.83 stable kernel

--- a/SPECS/kernel/CVE-2020-29661.nopatch
+++ b/SPECS/kernel/CVE-2020-29661.nopatch
@@ -1,0 +1,1 @@
+CVE-2020-29661 - already patched in linux-msft-5.4.83 stable kernel

--- a/SPECS/kernel/config
+++ b/SPECS/kernel/config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86_64 5.4.81 Kernel Configuration
+# Linux/x86_64 5.4.83 Kernel Configuration
 #
 
 #

--- a/SPECS/kernel/config_aarch64
+++ b/SPECS/kernel/config_aarch64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 5.4.81 Kernel Configuration
+# Linux/arm64 5.4.83 Kernel Configuration
 #
 
 #

--- a/SPECS/kernel/kernel.signatures.json
+++ b/SPECS/kernel/kernel.signatures.json
@@ -2,6 +2,6 @@
  "Signatures": {
   "config": "688ec482b7012da61011b3d248e0631197e4ebc9a1b65defea69941e750e5334",
   "config_aarch64": "ad1043afdffd1c61ca2d07564499dc2f1cf216fbb121b707878e3bcbac8be03e",
-  "linux-msft-5.4.81.tar.gz": "2d6af30b7472b7693c428900fcc90eb9cec9f54c8578d1867ebff02f675e7a1d"
+  "linux-msft-5.4.83.tar.gz": "aee2d028c87565ae41b6c8d9de0770e80e614fdeb8cfafe42ae64e280b8f10be"
  }
 }

--- a/SPECS/kernel/kernel.signatures.json
+++ b/SPECS/kernel/kernel.signatures.json
@@ -1,7 +1,7 @@
 {
  "Signatures": {
-  "config": "688ec482b7012da61011b3d248e0631197e4ebc9a1b65defea69941e750e5334",
-  "config_aarch64": "ad1043afdffd1c61ca2d07564499dc2f1cf216fbb121b707878e3bcbac8be03e",
+  "config": "830ceb15eefa5b8676bce08631f935c2bff299e24a3750c6d959fa5132c48eb5",
+  "config_aarch64": "4234aef7c4cfe29fd40fc93b8599ff48fcb7026fb1888b995af329ce9616849c",
   "linux-msft-5.4.83.tar.gz": "aee2d028c87565ae41b6c8d9de0770e80e614fdeb8cfafe42ae64e280b8f10be"
  }
 }

--- a/SPECS/kernel/kernel.spec
+++ b/SPECS/kernel/kernel.spec
@@ -2,7 +2,7 @@
 %define uname_r %{version}-%{release}
 Summary:        Linux Kernel
 Name:           kernel
-Version:        5.4.81
+Version:        5.4.83
 Release:        1%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
@@ -118,6 +118,11 @@ Patch1090:      CVE-2020-29372.nopatch
 Patch1091:      CVE-2020-27194.nopatch
 # CVE-2020-27152 - Introducing commit not in stable tree. No fix necessary at this time.
 Patch1092:      CVE-2020-27152.nopatch
+Patch1093:      CVE-2020-14351.nopatch
+Patch1094:      CVE-2020-14381.nopatch
+Patch1095:      CVE-2020-25656.nopatch
+Patch1096:      CVE-2020-25704.nopatch
+Patch1097:      CVE-2020-29534.nopatch
 BuildRequires:  audit-devel
 BuildRequires:  bc
 BuildRequires:  diffutils
@@ -425,6 +430,11 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %{_libdir}/perf/include/bpf/*
 
 %changelog
+* Tue Dec 15 2020 Henry Beberman <henry.beberman@microsoft.com> - 5.4.83-1
+- Update source to 5.4.83
+- Address CVE-2020-14351, CVE-2020-14381, CVE-2020-25656, CVE-2020-25704,
+  CVE-2020-29534, CVE-2020-29660, CVE-2020-29661
+
 * Fri Dec 04 2020 Chris Co <chrco@microsoft.com> - 5.4.81-1
 - Update source to 5.4.81
 - Remove patch for kexec in HyperV. Integrated in 5.4.81.

--- a/SPECS/kernel/kernel.spec
+++ b/SPECS/kernel/kernel.spec
@@ -123,6 +123,8 @@ Patch1094:      CVE-2020-14381.nopatch
 Patch1095:      CVE-2020-25656.nopatch
 Patch1096:      CVE-2020-25704.nopatch
 Patch1097:      CVE-2020-29534.nopatch
+Patch1098:      CVE-2020-29660.nopatch
+Patch1099:      CVE-2020-29661.nopatch
 BuildRequires:  audit-devel
 BuildRequires:  bc
 BuildRequires:  diffutils

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -1605,8 +1605,8 @@
         "type": "other",
         "other": {
           "name": "hyperv-daemons",
-          "version": "5.4.81",
-          "downloadUrl": "https://github.com/microsoft/WSL2-Linux-Kernel/archive/linux-msft-5.4.81.tar.gz"
+          "version": "5.4.83",
+          "downloadUrl": "https://github.com/microsoft/WSL2-Linux-Kernel/archive/linux-msft-5.4.83.tar.gz"
         }
       }
     },
@@ -1905,8 +1905,8 @@
         "type": "other",
         "other": {
           "name": "kernel-headers",
-          "version": "5.4.81",
-          "downloadUrl": "https://github.com/microsoft/WSL2-Linux-Kernel/archive/linux-msft-5.4.81.tar.gz"
+          "version": "5.4.83",
+          "downloadUrl": "https://github.com/microsoft/WSL2-Linux-Kernel/archive/linux-msft-5.4.83.tar.gz"
         }
       }
     },
@@ -1915,8 +1915,8 @@
         "type": "other",
         "other": {
           "name": "kernel-hyperv",
-          "version": "5.4.81",
-          "downloadUrl": "https://github.com/microsoft/WSL2-Linux-Kernel/archive/linux-msft-5.4.81.tar.gz"
+          "version": "5.4.83",
+          "downloadUrl": "https://github.com/microsoft/WSL2-Linux-Kernel/archive/linux-msft-5.4.83.tar.gz"
         }
       }
     },
@@ -1925,8 +1925,8 @@
         "type": "other",
         "other": {
           "name": "kernel",
-          "version": "5.4.81",
-          "downloadUrl": "https://github.com/microsoft/WSL2-Linux-Kernel/archive/linux-msft-5.4.81.tar.gz"
+          "version": "5.4.83",
+          "downloadUrl": "https://github.com/microsoft/WSL2-Linux-Kernel/archive/linux-msft-5.4.83.tar.gz"
         }
       }
     },

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -1,5 +1,5 @@
 filesystem-1.1-7.cm1.aarch64.rpm
-kernel-headers-5.4.81-1.cm1.noarch.rpm
+kernel-headers-5.4.83-1.cm1.noarch.rpm
 glibc-2.28-15.cm1.aarch64.rpm
 glibc-devel-2.28-15.cm1.aarch64.rpm
 glibc-i18n-2.28-15.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -1,5 +1,5 @@
 filesystem-1.1-7.cm1.x86_64.rpm
-kernel-headers-5.4.81-1.cm1.noarch.rpm
+kernel-headers-5.4.83-1.cm1.noarch.rpm
 glibc-2.28-15.cm1.x86_64.rpm
 glibc-devel-2.28-15.cm1.x86_64.rpm
 glibc-i18n-2.28-15.cm1.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -145,7 +145,7 @@ json-c-debuginfo-0.14-3.cm1.aarch64.rpm
 json-c-devel-0.14-3.cm1.aarch64.rpm
 kbd-2.0.4-5.cm1.aarch64.rpm
 kbd-debuginfo-2.0.4-5.cm1.aarch64.rpm
-kernel-headers-5.4.81-1.cm1.noarch.rpm
+kernel-headers-5.4.83-1.cm1.noarch.rpm
 kmod-25-4.cm1.aarch64.rpm
 kmod-debuginfo-25-4.cm1.aarch64.rpm
 kmod-devel-25-4.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -145,7 +145,7 @@ json-c-debuginfo-0.14-3.cm1.x86_64.rpm
 json-c-devel-0.14-3.cm1.x86_64.rpm
 kbd-2.0.4-5.cm1.x86_64.rpm
 kbd-debuginfo-2.0.4-5.cm1.x86_64.rpm
-kernel-headers-5.4.81-1.cm1.noarch.rpm
+kernel-headers-5.4.83-1.cm1.noarch.rpm
 kmod-25-4.cm1.x86_64.rpm
 kmod-debuginfo-25-4.cm1.x86_64.rpm
 kmod-devel-25-4.cm1.x86_64.rpm

--- a/toolkit/scripts/toolchain/container/toolchain-md5sums
+++ b/toolkit/scripts/toolchain/container/toolchain-md5sums
@@ -98,7 +98,7 @@ ef8c2c1d16a00bd95b9fdcef63b8a2ca  libXtst-1.2.3.tar.bz2
 4cbe1c1def7a5e1b0ed5fce8e512f4c6  libXvMC-1.0.10.tar.bz2
 d7dd9b9df336b7dd4028b6b56542ff2c  libXxf86dga-1.1.4.tar.bz2
 298b8fff82df17304dfdb5fe4066fe3a  libXxf86vm-1.1.4.tar.bz2
-a0fc901d224dc9e0909fcb8d11b5247b  linux-msft-5.4.81.tar.gz
+e54bb4bd2b41330f9456b6761e5df7f4  linux-msft-5.4.83.tar.gz
 63ecacd3ff6552537a73f8c30c396caf  lua-5.3.5-shared_library-1.patch
 4f4b4f323fd3514a68e0ab3da8ce3455  lua-5.3.5.tar.gz
 730bb15d96fffe47e148d1e09235af82  m4-1.4.18.tar.xz

--- a/toolkit/scripts/toolchain/container/toolchain-remote-wget-list
+++ b/toolkit/scripts/toolchain/container/toolchain-remote-wget-list
@@ -39,7 +39,7 @@ http://ftp.gnu.org/gnu/readline/readline-7.0.tar.gz
 http://ftp.gnu.org/gnu/tar/tar-1.30.tar.xz
 http://ftp.gnu.org/gnu/texinfo/texinfo-6.5.tar.xz
 https://www.cpan.org/src/5.0/perl-5.30.3.tar.gz
-https://github.com/microsoft/WSL2-Linux-Kernel/archive/linux-msft-5.4.81.tar.gz
+https://github.com/microsoft/WSL2-Linux-Kernel/archive/linux-msft-5.4.83.tar.gz
 http://ftp.gnu.org/gnu/bash/bash-4.4.18.tar.gz
 https://ftp.gnu.org/gnu/bison/bison-3.1.tar.xz
 https://sourceware.org/pub/bzip2/bzip2-1.0.6.tar.gz

--- a/toolkit/scripts/toolchain/container/toolchain_build_in_chroot.sh
+++ b/toolkit/scripts/toolchain/container/toolchain_build_in_chroot.sh
@@ -57,14 +57,14 @@ set -e
 #
 cd /sources
 
-echo Linux-5.4.81 API Headers
-tar xf linux-msft-5.4.81.tar.gz
-pushd WSL2-Linux-Kernel-linux-msft-5.4.81
+echo Linux-5.4.83 API Headers
+tar xf linux-msft-5.4.83.tar.gz
+pushd WSL2-Linux-Kernel-linux-msft-5.4.83
 make mrproper
 make headers
 cp -rv usr/include/* /usr/include
 popd
-rm -rf WSL2-Linux-Kernel-linux-msft-5.4.81
+rm -rf WSL2-Linux-Kernel-linux-msft-5.4.83
 touch /logs/status_kernel_headers_complete
 
 echo 6.8. Man-pages-5.02

--- a/toolkit/scripts/toolchain/container/toolchain_build_temp_tools.sh
+++ b/toolkit/scripts/toolchain/container/toolchain_build_temp_tools.sh
@@ -113,14 +113,14 @@ rm -rf gcc-9.1.0
 
 touch $LFS/logs/temptoolchain/status_gcc_pass1_complete
 
-echo Linux-5.4.81 API Headers
-tar xf linux-msft-5.4.81.tar.gz
-pushd WSL2-Linux-Kernel-linux-msft-5.4.81
+echo Linux-5.4.83 API Headers
+tar xf linux-msft-5.4.83.tar.gz
+pushd WSL2-Linux-Kernel-linux-msft-5.4.83
 make mrproper
 make headers
 cp -rv usr/include/* /tools/include
 popd
-rm -rf WSL2-Linux-Kernel-linux-msft-5.4.81
+rm -rf WSL2-Linux-Kernel-linux-msft-5.4.83
 
 touch $LFS/logs/temptoolchain/status_kernel_headers_complete
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Update kernel source to 5.4.83. New kernel source contains fixes for many kernel CVEs flagged by our tooling so address the CVEs.

###### Change Log  <!-- REQUIRED -->
- Update kernel-headers, kernel, kernel-hyperv, and hyperv-daemons specs to use 5.4.83
- Refresh version numbers for kernel-signed- specs
- Update toolchain to use 5.4.83 source when building kernel headers
- Address CVE-2020-14351, CVE-2020-14381, CVE-2020-25656, CVE-2020-25704,
  CVE-2020-29534, CVE-2020-29660, CVE-2020-29661
- Update cgmanifest's download URLs to point to 5.4.83 source location

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
**YES**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2020-14351
- https://nvd.nist.gov/vuln/detail/CVE-2020-14381
- https://nvd.nist.gov/vuln/detail/CVE-2020-25656
- https://nvd.nist.gov/vuln/detail/CVE-2020-25704
- https://nvd.nist.gov/vuln/detail/CVE-2020-29534
- https://nvd.nist.gov/vuln/detail/CVE-2020-29660
- https://nvd.nist.gov/vuln/detail/CVE-2020-29661

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local x64 build
