### PR TITLE
Patch python-cryptography CVE-2020-25659

### DIFF
--- a/SPECS/python-cryptography/CVE-2020-25659.patch
+++ b/SPECS/python-cryptography/CVE-2020-25659.patch
@@ -1,0 +1,91 @@
+From ce1bef6f1ee06ac497ca0c837fbd1c7ef6c2472b Mon Sep 17 00:00:00 2001
+From: Alex Gaynor <alex.gaynor@gmail.com>
+Date: Sun, 25 Oct 2020 19:01:50 -0400
+Subject: [PATCH] Attempt to mitigate Bleichenbacher attacks on RSA decryption
+Patch backported to python-cryptography version 2.3.1 by henry.beberman@microsoft.com
+
+diff -ur a/CHANGELOG.rst b/CHANGELOG.rst
+--- a/CHANGELOG.rst	2018-08-14 10:24:28.000000000 -0700
++++ b/CHANGELOG.rst	2021-01-20 11:09:02.661169269 -0800
+@@ -1,6 +1,16 @@
+ Changelog
+ =========
+ 
++2.3.1 - 2021-01-20
++~~~~~~~~~~~~~~~~~~
++
+++* **SECURITY ISSUE:** Attempted to make RSA PKCS#1v1.5 decryption more constant
+++  time, to protect against Bleichenbacher vulnerabilities. Due to limitations
+++  imposed by our API, we cannot completely mitigate this vulnerability and a
+++  future release will contain a new API which is designed to be resilient to
+++  these for contexts where it is required. Credit to **Hubert Kario** for
+++  reporting the issue. *CVE-2020-25659*
++
+ .. _v2-3-1:
+ 
+ 2.3.1 - 2018-08-14
+diff -ur a/docs/spelling_wordlist.txt b/docs/spelling_wordlist.txt
+--- a/docs/spelling_wordlist.txt	2018-08-14 10:24:28.000000000 -0700
++++ b/docs/spelling_wordlist.txt	2021-01-20 11:10:26.001031614 -0800
+@@ -5,6 +5,7 @@
+ Backends
+ backends
+ bcrypt
++Bleichenbacher
+ Blowfish
+ boolean
+ Botan
+diff -ur a/src/cryptography/hazmat/backends/openssl/rsa.py b/src/cryptography/hazmat/backends/openssl/rsa.py
+--- a/src/cryptography/hazmat/backends/openssl/rsa.py	2018-08-14 10:24:23.000000000 -0700
++++ b/src/cryptography/hazmat/backends/openssl/rsa.py	2021-01-20 11:10:20.461040920 -0800
+@@ -120,39 +120,19 @@
+ 
+     outlen = backend._ffi.new("size_t *", buf_size)
+     buf = backend._ffi.new("unsigned char[]", buf_size)
++    # Everything from this line onwards is written with the goal of being as
++    # constant-time as is practical given the constraints of Python and our
++    # API. See Bleichenbacher's '98 attack on RSA, and its many many variants.
++    # As such, you should not attempt to change this (particularly to "clean it
++    # up") without understanding why it was written this way (see
++    # Chesterton's Fence), and without measuring to verify you have not
++    # introduced observable time differences.
+     res = crypt(pkey_ctx, buf, outlen, data, len(data))
++    resbuf = backend._ffi.buffer(buf)[: outlen[0]]
++    backend._lib.ERR_clear_error()
+     if res <= 0:
+-        _handle_rsa_enc_dec_error(backend, key)
+-
+-    return backend._ffi.buffer(buf)[:outlen[0]]
+-
+-
+-def _handle_rsa_enc_dec_error(backend, key):
+-    errors = backend._consume_errors()
+-    backend.openssl_assert(errors)
+-    assert errors[0].lib == backend._lib.ERR_LIB_RSA
+-    if isinstance(key, _RSAPublicKey):
+-        assert (errors[0].reason ==
+-                backend._lib.RSA_R_DATA_TOO_LARGE_FOR_KEY_SIZE)
+-        raise ValueError(
+-            "Data too long for key size. Encrypt less data or use a "
+-            "larger key size."
+-        )
+-    else:
+-        decoding_errors = [
+-            backend._lib.RSA_R_BLOCK_TYPE_IS_NOT_01,
+-            backend._lib.RSA_R_BLOCK_TYPE_IS_NOT_02,
+-            backend._lib.RSA_R_OAEP_DECODING_ERROR,
+-            # Though this error looks similar to the
+-            # RSA_R_DATA_TOO_LARGE_FOR_KEY_SIZE, this occurs on decrypts,
+-            # rather than on encrypts
+-            backend._lib.RSA_R_DATA_TOO_LARGE_FOR_MODULUS,
+-        ]
+-        if backend._lib.Cryptography_HAS_RSA_R_PKCS_DECODING_ERROR:
+-            decoding_errors.append(backend._lib.RSA_R_PKCS_DECODING_ERROR)
+-
+-        assert errors[0].reason in decoding_errors
+-        raise ValueError("Decryption failed.")
++        raise ValueError("Encryption/decryption failed.")
++    return resbuf
+ 
+ 
+ def _rsa_sig_determine_padding(backend, key, padding, algorithm):

--- a/SPECS/python-cryptography/python-cryptography.spec
+++ b/SPECS/python-cryptography/python-cryptography.spec
@@ -4,14 +4,16 @@
 Summary:        Python cryptography library
 Name:           python-cryptography
 Version:        2.3.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 Url:            https://pypi.python.org/pypi/cryptography
 License:        ASL 2.0
 Group:          Development/Languages/Python
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Source0:        https://pypi.io/packages/source/c/cryptography/cryptography-%{version}.tar.gz
-%define sha1    cryptography=c550f9ba5a46ad33a0568edc2b9d0f4af3e4adab
+
+Patch0:         CVE-2020-25659.patch
+
 BuildRequires:  python2
 BuildRequires:  python2-libs
 BuildRequires:  python2-devel
@@ -58,7 +60,7 @@ Requires:       python3-asn1crypto
 Python 3 version.
 
 %prep
-%setup -q -n cryptography-%{version}
+%autosetup -p1 -n cryptography-%{version}
 rm -rf ../p3dir
 cp -a . ../p3dir
 
@@ -99,9 +101,11 @@ python3 setup.py test
 %{python3_sitelib}/*
 
 %changelog
-* Sat May 09 00:20:51 PST 2020 Nick Samson <nisamson@microsoft.com> - 2.3.1-3
-- Added %%license line automatically
-
+*   Wed Jan 20 2021 Henry Beberman <henry.beberman@microsoft.com> 2.3.1-4
+-   Patch CVE-2020-25659
+-   License verified
+*   Sat May 09 00:20:51 PST 2020 Nick Samson <nisamson@microsoft.com> 2.3.1-3
+-   Added %%license line automatically
 *   Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 2.3.1-2
 -   Initial CBL-Mariner import from Photon (license: Apache2).
 *   Sun Sep 09 2018 Tapas Kundu <tkundu@vmware.com> 2.3.1-1


### PR DESCRIPTION
Backport CVE-2020-25659 patch to python-cryptography 2.3.1

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Patch python-cryptography CVE-2020-25659

###### Change Log  <!-- REQUIRED -->
- Patch python-cryptography CVE-2020-25659


###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
***NO***

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2020-25659

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local build
