### PR TITLE
Align kernel specs to have matching Version/Release tags

### DIFF
--- a/SPECS-SIGNED/kernel-signed-aarch64/kernel-signed-aarch64.spec
+++ b/SPECS-SIGNED/kernel-signed-aarch64/kernel-signed-aarch64.spec
@@ -2,7 +2,7 @@
 Summary:        Signed Linux Kernel for aarch64 systems
 Name:           kernel-signed-aarch64
 Version:        5.4.51
-Release:        11%{?dist}
+Release:        12%{?dist}
 License:        GPLv2
 URL:            https://github.com/microsoft/WSL2-Linux-Kernel
 Group:          System Environment/Kernel
@@ -85,6 +85,8 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %config %{_localstatedir}/lib/initramfs/kernel/%{uname_r}
 
 %changelog
+*   Mon Jan 11 2021 Thomas Crain <thcrain@microsoft.com> - 5.4.51-12
+-   Update release number to match kernel spec
 *   Fri Oct 16 2020 Suresh Babu Chalamalasetty <schalam@microsoft.com> 5.4.51-11
 -   Update release number
 *   Fri Oct 02 2020 Chris Co <chrco@microsoft.com> 5.4.51-10

--- a/SPECS-SIGNED/kernel-signed-x64/kernel-signed-x64.spec
+++ b/SPECS-SIGNED/kernel-signed-x64/kernel-signed-x64.spec
@@ -2,7 +2,7 @@
 Summary:        Signed Linux Kernel for x86_64 systems
 Name:           kernel-signed-x64
 Version:        5.4.51
-Release:        11%{?dist}
+Release:        12%{?dist}
 License:        GPLv2
 URL:            https://github.com/microsoft/WSL2-Linux-Kernel
 Group:          System Environment/Kernel
@@ -85,6 +85,8 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %config %{_localstatedir}/lib/initramfs/kernel/%{uname_r}
 
 %changelog
+*   Mon Jan 11 2021 Thomas Crain <thcrain@microsoft.com> - 5.4.51-12
+-   Update release number to match kernel spec
 *   Fri Oct 16 2020 Suresh Babu Chalamalasetty <schalam@microsoft.com> 5.4.51-11
 -   Update release number
 *   Fri Oct 02 2020 Chris Co <chrco@microsoft.com> 5.4.51-10

--- a/SPECS/kernel-headers/kernel-headers.spec
+++ b/SPECS/kernel-headers/kernel-headers.spec
@@ -1,7 +1,7 @@
 Summary:        Linux API header files
 Name:           kernel-headers
 Version:        5.4.51
-Release:        3%{?dist}
+Release:        12%{?dist}
 License:        GPLv2
 URL:            https://github.com/microsoft/WSL2-Linux-Kernel
 Group:          System Environment/Kernel
@@ -28,6 +28,8 @@ cp -rv usr/include/* /%{buildroot}%{_includedir}
 %defattr(-,root,root)
 %{_includedir}/*
 %changelog
+*   Mon Jan 11 2021 Thomas Crain <thcrain@microsoft.com> - 5.4.51-12
+-   Update Release tag to match that of the kernel package
 *   Mon Sep 28 2020 Ruying Chen <v-ruyche@microsoft.com> 5.4.51-3
 -   Add explicit provide for glibc-kernheaders
 *   Tue Sep 01 2020 Chris Co <chrco@microsoft.com> 5.4.51-2

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -1,5 +1,5 @@
 filesystem-1.1-8.cm1.aarch64.rpm
-kernel-headers-5.4.51-3.cm1.noarch.rpm
+kernel-headers-5.4.51-12.cm1.noarch.rpm
 glibc-2.28-14.cm1.aarch64.rpm
 glibc-devel-2.28-14.cm1.aarch64.rpm
 glibc-i18n-2.28-14.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -1,5 +1,5 @@
 filesystem-1.1-8.cm1.x86_64.rpm
-kernel-headers-5.4.51-3.cm1.noarch.rpm
+kernel-headers-5.4.51-12.cm1.noarch.rpm
 glibc-2.28-14.cm1.x86_64.rpm
 glibc-devel-2.28-14.cm1.x86_64.rpm
 glibc-i18n-2.28-14.cm1.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -151,7 +151,7 @@ json-c-debuginfo-0.14-2.cm1.aarch64.rpm
 json-c-devel-0.14-2.cm1.aarch64.rpm
 kbd-2.0.4-5.cm1.aarch64.rpm
 kbd-debuginfo-2.0.4-5.cm1.aarch64.rpm
-kernel-headers-5.4.51-3.cm1.noarch.rpm
+kernel-headers-5.4.51-12.cm1.noarch.rpm
 kmod-25-5.cm1.aarch64.rpm
 kmod-debuginfo-25-5.cm1.aarch64.rpm
 kmod-devel-25-5.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -151,7 +151,7 @@ json-c-debuginfo-0.14-2.cm1.x86_64.rpm
 json-c-devel-0.14-2.cm1.x86_64.rpm
 kbd-2.0.4-5.cm1.x86_64.rpm
 kbd-debuginfo-2.0.4-5.cm1.x86_64.rpm
-kernel-headers-5.4.51-3.cm1.noarch.rpm
+kernel-headers-5.4.51-12.cm1.noarch.rpm
 kmod-25-5.cm1.x86_64.rpm
 kmod-debuginfo-25-5.cm1.x86_64.rpm
 kmod-devel-25-5.cm1.x86_64.rpm


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
The signed kernel specs should match their unsigned counterparts in both version and release tags. They've been out of sync for the dev branch since roughly October. It may not be a necessary change, if the desync hasn't been noticed yet, but it keeps the entanglement check from being red... which is probably a net good.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- kernel-signed-aarch64, kernel-signed-x64, and kernel-headers bumped to 5.4.51-12, to match kernel.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
**YES**

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local build of SRPMs, since this is a low-risk change
