### PR TITLE
kernel-signed: Use uname_r macro everywhere

### DIFF
--- a/SPECS-SIGNED/kernel-signed-aarch64/kernel-signed-aarch64.spec
+++ b/SPECS-SIGNED/kernel-signed-aarch64/kernel-signed-aarch64.spec
@@ -3,7 +3,7 @@
 Summary:        Signed Linux Kernel for aarch64 systems
 Name:           kernel-signed-aarch64
 Version:        5.10.13.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -22,7 +22,7 @@ URL:            https://github.com/microsoft/CBL-Mariner-Linux-Kernel
 #   3. Place the unsigned package and signed binary in this spec's folder
 #   4. Build this spec
 Source0:        kernel-%{version}-%{release}.aarch64.rpm
-Source1:        vmlinuz-%{version}-%{release}
+Source1:        vmlinuz-%{uname_r}
 BuildRequires:  cpio
 Requires:       filesystem
 Requires:       kmod
@@ -47,7 +47,7 @@ mkdir -p %{buildroot}/%{_localstatedir}/lib/initramfs/kernel
 cp -rp ./boot/* %{buildroot}/boot
 cp -rp ./lib/* %{buildroot}/lib
 cp -rp ./var/* %{buildroot}/%{_localstatedir}
-cp %{SOURCE1} %{buildroot}/boot/vmlinuz-%{version}-%{release}
+cp %{SOURCE1} %{buildroot}/boot/vmlinuz-%{uname_r}
 
 %triggerin -- initramfs
 mkdir -p %{_localstatedir}/lib/rpm-state/initramfs/pending
@@ -82,6 +82,9 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %config %{_localstatedir}/lib/initramfs/kernel/%{uname_r}
 
 %changelog
+* Tue Feb 23 2021 Chris Co <chrco@microsoft.com> - 5.10.13.1-2
+- Use uname_r macro instead of version-release for kernel version
+
 * Thu Feb 18 2021 Chris Co <chrco@microsoft.com> - 5.10.13.1-1
 - Update source to 5.10.13.1
 

--- a/SPECS-SIGNED/kernel-signed-x64/kernel-signed-x64.spec
+++ b/SPECS-SIGNED/kernel-signed-x64/kernel-signed-x64.spec
@@ -3,7 +3,7 @@
 Summary:        Signed Linux Kernel for x86_64 systems
 Name:           kernel-signed-x64
 Version:        5.10.13.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -22,7 +22,7 @@ URL:            https://github.com/microsoft/CBL-Mariner-Linux-Kernel
 #   3. Place the unsigned package and signed binary in this spec's folder
 #   4. Build this spec
 Source0:        kernel-%{version}-%{release}.x86_64.rpm
-Source1:        vmlinuz-%{version}-%{release}
+Source1:        vmlinuz-%{uname_r}
 BuildRequires:  cpio
 Requires:       filesystem
 Requires:       kmod
@@ -47,7 +47,7 @@ mkdir -p %{buildroot}/%{_localstatedir}/lib/initramfs/kernel
 cp -rp ./boot/* %{buildroot}/boot
 cp -rp ./lib/* %{buildroot}/lib
 cp -rp ./var/* %{buildroot}/%{_localstatedir}
-cp %{SOURCE1} %{buildroot}/boot/vmlinuz-%{version}-%{release}
+cp %{SOURCE1} %{buildroot}/boot/vmlinuz-%{uname_r}
 
 %triggerin -- initramfs
 mkdir -p %{_localstatedir}/lib/rpm-state/initramfs/pending
@@ -82,6 +82,9 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %config %{_localstatedir}/lib/initramfs/kernel/%{uname_r}
 
 %changelog
+* Tue Feb 23 2021 Chris Co <chrco@microsoft.com> - 5.10.13.1-2
+- Use uname_r macro instead of version-release for kernel version
+
 * Thu Feb 18 2021 Chris Co <chrco@microsoft.com> - 5.10.13.1-1
 - Update source to 5.10.13.1
 

--- a/SPECS/kernel-headers/kernel-headers.spec
+++ b/SPECS/kernel-headers/kernel-headers.spec
@@ -1,7 +1,7 @@
 Summary:        Linux API header files
 Name:           kernel-headers
 Version:        5.10.13.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -35,6 +35,9 @@ cp -rv usr/include/* /%{buildroot}%{_includedir}
 %{_includedir}/*
 
 %changelog
+* Tue Feb 23 2021 Chris Co <chrco@microsoft.com> - 5.10.13.1-2
+- Bump release to match kernel spec release number
+
 * Thu Feb 18 2021 Chris Co <chrco@microsoft.com> - 5.10.13.1-1
 - Update source to 5.10.13.1
 

--- a/SPECS/kernel-hyperv/kernel-hyperv.spec
+++ b/SPECS/kernel-hyperv/kernel-hyperv.spec
@@ -4,7 +4,7 @@
 Summary:        Linux Kernel optimized for Hyper-V
 Name:           kernel-hyperv
 Version:        5.10.13.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -274,6 +274,9 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %{_libdir}/perf/include/bpf/*
 
 %changelog
+* Tue Feb 23 2021 Chris Co <chrco@microsoft.com> - 5.10.13.1-2
+- Bump release to match kernel spec release number
+
 * Thu Feb 18 2021 Chris Co <chrco@microsoft.com> - 5.10.13.1-1
 - Update source to 5.10.13.1
 - Remove CONFIG_GCC_PLUGIN_RANDSTRUCT

--- a/SPECS/kernel/kernel.spec
+++ b/SPECS/kernel/kernel.spec
@@ -4,7 +4,7 @@
 Summary:        Linux Kernel
 Name:           kernel
 Version:        5.10.13.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -452,6 +452,9 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %endif
 
 %changelog
+* Tue Feb 23 2021 Chris Co <chrco@microsoft.com> - 5.10.13.1-2
+- Bump release to match signed spec release number
+
 * Thu Feb 18 2021 Chris Co <chrco@microsoft.com> - 5.10.13.1-1
 - Update source to 5.10.13.1
 - Remove patch to publish efi tpm event log on ARM. Present in updated source.

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -1,5 +1,5 @@
 filesystem-1.1-7.cm1.aarch64.rpm
-kernel-headers-5.10.13.1-1.cm1.noarch.rpm
+kernel-headers-5.10.13.1-2.cm1.noarch.rpm
 glibc-2.28-17.cm1.aarch64.rpm
 glibc-devel-2.28-17.cm1.aarch64.rpm
 glibc-i18n-2.28-17.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -1,5 +1,5 @@
 filesystem-1.1-7.cm1.x86_64.rpm
-kernel-headers-5.10.13.1-1.cm1.noarch.rpm
+kernel-headers-5.10.13.1-2.cm1.noarch.rpm
 glibc-2.28-17.cm1.x86_64.rpm
 glibc-devel-2.28-17.cm1.x86_64.rpm
 glibc-i18n-2.28-17.cm1.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -145,7 +145,7 @@ json-c-debuginfo-0.14-3.cm1.aarch64.rpm
 json-c-devel-0.14-3.cm1.aarch64.rpm
 kbd-2.0.4-5.cm1.aarch64.rpm
 kbd-debuginfo-2.0.4-5.cm1.aarch64.rpm
-kernel-headers-5.10.13.1-1.cm1.noarch.rpm
+kernel-headers-5.10.13.1-2.cm1.noarch.rpm
 kmod-25-4.cm1.aarch64.rpm
 kmod-debuginfo-25-4.cm1.aarch64.rpm
 kmod-devel-25-4.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -145,7 +145,7 @@ json-c-debuginfo-0.14-3.cm1.x86_64.rpm
 json-c-devel-0.14-3.cm1.x86_64.rpm
 kbd-2.0.4-5.cm1.x86_64.rpm
 kbd-debuginfo-2.0.4-5.cm1.x86_64.rpm
-kernel-headers-5.10.13.1-1.cm1.noarch.rpm
+kernel-headers-5.10.13.1-2.cm1.noarch.rpm
 kmod-25-4.cm1.x86_64.rpm
 kmod-debuginfo-25-4.cm1.x86_64.rpm
 kmod-devel-25-4.cm1.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
There was a build break due to an incorrect name used
for vmlinuz in SOURCE1.

The new 5.10 kernel source introduced a new versioning
scheme when built. EXTRAVERSION will always contain
"<local patch number>-rolling-lts-mariner".

In kernel.spec, the vmlinuz we output has the name:
vmlinuz-<version>-rolling-lts-mariner-<release>, which
is constructed using vmlinuz-%{uname_r}

So to fix, use vmlinuz-%{uname_r} in the kernel-signed
specs as well.

Signed-off-by: Chris Co <chrco@microsoft.com>

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- In kernel-signed specs, change every instance of vmlinuz-%{version}-%{release} to vmlinuz-%{uname_r}
- Bump release for all related kernel specs

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
**YES**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->

###### Links to CVEs  <!-- optional -->

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
Local build