### PR TITLE
[6/5 verity read-only root] Read-only root configuraiton documentation

### DIFF
--- a/toolkit/docs/formats/imageconfig.md
+++ b/toolkit/docs/formats/imageconfig.md
@@ -156,6 +156,50 @@ A sample KernelOptions specifying a default kernel and a specialized kernel for 
 },
 ```
 
+### ReadOnlyVerityRoot
+"ReadOnlyVerityRoot" key controls making the root filesystem read-only using dm-verity.
+It will create a verity disk from the partition mounted at "/". The verity data is stored as
+part of the image's initramfs. More details can be found in [Misc: Read Only Roots](../how_it_works/5_misc.md#dm-verity-read-only-roots)
+
+#### Considerations
+Having a read-only root filesystem will change the behavior of the image in some fundamental ways. There are several areas that should be considered before enabling a read-only root:
+
+##### Writable Data
+Any writable data which needs to be preserved will need to be stored into a separate writable partition. The `TmpfsOverlays` key will create throw-away writable partitions which are reset on every boot. The example configs create an overlay on `/var`, but the more refined the overlays are, the more secure they will be.
+
+##### GPL Licensing
+If using a read-only root in conjunction with a verified boot flow that uses a signed initramfs carefully consider the implications on GPLv3 code. The read-only nature of the filesystem means a user cannot replace GPLv3 components without re-signing a new initramfs.
+
+##### Users
+Since users are controlled by files in `/etc` they are read-only when this is set. It is recommended to either use SSH key based login, or pre-hash the password to avoid storing passwords is plain text in the config files (See [Users](#users)).
+
+##### Separate `/boot` Partition
+Since the root partition's hash tree is stored as part of the initramfs, the initramfs cannot be stored on the same root partition (it would invalidate the measurements). To avoid this a separate `/boot` partition is needed to house the hash tree (via the initramfs).
+
+##### ISO
+The ISO installer supports enabling read-only roots if they are configured through the configuration JSON file (see [full.json's](../../imageconfigs/full.json) `"CBL-Mariner Core Read-Only"` entry). The automatic partition creation mode will create the required `/boot` partition if the read-only root is enabled.
+- `Enable`: Enable dm-verity on the root filesystem
+- `Name`: Custom name for the mounted root (default is `"verity_root_fs"`)
+- `ErrorCorrectionEnable`: Enable automatic error correction of modified blocks (default is `true`)
+- `ErrorCorrectionEncodingRoots`: Increase overhead to increase resiliency of the forward error correction (default is `2` bytes of code per 255 bytes of data)
+- `RootHashSignatureEnable`: Validate the root hash against a key stored in the kernel's system keyring. The signature file should be called `<Name>.p7` and must be stored in the initramfs. This signature WILL NOT BE included automatically in the initramfs. It must be included via an out of band build step.
+- `ValidateOnBoot`: Run a validation of the full disk at boot time, normally blocks are validated only as needed. This can take several minutes if the disk is corrupted.
+- `VerityErrorBehavior`: Indicate additional special system behavior when encountering an unrecoverable verity corruption. One of `"ignore"`, `"restart"`, `"panic"`. Normal behavior is to return an IO error when reading corrupt blocks.
+- `TmpfsOverlays`: Mount these paths as writable overlays backed by a tmpfs in memory.
+- `TmpfsOverlaySize`: Maximum amount of memory the overlays may use. Maybe be one of three forms: `"1234"`, `"1234[k,m,g]"`, `"20%"` (default is `"20%"`) 
+- `TmpfsOverlayDebugEnabled`: Make the tmpfs overlay mounts easily accessible for debugging purposes. They can be found in /mnt/verity_overlay_debug_tmpfs. Include the
+    `verity-read-only-root-debug-tools` package to create the required mount points.
+
+A sample ReadOnlyVerityRoot specifying a basic read-only root using default error correction:
+``` json
+"ReadOnlyVerityRoot": {
+    "Enable": true,
+    "TmpfsOverlays": [
+        "/var"
+    ],
+},
+```
+
 ### KernelCommandLine
 
 KernelCommandLine is an optional key which allows additional parameters to be passed to the kernel when it is launched from Grub.

--- a/toolkit/docs/security/intro.md
+++ b/toolkit/docs/security/intro.md
@@ -4,3 +4,5 @@ Below topics are dedicated to security-related details of the operating system.
 
 ## 1. [Security features](security-features.md)
 ## 2. [SSL CA certificates management](ca-certificates.md)
+
+## 3. [Read-Only Roots](read-only-roots.md)

--- a/toolkit/docs/security/read-only-roots.md
+++ b/toolkit/docs/security/read-only-roots.md
@@ -1,0 +1,111 @@
+Read-Only Roots
+===
+
+- [dm-verity Read Only Roots](#dm-verity-read-only-roots)
+  - [Creating Verity Disks](#Creating-Verity-Disks)
+  - [Writable Areas](#Writable-Areas)
+  - [Root of Trust](#Root-of-Trust)
+  - [Users, Machine ID, Misc. Configuration](#Users-Machine-ID-Misc-Configuration)
+  - [Forward Error Correction (FEC)](#Forward-Error-Correction-(FEC))
+  - [Overhead](#Overhead)
+  - [Debugging](#Debugging)
+  - [ISO Installers](#ISO-Installers)
+
+## dm-verity Read Only Roots
+`dm-verity` is a Device Mapper target which creates read-only partitions with built-in integrity checking. This means a verity partition can detect (and if FEC is enabled, fix) changes to the data in the partition.
+
+A Merkle hash tree is created from the measurements of each block in the partition (Hash each 4k block, then hash those hashes. Repeat until you have a single hash). The root node of the tree, a single hash, is called the root hash.
+
+When data is read from disk the blocks are hashed and checked against the hash tree to detect any changes. Any change to a block will modify its branch of the tree, all the way down to the root hash. By securing the root hash the entire partition can be secured.
+
+### Creating Verity Disks
+Read-only roots can be enabled using the `"ReadOnlyVerityRoot"` key in the image configuration JSON file (See [imageconfig.md](../formats/imageconfig.md#ReadOnlyVerityRoot) for details)
+Since the read-only partition becomes unmodifiable as soon as its measured, the snapshot must be taken at the very end of the build process. The `imager` tool switches the root to read-only mode, then measures it into a hash tree, FEC data, and root hash using the `veritysetup` tool. These files are then placed into the `initramfs`.
+
+Any non-standard modifications to the image (adding symlinks, generating custom machine IDs, changing configs, etc.) need to be made prior to this point by using the `"PostInstallScripts"` key in the image config.
+
+### Writable Areas
+The build system currently supports two types of writable areas which are useful for read-only verity disks:
+
+#### Temporary Overlays
+Passing a list of directories using the `"TmpfsOverlays"` key in the `"ReadOnlyVerityRoot"` config will cause the initramfs to add `tmpfs` based writable overlays to each listed directory. These overlays are backed in RAM and will be reset after a reboot. These are useful for logging, or other transient data that is not security critical. Ideally the overlays should be kept as small as possible to minimize the number of files which may be maliciously modified at run time. The example configurations mount `/var` under a single overlay, but a more targeted approach is desirable. By default the overlays will consume at most 20% of the available memory. This can be configured using the `"TmpfsOverlaysSize"` key.
+
+#### Writable Mount Points
+Traditional mount points still function as expected. A writable data partition can be mounted using the normal configuration keys if desired.
+
+### Root of Trust
+The root of trust for a verity partition is the root hash. If this single hash is trusted, the entire hash tree, and then the full disk, can also be trusted. 
+
+The root hash may be protected three ways:
+- The file itself is stored in a safe location (signed `initramfs`)
+- The root hash is accompanied by a signature file which is validated against the kernel key ring
+- The root hash is passed on the kernel's command line in a secure manner
+
+The `imager` tool automatically places the root hash and hash tree in the initramfs and sets the kernel command line in the `grub.cfg` file to use the verity files. This means that both the grub configuration files and the initramfs must be part of the verified boot chain to fully tie the verity root filesystem into the chain of trust.
+
+### Users, Machine ID, Misc. Configuration
+Files in `/etc` such as the `passwd` and `machine-id` files are also part of the read-only filesystem, making them unmodifiable. If the machine-id is blank on system start, and the file is read-only, the systemd `systemd-machine-id-setup` command will create a tmpfs backed machine-id which will be different for every boot. If a stable `machine-id` is desired this file will need to be writable. Consider bind mounting the file early using the `x-initrd.mount` mount option and adding it to the `fstab` with `"PostInstallScripts"`.
+
+Ideally as much of `/etc` as possible should be left read-only to avoid miss-configuration.
+
+### Forward Error Correction (FEC)
+Verity supports error correction which will return the original data even if the underlying blocks have been modified (it does not restore the underlying data stored on disk however). FEC incurs some overhead but the hash tree, which is a sunk cost, makes it much more effective than normal Reed-Solomon codes. For a 2GiB disk, FEC with 2 roots (i.e. 2 bytes of error correction codes per 255 bytes of real data) can correct ~16MiB of errors with ~16MiB of overhead. See [veritydisk.go](../../tools/imagegen/configuration/veritydisk.go) for calculation details.
+
+### Overhead
+The extra data required for verity needs to be stored outside the measured partition. In the case of Mariner it is stored in the initramfs. Assuming the Merkle tree is a full m-ary tree with m=128 (128 branches per node, from `4k/sizeof(sha256)`), the size of the Merkle tree is:
+```
+blockSize = 4k
+m = blockSize / sizeof(sha256)
+leafNodes = diskSize/blockSize
+totalNodes = ceil((leafNodes*m - 1) / (m - 1))
+totalTreeSize = totalNodes * sizeof(sha256)
+```
+
+The FEC data grows linearly with the disk size. By default two bytes of error correction data are used for every 255 bytes of actual data. This gives:
+```
+fecBytesPerBlock = 2
+fecBlockSize = 255
+fecDataSize = ceil(diskSize / fecBlockSize) * fecBytesPerBlock
+```
+
+#### Examples
+For a 2GiB root disk we would expect:
+```
+leafNodes = 2GiB / 4KiB = 524288
+totalTreeSize = ceil((524288*128 - 1) / (128 - 1)) * 256 = 135274752 bits = 16.13 MiB
+
+fecDataSize = ceil(2GiB / 255 bits) * 2 bits = 134700000 = 16.06 MiB
+
+totalOverhead = 32.19 MiB (1.5% overhead)
+```
+For a 20GiB root disk we would expect:
+```
+totalTreeSize = 161.3 MiB
+
+fecDataSize = 160.6 MiB
+
+totalOverhead = 321.9 MiB (1.6% overhead)
+```
+
+### Debugging
+The read-only nature of these images can make debugging quite challenging.
+#### Serial Debugging
+Adding the following config will enable serial output (useful for both hardware and VM images), and will set `dracut` (The package which runs in the initramfs) to log its output and drop to an interactive shell in the event of a failure.
+```json
+"KernelCommandLine": {
+                "ExtraCommandLine": "console=tty0 console=ttyS0=9800 rd.debug rd.shell=1"
+}
+```
+
+#### Overlay Debugging
+If the `verity-read-only-root-debug-tools` package is included in the image, and the `"TmpfsOverlayDebugEnabled"` key is set to `true`, a read-only copy of the overlay upper directories (which will show the modified files for each overlay) will be visible under `/mnt/verity_overlay_debug_tmpfs`.
+
+#### Error Handling Debugging
+The `verity-read-only-root-debug-tools` package also includes the `/mnt/create_linear_mount.sh` script which will freeze the verity root and make a new, writable, mount at `/mnt/verity_writable_debug`. Interacting with the system while the root is frozen can be unstable however, so proceed with caution.
+
+Once the writable mount is created it is possible to write data back to the underlying disk. If the root partition is unfrozen again the changes will begin to be detected. Most changes will not show since the view of the disk is cached, but any changes to uncached files should trigger the error behavior. If FEC is enabled errors will simply be fixed until enough blocks are corrupted. The FEC correction is visible in the `dmesg` log.
+
+If enough blocks are corrupted the system will eventually be unable to recover them with FEC and the error handling behavior will trigger. The default behavior is to simply return an IO error, but other options are available by setting the `"VerityErrorBehavior"` key in the configuration file.
+
+## ISO Installers
+If a configuration used to create an ISO has a read-only root configured, the ISO installer will honor that configuration. (See `full.json`'s `"CBL-Mariner Core Read-Only"` entry).


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Read-only root and dm-verity: This set of ~~5~~ 6 PRs will enable dm-verity based read-only root file systems which can detect, and optionally repair modifications to files on the root file system. This supports both basic resilience to corruption as well as a number of additional security features.

PR [6/5] Adds documentation.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add documentation for read-only roots.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Test Methodology
None, only doc changes
