### PR TITLE
Fix handling of double-percent in cgmanifest check

### DIFF
--- a/.github/workflows/validate-cg-manifest.sh
+++ b/.github/workflows/validate-cg-manifest.sh
@@ -52,7 +52,7 @@ do
   if echo $ignore_list | grep -w "$name" > /dev/null
   then
     echo "    $name is being ignored, skipping"
-    #continue
+    continue
   fi
 
   version=$(rpmspec --srpm  --define "with_check 0" --qf "%{VERSION}" -q $spec 2>/dev/null )

--- a/.github/workflows/validate-cg-manifest.sh
+++ b/.github/workflows/validate-cg-manifest.sh
@@ -58,7 +58,7 @@ do
   version=$(rpmspec --srpm  --define "with_check 0" --qf "%{VERSION}" -q $spec 2>/dev/null )
 
   # Some source files have been renamed, look for a comment and also try that (while manually substituting the name/version)
-  source0alt=$(grep "^#[[:blank:]]*Source0:" $spec | awk '{print $NF}' | sed "s/%{name}/$name/g" | sed "s/%{version}/$version/g" )
+  source0alt=$(grep "^#[[:blank:]]*Source0:" $spec | awk '{print $NF}' | sed "s/%\?%{name}/$name/g" | sed "s/%\?%{version}/$version/g" )
   # Some packages define a %url as well
   # Use ' ' as delimiter to avoid conflict with URL characters
   specurl=$(rpmspec --srpm  --define "with_check 0" --qf "%{URL}" -q $spec 2>/dev/null )

--- a/.github/workflows/validate-cg-manifest.sh
+++ b/.github/workflows/validate-cg-manifest.sh
@@ -52,7 +52,7 @@ do
   if echo $ignore_list | grep -w "$name" > /dev/null
   then
     echo "    $name is being ignored, skipping"
-    continue
+    #continue
   fi
 
   version=$(rpmspec --srpm  --define "with_check 0" --qf "%{VERSION}" -q $spec 2>/dev/null )
@@ -62,7 +62,7 @@ do
   # Some packages define a %url as well
   # Use ' ' as delimiter to avoid conflict with URL characters
   specurl=$(rpmspec --srpm  --define "with_check 0" --qf "%{URL}" -q $spec 2>/dev/null )
-  [[ -z specurl ]] || source0alt=$(echo $source0alt | sed "s %{url} $specurl g" )
+  [[ -z specurl ]] || source0alt=$(echo $source0alt | sed "s %\?%{url} $specurl g" )
 
   # Pull the current registration from the cgmanifest file. Every registration should have a url, so if we don't find one
   # that implies the registration is missing.

--- a/SPECS/azure-storage-cpp/azure-storage-cpp.spec
+++ b/SPECS/azure-storage-cpp/azure-storage-cpp.spec
@@ -8,7 +8,7 @@ License:        ASL 2.0
 URL:            https://azure.github.io/azure-storage-cpp/
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
-#Source0:       https://github.com/Azure/azure-storage-cpp/archive/v%%{version}.tar.gz
+#Source0:       https://github.com/Azure/azure-storage-cpp/archive/v%{version}.tar.gz
 Source0:        %{name}-%{version}.tar.gz
 
 BuildRequires:  util-linux-devel

--- a/SPECS/azure-storage-cpp/azure-storage-cpp.spec
+++ b/SPECS/azure-storage-cpp/azure-storage-cpp.spec
@@ -8,7 +8,7 @@ License:        ASL 2.0
 URL:            https://azure.github.io/azure-storage-cpp/
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
-#Source0:       https://github.com/Azure/azure-storage-cpp/archive/v%{version}.tar.gz
+#Source0:       https://github.com/Azure/azure-storage-cpp/archive/v%%{version}.tar.gz
 Source0:        %{name}-%{version}.tar.gz
 
 BuildRequires:  util-linux-devel


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
RPM complains about un-escaped macros in spec comments. However, the cgmanifest check doesn't handle escaped macros in `#Source0` lines properly when calculating `$source0alt`. This PR modifies the `sed` expression to handle this case.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Handle escaped name/version/url macros in `#Source0` lines during the cgmanifest check.


###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local testing
