### PR TITLE
[1/5 verity read-only root] Improve /boot and device mapper support, random string gen

### DIFF
--- a/toolkit/docs/formats/imageconfig.md
+++ b/toolkit/docs/formats/imageconfig.md
@@ -65,6 +65,15 @@ Sample partitions entry, specifying a boot partition and a root partition:
 ]
 ```
 
+#### Flags
+"Flags" key controls special handling for certain partitions.
+
+- `esp` indicates this is the UEFI esp partition
+- `grub` indicates this is a grub boot partition
+- `bios_grub` indicates this is a bios grub boot partition
+- `boot` indicates this is a boot partition
+- `dmroot` indicates this partition will be used for a device mapper root device (i.e. `Encryption` or `ReadOnlyVerityRoot`)
+
 ## SystemConfigs
 
 SystemConfigs is an array of SystemConfig entries.

--- a/toolkit/resources/assets/efi/grub/grub.cfg
+++ b/toolkit/resources/assets/efi/grub/grub.cfg
@@ -1,2 +1,6 @@
 search -n -u {{.BootUUID}} -s
-configfile /boot/grub2/grub.cfg
+
+# If '/boot' is a seperate partition, BootUUID will point directly to '/boot'.
+# In this case we should omit the '/boot' prefix from all paths.
+set bootprefix={{.BootPrefix}}
+configfile $bootprefix/grub2/grub.cfg

--- a/toolkit/resources/assets/grub2/grub.cfg
+++ b/toolkit/resources/assets/grub2/grub.cfg
@@ -1,9 +1,9 @@
 set timeout=0
 search -n -u {{.BootUUID}} -s
 
-load_env -f /boot/mariner.cfg
-if [ -f  /boot/systemd.cfg ]; then
-	load_env -f /boot/systemd.cfg
+load_env -f $bootprefix/mariner.cfg
+if [ -f  $bootprefix/systemd.cfg ]; then
+	load_env -f $bootprefix/systemd.cfg
 else
 	set systemd_cmdline=net.ifnames=0
 fi
@@ -11,8 +11,8 @@ fi
 set rootdevice={{.RootPartition}}
 
 menuentry "CBL-Mariner" {
-	linux /boot/$mariner_linux {{.LuksUUID}} {{.LVM}} {{.IMAPolicy}} rd.auto=1 root=$rootdevice $mariner_cmdline $systemd_cmdline {{.ExtraCommandLine}}
-	if [ -f /boot/$mariner_initrd ]; then
-		initrd /boot/$mariner_initrd
+	linux $bootprefix/$mariner_linux {{.LuksUUID}} {{.LVM}} {{.IMAPolicy}} rd.auto=1 root=$rootdevice $mariner_cmdline $systemd_cmdline {{.ExtraCommandLine}}
+	if [ -f $bootprefix/$mariner_initrd ]; then
+		initrd $bootprefix/$mariner_initrd
 	fi
 }

--- a/toolkit/tools/imagegen/attendedinstaller/views/hostnameview/hostnameview.go
+++ b/toolkit/tools/imagegen/attendedinstaller/views/hostnameview/hostnameview.go
@@ -4,7 +4,6 @@
 package hostnameview
 
 import (
-	"crypto/rand"
 	"fmt"
 	"strings"
 
@@ -12,6 +11,7 @@ import (
 	"microsoft.com/pkggen/imagegen/attendedinstaller/uitext"
 	"microsoft.com/pkggen/imagegen/attendedinstaller/uiutils"
 	"microsoft.com/pkggen/imagegen/configuration"
+	"microsoft.com/pkggen/internal/randomization"
 
 	"github.com/gdamore/tcell"
 	"github.com/rivo/tview"
@@ -229,32 +229,12 @@ func validateFQDN(fqdn string) (err error) {
 func randomHostname(prefix string) (hostname string, err error) {
 	const postfixLength = 12
 
-	postfix, err := randomString(postfixLength, uitext.AlphaNumeric)
+	postfix, err := randomization.RandomString(postfixLength, uitext.AlphaNumeric)
 	if err != nil {
 		return
 	}
 
 	hostname = fmt.Sprintf("%s-%s", prefix, postfix)
 
-	return
-}
-
-// randomString generates a random string of the length specified
-// using the provided legalCharacters.  crypto.rand is more secure
-// than math.rand and does not need to be seeded.
-func randomString(length int, legalCharacters string) (output string, err error) {
-	b := make([]byte, length)
-	_, err = rand.Read(b)
-	if err != nil {
-		return
-	}
-
-	count := byte(len(legalCharacters))
-	for i := range b {
-		idx := b[i] % count
-		b[i] = legalCharacters[idx]
-	}
-
-	output = string(b)
 	return
 }

--- a/toolkit/tools/imagegen/configuration/configuration.go
+++ b/toolkit/tools/imagegen/configuration/configuration.go
@@ -23,22 +23,6 @@ type Artifact struct {
 	Type        string `json:"Type"`
 }
 
-// Partition defines the size, name and file system type
-// for a partition.
-// "Start" and "End" fields define the offset from the beginning of the disk in MBs.
-// An "End" value of 0 will determine the size of the partition using the next
-// partition's start offset or the value defined by "MaxSize", if this is the last
-// partition on the disk.
-type Partition struct {
-	FsType    string     `json:"FsType"`
-	ID        string     `json:"ID"`
-	Name      string     `json:"Name"`
-	End       uint64     `json:"End"`
-	Start     uint64     `json:"Start"`
-	Flags     []string   `json:"Flags"`
-	Artifacts []Artifact `json:"Artifacts"`
-}
-
 // RawBinary allow the users to specify a binary they would
 // like to copy byte-for-byte onto the disk.
 type RawBinary struct {
@@ -52,14 +36,6 @@ type RawBinary struct {
 type TargetDisk struct {
 	Type  string `json:"Type"`
 	Value string `json:"Value"`
-}
-
-// PartitionSetting holds the mounting information for each partition.
-type PartitionSetting struct {
-	RemoveDocs   bool   `json:"RemoveDocs"`
-	ID           string `json:"ID"`
-	MountOptions string `json:"MountOptions"`
-	MountPoint   string `json:"MountPoint"`
 }
 
 // PostInstallScript defines a script to be ran after other installation
@@ -92,12 +68,66 @@ type Config struct {
 	DefaultSystemConfig *SystemConfig // A system configuration with the "IsDefault" field set or the first system configuration if there is no explicit default.
 }
 
+// GetDiskPartByID returns the disk partition object with the desired ID, nil if no partition found
+func (c *Config) GetDiskPartByID(ID string) (disk *Partition) {
+	for i, d := range c.Disks {
+		for j, p := range d.Partitions {
+			if p.ID == ID {
+				return &c.Disks[i].Partitions[j]
+			}
+		}
+	}
+	return nil
+}
+
+// checkDeviceMapperFlags checks if Encryption and read-only roots have the required 'dmroot' flag.
+// They need the root partition to have a specific flag so we can find the partition and handle it
+// before we mount it.
+func checkDeviceMapperFlags(config *Config) (err error) {
+	for _, sysConfig := range config.SystemConfigs {
+		var dmRoot *Partition
+		if sysConfig.Encryption.Enable {
+			rootPartSetting := sysConfig.GetRootPartitionSetting()
+			if rootPartSetting == nil {
+				return fmt.Errorf("can't find a root ('/') [PartitionSetting] to work with either [ReadOnlyVerityRoot] or [Encryption]")
+			}
+			rootDiskPart := config.GetDiskPartByID(rootPartSetting.ID)
+			if rootDiskPart == nil {
+				return fmt.Errorf("can't find a [Disk] [Partition] to match with [PartitionSetting] '%s'", rootPartSetting.ID)
+			}
+			if !rootDiskPart.HasFlag(PartitionFlagDeviceMapperRoot) {
+				return fmt.Errorf("[Partition] '%s' must include 'dmroot' device mapper root flag in [Flags] for [SystemConfig] '%s's root partition since it uses [ReadOnlyVerityRoot] or [Encryption]", rootDiskPart.ID, sysConfig.Name)
+			}
+		}
+		// There is currently a limitation in diskutils.CreatePartitions() which requires us to know our device-mapper
+		// partitions prior to parsing the systemconfigs. We won't know if a given systemconfig will require
+		// the device mapper root functionality for the "/" mount point ahead of time, nor which partition will
+		// be mounted there. Make sure we only have one such root to choose from at any given time so we won't
+		// confuse them.
+		for _, partSetting := range sysConfig.PartitionSettings {
+			part := config.GetDiskPartByID(partSetting.ID)
+			if part != nil && part.HasFlag(PartitionFlagDeviceMapperRoot) {
+				if dmRoot != nil {
+					return fmt.Errorf("[SystemConfig] '%s' includes two (or more) device mapper root [PartitionSettings] '%s' and '%s', include only one", sysConfig.Name, dmRoot.ID, part.ID)
+				}
+				dmRoot = part
+			}
+		}
+	}
+	return
+}
+
 // IsValid returns an error if the Config is not valid
 func (c *Config) IsValid() (err error) {
 	for _, disk := range c.Disks {
 		if err = disk.IsValid(); err != nil {
 			return fmt.Errorf("invalid [Disks]: %w", err)
 		}
+	}
+	// Check the flags for the disks
+	err = checkDeviceMapperFlags(c)
+	if err != nil {
+		return fmt.Errorf("a config in [SystemConfigs] enables a device mapper based root (Encryption or Read-Only), but partitions are miss-configured: %w", err)
 	}
 
 	if len(c.SystemConfigs) == 0 {

--- a/toolkit/tools/imagegen/configuration/configuration_test.go
+++ b/toolkit/tools/imagegen/configuration/configuration_test.go
@@ -65,6 +65,100 @@ func TestShouldErrorForMissingFile(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestShouldFailForUntaggedEncryptionDeviceMapperRoot(t *testing.T) {
+	var checkedConfig Config
+	testConfig := expectedConfiguration
+
+	// Copy the current disks, then mangle one by removing the expected dmroot flag
+	badDisks := append([]Disk{}, testConfig.Disks...)
+	badDiskParts := append([]Partition{}, badDisks[0].Partitions...)
+	badDisks[0].Partitions = badDiskParts
+	testConfig.Disks = badDisks
+
+	// Clear the flags for the root
+	testConfig.GetDiskPartByID(testConfig.SystemConfigs[0].GetRootPartitionSetting().ID).Flags = []PartitionFlag{}
+
+	err := testConfig.IsValid()
+	assert.Error(t, err)
+	assert.Equal(t, "a config in [SystemConfigs] enables a device mapper based root (Encryption or Read-Only), but partitions are miss-configured: [Partition] 'MyRootfs' must include 'dmroot' device mapper root flag in [Flags] for [SystemConfig] 'SmallerDisk's root partition since it uses [ReadOnlyVerityRoot] or [Encryption]", err.Error())
+
+	err = remarshalJSON(testConfig, &checkedConfig)
+	assert.Error(t, err)
+	assert.Equal(t, "failed to parse [Config]: a config in [SystemConfigs] enables a device mapper based root (Encryption or Read-Only), but partitions are miss-configured: [Partition] 'MyRootfs' must include 'dmroot' device mapper root flag in [Flags] for [SystemConfig] 'SmallerDisk's root partition since it uses [ReadOnlyVerityRoot] or [Encryption]", err.Error())
+}
+
+func TestShouldFailDeviceMapperWithNoRootDisks(t *testing.T) {
+	var checkedConfig Config
+	testConfig := expectedConfiguration
+
+	// Clear the disks, add one empty one
+	testConfig.Disks = []Disk{{}}
+
+	err := testConfig.IsValid()
+	assert.Error(t, err)
+	assert.Equal(t, "a config in [SystemConfigs] enables a device mapper based root (Encryption or Read-Only), but partitions are miss-configured: can't find a [Disk] [Partition] to match with [PartitionSetting] 'MyRootfs'", err.Error())
+
+	err = remarshalJSON(testConfig, &checkedConfig)
+	assert.Error(t, err)
+	assert.Equal(t, "failed to parse [Config]: a config in [SystemConfigs] enables a device mapper based root (Encryption or Read-Only), but partitions are miss-configured: can't find a [Disk] [Partition] to match with [PartitionSetting] 'MyRootfs'", err.Error())
+}
+
+func TestShouldFailDeviceMapperWithNoRootPartitions(t *testing.T) {
+	var checkedConfig Config
+	testConfig := expectedConfiguration
+
+	// Clear the partitions, then add a missmatching one
+	testConfig.SystemConfigs = append([]SystemConfig{}, testConfig.SystemConfigs...)
+	testConfig.SystemConfigs[0].PartitionSettings = []PartitionSetting{{ID: "NotRoot", MountPoint: "/not/root"}}
+
+	err := testConfig.IsValid()
+	assert.Error(t, err)
+	assert.Equal(t, "a config in [SystemConfigs] enables a device mapper based root (Encryption or Read-Only), but partitions are miss-configured: can't find a root ('/') [PartitionSetting] to work with either [ReadOnlyVerityRoot] or [Encryption]", err.Error())
+
+	// remarshal runs IsValid() on [SystemConfig] prior to running it on [Config], so we get a different error message here.
+	err = remarshalJSON(testConfig, &checkedConfig)
+	assert.Error(t, err)
+	assert.Equal(t, "failed to parse [Config]: failed to parse [SystemConfig]: invalid [ReadOnlyVerityRoot] or [Encryption]: must have a partition mounted at '/'", err.Error())
+
+}
+
+func TestShouldFailDeviceMapperWithMultipleRoots(t *testing.T) {
+	var checkedConfig Config
+	testConfig := expectedConfiguration
+
+	// Copy the root partition settings
+	ExtraDmRoot := Partition{
+		ID: "MySecondRootfs",
+		Flags: []PartitionFlag{
+			"dmroot",
+		},
+		Start:  uint64(1024),
+		End:    uint64(2048),
+		FsType: "ext4",
+	}
+	ExtraPartitionSetting := PartitionSetting{
+		ID:         "MySecondRootfs",
+		MountPoint: "/OtherRoot",
+	}
+
+	// Copy the disks, then add the extra partition
+	testConfig.Disks = append([]Disk{}, expectedConfiguration.Disks...)
+	testConfig.Disks[0].Partitions = append(testConfig.Disks[0].Partitions, ExtraDmRoot)
+	// Copy the partition settings, then add the extra partition setting
+	testConfig.SystemConfigs = append([]SystemConfig{}, expectedConfiguration.SystemConfigs[0])
+	testConfig.SystemConfigs[0].PartitionSettings = append(testConfig.SystemConfigs[0].PartitionSettings, ExtraPartitionSetting)
+
+	err := testConfig.IsValid()
+	assert.Error(t, err)
+	assert.Equal(t, "a config in [SystemConfigs] enables a device mapper based root (Encryption or Read-Only), but partitions are miss-configured: [SystemConfig] 'SmallerDisk' includes two (or more) device mapper root [PartitionSettings] 'MyRootfs' and 'MySecondRootfs', include only one", err.Error())
+
+	// remarshal runs IsValid() on [SystemConfig] prior to running it on [Config], so we get a different error message here.
+	err = remarshalJSON(testConfig, &checkedConfig)
+	assert.Error(t, err)
+	assert.Equal(t, "failed to parse [Config]: a config in [SystemConfigs] enables a device mapper based root (Encryption or Read-Only), but partitions are miss-configured: [SystemConfig] 'SmallerDisk' includes two (or more) device mapper root [PartitionSettings] 'MyRootfs' and 'MySecondRootfs', include only one", err.Error())
+
+}
+
 var expectedConfiguration Config = Config{
 	Disks: []Disk{
 		{
@@ -100,7 +194,7 @@ var expectedConfiguration Config = Config{
 			Partitions: []Partition{
 				{
 					ID: "MyBoot",
-					Flags: []string{
+					Flags: []PartitionFlag{
 						"esp",
 						"boot",
 					},
@@ -109,7 +203,10 @@ var expectedConfiguration Config = Config{
 					FsType: "fat32",
 				},
 				{
-					ID:     "MyRootfs",
+					ID: "MyRootfs",
+					Flags: []PartitionFlag{
+						"dmroot",
+					},
 					Start:  uint64(9),
 					End:    uint64(1024),
 					FsType: "ext4",
@@ -126,7 +223,7 @@ var expectedConfiguration Config = Config{
 			Partitions: []Partition{
 				{
 					ID: "MyBootA",
-					Flags: []string{
+					Flags: []PartitionFlag{
 						"boot",
 					},
 					Start:  uint64(3),
@@ -137,10 +234,13 @@ var expectedConfiguration Config = Config{
 					Start:  uint64(9),
 					End:    uint64(1024),
 					FsType: "ext4",
+					Flags: []PartitionFlag{
+						"dmroot",
+					},
 				},
 				{
 					ID: "MyBootB",
-					Flags: []string{
+					Flags: []PartitionFlag{
 						"boot",
 					},
 					Start:  uint64(1024),
@@ -151,6 +251,9 @@ var expectedConfiguration Config = Config{
 					Start:  uint64(1033),
 					End:    uint64(2048),
 					FsType: "ext4",
+					Flags: []PartitionFlag{
+						"dmroot",
+					},
 				},
 				{
 					ID:     "SharedData",

--- a/toolkit/tools/imagegen/configuration/disk.go
+++ b/toolkit/tools/imagegen/configuration/disk.go
@@ -37,11 +37,11 @@ func (d *Disk) IsValid() (err error) {
 	// 		return
 	// 	}
 	// }
-	// for _, partition := range disk.Partitions {
-	// 	if err = partition.IsValid(); err != nil {
-	// 		return
-	// 	}
-	// }
+	for _, partition := range d.Partitions {
+		if err = partition.IsValid(); err != nil {
+			return
+		}
+	}
 	// for _, rawBinary := range disk.RawBinaries {
 	// 	if err = rawBinary.IsValid(); err != nil {
 	// 		return

--- a/toolkit/tools/imagegen/configuration/disk_test.go
+++ b/toolkit/tools/imagegen/configuration/disk_test.go
@@ -45,7 +45,7 @@ var (
 		Partitions: []Partition{
 			{
 				ID: "MyBoot",
-				Flags: []string{
+				Flags: []PartitionFlag{
 					"esp",
 					"boot",
 				},
@@ -70,6 +70,22 @@ func TestShouldSucceedParsingValidDisk_Disk(t *testing.T) {
 	err := remarshalJSON(validDisk, &checkedDisk)
 	assert.NoError(t, err)
 	assert.Equal(t, validDisk, checkedDisk)
+}
+
+func TestShouldFailParsingDiskWithBadPartition_Disk(t *testing.T) {
+	var checkedDisk Disk
+	invalidDisk := validDisk
+	invalidDisk.Partitions = append([]Partition{}, validPartition)
+	// Currently the only way a Partion can be invalid is by having an invalid flag
+	invalidDisk.Partitions[0].Flags = []PartitionFlag{invalidPartitionFlag}
+
+	err := invalidDisk.IsValid()
+	assert.Error(t, err)
+	assert.Equal(t, "invalid value for Flag (not_a_partition_flag)", err.Error())
+
+	err = remarshalJSON(invalidDisk, &checkedDisk)
+	assert.Error(t, err)
+	assert.Equal(t, "failed to parse [Disk]: failed to parse [Partition]: failed to parse [Flag]: invalid value for Flag (not_a_partition_flag)", err.Error())
 }
 
 func TestShouldFailParsingInvalidDisk_Disk(t *testing.T) {

--- a/toolkit/tools/imagegen/configuration/partition.go
+++ b/toolkit/tools/imagegen/configuration/partition.go
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Parser for the image builder's configuration schemas.
+
+package configuration
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Partition defines the size, name and file system type
+// for a partition.
+// "Start" and "End" fields define the offset from the beginning of the disk in MBs.
+// An "End" value of 0 will determine the size of the partition using the next
+// partition's start offset or the value defined by "MaxSize", if this is the last
+// partition on the disk.
+type Partition struct {
+	FsType    string          `json:"FsType"`
+	ID        string          `json:"ID"`
+	Name      string          `json:"Name"`
+	End       uint64          `json:"End"`
+	Start     uint64          `json:"Start"`
+	Flags     []PartitionFlag `json:"Flags"`
+	Artifacts []Artifact      `json:"Artifacts"`
+}
+
+// HasFlag returns true if a given partition has a specific flag set.
+func (p *Partition) HasFlag(flag PartitionFlag) bool {
+	for _, f := range p.Flags {
+		if f == flag {
+			return true
+		}
+	}
+	return false
+}
+
+// IsValid returns an error if the Partition is not valid
+func (p *Partition) IsValid() (err error) {
+	for _, f := range p.Flags {
+		if err = f.IsValid(); err != nil {
+			return
+		}
+	}
+	return nil
+}
+
+// UnmarshalJSON Unmarshals a Partition entry
+func (p *Partition) UnmarshalJSON(b []byte) (err error) {
+	// Use an intermediate type which will use the default JSON unmarshal implementation
+	type IntermediateTypePartition Partition
+	err = json.Unmarshal(b, (*IntermediateTypePartition)(p))
+	if err != nil {
+		return fmt.Errorf("failed to parse [Partition]: %w", err)
+	}
+
+	// Now validate the resulting unmarshaled object
+	err = p.IsValid()
+	if err != nil {
+		return fmt.Errorf("failed to parse [Partition]: %w", err)
+	}
+	return
+}

--- a/toolkit/tools/imagegen/configuration/partition_test.go
+++ b/toolkit/tools/imagegen/configuration/partition_test.go
@@ -1,0 +1,70 @@
+// Copyright Microsoft Corporation.
+// Licensed under the MIT License.
+
+package configuration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+//TestMain found in configuration_test.go.
+
+var (
+	validPartition Partition = Partition{
+		FsType: "ext4",
+		ID:     "MyPartID",
+		Name:   "MyPartitionName",
+		End:    0,
+		Start:  100,
+		Flags:  []PartitionFlag{PartitionFlagDeviceMapperRoot},
+	}
+	invalidvalidPartitionJSON = `{"End": "abc"}`
+)
+
+func TestShouldSucceedParsingDefaultPartition_Partition(t *testing.T) {
+	var checkedPartition Partition
+	err := marshalJSONString("{}", &checkedPartition)
+	assert.NoError(t, err)
+	assert.Equal(t, Partition{}, checkedPartition)
+}
+
+func TestShouldSucceedParsingValidPartition_Partition(t *testing.T) {
+	var checkedPartition Partition
+	err := remarshalJSON(validPartition, &checkedPartition)
+	assert.NoError(t, err)
+	assert.Equal(t, validPartition, checkedPartition)
+}
+
+func TestShouldSucceedFindingFlag_Partition(t *testing.T) {
+	assert.True(t, validPartition.HasFlag(PartitionFlagDeviceMapperRoot))
+}
+
+func TestShouldFailFindingBadFlag_Partition(t *testing.T) {
+	assert.False(t, validPartition.HasFlag(PartitionFlagBoot))
+	assert.False(t, validPartition.HasFlag("notaflag"))
+}
+
+func TestShouldFailParsingInvalidFlag_Partition(t *testing.T) {
+	var checkedPartition Partition
+	invalidPartition := validPartition
+
+	invalidPartition.Flags = []PartitionFlag{"not_a_flag"}
+
+	err := invalidPartition.IsValid()
+	assert.Error(t, err)
+	assert.Equal(t, "invalid value for Flag (not_a_flag)", err.Error())
+
+	err = remarshalJSON(invalidPartition, &checkedPartition)
+	assert.Error(t, err)
+	assert.Equal(t, "failed to parse [Partition]: failed to parse [Flag]: invalid value for Flag (not_a_flag)", err.Error())
+}
+
+func TestShouldFailParsingInvalidJSON_Partition(t *testing.T) {
+	var checkedPartition Partition
+
+	err := marshalJSONString(invalidvalidPartitionJSON, &checkedPartition)
+	assert.Error(t, err)
+	assert.Equal(t, "failed to parse [Partition]: json: cannot unmarshal string into Go struct field IntermediateTypePartition.End of type uint64", err.Error())
+}

--- a/toolkit/tools/imagegen/configuration/partitionflag.go
+++ b/toolkit/tools/imagegen/configuration/partitionflag.go
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Parser for the image builder's configuration schemas.
+
+package configuration
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// PartitionFlag describes the features of a partition
+type PartitionFlag string
+
+const (
+	// PartitionFlagESP indicates this is the UEFI esp partition
+	PartitionFlagESP PartitionFlag = "esp"
+	// PartitionFlagGrub indicates this is a grub boot partition
+	PartitionFlagGrub PartitionFlag = "grub"
+	// PartitionFlagBiosGrub indicates this is a bios grub boot partition
+	PartitionFlagBiosGrub PartitionFlag = "bios_grub"
+	// PartitionFlagBoot indicates this is a boot partition
+	PartitionFlagBoot PartitionFlag = "boot"
+	// PartitionFlagDeviceMapperRoot indicates this partition will be used for a device mapper root device
+	PartitionFlagDeviceMapperRoot PartitionFlag = "dmroot"
+)
+
+func (p PartitionFlag) String() string {
+	return fmt.Sprint(string(p))
+}
+
+// GetValidPartitionFlags returns a list of all the supported
+// partition flags
+func (p *PartitionFlag) GetValidPartitionFlags() (types []PartitionFlag) {
+	return []PartitionFlag{
+		PartitionFlagESP,
+		PartitionFlagGrub,
+		PartitionFlagBiosGrub,
+		PartitionFlagBoot,
+		PartitionFlagDeviceMapperRoot,
+	}
+}
+
+// IsValid returns an error if the PartitionFlag is not valid
+func (p *PartitionFlag) IsValid() (err error) {
+	for _, valid := range p.GetValidPartitionFlags() {
+		if *p == valid {
+			return
+		}
+	}
+	return fmt.Errorf("invalid value for Flag (%s)", p)
+}
+
+// UnmarshalJSON Unmarshals an PartitionFlag entry
+func (p *PartitionFlag) UnmarshalJSON(b []byte) (err error) {
+	// Use an intermediate type which will use the default JSON unmarshal implementation
+	type IntermediateTypePartitionFlag PartitionFlag
+	err = json.Unmarshal(b, (*IntermediateTypePartitionFlag)(p))
+	if err != nil {
+		return fmt.Errorf("failed to parse [Flag]: %w", err)
+	}
+
+	// Now validate the resulting unmarshaled object
+	err = p.IsValid()
+	if err != nil {
+		return fmt.Errorf("failed to parse [Flag]: %w", err)
+	}
+	return
+}

--- a/toolkit/tools/imagegen/configuration/partitionflag_test.go
+++ b/toolkit/tools/imagegen/configuration/partitionflag_test.go
@@ -1,0 +1,79 @@
+// Copyright Microsoft Corporation.
+// Licensed under the MIT License.
+
+package configuration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+//TestMain found in configuration_test.go.
+
+var (
+	validPartitionFlags = []PartitionFlag{
+		PartitionFlag("esp"),
+		PartitionFlag("grub"),
+		PartitionFlag("bios_grub"),
+		PartitionFlag("boot"),
+		PartitionFlag("dmroot"),
+	}
+	invalidPartitionFlag     = PartitionFlag("not_a_partition_flag")
+	validPartitionFlagJSON   = `"esp"`
+	invalidPartitionFlagJSON = `1234`
+)
+
+func TestShouldSucceedValidFlagsMatch_PartitionFlag(t *testing.T) {
+	var pf PartitionFlag
+	assert.Equal(t, len(validPartitionFlags), len(pf.GetValidPartitionFlags()))
+
+	for _, partitionFlag := range validPartitionFlags {
+		found := false
+		for _, validPartitionType := range pf.GetValidPartitionFlags() {
+			if partitionFlag == validPartitionType {
+				found = true
+			}
+		}
+		assert.True(t, found)
+	}
+}
+
+func TestShouldSucceedParsingValidPartitionFlag_PartitionFlag(t *testing.T) {
+	for _, validPartitionFlag := range validPartitionFlags {
+		var checkedPartitionFlag PartitionFlag
+
+		assert.NoError(t, validPartitionFlag.IsValid())
+		err := remarshalJSON(validPartitionFlag, &checkedPartitionFlag)
+		assert.NoError(t, err)
+		assert.Equal(t, validPartitionFlag, checkedPartitionFlag)
+	}
+}
+
+func TestShouldFailParsingInvalidPartitionFlag_PartitionFlag(t *testing.T) {
+	var checkedPartitionFlag PartitionFlag
+
+	err := invalidPartitionFlag.IsValid()
+	assert.Error(t, err)
+	assert.Equal(t, "invalid value for Flag (not_a_partition_flag)", err.Error())
+
+	err = remarshalJSON(invalidPartitionFlag, &checkedPartitionFlag)
+	assert.Error(t, err)
+	assert.Equal(t, "failed to parse [Flag]: invalid value for Flag (not_a_partition_flag)", err.Error())
+}
+
+func TestShouldSucceedParsingValidJSON_PartitionFlag(t *testing.T) {
+	var checkedPartitionFlag PartitionFlag
+
+	err := marshalJSONString(validPartitionFlagJSON, &checkedPartitionFlag)
+	assert.NoError(t, err)
+	assert.Equal(t, validPartitionFlags[0], checkedPartitionFlag)
+}
+
+func TestShouldFailParsingInvalidJSON_PartitionFlag(t *testing.T) {
+	var checkedPartitionFlag PartitionFlag
+
+	err := marshalJSONString(invalidPartitionFlagJSON, &checkedPartitionFlag)
+	assert.Error(t, err)
+	assert.Equal(t, "failed to parse [Flag]: json: cannot unmarshal number into Go value of type configuration.IntermediateTypePartitionFlag", err.Error())
+}

--- a/toolkit/tools/imagegen/configuration/partitionsetting.go
+++ b/toolkit/tools/imagegen/configuration/partitionsetting.go
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Parser for the image builder's configuration schemas.
+
+package configuration
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// PartitionSetting holds the mounting information for each partition.
+type PartitionSetting struct {
+	RemoveDocs   bool   `json:"RemoveDocs"`
+	ID           string `json:"ID"`
+	MountOptions string `json:"MountOptions"`
+	MountPoint   string `json:"MountPoint"`
+}
+
+// IsValid returns an error if the PartitionSetting is not valid
+func (p *PartitionSetting) IsValid() (err error) {
+	return nil
+}
+
+// UnmarshalJSON Unmarshals a PartitionSetting entry
+func (p *PartitionSetting) UnmarshalJSON(b []byte) (err error) {
+	// Use an intermediate type which will use the default JSON unmarshal implementation
+	type IntermediateTypePartitionSetting PartitionSetting
+	err = json.Unmarshal(b, (*IntermediateTypePartitionSetting)(p))
+	if err != nil {
+		return fmt.Errorf("failed to parse [PartitionSetting]: %w", err)
+	}
+
+	// Now validate the resulting unmarshaled object
+	err = p.IsValid()
+	if err != nil {
+		return fmt.Errorf("failed to parse [PartitionSetting]: %w", err)
+	}
+	return
+}

--- a/toolkit/tools/imagegen/configuration/partitionsetting_test.go
+++ b/toolkit/tools/imagegen/configuration/partitionsetting_test.go
@@ -1,0 +1,42 @@
+// Copyright Microsoft Corporation.
+// Licensed under the MIT License.
+
+package configuration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+//TestMain found in configuration_test.go.
+
+var (
+	validPartitionSetting PartitionSetting = PartitionSetting{
+		ID:         "testing",
+		MountPoint: "/",
+	}
+	invalidvalidPartitionSettingJSON = `{"RemoveDocs": 1234}`
+)
+
+func TestShouldSucceedParsingDefaultPartitionSetting_PartitionSetting(t *testing.T) {
+	var checkedPartitionSetting PartitionSetting
+	err := marshalJSONString("{}", &checkedPartitionSetting)
+	assert.NoError(t, err)
+	assert.Equal(t, PartitionSetting{}, checkedPartitionSetting)
+}
+
+func TestShouldSucceedParsingValidPartitionSetting_PartitionSetting(t *testing.T) {
+	var checkedPartitionSetting PartitionSetting
+	err := remarshalJSON(validPartitionSetting, &checkedPartitionSetting)
+	assert.NoError(t, err)
+	assert.Equal(t, validPartitionSetting, checkedPartitionSetting)
+}
+
+func TestShouldFailParsingInvalidJSON_PartitionSetting(t *testing.T) {
+	var checkedPartitionSetting PartitionSetting
+
+	err := marshalJSONString(invalidvalidPartitionSettingJSON, &checkedPartitionSetting)
+	assert.Error(t, err)
+	assert.Equal(t, "failed to parse [PartitionSetting]: json: cannot unmarshal number into Go struct field IntermediateTypePartitionSetting.RemoveDocs of type bool", err.Error())
+}

--- a/toolkit/tools/imagegen/configuration/systemconfig.go
+++ b/toolkit/tools/imagegen/configuration/systemconfig.go
@@ -29,6 +29,18 @@ type SystemConfig struct {
 	RemoveRpmDb        bool                `json:"RemoveRpmDb`
 }
 
