### PR TITLE
Addressing a few bash script issues highlighted by "SpellCheck".

### DIFF
--- a/.github/workflows/validate-cg-manifest.sh
+++ b/.github/workflows/validate-cg-manifest.sh
@@ -33,9 +33,9 @@ ignore_list=" \
 rm -f bad_registrations.txt
 rm -rf ./cgmanifest_test_dir/
 
-[[ -n "$@" ]] || echo "No specs passed to validate"
+[[ $# -eq 0 ]] && echo "No specs passed to validate"
 
-for spec in $@
+for spec in "$@"
 do
   echo Checking "$spec"
 
@@ -62,7 +62,7 @@ do
   # Some packages define a %url as well
   # Use ' ' as delimiter to avoid conflict with URL characters
   specurl=$(rpmspec --srpm  --define "with_check 0" --qf "%{URL}" -q $spec 2>/dev/null )
-  [[ -z specurl ]] || source0alt=$(echo $source0alt | sed "s %\?%{url} $specurl g" )
+  [[ -z $specurl ]] || source0alt=$(echo $source0alt | sed "s %\?%{url} $specurl g" )
 
   # Pull the current registration from the cgmanifest file. Every registration should have a url, so if we don't find one
   # that implies the registration is missing.
@@ -80,7 +80,7 @@ do
     else
       # Try a few times to download the source listed in the manifest
       mkdir -p ./cgmanifest_test_dir
-      for i in {1..10}
+      for _ in {1..10}
       do
         wget --quiet -P ./cgmanifest_test_dir $manifesturl && touch ./cgmanifest_test_dir/WORKED && break
         sleep 30


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
This is just fixing some small issues in our cgmanifest-checking script + addressing simple bash linter's (`SpellCheck` extensions for VS Code) suggestions.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Fixed `$@` expansion in the `for` loop to not re-expand elements with whitespaces in them.
- Added a missing `$`.
- Simple clean-up.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
No.

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- N/A.
