### PR TITLE
rust: Fix package test

### DIFF
--- a/SPECS/rust/ignore-linker-output-non-utf8-test.patch
+++ b/SPECS/rust/ignore-linker-output-non-utf8-test.patch
@@ -1,0 +1,76 @@
+From 000fe63b6fc57b09828930cacbab20c2ee6e6d15 Mon Sep 17 00:00:00 2001
+From: Mark Rousskov <mark.simulacrum@gmail.com>
+Date: Fri, 11 Oct 2019 17:41:55 -0400
+Subject: [PATCH] Remove painful test that is not pulling its weight
+
+Research suggests that we are not properly testing this case anyway, and
+even if we were, it is unlikely that we will regress here -- or, perhaps
+more accurately, if we do, I am uncertain that we care too much. It
+definitely seems like an edge case, and one that is particularly
+unlikely to occur as time goes on.
+---
+ .../linker-output-non-utf8/Makefile           | 23 -------------------
+ .../linker-output-non-utf8/exec.rs            |  6 -----
+ .../linker-output-non-utf8/library.rs         | 10 --------
+ 3 files changed, 39 deletions(-)
+ delete mode 100644 src/test/run-make-fulldeps/linker-output-non-utf8/Makefile
+ delete mode 100644 src/test/run-make-fulldeps/linker-output-non-utf8/exec.rs
+ delete mode 100644 src/test/run-make-fulldeps/linker-output-non-utf8/library.rs
+
+diff --git a/src/test/run-make-fulldeps/linker-output-non-utf8/Makefile b/src/test/run-make-fulldeps/linker-output-non-utf8/Makefile
+deleted file mode 100644
+index b47ce17ec8baa..0000000000000
+--- a/src/test/run-make-fulldeps/linker-output-non-utf8/Makefile
++++ /dev/null
+@@ -1,23 +0,0 @@
+--include ../tools.mk
+-
+-# Make sure we don't ICE if the linker prints a non-UTF-8 error message.
+-
+-# ignore-windows
+-#
+-# This does not work in its current form on windows, possibly due to
+-# gcc bugs or something about valid Windows paths.  See issue #29151
+-# for more information.
+-
+-# ignore-macos
+-#
+-# This also does not work on Apple APFS due to the filesystem requiring
+-# valid UTF-8 paths.
+-
+-# The zzz it to allow humans to tab complete or glob this thing.
+-bad_dir := $(TMPDIR)/zzz$$'\xff'
+-
+-all:
+-	$(RUSTC) library.rs
+-	mkdir $(bad_dir)
+-	mv $(TMPDIR)/liblibrary.a $(bad_dir)
+-	$(RUSTC) -L $(bad_dir) exec.rs 2>&1 | $(CGREP) this_symbol_not_defined
+diff --git a/src/test/run-make-fulldeps/linker-output-non-utf8/exec.rs b/src/test/run-make-fulldeps/linker-output-non-utf8/exec.rs
+deleted file mode 100644
+index 6864018d64e97..0000000000000
+--- a/src/test/run-make-fulldeps/linker-output-non-utf8/exec.rs
++++ /dev/null
+@@ -1,6 +0,0 @@
+-#[link(name="library")]
+-extern "C" {
+-    fn foo();
+-}
+-
+-fn main() { unsafe { foo(); } }
+diff --git a/src/test/run-make-fulldeps/linker-output-non-utf8/library.rs b/src/test/run-make-fulldeps/linker-output-non-utf8/library.rs
+deleted file mode 100644
+index 6689a82fa2c49..0000000000000
+--- a/src/test/run-make-fulldeps/linker-output-non-utf8/library.rs
++++ /dev/null
+@@ -1,10 +0,0 @@
+-#![crate_type = "staticlib"]
+-
+-extern "C" {
+-    fn this_symbol_not_defined();
+-}
+-
+-#[no_mangle]
+-pub extern "C" fn foo() {
+-    unsafe { this_symbol_not_defined(); }
+-}

--- a/SPECS/rust/rust.spec
+++ b/SPECS/rust/rust.spec
@@ -3,10 +3,10 @@ Name:           rust
 Version:        1.39.0
 Release:        8%{?dist}
 License:        ASL 2.0 and MIT
-URL:            https://www.rust-lang.org/
-Group:          Applications/System
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
+Group:          Applications/System
+URL:            https://www.rust-lang.org/
 Source0:        https://static.rust-lang.org/dist/rustc-%{version}-src.tar.xz
 Source1:        %{name}-%{version}-cargo.tar.gz
 Source2:        https://static.rust-lang.org/dist/2019-09-26/cargo-0.39.0-x86_64-unknown-linux-gnu.tar.gz
