### PR TITLE
[dev] Rework cycle detection in dependency graph to scale with larger graphs

### DIFF
--- a/toolkit/tools/grapher/grapher.go
+++ b/toolkit/tools/grapher/grapher.go
@@ -45,6 +45,7 @@ func main() {
 		logger.Log.Panic(err)
 	}
 
+	logger.Log.Info("Running cycle resolution to fix any cycles in the dependency graph")
 	err = depGraph.MakeDAG()
 	if err != nil {
 		logger.Log.Panic(err)

--- a/toolkit/tools/internal/pkggraph/cyclefind.go
+++ b/toolkit/tools/internal/pkggraph/cyclefind.go
@@ -25,6 +25,7 @@ type dfsData struct {
 }
 
 // FindAnyDirectedCycle returns any single cycle in the graph, if one exists.
+// Multiple instances of this routine should not be run at the same time on a given graph.
 func (g *PkgGraph) FindAnyDirectedCycle() (nodes []*PkgNode, err error) {
 	const goalNodeName = "_dfs_root_"
 
@@ -116,7 +117,7 @@ func cycleDFS(g *PkgGraph, rootID int64, metaData *dfsData) (foundCycle bool, er
 				return
 			}
 		case inProgress:
-			createCycle(g, metaData, rootID, v)
+			updateMetadataWithCycle(g, metaData, rootID, v)
 			foundCycle = true
 			return
 		default:
@@ -129,8 +130,8 @@ func cycleDFS(g *PkgGraph, rootID int64, metaData *dfsData) (foundCycle bool, er
 	return
 }
 
-// updateCycle records the cycle between startID and endID in metaData.cycle.
-func createCycle(g *PkgGraph, metaData *dfsData, startID, endID int64) {
+// updateMetadataWithCycle records the cycle between startID and endID in metaData.cycle.
+func updateMetadataWithCycle(g *PkgGraph, metaData *dfsData, startID, endID int64) {
 	// Construct a cycle that starts and ends with the same node id by backtracking
 	// from startID to endID
 	// 	a -> b -> ... -> a

--- a/toolkit/tools/internal/pkggraph/cyclefind.go
+++ b/toolkit/tools/internal/pkggraph/cyclefind.go
@@ -44,7 +44,7 @@ func (g *PkgGraph) FindAnyDirectedCycle() (nodes []*PkgNode, err error) {
 	// This call will also remove all edges connected to the temporary root node.
 	defer g.RemoveNode(rootNode.ID())
 
-	// Seed the initial metadata state
+	// Seed the initial metadata state.
 	metadata.parent[rootNode.ID()] = -1
 	metadata.state[rootNode.ID()] = unvisited
 
@@ -85,16 +85,16 @@ func cycleDFS(g *PkgGraph, rootID int64, metaData *dfsData) (foundCycle bool, er
 	//    b   b
 	//
 	// 1) visit(a)
-	//   - mark "a" as "inProgress"
+	//   - mark "a" as "inProgress".
 	//   - neighbor "b" is "unvisited", visit.
 	// 2) visit(b)
-	//   - mark "b" as "inProgress"
-	//   - no neighbors
-	//   - mark "b" as "done"
+	//   - mark "b" as "inProgress".
+	//   - no neighbors.
+	//   - mark "b" as "done".
 	// 3) Resume visit(a)
 	//   - neighbor "c" is "unvisited", visit.
 	// 4) visit(c)
-	//   - mark "c" as "inProgress"
+	//   - mark "c" as "inProgress".
 	//   - neighbor "b" is "done", skip.
 	//   - neighbor "a" is "inProgress", thus a cycle between "c" and "a" is found.
 

--- a/toolkit/tools/internal/pkggraph/cyclefind.go
+++ b/toolkit/tools/internal/pkggraph/cyclefind.go
@@ -1,0 +1,112 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package pkggraph
+
+import (
+	"fmt"
+
+	"gonum.org/v1/gonum/graph"
+
+	"microsoft.com/pkggen/internal/logger"
+)
+
+const (
+	invalid = iota
+	unvisited
+	inProgress
+	done
+)
+
+type dfsData struct {
+	state  map[int64]int
+	parent map[int64]int64
+	cycle  []int64
+}
+
+func createCycle(g *PkgGraph, metaData *dfsData, start, end int64) {
+	metaData.cycle = append(metaData.cycle, end)
+	logger.Log.Tracef("%s needed by %s", g.Node(end).(*PkgNode).FriendlyName(), g.Node(start).(*PkgNode).FriendlyName())
+	for end != start {
+		metaData.cycle = append(metaData.cycle, start)
+		logger.Log.Tracef("%s needed by %s", g.Node(start).(*PkgNode).FriendlyName(), g.Node(metaData.parent[start]).(*PkgNode).FriendlyName())
+		start = metaData.parent[start]
+	}
+	metaData.cycle = append(metaData.cycle, end)
+}
+
+func dfs(g *PkgGraph, u int64, metaData *dfsData) (foundCycle bool, err error) {
+	if metaData.state[u] != unvisited {
+		err = fmt.Errorf("Node %d is in a bad state (%d)", u, metaData.state[u])
+		return
+	}
+
+	metaData.state[u] = inProgress
+
+	foundCycle = false
+	for _, neighbor := range graph.NodesOf(g.From(u)) {
+		v := neighbor.ID()
+		if _, exists := metaData.state[v]; !exists {
+			metaData.state[v] = unvisited
+		}
+
+		switch metaData.state[v] {
+		case done:
+			continue
+		case unvisited:
+			metaData.parent[v] = u
+			foundCycle, err = dfs(g, v, metaData)
+			if err != nil || foundCycle {
+				return
+			}
+		case inProgress:
+			logger.Log.Debug("Found cycle!")
+			createCycle(g, metaData, u, v)
+			foundCycle = true
+			return
+		default:
+			err = fmt.Errorf("Node %d is in a bad state (%d)", v, metaData.state[v])
+			return
+		}
+	}
+
+	metaData.state[u] = done
+	return
+}
+
+// FindAnyDirectedCycle returns any single cycle in the graph, if one exists.
+func (g *PkgGraph) FindAnyDirectedCycle() (nodes []PkgNode, err error) {
+	const goalNodeName = "_dfs_root_"
+
+	metadata := dfsData{
+		make(map[int64]int),
+		make(map[int64]int64),
+		make([]int64, 0),
+	}
+
+	// Create a temporary root node, by using a constant goalNodeName, it will act as a mutex against concurrent
+	// cycle searches on a given graph as this below call will fail if there is already a goal node with the same value.
+	rootNode, err := g.AddGoalNode(goalNodeName, nil, false)
+	if err != nil {
+		return
+	}
+
+	// This call will also remove all edges connected to the temporary root node.
+	defer g.RemoveNode(rootNode.ID())
+
+	metadata.parent[rootNode.ID()] = -1
+	metadata.state[rootNode.ID()] = unvisited
+
+	foundCycle, err := dfs(g, rootNode.ID(), &metadata)
+	if err != nil {
+		return
+	}
+
+	if foundCycle {
+		for _, id := range metadata.cycle {
+			nodes = append(nodes, *g.Node(id).(*PkgNode))
+		}
+	}
+
+	return
+}

--- a/toolkit/tools/internal/pkggraph/cyclefind.go
+++ b/toolkit/tools/internal/pkggraph/cyclefind.go
@@ -85,18 +85,18 @@ func cycleDFS(g *PkgGraph, rootID int64, metaData *dfsData) (foundCycle bool, er
 	//    b   b
 	//
 	// 1) visit(a)
-	//   - mark a as "inProgress"
-	//   - neighbor b is "unvisited", visit.
+	//   - mark "a" as "inProgress"
+	//   - neighbor "b" is "unvisited", visit.
 	// 2) visit(b)
-	//   - mark b as "inProgress"
+	//   - mark "b" as "inProgress"
 	//   - no neighbors
-	//   - mark b as "done"
+	//   - mark "b" as "done"
 	// 3) Resume visit(a)
-	//   - neighbor c is "unvisited", visit.
+	//   - neighbor "c" is "unvisited", visit.
 	// 4) visit(c)
-	//   - mark as "inProgress"
-	//   - neighbor b is "done", skip.
-	//   - neighbor a is "inProgress", cycle between (c) and (a) found.
+	//   - mark "c" as "inProgress"
+	//   - neighbor "b" is "done", skip.
+	//   - neighbor "a" is "inProgress", thus a cycle between "c" and "a" is found.
 
 	metaData.state[rootID] = inProgress
 

--- a/toolkit/tools/internal/pkggraph/cyclefind_test.go
+++ b/toolkit/tools/internal/pkggraph/cyclefind_test.go
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package pkggraph
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDFSFindCycle(t *testing.T) {
+	g, err := buildTestGraphHelper()
+	assert.NoError(t, err)
+	assert.NotNil(t, g)
+
+	// Create a cycle
+	addEdgeHelper(g, *pkgCBuild, *pkgARun)
+
+	// Check the correctness of the disconnected components rooted in pkgARun, and pkgC2Run
+	checkTestGraph(t, g)
+
+	cycle, err := g.FindAnyDirectedCycle()
+	assert.NoError(t, err)
+	assert.NotNil(t, cycle)
+	assert.Equal(t, 7, len(cycle))
+	assert.Equal(t, cycle[0], cycle[6])
+}
+
+func TestDFSNoCycle(t *testing.T) {
+	g, err := buildTestGraphHelper()
+	assert.NoError(t, err)
+	assert.NotNil(t, g)
+
+	// Check the correctness of the disconnected components rooted in pkgARun, and pkgC2Run
+	checkTestGraph(t, g)
+
+	cycle, err := g.FindAnyDirectedCycle()
+	assert.NoError(t, err)
+	assert.Nil(t, cycle)
+}

--- a/toolkit/tools/internal/pkggraph/cyclefind_test.go
+++ b/toolkit/tools/internal/pkggraph/cyclefind_test.go
@@ -24,7 +24,7 @@ func TestDFSFindCycle(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, cycle)
 	assert.Equal(t, 7, len(cycle))
-	assert.Equal(t, cycle[0], cycle[6])
+	assert.Equal(t, cycle[0], cycle[len(cycle)-1])
 }
 
 func TestDFSNoCycle(t *testing.T) {

--- a/toolkit/tools/internal/pkggraph/pkggraph.go
+++ b/toolkit/tools/internal/pkggraph/pkggraph.go
@@ -1131,17 +1131,11 @@ func (g *PkgGraph) MakeDAG() (err error) {
 	}
 
 	for len(cycle) > 0 {
-		// Convert our list to pkggraph.PkgNodes
-		pkgCycle := make([]*PkgNode, 0, len(cycle))
-		for _, node := range cycle {
-			pkgCycle = append(pkgCycle, node.This)
-		}
-
-		err = g.fixCycle(pkgCycle)
+		err = g.fixCycle(cycle)
 		if err != nil {
 			var cycleStringBuilder strings.Builder
-			fmt.Fprintf(&cycleStringBuilder, "{%s}", pkgCycle[0].FriendlyName())
-			for _, node := range pkgCycle[1:] {
+			fmt.Fprintf(&cycleStringBuilder, "{%s}", cycle[0].FriendlyName())
+			for _, node := range cycle[1:] {
 				fmt.Fprintf(&cycleStringBuilder, " --> {%s}", node.FriendlyName())
 			}
 			logger.Log.Errorf("Unfixable circular dependency found:\t%s\terror: %s", cycleStringBuilder.String(), err)

--- a/toolkit/tools/internal/pkggraph/pkggraph.go
+++ b/toolkit/tools/internal/pkggraph/pkggraph.go
@@ -19,7 +19,6 @@ import (
 	"gonum.org/v1/gonum/graph/encoding"
 	"gonum.org/v1/gonum/graph/encoding/dot"
 	"gonum.org/v1/gonum/graph/simple"
-	"gonum.org/v1/gonum/graph/topo"
 	"gonum.org/v1/gonum/graph/traverse"
 
 	"microsoft.com/pkggen/internal/logger"
@@ -964,13 +963,13 @@ func (g *PkgGraph) AddGoalNode(goalName string, packages []*pkgjson.PackageVer, 
 
 	goalSet := make(map[*pkgjson.PackageVer]bool)
 	if len(packages) > 0 {
-		logger.Log.Infof("Adding \"%s\" goal", goalName)
+		logger.Log.Debugf("Adding \"%s\" goal", goalName)
 		for _, pkg := range packages {
 			logger.Log.Tracef("\t%s-%s", pkg.Name, pkg.Version)
 			goalSet[pkg] = true
 		}
 	} else {
-		logger.Log.Infof("Adding \"%s\" goal for all nodes", goalName)
+		logger.Log.Debugf("Adding \"%s\" goal for all nodes", goalName)
 		for _, node := range g.AllRunNodes() {
 			logger.Log.Tracef("\t%s-%s %d", node.VersionedPkg.Name, node.VersionedPkg.Version, node.ID())
 			goalSet[node.VersionedPkg] = true
@@ -1013,7 +1012,7 @@ func (g *PkgGraph) AddGoalNode(goalName string, packages []*pkgjson.PackageVer, 
 		}
 
 		if existingNode != nil {
-			logger.Log.Debugf("Found %s to satisfy %s", existingNode.RunNode, pkg)
+			logger.Log.Tracef("Found %s to satisfy %s", existingNode.RunNode, pkg)
 			goalEdge := g.NewEdge(goalNode, existingNode.RunNode)
 			g.SetEdge(goalEdge)
 			goalSet[pkg] = false
@@ -1126,17 +1125,16 @@ func (g *PkgGraph) DeepCopy() (deepCopy *PkgGraph, err error) {
 // MakeDAG ensures the graph is a directed acyclic graph (DAG).
 // If the graph is not a DAG, this routine will attempt to resolve any cycles to make the graph a DAG.
 func (g *PkgGraph) MakeDAG() (err error) {
-	cycles := topo.DirectedCyclesIn(g)
+	cycle, err := g.FindAnyDirectedCycle()
+	if err != nil {
+		return
+	}
 
-	// Try to fix the cycles if we can before reporting them
-	// Keep track of which cycles we've failed to fix
-	unfixableCycleCount := 0
-	for len(cycles) > 0 {
-		cycle := cycles[0]
+	for len(cycle) > 0 {
 		// Convert our list to pkggraph.PkgNodes
 		pkgCycle := make([]*PkgNode, 0, len(cycle))
 		for _, node := range cycle {
-			pkgCycle = append(pkgCycle, node.(*PkgNode).This)
+			pkgCycle = append(pkgCycle, node.This)
 		}
 
 		err = g.fixCycle(pkgCycle)
@@ -1146,17 +1144,15 @@ func (g *PkgGraph) MakeDAG() (err error) {
 			for _, node := range pkgCycle[1:] {
 				fmt.Fprintf(&cycleStringBuilder, " --> {%s}", node.FriendlyName())
 			}
-			logger.Log.Errorf("Unfixable circular dependency found %d:\t%s\terror: %s", unfixableCycleCount, cycleStringBuilder.String(), err)
-			unfixableCycleCount++
-		}
-
-		if unfixableCycleCount > 0 {
+			logger.Log.Errorf("Unfixable circular dependency found:\t%s\terror: %s", cycleStringBuilder.String(), err)
 			err = fmt.Errorf("cycles detected in dependency graph")
 			return err
 		}
 
-		// Recalculate the list of cycles
-		cycles = topo.DirectedCyclesIn(g)
+		cycle, err = g.FindAnyDirectedCycle()
+		if err != nil {
+			return
+		}
 	}
 	return
 }
@@ -1167,7 +1163,7 @@ func (g *PkgGraph) fixCycle(cycle []*PkgNode) (err error) {
 	srpmPath := cycle[0].SrpmPath
 	// Omit the first element of the cycle, since it is repeated as the last element
 	trimmedCycle := cycle[1:]
-	logger.Log.Debugf("Found cycle starting at %s", cycle[0].FriendlyName())
+	logger.Log.Debugf("Found cycle: %v", cycle)
 
 	// For each node, remove any edges which point to other nodes in the cycle, and move any remaining dependencies to a new
 	// meta node, then have everything in the cycle depend on the new meta node.


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Currently if a dependency graph is too large, grapher will consume excessive amounts of memory resulting in an out-of-memory crash on most reasonably resourced systems. On a local build machine, a 65MB dependency graph exhausted all 32GB of RAM.

The excessive memory usage stems from the dependency graph's cycle detection algorithm: [Johnson's algorithm](https://en.wikipedia.org/wiki/Johnson's_algorithm). While this works well for smaller dependency graphs, it is calculating a significant amount of extra information that is not needed by grapher, primarily it finds all cycles in a given graph. 

Grapher's cycle resolution code iteratively fixes one cycle at a time and then recalculates cycles in a graph, meaning it does not need to know all cycles in the graph.

The fix is to switch to a modified depth first search algorithm to find a single cycle in the graph, using significantly less memory and time.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Replace using Johnson's algorithm with a modified DFS to find a cycle in the dependency graph.
- Change the level of goal node related logs to trace level instead of info, as the new DFS relies on goal nodes and would result in a lot of unnecessary info messages.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local builds.
