### PR TITLE
[3/5 verity read-only root] Improve mount reliability, initramfs library, TdnfInstall

### DIFF
--- a/toolkit/tools/imagegen/diskutils/initramfs.go
+++ b/toolkit/tools/imagegen/diskutils/initramfs.go
@@ -1,0 +1,247 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Utility to create or modify Initramfs files
+
+package diskutils
+
+import (
+	"bytes"
+	"io"
+	"os"
+
+	"github.com/cavaliercoder/go-cpio"
+	"github.com/klauspost/pgzip"
+	"microsoft.com/pkggen/internal/logger"
+)
+
+// InitramfsMount represented an editable initramfs
+type InitramfsMount struct {
+	pgzWriter           *pgzip.Writer
+	cpioWriter          *cpio.Writer
+	outputBuffer        *bytes.Buffer
+	initramfsOutputFile *os.File
+}
+
+// CreateInitramfs creates a new initramfs
+// Caller is responsible for calling initramfs.Close() when finished
+func CreateInitramfs(initramfsPath string) (initramfs InitramfsMount, err error) {
+	// Initramfs traditionally is -rw-------
+	const initramfsModeBits = os.FileMode(0600)
+
+	initramfs.outputBuffer = new(bytes.Buffer)
+	initramfs.pgzWriter = pgzip.NewWriter(initramfs.outputBuffer)
+	initramfs.cpioWriter = cpio.NewWriter(initramfs.pgzWriter)
+
+	initramfs.initramfsOutputFile, err = os.OpenFile(initramfsPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, initramfsModeBits)
+	if err != nil {
+		logger.Log.Errorf("Failed to create a new initramfs at '%s': %s", initramfsPath, err.Error())
+	}
+
+	return
+}
+
+// OpenInitramfs makes an existing initramfs editable
+// Caller is responsible for calling initramfs.Close() when finished
+func OpenInitramfs(initramfsPath string) (initramfs InitramfsMount, err error) {
+	logger.Log.Debugf("Opening intramfs '%s'", initramfsPath)
+	inputFile, err := os.Open(initramfsPath)
+	if err != nil {
+		return
+	}
+	defer inputFile.Close()
+
+	gzReader, err := pgzip.NewReader(inputFile)
+	if err != nil {
+		return
+	}
+	defer gzReader.Close()
+	cpioReader := cpio.NewReader(gzReader)
+	//cpio.Reader has no Close() function to defer
+
+	initramfs.outputBuffer = new(bytes.Buffer)
+	initramfs.pgzWriter = pgzip.NewWriter(initramfs.outputBuffer)
+	initramfs.cpioWriter = cpio.NewWriter(initramfs.pgzWriter)
+
+	// Read until EOF or other error
+	for {
+		var (
+			bytesIO        int64
+			linkPayload    []byte
+			nextFileHeader *cpio.Header
+		)
+
+		nextFileHeader, err = cpioReader.Next()
+		if err == io.EOF {
+			// Expected end of archive
+			err = nil
+			break
+		}
+		if err != nil {
+			return
+		}
+
+		// For a given symlink, generate a payload that contains the read value of the link.
+		// The payload should be written after the header.
+		// e.g. A link from (/bin -> /usr/bin) would have a payload of "/usr/bin".
+		// cpio.ModeSymlink is two bits (one of which is reused), need to check for actual
+		// equality rather than non-zero after masking
+		isLink := ((nextFileHeader.Mode & cpio.ModeType) == cpio.ModeSymlink)
+		if isLink {
+			linkPayload = []byte(nextFileHeader.Linkname)
+			nextFileHeader.Size = int64(len(linkPayload))
+		}
+
+		err = initramfs.cpioWriter.WriteHeader(nextFileHeader)
+		if err != nil {
+			return
+		}
+
+		if isLink {
+			var bytesWrittenInt int
+
+			// Write returns an int, cast it to an int64 afterwards
+			logger.Log.Tracef("Creating link %s -> %s", nextFileHeader.Name, nextFileHeader.Linkname)
+			bytesWrittenInt, err = initramfs.cpioWriter.Write(linkPayload)
+			bytesIO = int64(bytesWrittenInt)
+		} else {
+			bytesIO, err = io.Copy(initramfs.cpioWriter, cpioReader)
+		}
+
+		if err != nil {
+			return
+		}
+
+		logger.Log.Tracef("File %s caused %d bytes to be transferred to new archive", nextFileHeader.Name, bytesIO)
+		logger.Log.Tracef("Buffer unread length: %d", initramfs.outputBuffer.Len())
+	}
+
+	inputFile.Close()
+
+	fileInfo, err := os.Stat(initramfsPath)
+	if err != nil {
+		return
+	}
+
+	// We can't edit a CPIO archive in place, completely overwrite the file with truncate
+	// The output buffer in memory will be used to re-create the initramfs.
+	initramfs.initramfsOutputFile, err = os.OpenFile(initramfsPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, fileInfo.Mode())
+
+	return
+}
+
+// Close flushes the archives and closes all initramfs resources
+func (i *InitramfsMount) Close() (err error) {
+	var bytesIO int
+
+	logger.Log.Debugf("Closing initramfs file '%s'", i.initramfsOutputFile.Name())
+
+	// Defer close calls to make sure we handle any errors, failing to
+	// close the file means we can't close the install root.
+	defer i.initramfsOutputFile.Close()
+	defer i.pgzWriter.Close()
+	defer i.cpioWriter.Close()
+
+	err = i.cpioWriter.Close()
+	if err != nil {
+		logger.Log.Errorf("Failed to close initramfs cpio writer: '%s'", err.Error())
+		return
+	}
+	err = i.pgzWriter.Close()
+	if err != nil {
+		logger.Log.Errorf("Failed to close initramfs pgzip writer: '%s'", err.Error())
+		return
+	}
+
+	logger.Log.Debugf("Writing %d bytes to file", i.outputBuffer.Len())
+	bytesIO, err = i.initramfsOutputFile.Write(i.outputBuffer.Bytes())
+	if err != nil {
+		logger.Log.Errorf("Failed to write initramfs file: '%s'", err.Error())
+		return
+	}
+	logger.Log.Infof("Bytes writen to file: %d", bytesIO)
+
+	// Explicit call to fsync, archive corruption was occuring occasionally otherwise.
+	err = i.initramfsOutputFile.Sync()
+	if err != nil {
+		logger.Log.Errorf("Failed to sync initramfs file: '%s'", err.Error())
+		return
+	}
+
+	err = i.initramfsOutputFile.Close()
+	if err != nil {
+		logger.Log.Errorf("Failed to close initramfs: '%s'", err.Error())
+		return
+	}
+	return
+}
+
+// AddFileToInitramfs places a single file in the initramfs at the destination path.
+// - sourcePath: Path to file which is to be added
+// - destPath: Final destination in the initramfs
+func (i *InitramfsMount) AddFileToInitramfs(sourcePath, destPath string) (err error) {
+	var bytesIO int64
+	fileInfo, err := os.Lstat(sourcePath)
+	if err != nil {
+		return
+	}
+	file, err := os.Open(sourcePath)
+	if err != nil {
+		return
+	}
+	defer file.Close()
+
+	// Symlinks need to be resolved to their target file to be added to the cpio archive.
+	var linkDestination string
+	// This is a Go symlink mode iota, distinct from the cpio symlink mode bits used in OpenInitramfs(),
+	// and may be checked directly.
+	isSymlink := (fileInfo.Mode() & os.ModeSymlink) != 0
+	if isSymlink {
+		linkDestination, err = os.Readlink(sourcePath)
+		if err != nil {
+			return
+		}
+
+		logger.Log.Debugf("--> Adding link: (%s) -> (%s)", sourcePath, linkDestination)
+	}
+
+	// Convert the OS header into a CPIO header
+	// Only symlink files will use the linkDestination parameter, may be "" for other files.
+	header, err := cpio.FileInfoHeader(fileInfo, linkDestination)
+	if err != nil {
+		return
+	}
+	header.Name = destPath
+
+	err = i.cpioWriter.WriteHeader(header)
+	if err != nil {
+		return
+	}
+
+	if fileInfo.Mode().IsRegular() {
+		bytesIO, err = io.Copy(i.cpioWriter, file)
+		if err != nil {
+			logger.Log.Errorf("Failed to add regular file '%s' into initramfs: %s", header.Name, err.Error())
+			return
+		}
+		logger.Log.Debugf("New file '%s' caused %d bytes to be transferred to new archive", header.Name, bytesIO)
+	} else {
+		// Special files (unix sockets, directories, symlinks, ...) need to be handled differently
+		// since a simple byte transfer of the file's content into the CPIO archive can't be achieved.
+		logger.Log.Debugf("Adding special file '%s' to initramfs", header.Name)
+
+		// For a symlink the reported size will be the size (in bytes) of the link's target.
+		// Write this data into the archive.
+		if isSymlink {
+			_, err = i.cpioWriter.Write([]byte(linkDestination))
+			if err != nil {
+				logger.Log.Errorf("Failed to add symlink '%s'->'%s' to initramfs: %s", header.Name, linkDestination, err.Error())
+				return
+			}
+		}
+
+		// For all other special files, they will be of size 0 and only contain the header in the archive.
+	}
+
+	return
+}

