### PR TITLE
WALinuxAgent change log directory

### DIFF
--- a/SPECS/WALinuxAgent/WALinuxAgent.spec
+++ b/SPECS/WALinuxAgent/WALinuxAgent.spec
@@ -1,7 +1,7 @@
 Summary:        The Windows Azure Linux Agent
 Name:           WALinuxAgent
 Version:        2.2.52
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -48,10 +48,8 @@ python2 setup.py build -b py2
 python2 -tt setup.py build -b py2 install --prefix=%{_prefix} --lnx-distro='mariner' --root=%{buildroot} --force
 mkdir -p  %{buildroot}/%{_localstatedir}/log
 mkdir -p -m 0700 %{buildroot}/%{_sharedstatedir}/waagent
-mkdir -p %{buildroot}/%{_localstatedir}/opt/waagent/log
-mkdir -p %{buildroot}/%{_localstatedir}/log/
-touch %{buildroot}/%{_localstatedir}/opt/waagent/log/waagent.log
-ln -sfv /opt/waagent/log/waagent.log %{buildroot}%{_localstatedir}/log/waagent.log
+mkdir -p %{buildroot}/%{_localstatedir}/log
+touch %{buildroot}/%{_localstatedir}/log/waagent.log
 
 %check
 python2 setup.py check && python2 setup.py test
@@ -73,13 +71,14 @@ python2 setup.py check && python2 setup.py test
 %attr(0755,root,root) %{_sbindir}/waagent
 %attr(0755,root,root) %{_sbindir}/waagent2.0
 %config %{_sysconfdir}/waagent.conf
-%dir %{_localstatedir}/opt/waagent/log
-%{_localstatedir}/log/waagent.log
-%ghost %{_localstatedir}/opt/waagent/log/waagent.log
+%ghost %{_localstatedir}/log/waagent.log
 %dir %attr(0700, root, root) %{_sharedstatedir}/waagent
 %{_lib}/python2.7/site-packages/*
 
 %changelog
+* Mon Jan 25 2021 Henry Beberman <henry.beberman@microsoft.com> 2.2.52-2
+- Remove log symlink and use /var/log/waagent.log directly
+
 * Tue Dec 08 2020 Henry Li <lihl@microsoft.com> - 2.2.52-1
 - Upgrade to version 2.2.52
 - Update add-distro.patch


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Currently WALinuxAgent is trying to write its log to /var/log/waagent.log, but that file is a symlink to /opt/waagent/log/waagent.log. Since /opt/waagent/log is not created by the package, those writes are silently failing. This change removes the symlink and just lets waagent log into /var/log/waagent.log directly.

###### Change Log  <!-- REQUIRED -->
- WALinuxAgent no longer creates the /var/log/waagent.log as a symlink and instead logs there directly.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
**NO**

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local build and installation 
