### PR TITLE
Adding a patch for 'unbound' to fix CVE-2020-28935

### DIFF
--- a/SPECS/unbound/CVE-2020-28935.patch
+++ b/SPECS/unbound/CVE-2020-28935.patch
@@ -1,0 +1,83 @@
+diff --git a/daemon/unbound.c b/daemon/unbound.c
+index cd0fd69..bc6d2bc 100644
+--- a/daemon/unbound.c
++++ b/daemon/unbound.c
+@@ -337,22 +337,44 @@ readpid (const char* file)
+ /** write pid to file. 
+  * @param pidfile: file name of pid file.
+  * @param pid: pid to write to file.
++ * @return false on failure
+  */
+-static void
++static int
+ writepid (const char* pidfile, pid_t pid)
+ {
+-	FILE* f;
++	int fd;
++	char pidbuf[32];
++	size_t count = 0;
++	snprintf(pidbuf, sizeof(pidbuf), "%lu\n", (unsigned long)pid);
+ 
+-	if ((f = fopen(pidfile, "w")) ==  NULL ) {
++	if((fd = open(pidfile, O_WRONLY | O_CREAT | O_TRUNC
++#ifdef O_NOFOLLOW
++		| O_NOFOLLOW
++#endif
++		, 0644)) == -1) {
+ 		log_err("cannot open pidfile %s: %s", 
+ 			pidfile, strerror(errno));
+-		return;
++		return 0;
+ 	}
+-	if(fprintf(f, "%lu\n", (unsigned long)pid) < 0) {
+-		log_err("cannot write to pidfile %s: %s", 
+-			pidfile, strerror(errno));
++	while(count < strlen(pidbuf)) {
++		ssize_t r = write(fd, pidbuf+count, strlen(pidbuf)-count);
++		if(r == -1) {
++			if(errno == EAGAIN || errno == EINTR)
++				continue;
++			log_err("cannot write to pidfile %s: %s",
++				pidfile, strerror(errno));
++			close(fd);
++			return 0;
++		} else if(r == 0) {
++			log_err("cannot write any bytes to pidfile %s: "
++				"write returns 0 bytes written", pidfile);
++			close(fd);
++			return 0;
++		}
++		count += r;
+ 	}
+-	fclose(f);
++	close(fd);
++	return 1;
+ }
+ 
+ /**
+@@ -506,16 +528,17 @@ perform_setup(struct daemon* daemon, struct config_file* cfg, int debug_mode,
+ 	/* write new pidfile (while still root, so can be outside chroot) */
+ #ifdef HAVE_KILL
+ 	if(cfg->pidfile && cfg->pidfile[0] && need_pidfile) {
+-		writepid(daemon->pidfile, getpid());
+-		if(cfg->username && cfg->username[0] && cfg_uid != (uid_t)-1 &&
+-			pidinchroot) {
++		if(writepid(daemon->pidfile, getpid())) {
++			if(cfg->username && cfg->username[0] && cfg_uid != (uid_t)-1 &&
++				pidinchroot) {
+ #  ifdef HAVE_CHOWN
+-			if(chown(daemon->pidfile, cfg_uid, cfg_gid) == -1) {
+-				verbose(VERB_QUERY, "cannot chown %u.%u %s: %s",
+-					(unsigned)cfg_uid, (unsigned)cfg_gid,
+-					daemon->pidfile, strerror(errno));
+-			}
++				if(chown(daemon->pidfile, cfg_uid, cfg_gid) == -1) {
++					verbose(VERB_QUERY, "cannot chown %u.%u %s: %s",
++						(unsigned)cfg_uid, (unsigned)cfg_gid,
++						daemon->pidfile, strerror(errno));
++				}
+ #  endif /* HAVE_CHOWN */
++			}
+ 		}
+ 	}
+ #else

--- a/SPECS/unbound/unbound.spec
+++ b/SPECS/unbound/unbound.spec
@@ -2,40 +2,38 @@ Summary:        unbound dns server
 Name:           unbound
 Version:        1.10.0
 Release:        4%{?dist}
-Group:          System/Servers
-Vendor:         Microsoft Corporation
 License:        BSD
+Vendor:         Microsoft Corporation
 Distribution:   Mariner
+Group:          System/Servers
 URL:            https://nlnetlabs.nl/projects/unbound/about/
 #Source0:       https://github.com/NLnetLabs/%{name}/archive/release-%{version}.tar.gz
 Source0:        %{name}-release-%{version}.tar.gz
 Source1:        %{name}.service
-
 # CVE-2020-12662.patch also fixes CVE-2020-12663
 Patch0:         CVE-2020-12662.patch
 Patch1:         CVE-2020-12663.nopatch
 Patch2:         CVE-2020-28935.patch
-
-BuildRequires:  systemd
 BuildRequires:  expat-devel
-
+BuildRequires:  systemd
 Requires:       systemd
-Requires(pre):  /usr/sbin/useradd /usr/sbin/groupadd
+Requires(pre):  %{_sbindir}/groupadd
+Requires(pre):  %{_sbindir}/useradd
 
 %description
 Unbound is a validating, recursive, and caching DNS resolver.
 
 %package    devel
-Summary:    unbound development libs and headers
-Group:      Development/Libraries
-Requires:   expat-devel
+Summary:        unbound development libs and headers
+Group:          Development/Libraries
+Requires:       expat-devel
 
 %description devel
 Development files for unbound dns server
 
 %package    docs
-Summary:    unbound docs
-Group:      Documentation
+Summary:        unbound docs
+Group:          Documentation
 
 %description docs
 unbound dns server docs
@@ -55,8 +53,8 @@ unbound dns server docs
 make
 
 %install
-make install DESTDIR=$RPM_BUILD_ROOT
-find %{buildroot} -name '*.la' -delete
+make install DESTDIR=%{buildroot}
+find %{buildroot} -type f -name "*.la" -delete -print
 install -vdm755 %{buildroot}%{_unitdir}
 install -pm 0644 %{SOURCE1} %{buildroot}%{_unitdir}/%{name}.service
 
@@ -75,6 +73,7 @@ useradd -r -g unbound -d %{_sysconfdir}/unbound -s /sbin/nologin \
 %clean
 rm -rf %{buildroot}/*
 
+
 %files
 %defattr(-,root,root)
 %license LICENSE
@@ -92,25 +91,34 @@ rm -rf %{buildroot}/*
 %{_mandir}/*
 
 %changelog
-*  Mon Dec 21 2020 Rachel Menge <rachelmenge@microsoft.com> 1.10.0-4
+*  Mon Dec 21 2020 Rachel Menge <rachelmenge@microsoft.com> - 1.10.0-4
 -  Fix CVE-2020-28935.
+
 *  Tue Oct 20 2020 Joe Schmitt <joschmit@microsoft.com> 1.10.0-3
 -  Fix CVE-2020-12662 and CVE-2020-12663.
+
 *  Sat May 09 2020 Nick Samson <nisamson@microsoft.com> 1.10.0-2
 -  Added %%license line automatically
+
 *  Fri May 01 2020 Pawel Winogrodzki <pawelwi@microsoft.com> 1.10.0-1
 -  Bumping version up to 1.10.0 to fix CVE-2019-16866 and CVE-2019-18934.
 -  Fixed "Source0" and "URL" tags.
 -  License verified.
+
 *  Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 1.8.0-2
 -  Initial CBL-Mariner import from Photon (license: Apache2).
+
 *  Mon Sep 10 2018 Michelle Wang <michellew@vmware.com> 1.8.0-1
 -  Update to version 1.8.0.
+
 *  Mon Sep 18 2017 Alexey Makhalov <amakhalov@vmware.com> 1.6.1-3
 -  Remove shadow from requires and use explicit tools for post actions
+
 *  Fri Apr 14 2017 Alexey Makhalov <amakhalov@vmware.com> 1.6.1-2
 -  Requires expat-devel
+
 *  Wed Apr 05 2017 Xiaolin Li <xiaolinl@vmware.com> 1.6.1-1
 -  Updated to version 1.6.1
+
 *  Fri Jan 06 2017 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 1.6.0-1
 -  Initial

--- a/SPECS/unbound/unbound.spec
+++ b/SPECS/unbound/unbound.spec
@@ -1,7 +1,7 @@
 Summary:        unbound dns server
 Name:           unbound
 Version:        1.10.0
-Release:        3%{?dist}
+Release:        4%{?dist}
 Group:          System/Servers
 Vendor:         Microsoft Corporation
 License:        BSD
@@ -14,6 +14,7 @@ Source1:        %{name}.service
 # CVE-2020-12662.patch also fixes CVE-2020-12663
 Patch0:         CVE-2020-12662.patch
 Patch1:         CVE-2020-12663.nopatch
+Patch2:         CVE-2020-28935.patch
 
 BuildRequires:  systemd
 BuildRequires:  expat-devel
@@ -40,8 +41,7 @@ Group:      Documentation
 unbound dns server docs
 
 %prep
-%setup -q -n %{name}-release-%{version}
-%patch0 -p1
+%autosetup -p1 -n %{name}-release-%{version}
 
 %build
 ./configure \
@@ -92,6 +92,8 @@ rm -rf %{buildroot}/*
 %{_mandir}/*
 
 %changelog
+*  Mon Dec 21 2020 Rachel Menge <rachelmenge@microsoft.com> 1.10.0-4
+-  Fix CVE-2020-28935.
 *  Tue Oct 20 2020 Joe Schmitt <joschmit@microsoft.com> 1.10.0-3
 -  Fix CVE-2020-12662 and CVE-2020-12663.
 *  Sat May 09 2020 Nick Samson <nisamson@microsoft.com> 1.10.0-2


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
- Adding a patch for unbound CVE-2020-28935. I'm using the [patch](https://nlnetlabs.nl/downloads/unbound/patch_cve-2020-28935_unbound.diff) recommended by [NIST](https://nvd.nist.gov/vuln/detail/CVE-2020-28935).

###### Change Log  <!-- REQUIRED -->
- Added a patch for unbound CVE-2020-28935.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2020-28935

###### Test Methodology
- Local package build.
