### PR TITLE
Fix check tests for: gnutls

### DIFF
--- a/SPECS/gnutls/gnutls.spec
+++ b/SPECS/gnutls/gnutls.spec
@@ -1,19 +1,25 @@
 Summary:        The GnuTLS Transport Layer Security Library
 Name:           gnutls
 Version:        3.6.14
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        GPLv3+ and LGPLv2+
 URL:            https://www.gnutls.org
 Source0:        ftp://ftp.gnutls.org/gcrypt/gnutls/v3.6/%{name}-%{version}.tar.xz
 Group:          System Environment/Libraries
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
+
 BuildRequires:  nettle-devel
 BuildRequires:  autogen-libopts-devel
 BuildRequires:  libtasn1-devel
 BuildRequires:  openssl-devel
 BuildRequires:  guile-devel
 BuildRequires:  gc-devel
+%if %{with_check}
+BuildRequires:  net-tools
+BuildRequires:  which
+%endif
+
 Requires:       nettle
 Requires:       autogen-libopts
 Requires:       libtasn1
@@ -47,7 +53,7 @@ developing applications that use gnutls.
     --disable-openssl-compatibility \
     --with-included-unistring \
     --with-system-priority-file=%{_sysconfdir}/gnutls/default-priorities \
-    --with-default-trust-store-file=%{_sysconfdir}/pki/tls/certs/ca-bundle.trust.crt \
+    --with-default-trust-store-file=%{_sysconfdir}/ssl/certs/ca-bundle.crt \
     --with-default-trust-store-dir=%{_sysconfdir}/ssl/certs
 make %{?_smp_mflags}
 
@@ -62,6 +68,9 @@ SYSTEM=NONE:!VERS-SSL3.0:!VERS-TLS1.0:+VERS-TLS1.1:+VERS-TLS1.2:+AES-128-CBC:+RS
 EOF
 
 %check
+# Disable test-ciphers-openssl.sh test, which relies on ciphers our openssl.spec has disabled.
+#     Observed error: "cipher_test:50: EVP_get_cipherbyname failed for chacha20-poly1305"
+sed -i 's/TESTS += test-ciphers-openssl.sh//'  tests/slow/Makefile.am
 make %{?_smp_mflags} check
 
 %post
@@ -91,6 +100,8 @@ make %{?_smp_mflags} check
 %{_mandir}/man3/*
 
 %changelog
+*   Tue Jan 26 2021 Andrew Phelps <anphel@microsoft.com> 3.6.14-4
+-   Fix check tests.
 *   Wed Oct 21 2020 Henry Beberman <henry.beberman@microsoft.com> 3.6.14-3
 -   Apply patch for CVE-2020-24659 from upstream.
 -   Switch setup to autosetup.


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Fix check tests for gnutls. Add missing dependency packages. Fix the default trust store file during configure; which resolves the error "doit:64: no certificates were found in system trust store!" from the "trust-store" test.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Fix check tests for gnutls

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
YES
**NO**

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local package build with RUN_CHECK=y
