### PR TITLE
Update e2fsprogs from 1.44.6 to 1.45.6 in dev branch

### DIFF
--- a/SPECS/e2fsprogs/e2fsprogs.signatures.json
+++ b/SPECS/e2fsprogs/e2fsprogs.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "e2fsprogs-1.44.6.tar.gz": "9bf7200d2737ed13f50a080af285c11529f91b088d84ecb71aae9fac58a8fbee"
+  "e2fsprogs-1.45.6.tar.gz": "5f64ac50a2b60b8e67c5b382bb137dec39344017103caffc3a61554424f2d693"
  }
 }

--- a/SPECS/e2fsprogs/e2fsprogs.spec
+++ b/SPECS/e2fsprogs/e2fsprogs.spec
@@ -1,7 +1,7 @@
 Summary:        Contains the utilities for the ext2 file system
 Name:           e2fsprogs
-Version:        1.44.6
-Release:        3%{?dist}
+Version:        1.45.6
+Release:        1%{?dist}
 License:        GPLv2 and LGPLv2 and BSD and MIT
 URL:            http://e2fsprogs.sourceforge.net
 Group:          System Environment/Base
@@ -127,40 +127,59 @@ make %{?_smp_mflags} check
 %defattr(-,root,root)
 
 %changelog
+* Wed Jan 13 2021 Daniel McIlvaney <damcilva@microsoft.com> - 1.45.6-1
+- Upgrade to version 1.45.6
+
 * Fri Jul 31 2020 Leandro Pereira <leperei@microsoft.com> - 1.44.6-3
 - Don't stomp on CFLAGS.
+
 * Sat May 09 00:21:25 PST 2020 Nick Samson <nisamson@microsoft.com> - 1.44.6-2
 - Added %%license line automatically
 
