### PR TITLE
Fix issue with multiple empty mount validation

### DIFF
--- a/toolkit/tools/imagegen/configuration/systemconfig.go
+++ b/toolkit/tools/imagegen/configuration/systemconfig.go
@@ -92,7 +92,10 @@ func (s *SystemConfig) IsValid() (err error) {
 		if mountPointUsed[partitionSetting.MountPoint] {
 			return fmt.Errorf("invalid [PartitionSettings]: duplicate mount point found at '%s'", partitionSetting.MountPoint)
 		}
-		mountPointUsed[partitionSetting.MountPoint] = true
+		if partitionSetting.MountPoint != "" {
+			// Don't track unmounted partition duplication (They will all mount at "")
+			mountPointUsed[partitionSetting.MountPoint] = true
+		}
 	}
 
 	if s.ReadOnlyVerityRoot.Enable || s.Encryption.Enable {

--- a/toolkit/tools/imagegen/configuration/systemconfig_test.go
+++ b/toolkit/tools/imagegen/configuration/systemconfig_test.go
@@ -177,6 +177,22 @@ func TestShouldFailToParsingMultipleSameMounts_SystemConfig(t *testing.T) {
 	assert.Equal(t, "failed to parse [SystemConfig]: invalid [PartitionSettings]: duplicate mount point found at '/'", err.Error())
 }
 
+func TestShouldSucceedParsingMultipleSameEmptyMounts_SystemConfig(t *testing.T) {
+	var checkedSystemConfig SystemConfig
+
+	badPartitionSettingsConfig := validSystemConfig
+	badPartitionSettingsConfig.PartitionSettings = []PartitionSetting{
+		{MountPoint: ""},
+		{MountPoint: ""},
+	}
+
+	err := badPartitionSettingsConfig.IsValid()
+	assert.NoError(t, err)
+
+	err = remarshalJSON(badPartitionSettingsConfig, &checkedSystemConfig)
+	assert.NoError(t, err)
+}
+
 func TestShouldFailParsingBothVerityAndEncryption_SystemConfig(t *testing.T) {
 	var checkedSystemConfig SystemConfig
 

--- a/toolkit/tools/imagegen/configuration/systemconfig_test.go
+++ b/toolkit/tools/imagegen/configuration/systemconfig_test.go
@@ -180,17 +180,18 @@ func TestShouldFailToParsingMultipleSameMounts_SystemConfig(t *testing.T) {
 func TestShouldSucceedParsingMultipleSameEmptyMounts_SystemConfig(t *testing.T) {
 	var checkedSystemConfig SystemConfig
 
-	badPartitionSettingsConfig := validSystemConfig
-	badPartitionSettingsConfig.PartitionSettings = []PartitionSetting{
+	emptyPartitionSettingsConfig := validSystemConfig
+	emptyPartitionSettingsConfig.PartitionSettings = []PartitionSetting{
 		{MountPoint: ""},
 		{MountPoint: ""},
 	}
 
-	err := badPartitionSettingsConfig.IsValid()
+	err := emptyPartitionSettingsConfig.IsValid()
 	assert.NoError(t, err)
 
-	err = remarshalJSON(badPartitionSettingsConfig, &checkedSystemConfig)
+	err = remarshalJSON(emptyPartitionSettingsConfig, &checkedSystemConfig)
 	assert.NoError(t, err)
+	assert.Equal(t, emptyPartitionSettingsConfig, checkedSystemConfig)
 }
 
 func TestShouldFailParsingBothVerityAndEncryption_SystemConfig(t *testing.T) {


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Images configs may create multiple unmounted partitions. They will all have the same mount point (`""`). The duplicate mount point detection was flagging these as conflicting. Don't check empty mount points for duplication to avoid this.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Don't validate partition mounts are not duplicated when they are not mounted (ie `PartitionSetting.MountPoint = ""`)
- Add test to check this case

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local unit tests
- Ran validation against problematic config file
