### PR TITLE
[cross] GCC emulation tests

### DIFF
--- a/toolkit/scripts/toolchain/cross/aarch64-linux-gnu.xfail
+++ b/toolkit/scripts/toolchain/cross/aarch64-linux-gnu.xfail
@@ -1,0 +1,27 @@
+FAIL: gcc.target/aarch64/fuse_adrp_add_1.c scan-assembler adrp\tx.*, fixed_regs\n\tadd\tx.*, x.*fixed_regs
+FAIL: gcc.target/aarch64/insv_1.c scan-assembler bfi\tx[0-9]+, x[0-9]+, 0, 8
+FAIL: gcc.target/aarch64/insv_1.c scan-assembler bfi\tx[0-9]+, x[0-9]+, 16, 5
+FAIL: gcc.target/aarch64/insv_1.c scan-assembler movk\tx[0-9]+, 0x1d6b, lsl 32
+FAIL: gcc.target/aarch64/ldp_stp_6.c scan-assembler stp\td[0-9]+, d[0-9]+, \\[x[0-9]+\\]
+FAIL: gcc.target/aarch64/lsl_asr_sbfiz.c scan-assembler sbfiz\tw
+FAIL: gcc.target/aarch64/pr63304_1.c (test for excess errors)
+FAIL: gcc.target/aarch64/pr63304_1.c scan-assembler-times adrp 6
+FAIL: gcc.target/aarch64/pr70120-2.c (test for excess errors)
+FAIL: gcc.target/aarch64/pr78733.c (test for excess errors)
+UNRESOLVED: gcc.target/aarch64/pr78733.c scan-assembler adr
+UNRESOLVED: gcc.target/aarch64/pr78733.c scan-assembler-not adrp
+FAIL: gcc.target/aarch64/pr79041-2.c (test for excess errors)
+UNRESOLVED: gcc.target/aarch64/pr79041-2.c scan-assembler adr
+UNRESOLVED: gcc.target/aarch64/pr79041-2.c scan-assembler-not adrp
+FAIL: gcc.target/aarch64/reload-valid-spoff.c (test for excess errors)
+FAIL: gcc.target/aarch64/vec_init_1.c scan-assembler-times ins\\t 2
+FAIL: gcc.target/aarch64/vect-add-sub-cond.c scan-assembler-not \tld[^\t]*\t[wx]
+FAIL: g++.dg/other/anon5.C -std=gnu++14 (test for excess errors)
+FAIL: g++.dg/other/anon5.C -std=gnu++17 (test for excess errors)
+FAIL: g++.dg/other/anon5.C -std=gnu++98 (test for excess errors)
+XPASS: gfortran.dg/ieee/ieee_8.f90 -O0  execution test
+XPASS: gfortran.dg/ieee/ieee_8.f90 -O1  execution test
+XPASS: gfortran.dg/ieee/ieee_8.f90 -O2  execution test
+XPASS: gfortran.dg/ieee/ieee_8.f90 -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions  execution test
+XPASS: gfortran.dg/ieee/ieee_8.f90 -O3 -g  execution test
+XPASS: gfortran.dg/ieee/ieee_8.f90 -Os  execution test

--- a/toolkit/scripts/toolchain/cross/gcc_cross_test.sh
+++ b/toolkit/scripts/toolchain/cross/gcc_cross_test.sh
@@ -1,6 +1,11 @@
 # This script assumes that gcc_cross.sh has been run with the gcc extracted sources at $HOME/cross/gcc-9.1.0 and the gcc cross compilation binaries at /opt/cross/bin
+scriptDir="$( cd "$( dirname "$0" )" && pwd )"
+gccDir=$HOME/cross/gcc-9.1.0
+gccBuildDir=$HOME/cross/build-gcc
+cd ${gccDir}
 
-cd $HOME/cross/gcc-9.1.0
+# delete previous test results
+rm -rf ${gccBuildDir}/gcc/testsuite
 
 # version 2021a installed via apt-get
 # version 2019c in tzdata spec file
@@ -13,18 +18,36 @@ sudo apt-get install -y dejagnu
 # version 6.5 installed via apt-get and texinfo spec file
 sudo apt install -y texinfo
 ./contrib/download_prerequisites
-cd ../build-gcc
+cd ${gccBuildDir}
 export PATH="/opt/cross/bin":$PATH
 
+# Run the compile only tests
 # for less verbose output, remove the "-v -v"
 make -j$(nproc) -k check-gcc RUNTESTFLAGS="-v -v compile.exp"
 
 # version 2.7.15 installed via apt-get
 # version 2.7.18 in python spec file
 sudo apt-get install -y python
-if ../gcc-9.1.0/contrib/testsuite-management/validate_failures.py; then
+if ${gccDir}/contrib/testsuite-management/validate_failures.py; then
     echo "compile.exp tests passed"
 else
     echo "compile.exp tests failed. Stopping..."
     exit 1
+fi
+
+# Run the execution tests via qemu user mode emulation
+
+# version 2.11 installed via apt-get
+# version 4.2 in qemu-kvm SPEC file
+sudo apt-get install -y qemu qemu-user-static
+export LD_LIBRARY_PATH="/opt/cross/aarch64-linux-gnu/lib64"
+export QEMU_LD_PREFIX="/opt/cross/aarch64-linux-gnu/sysroot"
+
+make -j$(nproc) -k check-gcc RUNTESTFLAGS="-v -v aarch64.exp execute.exp dg.exp ieee.exp builtins.exp"
+cp ${scriptDir}/aarch64-linux-gnu.xfail ${gccDir}/contrib/testsuite-management
+if ${gccDir}/contrib/testsuite-management/validate_failures.py; then
+    echo "aarch64.exp execute.exp dg.exp ieee.exp builtins.exp tests passed"
+else
+    echo "aarch64.exp execute.exp dg.exp ieee.exp builtins.exp tests failed. Stopping..."
+    exit 2
 fi


### PR DESCRIPTION
This change adds the GCC emulation tests to the existing `gcc_cross_test.sh` script. There were some tests that weren't passing and seemed to be broken tests. I disabled them by adding them to a .xfail file so we have a clean baseline.

I tested the script in a new Ubuntu docker environment after running the `gcc_cross.sh` script to build the gcc cross toolchain. The docker environment is in an Ubuntu VM (run via Hyper-V) and the emulation tests took about 12 minutes to run on my 8 core Ryzen CPU.