### PR TITLE
[cross] create minimal aarch64 image that boots in qemu 

### DIFF
--- a/toolkit/scripts/toolchain/cross/generate_minimal_rootfs.sh
+++ b/toolkit/scripts/toolchain/cross/generate_minimal_rootfs.sh
@@ -1,0 +1,34 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# Currently assumes you have already run busybox_cross.sh and kernel_cross.sh
+
+toolchainTuple="aarch64-linux-gnu"
+installDir="/opt/cross"
+sysrootDir="/opt/cross/${toolchainTuple}/sysroot"
+scriptDir="$( cd "$( dirname "$0" )" && pwd )"
+standaloneRootfsDir=${installDir}/rootfs
+
+sudo rm -rf ${standaloneRootfsDir}
+
+mkdir -p ${standaloneRootfsDir}
+
+# Create mountpoint directories in sysroot
+# This step is not required for extremely barebones busybox systems
+# but I have included it here since these are common mountpoints to have
+#mkdir -p ${sysrootDir}/proc
+#mkdir -p ${sysrootDir}/sys
+#
+# Then in your custom init script, do the following:
+#mount -t proc none /proc
+#mount -t sysfs none /sys
+
+# Symlink busybox's /sbin/init to /init so QEMU runs it
+ln -sf /sbin/init ${sysrootDir}/init
+
+# Copy our custom busybox inittab over to sysroot/etc/inittab
+cp ${scriptDir}/inittab ${sysrootDir}/etc
+
+# Create gziped cpio archive so we can load this as an initramfs
+cd ${sysrootDir}
+find . -print0 | cpio --null -ov --format=newc | gzip -9 > ${standaloneRootfsDir}/rootfs.cpio.gz

--- a/toolkit/scripts/toolchain/cross/inittab
+++ b/toolkit/scripts/toolchain/cross/inittab
@@ -1,0 +1,1 @@
+::respawn:-/bin/sh

--- a/toolkit/scripts/toolchain/cross/kernel_cross.sh
+++ b/toolkit/scripts/toolchain/cross/kernel_cross.sh
@@ -9,9 +9,13 @@ installDir="/opt/cross"
 sysrootDir="/opt/cross/${toolchainTuple}/sysroot"
 buildDir="$HOME/cross"
 kernelBuildDir=${buildDir}/kernel
+kernelStandaloneInstallDir=${installDir}/kernel
 
 sudo rm -rf ${kernelBuildDir}
+sudo rm -rf ${kernelStandaloneInstallDir}
+
 mkdir -p ${kernelBuildDir}
+mkdir -p ${kernelStandaloneInstallDir}
 
 export PATH="${installDir}/bin":$PATH
 
@@ -27,3 +31,6 @@ make ARCH=${kernelTargetArch} CROSS_COMPILE=${toolchainTuple}- -j$(nproc)
 mkdir -p ${sysrootDir}/boot
 make ARCH=${kernelTargetArch} CROSS_COMPILE=${toolchainTuple}- INSTALL_PATH=${sysrootDir}/boot install
 make ARCH=${kernelTargetArch} CROSS_COMPILE=${toolchainTuple}- INSTALL_MOD_PATH=${sysrootDir} modules_install
+
+# Also install the kernel binary outside of the sysroot. Useful for running with QEMU
+make ARCH=${kernelTargetArch} CROSS_COMPILE=${toolchainTuple}- INSTALL_PATH=${kernelStandaloneInstallDir} install

--- a/toolkit/scripts/toolchain/cross/launch_qemu.sh
+++ b/toolkit/scripts/toolchain/cross/launch_qemu.sh
@@ -1,0 +1,34 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# Currently assumes you have already run busybox_cross.sh, kernel_cross.sh, and generate_minimal_rootfs.sh
+
+# Kernel should be located at /opt/cross/kernel
+# Rootfs should be located as a cpio.gz in /opt/cross/rootfs
+
+installDir="/opt/cross"
+kernelStandaloneInstallDir=${installDir}/kernel
+standaloneRootfsDir=${installDir}/rootfs
+kernelVersion="5.4.83"
+
+# Note: Current rootfs unpacks to be fairly big. 2GB memory was not enough size to hold the unpacked initramfs
+# so when QEMU ran, it would fail with:
+#
+# [   16.532507] ---[ end Kernel panic - not syncing: VFS: Unable to mount root fs on unknown-block(0,0) ]---
+#
+# But this is a lie - the true error is immediately after the unpacking initramfs message:
+#
+# [    0.321246] Unpacking initramfs...
+# [   15.549898] Initramfs unpacking failed: write error
+#
+# 4GB can hold the current rootfs. But tweak the -m parameter as necessary.
+qemu-system-aarch64 \
+    -M virt \
+    -cpu cortex-a57 \
+    -machine type=virt \
+    -smp 1 \
+    -m 4096 \
+    -kernel ${kernelStandaloneInstallDir}/vmlinuz-${kernelVersion} \
+    -initrd ${standaloneRootfsDir}/rootfs.cpio.gz \
+    -nographic \
+    -append "console=ttyAMA0"


### PR DESCRIPTION
Update the kernel_cross script to also install the kernel image
into a standalone kernel folder under /opt/cross/kernel

Add a minimal init script and generate a minimal rootfs from the
contents of sysroot. Compress the rootfs into a gzipped cpio
archive which qemu can easily ingest as an initrd

Add a script to launch qemu-system-aarch64 with the special
settings needed to boot our standalone kernel and rootfs as an
initrd.

Signed-off-by: Chris Co <chrco@microsoft.com>