@@ -19,15 +19,16 @@ Source7:        https://static.rust-lang.org/dist/2019-09-26/rust-std-1.38.0-aar
 Patch0:         robust-build.patch
 Patch1:         ignore-linker-output-non-utf8-test.patch
 
-BuildRequires:  git
-BuildRequires:  cmake
-BuildRequires:  glibc
 BuildRequires:  binutils
+BuildRequires:  cmake
+BuildRequires:  curl-devel
+BuildRequires:  git
+BuildRequires:  glibc
 BuildRequires:  python2
 %if %{with_check}
 BuildRequires:  python-xml
 %endif
-BuildRequires:  curl-devel
+
 
 %description
 Rust Programming Language
@@ -112,23 +113,33 @@ rm %{buildroot}%{_docdir}/%{name}/*.old
 %changelog
 * Tue Dec 22 2020 Thomas Crain <thcrain@microsoft.com> - 1.39.0-8
 - Add python-xml BR for package test
-*   Wed Aug 12 2020 Mateusz Malisz <mamalisz@microsoft.com> 1.39.0-7
--   Add patch for the build to not fail on file not found error.
-*   Fri Jun 12 2020 Henry Beberman <henry.beberman@microsoft.com> 1.39.0-6
--   Temporarily disable generation of debug symbols.
-*   Thu May 28 2020 Chris Co <chrco@microsoft.com> - 1.39.0-5
--   Update source checkout and prep steps
-*   Sat May 09 00:20:39 PST 2020 Nick Samson <nisamson@microsoft.com> - 1.39.0-4
--   Added %%license line automatically
-*   Mon May 4 2020 Nicolas Guibourge <nicolasg@microsoft.com> 1.39.0-3
--   Fix build issue when building from Docker
-*   Tue Apr 21 2020 Andrew Phelps <anphel@microsoft.com> 1.39.0-2
--   Support building offline.
-*   Thu Mar 19 2020 Henry Beberman <henry.beberman@microsoft.com> 1.39.0-1
--   Update to 1.39.0. Fix URL. Fix Source0 URL. License verified.
-*   Thu Feb 27 2020 Henry Beberman <hebeberm@microsoft.com> 1.34.2-3
--   Set SUDO_USER and USER to allow rust to hydrate as root
-*   Wed Sep 25 2019 Saravanan Somasundaram <sarsoma@microsoft.com> 1.34.2-2
--   Initial CBL-Mariner import from Photon (license: Apache2)
-*   Wed May 15 2019 Ankit Jain <ankitja@vmware.com> 1.34.2-1
--   Initial build. First version
+
+* Wed Aug 12 2020 Mateusz Malisz <mamalisz@microsoft.com> - 1.39.0-7
+- Add patch for the build to not fail on file not found error.
+
+* Fri Jun 12 2020 Henry Beberman <henry.beberman@microsoft.com> - 1.39.0-6
+- Temporarily disable generation of debug symbols.
+
+* Thu May 28 2020 Chris Co <chrco@microsoft.com> - 1.39.0-5
+- Update source checkout and prep steps
+
+* Sat May 09 00:20:39 PST 2020 Nick Samson <nisamson@microsoft.com> - 1.39.0-4
+- Added %%license line automatically
+
+* Mon May 4 2020 Nicolas Guibourge <nicolasg@microsoft.com> - 1.39.0-3
+- Fix build issue when building from Docker
+
+* Tue Apr 21 2020 Andrew Phelps <anphel@microsoft.com> - 1.39.0-2
+- Support building offline.
+
+* Thu Mar 19 2020 Henry Beberman <henry.beberman@microsoft.com> - 1.39.0-1
+- Update to 1.39.0. Fix URL. Fix Source0 URL. License verified.
+
+* Thu Feb 27 2020 Henry Beberman <hebeberm@microsoft.com> - 1.34.2-3
+- Set SUDO_USER and USER to allow rust to hydrate as root
+
+* Wed Sep 25 2019 Saravanan Somasundaram <sarsoma@microsoft.com> - 1.34.2-2
+- Initial CBL-Mariner import from Photon (license: Apache2)
+
+* Wed May 15 2019 Ankit Jain <ankitja@vmware.com> - 1.34.2-1
+- Initial build. First version

--- a/SPECS/rust/rust.spec
+++ b/SPECS/rust/rust.spec
@@ -111,7 +111,7 @@ rm %{buildroot}%{_docdir}/%{name}/*.old
 %{_sysconfdir}/bash_completion.d/cargo
 
 %changelog
-* Tue Dec 22 2020 Thomas Crain <thcrain@microsoft.com> - 1.39.0-8
+* Wed Jan 06 2021 Thomas Crain <thcrain@microsoft.com> - 1.39.0-8
 - Add python-xml BR for package test
 - Add ignore-linker-output-non-utf8-test patch to skip faulty test 
 

--- a/SPECS/rust/rust.spec
+++ b/SPECS/rust/rust.spec
@@ -17,6 +17,7 @@ Source6:        https://static.rust-lang.org/dist/2019-09-26/rustc-1.38.0-aarch6
 Source7:        https://static.rust-lang.org/dist/2019-09-26/rust-std-1.38.0-aarch64-unknown-linux-gnu.tar.gz
 
 Patch0:         robust-build.patch
+Patch1:         ignore-linker-output-non-utf8-test.patch
 
 BuildRequires:  git
 BuildRequires:  cmake
@@ -40,6 +41,7 @@ popd
 %setup -q -n rustc-%{version}-src
 
 %patch0 -p1
+%patch1 -p1
 
 # Setup build/cache directory
 %define BUILD_CACHE_DIR build/cache/2019-09-26/
@@ -68,6 +70,9 @@ export SUDO_USER=root
 make %{?_smp_mflags}
 
 %check
+# src/test/run-make-fulldeps/linker-output-non-utf8 fails, but given that it was removed in
+# rustc 1.40.0 for "not pulling its weight" and "not properly testing this case", we ignore it.
+# See ignore-linker-output-non-utf8-test.patch for more details.
 make check
 
 %install

--- a/SPECS/rust/rust.spec
+++ b/SPECS/rust/rust.spec
@@ -113,6 +113,7 @@ rm %{buildroot}%{_docdir}/%{name}/*.old
 %changelog
 * Tue Dec 22 2020 Thomas Crain <thcrain@microsoft.com> - 1.39.0-8
 - Add python-xml BR for package test
+- Add ignore-linker-output-non-utf8-test patch to skip faulty test 
 
 * Wed Aug 12 2020 Mateusz Malisz <mamalisz@microsoft.com> - 1.39.0-7
 - Add patch for the build to not fail on file not found error.

--- a/SPECS/rust/rust.spec
+++ b/SPECS/rust/rust.spec
@@ -113,7 +113,7 @@ rm %{buildroot}%{_docdir}/%{name}/*.old
 %changelog
 * Wed Jan 06 2021 Thomas Crain <thcrain@microsoft.com> - 1.39.0-8
 - Add python-xml BR for package test
-- Add ignore-linker-output-non-utf8-test patch to skip faulty test 
+- Add ignore-linker-output-non-utf8-test patch to skip faulty test
 
 * Wed Aug 12 2020 Mateusz Malisz <mamalisz@microsoft.com> - 1.39.0-7
 - Add patch for the build to not fail on file not found error.

--- a/SPECS/rust/rust.spec
+++ b/SPECS/rust/rust.spec
@@ -1,7 +1,7 @@
 Summary:        Rust Programming Language
 Name:           rust
 Version:        1.39.0
-Release:        7%{?dist}
+Release:        8%{?dist}
 License:        ASL 2.0 and MIT
 URL:            https://www.rust-lang.org/
 Group:          Applications/System
@@ -23,6 +23,9 @@ BuildRequires:  cmake
 BuildRequires:  glibc
 BuildRequires:  binutils
 BuildRequires:  python2
+%if %{with_check}
+BuildRequires:  python-xml
+%endif
 BuildRequires:  curl-devel
 
 %description
@@ -102,6 +105,8 @@ rm %{buildroot}%{_docdir}/%{name}/*.old
 %{_sysconfdir}/bash_completion.d/cargo
 
 %changelog
+* Tue Dec 22 2020 Thomas Crain <thcrain@microsoft.com> - 1.39.0-8
+- Add python-xml BR for package test
 *   Wed Aug 12 2020 Mateusz Malisz <mamalisz@microsoft.com> 1.39.0-7
 -   Add patch for the build to not fail on file not found error.
 *   Fri Jun 12 2020 Henry Beberman <henry.beberman@microsoft.com> 1.39.0-6


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Rust package tests were failing due to a missing BR and a bad test- this PR fixes both.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add conditional dependency for rust on python-xml when running package tests
- Removed a low signal-to-noise ratio test from Rust. This test was removed in version 1.40.0- more context can be found in rust-lang/rust#63520

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local build with RUN_CHECK=y
