### PR TITLE
Add missing VHDX instrution and fix layout issue

### DIFF
--- a/toolkit/docs/quick_start/quickstart.md
+++ b/toolkit/docs/quick_start/quickstart.md
@@ -49,10 +49,10 @@ sudo make image REBUILD_TOOLS=y REBUILD_PACKAGES=n CONFIG_FILE=./imageconfigs/co
 # Build the cloud-init configuration image 
 # The output image is ../out/images/meta-user-data.iso
 sudo make meta-user-data
-
 ```
 
 **Copy VHD(X) and ISO Images to Your VM Host Machine**
+
 Copy your binary image(s) to your VM Host Machine using your preferred technique.
 
 **Create VHD(X) Virtual Machine with Hyper-V**
@@ -70,7 +70,7 @@ Copy your binary image(s) to your VM Host Machine using your preferred technique
 1. Select _Settings..._.
 1. Select Security and disable _Enable Secure Boot_.
 1. Select the SCSI Controller from the Hardware panel.
-
+1. Select DVD Drive and press Add.
 
 **Mount the Meta-User-Data.Iso Image**
 
@@ -103,6 +103,7 @@ cd toolkit
 sudo make iso REBUILD_TOOLS=y REBUILD_PACKAGES=n CONFIG_FILE=./imageconfigs/full.json
 ```
 **Copy ISO Image to Your VM Host Machine**
+
 Copy your binary image(s) to your VM Host Machine using your preferred technique.
 
 **Create VHD(X) Virtual Machine with Hyper-V**


### PR DESCRIPTION
Minor updates to the VHDX instructions.

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
This change fixes some instructions related to VHDX, and fixes some spacing issues.


###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
YES
**NO**