--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -305,11 +305,11 @@ func PopulateInstallRoot(installChroot *safechroot.Chroot, packagesToInstall []s
 		return
 	}
 
-	// Keep a running total of how many packages have be installed through all the `tdnfInstall` invocations
+	// Keep a running total of how many packages have been installed through all the `TdnfInstallWithProgress` invocations
 	packagesInstalled := 0
 
 	// Install filesystem package first
-	packagesInstalled, err = tdnfInstall(filesystemPkg, installRoot, packagesInstalled, totalPackages)
+	packagesInstalled, err = TdnfInstallWithProgress(filesystemPkg, installRoot, packagesInstalled, totalPackages, true)
 	if err != nil {
 		return
 	}
@@ -326,7 +326,7 @@ func PopulateInstallRoot(installChroot *safechroot.Chroot, packagesToInstall []s
 	// Install packages one-by-one to avoid exhausting memory
 	// on low resource systems
 	for _, pkg := range packagesToInstall {
-		packagesInstalled, err = tdnfInstall(pkg, installRoot, packagesInstalled, totalPackages)
+		packagesInstalled, err = TdnfInstallWithProgress(pkg, installRoot, packagesInstalled, totalPackages, true)
 		if err != nil {
 			return
 		}
@@ -387,6 +387,55 @@ func initializeRpmDatabase(installRoot string) (err error) {
 	}
 
 	err = initializeTdnfConfiguration(installRoot)
+	return
+}
+
+// TdnfInstall installs a package into the current environment without calculating progress
+func TdnfInstall(packageName, installRoot string) (packagesInstalled int, err error) {
+	packagesInstalled, err = TdnfInstallWithProgress(packageName, installRoot, 0, 0, false)
+	return
+}
+
+// TdnfInstallWithProgress installs a package in the current environment while optionally reporting progress
+func TdnfInstallWithProgress(packageName, installRoot string, currentPackagesInstalled, totalPackages int, reportProgress bool) (packagesInstalled int, err error) {
+	packagesInstalled = currentPackagesInstalled
+
+	onStdout := func(args ...interface{}) {
+		const tdnfInstallPrefix = "Installing/Updating: "
+
+		// Only process lines that match tdnfInstallPrefix
+		if len(args) == 0 {
+			return
+		}
+
+		line := args[0].(string)
+		if !strings.HasPrefix(line, tdnfInstallPrefix) {
+			return
+		}
+
+		status := fmt.Sprintf("Installing: %s", strings.TrimPrefix(line, tdnfInstallPrefix))
+		if reportProgress {
+			ReportAction(status)
+		} else {
+			// ReportAction() logs at debug level
+			logger.Log.Debug(status)
+		}
+
+		packagesInstalled++
+
+		if reportProgress {
+			// Calculate and report what percentage of packages have been installed
+			percentOfPackagesInstalled := float32(packagesInstalled) / float32(totalPackages)
+			progress := int(percentOfPackagesInstalled * 100)
+			ReportPercentComplete(progress)
+		}
+	}
+
+	err = shell.ExecuteLiveWithCallback(onStdout, logger.Log.Warn, true, "tdnf", "-v", "install", packageName, "--installroot", installRoot, "--nogpgcheck", "--assumeyes")
+	if err != nil {
+		logger.Log.Warnf("Failed to tdnf install: %v. Package name: %v", err, packageName)
+	}
+
 	return
 }
 
@@ -1187,41 +1236,6 @@ func updateUserPassword(installRoot, username, password string) (err error) {
 		logger.Log.Warnf("Failed to write hashed password to shadow file")
 		return
 	}
-	return
-}
-
-func tdnfInstall(packageName, installRoot string, currentPackagesInstalled, totalPackages int) (packagesInstalled int, err error) {
-	packagesInstalled = currentPackagesInstalled
-
-	onStdout := func(args ...interface{}) {
-		const tdnfInstallPrefix = "Installing/Updating: "
-
-		// Only process lines that match tdnfInstallPrefix
-		if len(args) == 0 {
-			return
-		}
-
-		line := args[0].(string)
-		if !strings.HasPrefix(line, tdnfInstallPrefix) {
-			return
-		}
-
-		status := fmt.Sprintf("Installing: %s", strings.TrimPrefix(line, tdnfInstallPrefix))
-		ReportAction(status)
-
-		packagesInstalled++
-
-		// Calculate and report what percentage of packages have been installed
-		percentOfPackagesInstalled := float32(packagesInstalled) / float32(totalPackages)
-		progress := int(percentOfPackagesInstalled * 100)
-		ReportPercentComplete(progress)
-	}
-
-	err = shell.ExecuteLiveWithCallback(onStdout, logger.Log.Warn, true, "tdnf", "install", packageName, "--installroot", installRoot, "--nogpgcheck", "--assumeyes")
-	if err != nil {
-		logger.Log.Warnf("Failed to tdnf install: %v. Package name: %v", err, packageName)
-	}
-
 	return
 }
 