+// GetRootPartitionSetting returns a pointer to the partition setting describing the disk which
+// will be mounted at "/", or nil if no partition is found
+func (s *SystemConfig) GetRootPartitionSetting() (rootPartitionSetting *PartitionSetting) {
+	for i, p := range s.PartitionSettings {
+		if p.MountPoint == "/" {
+			// We want to refernce the actual object in the slice
+			return &s.PartitionSettings[i]
+		}
+	}
+	return nil
+}
+
 // IsValid returns an error if the SystemConfig is not valid
 func (s *SystemConfig) IsValid() (err error) {
 	// IsDefault must be validated by a parent struct
@@ -61,12 +73,24 @@ func (s *SystemConfig) IsValid() (err error) {
 				return fmt.Errorf("empty kernel entry found in the [KernelOptions] field (%s); remember that kernels are FORBIDDEN from appearing in any of the [PackageLists]", name)
 			}
 		}
+	}
 
-		// for _, partitionSetting := range sysConfig.PartitionSettings {
-		// 	if err = partitionSetting.IsValid(); err != nil {
-		// 		return fmt.Errorf("invalid [PartitionSettings]: %w", err)
-		// 	}
-		// }
+	// Validate the partitions this system config will be including
+	mountPointUsed := make(map[string]bool)
+	for _, partitionSetting := range s.PartitionSettings {
+		if err = partitionSetting.IsValid(); err != nil {
+			return fmt.Errorf("invalid [PartitionSettings]: %w", err)
+		}
+		if mountPointUsed[partitionSetting.MountPoint] {
+			return fmt.Errorf("invalid [PartitionSettings]: duplicate mount point found at '%s'", partitionSetting.MountPoint)
+		}
+		mountPointUsed[partitionSetting.MountPoint] = true
+	}
+
+	if s.Encryption.Enable {
+		if !mountPointUsed["/"] {
+			return fmt.Errorf("invalid [ReadOnlyVerityRoot] or [Encryption]: must have a partition mounted at '/'")
+		}
 	}
 
 	if err = s.KernelCommandLine.IsValid(); err != nil {

--- a/toolkit/tools/imagegen/configuration/testdata/test_configuration.json
+++ b/toolkit/tools/imagegen/configuration/testdata/test_configuration.json
@@ -45,7 +45,10 @@
                     "ID": "MyRootfs",
                     "Start": 9,
                     "End": 1024,
-                    "FsType": "ext4"
+                    "FsType": "ext4",
+                    "Flags": [
+                        "dmroot"
+                    ]
                 }
             ]
         },