-*   Thu Mar 19 2020 Nicolas Ontiveros <niontive@microsoft.com> 1.44.6-1
--   Update version to 1.44.6. License verified.
-*   Tue Oct 01 2019 Mateusz Malisz <mamalisz@microsoft.com> 1.44.3-4
--   Fix libs file list removing static libraries.
-*   Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 1.44.3-3
--   Initial CBL-Mariner import from Photon (license: Apache2).
-*   Tue Oct 2 2018 Michelle Wang <michellew@vmware.com> 1.44.3-2
--   Add conflicts toybox.
-*   Mon Sep 10 2018 Alexey Makhalov <amakhalov@vmware.com> 1.44.3-1
--   Version update to fix compilation issue againts glibc-2.28.
-*   Tue May 02 2017 Anish Swaminathan <anishs@vmware.com> 1.43.4-2
--   Add lang package.
-*   Mon Apr 03 2017 Chang Lee <changlee@vmware.com> 1.43.4-1
--   Updated to version 1.43.4.
-*   Wed Dec 07 2016 Xiaolin Li <xiaolinl@vmware.com> 1.42.13-5
--   Moved man3 to devel subpackage.
-*   Wed Nov 16 2016 Alexey Makhalov <amakhalov@vmware.com> 1.42.13-4
--   Create libs subpackage for krb5.
-*   Tue Sep 20 2016 Alexey Makhalov <amakhalov@vmware.com> 1.42.13-3
--   Use symlinks - save a diskspace.
-*   Tue May 24 2016 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 1.42.13-2
--   GA - Bump release of all rpms.
-*   Tue Jan 12 2016 Xiaolin Li <xiaolinl@vmware.com> 1.42.13-1
--   Updated to version 1.42.13.
-*   Wed Dec 09 2015 Anish Swaminathan <anishs@vmware.com> 1.42.9-4
--   Edit post script.
-*   Tue Nov 10 2015 Xiaolin Li <xiaolinl@vmware.com> 1.42.9-3
--   Handled locale files with macro find_lang.
-*   Mon May 18 2015 Touseef Liaqat <tliaqat@vmware.com> 1.42.9-2
--   Update according to UsrMove.
-*   Wed Nov 5 2014 Divya Thaluru <dthaluru@vmware.com> 1.42.9-1
--   Initial build First version.
+* Thu Mar 19 2020 Nicolas Ontiveros <niontive@microsoft.com> 1.44.6-1
+- Update version to 1.44.6. License verified.
+
+* Tue Oct 01 2019 Mateusz Malisz <mamalisz@microsoft.com> 1.44.3-4
+- Fix libs file list removing static libraries.
+
+* Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 1.44.3-3
+- Initial CBL-Mariner import from Photon (license: Apache2).
+
+* Tue Oct 2 2018 Michelle Wang <michellew@vmware.com> 1.44.3-2
+- Add conflicts toybox.
+
+* Mon Sep 10 2018 Alexey Makhalov <amakhalov@vmware.com> 1.44.3-1
+- Version update to fix compilation issue againts glibc-2.28.
+
+* Tue May 02 2017 Anish Swaminathan <anishs@vmware.com> 1.43.4-2
+- Add lang package.
+
+* Mon Apr 03 2017 Chang Lee <changlee@vmware.com> 1.43.4-1
+- Updated to version 1.43.4.
+
+* Wed Dec 07 2016 Xiaolin Li <xiaolinl@vmware.com> 1.42.13-5
+- Moved man3 to devel subpackage.
+
+* Wed Nov 16 2016 Alexey Makhalov <amakhalov@vmware.com> 1.42.13-4
+- Create libs subpackage for krb5.
+
+* Tue Sep 20 2016 Alexey Makhalov <amakhalov@vmware.com> 1.42.13-3
+- Use symlinks - save a diskspace.
+
+* Tue May 24 2016 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 1.42.13-2
+- GA - Bump release of all rpms.
+
+* Tue Jan 12 2016 Xiaolin Li <xiaolinl@vmware.com> 1.42.13-1
+- Updated to version 1.42.13.
+
+* Wed Dec 09 2015 Anish Swaminathan <anishs@vmware.com> 1.42.9-4
+- Edit post script.
+
+* Tue Nov 10 2015 Xiaolin Li <xiaolinl@vmware.com> 1.42.9-3
+- Handled locale files with macro find_lang.
+
+* Mon May 18 2015 Touseef Liaqat <tliaqat@vmware.com> 1.42.9-2
+- Update according to UsrMove.
+
+* Wed Nov 5 2014 Divya Thaluru <dthaluru@vmware.com> 1.42.9-1
+- Initial build First version.

--- a/SPECS/e2fsprogs/e2fsprogs.spec
+++ b/SPECS/e2fsprogs/e2fsprogs.spec
@@ -70,6 +70,7 @@ make %{?_smp_mflags} check
 %files
 %defattr(-,root,root)
 %license NOTICE
+%config %{_sysconfdir}/e2scrub.conf
 %config %{_sysconfdir}/mke2fs.conf
 %{_bindir}/compile_et
 %{_bindir}/mk_cmds

--- a/SPECS/e2fsprogs/e2fsprogs.spec
+++ b/SPECS/e2fsprogs/e2fsprogs.spec
@@ -2,11 +2,11 @@ Summary:        Contains the utilities for the ext2 file system
 Name:           e2fsprogs
 Version:        1.45.6
 Release:        1%{?dist}
-License:        GPLv2 and LGPLv2 and BSD and MIT
-URL:            http://e2fsprogs.sourceforge.net
-Group:          System Environment/Base
+License:        GPLv2 AND LGPLv2 AND BSD AND MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
+Group:          System Environment/Base
+URL:            http://e2fsprogs.sourceforge.net
 Source0:        https://prdownloads.sourceforge.net/e2fsprogs/%{name}-%{version}.tar.gz
 Requires:       %{name}-libs = %{version}-%{release}
 Conflicts:      toybox
@@ -15,20 +15,23 @@ Conflicts:      toybox
 The E2fsprogs package contains the utilities for handling the ext2 file system.
 
 %package    libs
-Summary:    contains libraries used by other packages
+Summary:        contains libraries used by other packages
+
 %description    libs
 It contains the libraries: libss and libcom_err
 
 %package    devel
