### PR TITLE
Patch e2fsprogs CVE-2019-5094, CVE-2019-5188

### DIFF
--- a/SPECS/e2fsprogs/CVE-2019-5188.patch
+++ b/SPECS/e2fsprogs/CVE-2019-5188.patch
@@ -1,0 +1,100 @@
+From 87de28fb02f853892bd77b5c84a1609afa0bab1f Mon Sep 17 00:00:00 2001
+From: Theodore Ts'o <tytso@mit.edu>
+Date: Thu, 19 Dec 2019 19:37:34 -0500
+Subject: [PATCH 1/2] e2fsck: abort if there is a corrupted directory block
+ when rehashing
+
+In e2fsck pass 3a, when we are rehashing directories, at least in
+theory, all of the directories should have had corruptions with
+respect to directory entry structure fixed.  However, it's possible
+(for example, if the user declined a fix) that we can reach this stage
+of processing with a corrupted directory entries.
+
+So check for that case and don't try to process a corrupted directory
+block so we don't run into trouble in mutate_name() if there is a
+zero-length file name.
+
+Addresses: TALOS-2019-0973
+Addresses: CVE-2019-5188
+Signed-off-by: Theodore Ts'o <tytso@mit.edu>
+---
+ e2fsck/rehash.c | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/e2fsck/rehash.c b/e2fsck/rehash.c
+index 7c4ab08..27e1429 100644
+--- a/e2fsck/rehash.c
++++ b/e2fsck/rehash.c
+@@ -159,6 +159,10 @@ static int fill_dir_block(ext2_filsys fs,
+ 		dir_offset += rec_len;
+ 		if (dirent->inode == 0)
+ 			continue;
++		if ((name_len) == 0) {
++			fd->err = EXT2_ET_DIR_CORRUPTED;
++			return BLOCK_ABORT;
++		}
+ 		if (!fd->compress && (name_len == 1) &&
+ 		    (dirent->name[0] == '.'))
+ 			continue;
+@@ -398,6 +402,11 @@ static int duplicate_search_and_fix(e2fsck_t ctx, ext2_filsys fs,
+ 			continue;
+ 		}
+ 		new_len = ext2fs_dirent_name_len(ent->dir);
++		if (new_len == 0) {
++			 /* should never happen */
++			ext2fs_unmark_valid(fs);
++			continue;
++		}
+ 		memcpy(new_name, ent->dir->name, new_len);
+ 		mutate_name(new_name, &new_len);
+ 		for (j=0; j < fd->num_array; j++) {
+-- 
+2.17.1
+
+
+From 2ab2c4ac3db3c287fd5ddadf7ed1f1641249859a Mon Sep 17 00:00:00 2001
+From: Theodore Ts'o <tytso@mit.edu>
+Date: Thu, 19 Dec 2019 19:45:06 -0500
+Subject: [PATCH 2/2] e2fsck: don't try to rehash a deleted directory
+
+If directory has been deleted in pass1[bcd] processing, then we
+shouldn't try to rehash the directory in pass 3a when we try to
+rehash/reoptimize directories.
+
+Signed-off-by: Theodore Ts'o <tytso@mit.edu>
+---
+ e2fsck/pass1b.c | 4 ++++
+ e2fsck/rehash.c | 2 ++
+ 2 files changed, 6 insertions(+)
+
+diff --git a/e2fsck/pass1b.c b/e2fsck/pass1b.c
+index 5693b9c..bca701c 100644
+--- a/e2fsck/pass1b.c
++++ b/e2fsck/pass1b.c
+@@ -705,6 +705,10 @@ static void delete_file(e2fsck_t ctx, ext2_ino_t ino,
+ 		fix_problem(ctx, PR_1B_BLOCK_ITERATE, &pctx);
+ 	if (ctx->inode_bad_map)
+ 		ext2fs_unmark_inode_bitmap2(ctx->inode_bad_map, ino);
++	if (ctx->inode_reg_map)
++		ext2fs_unmark_inode_bitmap2(ctx->inode_reg_map, ino);
++	ext2fs_unmark_inode_bitmap2(ctx->inode_dir_map, ino);
++	ext2fs_unmark_inode_bitmap2(ctx->inode_used_map, ino);
+ 	ext2fs_inode_alloc_stats2(fs, ino, -1, LINUX_S_ISDIR(dp->inode.i_mode));
+ 	quota_data_sub(ctx->qctx, &dp->inode, ino,
+ 		       pb.dup_blocks * fs->blocksize);
+diff --git a/e2fsck/rehash.c b/e2fsck/rehash.c
+index 27e1429..0a5888a 100644
+--- a/e2fsck/rehash.c
++++ b/e2fsck/rehash.c
+@@ -1024,6 +1024,8 @@ void e2fsck_rehash_directories(e2fsck_t ctx)
+ 			if (!ext2fs_u32_list_iterate(iter, &ino))
+ 				break;
+ 		}
++		if (!ext2fs_test_inode_bitmap2(ctx->inode_dir_map, ino))
++			continue;
+ 
+ 		pctx.dir = ino;
+ 		if (first) {
+-- 
+2.17.1
+

--- a/SPECS/e2fsprogs/e2fsprogs.spec
+++ b/SPECS/e2fsprogs/e2fsprogs.spec
@@ -133,7 +133,7 @@ make %{?_smp_mflags} check
 
 %changelog
 * Tue Jan 12 2021 Daniel McIlvaney <damcilva@microsoft.com> - 1.44.6-4
-- Address CVE-2019-5094
+- Address CVE-2019-5094 and CVE-2019-5188
 
 * Fri Jul 31 2020 Leandro Pereira <leperei@microsoft.com> - 1.44.6-3
 - Don't stomp on CFLAGS.

--- a/SPECS/e2fsprogs/e2fsprogs.spec
+++ b/SPECS/e2fsprogs/e2fsprogs.spec
@@ -1,13 +1,18 @@
 Summary:        Contains the utilities for the ext2 file system
 Name:           e2fsprogs
 Version:        1.44.6
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        GPLv2 and LGPLv2 and BSD and MIT
 URL:            http://e2fsprogs.sourceforge.net
 Group:          System Environment/Base
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Source0:        https://prdownloads.sourceforge.net/e2fsprogs/%{name}-%{version}.tar.gz
+# Patch taken from https://git.kernel.org/pub/scm/fs/ext2/e2fsprogs.git/patch/?id=8dbe7b475ec5e91ed767239f0e85880f416fc384
+# Resolved in version 1.45.6
+Patch0:         libsupport-add-checks-to-prevent-buffer-overrun-bugs-CVE-2019-5094.patch
+# Fixed in 1.45.5
+Patch1:         CVE-2019-5188.patch
 Requires:       %{name}-libs = %{version}-%{release}
 Conflicts:      toybox
 
@@ -33,7 +38,7 @@ Requires: %{name} = %{version}-%{release}
 These are the additional language files of e2fsprogs
 
 %prep
-%setup -q
+%autosetup -p1
 sed -i -e 's|^LD_LIBRARY_PATH.*|&:/tools/lib|' tests/test_config
 
 %build
@@ -127,6 +132,8 @@ make %{?_smp_mflags} check
 %defattr(-,root,root)
 
 %changelog
+* Tue Jan 12 2021 Daniel McIlvaney <damcilva@microsoft.com> - 1.44.6-4
+- Address CVE-2019-5094
 * Fri Jul 31 2020 Leandro Pereira <leperei@microsoft.com> - 1.44.6-3
 - Don't stomp on CFLAGS.
 * Sat May 09 00:21:25 PST 2020 Nick Samson <nisamson@microsoft.com> - 1.44.6-2

--- a/SPECS/e2fsprogs/e2fsprogs.spec
+++ b/SPECS/e2fsprogs/e2fsprogs.spec
@@ -2,11 +2,11 @@ Summary:        Contains the utilities for the ext2 file system
 Name:           e2fsprogs
 Version:        1.44.6
 Release:        4%{?dist}
-License:        GPLv2 and LGPLv2 and BSD and MIT
-URL:            http://e2fsprogs.sourceforge.net
-Group:          System Environment/Base
+License:        GPLv2 AND LGPLv2 AND BSD AND MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
+Group:          System Environment/Base
+URL:            http://e2fsprogs.sourceforge.net
 Source0:        https://prdownloads.sourceforge.net/e2fsprogs/%{name}-%{version}.tar.gz
 # Patch taken from https://git.kernel.org/pub/scm/fs/ext2/e2fsprogs.git/patch/?id=8dbe7b475ec5e91ed767239f0e85880f416fc384
 # Resolved in version 1.45.6
@@ -20,20 +20,23 @@ Conflicts:      toybox
 The E2fsprogs package contains the utilities for handling the ext2 file system.
 
 %package    libs
-Summary:    contains libraries used by other packages
+Summary:        contains libraries used by other packages
+
 %description    libs
 It contains the libraries: libss and libcom_err
 
 %package    devel
-Summary:    Header and development files for e2fsprogs
-Requires:   %{name} = %{version}
+Summary:        Header and development files for e2fsprogs
+Requires:       %{name} = %{version}
+
 %description    devel
 It contains the libraries and header files to create applications
 
 %package lang
-Summary: Additional language files for e2fsprogs
-Group:   System Environment/Base
-Requires: %{name} = %{version}-%{release}
+Summary:        Additional language files for e2fsprogs
+Group:          System Environment/Base
+Requires:       %{name} = %{version}-%{release}
+
 %description lang
 These are the additional language files of e2fsprogs
 
@@ -66,11 +69,8 @@ rm -rf %{buildroot}%{_infodir}
 %check
 make %{?_smp_mflags} check
 
-%post
-/sbin/ldconfig
-
-%postun
-/sbin/ldconfig
+%post -p /sbin/ldconfig
+%postun -p /sbin/ldconfig
 
 %files
 %defattr(-,root,root)
@@ -132,42 +132,59 @@ make %{?_smp_mflags} check
 %defattr(-,root,root)
 
 %changelog
-* Tue Jan 12 2021 Daniel McIlvaney <damcilva@microsoft.com> - 1.44.6-4
-- Address CVE-2019-5094
-* Fri Jul 31 2020 Leandro Pereira <leperei@microsoft.com> - 1.44.6-3
-- Don't stomp on CFLAGS.
-* Sat May 09 00:21:25 PST 2020 Nick Samson <nisamson@microsoft.com> - 1.44.6-2
-- Added %%license line automatically
+*   Tue Jan 12 2021 Daniel McIlvaney <damcilva@microsoft.com> - 1.44.6-4
+-   Address CVE-2019-5094
+
+*   Fri Jul 31 2020 Leandro Pereira <leperei@microsoft.com> - 1.44.6-3
+-   Don't stomp on CFLAGS.
+
+*   Sat May 09 00:21:25 PST 2020 Nick Samson <nisamson@microsoft.com> - 1.44.6-2
+-   Added %%license line automatically
 
 *   Thu Mar 19 2020 Nicolas Ontiveros <niontive@microsoft.com> 1.44.6-1
 -   Update version to 1.44.6. License verified.
+
 *   Tue Oct 01 2019 Mateusz Malisz <mamalisz@microsoft.com> 1.44.3-4
 -   Fix libs file list removing static libraries.
+
 *   Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 1.44.3-3
 -   Initial CBL-Mariner import from Photon (license: Apache2).
+
 *   Tue Oct 2 2018 Michelle Wang <michellew@vmware.com> 1.44.3-2
 -   Add conflicts toybox.
+
 *   Mon Sep 10 2018 Alexey Makhalov <amakhalov@vmware.com> 1.44.3-1
 -   Version update to fix compilation issue againts glibc-2.28.
+
 *   Tue May 02 2017 Anish Swaminathan <anishs@vmware.com> 1.43.4-2
 -   Add lang package.
+
 *   Mon Apr 03 2017 Chang Lee <changlee@vmware.com> 1.43.4-1
 -   Updated to version 1.43.4.
+
 *   Wed Dec 07 2016 Xiaolin Li <xiaolinl@vmware.com> 1.42.13-5
 -   Moved man3 to devel subpackage.
+
 *   Wed Nov 16 2016 Alexey Makhalov <amakhalov@vmware.com> 1.42.13-4
 -   Create libs subpackage for krb5.
+
 *   Tue Sep 20 2016 Alexey Makhalov <amakhalov@vmware.com> 1.42.13-3
 -   Use symlinks - save a diskspace.
+
 *   Tue May 24 2016 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 1.42.13-2
 -   GA - Bump release of all rpms.
+
 *   Tue Jan 12 2016 Xiaolin Li <xiaolinl@vmware.com> 1.42.13-1
 -   Updated to version 1.42.13.
+
 *   Wed Dec 09 2015 Anish Swaminathan <anishs@vmware.com> 1.42.9-4
 -   Edit post script.
+
 *   Tue Nov 10 2015 Xiaolin Li <xiaolinl@vmware.com> 1.42.9-3
 -   Handled locale files with macro find_lang.
+
 *   Mon May 18 2015 Touseef Liaqat <tliaqat@vmware.com> 1.42.9-2
 -   Update according to UsrMove.
+
 *   Wed Nov 5 2014 Divya Thaluru <dthaluru@vmware.com> 1.42.9-1
 -   Initial build First version.

--- a/SPECS/e2fsprogs/e2fsprogs.spec
+++ b/SPECS/e2fsprogs/e2fsprogs.spec
@@ -132,59 +132,59 @@ make %{?_smp_mflags} check
 %defattr(-,root,root)
 
 %changelog
-*   Tue Jan 12 2021 Daniel McIlvaney <damcilva@microsoft.com> - 1.44.6-4
--   Address CVE-2019-5094
+* Tue Jan 12 2021 Daniel McIlvaney <damcilva@microsoft.com> - 1.44.6-4
+- Address CVE-2019-5094
 
-*   Fri Jul 31 2020 Leandro Pereira <leperei@microsoft.com> - 1.44.6-3
--   Don't stomp on CFLAGS.
+* Fri Jul 31 2020 Leandro Pereira <leperei@microsoft.com> - 1.44.6-3
+- Don't stomp on CFLAGS.
 
-*   Sat May 09 00:21:25 PST 2020 Nick Samson <nisamson@microsoft.com> - 1.44.6-2
--   Added %%license line automatically
+* Sat May 09 00:21:25 PST 2020 Nick Samson <nisamson@microsoft.com> - 1.44.6-2
+- Added %%license line automatically
 
-*   Thu Mar 19 2020 Nicolas Ontiveros <niontive@microsoft.com> 1.44.6-1
--   Update version to 1.44.6. License verified.
+* Thu Mar 19 2020 Nicolas Ontiveros <niontive@microsoft.com> 1.44.6-1
+- Update version to 1.44.6. License verified.
 
-*   Tue Oct 01 2019 Mateusz Malisz <mamalisz@microsoft.com> 1.44.3-4
--   Fix libs file list removing static libraries.
+* Tue Oct 01 2019 Mateusz Malisz <mamalisz@microsoft.com> 1.44.3-4
+- Fix libs file list removing static libraries.
 
-*   Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 1.44.3-3
--   Initial CBL-Mariner import from Photon (license: Apache2).
+* Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 1.44.3-3
+- Initial CBL-Mariner import from Photon (license: Apache2).
 
-*   Tue Oct 2 2018 Michelle Wang <michellew@vmware.com> 1.44.3-2
--   Add conflicts toybox.
+* Tue Oct 2 2018 Michelle Wang <michellew@vmware.com> 1.44.3-2
+- Add conflicts toybox.
 
-*   Mon Sep 10 2018 Alexey Makhalov <amakhalov@vmware.com> 1.44.3-1
--   Version update to fix compilation issue againts glibc-2.28.
+* Mon Sep 10 2018 Alexey Makhalov <amakhalov@vmware.com> 1.44.3-1
+- Version update to fix compilation issue againts glibc-2.28.
 
-*   Tue May 02 2017 Anish Swaminathan <anishs@vmware.com> 1.43.4-2
--   Add lang package.
+* Tue May 02 2017 Anish Swaminathan <anishs@vmware.com> 1.43.4-2
+- Add lang package.
 
-*   Mon Apr 03 2017 Chang Lee <changlee@vmware.com> 1.43.4-1
--   Updated to version 1.43.4.
+* Mon Apr 03 2017 Chang Lee <changlee@vmware.com> 1.43.4-1
+- Updated to version 1.43.4.
 
-*   Wed Dec 07 2016 Xiaolin Li <xiaolinl@vmware.com> 1.42.13-5
--   Moved man3 to devel subpackage.
+* Wed Dec 07 2016 Xiaolin Li <xiaolinl@vmware.com> 1.42.13-5
+- Moved man3 to devel subpackage.
 
-*   Wed Nov 16 2016 Alexey Makhalov <amakhalov@vmware.com> 1.42.13-4
--   Create libs subpackage for krb5.
+* Wed Nov 16 2016 Alexey Makhalov <amakhalov@vmware.com> 1.42.13-4
+- Create libs subpackage for krb5.
 
-*   Tue Sep 20 2016 Alexey Makhalov <amakhalov@vmware.com> 1.42.13-3
--   Use symlinks - save a diskspace.
+* Tue Sep 20 2016 Alexey Makhalov <amakhalov@vmware.com> 1.42.13-3
+- Use symlinks - save a diskspace.
 
-*   Tue May 24 2016 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 1.42.13-2
--   GA - Bump release of all rpms.
+* Tue May 24 2016 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 1.42.13-2
+- GA - Bump release of all rpms.
 
-*   Tue Jan 12 2016 Xiaolin Li <xiaolinl@vmware.com> 1.42.13-1
--   Updated to version 1.42.13.
+* Tue Jan 12 2016 Xiaolin Li <xiaolinl@vmware.com> 1.42.13-1
+- Updated to version 1.42.13.
 
-*   Wed Dec 09 2015 Anish Swaminathan <anishs@vmware.com> 1.42.9-4
--   Edit post script.
+* Wed Dec 09 2015 Anish Swaminathan <anishs@vmware.com> 1.42.9-4
+- Edit post script.
 
-*   Tue Nov 10 2015 Xiaolin Li <xiaolinl@vmware.com> 1.42.9-3
--   Handled locale files with macro find_lang.
+* Tue Nov 10 2015 Xiaolin Li <xiaolinl@vmware.com> 1.42.9-3
+- Handled locale files with macro find_lang.
 
-*   Mon May 18 2015 Touseef Liaqat <tliaqat@vmware.com> 1.42.9-2
--   Update according to UsrMove.
+* Mon May 18 2015 Touseef Liaqat <tliaqat@vmware.com> 1.42.9-2
+- Update according to UsrMove.
 
-*   Wed Nov 5 2014 Divya Thaluru <dthaluru@vmware.com> 1.42.9-1
--   Initial build First version.
+* Wed Nov 5 2014 Divya Thaluru <dthaluru@vmware.com> 1.42.9-1
+- Initial build First version.

--- a/SPECS/e2fsprogs/libsupport-add-checks-to-prevent-buffer-overrun-bugs-CVE-2019-5094.patch
+++ b/SPECS/e2fsprogs/libsupport-add-checks-to-prevent-buffer-overrun-bugs-CVE-2019-5094.patch
@@ -1,0 +1,211 @@
+From 8dbe7b475ec5e91ed767239f0e85880f416fc384 Mon Sep 17 00:00:00 2001
+From: Theodore Ts'o <tytso@mit.edu>
+Date: Sun, 1 Sep 2019 00:59:16 -0400
+Subject: libsupport: add checks to prevent buffer overrun bugs in quota code
+
+A maliciously corrupted file systems can trigger buffer overruns in
+the quota code used by e2fsck.  To fix this, add sanity checks to the
+quota header fields as well as to block number references in the quota
+tree.
+
+Addresses: CVE-2019-5094
+Addresses: TALOS-2019-0887
+Signed-off-by: Theodore Ts'o <tytso@mit.edu>
+---
+ lib/support/mkquota.c      |  1 +
+ lib/support/quotaio_tree.c | 71 ++++++++++++++++++++++++++++++----------------
+ lib/support/quotaio_v2.c   | 28 ++++++++++++++++++
+ 3 files changed, 76 insertions(+), 24 deletions(-)
+
+diff --git a/lib/support/mkquota.c b/lib/support/mkquota.c
+index 0b9e7665..ddb53124 100644
+--- a/lib/support/mkquota.c
++++ b/lib/support/mkquota.c
+@@ -671,6 +671,7 @@ errcode_t quota_compare_and_update(quota_ctx_t qctx, enum quota_type qtype,
+ 	err = qh.qh_ops->scan_dquots(&qh, scan_dquots_callback, &scan_data);
+ 	if (err) {
+ 		log_debug("Error scanning dquots");
++		*usage_inconsistent = 1;
+ 		goto out_close_qh;
+ 	}
+ 
+diff --git a/lib/support/quotaio_tree.c b/lib/support/quotaio_tree.c
+index a7c2028c..6cc4fb5b 100644
+--- a/lib/support/quotaio_tree.c
++++ b/lib/support/quotaio_tree.c
+@@ -540,6 +540,17 @@ struct dquot *qtree_read_dquot(struct quota_handle *h, qid_t id)
+ 	return dquot;
+ }
+ 
++static int check_reference(struct quota_handle *h, unsigned int blk)
++{
++	if (blk >= h->qh_info.u.v2_mdqi.dqi_qtree.dqi_blocks) {
++		log_err("Illegal reference (%u >= %u) in %s quota file",
++			blk, h->qh_info.u.v2_mdqi.dqi_qtree.dqi_blocks,
++			quota_type2name(h->qh_type));
++		return -1;
++	}
++	return 0;
++}
++
+ /*
+  * Scan all dquots in file and call callback on each
+  */
+@@ -558,7 +569,7 @@ static int report_block(struct dquot *dquot, unsigned int blk, char *bitmap,
+ 	int entries, i;
+ 
+ 	if (!buf)
+-		return 0;
++		return -1;
+ 
+ 	set_bit(bitmap, blk);
+ 	read_blk(dquot->dq_h, blk, buf);
+@@ -580,23 +591,12 @@ static int report_block(struct dquot *dquot, unsigned int blk, char *bitmap,
+ 	return entries;
+ }
+ 
+-static void check_reference(struct quota_handle *h, unsigned int blk)
+-{
+-	if (blk >= h->qh_info.u.v2_mdqi.dqi_qtree.dqi_blocks)
+-		log_err("Illegal reference (%u >= %u) in %s quota file. "
+-			"Quota file is probably corrupted.\n"
+-			"Please run e2fsck (8) to fix it.",
+-			blk,
+-			h->qh_info.u.v2_mdqi.dqi_qtree.dqi_blocks,
+-			quota_type2name(h->qh_type));
+-}
+-
+ static int report_tree(struct dquot *dquot, unsigned int blk, int depth,
+ 		       char *bitmap,
+ 		       int (*process_dquot) (struct dquot *, void *),
+ 		       void *data)
+ {
+-	int entries = 0, i;
++	int entries = 0, ret, i;
+ 	dqbuf_t buf = getdqbuf();
+ 	__le32 *ref = (__le32 *) buf;
+ 
+@@ -607,22 +607,40 @@ static int report_tree(struct dquot *dquot, unsigned int blk, int depth,
+ 	if (depth == QT_TREEDEPTH - 1) {
+ 		for (i = 0; i < QT_BLKSIZE >> 2; i++) {
+ 			blk = ext2fs_le32_to_cpu(ref[i]);
+-			check_reference(dquot->dq_h, blk);
+-			if (blk && !get_bit(bitmap, blk))
+-				entries += report_block(dquot, blk, bitmap,
+-							process_dquot, data);
++			if (check_reference(dquot->dq_h, blk)) {
++				entries = -1;
++				goto errout;
++			}
++			if (blk && !get_bit(bitmap, blk)) {
++				ret = report_block(dquot, blk, bitmap,
++						   process_dquot, data);
++				if (ret < 0) {
++					entries = ret;
++					goto errout;
++				}
++				entries += ret;
++			}
+ 		}
+ 	} else {
+ 		for (i = 0; i < QT_BLKSIZE >> 2; i++) {
+ 			blk = ext2fs_le32_to_cpu(ref[i]);
+ 			if (blk) {
+-				check_reference(dquot->dq_h, blk);
+-				entries += report_tree(dquot, blk, depth + 1,
+-						       bitmap, process_dquot,
+-						       data);
++				if (check_reference(dquot->dq_h, blk)) {
++					entries = -1;
++					goto errout;
++				}
++				ret = report_tree(dquot, blk, depth + 1,
++						  bitmap, process_dquot,
++						  data);
++				if (ret < 0) {
++					entries = ret;
++					goto errout;
++				}
++				entries += ret;
+ 			}
+ 		}
+ 	}
++errout:
+ 	freedqbuf(buf);
+ 	return entries;
+ }
+@@ -642,6 +660,7 @@ int qtree_scan_dquots(struct quota_handle *h,
+ 		      int (*process_dquot) (struct dquot *, void *),
+ 		      void *data)
+ {
++	int ret;
+ 	char *bitmap;
+ 	struct v2_mem_dqinfo *v2info = &h->qh_info.u.v2_mdqi;
+ 	struct qtree_mem_dqinfo *info = &v2info->dqi_qtree;
+@@ -655,10 +674,14 @@ int qtree_scan_dquots(struct quota_handle *h,
+ 		ext2fs_free_mem(&dquot);
+ 		return -1;
+ 	}
+-	v2info->dqi_used_entries = report_tree(dquot, QT_TREEOFF, 0, bitmap,
+-					       process_dquot, data);
++	ret = report_tree(dquot, QT_TREEOFF, 0, bitmap, process_dquot, data);
++	if (ret < 0)
++		goto errout;
++	v2info->dqi_used_entries = ret;
+ 	v2info->dqi_data_blocks = find_set_bits(bitmap, info->dqi_blocks);
++	ret = 0;
++errout:
+ 	ext2fs_free_mem(&bitmap);
+ 	ext2fs_free_mem(&dquot);
+-	return 0;
++	return ret;
+ }
+diff --git a/lib/support/quotaio_v2.c b/lib/support/quotaio_v2.c
+index 38be2a34..73906676 100644
+--- a/lib/support/quotaio_v2.c
++++ b/lib/support/quotaio_v2.c
+@@ -175,6 +175,8 @@ static int v2_check_file(struct quota_handle *h, int type, int fmt)
+ static int v2_init_io(struct quota_handle *h)
+ {
+ 	struct v2_disk_dqinfo ddqinfo;
++	struct v2_mem_dqinfo *info;
++	__u64 filesize;
+ 
+ 	h->qh_info.u.v2_mdqi.dqi_qtree.dqi_entry_size =
+ 		sizeof(struct v2r1_disk_dqblk);
+@@ -185,6 +187,32 @@ static int v2_init_io(struct quota_handle *h)
+ 			 sizeof(ddqinfo)) != sizeof(ddqinfo))
+ 		return -1;
+ 	v2_disk2memdqinfo(&h->qh_info, &ddqinfo);
++
++	/* Check to make sure quota file info is sane */
++	info = &h->qh_info.u.v2_mdqi;
++	if (ext2fs_file_get_lsize(h->qh_qf.e2_file, &filesize))
++		return -1;
++	if ((filesize > (1U << 31)) ||
++	    (info->dqi_qtree.dqi_blocks >
++	     (filesize + QT_BLKSIZE - 1) >> QT_BLKSIZE_BITS)) {
++		log_err("Quota inode %u corrupted: file size %llu; "
++			"dqi_blocks %u", h->qh_qf.ino,
++			filesize, info->dqi_qtree.dqi_blocks);
++		return -1;
++	}
++	if (info->dqi_qtree.dqi_free_blk >= info->dqi_qtree.dqi_blocks) {
++		log_err("Quota inode %u corrupted: free_blk %u; dqi_blocks %u",
++			h->qh_qf.ino, info->dqi_qtree.dqi_free_blk,
++			info->dqi_qtree.dqi_blocks);
++		return -1;
++	}
++	if (info->dqi_qtree.dqi_free_entry >= info->dqi_qtree.dqi_blocks) {
++		log_err("Quota inode %u corrupted: free_entry %u; "
++			"dqi_blocks %u", h->qh_qf.ino,
++			info->dqi_qtree.dqi_free_entry,
++			info->dqi_qtree.dqi_blocks);
++		return -1;
++	}
+ 	return 0;
+ }
+ 
+-- 
+cgit 1.2.3-1.el7
+

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -124,7 +124,7 @@ rpm-lang-4.14.2-10.cm1.aarch64.rpm
 rpm-libs-4.14.2-10.cm1.aarch64.rpm
 cpio-2.13-2.cm1.aarch64.rpm
 cpio-lang-2.13-2.cm1.aarch64.rpm
-e2fsprogs-libs-1.44.6-3.cm1.aarch64.rpm
+e2fsprogs-libs-1.44.6-4.cm1.aarch64.rpm
 libsolv-0.7.7-4.cm1.aarch64.rpm
 libsolv-devel-0.7.7-4.cm1.aarch64.rpm
 libssh2-1.9.0-1.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -124,7 +124,7 @@ rpm-lang-4.14.2-10.cm1.x86_64.rpm
 rpm-libs-4.14.2-10.cm1.x86_64.rpm
 cpio-2.13-2.cm1.x86_64.rpm
 cpio-lang-2.13-2.cm1.x86_64.rpm
-e2fsprogs-libs-1.44.6-3.cm1.x86_64.rpm
+e2fsprogs-libs-1.44.6-4.cm1.x86_64.rpm
 libsolv-0.7.7-4.cm1.x86_64.rpm
 libsolv-devel-0.7.7-4.cm1.x86_64.rpm
 libssh2-1.9.0-1.cm1.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -61,11 +61,11 @@ diffutils-3.6-4.cm1.aarch64.rpm
 diffutils-debuginfo-3.6-4.cm1.aarch64.rpm
 docbook-dtd-xml-4.5-11.cm1.noarch.rpm
 docbook-style-xsl-1.79.1-10.cm1.noarch.rpm
-e2fsprogs-1.44.6-3.cm1.aarch64.rpm
-e2fsprogs-debuginfo-1.44.6-3.cm1.aarch64.rpm
-e2fsprogs-devel-1.44.6-3.cm1.aarch64.rpm
-e2fsprogs-lang-1.44.6-3.cm1.aarch64.rpm
-e2fsprogs-libs-1.44.6-3.cm1.aarch64.rpm
+e2fsprogs-1.44.6-4.cm1.aarch64.rpm
+e2fsprogs-debuginfo-1.44.6-4.cm1.aarch64.rpm
+e2fsprogs-devel-1.44.6-4.cm1.aarch64.rpm
+e2fsprogs-lang-1.44.6-4.cm1.aarch64.rpm
+e2fsprogs-libs-1.44.6-4.cm1.aarch64.rpm
 elfutils-0.176-4.cm1.aarch64.rpm
 elfutils-debuginfo-0.176-4.cm1.aarch64.rpm
 elfutils-devel-0.176-4.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -61,11 +61,11 @@ diffutils-3.6-4.cm1.x86_64.rpm
 diffutils-debuginfo-3.6-4.cm1.x86_64.rpm
 docbook-dtd-xml-4.5-11.cm1.noarch.rpm
 docbook-style-xsl-1.79.1-10.cm1.noarch.rpm
-e2fsprogs-1.44.6-3.cm1.x86_64.rpm
-e2fsprogs-debuginfo-1.44.6-3.cm1.x86_64.rpm
-e2fsprogs-devel-1.44.6-3.cm1.x86_64.rpm
-e2fsprogs-lang-1.44.6-3.cm1.x86_64.rpm
-e2fsprogs-libs-1.44.6-3.cm1.x86_64.rpm
+e2fsprogs-1.44.6-4.cm1.x86_64.rpm
+e2fsprogs-debuginfo-1.44.6-4.cm1.x86_64.rpm
+e2fsprogs-devel-1.44.6-4.cm1.x86_64.rpm
+e2fsprogs-lang-1.44.6-4.cm1.x86_64.rpm
+e2fsprogs-libs-1.44.6-4.cm1.x86_64.rpm
 elfutils-0.176-4.cm1.x86_64.rpm
 elfutils-debuginfo-0.176-4.cm1.x86_64.rpm
 elfutils-devel-0.176-4.cm1.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Patch CVE-2019-5094 and CVE-2019-5188 for `e2fsprogs` package in the 1.0 branch.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- fix CVE-2019-5094
- fix CVE-2019-5188

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
**YES**

###### Links to CVEs  <!-- optional -->
- https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2019-5094
- https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2019-5188

###### Test Methodology
- Pipeline build id: 59147
