### PR TITLE
Moving "Provides: pkgconfig(*)" for "libpng" to correct subpackage.

### DIFF
--- a/SPECS/libpng/libpng.spec
+++ b/SPECS/libpng/libpng.spec
@@ -1,21 +1,22 @@
 Summary:        contains libraries for reading and writing PNG files.
 Name:           libpng
 Version:        1.6.37
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        zlib
-# The site does NOT have an HTTPS cert available.
-URL:            http://www.libpng.org/
-Group:          System Environment/Libraries
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
+Group:          System Environment/Libraries
+# The site does NOT have an HTTPS cert available.
+URL:            http://www.libpng.org/
 Source0:        https://downloads.sourceforge.net/libpng/%{name}-%{version}.tar.xz
 
 %description
 The libpng package contains libraries used by other programs for reading and writing PNG files. The PNG format was designed as a replacement for GIF and, to a lesser extent, TIFF, with many improvements and extensions and lack of patent problems.
 
 %package    devel
-Summary:    Header and development files
-Requires:   %{name} = %{version}-%{release}
+Summary:        Header and development files
+
+Requires:       %{name} = %{version}-%{release}
 
 Provides:       pkgconfig(libpng) = %{version}-%{release}
 Provides:       pkgconfig(libpng16) = %{version}-%{release}
@@ -25,6 +26,7 @@ It contains the libraries and header files to create applications
 
 %prep
 %setup -q
+
 %build
 %configure
 make %{?_smp_mflags}
@@ -35,11 +37,8 @@ make DESTDIR=%{buildroot} install
 %check
 make %{?_smp_mflags} -k check
 
-%post
-/sbin/ldconfig
-
-%postun
-/sbin/ldconfig
+%post -p /sbin/ldconfig
+%postun -p /sbin/ldconfig
 
 %files
 %defattr(-,root,root)
