### PR TITLE
[dev] Use dependency graph to calculate RPMs from an SRPM

### DIFF
--- a/toolkit/tools/internal/rpm/rpm.go
+++ b/toolkit/tools/internal/rpm/rpm.go
@@ -19,6 +19,9 @@ const (
 	// QueryHeaderArgument specifies the srpm argument to be used with rpm tools
 	QueryHeaderArgument = "--srpm"
 
+	// QueryBuiltRPMHeadersArgument specifies that only rpm packages that would be built from a given spec should be queried.
+	QueryBuiltRPMHeadersArgument = "--builtrpms"
+
 	// DistTagDefine specifies the dist tag option for rpm tool commands
 	DistTagDefine = "dist"
 

--- a/toolkit/tools/scheduler/schedulerutils/buildworker.go
+++ b/toolkit/tools/scheduler/schedulerutils/buildworker.go
@@ -86,11 +86,9 @@ func BuildNodeWorker(channels *BuildChannels, agent buildagents.BuildAgent, grap
 
 // buildBuildNode builds a TypeBuild node, either used a cached copy if possible or building the corresponding SRPM.
 func buildBuildNode(node *pkggraph.PkgNode, pkgGraph *pkggraph.PkgGraph, graphMutex *sync.RWMutex, agent buildagents.BuildAgent, canUseCache bool, buildAttempts int) (usedCache bool, builtFiles []string, logFile string, err error) {
-	cfg := agent.Config()
-
 	baseSrpmName := filepath.Base(node.SrpmPath)
 	if canUseCache {
-		usedCache, builtFiles = isSRPMPrebuilt(node.SpecPath, cfg.RpmDir, node.SourceDir, cfg.DistTag)
+		usedCache, builtFiles = isSRPMPrebuilt(node.SrpmPath, pkgGraph, graphMutex)
 		if usedCache {
 			logger.Log.Debugf("%s is prebuilt, skipping", baseSrpmName)
 			return

--- a/toolkit/tools/specreader/specreader.go
+++ b/toolkit/tools/specreader/specreader.go
@@ -295,7 +295,7 @@ func readSpecWorker(requests <-chan string, results chan<- *parseResult, cancel 
 		}
 
 		// Find every package that the spec provides
-		queryResults, err := rpm.QuerySPEC(specfile, sourcedir, queryProvidedPackages, defines)
+		queryResults, err := rpm.QuerySPEC(specfile, sourcedir, queryProvidedPackages, defines, rpm.QueryBuiltRPMHeadersArgument)
 		if err == nil && len(queryResults) != 0 {
 			providerList, err = parseProvides(rpmsDir, srpmPath, queryResults)
 			if err != nil {


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Update `scheduler` to use the dependency graph to find all RPMs a given SRPM will produce instead of querying the spec. Querying the spec on the host system runs into problems when the spec uses complex macros that are defined in `mariner-rpm-macros` but not the host system. Instead, leverage the information already captured by `specreader` in the CBL-Mariner context.

Currently the dependency graph references RPMs that do not actually exist, e.g. if a spec does not produce a main package but instead only produces a subpackage, specreader will still return that the spec has a main rpm package. The fix for this is to alter the `rpmspec` invocation to only query RPM headers for packages with file lists.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Update `specreader` to only query RPM headers for packages that will be built.
- Update `scheduler` to use the dependency graph to find all RPMs a given SRPM will product instead of querying the spec.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local builds.
