### PR TITLE
Extending `mariner-repos`.

### DIFF
--- a/SPECS/mariner-repos/mariner-repos.signatures.json
+++ b/SPECS/mariner-repos/mariner-repos.signatures.json
@@ -4,6 +4,8 @@
   "MICROSOFT-METADATA-GPG-KEY": "1824ecffeda90cfe4178a99bddde450f09fd40e8faf4f0124fba16ea79998c4c",
   "mariner-official-base.repo": "af485f85c5c856536c6ec2f73f0afd1d9c424396fce1c9ae6f40745a5f41503d",
   "mariner-official-update.repo": "d80ed87ba6cf1e535131a9a68499b832dc87fc9add29cbae0f6cc76ebc36fbf3",
-  "mariner-preview.repo": "7b5731bce3d0c81647144822a886a01912e325db10f7519e105b5224a25f1568"
+  "mariner-preview.repo": "7b5731bce3d0c81647144822a886a01912e325db10f7519e105b5224a25f1568",
+  "mariner-ui.repo": "3e434c6418de638ff919f373f666866d0e075b8f26deeec4b96fb47e1d62d9b3",
+  "mariner-ui-preview.repo": "77a094a136cab2a927cffe92753e853f44b28607010cf48af7a2781edb7aded0"
  }
 }

--- a/SPECS/mariner-repos/mariner-repos.spec
+++ b/SPECS/mariner-repos/mariner-repos.spec
@@ -1,7 +1,7 @@
 Summary:        CBL-Mariner repo files, gpg keys
 Name:           mariner-repos
 Version:        1.0
-Release:        11%{?dist}
+Release:        12%{?dist}
 License:        Apache License
 Group:          System Environment/Base
 URL:            https://aka.ms/mariner
@@ -12,6 +12,8 @@ Source1:        MICROSOFT-METADATA-GPG-KEY
 Source2:        mariner-official-base.repo
 Source3:        mariner-official-update.repo
 Source4:        mariner-preview.repo
+Source5:        mariner-ui.repo
+Source6:        mariner-ui-preview.repo
 
 Requires(post): gpgme
 Requires(post): rpm
@@ -30,12 +32,30 @@ Requires:   %{name} = %{version}-%{release}
 %description preview
 %{summary}
 
+%package ui
+Summary:    CBL-Mariner UI repo file.
+Group:      System Environment/Base
+Requires:   %{name} = %{version}-%{release}
+
+%description ui
+%{summary}
+
+%package ui-preview
+Summary:    CBL-Mariner UI preview repo file.
+Group:      System Environment/Base
+Requires:   %{name}-ui = %{version}-%{release}
+
+%description ui-preview
+%{summary}
+
 %install
 rm -rf $RPM_BUILD_ROOT
 install -d -m 755 $RPM_BUILD_ROOT/etc/yum.repos.d
 install -m 644 %{SOURCE2} $RPM_BUILD_ROOT/etc/yum.repos.d
 install -m 644 %{SOURCE3} $RPM_BUILD_ROOT/etc/yum.repos.d
 install -m 644 %{SOURCE4} $RPM_BUILD_ROOT/etc/yum.repos.d
+install -m 644 %{SOURCE5} $RPM_BUILD_ROOT/etc/yum.repos.d
+install -m 644 %{SOURCE6} $RPM_BUILD_ROOT/etc/yum.repos.d
 
 install -d -m 755 $RPM_BUILD_ROOT/etc/pki/rpm-gpg
 install -m 644 %{SOURCE0} $RPM_BUILD_ROOT/etc/pki/rpm-gpg
@@ -66,8 +86,18 @@ gpg --batch --yes --delete-keys 2BC94FFF7015A5F28F1537AD0CD9FED33135CE90
 %defattr(-,root,root,-)
 %config(noreplace) /etc/yum.repos.d/mariner-preview.repo
 
+%files ui
+%defattr(-,root,root,-)
+%config(noreplace) /etc/yum.repos.d/mariner-ui.repo
+
+%files ui-preview
+%defattr(-,root,root,-)
+%config(noreplace) /etc/yum.repos.d/mariner-ui-preview.repo
+
 %changelog
-*   Thu Oct 01 2020 Emre Girgin <sarsoma@microsoft.com> - 1.0-11
+*   Fri Jan 22 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.0-12
+-   Adding a set of repos with the UI components.
+*   Thu Oct 01 2020 Emre Girgin <mrgirgin@microsoft.com> - 1.0-11
 -   Change %%post scriptlet to %%posttrans in order to ensure it runs after %%postun during an upgrade.
 *   Mon Sep 28 2020 Pawel Winogrodzki <pawelwi@microsoft.com> 1.0-10
 -   Adding configuration to access the preview repository.

