### PR TITLE
Fixing `Requires` cycles resolution across specs.

### DIFF
--- a/toolkit/tools/grapher/grapher.go
+++ b/toolkit/tools/grapher/grapher.go
@@ -285,9 +285,6 @@ func fixCycle(g *pkggraph.PkgGraph, cycle []*pkggraph.PkgNode) (err error) {
 	groupedDependencies := make(map[int64]bool)
 	for _, currentNode := range trimmedCycle {
 		logger.Log.Tracef("\tCycle node: %s", currentNode.FriendlyName())
-		if currentNode.SrpmPath != specFile {
-			return fmt.Errorf("cycle contains packages from multiple SPEC files, unresolvable")
-		}
 		if currentNode.Type == pkggraph.TypeBuild {
 			return fmt.Errorf("cycle contains build dependencies, unresolvable")
 		}

--- a/toolkit/tools/grapher/grapher.go
+++ b/toolkit/tools/grapher/grapher.go
@@ -334,7 +334,7 @@ func validateGraph(g *pkggraph.PkgGraph) (err error) {
 			if err != nil {
 				var cycleStringBuilder strings.Builder
 
-				logger.Log.Errorf("Error found while resolving package dependency cycles: %v.", err)
+				logger.Log.Errorf("Error found while resolving package dependency cycles: %v", err)
 
 				fmt.Fprintf(&cycleStringBuilder, "{%s}", pkgCycle[0].FriendlyName())
 				for _, node := range pkgCycle[1:] {

--- a/toolkit/tools/grapher/grapher.go
+++ b/toolkit/tools/grapher/grapher.go
@@ -333,11 +333,14 @@ func validateGraph(g *pkggraph.PkgGraph) (err error) {
 			err = fixCycle(g, pkgCycle)
 			if err != nil {
 				var cycleStringBuilder strings.Builder
+
+				logger.Log.Errorf("Error found while resolving package dependency cycles: %v.", err)
+
 				fmt.Fprintf(&cycleStringBuilder, "{%s}", pkgCycle[0].FriendlyName())
 				for _, node := range pkgCycle[1:] {
 					fmt.Fprintf(&cycleStringBuilder, " --> {%s}", node.FriendlyName())
 				}
-				logger.Log.Errorf("Unfixable circular dependency found %d:\t%s", unfixableCycleCount, cycleStringBuilder.String())
+				logger.Log.Errorf("Unfixable circular dependency of length %d:\t%s", unfixableCycleCount, cycleStringBuilder.String())
 				unfixableCycleCount++
 			}
 		}


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Fixing `Requires` cycles resolution across specs. Right now if a package from spec "A" run-time depends on a package from spec "B" that's considered an error, while it shouldn't.

This fix is already present inside the `dev` branch: #328.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Made run-time cycle dependencies non-breaking.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
No.

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local package build run with run-time dependencies between specs.
