### PR TITLE
Tweak installer to meet accessibility standards

### DIFF
--- a/toolkit/tools/cgmanifest.json
+++ b/toolkit/tools/cgmanifest.json
@@ -130,6 +130,15 @@
             "Component": {
                 "Type": "Go",
                 "Go": {
+                    "Name": "github.com/bendahl/uinput",
+                    "Version": "v1.4.0"
+                }
+            }
+        },
+        {
+            "Component": {
+                "Type": "Go",
+                "Go": {
                     "Name": "gopkg.in/alecthomas/kingpin.v2",
                     "Version": "v2.2.6"
                 }

--- a/toolkit/tools/go.mod
+++ b/toolkit/tools/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
 	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
+	github.com/bendahl/uinput v1.4.0
 	github.com/cavaliercoder/go-cpio v0.0.0-20180626203310-925f9528c45e
 	github.com/gdamore/tcell v1.3.0
 	github.com/klauspost/compress v1.10.5 // indirect

--- a/toolkit/tools/go.sum
+++ b/toolkit/tools/go.sum
@@ -5,6 +5,8 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafo
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d h1:UQZhZ2O0vMHr2cI+DC1Mbh0TJxzA3RcLoMsFw+aXw7E=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
+github.com/bendahl/uinput v1.4.0 h1:aVJhayM1wEv7yXXLvC/fbXMmA1uB+jAspKhXQaV+76U=
+github.com/bendahl/uinput v1.4.0/go.mod h1:Np7w3DINc9wB83p12fTAM3DPPhFnAKP0WTXRqCQJ6Z8=
 github.com/cavaliercoder/go-cpio v0.0.0-20180626203310-925f9528c45e h1:hHg27A0RSSp2Om9lubZpiMgVbvn39bsUmW9U5h0twqc=
 github.com/cavaliercoder/go-cpio v0.0.0-20180626203310-925f9528c45e/go.mod h1:oDpT4efm8tSYHXV5tHSdRvBet/b/QzxZ+XyyPehvm3A=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/toolkit/tools/imagegen/attendedinstaller/attendedinstaller.go
+++ b/toolkit/tools/imagegen/attendedinstaller/attendedinstaller.go
@@ -191,6 +191,7 @@ func (ai *AttendedInstaller) showView(newView int) (err error) {
 	err = speakuputils.ClearSpeakupBuffer(ai.keyboard)
 	if err != nil {
 		logger.Log.Warnf("Error clearing speakup buffer")
+		err = nil
 	}
 
 	ai.grid.AddItem(view.Primitive(), primaryContentRow, primaryContentColumn, primaryContentRowSpan, primaryContentColumnSpan, primaryContentMinSize, primaryContentMinSize, true)
@@ -236,8 +237,12 @@ func (ai *AttendedInstaller) globalInputCapture(event *tcell.EventKey) *tcell.Ev
 func (ai *AttendedInstaller) initializeUI() (err error) {
 	ai.keyboard, err = speakuputils.CreateVirtualKeyboard()
 	if err != nil {
+		// Non-fatal - results in a slightlydegraded experience due to the lack of a
+		// text-to-speech buffer clear between views, but not bad enough to exit outright
 		logger.Log.Warnf("Failed to initialize virtual keyboard via uinput")
+		err = nil
 	}
+
 	const osReleaseFile = "/etc/os-release"
 
 	ai.backdropStyle = tview.Theme{

--- a/toolkit/tools/imagegen/attendedinstaller/attendedinstaller.go
+++ b/toolkit/tools/imagegen/attendedinstaller/attendedinstaller.go
@@ -72,7 +72,7 @@ type AttendedInstaller struct {
 	allViews         []views.View
 	backdropStyle    tview.Theme
 	titleText        *tview.TextView
-	keyboard		 uinput.Keyboard
+	keyboard         uinput.Keyboard
 
 	installationFunc     func(configuration.Config, chan int, chan string) error
 	calamaresInstallFunc func() error
@@ -101,8 +101,6 @@ func New(cfg configuration.Config, installationFunc func(configuration.Config, c
 		installationFunc:     installationFunc,
 		calamaresInstallFunc: calamaresInstallFunc,
 	}
-
-
 
 	err = attendedInstaller.initializeUI()
 	return

--- a/toolkit/tools/imagegen/attendedinstaller/primitives/progressbar/progressbar.go
+++ b/toolkit/tools/imagegen/attendedinstaller/primitives/progressbar/progressbar.go
@@ -4,8 +4,6 @@
 package progressbar
 
 import (
-	"fmt"
-
 	"github.com/gdamore/tcell"
 	"github.com/rivo/tview"
 )
@@ -101,9 +99,6 @@ func (p *ProgressBar) Draw(screen tcell.Screen) {
 	filledInWidth := int(float32(width) * (float32(p.progress) / 100))
 	filledInX := x + filledInWidth
 
-	percentageText := fmt.Sprintf(" %d%% ", p.progress)
-	percentageStart := (endX - len(percentageText)) / 2
-
 	for i := x; i < endX; i++ {
 		var toPrint string
 		if i < filledInX {
@@ -114,7 +109,4 @@ func (p *ProgressBar) Draw(screen tcell.Screen) {
 
 		tview.Print(screen, toPrint, i, y, len(toPrint), textAlign, p.fillColor)
 	}
-
-	tview.Print(screen, percentageText, percentageStart, y, len(percentageText), textAlign, p.labelColor)
-	tview.Print(screen, p.status, x, y+statusYOffset, len(p.status), textAlign, p.labelColor)
 }

--- a/toolkit/tools/imagegen/attendedinstaller/speakuputils/speakuputils.go
+++ b/toolkit/tools/imagegen/attendedinstaller/speakuputils/speakuputils.go
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package speakuputils
+
+import (
+	"github.com/bendahl/uinput"
+)
+
+func CreateVirtualKeyboard() (keyboard uinput.Keyboard, err error) {
+	keyboard, err = uinput.CreateKeyboard("/dev/uinput", []byte("MarinerVirtualKeyboard"))
+	return
+}
+
+func ClearSpeakupBuffer(k uinput.Keyboard) (err error) {
+	if k == nil {
+		return
+	}
+	err = k.KeyPress(uinput.KeyKpenter)
+	if err != nil { 
+		return err
+	}
+	err = k.KeyPress(uinput.KeyKpenter)
+	return
+} 

--- a/toolkit/tools/imagegen/attendedinstaller/speakuputils/speakuputils.go
+++ b/toolkit/tools/imagegen/attendedinstaller/speakuputils/speakuputils.go
@@ -17,9 +17,9 @@ func ClearSpeakupBuffer(k uinput.Keyboard) (err error) {
 		return
 	}
 	err = k.KeyPress(uinput.KeyKpenter)
-	if err != nil { 
+	if err != nil {
 		return err
 	}
 	err = k.KeyPress(uinput.KeyKpenter)
 	return
-} 
+}

--- a/toolkit/tools/imagegen/attendedinstaller/uitext/uitext.go
+++ b/toolkit/tools/imagegen/attendedinstaller/uitext/uitext.go
@@ -12,16 +12,16 @@ const (
 
 // Navigation text.
 const (
-	ButtonAccept  = "[Accept[]"
-	ButtonCancel  = "[Cancel[]"
+	ButtonAccept     = "[Accept[]"
+	ButtonCancel     = "[Cancel[]"
 	ButtonCancelBold = BoldPrefix + ButtonCancel
-	ButtonConfirm = "[Confirm[]"
-	ButtonGoBack  = "[Go Back[]"
-	ButtonNext    = "[Next[]"
-	ButtonYes     = "[Yes[]"
-	ButtonQuit    = "[Quit[]"
-	ButtonQuitBold = BoldPrefix + ButtonQuit
-	ButtonRestart = "[Restart[]"
+	ButtonConfirm    = "[Confirm[]"
+	ButtonGoBack     = "[Go Back[]"
+	ButtonNext       = "[Next[]"
+	ButtonYes        = "[Yes[]"
+	ButtonQuit       = "[Quit[]"
+	ButtonQuitBold   = BoldPrefix + ButtonQuit
+	ButtonRestart    = "[Restart[]"
 )
 
 // AttendedInstaller wrapper text.

--- a/toolkit/tools/imagegen/attendedinstaller/uitext/uitext.go
+++ b/toolkit/tools/imagegen/attendedinstaller/uitext/uitext.go
@@ -5,22 +5,29 @@ package uitext
 
 // "]" is a special character for the TUI text, escape it with "[]"
 
+// Control sequences for text formatting
+const (
+	BoldPrefix = "[::b]"
+)
+
 // Navigation text.
 const (
 	ButtonAccept  = "[Accept[]"
 	ButtonCancel  = "[Cancel[]"
+	ButtonCancelBold = BoldPrefix + ButtonCancel
 	ButtonConfirm = "[Confirm[]"
 	ButtonGoBack  = "[Go Back[]"
 	ButtonNext    = "[Next[]"
 	ButtonYes     = "[Yes[]"
 	ButtonQuit    = "[Quit[]"
+	ButtonQuitBold = BoldPrefix + ButtonQuit
 	ButtonRestart = "[Restart[]"
 )
 
 // AttendedInstaller wrapper text.
 const (
 	NavigationHelp = "Arrow keys make selections. Enter activates."
-	ExitModalTitle = "Do you want to quit setup?"
+	ExitModalTitle = BoldPrefix + "Do you want to quit setup?"
 )
 
 // ConfirmView text.
@@ -141,7 +148,7 @@ const (
 // FinishView text.
 const (
 	FinishTitle   = "CBL-Mariner Installation Complete"
-	FinishTextFmt = "Total installation time: %v seconds."
+	FinishTextFmt = "Total installation time: %v seconds. Press Enter to restart."
 )
 
 // Common for input validation.

--- a/toolkit/tools/imagegen/attendedinstaller/views/diskview/manualpartitionwidget/manualpartitionwidget.go
+++ b/toolkit/tools/imagegen/attendedinstaller/views/diskview/manualpartitionwidget/manualpartitionwidget.go
@@ -132,9 +132,10 @@ func (mp *ManualPartitionWidget) Initialize(backButtonText string, sysConfig *co
 	// Alter the defaults now so they are captured by the dropdowns and then restore the style
 	// for future elements.
 	originalStyle := tview.Styles
+	tview.Styles.ContrastBackgroundColor = tcell.ColorWhite
 	tview.Styles.MoreContrastBackgroundColor = tcell.ColorBlack
 	tview.Styles.PrimitiveBackgroundColor = tcell.ColorWhite
-	tview.Styles.PrimaryTextColor = tcell.ColorGreen
+	tview.Styles.PrimaryTextColor = tcell.ColorBlue
 
 	mp.formatDropDown = tview.NewDropDown().
 		SetLabel(uitext.DiskFormatLabel).
@@ -150,15 +151,18 @@ func (mp *ManualPartitionWidget) Initialize(backButtonText string, sysConfig *co
 	mp.nameInput = tview.NewInputField().
 		SetLabel(uitext.DiskNameLabel).
 		SetFieldWidth(maxParittionLabelSize).
-		SetAcceptanceFunc(mp.nameInputValidation)
+		SetAcceptanceFunc(mp.nameInputValidation).
+		SetFieldBackgroundColor(tcell.ColorWhite)
 
 	mp.mountPointInput = tview.NewInputField().
 		SetLabel(uitext.DiskMountPointLabel).
-		SetAcceptanceFunc(mp.mountPointInputValidation)
+		SetAcceptanceFunc(mp.mountPointInputValidation).
+		SetFieldBackgroundColor(tcell.ColorWhite)
 
 	mp.sizeInput = tview.NewInputField().
 		SetLabel(fmt.Sprintf("%s %s", uitext.DiskSizeLabel, uitext.DiskSizeLabelMaxHelp)).
-		SetAcceptanceFunc(mp.sizeInputValidation)
+		SetAcceptanceFunc(mp.sizeInputValidation).
+		SetFieldBackgroundColor(tcell.ColorWhite)
 
 	mp.formNavBar = navigationbar.NewNavigationBar().
 		AddButton(uitext.ButtonCancel, func() {


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
The installer does not meet some accessibility requirements, when it comes to things like contrast and screen reading. This PR adds some tweaks to meet those requirements.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Tweak and remove sections that are tricky for speakup to read in a sensible manner
- Adjust contrast in the exit modal

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local test of image