@@ -47,7 +46,7 @@ make %{?_smp_mflags} -k check
 %{_bindir}/pngfix
 %{_bindir}/png-fix-itxt
 %{_libdir}/*.so.*
-%{_datadir}/man/man5/*
+%{_mandir}/man5/*
 
 %files devel
 %defattr(-,root,root)
@@ -57,26 +56,34 @@ make %{?_smp_mflags} -k check
 %{_libdir}/*.la
 %{_libdir}/*.a
 %{_libdir}/pkgconfig/*.pc
-%{_datadir}/man/man3/*
+%{_mandir}/man3/*
 
 %changelog
 * Tue Jan 19 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.6.37-3
 - Moved "Provides" for "pkgconfig(*)" to the correct (-devel) subpackage.
-*   Sat May 09 00:20:35 PST 2020 Nick Samson <nisamson@microsoft.com> - 1.6.37-2
--   Added %%license line automatically
-*   Fri May 08 2020 Nick Samson <nisamson@microsoft.com> 1.6.37-1
--   Updated to 1.6.37 to resolve CVE-2018-14550 and CVE-2019-7317.
--   Updated Source0 URL. Removed %%sha line.
--   License verified; moniker changed to reflect Fedora standards. 
-*   Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 1.6.35-2
--   Initial CBL-Mariner import from Photon (license: Apache2).
-*       Mon Sep 10 2018 Bo Gan <ganb@vmware.com> 1.6.35-1
--       Update to 1.6.35
-*    Tue Apr 11 2017 Harish Udaiya Kumar <hudaiyakumar@vmware.com> 1.6.29-1
--    Updated to version 1.6.29
-*       Thu Feb 23 2017 Divya Thaluru <dthaluru@vmware.com> 1.6.27-1
--       Updated to version 1.6.27
-*       Mon Sep 12 2016 Harish Udaiya Kumar <hudaiyakumar@vmware.com> 1.6.23-2
--       Included the libpng16 pkgconfig
-*       Wed Jul 27 2016 Divya Thaluru <dthaluru@vmware.com> 1.6.23-1
--       Initial version
+
+* Sat May 09 00:20:35 PST 2020 Nick Samson <nisamson@microsoft.com> - 1.6.37-2
+- Added %%license line automatically
+
+* Fri May 08 2020 Nick Samson <nisamson@microsoft.com> - 1.6.37-1
+- Updated to 1.6.37 to resolve CVE-2018-14550 and CVE-2019-7317.
+- Updated Source0 URL. Removed %%sha line.
+- License verified; moniker changed to reflect Fedora standards.
+
+* Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> - 1.6.35-2
+- Initial CBL-Mariner import from Photon (license: Apache2).
+
+* Mon Sep 10 2018 Bo Gan <ganb@vmware.com> - 1.6.35-1
+- Update to 1.6.35
+
+* Tue Apr 11 2017 Harish Udaiya Kumar <hudaiyakumar@vmware.com> - 1.6.29-1
+- Updated to version 1.6.29
+
+* Thu Feb 23 2017 Divya Thaluru <dthaluru@vmware.com> - 1.6.27-1
+- Updated to version 1.6.27
+
+* Mon Sep 12 2016 Harish Udaiya Kumar <hudaiyakumar@vmware.com> - 1.6.23-2
+- Included the libpng16 pkgconfig
+
+* Wed Jul 27 2016 Divya Thaluru <dthaluru@vmware.com> - 1.6.23-1
+- Initial version

--- a/SPECS/libpng/libpng.spec
+++ b/SPECS/libpng/libpng.spec
@@ -9,15 +9,18 @@ Group:          System Environment/Libraries
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Source0:        https://downloads.sourceforge.net/libpng/%{name}-%{version}.tar.xz
-Provides:       pkgconfig(libpng)
-Provides:       pkgconfig(libpng16)
+
 %description
 The libpng package contains libraries used by other programs for reading and writing PNG files. The PNG format was designed as a replacement for GIF and, to a lesser extent, TIFF, with many improvements and extensions and lack of patent problems.
 
-%package	devel
-Summary:	Header and development files
-Requires:	%{name} = %{version}-%{release}
-%description	devel
+%package    devel
+Summary:    Header and development files
+Requires:   %{name} = %{version}-%{release}
+
+Provides:       pkgconfig(libpng) = %{version}-%{release}
+Provides:       pkgconfig(libpng16) = %{version}-%{release}
+
+%description    devel
 It contains the libraries and header files to create applications
 
 %prep
@@ -57,6 +60,8 @@ make %{?_smp_mflags} -k check
 %{_datadir}/man/man3/*
 
 %changelog
+* Tue Jan 19 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.6.37-3
+- Moved "Provides" for "pkgconfig(*)" to the correct (-devel) subpackage.
 *   Sat May 09 00:20:35 PST 2020 Nick Samson <nisamson@microsoft.com> - 1.6.37-2
 -   Added %%license line automatically
 *   Fri May 08 2020 Nick Samson <nisamson@microsoft.com> 1.6.37-1
@@ -67,8 +72,8 @@ make %{?_smp_mflags} -k check
 -   Initial CBL-Mariner import from Photon (license: Apache2).
 *       Mon Sep 10 2018 Bo Gan <ganb@vmware.com> 1.6.35-1
 -       Update to 1.6.35
-*	Tue Apr 11 2017 Harish Udaiya Kumar <hudaiyakumar@vmware.com> 1.6.29-1
--	Updated to version 1.6.29
+*    Tue Apr 11 2017 Harish Udaiya Kumar <hudaiyakumar@vmware.com> 1.6.29-1
+-    Updated to version 1.6.29
 *       Thu Feb 23 2017 Divya Thaluru <dthaluru@vmware.com> 1.6.27-1
 -       Updated to version 1.6.27
 *       Mon Sep 12 2016 Harish Udaiya Kumar <hudaiyakumar@vmware.com> 1.6.23-2


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Moving `Provides: pkgconfig(*)` for `libpng` to correct subpackage. So far we've been saying that the default `libpng` package is providing the package configs, while in reality they are included inside the `libpng-devel` subpackage. This is breaking any build depending on `pkgconfig(libpng)` or `pkgconfig(libpng16)`.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Moved `Provides: pkgconfig(*)` for `libpng` to correct subpackage.
- Performed a linter spec clean-up.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
No.

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- None - simple configuration change.
