### PR TITLE
Clarifying repository search order.

### DIFF
--- a/toolkit/docs/building/building.md
+++ b/toolkit/docs/building/building.md
@@ -1,4 +1,6 @@
 # Building
+
+- [Building](#building)
 - [Overview](#overview)
 - [Building in Stages](#building-in-stages)
    - [Install Prerequisites](#install-prerequisites)
@@ -292,9 +294,18 @@ While `tdnf` uses a list of repo files:
 REPO_LIST ?=
 ```
 
-The `REPO_LIST` variable supports multiple repo files, and they are prioritized in the order they appear in the list.
+The `REPO_LIST` variable supports multiple, space-separated repo files, and they are prioritized in the order they appear in the list.
 The CBL-Mariner base and update repos are implicitly provided and an optional preview repo is available by setting `USE_PREVIEW_REPO=y`.
 To disable the update repo set `USE_UPDATE_REPO=n`. If `DISABLE_UPSTREAM_REPOS=y` is set, any repo that is accessed through the network is disabled.
+
+The tooling will use the first package it can find by looking through the repositories in the following order:
+
+1. the worker chroot environment;
+2. already built local RPMs in `out/RPMS/`;
+3. the core CBL-Mariner upstream **preview** repository if `USE_PREVIEW_REPO` is set to `y`;
+4. the core CBL-Mariner upstream **update** repository if `USE_UPDATE_REPO` is **not** set to `n`;
+5. the core CBL-Mariner upstream **base** repository;
+6. any remote repo in order listed by `REPO_LIST`.
 
 ### Authentication
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Extending the wiki to clarify the packages search order when using the `REPO_LIST` argument.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Added an ordered list of repositories searched by the tooling to find a package needed during build time.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
No.

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- N/A.
