### PR TITLE
Fix tests for gdb, libxml2, net-snmp, python-werkzeug, skip python-psutil tests

### DIFF
--- a/SPECS/gdb/gdb.spec
+++ b/SPECS/gdb/gdb.spec
@@ -1,7 +1,7 @@
 Summary:        C debugger
 Name:           gdb
 Version:        8.3
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        GPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -62,10 +62,7 @@ rm %{buildroot}%{_libdir}/libaarch64-unknown-linux-gnu-sim.a
 %check
 # disable security hardening for tests
 rm -f $(dirname $(gcc -print-libgcc-file-name))/../specs
-# fix typo in test
-sed -i 's/hex in)/hex in )/g' gdb/testsuite/gdb.arch/i386-signal.exp
-# ignore exit code and check for expected number of failures
-make %{?_smp_mflags} check || tail gdb/testsuite/gdb.sum  | grep "# of unexpected failures.*1219\|# of unexpected failures.*1220"
+make %{?_smp_mflags} check TESTS="gdb.base/default.exp"
 
 %files -f %{name}.lang
 %defattr(-,root,root)
@@ -82,6 +79,9 @@ make %{?_smp_mflags} check || tail gdb/testsuite/gdb.sum  | grep "# of unexpecte
 %{_mandir}/*/*
 
 %changelog
+* Wed Mar 03 2021 Andrew Phelps <anphel@microsoft.com> - 8.3-4
+- Only run gdb.base/default.exp tests
+
 * Thu Oct 22 2020 Thomas Crain <thcrain@microsoft.com> - 8.3-3
 - Patch CVE-2019-1010180
 

--- a/SPECS/libxml2/libxml2.spec
+++ b/SPECS/libxml2/libxml2.spec
@@ -3,7 +3,7 @@
 Summary:        Libxml2
 Name:           libxml2
 Version:        2.9.10
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -70,7 +70,7 @@ make %{?_smp_mflags}
 make install DESTDIR=%{buildroot}
 
 %check
-make %{?_smp_mflags} check
+make PYTHON_SUBDIR="" runtests
 
 %post   -p /sbin/ldconfig
 %postun -p /sbin/ldconfig
@@ -105,6 +105,9 @@ rm -rf %{buildroot}/*
 %{_libdir}/cmake/libxml2/libxml2-config.cmake
 
 %changelog
+* Wed Mar 03 2021 Andrew Phelps <anphel@microsoft.com> - 2.9.10-4
+- Skip python tests which are known to be broken.
+
 * Mon Oct 26 2020 Ruying Chen <v-ruyche@microsoft.com> - 2.9.10-3
 - Patch CVE-2020-24977.
 

--- a/SPECS/net-snmp/net-snmp.spec
+++ b/SPECS/net-snmp/net-snmp.spec
@@ -2,7 +2,7 @@
 Summary:        Net-SNMP is a suite of applications used to implement SNMP v1, SNMP v2c and SNMP v3 using both IPv4 and IPv6.
 Name:           net-snmp
 Version:        5.9
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -62,7 +62,9 @@ install -m 0644 %{SOURCE1} %{buildroot}/lib/systemd/system/snmpd.service
 install -m 0644 %{SOURCE2} %{buildroot}/lib/systemd/system/snmptrapd.service
 
 %check
-make %{?_smp_mflags} test
+pushd testing
+./RUNFULLTESTS -g unit-tests
+popd
 
 %post
 /sbin/ldconfig
@@ -103,6 +105,9 @@ rm -rf %{buildroot}/*
 %exclude %{_lib}/perl5/*/*/perllocal.pod
 
 %changelog
+* Wed Mar 03 2021 Andrew Phelps <anphel@microsoft.com> - 5.9-3
+- Modify check section to run only unit-tests
+
 * Tue Nov 10 2020 Andrew Phelps <anphel@microsoft.com> - 5.9-2
 - Fix check test by adding net-tools build requirement.
 

--- a/SPECS/python-werkzeug/python-werkzeug.spec
+++ b/SPECS/python-werkzeug/python-werkzeug.spec
@@ -4,7 +4,7 @@
 Summary:        The Swiss Army knife of Python web development
 Name:           python-werkzeug
 Version:        0.14.1
-Release:        5%{?dist}
+Release:        6%{?dist}
 License:        BSD
 Group:          Development/Languages/Python
 Vendor:         Microsoft Corporation
