### PR TITLE
Script to cross compile GCC for aarch64-linux

### DIFF
--- a/toolkit/scripts/toolchain/cross/gcc_cross.sh
+++ b/toolkit/scripts/toolchain/cross/gcc_cross.sh
@@ -1,0 +1,80 @@
+installDir="/opt/cross"
+buildDir="$HOME/cross"
+scriptDir=$(dirname "$0")
+
+echo ${scriptDir}
+
+sudo rm -rf ${installDir}
+sudo rm -rf ${buildDir}
+
+mkdir ${buildDir}
+cd ${buildDir}
+
+wget http://ftp.gnu.org/gnu/binutils/binutils-2.32.tar.xz
+wget https://ftp.gnu.org/gnu/gcc/gcc-9.1.0/gcc-9.1.0.tar.xz
+wget https://github.com/microsoft/WSL2-Linux-Kernel/archive/linux-msft-5.4.83.tar.gz
+wget https://ftp.gnu.org/gnu/glibc/glibc-2.28.tar.xz
+wget http://www.mpfr.org/mpfr-4.0.1/mpfr-4.0.1.tar.gz
+wget http://ftp.gnu.org/gnu/gmp/gmp-6.1.2.tar.xz
+wget https://ftp.gnu.org/gnu/mpc/mpc-1.1.0.tar.gz
+
+sudo apt-get install gawk
+
+for f in *.tar*; do tar xf $f; done
+
+cd gcc-9.1.0
+ln -s ../mpfr-4.0.1 mpfr
+ln -s ../gmp-6.1.2 gmp
+ln -s ../mpc-1.1.0 mpc
+
+# Patch GCC to avoid an error where PATH_MAX isn't defined
+patch -p1 < "${scriptDir}/pathmax.patch"
+cd ..
+
+sudo mkdir -p ${installDir}
+sudo chown vitong ${installDir}
+export PATH="${installDir}/bin":$PATH
+
+mkdir build-binutils
+cd build-binutils
+../binutils-2.32/configure --prefix=${installDir} --target=aarch64-linux --disable-multilib
+make -j$(nproc)
+make install
+cd ..
+
+cd WSL2-Linux-Kernel-linux-msft-5.4.83
+make ARCH=arm64 INSTALL_HDR_PATH="${installDir}/aarch64-linux" headers_install
+cd ..
+
+mkdir -p build-gcc
+cd build-gcc
+../gcc-9.1.0/configure --prefix=${installDir} --target=aarch64-linux --disable-multilib --enable-shared --enable-threads=posix --enable-__cxa_atexit --enable-clocale=gnu --enable-languages=c,c++,fortran --disable-bootstrap --enable-linker-build-id  --enable-plugin --enable-default-pie
+make -j$(nproc) all-gcc
+make install-gcc
+cd ..
+
+mkdir -p build-glibc
+cd build-glibc
+../glibc-2.28/configure --prefix="${installDir}/aarch64-linux" --build=$MACHTYPE --host=aarch64-linux --target=aarch64-linux --with-headers="${installDir}/aarch64-linux/include" --disable-multilib libc_cv_forced_unwind=yes  --disable-werror
+
+make install-bootstrap-headers=yes install-headers
+make -j$(nproc) csu/subdir_lib
+install csu/crt1.o csu/crti.o csu/crtn.o "${installDir}/aarch64-linux/lib"
+aarch64-linux-gcc -nostdlib -nostartfiles -shared -x c /dev/null -o "${installDir}/aarch64-linux/lib/libc.so"
+touch "${installDir}/aarch64-linux/include/gnu/stubs.h"
+cd ..
+
+cd build-gcc
+make -j$(nproc) all-target-libgcc
+make install-target-libgcc
+cd ..
+
+cd build-glibc
+make -j$(nproc)
+make install
+cd ..
+
+cd build-gcc
+make -j$(nproc)
+make install
+cd ..

--- a/toolkit/scripts/toolchain/cross/gcc_cross.sh
+++ b/toolkit/scripts/toolchain/cross/gcc_cross.sh
@@ -5,9 +5,7 @@
 
 installDir="/opt/cross"
 buildDir="$HOME/cross"
-scriptDir=$(dirname "$0")
-
-echo ${scriptDir}
+scriptDir="$( cd "$( dirname "$0" )" && pwd )"
 
 sudo rm -rf ${installDir}
 sudo rm -rf ${buildDir}
