### PR TITLE
[Tools] Fix parsing of new lsblk JSON output format in diskutils

### DIFF
--- a/toolkit/tools/imagegen/diskutils/diskutils.go
+++ b/toolkit/tools/imagegen/diskutils/diskutils.go
@@ -26,10 +26,10 @@ type blockDevicesOutput struct {
 }
 
 type blockDeviceInfo struct {
-	Name   string `json:"name"`    // Example: sda
-	MajMin string `json:"maj:min"` // Example: 1:2
-	Size   string `json:"size"`    // Number of bytes.
-	Model  string `json:"model"`   // Example: 'Virtual Disk'
+	Name   string      `json:"name"`    // Example: sda
+	MajMin string      `json:"maj:min"` // Example: 1:2
+	Size   json.Number `json:"size"`    // Number of bytes. Can be a quoted string or a JSON number, depending on the util-linux version
+	Model  string      `json:"model"`   // Example: 'Virtual Disk'
 }
 
 // SystemBlockDevice defines a block device on the host computer
@@ -519,7 +519,7 @@ func SystemBlockDevices() (systemDevices []SystemBlockDevice, err error) {
 	for i, disk := range blockDevices.Devices {
 		systemDevices[i].DevicePath = fmt.Sprintf("/dev/%s", disk.Name)
 
-		systemDevices[i].RawDiskSize, err = strconv.ParseUint(disk.Size, 10, 64)
+		systemDevices[i].RawDiskSize, err = strconv.ParseUint(disk.Size.String(), 10, 64)
 		if err != nil {
 			return
 		}

--- a/toolkit/tools/imagegen/diskutils/diskutils_test.go
+++ b/toolkit/tools/imagegen/diskutils/diskutils_test.go
@@ -1,0 +1,48 @@
+// Copyright Microsoft Corporation.
+// Licensed under the MIT License.
+
+package diskutils
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Tests the validity of the blockDeviceInfo struct's data modeling of size as `json.Number`
+// with respect to the ability of the standard json.Unmarshal function to handle input from
+// old and new versions of lsblk.
+func TestValidBlockDevicesOutputSizeVariance(t *testing.T) {
+	// The first device, with size as a number, is typical output for lsblk from util-linux >= v2.33
+	// The second device, with size as a quoted string, is typical output for lsblk from util-linux < v2.33
+	const validSizeVarianceJSON = `{
+		"blockdevices": [
+		   {"name":"nvme0n1", "size":1000204886016, "model":"Super Cool NVMe SSD 1TB", "maj:min":"259:1"},
+		   {"name":"nvme1n1", "size":"1000204886016", "model":"Super Cool NVMe SSD 1TB", "maj:min":"259:1"}
+		]
+	 }`
+
+	expectedBlockDevicesOutput := blockDevicesOutput{
+		Devices: []blockDeviceInfo{
+			{
+				Name:   "nvme0n1",
+				Size:   "1000204886016",
+				Model:  "Super Cool NVMe SSD 1TB",
+				MajMin: "259:1",
+			},
+			{
+				Name:   "nvme1n1",
+				Size:   "1000204886016",
+				Model:  "Super Cool NVMe SSD 1TB",
+				MajMin: "259:1",
+			},
+		},
+	}
+
+	var blockDevices blockDevicesOutput
+	bytes := []byte(validSizeVarianceJSON)
+	err := json.Unmarshal(bytes, &blockDevices)
+	assert.NoError(t, err)
+	assert.EqualValues(t, expectedBlockDevicesOutput, blockDevices)
+}


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
In `diskutils.go`, the `blockDeviceInfo` struct is populated by lsblk's json output. In util-linux 2.33, the output format was changed from "every value is a string!" to "let's use the number type where it makes sense to do so". The current type of `blockDeviceInfo.Size` is `string`, so we get an error trying to unmarshal input from the newer util-linux versions. By changing `Size` to be a `json.Number`, the unmarshaler knows that it should accept either a quoted string or a number input. 

It's a bit odd that the unmarshaler accepts a string for `json.Number`... but the type underlying `json.Number` seems to be just a `string`, so we roll with it.

Currently we ship util-linux 2.32, so our installer isn't currently broken. However, it's still possible to trigger this error locally by having a more recent version of util-linux on your dev box and running the installer manually using `go run toolkit/tools/imagegen/attendedinstaller/manualrun/manualrun.go`, since that version uses local lsblk to populate `blockDeviceInfo`. 

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change the type of `blockDeviceInfo.Size` to `json.Number`
- Add test for above change
- 
###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local test of installer + go test added
