### PR TITLE
Fix test for python-attrs, libmodulemd, skip dracut tests

### DIFF
--- a/SPECS/libmodulemd/libmodulemd.spec
+++ b/SPECS/libmodulemd/libmodulemd.spec
@@ -3,13 +3,15 @@
 Summary:        Module manipulating metadata files
 Name:           libmodulemd
 Version:        2.5.0
-Release:        4%{?dist}
+Release:        5%{?dist}
 License:        MIT
 URL:            https://github.com/fedora-modularity/libmodulemd
 Source0:        https://github.com/fedora-modularity/libmodulemd/releases/download/%{name}-%{version}/modulemd-%{version}.tar.xz
 Group:          Applications/System
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
+
+Patch1:         test_v1_import_headers_timeout.patch
 
 BuildRequires:  meson
 BuildRequires:  clang-devel
@@ -35,6 +37,7 @@ It contains the libraries and header files.
 
 %prep
 %setup -q -n modulemd-%{version}
+%patch1 -p1
 
 %build
 meson -Dprefix=%{_prefix} -Ddeveloper_build=false -Dbuild_api_v1=true -Dbuild_api_v2=false \
@@ -70,6 +73,8 @@ DESTDIR=%{buildroot}/ ninja install
 %{_includedir}/modulemd/*
 
 %changelog
+*   Tue Jan 05 2021 Andrew Phelps <anphel@microsoft.com> 2.5.0-5
+-   Improve test reliability by increasing timeout.
 *   Thu Nov 19 2020 Andrew Phelps <anphel@microsoft.com> 2.5.0-4
 -   Fix check test.
 *   Sat May 09 2020 Nick Samson <nisamson@microsoft.com> 2.5.0-3

--- a/SPECS/libmodulemd/test_v1_import_headers_timeout.patch
+++ b/SPECS/libmodulemd/test_v1_import_headers_timeout.patch
@@ -1,0 +1,12 @@
+--- a/modulemd/meson.build	2021-01-05 17:22:11.418212214 -0800
++++ b/modulemd/meson.build	2021-01-05 17:23:31.586567370 -0800
+@@ -299,7 +299,8 @@
+     import_header_script = find_program('common/tests/test-import-headers.sh')
+     test ('test_v1_import_headers', import_header_script,
+           env : test_env,
+-          args : modulemd_v1_hdrs)
++          args : modulemd_v1_hdrs,
++          timeout : 600)
+ endif
+ 
+ if build_api_v2

--- a/SPECS/python-attrs/python-attrs.spec
+++ b/SPECS/python-attrs/python-attrs.spec
@@ -4,7 +4,7 @@
 Summary:        Attributes without boilerplate.
 Name:           python-attrs
 Version:        18.2.0
-Release:        6%{?dist}
+Release:        7%{?dist}
 Url:            https://pypi.python.org/pypi/attrs
 License:        MIT
 Group:          Development/Languages/Python
@@ -28,6 +28,7 @@ BuildRequires:  python3-xml
 BuildRequires:  curl-devel
 BuildRequires:  openssl-devel
 BuildRequires:  python3-zope-interface
+BuildRequires:  python3-pip
 %endif
 Requires:       python2
 Requires:       python2-libs
@@ -63,10 +64,9 @@ python3 setup.py install --prefix=%{_prefix} --root=%{buildroot}
 popd
 
 %check
-#python2 does not support for tests
-easy_install_3=$(ls /usr/bin |grep easy_install |grep 3)
-$easy_install_3 pytest hypothesis
-python3 setup.py test
+# Tests are only supported with Python3
+pip3 install pytest hypothesis==4.38.0 tox
+LANG=en_US.UTF-8 tox -e py37
 
 %files
 %defattr(-,root,root)
@@ -78,6 +78,8 @@ python3 setup.py test
 %{python3_sitelib}/*
 
 %changelog
+*   Tue Jan 05 2021 Andrew Phelps <anphel@microsoft.com> 18.2.0-7
+-   Use tox to run tests.
 *   Wed Jul 08 2020 Henry Beberman <henry.beberman@microsoft.com> 18.2.0-6
 -   Fix typo in BuildRequires for python3-zope-interface
 *   Sat May 09 00:20:45 PST 2020 Nick Samson <nisamson@microsoft.com> 18.2.0-5

--- a/toolkit/resources/manifests/package/macros.override
+++ b/toolkit/resources/manifests/package/macros.override
@@ -27,6 +27,9 @@
 # JNA requires X11 dependencies which are only available in toolchain build environment
 %skip_check_jna 1
 
+# We are missing many of the dependency packages for the Dracut tests
+%skip_check_dracut 1
+
 # Still fails package build when it fails
 %skip_check_gcc 1
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Fix python-attrs test. Improve reliability of libmodulemd test by increasing timeout. Skip dracut tests which are expected to fail due to missing dependencies

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Fix python-attrs check test
- Add patch to increase timeout in libmodulemd
- Skip dracut in macros.override

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
YES
**NO**

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local package build
