### PR TITLE
Move dracut FIPS config to /etc/dracut.conf.d/

### DIFF
--- a/SPECS/dracut/dracut.spec
+++ b/SPECS/dracut/dracut.spec
@@ -5,7 +5,7 @@
 Summary:        dracut to create initramfs
 Name:           dracut
 Version:        049
-Release:        3%{?dist}
+Release:        4%{?dist}
 # The entire source code is GPLv2+
 # except install/* which is LGPLv2+
 License:        GPLv2+ AND LGPLv2+
@@ -99,7 +99,7 @@ mkdir -p %{buildroot}%{_sharedstatedir}/initramfs
 
 rm -f %{buildroot}%{_mandir}/man?/*suse*
 
-install -m 0644 dracut.conf.d/fips.conf.example %{buildroot}%{dracutlibdir}/dracut.conf.d/40-fips.conf
+install -m 0644 dracut.conf.d/fips.conf.example %{buildroot}%{_sysconfdir}/dracut.conf.d/40-fips.conf
 > %{buildroot}%{_sysconfdir}/system-fips
 
 # create compat symlink
@@ -164,7 +164,7 @@ rm -rf -- %{buildroot}
 %files fips
 %defattr(-,root,root,0755)
 %{dracutlibdir}/modules.d/01fips
-%{dracutlibdir}/dracut.conf.d/40-fips.conf
+%{_sysconfdir}/dracut.conf.d/40-fips.conf
 %config(missingok) %{_sysconfdir}/system-fips
 
 %files tools
@@ -176,6 +176,9 @@ rm -rf -- %{buildroot}
 %dir %{_sharedstatedir}/dracut/overlay
 
 %changelog
+* Wed Feb 10 2021 Nicolas Ontiveros <niontive@microsoft.com> - 049-4
+- Move 40-fips.conf to /etc/dracut.conf.d/
+
 * Mon Feb 01 2021 Nicolas Ontiveros <niontive@microsoft.com> - 049-3
 - Add dracut-fips package.
 - Disable kernel crypto testing in dracut-fips.

--- a/toolkit/imageconfigs/core-fips.json
+++ b/toolkit/imageconfigs/core-fips.json
@@ -44,9 +44,9 @@
             ],
             "PackageLists": [
                 "packagelists/hyperv-packages.json",
+                "packagelists/fips-packages.json",
                 "packagelists/core-packages-image.json",
-                "packagelists/cloud-init-packages.json",
-                "packagelists/fips-packages.json"
+                "packagelists/cloud-init-packages.json"
             ],
             "KernelOptions": {
                 "default": "kernel"

--- a/toolkit/imageconfigs/packagelists/fips-packages.json
+++ b/toolkit/imageconfigs/packagelists/fips-packages.json
@@ -1,5 +1,6 @@
 {
     "packages": [
         "dracut-fips"
-    ]
+    ],
+    "_comment": "Put dracut-fips before initramfs package to prevent extra initramfs generation"
 }


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
40-fips.conf adds the dracut "fips" module to the initramfs. Currently, we install this config in `/usr/lib/dracut.conf.d/`. This config should be installed in `/etc/dracut.conf.d/` since:

- Other Mariner dracut configs (fscks.conf and verity.conf) are installed in  `/etc/dracut.conf.d/`
- RHEL8 installs this conf in `/etc/dracut.conf.d/`
- Mariner's `initramfs` package does initramfs regeneration if `/etc/dracut.conf.d/` is modified. Initramfs regeneration is not triggered by `/usr/lib/dracut.conf.d/`.

Also, in core-fips image config, place `dracut-fips` package before `initramfs` package to prevent extra initramfs generation. This is a perf boost.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Move dracut FIPS config to /etc/dracut.conf.d/
- In core-fips image config, place "dracut-fips" package before "core-packages-image" to prevent extra initramfs generation. 

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
No

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
None

###### Links to CVEs  <!-- optional -->
None

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
Local build
