### PR TITLE
[2/5 verity read-only root] Support validating packages during config check

### DIFF
--- a/toolkit/scripts/imggen.mk
+++ b/toolkit/scripts/imggen.mk
@@ -72,7 +72,8 @@ fetch-external-image-packages: $(image_external_package_cache_summary)
 validate-image-config: $(validate-config)
 $(STATUS_FLAGS_DIR)/validate-image-config%.flag: $(go-imageconfigvalidator) $(depend_CONFIG_FILE) $(CONFIG_FILE) $(config_other_files)
 	$(go-imageconfigvalidator) \
-		--input=$(CONFIG_FILE) && \
+		--input=$(CONFIG_FILE) \
+		--dir=$(CONFIG_BASE_DIR) && \
 	touch $@
 
 
@@ -120,8 +121,8 @@ $(STATUS_FLAGS_DIR)/imager_disk_output.flag: $(go-imager) $(image_package_cache_
 		--build-dir $(workspace_dir) \
 		--input $(CONFIG_FILE) \
 		--base-dir=$(CONFIG_BASE_DIR) \
-		--log-level $(LOG_LEVEL) \
-		--log-file $(LOGS_DIR)/imggen/imager.log \
+		--log-level=$(LOG_LEVEL) \
+		--log-file=$(LOGS_DIR)/imggen/imager.log \
 		--local-repo $(local_and_external_rpm_cache) \
 		--tdnf-worker $(BUILD_DIR)/worker/worker_chroot.tar.gz \
 		--repo-file=$(imggen_local_repo) \
@@ -141,8 +142,8 @@ image: $(imager_disk_output_dir) $(imager_disk_output_files) $(go-roast) $(depen
 		--output-dir $(artifact_dir) \
 		--tmp-dir $(image_roaster_tmp_dir) \
 		--release-version $(RELEASE_VERSION) \
-		--log-level $(LOG_LEVEL) \
-		--log-file $(LOGS_DIR)/imggen/roast.log \
+		--log-level=$(LOG_LEVEL) \
+		--log-file=$(LOGS_DIR)/imggen/roast.log \
 		--image-tag=$(IMAGE_TAG)
 
 $(image_external_package_cache_summary): $(cached_file) $(go-imagepkgfetcher) $(depend_CONFIG_FILE) $(CONFIG_FILE) $(validate-config)
@@ -183,8 +184,8 @@ iso: $(go-isomaker) $(go-liveinstaller) $(go-imager) $(depend_CONFIG_FILE) $(CON
 		--release-version $(RELEASE_VERSION) \
 		--resources $(RESOURCES_DIR) \
 		--iso-repo $(local_and_external_rpm_cache) \
-		--log-level $(LOG_LEVEL) \
-		--log-file $(LOGS_DIR)/imggen/isomaker.log \
+		--log-level=$(LOG_LEVEL) \
+		--log-file=$(LOGS_DIR)/imggen/isomaker.log \
 		$(if $(UNATTENDED_INSTALLER),--unattended-install) \
 		--output-dir $(artifact_dir) \
 		--image-tag=$(IMAGE_TAG)

--- a/toolkit/scripts/pkggen.mk
+++ b/toolkit/scripts/pkggen.mk
@@ -33,7 +33,7 @@ optimized_file    = $(PKGBUILD_DIR)/scrubbed_graph.dot
 cached_file       = $(PKGBUILD_DIR)/cached_graph.dot
 workplan          = $(PKGBUILD_DIR)/workplan.mk
 
-logging_command = --log-file $(LOGS_DIR)/pkggen/workplan/$(notdir $@).log --log-level $(LOG_LEVEL)
+logging_command = --log-file=$(LOGS_DIR)/pkggen/workplan/$(notdir $@).log --log-level=$(LOG_LEVEL)
 $(call create_folder,$(LOGS_DIR)/pkggen/workplan)
 $(call create_folder,$(LOGS_DIR)/pkggen/rpmbuilding)
 

--- a/toolkit/scripts/srpm_pack.mk
+++ b/toolkit/scripts/srpm_pack.mk
@@ -67,6 +67,8 @@ $(STATUS_FLAGS_DIR)/build_srpms.flag: $(local_specs) $(local_spec_dirs) $(local_
 		--tls-cert=$(TLS_CERT) \
 		--tls-key=$(TLS_KEY) \
 		--build-dir=$(BUILD_DIR)/SRPM_packaging \
-		--signature-handling=$(SRPM_FILE_SIGNATURE_HANDLING)
+		--signature-handling=$(SRPM_FILE_SIGNATURE_HANDLING) \
+		--log-file=$(LOGS_DIR)/pkggen/workplan/intermediate_srpms.log \
+		--log-level=$(LOG_LEVEL)
 	touch $@
 endif

--- a/toolkit/tools/imageconfigvalidator/imageconfigvalidator.go
+++ b/toolkit/tools/imageconfigvalidator/imageconfigvalidator.go
@@ -21,7 +21,8 @@ var (
 	logFile  = exe.LogFileFlag(app)
 	logLevel = exe.LogLevelFlag(app)
 
-	input = exe.InputStringFlag(app, "Path to the image config file.")
+	input       = exe.InputStringFlag(app, "Path to the image config file.")
+	baseDirPath = exe.InputDirFlag(app, "Base directory for relative file paths from the config.")
 )
 
 func main() {
@@ -33,9 +34,11 @@ func main() {
 
 	inPath, err := filepath.Abs(*input)
 	logger.PanicOnError(err, "Error when calculating input path")
+	baseDir, err := filepath.Abs(*baseDirPath)
+	logger.PanicOnError(err, "Error when calculating input directory")
 
 	logger.Log.Infof("Reading configuration file (%s)", inPath)
-	config, err := configuration.Load(inPath)
+	config, err := configuration.LoadWithAbsolutePaths(inPath, baseDir)
 	if err != nil {
 		logger.Log.Fatalf("Failed while loading image configuration '%s': %s", inPath, err)
 	}
@@ -54,5 +57,13 @@ func main() {
 // ValidateConfiguration will run sanity checks on a configuration structure
 func ValidateConfiguration(config configuration.Config) (err error) {
 	err = config.IsValid()
+	if err != nil {
+		return
+	}
+	err = validatePackages(config)
+	return
+}
+
+func validatePackages(config configuration.Config) (err error) {
 	return
 }

--- a/toolkit/tools/imagegen/configuration/systemconfig.go
+++ b/toolkit/tools/imagegen/configuration/systemconfig.go
@@ -56,6 +56,8 @@ func (s *SystemConfig) IsValid() (err error) {
 	if len(s.PackageLists) == 0 {
 		return fmt.Errorf("system configuration must provide at least one package list inside the [PackageLists] field")
 	}
+	// Additional package list validation must be done via the imageconfigvalidator tool since there is no guranatee that
+	// the paths are valid at this point.
 
 	// Enforce that any non-rootfs configuration has a default kernel.
 	if len(s.PartitionSettings) != 0 {
@@ -97,7 +99,6 @@ func (s *SystemConfig) IsValid() (err error) {
 		return fmt.Errorf("invalid [KernelCommandLine]: %w", err)
 	}
 
-	//Validate PartitionSettings
 	//Validate PostInstallScripts
 	//Validate Groups
 	//Validate Users


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- ~~[ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass~~ Partial changes won't pass testing, need all 5/5 PRs.
- ~~[ ] Documentation has been updated to match any changes to the build system~~ Documentation to follow later.
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Read-only root and dm-verity: This set of 5 PRs will enable dm-verity based read-only root file systems which can detect, and optionally repair modifications to files on the root file system. This supports both basic resilience to corruption as well as a number of additional security features.

PR [2/5] Enables the configuration checker to look at top level packages to make sure we include any required ones (ie we will need the verity packages to support the read-only-root feature).

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- `imageconfigvalidator` now does some basic package validation
  - Currently a no-op

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Test Methodology
Local builds and testing via hyper-v
