### PR TITLE
Fix check test for strace

### DIFF
--- a/SPECS/strace/gen_tests_fixes.patch
+++ b/SPECS/strace/gen_tests_fixes.patch
@@ -1,0 +1,24 @@
+diff -u a/tests/gen_tests.in b/tests/gen_tests.in
+--- a/tests/gen_tests.in	2021-01-06 12:33:00.135456397 -0800
++++ b/tests/gen_tests.in	2021-01-06 12:34:32.351368901 -0800
+@@ -160,16 +160,16 @@
+ ipc_msg-Xraw	+ipc.sh -Xraw -a16
+ ipc_msg-Xverbose	+ipc.sh -Xverbose -a34
+ ipc_msgbuf-Xabbrev	+ipc_msgbuf.test -Xabbrev
+-ipc_msgbuf-Xraw	+ipc_msgbuf.test -Xraw -a22
++ipc_msgbuf-Xraw	+ipc_msgbuf.test -Xraw -a19
+ ipc_msgbuf-Xverbose	+ipc_msgbuf.test -Xverbose
+ ipc_sem	+ipc.sh -a29
+ ipc_sem-Xabbrev	+ipc.sh -Xabbrev -a29
+ ipc_sem-Xraw	+ipc.sh -Xraw -a19
+ ipc_sem-Xverbose	+ipc.sh -Xverbose -a36
+-ipc_shm	+ipc.sh -a29
+-ipc_shm-Xabbrev	+ipc.sh -Xabbrev -a29
++ipc_shm	+ipc.sh -a26
++ipc_shm-Xabbrev	+ipc.sh -Xabbrev -a26
+ ipc_shm-Xraw	+ipc.sh -Xraw -a19
+-ipc_shm-Xverbose	+ipc.sh -Xverbose -a36
++ipc_shm-Xverbose	+ipc.sh -Xverbose -a34
+ kcmp	-a22
+ kcmp-y	-a22 -y -e trace=kcmp
+ kern_features -a16

--- a/SPECS/strace/strace.spec
+++ b/SPECS/strace/strace.spec
@@ -1,14 +1,18 @@
-Summary:	Tracks system calls that are made by a running process
-Name:		strace
-Version:    5.1
-Release:    2%{?dist}
-License:    LGPL-2.1+ and GPL-2.0+
-URL:		https://strace.io/
-Group:		Development/Debuggers
+Summary:        Tracks system calls that are made by a running process
+Name:           strace
+Version:        5.1
+Release:        3%{?dist}
+License:        LGPL-2.1+ and GPL-2.0+
+URL:            https://strace.io/
+Group:          Development/Debuggers
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
-Source0:	https://strace.io/files/%{version}/%{name}-%{version}.tar.xz
-BuildRequires:	libacl-devel, libaio-devel
+Source0:        https://strace.io/files/%{version}/%{name}-%{version}.tar.xz
+Patch1:         gen_tests_fixes.patch
+
+BuildRequires:  libacl-devel
+BuildRequires:  libaio-devel
+
 %global __requires_exclude ^/usr/bin/perl$
 
 %description
@@ -17,15 +21,16 @@ all the arugments and return values from the system calls. This is useful in deb
 
 %prep
 %setup -q
+%patch1 -p1
 
 %build
 %ifarch aarch64
 %configure \
-	--disable-mpers \
-	--prefix=%{_prefix}
+    --disable-mpers \
+    --prefix=%{_prefix}
 %else
 %configure \
-	--prefix=%{_prefix}
+    --prefix=%{_prefix}
 %endif
 
 # to resolve build issue with glibc-2.26
@@ -39,7 +44,7 @@ make %{?_smp_mflags}
 make install DESTDIR=%{buildroot}
 
 %check
-make -k check
+make %{?_smp_mflags} -k check TIMEOUT_DURATION=1200
 
 %clean
 rm -rf %{buildroot}/*
@@ -51,9 +56,10 @@ rm -rf %{buildroot}/*
 %{_mandir}/man1/*
 
 %changelog
-* Sat May 09 00:21:09 PST 2020 Nick Samson <nisamson@microsoft.com> - 5.1-2
-- Added %%license line automatically
-
+*   Wed Jan 06 2021 Andrew Phelps <anphel@microsoft.com> 5.1-3
+-   Patch tests with expected results. Increase test timeout.
+*   Sat May 09 2020 Nick Samson <nisamson@microsoft.com> 5.1-2
+-   Added %%license line automatically
 *   Wed Mar 18 2020 Henry Beberman <henry.beberman@microsoft.com> 5.1-1
 -   Update to 5.1. License fixed.
 *   Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 4.25-2


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Fix broken strace tests by patching expected results from upstream. The proper values come from the upstream source repo from these two commits.
https://github.com/strace/strace/commit/4377e3a1535a0ec3a42da8a1366ad6943f4efa0e
https://github.com/strace/strace/commit/a75c7c4bcb6b48680275de3e99e17e0ebec811ec

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Patch strace test file

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
YES
**NO**

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local package with with RUN_TESTS=y
