### PR TITLE
[dev] Fix runtime requirement for cppunit-devel

### DIFF
--- a/SPECS/cppunit/cppunit.spec
+++ b/SPECS/cppunit/cppunit.spec
@@ -1,20 +1,20 @@
-Summary:	C++ port of Junit test framework
-Name:		cppunit
-Version:	1.12.1
-Release:        6%{?dist}
-License:	LGPLv2
-URL:		https://sourceforge.net/projects/cppunit/
-Source0:	https://sourceforge.net/projects/cppunit/files/%{name}/%{version}/%{name}-%{version}.tar.gz
 %define sha1 cppunit=f1ab8986af7a1ffa6760f4bacf5622924639bf4a
-Group:		Development/Tools
+Summary:        C++ port of Junit test framework
+Name:           cppunit
+Version:        1.12.1
+Release:        6%{?dist}
+License:        LGPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
+Group:          Development/Tools
+URL:            https://sourceforge.net/projects/cppunit/
+Source0:        https://sourceforge.net/projects/cppunit/files/%{name}/%{version}/%{name}-%{version}.tar.gz
 BuildRequires:  autoconf
 BuildRequires:  automake
-BuildRequires:  make
 BuildRequires:  gcc
 BuildRequires:  libgcc
 BuildRequires:  libtool
+BuildRequires:  make
 
 %description
 CppUnit is the C++ port of the famous JUnit framework for unit testing. Test
@@ -25,11 +25,12 @@ supervised tests
 Summary:        cppunit devel
 Group:          Development/Tools
 Requires:       %{name} = %{version}-%{release}
+
 %description devel
 This contains headers and libs for development with cppunit.
 
 %prep
-%setup -n %{name}-%{version}
+%setup -q
 
 %build
 export LDFLAGS="`echo " %{build_ldflags} " | sed 's/ -Wl,--as-needed//'`"
@@ -39,7 +40,7 @@ make %{?_smp_mflags}
 
 %install
 make DESTDIR=%{buildroot} install
-find %{buildroot} -name '*.la' -delete
+find %{buildroot} -type f -name "*.la" -delete -print
 
 %files
 %defattr(-,root,root)
@@ -53,19 +54,23 @@ find %{buildroot} -name '*.la' -delete
 %{_libdir}/libcppunit.a
 %{_libdir}/libcppunit.so
 %{_libdir}/pkgconfig*
-/usr/share/*
+%{_datadir}/*
 
 %changelog
-*   Mon Feb 08 2021 Henry Li <lihl@microsoft.com> - 1.12.1-6
--   Add cppunit as Requires for cppunit-devel
--   Disable link as-needed to fix compilation errors updated ldflags.
+* Mon Feb 08 2021 Henry Li <lihl@microsoft.com> - 1.12.1-6
+- Add cppunit as Requires for cppunit-devel
+
 *   Thu Jun 11 2020 Henry Beberman <henry.beberman@microsoft.com> - 1.12.1-5
 -   Disable link as-needed to fix compilation errors updated ldflags.
+
 *   Sat May 09 00:21:26 PST 2020 Nick Samson <nisamson@microsoft.com> - 1.12.1-4
 -   Added %%license line automatically
+
 *   Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 1.12.1-3
 -   Initial CBL-Mariner import from Photon (license: Apache2).
+
 *   Fri Oct 13 2017 Alexey Makhalov <amakhalov@vmware.com> 1.12.1-2
 -   Use standard configure macros
+
 *   Sun Mar 26 2017 Vinay Kulkarni <kulkarniv@vmware.com> 1.12.1-1
 -   Initial version of cppunit for Photon.

--- a/SPECS/cppunit/cppunit.spec
+++ b/SPECS/cppunit/cppunit.spec
@@ -1,7 +1,7 @@
 Summary:	C++ port of Junit test framework
 Name:		cppunit
 Version:	1.12.1
-Release:        5%{?dist}
+Release:        6%{?dist}
 License:	LGPLv2
 URL:		https://sourceforge.net/projects/cppunit/
 Source0:	https://sourceforge.net/projects/cppunit/files/%{name}/%{version}/%{name}-%{version}.tar.gz
@@ -24,6 +24,7 @@ supervised tests
 %package devel
 Summary:        cppunit devel
 Group:          Development/Tools
+Requires:       %{name} = %{version}-%{release}
 %description devel
 This contains headers and libs for development with cppunit.
 
@@ -55,6 +56,9 @@ find %{buildroot} -name '*.la' -delete
 /usr/share/*
 
 %changelog
+*   Mon Feb 08 2021 Henry Li <lihl@microsoft.com> - 1.12.1-6
+-   Add cppunit as Requires for cppunit-devel
+-   Disable link as-needed to fix compilation errors updated ldflags.
 *   Thu Jun 11 2020 Henry Beberman <henry.beberman@microsoft.com> - 1.12.1-5
 -   Disable link as-needed to fix compilation errors updated ldflags.
 *   Sat May 09 00:21:26 PST 2020 Nick Samson <nisamson@microsoft.com> - 1.12.1-4


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Fix runtime requirement for cppunit-devel

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add cppunit as runtime requirement for cppunit-devel

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
**YES**
NO

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/...

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local Build
