### PR TITLE
Fix test: mariadb

### DIFF
--- a/SPECS/mariadb/mariadb.spec
+++ b/SPECS/mariadb/mariadb.spec
@@ -1,7 +1,7 @@
 Summary:        Database servers made by the original developers of MySQL.
 Name:           mariadb
 Version:        10.3.17
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        GPLv2 with exceptions and LGPLv2 and BSD
 Group:          Applications/Databases
 Vendor:         Microsoft Corporation
@@ -54,6 +54,8 @@ errmsg for maridb
 %setup -q -n %{name}-%{version}
 # Remove PerconaFT from here because of AGPL licence
 rm -rf storage/tokudb/PerconaFT
+# Disable "embedded" directory which only contains "test-connect" test
+sed -i '/ADD_SUBDIRECTORY(unittest\/embedded)/d' ./CMakeLists.txt
 
 %build
 # Disable symbol generation
@@ -156,7 +158,6 @@ rm -rf %{buildroot}
 %{_bindir}/mysqlshow
 %{_bindir}/mysqlslap
 %{_bindir}/mariadb_config
-%{_bindir}/test-connect-t
 %{_bindir}/mysql_client_test
 %{_bindir}/mysql_client_test_embedded
 %{_bindir}/mysql_config
@@ -364,6 +365,8 @@ rm -rf %{buildroot}
 %{_datadir}/mysql/hindi/errmsg.sys
 
 %changelog
+*   Thu Jan 14 2021 Andrew Phelps <anphel@microsoft.com> 10.3.17-4
+-   Disable failing "test-connect" test and binary "test-connect-t"
 *   Fri Jun 12 2020 Henry Beberman <henry.beberman@microsoft.com> 10.3.17-3
 -   Temporarily disable generation of debug symbols.
 *   Tue Apr 28 2020 Emre Girgin <mrgirgin@microsoft.com> 10.3.17-2


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Fix Mariadb check tests by disabling "test-connect" test which is known to fail (according to LFS: http://www.linuxfromscratch.org/blfs/view/svn/server/mariadb.html)

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Disable "test-connect" test in mariadb spec

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
YES
**NO**

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local package build with RUN_CHECK=y
