### PR TITLE
Updating `python-py` to 1.10.0 to fix CVE-2020-29651

### DIFF
--- a/SPECS/python-py/python-py.signatures.json
+++ b/SPECS/python-py/python-py.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "1.10.0.tar.gz": "72620e8d9b28f85f475e833de86a3f4fd1aab21ea883e2ea5f2be55d8bc31f9e"
+  "py-1.10.0.tar.gz": "21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3"
  }
 }

--- a/SPECS/python-py/python-py.signatures.json
+++ b/SPECS/python-py/python-py.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "py-1.6.0.tar.gz": "06a30435d058473046be836d3fc4f27167fd84c45b99704f2fb5509ef61f9af1"
+  "1.10.0.tar.gz": "72620e8d9b28f85f475e833de86a3f4fd1aab21ea883e2ea5f2be55d8bc31f9e"
  }
 }

--- a/SPECS/python-py/python-py.spec
+++ b/SPECS/python-py/python-py.spec
@@ -10,7 +10,7 @@ Group:          Development/Languages/Python
 Url:            https://github.com/pytest-dev/py
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
-Source0:        https://github.com/pytest-dev/py/archive/%{version}.tar.gz
+Source0:        https://files.pythonhosted.org/packages/0d/8c/50e9f3999419bb7d9639c37e83fa9cdcf0f601a9d407162d6c37ad60be71/py-%{version}.tar.gz
 
 BuildRequires:  python2
 BuildRequires:  python2-devel
@@ -79,7 +79,6 @@ make -k check |& tee %{_specdir}/%{name}-check-log || %{nocheck}
 %changelog
 * Tue Dec 22 2020 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.10.0-1
 - Updated to version 1.10.0 to fix CVE-2020-29651.
-- Updated the source to use the release from the project's GitHub repository.
 - License verified.
 
 * Sat May 09 2020 Nick Samson <nisamson@microsoft.com> - 1.6.0-4

--- a/SPECS/python-py/python-py.spec
+++ b/SPECS/python-py/python-py.spec
@@ -2,22 +2,22 @@
 %{!?python3_sitelib: %define python3_sitelib %(python3 -c "from distutils.sysconfig import get_python_lib;print(get_python_lib())")}
 
 Name:           python-py
-Version:        1.6.0
-Release:        4%{?dist}
+Version:        1.10.0
+Release:        1%{?dist}
 Summary:        Python development support library
 License:        MIT
 Group:          Development/Languages/Python
 Url:            https://github.com/pytest-dev/py
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
-#Source0:       https://github.com/pytest-dev/py/archive/%{version}.tar.gz
-Source0:        https://files.pythonhosted.org/packages/4f/38/5f427d1eedae73063ce4da680d2bae72014995f9fdeaa57809df61c968cd/py-%{version}.tar.gz
+Source0:        https://github.com/pytest-dev/py/archive/%{version}.tar.gz
 
 BuildRequires:  python2
 BuildRequires:  python2-devel
 BuildRequires:  python2-libs
 BuildRequires:  python-setuptools
 BuildRequires:  python-setuptools_scm
+
 Requires:       python2
 Requires:       python2-libs
 
@@ -47,7 +47,7 @@ Requires:       python3-libs
 Python 3 version.
 
 %prep
-%setup -n py-%{version}
+%autosetup -n py-%{version}
 rm -rf ../p3dir
 cp -a . ../p3dir
 