-Summary:    Header and development files for e2fsprogs
-Requires:   %{name} = %{version}
+Summary:        Header and development files for e2fsprogs
+Requires:       %{name} = %{version}
+
 %description    devel
 It contains the libraries and header files to create applications
 
 %package lang
-Summary: Additional language files for e2fsprogs
-Group:   System Environment/Base
-Requires: %{name} = %{version}-%{release}
+Summary:        Additional language files for e2fsprogs
+Group:          System Environment/Base
+Requires:       %{name} = %{version}-%{release}
+
 %description lang
 These are the additional language files of e2fsprogs
 
@@ -61,11 +64,8 @@ rm -rf %{buildroot}%{_infodir}
 %check
 make %{?_smp_mflags} check
 
-%post
-/sbin/ldconfig
-
-%postun
-/sbin/ldconfig
+%post -p /sbin/ldconfig
+%postun -p /sbin/ldconfig
 
 %files
 %defattr(-,root,root)

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -1016,8 +1016,8 @@
         "type": "other",
         "other": {
           "name": "e2fsprogs",
-          "version": "1.44.6",
-          "downloadUrl": "https://prdownloads.sourceforge.net/e2fsprogs/e2fsprogs-1.44.6.tar.gz"
+          "version": "1.45.6",
+          "downloadUrl": "https://prdownloads.sourceforge.net/e2fsprogs/e2fsprogs-1.45.6.tar.gz"
         }
       }
     },

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -183,7 +183,7 @@ rpm-lang-4.14.2-11.cm1.aarch64.rpm
 rpm-libs-4.14.2-11.cm1.aarch64.rpm
 cpio-2.13-2.cm1.aarch64.rpm
 cpio-lang-2.13-2.cm1.aarch64.rpm
-e2fsprogs-libs-1.44.6-3.cm1.aarch64.rpm
+e2fsprogs-libs-1.45.6-1.cm1.aarch64.rpm
 libsolv-0.7.7-4.cm1.aarch64.rpm
 libsolv-devel-0.7.7-4.cm1.aarch64.rpm
 libssh2-1.9.0-1.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -183,7 +183,7 @@ rpm-lang-4.14.2-11.cm1.x86_64.rpm
 rpm-libs-4.14.2-11.cm1.x86_64.rpm
 cpio-2.13-2.cm1.x86_64.rpm
 cpio-lang-2.13-2.cm1.x86_64.rpm
-e2fsprogs-libs-1.44.6-3.cm1.x86_64.rpm
+e2fsprogs-libs-1.45.6-1.cm1.x86_64.rpm
 libsolv-0.7.7-4.cm1.x86_64.rpm
 libsolv-devel-0.7.7-4.cm1.x86_64.rpm
 libssh2-1.9.0-1.cm1.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -63,11 +63,11 @@ docbook-dtd-xml-4.5-11.cm1.noarch.rpm
 docbook-style-xsl-1.79.1-13.cm1.noarch.rpm
 dwz-0.13-4.cm1.aarch64.rpm
 dwz-debuginfo-0.13-4.cm1.aarch64.rpm
-e2fsprogs-1.44.6-3.cm1.aarch64.rpm
-e2fsprogs-debuginfo-1.44.6-3.cm1.aarch64.rpm
-e2fsprogs-devel-1.44.6-3.cm1.aarch64.rpm
-e2fsprogs-lang-1.44.6-3.cm1.aarch64.rpm
-e2fsprogs-libs-1.44.6-3.cm1.aarch64.rpm
+e2fsprogs-1.45.6-1.cm1.aarch64.rpm
+e2fsprogs-debuginfo-1.45.6-1.cm1.aarch64.rpm
+e2fsprogs-devel-1.45.6-1.cm1.aarch64.rpm
+e2fsprogs-lang-1.45.6-1.cm1.aarch64.rpm
+e2fsprogs-libs-1.45.6-1.cm1.aarch64.rpm
 elfutils-0.176-3.cm1.aarch64.rpm
 elfutils-debuginfo-0.176-3.cm1.aarch64.rpm
 elfutils-devel-0.176-3.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -63,11 +63,11 @@ docbook-dtd-xml-4.5-11.cm1.noarch.rpm
 docbook-style-xsl-1.79.1-13.cm1.noarch.rpm
 dwz-0.13-4.cm1.x86_64.rpm
 dwz-debuginfo-0.13-4.cm1.x86_64.rpm
