### PR TITLE
Adding Fedora 32 patch to make `perl-WWW-Curl` work with new version of `curl`

### DIFF
--- a/SPECS/perl-WWW-Curl/WWW-Curl-4.17-Adapt-to-changes-in-cURL-7.69.0.patch
+++ b/SPECS/perl-WWW-Curl/WWW-Curl-4.17-Adapt-to-changes-in-cURL-7.69.0.patch
@@ -1,0 +1,41 @@
+From ee910449bf764d9f582e612c9b8b61b1d18e3a7c Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Petr=20P=C3=ADsa=C5=99?= <ppisar@redhat.com>
+Date: Thu, 9 Apr 2020 14:31:05 +0200
+Subject: [PATCH] Adapt to changes in cURL 7.69.0
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+WIN32 macro was removed (1adebe7886ddf20b0733bf9ccbae4ed4866dcfb6) and
+then added under a CURL_WIN32 name
+(8bd863f97b6c79f561bc063e634cecdf4badf776). This a C preprocessor
+macro for driving the C compiler, not a cURL  option. Thus this fix
+ignores it.
+
+CURLOPT(na,t,nu) macro was added
+(920deff8618a19ae80bd319851722f1b05751f69) as replacement for CINIT()
+macro. It's not a cURL option. This fix also ignores it.
+
+CPAN RT#132197
+
+Signed-off-by: Petr Písař <ppisar@redhat.com>
+---
+ Makefile.PL | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile.PL b/Makefile.PL
+index ad2bd3d..b9e6a46 100644
+--- a/Makefile.PL
++++ b/Makefile.PL
+@@ -127,7 +127,7 @@ if (!defined($curl_h)) {
+     close H;
+ 
+     for my $e (sort @syms) {
+-       if($e =~ /(OBSOLETE|^CURL_EXTERN|_LAST\z|_LASTENTRY\z)/) {
++       if($e =~ /(OBSOLETE|^CURL_EXTERN|^CURL_WIN32\z|^CURLOPT\z|_LAST\z|_LASTENTRY\z)/) {
+           next;
+        }
+        my ($group) = $e =~ m/^([^_]+_)/;
+-- 
+2.21.1
+

--- a/SPECS/perl-WWW-Curl/perl-WWW-Curl.spec
+++ b/SPECS/perl-WWW-Curl/perl-WWW-Curl.spec
@@ -9,21 +9,22 @@ Name:           perl-WWW-Curl
 Version:        4.17
 Release:        10%{?dist}
 License:        MIT
-Group:          Development/Libraries
-URL:            https://search.cpan.org/dist/WWW-Curl/
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
+Group:          Development/Libraries
+URL:            https://search.cpan.org/dist/WWW-Curl/
 Source0:        https://search.cpan.org/CPAN/authors/id/S/SZ/SZBALINT/WWW-Curl-%{version}.tar.gz
+
 Patch0:         0001-Curl-macros-fix.patch
 Patch1:         WWW-Curl-4.17-Adapt-to-changes-in-cURL-7.69.0.patch
 
+BuildRequires:  curl-devel
 BuildRequires:  perl >= 5.28.0
 BuildRequires:  perl-Module-Install
 BuildRequires:  perl-YAML-Tiny
-BuildRequires:  curl-devel
-Requires:       perl >= 5.28.0
-Requires:       curl
 
+Requires:       curl
+Requires:       perl >= 5.28.0
 Provides:       perl(WWW::Curl::Easy)
 
 %description
@@ -69,25 +70,34 @@ make test
 %{_mandir}/man3/*
 
 %changelog
-*   Tue Dec 29 2020 Pawel Winogrodzki <pawelwi@microsoft.com> 4.17-10
--   Adapting Fedora 32 patch (license: MIT) for "curl" versions >= 7.69.0.
-*   Tue Aug 11 2020 Andrew Phelps <anphel@microsoft.com> 4.17-9
--   Add provides for perl(WWW::Curl::Easy)
-*   Tue May 19 2020 Pawel Winogrodzki <pawelwi@microsoft.com> 4.17-8
--   Adding a patch to build with "curl" version >= 7.66.0.
--   License verified.
--   Updated the 'Source0' and 'URL' tags.
-*   Sat May 09 00:20:47 PST 2020 Nick Samson <nisamson@microsoft.com> - 4.17-7
--   Added %%license line automatically
-*   Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 4.17-6
--   Initial CBL-Mariner import from Photon (license: Apache2).
-*   Fri Sep 21 2018 Dweep Advani <dadvani@vmware.com> 4.17-5
--   Consuming perl version upgrade of 5.28.0
-*   Wed Dec 07 2016 Xiaolin Li <xiaolinl@vmware.com> 4.17-4
--   BuildRequires curl-devel.
-*   Thu Sep 15 2016 Xiaolin Li <xiaolinl@vmware.com> 4.17-3
--   Build WWW-Curl with curl 7.50.3
-*   Tue May 24 2016 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 4.17-2
--   GA - Bump release of all rpms
-*   Fri Apr 3 2015 Divya Thaluru <dthaluru@vmware.com> 4.17-1
--   Initial version.
+* Tue Dec 29 2020 Pawel Winogrodzki <pawelwi@microsoft.com> - 4.17-10
+- Adapting Fedora 32 patch (license: MIT) for "curl" versions >= 7.69.0.
+
+* Tue Aug 11 2020 Andrew Phelps <anphel@microsoft.com> - 4.17-9
+- Add provides for perl(WWW::Curl::Easy)
+
+* Tue May 19 2020 Pawel Winogrodzki <pawelwi@microsoft.com> - 4.17-8
+- Adding a patch to build with "curl" version >= 7.66.0.
+- License verified.
+- Updated the 'Source0' and 'URL' tags.
+
+* Sat May 09 00:20:47 PST 2020 Nick Samson <nisamson@microsoft.com> - 4.17-7
+- Added %%license line automatically
+
+* Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> - 4.17-6
+- Initial CBL-Mariner import from Photon (license: Apache2).
+
+* Fri Sep 21 2018 Dweep Advani <dadvani@vmware.com> - 4.17-5
+- Consuming perl version upgrade of 5.28.0
+
+* Wed Dec 07 2016 Xiaolin Li <xiaolinl@vmware.com> - 4.17-4
+- BuildRequires curl-devel.
+
+* Thu Sep 15 2016 Xiaolin Li <xiaolinl@vmware.com> - 4.17-3
+- Build WWW-Curl with curl 7.50.3
+
+* Tue May 24 2016 Priyesh Padmavilasom <ppadmavilasom@vmware.com> - 4.17-2
+- GA - Bump release of all rpms
+
+* Fri Apr 3 2015 Divya Thaluru <dthaluru@vmware.com> - 4.17-1
+- Initial version.

--- a/SPECS/perl-WWW-Curl/perl-WWW-Curl.spec
+++ b/SPECS/perl-WWW-Curl/perl-WWW-Curl.spec
@@ -7,7 +7,7 @@
 Summary:        Perl extension interface for libcurl
 Name:           perl-WWW-Curl
 Version:        4.17
-Release:        9%{?dist}
+Release:        10%{?dist}
 License:        MIT
 Group:          Development/Libraries
 URL:            https://search.cpan.org/dist/WWW-Curl/
@@ -15,6 +15,7 @@ Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Source0:        https://search.cpan.org/CPAN/authors/id/S/SZ/SZBALINT/WWW-Curl-%{version}.tar.gz
 Patch0:         0001-Curl-macros-fix.patch
+Patch1:         WWW-Curl-4.17-Adapt-to-changes-in-cURL-7.69.0.patch
 
 BuildRequires:  perl >= 5.28.0
 BuildRequires:  perl-Module-Install
@@ -29,8 +30,7 @@ Provides:       perl(WWW::Curl::Easy)
 WWW::Curl is a Perl extension interface for libcurl.
 
 %prep
-%setup -q -n WWW-Curl-%{version}
-%patch0 -p1
+%autosetup -p1 -n WWW-Curl-%{version}
 rm -rf inc && sed -i -e '/^inc\//d' MANIFEST
 sed -i 's/_LASTENTRY\\z/_LASTENTRY\\z|CURL_DID_MEMORY_FUNC_TYPEDEFS\\z/' Makefile.PL
 
@@ -69,6 +69,8 @@ make test
 %{_mandir}/man3/*
 
 %changelog
+*   Tue Dec 29 2020 Pawel Winogrodzki <pawelwi@microsoft.com> 4.17-10
+-   Adapting Fedora 32 patch (license: MIT) for "curl" versions >= 7.69.0.
 *   Tue Aug 11 2020 Andrew Phelps <anphel@microsoft.com> 4.17-9
 -   Add provides for perl(WWW::Curl::Easy)
 *   Tue May 19 2020 Pawel Winogrodzki <pawelwi@microsoft.com> 4.17-8


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
After updating to `curl` 7.74.0 this package fails to build. From [this bug](https://bugzilla.redhat.com/show_bug.cgi?id=1812910) it seems to be a known issue and I've applied the same patch Fedora used for their release 32 update.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Applied a fix to enable building with `curl` >= 7.69.0.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
No.

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local package build with tests. Package built, tests passed.
