### PR TITLE
Kubernetes: nopatch CVE-2020-8563, fix tests issue when built against golang 1.15 (k8s 1.17 and 1.18)

### DIFF
--- a/SPECS/kubernetes/golang-1.15-k8s-1.17-test.patch
+++ b/SPECS/kubernetes/golang-1.15-k8s-1.17-test.patch
@@ -1,0 +1,20 @@
+--- test.sh	2020-10-14 17:58:31.000000000 -0700
++++ test-golang-1.15.sh	2021-01-05 10:55:19.515412980 -0800
+@@ -267,6 +267,17 @@
+ 
+   verifyPathsToPackagesUnderTest "$@"
+ 
++  # vet tool which is by default invoked by 'go test' command will fail 
++  # because of a verification that is specific to golang 1.15 (stringintconv)
++  # => exclude that verification from the vet check list (see golang doc for more)
++  #
++  # this version of kubernetes was initially built against golang 1.13 which vet tool does not
++  # has the problematic check. CBL-Mariner moved to golang 1.15 and consequenlty build this version of kubernetes
++  # against golang 1.15
++  #
++  go_vet_tests=asmdecl,assign,atomic,bools,buildtag,cgocall,composites,copylocks,errorsas,httpresponse,ifaceassert,loopclosure,lostcancel,nilfunc,printf,shift,stdmethods,structtag,tests,unmarshal,unreachable,unsafeptr,unusedresult
++  goflags+=(-vet $go_vet_tests)
++
+   # If we're not collecting coverage, run all requested tests with one 'go test'
+   # command, which is much faster.
+   if [[ ! ${KUBE_COVER} =~ ^[yY]$ ]]; then

--- a/SPECS/kubernetes/golang-1.15-k8s-1.18-test.patch
+++ b/SPECS/kubernetes/golang-1.15-k8s-1.18-test.patch
@@ -1,0 +1,20 @@
+--- test.sh	2020-09-24 18:43:24.000000000 -0700
++++ test-golang-1.15.sh	2021-01-05 10:35:13.514802863 -0800
+@@ -243,6 +243,17 @@
+ 
+   verifyPathsToPackagesUnderTest "$@"
+ 
++  # vet tool which is by default invoked by 'go test' command will fail 
++  # because of a verification that is specific to golang 1.15 (stringintconv)
++  # => exclude that verification from the vet check list (see golang doc for more)
++  #
++  # this version of kubernetes was initially built against golang 1.13 which vet tool does not
++  # has the problematic check. CBL-Mariner moved to golang 1.15 and consequenlty build this version of kubernetes
++  # against golang 1.15
++  #
++  go_vet_tests=asmdecl,assign,atomic,bools,buildtag,cgocall,composites,copylocks,errorsas,httpresponse,ifaceassert,loopclosure,lostcancel,nilfunc,printf,shift,stdmethods,structtag,tests,unmarshal,unreachable,unsafeptr,unusedresult
++  goflags+=(-vet $go_vet_tests)
++
+   # If we're not collecting coverage, run all requested tests with one 'go test'
+   # command, which is much faster.
+   if [[ ! ${KUBE_COVER} =~ ^[yY]$ ]]; then