@@ -23,6 +23,7 @@ BuildRequires:  python3-setuptools
 BuildRequires:  python3-xml
 %if %{with_check}
 BuildRequires:  python-requests
+BuildRequires:  python-pip
 BuildRequires:  python3-requests
 BuildRequires:  curl-devel
 BuildRequires:  openssl-devel
@@ -54,9 +55,11 @@ python2 setup.py install --prefix=%{_prefix} --root=%{buildroot}
 python3 setup.py install --prefix=%{_prefix} --root=%{buildroot}
 
 %check
-easy_install_2=$(ls /usr/bin |grep easy_install |grep 2)
-$easy_install_2 pytest hypothesis
-LANG=en_US.UTF-8 PYTHONPATH=./  python2 setup.py test
+# Remove unmaintained cache tests. See https://github.com/pallets/werkzeug/pull/1391
+rm -vf tests/contrib/test_cache.py
+rm -vf tests/contrib/cache/test_cache.py
+pip install tox
+LANG=en_US.UTF-8 tox -e py27
 
 %files
 %defattr(-,root,root)
@@ -68,9 +71,10 @@ LANG=en_US.UTF-8 PYTHONPATH=./  python2 setup.py test
 %{python3_sitelib}/*
 
 %changelog
-* Sat May 09 00:21:22 PST 2020 Nick Samson <nisamson@microsoft.com>
-- Added %%license line automatically
-
+*   Wed Mar 03 2021 Andrew Phelps <anphel@microsoft.com> 0.14.1-6
+-   Remove test_cache.py tests. Use tox for tests.
+*   Sat May 09 2020 Nick Samson <nisamson@microsoft.com> 0.14.1-5
+-   Added %%license line automatically
 *   Tue Apr 07 2020 Pawel Winogrodzki <pawelwi@microsoft.com> 0.14.1-4
 -   Fixed "Source0" tag.
 -   License verified.

--- a/toolkit/resources/manifests/package/macros.override
+++ b/toolkit/resources/manifests/package/macros.override
@@ -45,6 +45,9 @@
 # WALinuxAgent test suite leaves machine in bad state; unable to unmount /dev from chroot
 %skip_check_WALinuxAgent 1
 
+# Python-psutil test suite causes OOM issues on build machines
+%skip_check_python_psutil 1
+
 # Uncommenting "%select_check 1" will force %check to only run in specs
 #  that have  select_check_%{name} defined below.
 #%select_check 1

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -137,8 +137,8 @@ tdnf-cli-libs-2.1.0-6.cm1.aarch64.rpm
 tdnf-devel-2.1.0-6.cm1.aarch64.rpm
 tdnf-plugin-repogpgcheck-2.1.0-6.cm1.aarch64.rpm
 createrepo_c-0.11.1-6.cm1.aarch64.rpm
-libxml2-2.9.10-3.cm1.aarch64.rpm
-libxml2-devel-2.9.10-3.cm1.aarch64.rpm
+libxml2-2.9.10-4.cm1.aarch64.rpm
+libxml2-devel-2.9.10-4.cm1.aarch64.rpm
 glib-2.58.0-7.cm1.aarch64.rpm
 libltdl-2.4.6-5.cm1.aarch64.rpm
 libltdl-devel-2.4.6-5.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -137,8 +137,8 @@ tdnf-cli-libs-2.1.0-6.cm1.x86_64.rpm
 tdnf-devel-2.1.0-6.cm1.x86_64.rpm
 tdnf-plugin-repogpgcheck-2.1.0-6.cm1.x86_64.rpm
 createrepo_c-0.11.1-6.cm1.x86_64.rpm
-libxml2-2.9.10-3.cm1.x86_64.rpm
-libxml2-devel-2.9.10-3.cm1.x86_64.rpm
+libxml2-2.9.10-4.cm1.x86_64.rpm
+libxml2-devel-2.9.10-4.cm1.x86_64.rpm
 glib-2.58.0-7.cm1.x86_64.rpm
 libltdl-2.4.6-5.cm1.x86_64.rpm
 libltdl-devel-2.4.6-5.cm1.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -218,10 +218,10 @@ libtasn1-debuginfo-4.14-2.cm1.aarch64.rpm
 libtasn1-devel-4.14-2.cm1.aarch64.rpm
 libtool-2.4.6-5.cm1.aarch64.rpm
 libtool-debuginfo-2.4.6-5.cm1.aarch64.rpm
-libxml2-2.9.10-3.cm1.aarch64.rpm
-libxml2-debuginfo-2.9.10-3.cm1.aarch64.rpm
-libxml2-devel-2.9.10-3.cm1.aarch64.rpm
-libxml2-python-2.9.10-3.cm1.aarch64.rpm
+libxml2-2.9.10-4.cm1.aarch64.rpm
+libxml2-debuginfo-2.9.10-4.cm1.aarch64.rpm
+libxml2-devel-2.9.10-4.cm1.aarch64.rpm
+libxml2-python-2.9.10-4.cm1.aarch64.rpm
 libxslt-1.1.34-2.cm1.aarch64.rpm
 libxslt-debuginfo-1.1.34-2.cm1.aarch64.rpm
 libxslt-devel-1.1.34-2.cm1.aarch64.rpm
@@ -331,7 +331,7 @@ python2-test-2.7.18-5.cm1.aarch64.rpm
 python2-tools-2.7.18-5.cm1.aarch64.rpm
 python3-cracklib-2.9.7-2.cm1.aarch64.rpm
 python3-gpg-1.13.1-6.cm1.aarch64.rpm
-python3-libxml2-2.9.10-3.cm1.aarch64.rpm
+python3-libxml2-2.9.10-4.cm1.aarch64.rpm
 python3-pwquality-1.4.2-6.cm1.aarch64.rpm
 python3-rpm-4.14.2-10.cm1.aarch64.rpm
 python-curses-2.7.18-5.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -218,10 +218,10 @@ libtasn1-debuginfo-4.14-2.cm1.x86_64.rpm
 libtasn1-devel-4.14-2.cm1.x86_64.rpm
 libtool-2.4.6-5.cm1.x86_64.rpm
 libtool-debuginfo-2.4.6-5.cm1.x86_64.rpm
-libxml2-2.9.10-3.cm1.x86_64.rpm
-libxml2-debuginfo-2.9.10-3.cm1.x86_64.rpm
-libxml2-devel-2.9.10-3.cm1.x86_64.rpm
-libxml2-python-2.9.10-3.cm1.x86_64.rpm
+libxml2-2.9.10-4.cm1.x86_64.rpm
+libxml2-debuginfo-2.9.10-4.cm1.x86_64.rpm
+libxml2-devel-2.9.10-4.cm1.x86_64.rpm
+libxml2-python-2.9.10-4.cm1.x86_64.rpm
 libxslt-1.1.34-2.cm1.x86_64.rpm
 libxslt-debuginfo-1.1.34-2.cm1.x86_64.rpm
 libxslt-devel-1.1.34-2.cm1.x86_64.rpm
@@ -331,7 +331,7 @@ python2-test-2.7.18-5.cm1.x86_64.rpm
 python2-tools-2.7.18-5.cm1.x86_64.rpm
 python3-cracklib-2.9.7-2.cm1.x86_64.rpm
 python3-gpg-1.13.1-6.cm1.x86_64.rpm
-python3-libxml2-2.9.10-3.cm1.x86_64.rpm
+python3-libxml2-2.9.10-4.cm1.x86_64.rpm
 python3-pwquality-1.4.2-6.cm1.x86_64.rpm
 python3-rpm-4.14.2-10.cm1.x86_64.rpm
 python-curses-2.7.18-5.cm1.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Fix tests for gdb, libxml2, net-snmp, python-werkzeug, skip python-psutil tests

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- gdb tests: restrict check section to gdb.base default tests, since many of the gdb tests are known to fail (see http://www.linuxfromscratch.org/blfs/view/9.0/general/gdb.html)
- libxml2 tests: skip known bad python tests (we seem to have the same failures as F30 as seen here: https://github.com/GNOME/libxml2/commit/9acef289285008f81b4b66b4880baf600773cf67)
- net-snmp tests: run unit-tests in check section. This avoids the flaky tests in the testing/fulltests/default directory
- python-werkzeug tests: use tox to run tests. Remove test_cache tests that are not being maintained upstream and were failing (see: https://github.com/pallets/werkzeug/pull/1391)
- python-psutil tests: Add to skip list, since these tests put the build machines in a bad state by running out of memory

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
YES
**NO**

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local package build with RUN_CHECK=y