@@ -20,12 +18,12 @@ wget http://ftp.gnu.org/gnu/binutils/binutils-2.32.tar.xz
 wget https://ftp.gnu.org/gnu/gcc/gcc-9.1.0/gcc-9.1.0.tar.xz
 wget https://github.com/microsoft/WSL2-Linux-Kernel/archive/linux-msft-5.4.83.tar.gz
 wget https://ftp.gnu.org/gnu/glibc/glibc-2.28.tar.xz
-wget http://www.mpfr.org/mpfr-4.0.1/mpfr-4.0.1.tar.gz
+wget https://ftp.gnu.org/gnu/mpfr/mpfr-4.0.1.tar.gz
 wget http://ftp.gnu.org/gnu/gmp/gmp-6.1.2.tar.xz
 wget https://ftp.gnu.org/gnu/mpc/mpc-1.1.0.tar.gz
 
-# Install gawk
-sudo apt-get install gawk
+# Install dependencies
+sudo apt-get install -y gawk rsync bison
 
 # Unzip source tarballs
 for f in *.tar*; do tar xf $f; done
@@ -40,35 +38,36 @@ patch -p1 < "${scriptDir}/pathmax.patch"
 cd ..
 
 sudo mkdir -p ${installDir}
-sudo chown vitong ${installDir}
 export PATH="${installDir}/bin":$PATH
 
 mkdir build-binutils
 cd build-binutils
-../binutils-2.32/configure --prefix=${installDir} --target=aarch64-linux --disable-multilib
+../binutils-2.32/configure --prefix=${installDir} --target=aarch64-linux-gnu --disable-multilib
 make -j$(nproc)
 make install
 cd ..
 
 cd WSL2-Linux-Kernel-linux-msft-5.4.83
-make ARCH=arm64 INSTALL_HDR_PATH="${installDir}/aarch64-linux" headers_install
+make mrproper
+make ARCH=arm64 headers_check
+make ARCH=arm64 INSTALL_HDR_PATH="${installDir}/aarch64-linux-gnu" headers_install
 cd ..
 
 mkdir -p build-gcc
 cd build-gcc
-../gcc-9.1.0/configure --prefix=${installDir} --target=aarch64-linux --disable-multilib --enable-shared --enable-threads=posix --enable-__cxa_atexit --enable-clocale=gnu --enable-languages=c,c++,fortran --disable-bootstrap --enable-linker-build-id  --enable-plugin --enable-default-pie
+../gcc-9.1.0/configure --prefix=${installDir} --target=aarch64-linux-gnu --disable-multilib --enable-shared --enable-threads=posix --enable-__cxa_atexit --enable-clocale=gnu --enable-languages=c,c++,fortran --disable-bootstrap --enable-linker-build-id  --enable-plugin --enable-default-pie
 make -j$(nproc) all-gcc
 make install-gcc
 cd ..
 
 mkdir -p build-glibc
 cd build-glibc
-../glibc-2.28/configure --prefix="${installDir}/aarch64-linux" --build=$MACHTYPE --host=aarch64-linux --target=aarch64-linux --with-headers="${installDir}/aarch64-linux/include" --disable-multilib libc_cv_forced_unwind=yes  --disable-werror
+../glibc-2.28/configure --prefix="${installDir}/aarch64-linux-gnu" --build=$MACHTYPE --host=aarch64-linux-gnu --target=aarch64-linux-gnu --with-headers="${installDir}/aarch64-linux-gnu/include" --disable-multilib libc_cv_forced_unwind=yes  --disable-werror
 make install-bootstrap-headers=yes install-headers
 make -j$(nproc) csu/subdir_lib
-install csu/crt1.o csu/crti.o csu/crtn.o "${installDir}/aarch64-linux/lib"
-aarch64-linux-gcc -nostdlib -nostartfiles -shared -x c /dev/null -o "${installDir}/aarch64-linux/lib/libc.so"
-touch "${installDir}/aarch64-linux/include/gnu/stubs.h"
+install csu/crt1.o csu/crti.o csu/crtn.o "${installDir}/aarch64-linux-gnu/lib"
+aarch64-linux-gnu-gcc -nostdlib -nostartfiles -shared -x c /dev/null -o "${installDir}/aarch64-linux-gnu/lib/libc.so"
+touch "${installDir}/aarch64-linux-gnu/include/gnu/stubs.h"
 cd ..
 
 cd build-gcc

--- a/toolkit/scripts/toolchain/cross/gcc_cross.sh
+++ b/toolkit/scripts/toolchain/cross/gcc_cross.sh
@@ -1,7 +1,20 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 # Docs used to create this script:
 # https://preshing.com/20141119/how-to-build-a-gcc-cross-compiler/
 # https://mdeva2.home.blog/2019/07/08/building-gcc-as-a-cross-compiler-for-raspberry-pi/
 # http://jiadongsun.cc/2019/09/03/Cross_Compile_Gcc/#6-build-glibc