--- a/SPECS/mariner-repos/mariner-ui-preview.repo
+++ b/SPECS/mariner-repos/mariner-ui-preview.repo
@@ -1,0 +1,9 @@
+[mariner-ui-preview]
+name=CBL-Mariner UI Official Preview $releasever $basearch
+baseurl=https://packages.microsoft.com/cbl-mariner/$releasever/preview/coreui/$basearch/rpms
+gpgkey=file:///etc/pki/rpm-gpg/MICROSOFT-RPM-GPG-KEY file:///etc/pki/rpm-gpg/MICROSOFT-METADATA-GPG-KEY
+gpgcheck=1
+repo_gpgcheck=1
+enabled=1
+skip_if_unavailable=True
+sslverify=1

--- a/SPECS/mariner-repos/mariner-ui.repo
+++ b/SPECS/mariner-repos/mariner-ui.repo
@@ -1,0 +1,9 @@
+[mariner-ui]
+name=CBL-Mariner UI Official $releasever $basearch
+baseurl=https://packages.microsoft.com/cbl-mariner/$releasever/prod/coreui/$basearch/rpms
+gpgkey=file:///etc/pki/rpm-gpg/MICROSOFT-RPM-GPG-KEY file:///etc/pki/rpm-gpg/MICROSOFT-METADATA-GPG-KEY
+gpgcheck=1
+repo_gpgcheck=1
+enabled=1
+skip_if_unavailable=True
+sslverify=1

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -155,8 +155,8 @@ npth-1.6-3.cm1.aarch64.rpm
 pinentry-1.1.0-3.cm1.aarch64.rpm
 gnupg2-2.2.20-3.cm1.aarch64.rpm
 gpgme-1.13.1-6.cm1.aarch64.rpm
-mariner-repos-1.0-11.cm1.noarch.rpm
-mariner-repos-preview-1.0-11.cm1.noarch.rpm
+mariner-repos-1.0-12.cm1.noarch.rpm
+mariner-repos-preview-1.0-12.cm1.noarch.rpm
 libffi-3.2.1-12.cm1.aarch64.rpm
 libtasn1-4.14-2.cm1.aarch64.rpm
 p11-kit-0.23.22-1.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -155,8 +155,8 @@ npth-1.6-3.cm1.x86_64.rpm
 pinentry-1.1.0-3.cm1.x86_64.rpm
 gnupg2-2.2.20-3.cm1.x86_64.rpm
 gpgme-1.13.1-6.cm1.x86_64.rpm
-mariner-repos-1.0-11.cm1.noarch.rpm
-mariner-repos-preview-1.0-11.cm1.noarch.rpm
+mariner-repos-1.0-12.cm1.noarch.rpm
+mariner-repos-preview-1.0-12.cm1.noarch.rpm
 libffi-3.2.1-12.cm1.x86_64.rpm
 libtasn1-4.14-2.cm1.x86_64.rpm
 p11-kit-0.23.22-1.cm1.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -238,8 +238,8 @@ make-4.2.1-5.cm1.aarch64.rpm
 make-debuginfo-4.2.1-5.cm1.aarch64.rpm
 mariner-check-macros-1.0-3.cm1.noarch.rpm
 mariner-release-1.0-12.cm1.noarch.rpm
-mariner-repos-1.0-11.cm1.noarch.rpm
-mariner-repos-preview-1.0-11.cm1.noarch.rpm
+mariner-repos-1.0-12.cm1.noarch.rpm
+mariner-repos-preview-1.0-12.cm1.noarch.rpm
 mariner-rpm-macros-1.0-3.cm1.noarch.rpm
 meson-0.56.0-1.cm1.noarch.rpm
 mpfr-4.0.1-3.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -238,8 +238,8 @@ make-4.2.1-5.cm1.x86_64.rpm
 make-debuginfo-4.2.1-5.cm1.x86_64.rpm
 mariner-check-macros-1.0-3.cm1.noarch.rpm
 mariner-release-1.0-12.cm1.noarch.rpm
-mariner-repos-1.0-11.cm1.noarch.rpm
-mariner-repos-preview-1.0-11.cm1.noarch.rpm
+mariner-repos-1.0-12.cm1.noarch.rpm
+mariner-repos-preview-1.0-12.cm1.noarch.rpm
 mariner-rpm-macros-1.0-3.cm1.noarch.rpm
 meson-0.56.0-1.cm1.noarch.rpm
 mpfr-4.0.1-3.cm1.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge.

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
We've recently set-up some new repositories on PMC and thus need to also provide appropriate .repo files.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Added .repo files to point to the new repositories.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
No.

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local package build.