@@ -77,18 +77,28 @@ make -k check |& tee %{_specdir}/%{name}-check-log || %{nocheck}
 %{python3_sitelib}/*
 
 %changelog
-* Sat May 09 00:21:41 PST 2020 Nick Samson <nisamson@microsoft.com> - 1.6.0-4
+* Tue Dec 22 2020 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.10.0-1
+- Updated to version 1.10.0 to fix CVE-2020-29651.
+- Updated the source to use the release from the project's GitHub repository.
+- License verified.
+
+* Sat May 09 2020 Nick Samson <nisamson@microsoft.com> - 1.6.0-4
 - Added %%license line automatically
 
-*   Mon Apr 20 2020 Eric Li <eli@microsoft.com> 1.6.0-3
--   Update Source0:, add #Source0:, and delete sha1. License verified
-*   Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 1.6.0-2
--   Initial CBL-Mariner import from Photon (license: Apache2).
-*   Thu Sep 13 2018 Tapas Kundu <tkundu@vmware.com> 1.6.0-1
--   Updated to versiob 1.6.0
-*   Wed Jun 07 2017 Xiaolin Li <xiaolinl@vmware.com> 1.4.33-3
--   Add python3-setuptools and python3-xml to python3 sub package Buildrequires.
-*   Thu Jun 01 2017 Dheeraj Shetty <dheerajs@vmware.com> 1.4.33-2
--   Use python2_sitelib
-*   Tue Apr 25 2017 Dheeraj Shetty <dheerajs@vmware.com> 1.4.33-1
--   Initial
+* Mon Apr 20 2020 Eric Li <eli@microsoft.com> 1.6.0-3
+- Update Source0:, add #Source0:, and delete sha1. License verified
+
+* Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 1.6.0-2
+- Initial CBL-Mariner import from Photon (license: Apache2).
+
+* Thu Sep 13 2018 Tapas Kundu <tkundu@vmware.com> 1.6.0-1
+- Updated to versiob 1.6.0
+
+* Wed Jun 07 2017 Xiaolin Li <xiaolinl@vmware.com> 1.4.33-3
+- Add python3-setuptools and python3-xml to python3 sub package Buildrequires.
+
+* Thu Jun 01 2017 Dheeraj Shetty <dheerajs@vmware.com> 1.4.33-2
+- Use python2_sitelib
+
+* Tue Apr 25 2017 Dheeraj Shetty <dheerajs@vmware.com> 1.4.33-1
+- Initial

--- a/SPECS/python-py/python-py.spec
+++ b/SPECS/python-py/python-py.spec
@@ -1,22 +1,22 @@
 %{!?python2_sitelib: %define python2_sitelib %(python2 -c "from distutils.sysconfig import get_python_lib;print(get_python_lib())")}
 %{!?python3_sitelib: %define python3_sitelib %(python3 -c "from distutils.sysconfig import get_python_lib;print(get_python_lib())")}
-
+Summary:        Python development support library
 Name:           python-py
 Version:        1.10.0
 Release:        1%{?dist}
-Summary:        Python development support library
 License:        MIT
-Group:          Development/Languages/Python
-Url:            https://github.com/pytest-dev/py
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
+Group:          Development/Languages/Python
+URL:            https://github.com/pytest-dev/py
+# Must use PyPI sources. Building from GitHub's release sources fails with a message to use PyPI.
 Source0:        https://files.pythonhosted.org/packages/0d/8c/50e9f3999419bb7d9639c37e83fa9cdcf0f601a9d407162d6c37ad60be71/py-%{version}.tar.gz
 
+BuildRequires:  python-setuptools
+BuildRequires:  python-setuptools_scm
 BuildRequires:  python2
 BuildRequires:  python2-devel
 BuildRequires:  python2-libs
-BuildRequires:  python-setuptools
-BuildRequires:  python-setuptools_scm
 
 Requires:       python2
 Requires:       python2-libs
@@ -33,6 +33,7 @@ py.code: dynamic code generation and introspection
 
 %package -n     python3-py
 Summary:        Python development support library
+
 BuildRequires:  python3
 BuildRequires:  python3-devel
 BuildRequires:  python3-setuptools

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -4956,7 +4956,7 @@
         "other": {
           "name": "python-py",
           "version": "1.10.0",
-          "downloadUrl": "https://github.com/pytest-dev/py/archive/1.10.0.tar.gz"
+          "downloadUrl": "https://files.pythonhosted.org/packages/0d/8c/50e9f3999419bb7d9639c37e83fa9cdcf0f601a9d407162d6c37ad60be71/py-1.10.0.tar.gz"
         }
       }
     },

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -4955,8 +4955,8 @@
         "type": "other",
         "other": {
           "name": "python-py",
-          "version": "1.6.0",
-          "downloadUrl": "https://github.com/pytest-dev/py/archive/1.6.0.tar.gz"
+          "version": "1.10.0",
+          "downloadUrl": "https://github.com/pytest-dev/py/archive/1.10.0.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Fixing CVE-2020-29651 by updating `python-py` to 1.10.0. According to the authors the library is in maintenance mode and no significant changes have been made since 1.6.0.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Fixed CVE-2020-29651.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
No.

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2020-29651

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local package build for `python-py` and `pytest`.