--- a/toolkit/tools/imager/imager.go
+++ b/toolkit/tools/imager/imager.go
@@ -129,15 +129,15 @@ func buildSystemConfig(systemConfig configuration.SystemConfig, disks []configur
 			return
 		}
 
+		if isLoopDevice {
+			isOfflineInstall = true
+			defer diskutils.DetachLoopbackDevice(diskDevPath)
+			defer diskutils.BlockOnDiskIO(diskDevPath)
+		}
 		// Add additional system settings for root encryption
 		err = setupDiskEncryption(&systemConfig, &encryptedRoot, buildDir)
 		if err != nil {
 			return
-		}
-
-		if isLoopDevice {
-			isOfflineInstall = true
-			defer diskutils.DetachLoopbackDevice(diskDevPath)
 		}
 
 		// Select the best kernel package for this environment


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- ~~[ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass~~ Partial changes won't pass testing, need all 5/5 PRs.
- ~~[ ] Documentation has been updated to match any changes to the build system~~ Documentation to follow later.
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Read-only root and dm-verity: This set of 5 PRs will enable dm-verity based read-only root file systems which can detect, and optionally repair modifications to files on the root file system. This supports both basic resilience to corruption as well as a number of additional security features.

PR [3/5] sets up additional groundwork required to support the feature.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Disk mount/unmount improved
  - BlockOnDiskIO will loop until the requested disk has quiesced. I was occasionally seeing data corruption when writing large files immediately prior to disk unmount.
  - Sort mount points
    - Go map iterators are random, there is no way to define a mount ordering in the config file. Sort the mounts so we make sure nested mounts are handled in the correct order.
- Add initramfs package
  - Will need to edit the initramfs cpio archive in the future, add a package to handle this.
  - **There is code duplication with the ISO tooling, we should unify them**
- TdnfInstall is now a public function so we can easily install packges into our worker environment if needed (we will need veritysetup, but only if we are doing dm-verity roots)

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Test Methodology
Local builds and testing via hyper-v
