### PR TITLE
[dev] Add additional provides and compatibility links

### DIFF
--- a/SPECS/docbook-style-xsl/docbook-style-xsl.spec
+++ b/SPECS/docbook-style-xsl/docbook-style-xsl.spec
@@ -1,7 +1,7 @@
 Summary:        Docbook-xsl-1.79.1
 Name:           docbook-style-xsl
 Version:        1.79.1
-Release:        12%{?dist}
+Release:        13%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -10,6 +10,7 @@ URL:            https://www.docbook.org
 Source0:        http://downloads.sourceforge.net/docbook/docbook-xsl-%{version}.tar.bz2
 BuildRequires:  libxml2
 BuildRequires:  zip
+Requires:       docbook-dtd-xml
 Requires:       libxml2
 Provides:       docbook-xsl = %{version}-%{release}
 Provides:       docbook-xsl-stylesheets = %{version}-%{release}
@@ -29,15 +30,15 @@ zip -d tools/lib/jython.jar Lib/distutils/command/wininst-6.exe
 zip -d tools/lib/jython.jar Lib/distutils/command/wininst-7.1.exe
 
 %install
-install -v -m755 -d %{buildroot}/usr/share/xml/docbook/xsl-stylesheets-1.79.1 &&
+install -v -m755 -d %{buildroot}%{_datadir}/xml/docbook/xsl-stylesheets-%{version} &&
 
 cp -v -R VERSION common eclipse epub extensions fo highlighting html \
          htmlhelp images javahelp lib manpages params profiling \
          roundtrip slides template tests tools webhelp website \
          xhtml xhtml-1_1 \
-    %{buildroot}/usr/share/xml/docbook/xsl-stylesheets-1.79.1
+    %{buildroot}%{_datadir}/xml/docbook/xsl-stylesheets-%{version}
 
-pushd %{buildroot}/usr/share/xml/docbook/xsl-stylesheets-1.79.1
+pushd %{buildroot}%{_datadir}/xml/docbook/xsl-stylesheets-%{version}
 rm extensions/saxon65.jar
 rm tools/lib/saxon.jar
 rm tools/lib/saxon9-ant.jar
@@ -49,6 +50,10 @@ install -v -m644 -D README \
                     %{buildroot}%{_docdir}/docbook-xsl-%{version}/README.txt &&
 install -v -m644    RELEASE-NOTES* NEWS* \
                     %{buildroot}%{_docdir}/docbook-xsl-%{version}
+
+mkdir -p %{buildroot}%{_datadir}/sgml/docbook
+ln -s %{_datadir}/xml/docbook/xsl-stylesheets-%{version} \
+	%{buildroot}%{_datadir}/sgml/docbook/xsl-stylesheets
 
 #There is no source code for make check
 #%check
@@ -92,10 +97,15 @@ fi
 %files
 %defattr(-,root,root)
 %license COPYING