-e2fsprogs-1.44.6-3.cm1.x86_64.rpm
-e2fsprogs-debuginfo-1.44.6-3.cm1.x86_64.rpm
-e2fsprogs-devel-1.44.6-3.cm1.x86_64.rpm
-e2fsprogs-lang-1.44.6-3.cm1.x86_64.rpm
-e2fsprogs-libs-1.44.6-3.cm1.x86_64.rpm
+e2fsprogs-1.45.6-1.cm1.x86_64.rpm
+e2fsprogs-debuginfo-1.45.6-1.cm1.x86_64.rpm
+e2fsprogs-devel-1.45.6-1.cm1.x86_64.rpm
+e2fsprogs-lang-1.45.6-1.cm1.x86_64.rpm
+e2fsprogs-libs-1.45.6-1.cm1.x86_64.rpm
 elfutils-0.176-3.cm1.x86_64.rpm
 elfutils-debuginfo-0.176-3.cm1.x86_64.rpm
 elfutils-devel-0.176-3.cm1.x86_64.rpm

--- a/toolkit/scripts/toolchain/container/toolchain-md5sums
+++ b/toolkit/scripts/toolchain/container/toolchain-md5sums
@@ -26,7 +26,7 @@ e1b07516533f351b3aba3423fafeffd6  dejagnu-1.6.2.tar.gz
 4ee175bbd44d05c34d43bb129be5098a  dmxproto-2.3.1.tar.bz2
 b2721d5d24c04d9980a0c6540cb5396a  dri2proto-2.8.tar.bz2
 a3d2cbe60a9ca1bf3aea6c93c817fee3  dri3proto-1.0.tar.bz2
-d010e5b1b66a8755a4cdd96e189eb069  e2fsprogs-1.44.6.tar.gz
+cccfb706d162514e4f9dbfbc9e5d65ee  e2fsprogs-1.45.6.tar.gz
 077e4f49320cad82bf17a997068b1db9  elfutils-0.176.tar.bz2
 ca047ae951b40020ac831c28859161b2  expat-2.2.6.tar.bz2
 00fce8de158422f5ccd2666512329bd2  expect5.45.4.tar.gz

--- a/toolkit/scripts/toolchain/container/toolchain-remote-wget-list
+++ b/toolkit/scripts/toolchain/container/toolchain-remote-wget-list
@@ -2,7 +2,7 @@ http://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.xz
 http://ftp.gnu.org/gnu/automake/automake-1.16.1.tar.xz
 http://ftp.gnu.org/gnu/binutils/binutils-2.32.tar.xz
 http://ftp.gnu.org/gnu/dejagnu/dejagnu-1.6.2.tar.gz
-https://prdownloads.sourceforge.net/e2fsprogs/e2fsprogs-1.44.6.tar.gz
+https://prdownloads.sourceforge.net/e2fsprogs/e2fsprogs-1.45.6.tar.gz
 https://sourceware.org/ftp/elfutils/0.176/elfutils-0.176.tar.bz2
 https://prdownloads.sourceforge.net/expect/expect5.45.4.tar.gz
 http://ftp.gnu.org/gnu/findutils/findutils-4.6.0.tar.gz


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Upgrade e2fsprogs to fix CVE-2019-5094 and CVE-2019-5188 in the dev branch.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Update e2fsprogs from 1.44.6 to 1.45.6

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
**YES**

###### Links to CVEs  <!-- optional -->
- https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2019-5094
- https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2019-5188

###### Test Methodology
- Pipeline build id: 59240