+
+# ====== Prerequisites ======
+# The following packages need to be installed before running this script
+# For Ubuntu/Mariner:
+# gawk rsync bison
+
+# For Mariner, these additional packages need to be installed:
+# make patch texinfo diffutils
+# ====================
+
 
 installDir="/opt/cross"
 buildDir="$HOME/cross"
@@ -21,9 +34,6 @@ wget https://ftp.gnu.org/gnu/glibc/glibc-2.28.tar.xz
 wget https://ftp.gnu.org/gnu/mpfr/mpfr-4.0.1.tar.gz
 wget http://ftp.gnu.org/gnu/gmp/gmp-6.1.2.tar.xz
 wget https://ftp.gnu.org/gnu/mpc/mpc-1.1.0.tar.gz
-
-# Install dependencies
-sudo apt-get install -y gawk rsync bison
 
 # Unzip source tarballs
 for f in *.tar*; do tar xf $f; done

--- a/toolkit/scripts/toolchain/cross/gcc_cross.sh
+++ b/toolkit/scripts/toolchain/cross/gcc_cross.sh
@@ -1,3 +1,8 @@
+# Docs used to create this script:
+# https://preshing.com/20141119/how-to-build-a-gcc-cross-compiler/
+# https://mdeva2.home.blog/2019/07/08/building-gcc-as-a-cross-compiler-for-raspberry-pi/
+# http://jiadongsun.cc/2019/09/03/Cross_Compile_Gcc/#6-build-glibc
+
 installDir="/opt/cross"
 buildDir="$HOME/cross"
 scriptDir=$(dirname "$0")
@@ -10,6 +15,7 @@ sudo rm -rf ${buildDir}
 mkdir ${buildDir}
 cd ${buildDir}
 
+# Download source tarballs
 wget http://ftp.gnu.org/gnu/binutils/binutils-2.32.tar.xz
 wget https://ftp.gnu.org/gnu/gcc/gcc-9.1.0/gcc-9.1.0.tar.xz
 wget https://github.com/microsoft/WSL2-Linux-Kernel/archive/linux-msft-5.4.83.tar.gz
@@ -18,8 +24,10 @@ wget http://www.mpfr.org/mpfr-4.0.1/mpfr-4.0.1.tar.gz
 wget http://ftp.gnu.org/gnu/gmp/gmp-6.1.2.tar.xz
 wget https://ftp.gnu.org/gnu/mpc/mpc-1.1.0.tar.gz
 
+# Install gawk
 sudo apt-get install gawk
 
+# Unzip source tarballs
 for f in *.tar*; do tar xf $f; done
 
 cd gcc-9.1.0
@@ -56,7 +64,6 @@ cd ..
 mkdir -p build-glibc
 cd build-glibc
 ../glibc-2.28/configure --prefix="${installDir}/aarch64-linux" --build=$MACHTYPE --host=aarch64-linux --target=aarch64-linux --with-headers="${installDir}/aarch64-linux/include" --disable-multilib libc_cv_forced_unwind=yes  --disable-werror
-
 make install-bootstrap-headers=yes install-headers
 make -j$(nproc) csu/subdir_lib
 install csu/crt1.o csu/crti.o csu/crtn.o "${installDir}/aarch64-linux/lib"

--- a/toolkit/scripts/toolchain/cross/pathmax.patch
+++ b/toolkit/scripts/toolchain/cross/pathmax.patch
@@ -1,0 +1,15 @@
+diff --git a/libsanitizer/asan/asan_linux.cc b/libsanitizer/asan/asan_linux.cc
+index d92d0596b7c..116c463895c 100644
+--- a/libsanitizer/asan/asan_linux.cc
++++ b/libsanitizer/asan/asan_linux.cc
+@@ -75,6 +75,10 @@ SANITIZER_INTERFACE_ATTRIBUTE
+ asan_rt_version_t  __asan_rt_version;
+ }
+ 
++#ifndef PATH_MAX
++#define PATH_MAX 4096
++#endif
++
+ namespace __asan {
+ 
+ void InitializePlatformInterceptors() {}


### PR DESCRIPTION
What does the PR accomplish, why was it needed?

This PR adds a script that can be used to build the GCC cross-target toolchain targeting aarch64-linux. It downloads the source zips required and then creates a directory to build (under $HOME/cross and a separate directory to install the toolset at /opt/cross). I verified that the compiled GCC binary builds a simple lambda test cpp file and generates an ARM64 binary.