--- a/SPECS/kubernetes/kubernetes-1.17.11.signatures.json
+++ b/SPECS/kubernetes/kubernetes-1.17.11.signatures.json
@@ -1,5 +1,6 @@
 {
  "Signatures": {
+  "golang-1.15-k8s-1.17-test.patch": "4607a1675331e309f651737cd10114e2a610dcd0250ec06a46e4de7feb000161",
   "kubelet.service": "22ea9e0b85aa9db9e1accfb6c21843683425fc1af9c0a2669523e42a455dc57e",
   "kubernetes-node-linux-amd64-1.17.11-hotfix.20200901.tar.gz": "e901a01e6b626a9c621b63306a86959e0063ea0a4c36289317a4ece615355133"
  }

--- a/SPECS/kubernetes/kubernetes-1.17.11.spec
+++ b/SPECS/kubernetes/kubernetes-1.17.11.spec
@@ -23,6 +23,9 @@ Source2:        golang-1.15-k8s-1.17-test.patch
 Patch0:         CVE-2020-8564.nopatch
 Patch1:         CVE-2020-8565.nopatch
 Patch2:         CVE-2020-8566.nopatch
+# CVE-2020-8563 Only applies when using VSphere as cloud provider,
+#               Kubernetes doc on website recommend to not enable debug level logging in production (no patch available)
+Patch3:         CVE-2020-8563.nopatch
 BuildRequires:  flex-devel
 BuildRequires:  golang >= 1.13.15
 BuildRequires:  rsync
@@ -182,6 +185,7 @@ fi
 %changelog
 * Tue Jan 05 2021 Nicolas Guibourge <nicolasg@microsoft.com> - 1.17.11-6
 - Fix test issue when building against golang 1.15
+- CVE-2020-8563
 
 * Mon Jan 04 2021 Nicolas Guibourge <nicolasg@microsoft.com> - 1.17.11-5
 - CVE-2020-8564, CVE-2020-8565, CVE-2020-8566

--- a/SPECS/kubernetes/kubernetes-1.17.11.spec
+++ b/SPECS/kubernetes/kubernetes-1.17.11.spec
@@ -8,7 +8,7 @@
 Summary:        Microsoft Kubernetes
 Name:           kubernetes
 Version:        1.17.11
-Release:        5%{?dist}
+Release:        6%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -18,15 +18,16 @@ URL:            https://mcr.microsoft.com/oss
 #               Note that only amd64 tarball exist which is OK since kubernetes is built from source
 Source0:        kubernetes-node-linux-amd64-%{version}-hotfix.20200901.tar.gz
 Source1:        kubelet.service
+Source2:        golang-1.15-k8s-1.17-test.patch
 # CVE-2020-8564, CVE-2020-8565, CVE-2020-8566 Kubernetes doc on website recommend to not enable debug level logging in production (no patch available)
 Patch0:         CVE-2020-8564.nopatch
 Patch1:         CVE-2020-8565.nopatch
 Patch2:         CVE-2020-8566.nopatch
+BuildRequires:  flex-devel
 BuildRequires:  golang >= 1.13.15
 BuildRequires:  rsync
-BuildRequires:  which
-BuildRequires:  flex-devel
 BuildRequires:  systemd-devel
+BuildRequires:  which
 Requires:       cni
 Requires:       cri-tools
 Requires:       ebtables
@@ -80,13 +81,17 @@ for component in ${components_to_build}; do
 done
 
 %check
-cd %{_builddir}/%{name}/src
-components_to_test=$(ls -1 %{_builddir}/%{name}/node/bin)
+# patch test script so it supports golang 1.15 which is now used to build kubernetes
+cd %{_builddir}/%{name}/src/hack/make-rules
+patch -p1 test.sh < %{SOURCE2}
 
 # perform unit tests
 # Note:
 #   - components are not unit tested the same way
 #   - not all components have unit
+cd %{_builddir}/%{name}/src
+components_to_test=$(ls -1 %{_builddir}/%{name}/node/bin)
+
 for component in ${components_to_test}; do
   if [[ ${component} == "kubelet" || ${component} == "kubectl" ]]; then
     echo "+++ unit test pkg ${component}"
@@ -175,6 +180,9 @@ fi
 %{_bindir}/kubeadm
 
 %changelog
+* Tue Jan 05 2021 Nicolas Guibourge <nicolasg@microsoft.com> - 1.17.11-6
+- Fix test issue when building against golang 1.15
+
 * Mon Jan 04 2021 Nicolas Guibourge <nicolasg@microsoft.com> - 1.17.11-5
 - CVE-2020-8564, CVE-2020-8565, CVE-2020-8566
 

--- a/SPECS/kubernetes/kubernetes-1.17.13.signatures.json
+++ b/SPECS/kubernetes/kubernetes-1.17.13.signatures.json
@@ -1,5 +1,6 @@
 {
  "Signatures": {
+  "golang-1.15-k8s-1.17-test.patch": "4607a1675331e309f651737cd10114e2a610dcd0250ec06a46e4de7feb000161",
   "kubelet.service": "22ea9e0b85aa9db9e1accfb6c21843683425fc1af9c0a2669523e42a455dc57e",
   "kubernetes-node-linux-amd64-1.17.13.tar.gz": "ce4f8cb33e47423b1e70be248cb2b1c2edafbc338db9feb72c27f245f060ac5a"
  }

--- a/SPECS/kubernetes/kubernetes-1.17.13.spec
+++ b/SPECS/kubernetes/kubernetes-1.17.13.spec
@@ -8,7 +8,7 @@
 Summary:        Microsoft Kubernetes
 Name:           kubernetes
 Version:        1.17.13
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -18,13 +18,14 @@ URL:            https://mcr.microsoft.com/oss
 #               Note that only amd64 tarball exist which is OK since kubernetes is built from source
 Source0:        kubernetes-node-linux-amd64-%{version}.tar.gz
 Source1:        kubelet.service
+Source2:        golang-1.15-k8s-1.17-test.patch
 # CVE-2020-8565 Kubernetes doc on website recommend to not enable debug level logging in production (no patch available)
 Patch0:         CVE-2020-8565.nopatch
+BuildRequires:  flex-devel
 BuildRequires:  golang >= 1.13.15
 BuildRequires:  rsync
-BuildRequires:  which
-BuildRequires:  flex-devel
 BuildRequires:  systemd-devel
+BuildRequires:  which
 Requires:       cni
 Requires:       cri-tools
 Requires:       ebtables
@@ -78,13 +79,17 @@ for component in ${components_to_build}; do
 done
 
 %check
-cd %{_builddir}/%{name}/src
-components_to_test=$(ls -1 %{_builddir}/%{name}/node/bin)
+# patch test script so it supports golang 1.15 which is now used to build kubernetes
+cd %{_builddir}/%{name}/src/hack/make-rules
+patch -p1 test.sh < %{SOURCE2}
 
 # perform unit tests
 # Note:
 #   - components are not unit tested the same way
 #   - not all components have unit
+cd %{_builddir}/%{name}/src
+components_to_test=$(ls -1 %{_builddir}/%{name}/node/bin)
+
 for component in ${components_to_test}; do
   if [[ ${component} == "kubelet" || ${component} == "kubectl" ]]; then
     echo "+++ unit test pkg ${component}"
@@ -173,6 +178,9 @@ fi
 %{_bindir}/kubeadm
 
 %changelog
+* Tue Jan 05 2021 Nicolas Guibourge <nicolasg@microsoft.com> - 1.17.13-3
+- Fix test issue when building against golang 1.15
+
 * Mon Jan 04 2021 Nicolas Guibourge <nicolasg@microsoft.com> - 1.17.13-2
 - CVE-2020-8565
 

--- a/SPECS/kubernetes/kubernetes-1.17.13.spec
+++ b/SPECS/kubernetes/kubernetes-1.17.13.spec
@@ -21,6 +21,9 @@ Source1:        kubelet.service
 Source2:        golang-1.15-k8s-1.17-test.patch
 # CVE-2020-8565 Kubernetes doc on website recommend to not enable debug level logging in production (no patch available)
 Patch0:         CVE-2020-8565.nopatch
+# CVE-2020-8563 Only applies when using VSphere as cloud provider,
+#               Kubernetes doc on website recommend to not enable debug level logging in production (no patch available)
+Patch1:         CVE-2020-8563.nopatch
 BuildRequires:  flex-devel
 BuildRequires:  golang >= 1.13.15
 BuildRequires:  rsync
@@ -180,6 +183,7 @@ fi
 %changelog
 * Tue Jan 05 2021 Nicolas Guibourge <nicolasg@microsoft.com> - 1.17.13-3
 - Fix test issue when building against golang 1.15
+- CVE-2020-8563
 
 * Mon Jan 04 2021 Nicolas Guibourge <nicolasg@microsoft.com> - 1.17.13-2
 - CVE-2020-8565

--- a/SPECS/kubernetes/kubernetes-1.18.10.signatures.json
+++ b/SPECS/kubernetes/kubernetes-1.18.10.signatures.json
@@ -1,5 +1,6 @@
 {
  "Signatures": {
+  "golang-1.15-k8s-1.18-test.patch": "043a5ae433066335578701d29544c81669ffaa19fa14d987a82fd8b5a3acdd88",
   "kubelet.service": "22ea9e0b85aa9db9e1accfb6c21843683425fc1af9c0a2669523e42a455dc57e",
   "kubernetes-node-linux-amd64-1.18.10.tar.gz": "85078d8322f3641606569ea77d045fc789f8663c8b83fe21aeee600492974d6c"
  }

--- a/SPECS/kubernetes/kubernetes-1.18.10.spec
+++ b/SPECS/kubernetes/kubernetes-1.18.10.spec
@@ -8,7 +8,7 @@
 Summary:        Microsoft Kubernetes
 Name:           kubernetes
 Version:        1.18.10
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -18,13 +18,14 @@ URL:            https://mcr.microsoft.com/oss
 #               Note that only amd64 tarball exist which is OK since kubernetes is built from source
 Source0:        kubernetes-node-linux-amd64-%{version}.tar.gz
 Source1:        kubelet.service
+Source2:        golang-1.15-k8s-1.18-test.patch
 # CVE-2020-8565 Kubernetes doc on website recommend to not enable debug level logging in production (no patch available)
 Patch0:         CVE-2020-8565.nopatch
+BuildRequires:  flex-devel
 BuildRequires:  golang >= 1.13.15
 BuildRequires:  rsync
-BuildRequires:  which
-BuildRequires:  flex-devel
 BuildRequires:  systemd-devel
+BuildRequires:  which
 Requires:       cni
 Requires:       cri-tools
 Requires:       ebtables
@@ -78,13 +79,17 @@ for component in ${components_to_build}; do
 done
 
 %check
-cd %{_builddir}/%{name}/src
-components_to_test=$(ls -1 %{_builddir}/%{name}/node/bin)
+# patch test script so it supports golang 1.15 which is now used to build kubernetes
+cd %{_builddir}/%{name}/src/hack/make-rules
+patch -p1 test.sh < %{SOURCE2}
 
 # perform unit tests
 # Note:
 #   - components are not unit tested the same way
 #   - not all components have unit
+cd %{_builddir}/%{name}/src
+components_to_test=$(ls -1 %{_builddir}/%{name}/node/bin)
+
 for component in ${components_to_test}; do
   if [[ ${component} == "kubelet" || ${component} == "kubectl" ]]; then
     echo "+++ unit test pkg ${component}"
@@ -173,8 +178,11 @@ fi
 %{_bindir}/kubeadm
 
 %changelog
-* Mon Jan 04 2021 Nicolas Guibourge <nicolasg@microsoft.com> - 1.18.10-2
+* Mon Jan 04 2021 Nicolas Guibourge <nicolasg@microsoft.com> - 1.18.10-3
 - CVE-2020-8565
+
+* Tue Jan 05 2021 Nicolas Guibourge <nicolasg@microsoft.com> - 1.18.10-2
+- Fix test issue when building against golang 1.15
 
 * Thu Dec 17 2020 Nicolas Guibourge <nicolasg@microsoft.com> - 1.18.10-1
 - Initial version of K8s 1.18.10.

--- a/SPECS/kubernetes/kubernetes-1.18.10.spec
+++ b/SPECS/kubernetes/kubernetes-1.18.10.spec
@@ -21,6 +21,9 @@ Source1:        kubelet.service
 Source2:        golang-1.15-k8s-1.18-test.patch
 # CVE-2020-8565 Kubernetes doc on website recommend to not enable debug level logging in production (no patch available)
 Patch0:         CVE-2020-8565.nopatch
+# CVE-2020-8563 Only applies when using VSphere as cloud provider,
+#               Kubernetes doc on website recommend to not enable debug level logging in production (no patch available)
+Patch1:         CVE-2020-8563.nopatch
 BuildRequires:  flex-devel
 BuildRequires:  golang >= 1.13.15
 BuildRequires:  rsync
@@ -178,11 +181,12 @@ fi
 %{_bindir}/kubeadm
 
 %changelog
-* Mon Jan 04 2021 Nicolas Guibourge <nicolasg@microsoft.com> - 1.18.10-3
-- CVE-2020-8565
-
-* Tue Jan 05 2021 Nicolas Guibourge <nicolasg@microsoft.com> - 1.18.10-2
+* Tue Jan 05 2021 Nicolas Guibourge <nicolasg@microsoft.com> - 1.18.10-3
 - Fix test issue when building against golang 1.15
+- CVE-2020-8563
+
+* Mon Jan 04 2021 Nicolas Guibourge <nicolasg@microsoft.com> - 1.18.10-2
+- CVE-2020-8565
 
 * Thu Dec 17 2020 Nicolas Guibourge <nicolasg@microsoft.com> - 1.18.10-1
 - Initial version of K8s 1.18.10.

--- a/SPECS/kubernetes/kubernetes-1.18.8.signatures.json
+++ b/SPECS/kubernetes/kubernetes-1.18.8.signatures.json
@@ -1,5 +1,6 @@
 {
  "Signatures": {
+  "golang-1.15-k8s-1.18-test.patch": "043a5ae433066335578701d29544c81669ffaa19fa14d987a82fd8b5a3acdd88",
   "kubelet.service": "22ea9e0b85aa9db9e1accfb6c21843683425fc1af9c0a2669523e42a455dc57e",
   "kubernetes-node-linux-amd64-1.18.8-hotfix.20200924.tar.gz": "5512b523bba2dd4089115ec14ca40ecea9ce6c4052ccc74bc5eaa0c32c1a4a84"
  }

--- a/SPECS/kubernetes/kubernetes-1.18.8.spec
+++ b/SPECS/kubernetes/kubernetes-1.18.8.spec
@@ -23,6 +23,9 @@ Source2:        golang-1.15-k8s-1.18-test.patch
 Patch0:         CVE-2020-8564.nopatch
 Patch1:         CVE-2020-8565.nopatch
 Patch2:         CVE-2020-8566.nopatch
+# CVE-2020-8563 Only applies when using VSphere as cloud provider,
+#               Kubernetes doc on website recommend to not enable debug level logging in production (no patch available)
+Patch3:         CVE-2020-8563.nopatch
 BuildRequires:  flex-devel
 BuildRequires:  golang >= 1.13.15
 BuildRequires:  rsync
@@ -182,6 +185,7 @@ fi
 %changelog
 * Tue Jan 05 2021 Nicolas Guibourge <nicolasg@microsoft.com> - 1.18.8-7
 - Fix test issue when building against golang 1.15
+- CVE-2020-8563
 
 * Mon Jan 04 2021 Nicolas Guibourge <nicolasg@microsoft.com> - 1.18.8-6
 - CVE-2020-8564, CVE-2020-8565, CVE-2020-8566

--- a/SPECS/kubernetes/kubernetes-1.18.8.spec
+++ b/SPECS/kubernetes/kubernetes-1.18.8.spec
@@ -8,7 +8,7 @@
 Summary:        Microsoft Kubernetes
 Name:           kubernetes
 Version:        1.18.8
-Release:        6%{?dist}
+Release:        7%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -18,15 +18,16 @@ URL:            https://mcr.microsoft.com/oss
 #               Note that only amd64 tarball exist which is OK since kubernetes is built from source
 Source0:        kubernetes-node-linux-amd64-%{version}-hotfix.20200924.tar.gz
 Source1:        kubelet.service
+Source2:        golang-1.15-k8s-1.18-test.patch
 # CVE-2020-8564, CVE-2020-8565, CVE-2020-8566 Kubernetes doc on website recommend to not enable debug level logging in production (no patch available)
 Patch0:         CVE-2020-8564.nopatch
 Patch1:         CVE-2020-8565.nopatch
 Patch2:         CVE-2020-8566.nopatch
+BuildRequires:  flex-devel
 BuildRequires:  golang >= 1.13.15
 BuildRequires:  rsync
-BuildRequires:  which
-BuildRequires:  flex-devel
 BuildRequires:  systemd-devel
+BuildRequires:  which
 Requires:       cni
 Requires:       cri-tools
 Requires:       ebtables
@@ -80,13 +81,17 @@ for component in ${components_to_build}; do
 done
 
 %check
-cd %{_builddir}/%{name}/src
-components_to_test=$(ls -1 %{_builddir}/%{name}/node/bin)
+# patch test script so it supports golang 1.15 which is now used to build kubernetes
+cd %{_builddir}/%{name}/src/hack/make-rules
+patch -p1 test.sh < %{SOURCE2}
 
 # perform unit tests
 # Note:
 #   - components are not unit tested the same way
 #   - not all components have unit
+cd %{_builddir}/%{name}/src
+components_to_test=$(ls -1 %{_builddir}/%{name}/node/bin)
+
 for component in ${components_to_test}; do
   if [[ ${component} == "kubelet" || ${component} == "kubectl" ]]; then
     echo "+++ unit test pkg ${component}"
@@ -175,6 +180,9 @@ fi
 %{_bindir}/kubeadm
 
 %changelog
+* Tue Jan 05 2021 Nicolas Guibourge <nicolasg@microsoft.com> - 1.18.8-7
+- Fix test issue when building against golang 1.15
+
 * Mon Jan 04 2021 Nicolas Guibourge <nicolasg@microsoft.com> - 1.18.8-6
 - CVE-2020-8564, CVE-2020-8565, CVE-2020-8566
 

--- a/SPECS/kubernetes/kubernetes-1.19.1.spec
+++ b/SPECS/kubernetes/kubernetes-1.19.1.spec
@@ -8,7 +8,7 @@
 Summary:        Microsoft Kubernetes
 Name:           kubernetes
 Version:        1.19.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -22,11 +22,14 @@ Source1:        kubelet.service
 Patch0:         CVE-2020-8564.nopatch
 Patch1:         CVE-2020-8565.nopatch
 Patch2:         CVE-2020-8566.nopatch
+# CVE-2020-8563 Only applies when using VSphere as cloud provider,
+#               Kubernetes doc on website recommend to not enable debug level logging in production (no patch available)
+Patch3:         CVE-2020-8563.nopatch
+BuildRequires:  flex-devel
 BuildRequires:  golang >= 1.15.5
 BuildRequires:  rsync
-BuildRequires:  which
-BuildRequires:  flex-devel
 BuildRequires:  systemd-devel
+BuildRequires:  which
 Requires:       cni
 Requires:       cri-tools
 Requires:       ebtables
@@ -175,6 +178,9 @@ fi
 %{_bindir}/kubeadm
 
 %changelog
+* Tue Jan 05 2021 Nicolas Guibourge <nicolasg@microsoft.com> - 1.19.1-4
+- CVE-2020-8563
+
 * Mon Jan 04 2021 Nicolas Guibourge <nicolasg@microsoft.com> - 1.19.1-3
 - CVE-2020-8564, CVE-2020-8565, CVE-2020-8566
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
nopatch for CVE-2020-8563
fix %check failure when k8s 1.17 or 1.18 are built against golang 1.15

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
spec files, k8s patch file and CVE nopatch file

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2020-8563
