### PR TITLE
Update postgresql for CVE-2021-20229 & CVE-2021-3393

### DIFF
--- a/SPECS/postgresql/postgresql.signatures.json
+++ b/SPECS/postgresql/postgresql.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "postgresql-12.5.tar.bz2": "bd0d25341d9578b5473c9506300022de26370879581f5fddd243a886ce79ff95"
+  "postgresql-12.6.tar.bz2": "df7dd98d5ccaf1f693c7e1d0d084e9fed7017ee248bba5be0167c42ad2d70a09"
  }
 }

--- a/SPECS/postgresql/postgresql.spec
+++ b/SPECS/postgresql/postgresql.spec
@@ -1,7 +1,7 @@
 Summary:        PostgreSQL database engine
 Name:           postgresql
-Version:        12.5
-Release:        2%{?dist}
+Version:        12.6
+Release:        1%{?dist}
 License:        PostgreSQL
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -169,6 +169,9 @@ rm -rf %{buildroot}/*
 %{_libdir}/libpgtypes.a
 
 %changelog
+* Tue Mar 02 2021 Neha Agarwal <nehaagarwal@microsoft.com> - 12.6-1
+- Update package version to resolve CVE-2021-20229 and CVE-2021-3393.
+
 * Wed Dec 09 2020 Andrew Phelps <anphel@microsoft.com> - 12.5-2
 - Add sudo package to resolve test issue.
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -4395,8 +4395,8 @@
         "type": "other",
         "other": {
           "name": "postgresql",
-          "version": "12.5",
-          "downloadUrl": "https://ftp.postgresql.org/pub/source/v12.5/postgresql-12.5.tar.bz2"
+          "version": "12.6",
+          "downloadUrl": "https://ftp.postgresql.org/pub/source/v12.6/postgresql-12.6.tar.bz2"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Update the postgresql version from 12.5 to 12.6 to fix CVE-2021-3393 and CVE-2021-20229 

###### Change Log  <!-- REQUIRED -->
Update the postgresql version from 12.5 to 12.6 to fix CVE-2021-3393 and CVE-2021-20229 

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2021-20229

###### Test Methodology
local build