### PR TITLE
Update sudo package to 1.9.5p1

### DIFF
--- a/SPECS/sudo/sudo.signatures.json
+++ b/SPECS/sudo/sudo.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "sudo-1.8.31p1.tar.gz": "c73cfdfbc1c5cc259fcc3a355e1bacfed99c5580daeadec9704a24cd5e6d15d8"
+  "sudo-1.9.5p1.tar.gz": "4dddf37c22653defada299e5681e0daef54bb6f5fc950f63997bb8eb966b7882"
  }
 }

--- a/SPECS/sudo/sudo.spec
+++ b/SPECS/sudo/sudo.spec
@@ -1,7 +1,7 @@
 Summary:        Sudo
 Name:           sudo
-Version:        1.8.31p1
-Release:        4%{?dist}
+Version:        1.9.5p1
+Release:        1%{?dist}
 License:        ISC
 URL:            https://www.sudo.ws/
 Group:          System Environment/Security
@@ -77,23 +77,26 @@ rm -rf %{buildroot}/*
 %attr(0440,root,root) %config(noreplace) %{_sysconfdir}/sudoers
 %attr(0750,root,root) %dir %{_sysconfdir}/sudoers.d/
 %config(noreplace) %{_sysconfdir}/pam.d/sudo
+%config(noreplace) %{_sysconfdir}/sudo_logsrvd.conf
+%config(noreplace) %{_sysconfdir}/sudo.conf
 %{_bindir}/*
 %{_includedir}/*
 %{_libdir}/sudo/*.so
 %{_libdir}/sudo/*.so.*
 %{_sbindir}/*
+%{_datarootdir}/locale/*
 %{_mandir}/man1/*
 %{_mandir}/man5/*
 %{_mandir}/man8/*
 %{_docdir}/%{name}-%{version}/*
-%{_datarootdir}/locale/*
 %attr(0644,root,root) %{_libdir}/tmpfiles.d/sudo.conf
 %exclude  /etc/sudoers.dist
 
 %changelog
-* Sat May 09 00:20:42 PST 2020 Nick Samson <nisamson@microsoft.com> - 1.8.31p1-4
-- Added %%license line automatically
-
+*   Fri Jan 15 2021 Mateusz Malisz <mamalisz@microsoft.com> 1.9.5p1-1
+-   Update to version 1.9.5.p1 to fix CVE-2021-23240.
+*   Sat May 09 2020 Nick Samson <nisamson@microsoft.com> 1.8.31p1-4
+-   Added %%license line automatically
 *   Tue Apr 28 2020 Emre Girgin <mrgirgin@microsoft.com> 1.8.31p1-3
 -   Renaming Linux-PAM to pam
 *   Fri Apr 17 2020 Emre Girgin <mrgirgin@microsoft.com> 1.8.31p1-2

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -6335,8 +6335,8 @@
         "type": "other",
         "other": {
           "name": "sudo",
-          "version": "1.8.31p1",
-          "downloadUrl": "https://www.sudo.ws/sudo/dist/sudo-1.8.31p1.tar.gz"
+          "version": "1.9.5p1",
+          "downloadUrl": "https://www.sudo.ws/sudo/dist/sudo-1.9.5p1.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
This change updates sudo package to fix CVE-2021-23240.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Update sudo to 1.9.5p1, fixing CVE-2021-23240 .


###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Links to CVEs  <!-- optional -->
- https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2021-23240

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local package build