@@ -69,7 +72,10 @@
                     "ID": "MyRootfsA",
                     "Start": 9,
                     "End": 1024,
-                    "FsType": "ext4"
+                    "FsType": "ext4",
+                    "Flags": [
+                        "dmroot"
+                    ]
                 },
                 {
                     "ID": "MyBootB",
@@ -83,7 +89,10 @@
                     "ID": "MyRootfsB",
                     "Start": 1033,
                     "End": 2048,
-                    "FsType": "ext4"
+                    "FsType": "ext4",
+                    "Flags": [
+                        "dmroot"
+                    ]
                 },
                 {
                     "ID": "SharedData",

--- a/toolkit/tools/imagegen/diskutils/diskutils.go
+++ b/toolkit/tools/imagegen/diskutils/diskutils.go
@@ -229,10 +229,6 @@ func DetachLoopbackDevice(diskDevPath string) (err error) {
 
 // CreatePartitions creates partitions on the specified disk according to the disk config
 func CreatePartitions(diskDevPath string, disk configuration.Disk, rootEncryption configuration.RootEncryption) (partDevPathMap map[string]string, partIDToFsTypeMap map[string]string, encryptedRoot EncryptedRootDevice, err error) {
-	const (
-		rootFsID = "rootfs"
-	)
-
 	partDevPathMap = make(map[string]string)
 	partIDToFsTypeMap = make(map[string]string)
 
@@ -271,8 +267,12 @@ func CreatePartitions(diskDevPath string, disk configuration.Disk, rootEncryptio
 			return partDevPathMap, partIDToFsTypeMap, encryptedRoot, err
 		}
 
-		if rootEncryption.Enable && partition.ID == rootFsID {
+		if rootEncryption.Enable && partition.HasFlag(configuration.PartitionFlagDeviceMapperRoot) {
 			encryptedRoot, err = encryptRootPartition(partDevPath, partition, rootEncryption)
+			if err != nil {
+				logger.Log.Warnf("Failed to initialize encrypted root")
+				return partDevPathMap, partIDToFsTypeMap, encryptedRoot, err
+			}
 			partDevPathMap[partition.ID] = GetEncryptedRootVolMapping()
 		} else {
 			partDevPathMap[partition.ID] = partDevPath
@@ -339,12 +339,14 @@ func InitializeSinglePartition(diskDevPath string, partitionNumber int, partitio
 		args := []string{diskDevPath, "--script", "set", partitionNumberStr}
 		var flagToSet string
 		switch flag {
-		case "esp":
+		case configuration.PartitionFlagESP:
 			flagToSet = "esp"
-		case "grub", "bios-grub":
+		case configuration.PartitionFlagGrub, configuration.PartitionFlagBiosGrub:
 			flagToSet = "bios_grub"
-		case "boot":
+		case configuration.PartitionFlagBoot:
 			flagToSet = "boot"
+		case configuration.PartitionFlagDeviceMapperRoot:
+			//Ignore, only used for internal tooling
 		default:
 			return partDevPath, fmt.Errorf("Partition %v - Unknown partition flag: %v", partitionNumber, flag)
 		}
@@ -446,14 +448,14 @@ func SystemBootType() (bootType string) {
 
 // BootPartitionConfig returns the partition flags and mount point that should be used
 // for a given boot type.
-func BootPartitionConfig(bootType string) (mountPoint, mountOptions string, flags []string, err error) {
+func BootPartitionConfig(bootType string) (mountPoint, mountOptions string, flags []configuration.PartitionFlag, err error) {
 	switch bootType {
 	case "efi":
-		flags = []string{"esp", "boot"}
+		flags = []configuration.PartitionFlag{configuration.PartitionFlagESP, configuration.PartitionFlagBoot}
 		mountPoint = "/boot/efi"
 		mountOptions = "umask=0077"
 	case "legacy":
-		flags = []string{"grub"}
+		flags = []configuration.PartitionFlag{configuration.PartitionFlagGrub}
 		mountPoint = ""
 		mountOptions = ""
 	default:

--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -4,7 +4,6 @@
 package installutils
 
 import (
-	"crypto/rand"
 	"fmt"
 	"os"
 	"path"
@@ -21,6 +20,7 @@ import (
 	"microsoft.com/pkggen/internal/jsonutils"
 	"microsoft.com/pkggen/internal/logger"
 	"microsoft.com/pkggen/internal/pkgjson"
+	"microsoft.com/pkggen/internal/randomization"
 	"microsoft.com/pkggen/internal/retry"
 	"microsoft.com/pkggen/internal/safechroot"
 	"microsoft.com/pkggen/internal/shell"
@@ -897,7 +897,7 @@ func createUserWithPassword(installChroot *safechroot.Chroot, user configuration
 	if user.PasswordHashed {
 		hashedPassword = user.Password
 	} else {
-		salt, err = randomString(postfixLength, alphaNumeric)
+		salt, err = randomization.RandomString(postfixLength, alphaNumeric)
 		if err != nil {
 			return
 		}
@@ -1637,26 +1637,6 @@ func createRawArtifact(workDirPath, devPath, name string) (err error) {
 	}
 
 	return shell.ExecuteLive(squashErrors, "dd", ddArgs...)
-}
-
-// randomString generates a random string of the length specified
-// using the provided legalCharacters.  crypto.rand is more secure
-// than math.rand and does not need to be seeded.
-func randomString(length int, legalCharacters string) (output string, err error) {
-	b := make([]byte, length)
-	_, err = rand.Read(b)
-	if err != nil {
-		return
-	}
-
-	count := byte(len(legalCharacters))
-	for i := range b {
-		idx := b[i] % count
-		b[i] = legalCharacters[idx]
-	}
-
-	output = string(b)
-	return
 }
 
 // isRunningInHyperV checks if the program is running in a Hyper-V Virtual Machine.

--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -1247,7 +1247,7 @@ func getPackagesFromJSON(file string) (pkgList PackageList, err error) {
 // - bootUUID is the UUID of the boot partition
 // Note: this boot partition could be different than the boot partition specified in the main grub config.
 // This boot partition specifically indicates where to find the main grub cfg
-func InstallBootloader(installChroot *safechroot.Chroot, encryptEnabled bool, bootType, bootUUID, bootDevPath string) (err error) {
+func InstallBootloader(installChroot *safechroot.Chroot, encryptEnabled bool, bootType, bootUUID, bootPrefix, bootDevPath string) (err error) {
 	const (
 		efiMountPoint  = "/boot/efi"
 		efiBootType    = "efi"
@@ -1265,7 +1265,7 @@ func InstallBootloader(installChroot *safechroot.Chroot, encryptEnabled bool, bo
 		}
 	case efiBootType:
 		efiPath := filepath.Join(installChroot.RootDir(), efiMountPoint)
-		err = installEfiBootloader(encryptEnabled, efiPath, bootUUID)
+		err = installEfiBootloader(encryptEnabled, efiPath, bootUUID, bootPrefix)
 		if err != nil {
 			return
 		}
@@ -1352,7 +1352,7 @@ func GetPartUUID(device string) (stdout string, err error) {
 // installRoot/boot/efi folder
 // It is expected that shim (bootx64.efi) and grub2 (grub2.efi) are installed
 // into the EFI directory via the package list installation mechanism.
-func installEfiBootloader(encryptEnabled bool, installRoot, bootUUID string) (err error) {
+func installEfiBootloader(encryptEnabled bool, installRoot, bootUUID, bootPrefix string) (err error) {
 	const (
 		defaultCfgFilename = "grub.cfg"
 		encryptCfgFilename = "grubEncrypt.cfg"
@@ -1378,6 +1378,13 @@ func installEfiBootloader(encryptEnabled bool, installRoot, bootUUID string) (er
 	err = setGrubCfgBootUUID(bootUUID, grubFinalPath)
 	if err != nil {
 		logger.Log.Warnf("Failed to set bootUUID in grub.cfg: %v", err)
+		return
+	}
+
+	// Set the boot prefix
+	err = setGrubCfgBootPrefix(bootPrefix, grubFinalPath)
+	if err != nil {
+		logger.Log.Warnf("Failed to set bootPrefix in grub.cfg: %v", err)
 		return
 	}
 
@@ -1471,7 +1478,7 @@ func setGrubCfgAdditionalCmdLine(grubPath string, kernelCommandline configuratio
 		extraPattern = "{{.ExtraCommandLine}}"
 	)
 
-	logger.Log.Debugf("Adding ExtraCommandLine('%s') to %s", kernelCommandline.ExtraCommandLine, grubPath)
+	logger.Log.Debugf("Adding ExtraCommandLine('%s') to '%s'", kernelCommandline.ExtraCommandLine, grubPath)
 	err = sed(extraPattern, kernelCommandline.ExtraCommandLine, kernelCommandline.GetSedDelimeter(), grubPath)
 	if err != nil {
 		logger.Log.Warnf("Failed to append extra paramters to grub.cfg: %v", err)
@@ -1492,7 +1499,7 @@ func setGrubCfgIMA(grubPath string, kernelCommandline configuration.KernelComman
 		ima += fmt.Sprintf("%v%v ", imaPrefix, policy)
 	}
 
-	logger.Log.Debugf("Adding ImaPolicy('%s') to %s", ima, grubPath)
+	logger.Log.Debugf("Adding ImaPolicy('%s') to '%s'", ima, grubPath)
 	err = sed(imaPattern, ima, kernelCommandline.GetSedDelimeter(), grubPath)
 	if err != nil {
 		logger.Log.Warnf("Failed to set grub.cfg's IMA setting: %v", err)
@@ -1513,7 +1520,7 @@ func setGrubCfgLVM(grubPath, luksUUID string) (err error) {
 		lvm = fmt.Sprintf("%v%v", lvmPrefix, diskutils.GetEncryptedRootVolPath())
 	}
 
-	logger.Log.Debugf("Adding lvm('%s') to %s", lvm, grubPath)
+	logger.Log.Debugf("Adding lvm('%s') to '%s'", lvm, grubPath)
 	err = sed(lvmPattern, lvm, cmdline.GetSedDelimeter(), grubPath)
 	if err != nil {
 		logger.Log.Warnf("Failed to set grub.cfg's LVM setting: %v", err)
@@ -1535,7 +1542,7 @@ func setGrubCfgLuksUUID(grubPath, uuid string) (err error) {
 		luksUUID = fmt.Sprintf("%v%v", luksUUIDPrefix, uuid)
 	}
 
-	logger.Log.Debugf("Adding luks('%s') to %s", luksUUID, grubPath)
+	logger.Log.Debugf("Adding luks('%s') to '%s'", luksUUID, grubPath)
 	err = sed(luksUUIDPattern, luksUUID, cmdline.GetSedDelimeter(), grubPath)
 	if err != nil {
 		logger.Log.Warnf("Failed to set grub.cfg's luksUUID: %v", err)
@@ -1551,10 +1558,25 @@ func setGrubCfgBootUUID(bootUUID, grubPath string) (err error) {
 	)
 	var cmdline configuration.KernelCommandLine
 
-	logger.Log.Debugf("Adding UUID('%s') to %s", bootUUID, grubPath)
+	logger.Log.Debugf("Adding UUID('%s') to '%s'", bootUUID, grubPath)
 	err = sed(bootUUIDPattern, bootUUID, cmdline.GetSedDelimeter(), grubPath)
 	if err != nil {
 		logger.Log.Warnf("Failed to set grub.cfg's bootUUID: %v", err)
+		return
+	}
+	return
+}
+
+func setGrubCfgBootPrefix(bootPrefix, grubPath string) (err error) {
+	const (
+		bootPrefixPattern = "{{.BootPrefix}}"
+	)
+	var cmdline configuration.KernelCommandLine
+
+	logger.Log.Debugf("Adding BootPrefix('%s') to '%s'", bootPrefix, grubPath)
+	err = sed(bootPrefixPattern, bootPrefix, cmdline.GetSedDelimeter(), grubPath)
+	if err != nil {
+		logger.Log.Warnf("Failed to set grub.cfg's bootPrefix: %v", err)
 		return
 	}
 	return
@@ -1568,7 +1590,7 @@ func setGrubCfgEncryptedVolume(grubPath string) (err error) {
 	var cmdline configuration.KernelCommandLine
 
 	encryptedVol := fmt.Sprintf("%v%v%v%v", "(", lvmPrefix, diskutils.GetEncryptedRootVol(), ")")
-	logger.Log.Debugf("Adding EncryptedVolume('%s') to %s", encryptedVol, grubPath)
+	logger.Log.Debugf("Adding EncryptedVolume('%s') to '%s'", encryptedVol, grubPath)
 	err = sed(encryptedVolPattern, encryptedVol, cmdline.GetSedDelimeter(), grubPath)
 	if err != nil {
 		logger.Log.Warnf("Failed to grub.cfg's encryptedVolume: %v", err)
@@ -1587,7 +1609,7 @@ func setGrubCfgRootDevice(rootDevice, grubPath, luksUUID string) (err error) {
 		rootDevice = diskutils.GetEncryptedRootVolMapping()
 	}
 
-	logger.Log.Debugf("Adding RootDevice('%s') to %s", rootDevice, grubPath)
+	logger.Log.Debugf("Adding RootDevice('%s') to '%s'", rootDevice, grubPath)
 	err = sed(rootDevicePattern, rootDevice, cmdline.GetSedDelimeter(), grubPath)
 	if err != nil {
 		logger.Log.Warnf("Failed to set grub.cfg's rootDevice: %v", err)

--- a/toolkit/tools/imager/imager.go
+++ b/toolkit/tools/imager/imager.go
@@ -474,11 +474,19 @@ func buildImage(mountPointMap, mountPointToFsTypeMap, mountPointToMountArgsMap m
 
 func configureDiskBootloader(systemConfig configuration.SystemConfig, installChroot *safechroot.Chroot, diskDevPath string, installMap map[string]string, encryptedRoot diskutils.EncryptedRootDevice) (err error) {
 	const rootMountPoint = "/"
+	const bootMountPoint = "/boot"
 
 	var rootDevice string
 
-	// Add bootloader
-	bootUUID, err := installutils.GetUUID(installMap[rootMountPoint])
+	// Add bootloader. Prefer a seperate boot partition if one exists.
+	bootDevice, ok := installMap[bootMountPoint]
+	bootPrefix := ""
+	if !ok {
+		bootDevice = installMap[rootMountPoint]
+		// If we do not have a seperate boot partition we will need to add a prefix to all paths used in the configs.
+		bootPrefix = "/boot"
+	}
+	bootUUID, err := installutils.GetUUID(bootDevice)
 	if err != nil {
 		err = fmt.Errorf("failed to get UUID: %s", err)
 		return
@@ -493,7 +501,7 @@ func configureDiskBootloader(systemConfig configuration.SystemConfig, installChr
 		}
 	}
 
-	err = installutils.InstallBootloader(installChroot, systemConfig.Encryption.Enable, bootType, bootUUID, diskDevPath)
+	err = installutils.InstallBootloader(installChroot, systemConfig.Encryption.Enable, bootType, bootUUID, bootPrefix, diskDevPath)
 	if err != nil {
 		err = fmt.Errorf("failed to install bootloader: %s", err)
 		return

--- a/toolkit/tools/internal/randomization/randomization.go
+++ b/toolkit/tools/internal/randomization/randomization.go
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package randomization
+
+import (
+	"crypto/rand"
+	"fmt"
+	"math/big"
+	"strings"
+)
+
+// RandomString generates a random string consisting of "length" runes
+// randomly selected from the provided legalCharacters.  crypto.rand is more secure
+// than math.rand and does not need to be seeded.
+func RandomString(length int, legalCharacters string) (output string, err error) {
+	builder := strings.Builder{}
+	legalRunes := []rune(legalCharacters)
+	// Max index is length of the valid runes. rand.Int() returns values in the range [0, max),
+	// i.e. exclusive. So for "abcd", we want max = 4, so rand.Int() can return indices {0,1,2,3}
+	maxIdx := big.NewInt((int64)(len(legalRunes)))
+
+	if maxIdx.Int64() <= 0 {
+		err = fmt.Errorf("legalCharacters may not be empty string")
+		return
+	}
+
+	for i := 0; i < length; i++ {
+		// Randomly select one of the characters in legalRunes to add to the string
+		var randIdx *big.Int
+		randIdx, err = rand.Int(rand.Reader, maxIdx)
+		if err != nil {
+			return
+		}
+		randomRune := legalRunes[randIdx.Int64()]
+		builder.WriteString(string(randomRune))
+	}
+
+	output = builder.String()
+	return
+}

--- a/toolkit/tools/internal/randomization/randomization_test.go
+++ b/toolkit/tools/internal/randomization/randomization_test.go
@@ -1,0 +1,149 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package randomization
+
+import (
+	"math"
+	"math/big"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gonum.org/v1/gonum/stat/distuv"
+)
+
+const (
+	normalString                    = "abcde12345"
+	multiByteString                 = "世界您好IsHelloWorld"
+	emojiString                     = "1🤷‍♂️2@3( •_•)>⌐■~■ab~52(⌐■_■)67👩‍💻"
+	maxAllowableFailureRate float64 = 1e-100 // Max allowable probability of failure
+)
+
+func TestMain(m *testing.M) {
+	testResult := 0
+
+	testResult = m.Run()
+
+	os.Exit(testResult)
+}
+
+// Check if we are running enough trials to satisfy our probability threshold
+// This is an approximation based on a binomial distribution. It slightly over-estimates the failure rates of the test
+// which is acceptable here (~3% error).
+func checkSufficientTrials(lenInputString, lenOutputString int) (isSufficientTrials bool, probabilityOfTrialFailing *big.Float) {
+	// What is the probability we always roll less than (expected # of char) / 2?
+	// ie 100/10 = 10, 10/2 = 5, make sure every character shows up at least 5 times
+	minimumNumberOfOccurrences := (lenOutputString / lenInputString) / 2
+
+	// Sum the probabilities of rolling 0,1,2,3,...(minimumNumberOfOccurrences-1) of any given character
+	// i.e. the cumulative distribution function (CDF) of a binomial distribution
+	distribution := distuv.Binomial{N: (float64)(lenOutputString), P: (1.0 / (float64)(lenInputString))}
+	probabilityOfSingleCharFailure := big.NewFloat(distribution.CDF((float64)(minimumNumberOfOccurrences - 1)))
+
+	// This probability is for one character, we could fail ANY of the characters...
+	// i.e. Probability of rolling a 6 less than 3 times out of 10 rolls.
+	// Need the probability of rolling any result less than 3 times out of 10 rolls.
+	probabilityOfTrialFailing = big.NewFloat(1.0)
+	probabilityOfTrialFailing.Mul(probabilityOfSingleCharFailure, big.NewFloat((float64)(lenInputString)))
+
+	isSufficientTrials = probabilityOfTrialFailing.Cmp(big.NewFloat(maxAllowableFailureRate)) < 0
+	return
+}
+
+// Generate a random string and validate that on the strings contain
+// roughly the expected number of each character. Also make sure there are no
+// unexpected characters included in the string. With a long enough string the chance of
+// the test failing is vanishingly small (recommend at least 100000).
+func runTrials(inputString string, length int, t *testing.T) {
+	// Heuristic to check we are getting a "roughly" random distribution:
+	// Generate random strings, check if each character is used at least an (average / 2) number of times at some point during the trials
+	// ie 100/10 = 10, 10/2 = 5, make sure every character shows up at least 5 times at least once during the repeated trials
+
+	enoughTrials, probOfFailure := checkSufficientTrials(len([]rune(inputString)), length)
+	if !enoughTrials {
+		assert.FailNowf(t, "Insufficient string length", "Require more than %d characters to reach required threshold (Probability of failure is: %v, we want: %v)", length, probOfFailure.String(), maxAllowableFailureRate)
+	}
+
+	randomString, err := RandomString(length, inputString)
+	assert.NoError(t, err)
+	// We need to count runes, not bytes, since there are multi-byte characters possible
+	assert.Equal(t, length, len([]rune(randomString)))
+
+	expectedCount := (length / len(inputString)) / 2
+	for _, c := range inputString {
+		count := strings.Count(randomString, string(c))
+		assert.Truef(t, count > expectedCount, "Char '%c' from '%s' did not show up expected number of times in random string (found %d, expected %d)", c, randomString, count, expectedCount)
+	}
+
+	// Make sure we only have runes from the input string in our output
+	for i, c := range randomString {
+		if !strings.Contains(inputString, string(c)) {
+			assert.FailNowf(t, "Illegal character in return", "Random string '%s' contained an unexpected character '%c' at index '%d' not found in set '%s'", randomString, c, i, inputString)
+		}
+	}
+}
+
+func TestRandomNoNormalStringError(t *testing.T) {
+	var (
+		inputString = normalString
+		length      = 100000
+	)
+	runTrials(inputString, length, t)
+}
+
+func TestRandomNoMultiByteStringError(t *testing.T) {
+	var (
+		inputString = multiByteString
+		length      = 100000
+	)
+	runTrials(inputString, length, t)
+}
+
+func TestRandomNoEmojiStringError(t *testing.T) {
+	var (
+		inputString = emojiString
+		length      = 100000
+	)
+	runTrials(inputString, length, t)
+}
+
+func TestRandomEmptyInputString(t *testing.T) {
+	var (
+		inputString = ""
+		length      = 100
+	)
+	randomString, err := RandomString(length, inputString)
+	assert.Equal(t, "", randomString)
+	assert.Error(t, err)
+	assert.Equal(t, "legalCharacters may not be empty string", err.Error())
+}
+
+func TestRandomZeroLength(t *testing.T) {
+	var (
+		inputString = "abcde12345"
+		length      = 0
+	)
+	randomString, err := RandomString(length, inputString)
+	assert.Equal(t, "", randomString)
+	assert.NoError(t, err)
+}
+
+// Make sure we aren't getting unseeded random values (i.e. math.random would give us the
+// same strings since we don't seed it)
+func TestNoDuplicates(t *testing.T) {
+	var (
+		inputString = "abcde12345"
+	)
+
+	probOfChar := 1.0 / (float64)(len([]rune(inputString)))
+
+	// Figure out how long our string needs to be to get our desired probability of no collisions (~100)
+	length := (int)(math.Ceil(math.Log(maxAllowableFailureRate) / math.Log(probOfChar)))
+	s1, err1 := RandomString(length, inputString)
+	s2, err2 := RandomString(length, inputString)
+	assert.NoError(t, err1)
+	assert.NoError(t, err2)
+	assert.NotEqual(t, s1, s2)
+}


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- ~~[ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass~~ Partial changes won't pass testing, need all 5/5 PRs.
- ~~[ ] Documentation has been updated to match any changes to the build system~~ Documentation to follow later.
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Read-only root and dm-verity: This set of 5 PRs will enable dm-verity based read-only root file systems which can detect, and optionally repair modifications to files on the root file system. This supports both basic resilience to corruption as well as a number of additional security features.

PR [1/5] sets up some of the initial groundwork for this feature.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Move RandomString() to `randomization` package to avoid redefining it for the 3rd time (will be needed to generate dm-verity salt values).
  - Added unit tests
- Our dm-verity implementation will rely on storing the dm-verity disk measurements as part of the initramfs. Traditionally the initramfs is stored in `/boot`, but if `/boot` is part of the rootfs the act of storing the measurements there will change the disk which we just measured.
  - Update `grub.cfg` so it can support `/boot` being a separate partition via a `bootprefix` variable
- Device mapper roots (currently encryption, soon to also be dm-verity) need to be aware of what their underlying disk is earlier in the flow than normal.
  - Add a flag (`"dmroot"`) to the `Partition` structure which signifies which partition is the root
  -  Split the partition structure into its own file
  - Add some getter functions for disks/partitions
  - Add some checks to the configuration validator to detect missing/incompatible setups

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Test Methodology
Local builds and testing via hyper-v
