### PR TITLE
[cross] Add prebuilt cross compiling toolchains for early testing

### DIFF
--- a/SPECS-CROSS/aarch64-mariner-linux-gnu-prebuilt-toolchain/aarch64-mariner-linux-gnu-prebuilt-toolchain.signatures.json
+++ b/SPECS-CROSS/aarch64-mariner-linux-gnu-prebuilt-toolchain/aarch64-mariner-linux-gnu-prebuilt-toolchain.signatures.json
@@ -1,0 +1,5 @@
+{
+ "Signatures": {
+  "aarch64-mariner-linux-gnu-prebuilt-toolchain-0.1.0.tar.gz": "25cfddd3330343883bb09a486ef3acd38ef3c83a5aa8210b0c22b64a79565129"
+ }
+}

--- a/SPECS-CROSS/aarch64-mariner-linux-gnu-prebuilt-toolchain/aarch64-mariner-linux-gnu-prebuilt-toolchain.spec
+++ b/SPECS-CROSS/aarch64-mariner-linux-gnu-prebuilt-toolchain/aarch64-mariner-linux-gnu-prebuilt-toolchain.spec
@@ -1,0 +1,31 @@
+Summary:        Prebuilt aarch64-mariner-linux-gnu cross compiling toolchain
+Name:           aarch64-mariner-linux-gnu-prebuilt-toolchain
+Version:        0.1.0
+Release:        1%{?dist}
+License:        GPLv2+
+Vendor:         Microsoft Corporation
+Distribution:   Mariner
+Group:          Development/Tools
+AutoReqProv:    no
+ExclusiveArch:  x86_64
+Source0:        %{name}-%{version}.tar.gz
+
+%description
+Prebuilt aarch64-mariner-linux-gnu cross compiling toolchain
+
+%prep
+%autosetup -c
+
+%build
+
+%install
+install -d %{buildroot}/opt/cross
+cp -r * %{buildroot}/opt/cross
+
+%files
+%defattr(-,root,root)
+/opt/cross/*
+
+%changelog
+* Fri Feb 19 2021 Chris Co <chrco@microsoft.com> 0.1.0-1
+- Initial version

--- a/SPECS-CROSS/aarch64-none-linux-gnu-toolchain/aarch64-none-linux-gnu-toolchain.signatures.json
+++ b/SPECS-CROSS/aarch64-none-linux-gnu-toolchain/aarch64-none-linux-gnu-toolchain.signatures.json
@@ -1,0 +1,5 @@
+{
+ "Signatures": {
+  "gcc-arm-9.2-2019.12-x86_64-aarch64-none-linux-gnu.tar.xz": "8dfe681531f0bd04fb9c53cf3c0a3368c616aa85d48938eebe2b516376e06a66"
+ }
+}

--- a/SPECS-CROSS/aarch64-none-linux-gnu-toolchain/aarch64-none-linux-gnu-toolchain.spec
+++ b/SPECS-CROSS/aarch64-none-linux-gnu-toolchain/aarch64-none-linux-gnu-toolchain.spec
@@ -21,7 +21,7 @@ Prebuilt aarch64-none-linux-gnu cross compiling toolchain from Linaro/ARM
 
 %install
 install -d %{buildroot}/opt/cross
-cp -r gcc-arm-9.2-2019.12-x86_64-aarch64-none-linux-gnu/* %{buildroot}/opt/cross
+cp -r * %{buildroot}/opt/cross
 
 %files
 %defattr(-,root,root)

--- a/SPECS-CROSS/aarch64-none-linux-gnu-toolchain/aarch64-none-linux-gnu-toolchain.spec
+++ b/SPECS-CROSS/aarch64-none-linux-gnu-toolchain/aarch64-none-linux-gnu-toolchain.spec
@@ -1,0 +1,32 @@
+Summary:        Prebuilt aarch64-none-linux-gnu cross compiling toolchain
+Name:           aarch64-none-linux-gnu-toolchain
+Version:        0.1.0
+Release:        1%{?dist}
+License:        GPLv2+
+Vendor:         Microsoft Corporation
+Distribution:   Mariner
+Group:          Development/Tools
+AutoReqProv:    no
+ExclusiveArch:  x86_64
+URL:            https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-a/downloads
+Source0:        gcc-arm-9.2-2019.12-x86_64-aarch64-none-linux-gnu.tar.xz
+
+%description
+Prebuilt aarch64-none-linux-gnu cross compiling toolchain from Linaro/ARM
+
+%prep
+%autosetup -c -p1
+
+%build
+
+%install
+install -d %{buildroot}/opt/cross
+cp -r gcc-arm-9.2-2019.12-x86_64-aarch64-none-linux-gnu/* %{buildroot}/opt/cross
+
+%files
+%defattr(-,root,root)
+/opt/cross/*
+
+%changelog
+* Fri Feb 19 2021 Chris Co <chrco@microsoft.com> 0.1.0-1
+- Initial version

--- a/toolkit/scripts/toolchain/cross/busybox_container.sh
+++ b/toolkit/scripts/toolchain/cross/busybox_container.sh
@@ -60,7 +60,7 @@ docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 echo "Creating base container"
 mkdir ${dockerBuildDir}
 cp ${scriptDir}/Dockerfile                      ${dockerBuildDir}/
-cp -r ${installDir}/aarch64-linux-gnu/sysroot   ${dockerBuildDir}/
+cp -r ${installDir}/aarch64-mariner-linux-gnu/sysroot   ${dockerBuildDir}/
 
 docker build -t ${cross_image_name}:${cross_image_tag} ${dockerBuildDir}
 

--- a/toolkit/scripts/toolchain/cross/busybox_cross.sh
+++ b/toolkit/scripts/toolchain/cross/busybox_cross.sh
@@ -5,7 +5,7 @@
 # http://clfs.org/view/clfs-embedded/x86/final-system/busybox.html
 
 installDir="/opt/cross"
-busyboxInstallDir="/opt/cross/aarch64-linux-gnu/sysroot"
+busyboxInstallDir="/opt/cross/aarch64-mariner-linux-gnu/sysroot"
 buildDir="$HOME/cross"
 scriptDir="$( cd "$( dirname "$0" )" && pwd )"
 
@@ -29,5 +29,5 @@ cd busybox-1.32.0
 # Use the default busybox configuration
 make ARCH=arm64 defconfig
 
-make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu-
-make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- CONFIG_PREFIX=${busyboxInstallDir} install
+make ARCH=arm64 CROSS_COMPILE=aarch64-mariner-linux-gnu-
+make ARCH=arm64 CROSS_COMPILE=aarch64-mariner-linux-gnu- CONFIG_PREFIX=${busyboxInstallDir} install

--- a/toolkit/scripts/toolchain/cross/gcc_cross.sh
+++ b/toolkit/scripts/toolchain/cross/gcc_cross.sh
@@ -19,7 +19,7 @@
 
 
 installDir="/opt/cross"
-sysroot="${installDir}/aarch64-linux-gnu/sysroot"
+sysroot="${installDir}/aarch64-mariner-linux-gnu/sysroot"
 buildDir="$HOME/cross"
 scriptDir="$( cd "$( dirname "$0" )" && pwd )"
 
@@ -61,7 +61,7 @@ cd ..
 
 mkdir build-binutils
 cd build-binutils
-../binutils-2.32/configure --prefix=${installDir} --target=aarch64-linux-gnu --disable-multilib --with-sysroot=${sysroot}
+../binutils-2.32/configure --prefix=${installDir} --target=aarch64-mariner-linux-gnu --disable-multilib --with-sysroot=${sysroot}
 make -j$(nproc)
 make install
 cd ..
@@ -69,31 +69,31 @@ cd ..
 
 mkdir -p build-gcc
 cd build-gcc
-../gcc-9.1.0/configure --prefix=${installDir} --target=aarch64-linux-gnu --disable-multilib --enable-shared --enable-threads=posix --enable-__cxa_atexit --enable-clocale=gnu --enable-languages=c,c++,fortran --disable-bootstrap --enable-linker-build-id  --enable-plugin --enable-default-pie --with-sysroot=${sysroot} --with-native-system-header-dir=/include
+../gcc-9.1.0/configure --prefix=${installDir} --target=aarch64-mariner-linux-gnu --disable-multilib --enable-shared --enable-threads=posix --enable-__cxa_atexit --enable-clocale=gnu --enable-languages=c,c++,fortran --disable-bootstrap --enable-linker-build-id  --enable-plugin --enable-default-pie --with-sysroot=${sysroot} --with-native-system-header-dir=/include
 make -j$(nproc) all-gcc
 make install-gcc
 cd ..
 
 mkdir -p build-glibc
 cd build-glibc
-../glibc-2.28/configure --prefix=/ --build=$MACHTYPE --host=aarch64-linux-gnu --target=aarch64-linux-gnu --with-sysroot=${sysroot} --with-headers="${sysroot}/include" --disable-multilib libc_cv_forced_unwind=yes  --disable-werror
-make DESTDIR=${sysroot} install-bootstrap-headers=yes install-headers 
+../glibc-2.28/configure --prefix=/ --build=$MACHTYPE --host=aarch64-mariner-linux-gnu --target=aarch64-mariner-linux-gnu --with-sysroot=${sysroot} --with-headers="${sysroot}/include" --disable-multilib libc_cv_forced_unwind=yes  --disable-werror
+make DESTDIR=${sysroot} install-bootstrap-headers=yes install-headers
 make -j$(nproc) csu/subdir_lib
-install csu/crt1.o csu/crti.o csu/crtn.o "${sysroot}/lib" 
-aarch64-linux-gnu-gcc -nostdlib -nostartfiles -shared -x c /dev/null -o "${sysroot}/lib/libc.so"
+install csu/crt1.o csu/crti.o csu/crtn.o "${sysroot}/lib"
+aarch64-mariner-linux-gnu-gcc -nostdlib -nostartfiles -shared -x c /dev/null -o "${sysroot}/lib/libc.so"
 touch "${sysroot}/include/gnu/stubs.h"
 cd ..
 
 mkdir -p "${sysroot}/usr"
 ln -s ../include "${sysroot}/usr"
 cd build-gcc
-../gcc-9.1.0/configure --prefix=${installDir} --target=aarch64-linux-gnu --disable-multilib --enable-shared --enable-threads=posix --enable-__cxa_atexit --enable-clocale=gnu --enable-languages=c,c++,fortran --disable-bootstrap --enable-linker-build-id  --enable-plugin --enable-default-pie --with-sysroot=${sysroot} --with-build-sysroot=${sysroot}
+../gcc-9.1.0/configure --prefix=${installDir} --target=aarch64-mariner-linux-gnu --disable-multilib --enable-shared --enable-threads=posix --enable-__cxa_atexit --enable-clocale=gnu --enable-languages=c,c++,fortran --disable-bootstrap --enable-linker-build-id  --enable-plugin --enable-default-pie --with-sysroot=${sysroot} --with-build-sysroot=${sysroot}
 make -j$(nproc) all-target-libgcc
 make install-target-libgcc
 cd ..
 
 cd build-glibc
-make DESTDIR=${sysroot} -j$(nproc) 
+make DESTDIR=${sysroot} -j$(nproc)
 make DESTDIR=${sysroot} install
 cd ..
 

--- a/toolkit/scripts/toolchain/cross/generate_minimal_rootfs.sh
+++ b/toolkit/scripts/toolchain/cross/generate_minimal_rootfs.sh
@@ -3,7 +3,7 @@
 
 # Currently assumes you have already run busybox_cross.sh and kernel_cross.sh
 
-toolchainTuple="aarch64-linux-gnu"
+toolchainTuple="aarch64-mariner-linux-gnu"
 installDir="/opt/cross"
 sysrootDir="/opt/cross/${toolchainTuple}/sysroot"
 scriptDir="$( cd "$( dirname "$0" )" && pwd )"

--- a/toolkit/scripts/toolchain/cross/kernel_cross.sh
+++ b/toolkit/scripts/toolchain/cross/kernel_cross.sh
@@ -3,7 +3,7 @@
 
 kernelVersion="5.4.83"
 kernelTargetArch="arm64"
-toolchainTuple="aarch64-linux-gnu"
+toolchainTuple="aarch64-mariner-linux-gnu"
 
 installDir="/opt/cross"
 sysrootDir="/opt/cross/${toolchainTuple}/sysroot"


### PR DESCRIPTION
This adds two cross compiling toolchain packages:
1. aarch64-mariner-linux-gnu-prebuilt-toolchain
2. aarch64-none-linux-gnu-toolchain

aarch64-mariner-linux-gnu-prebuilt-toolchain
package contains the prebuilt binaries generated from running the
cross toolchain scripts in the toolkit folder. We will use this
as a stop-gap while the actual aarch64-mariner-linux-gnu-toolchain
is being created.

Additionally set AutoReqProv no. By default, rpmbuild will
dynamically scan for provides/requires. So by default this
aarch64-linux-gnu-prebuilt-toolchain package leads to
unsatisfiable requires, found when installing the resulting package.

So tell rpmbuild not to do this.

aarch64-none-linux-gnu-toolchain adds the ARM/Linaro GCC 9.2
cross compiler toolchain so we can sanity check our cross compile
results against another cross toolchain variant.

Signed-off-by: Chris Co <chrco@microsoft.com>
