### PR TITLE
Fix sudo CVE-2021-3156 and sudoer config.

### DIFF
--- a/SPECS/sudo/sudo.signatures.json
+++ b/SPECS/sudo/sudo.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "sudo-1.9.5p1.tar.gz": "4dddf37c22653defada299e5681e0daef54bb6f5fc950f63997bb8eb966b7882"
+  "sudo-1.9.5p2.tar.gz": "539e2ef43c8a55026697fb0474ab6a925a11206b5aa58710cb42a0e1c81f0978"
  }
 }

--- a/SPECS/sudo/sudo.spec
+++ b/SPECS/sudo/sudo.spec
@@ -1,6 +1,6 @@
 Summary:        Sudo
 Name:           sudo
-Version:        1.9.5p1
+Version:        1.9.5p2
 Release:        1%{?dist}
 License:        ISC
 URL:            https://www.sudo.ws/
@@ -30,7 +30,7 @@ the ability to run some (or all) commands as root or another user while logging 
     --with-all-insults \
     --with-env-editor \
     --with-pam \
-    --with-passprompt="[sudo] password for %p"
+    --with-passprompt="[sudo] password for %p: "
 
 make %{?_smp_mflags}
 
@@ -40,9 +40,9 @@ make install DESTDIR=%{buildroot}
 install -v -dm755 %{buildroot}/%{_docdir}/%{name}-%{version}
 find %{buildroot}/%{_libdir} -name '*.la' -delete
 find %{buildroot}/%{_libdir} -name '*.so~' -delete
-sed -i '/#includedir.*/i \
-%wheel ALL=(ALL) ALL \
-%sudo   ALL=(ALL) ALL' %{buildroot}/etc/sudoers
+# Add default user to sudoers group
+echo '%wheel ALL=(ALL) ALL' >> %{buildroot}/etc/sudoers
+echo '%sudo  ALL=(ALL) ALL' >> %{buildroot}/etc/sudoers
 install -vdm755 %{buildroot}/etc/pam.d
 cat > %{buildroot}/etc/pam.d/sudo << EOF
 #%%PAM-1.0
@@ -93,6 +93,10 @@ rm -rf %{buildroot}/*
 %exclude  /etc/sudoers.dist
 
 %changelog
+*   Tue Jan 26 2021 Mateusz Malisz <mamalisz@microsoft.com> 1.9.5p2-1
+-   Update to version 1.9.5.p2 to fix CVE-2021-3156.
+-   Change the password prompt to include ": " at the end.
+-   Unconditionally add wheel/sudo groups.
 *   Fri Jan 15 2021 Mateusz Malisz <mamalisz@microsoft.com> 1.9.5p1-1
 -   Update to version 1.9.5.p1 to fix CVE-2021-23240.
 *   Sat May 09 2020 Nick Samson <nisamson@microsoft.com> 1.8.31p1-4

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -6335,8 +6335,8 @@
         "type": "other",
         "other": {
           "name": "sudo",
-          "version": "1.9.5p1",
-          "downloadUrl": "https://www.sudo.ws/sudo/dist/sudo-1.9.5p1.tar.gz"
+          "version": "1.9.5p2",
+          "downloadUrl": "https://www.sudo.ws/sudo/dist/sudo-1.9.5p2.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
This PR fixes the regression in sudo regarding the default wheel group addition to sudoers. It also fixes CVE and makes prompt look nicer.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
-   Update to version 1.9.5.p2 to fix CVE-2021-3156.
-   Change the password prompt to include ": " at the end.
-   Unconditionally add wheel/sudo groups.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2021-3156

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local build, buddy buid