-%{_datadir}/xml/docbook/*
+%{_datadir}/xml/docbook/xsl-stylesheets-%{version}
+%{_datadir}/sgml/docbook/xsl-stylesheets
 %{_docdir}/*
 
 %changelog
+* Tue Jan 05 2021 Joe Schmitt <joschmit@microsoft.com> - 1.79.1-13
+- Symlink versioned stylesheets to unversioned %%{_datadir}/sgml/docbook/xsl-stylesheets.
+- Add runtime requirement on docbook-dtd-xml since the xsl stylesheets reference the DTD schema.
+
 * Tue Dec 01 2020 Joe Schmitt <joschmit@microsoft.com> - 1.79.1-12
 - Provide docbook-xsl-stylesheets.
 

--- a/SPECS/guile/guile.spec
+++ b/SPECS/guile/guile.spec
@@ -1,34 +1,35 @@
-Summary:	GNU Ubiquitous Intelligent Language for Extensions
-Name:		guile
-Version:    2.0.14
-Release:    2%{?dist}
-License: 	LGPLv3+
-URL:		https://www.gnu.org/software/guile/
-Source0: 	ftp://ftp.gnu.org/pub/gnu/guile/%{name}-%{version}.tar.gz
-Group: 		Development/Languages
+Summary:        GNU Ubiquitous Intelligent Language for Extensions
+Name:           guile
+Version:        2.0.14
+Release:        3%{?dist}
+License:        LGPLv3+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
-BuildRequires:	libltdl-devel
-BuildRequires:	libunistring-devel
-BuildRequires:	gc-devel
-BuildRequires:	libffi-devel
-Requires:	libltdl
-Requires:	libunistring
-Requires:	gc
-Requires:	libffi
-Requires:	gmp
+Group:          Development/Languages
+URL:            https://www.gnu.org/software/guile/
+Source0:        ftp://ftp.gnu.org/pub/gnu/guile/%{name}-%{version}.tar.gz
+BuildRequires:  gc-devel
+BuildRequires:  libffi-devel
+BuildRequires:  libltdl-devel
+BuildRequires:  libunistring-devel
+Requires:       gc
 Requires:       glibc-iconv
+Requires:       gmp
+Requires:       libffi
+Requires:       libltdl
+Requires:       libunistring
 
 %description
 GUILE (GNU's Ubiquitous Intelligent Language for Extension) is a library
 implementation of the Scheme programming language, written in C.  GUILE
 provides a machine-independent execution platform that can be linked in
 as a library during the building of extensible programs.
+
 %package devel
-Summary:	Development libraries and header files for guile
-Requires:	guile
-Requires:	libltdl-devel
-Requires:	libunistring-devel
+Summary:        Development libraries and header files for guile
+Requires:       guile
+Requires:       libltdl-devel
+Requires:       libunistring-devel
 
 %description devel
 The package contains libraries and header files for
@@ -36,19 +37,28 @@ developing applications that use guile.
 
 %prep
 %setup -q
+
 %build
 ./configure \
 	--prefix=%{_prefix} \
 	--disable-static
 make %{?_smp_mflags}
+
 %install
 make DESTDIR=%{buildroot} install
 rm %{buildroot}%{_libdir}/*.scm
 rm %{buildroot}%{_infodir}/*
+
+# Create symlinks for compatibility
+ln -s guile %{buildroot}%{_bindir}/guile2
+ln -s guile-tools %{buildroot}%{_bindir}/guile2-tools
+
 %check
 make  %{?_smp_mflags} check
+
 %post	-p /sbin/ldconfig
 %postun	-p /sbin/ldconfig
+
 %files
 %defattr(-,root,root)
 %license LICENSE
@@ -59,6 +69,7 @@ make  %{?_smp_mflags} check
 %{_datadir}/aclocal/*.m4
 %{_datadir}/guile/*
 %{_libdir}/*.la
+
 %files devel
 %defattr(-,root,root)
 %{_includedir}/guile/2.0/*.h
@@ -67,20 +78,29 @@ make  %{?_smp_mflags} check
 %{_libdir}/pkgconfig/*.pc
 
 %changelog
-* Sat May 09 00:20:35 PST 2020 Nick Samson <nisamson@microsoft.com> - 2.0.14-2
+* Tue Jan 05 2021 Joe Schmitt <joschmit@microsoft.com> - 2.0.14-3
+- Add compatibility symlinks for guile and guile-tools binaries.
+
+* Sat May 09 2020 Nick Samson <nisamson@microsoft.com> - 2.0.14-2
 - Added %%license line automatically
 
 *   Mon Mar 16 2020 Henry Beberman <henry.beberman@microsoft.com> 2.0.14-1
 -   Update to 2.0.14. License verified.
+
 *   Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 2.0.13-3
 -   Initial CBL-Mariner import from Photon (license: Apache2).
+
 *       Wed May 03 2017 Dheeraj Shetty <dheerajs@vmware.com> 2.0.13-2
 -       Adding glibc-iconv to Requires section
+
 *       Wed Jan 18 2017 Dheeraj Shetty <dheerajs@vmware.com> 2.0.13-1
 -       Bumped to latest version 2.0.13 to handle CVE-2016-8606
+
 *       Thu Oct 06 2016 ChangLee <changlee@vmware.com> 2.0.11-3
 -       Modified %check
+
 *	Tue May 24 2016 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 2.0.11-2
 -	GA - Bump release of all rpms
+
 *	Thu Jun 18 2015 Divya Thaluru <dthaluru@vmware.com> 2.0.11-1
 -	Initial build. First version

--- a/SPECS/keyutils/keyutils.spec
+++ b/SPECS/keyutils/keyutils.spec
@@ -1,13 +1,13 @@
 Summary:        Linux Key Management Utilities
 Name:           keyutils
 Version:        1.5.10
-Release:        3%{?dist}
-License:        GPLv2+ and LGPLv2+
-URL:            https://people.redhat.com/~dhowells/keyutils/
-Source0:        https://people.redhat.com/~dhowells/keyutils/keyutils-%{version}.tar.bz2
-Group:          System Environment/Base
+Release:        4%{?dist}
+License:        GPLv2+ AND LGPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
+Group:          System Environment/Base
+URL:            https://people.redhat.com/~dhowells/keyutils/
+Source0:        https://people.redhat.com/~dhowells/keyutils/keyutils-%{version}.tar.bz2
 
 %description
 Utilities to control the kernel key management facility and to provide
@@ -15,8 +15,10 @@ a mechanism by which the kernel call back to user space to get a key
 instantiated.
 
 %package   devel
-Summary:    Header and development files
-Requires:   %{name} = %{version}
+Summary:        Header and development files
+Requires:       %{name} = %{version}
+Provides:       %{name}-libs = %{version}-%{release}
+Provides:       %{name}-libs-devel = %{version}-%{release}
 
 %description   devel
 It contains the libraries and header files to create applications
@@ -34,17 +36,18 @@ find %{buildroot} -name '*.a'  -delete
 %clean
 rm -rf %{buildroot}
 
+
 %check
 make -k check |& tee %{_specdir}/%{name}-check-log || %{nocheck}
 
 %post -p /sbin/ldconfig
-
 %postun -p /sbin/ldconfig
 
 %files
 %defattr(-,root,root)
 %license LICENCE.GPL LICENCE.LGPL
-%doc README LICENCE.GPL
+%license LICENCE.GPL
+%doc README
 /sbin/*
 /bin/*
 %{_libdir}/*.so.*
@@ -64,14 +67,20 @@ make -k check |& tee %{_specdir}/%{name}-check-log || %{nocheck}
 %{_mandir}/man3/*
 
 %changelog
+* Tue Jan 05 2021 Joe Schmitt <joschmit@microsoft.com> - 1.5.10-4
+- Provide keyutils-libs and keyutils-libs-devel.
+
 *   Mon Jun 01 2020 Pawel Winogrodzki <pawelwi@microsoft.com> 1.5.10-3
 -   Adding a license reference.
 -   License verified.
 -   Removed "sha1" macro.
 -   Switched to HTTPS URLs.
+
 *   Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 1.5.10-2
 -   Initial CBL-Mariner import from Photon (license: Apache2).
+
 *   Mon Apr 03 2017 Divya Thaluru <dthaluru@vmware.com> 1.5.10-1
 -   Updated to version 1.5.10
+
 *   Fri Dec 16 2016 Dheeraj Shetty <Dheerajs@vmware.com> 1.5.9-1
 -   Initial build. First version

--- a/SPECS/ruby/ruby.spec
+++ b/SPECS/ruby/ruby.spec
@@ -1,34 +1,39 @@
 Summary:        Ruby
 Name:           ruby
 Version:        2.6.6
-Release:        1%{?dist}
-License:        (Ruby or BSD) and Public Domain and MIT and CC0 and zlib and UCD
-URL:            https://www.ruby-lang.org/en/
-Group:          System Environment/Security
+Release:        2%{?dist}
+License:        (Ruby OR BSD) AND Public Domain AND MIT AND CC0 AND zlib AND UCD
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
+Group:          System Environment/Security
+URL:            https://www.ruby-lang.org/en/
 Source0:        https://cache.ruby-lang.org/pub/ruby/2.6/%{name}-%{version}.tar.xz
 BuildRequires:  openssl-devel
-BuildRequires:  readline-devel
 BuildRequires:  readline
+BuildRequires:  readline-devel
 BuildRequires:  tzdata
-Requires:       openssl
 Requires:       gmp
+Requires:       openssl
+Provides:       %{name}-devel = %{version}-%{release}
+
 %description
 The Ruby package contains the Ruby development environment.
 This is useful for object-oriented scripting.
 
 %prep
 %setup -q
+
 %build
 %configure \
         --enable-shared \
         --with-compress-debug-sections=no \
         --docdir=%{_docdir}/%{name}-%{version}
 make %{?_smp_mflags} COPY="cp -p"
+
 %install
 [ %{buildroot} != "/"] && rm -rf %{buildroot}/*
 make DESTDIR=%{buildroot} install
+
 %check
 chmod g+w . -R
 useradd test -G root -m
@@ -36,8 +41,10 @@ sudo -u test  make check TESTS="-v"
 
 %post   -p /sbin/ldconfig
 %postun -p /sbin/ldconfig
+
 %clean
 rm -rf %{buildroot}/*
+
 %files
 %defattr(-,root,root)
 %license COPYING
@@ -53,52 +60,78 @@ rm -rf %{buildroot}/*
 %{_mandir}/man5/*
 
 %changelog
+* Tue Jan 05 2021 Joe Schmitt <joschmit@microsoft.com> - 2.6.6-2
+- Provide ruby-devel.
+
 *   Thu Oct 15 2020 Emre Girgin <mrgirgin@microsoft.com> 2.6.6-1
 -   Upgrade to 2.6.6 to resolve CVEs.
+
 *   Sat May 09 00:20:42 PST 2020 Nick Samson <nisamson@microsoft.com> - 2.6.3-3
 -   Added %%license line automatically
+
 *   Wed May 06 2020 Pawel Winogrodzki <pawelwi@microsoft.com> 2.6.3-2
 -   Removing *Requires for "ca-certificates".
+
 *   Fri Mar 13 2020 Paul Monson <paulmon@microsoft.com> 2.6.3-1
 -   Update to version 2.6.3. License verified.
+
 *   Mon Feb 3 2020 Andrew Phelps <anphel@microsoft.com> 2.5.3-3
 -   Disable compressing debug sections
+
 *   Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 2.5.3-2
 -   Initial CBL-Mariner import from Photon (license: Apache2).
+
 *   Tue Jan 01 2019 Sujay G <gsujay@vmware.com> 2.5.3-1
 -   Update to version 2.5.3, to fix CVE-2018-16395 & CVE-2018-16396
+
 *   Tue Sep 11 2018 srinidhira0 <srinidhir@vmware.com> 2.5.1-1
 -   Update to version 2.5.1
+
 *   Fri Jan 12 2018 Xiaolin Li <xiaolinl@vmware.com> 2.4.3-2
 -   Fix CVE-2017-17790
+
 *   Wed Jan 03 2018 Xiaolin Li <xiaolinl@vmware.com> 2.4.3-1
 -   Update to version 2.4.3, fix CVE-2017-17405
+
 *   Fri Sep 29 2017 Xiaolin Li <xiaolinl@vmware.com> 2.4.2-1
 -   Update to version 2.4.2
+
 *   Fri Sep 15 2017 Xiaolin Li <xiaolinl@vmware.com> 2.4.1-5
 -   [security] CVE-2017-14064
+
 *   Tue Sep 05 2017 Chang Lee <changlee@vmware.com> 2.4.1-4
 -   Built with copy preserve mode and fixed %check
+
 *   Mon Jul 24 2017 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 2.4.1-3
 -   [security] CVE-2017-9228
+
 *   Tue Jun 13 2017 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 2.4.1-2
 -   [security] CVE-2017-9224,CVE-2017-9225
 -   [security] CVE-2017-9227,CVE-2017-9229
+
 *   Thu Apr 13 2017 Siju Maliakkal <smaliakkal@vmware.com> 2.4.1-1
 -   Update to latest 2.4.1
+
 *   Wed Jan 18 2017 Anish Swaminathan <anishs@vmware.com> 2.4.0-1
 -   Update to 2.4.0 - Fixes CVE-2016-2339
+
 *   Mon Oct 10 2016 ChangLee <changlee@vmware.com> 2.3.0-4
 -   Modified %check
+
 *   Tue May 24 2016 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 2.3.0-3
 -   GA - Bump release of all rpms
+
 *   Wed Mar 09 2016 Divya Thaluru <dthaluru@vmware.com> 2.3.0-2
 -   Adding readline support
+
 *   Wed Jan 20 2016 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 2.3.0-1
 -   Updated to 2.3.0-1
+
 *   Tue Apr 28 2015 Fabio Rapposelli <fabio@vmware.com> 2.2.1-2
 -   Added SSL support
+
 *   Mon Apr 6 2015 Mahmoud Bassiouny <mbassiouny@vmware.com> 2.2.1-1
 -   Version upgrade to 2.2.1
+
 *   Fri Oct 10 2014 Divya Thaluru <dthaluru@vmware.com> 2.1.3-1
 -   Initial build.  First version

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -60,7 +60,7 @@ device-mapper-libs-2.03.05-6.cm1.aarch64.rpm
 diffutils-3.6-4.cm1.aarch64.rpm
 diffutils-debuginfo-3.6-4.cm1.aarch64.rpm
 docbook-dtd-xml-4.5-11.cm1.noarch.rpm
-docbook-style-xsl-1.79.1-12.cm1.noarch.rpm
+docbook-style-xsl-1.79.1-13.cm1.noarch.rpm
 dwz-0.13-4.cm1.aarch64.rpm
 dwz-debuginfo-0.13-4.cm1.aarch64.rpm
 e2fsprogs-1.44.6-3.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -60,7 +60,7 @@ device-mapper-libs-2.03.05-6.cm1.x86_64.rpm
 diffutils-3.6-4.cm1.x86_64.rpm
 diffutils-debuginfo-3.6-4.cm1.x86_64.rpm
 docbook-dtd-xml-4.5-11.cm1.noarch.rpm
-docbook-style-xsl-1.79.1-12.cm1.noarch.rpm
+docbook-style-xsl-1.79.1-13.cm1.noarch.rpm
 dwz-0.13-4.cm1.x86_64.rpm
 dwz-debuginfo-0.13-4.cm1.x86_64.rpm
 e2fsprogs-1.44.6-3.cm1.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Add compatibility symlinks to select packages for broader compatibility and add additional provides to other packages which they satisfy.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Create compatibility symlinks for `guile*` binaries in the `guile` package.
- Create compatibility symlink from versioned stylesheets to the unversioned path `%{_datadir}/sgml/docbook/xsl-stylesheets` in the `docbook-style-xsl` package.
- Add missing runtime requirement on `docbook-dtd-xml` in the `docbook-style-xsl` package since the xsl stylesheets reference the DTD schema.
- Provide `keyutils-libs` and `keyutils-libs-devel` from `keyutils-devel`.
- Provide `ruby-devel` from the `ruby` package.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
**YES**

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local builds.