### PR TITLE
[dev] Curb expansion in srpm_expand.mk

### DIFF
--- a/toolkit/scripts/srpm_expand.mk
+++ b/toolkit/scripts/srpm_expand.mk
@@ -9,6 +9,7 @@ $(call create_folder,$(BUILD_SPECS_DIR))
 ######## SRPM EXPANDING ########
 
 srpms = $(shell find $(BUILD_SRPMS_DIR)/ -type f -name '*.src.rpm')
+srpms_basename = $(foreach srpm,$(srpms),$(notdir $(srpm)))
 
 .PHONY: expand-specs clean-expand-specs
 expand-specs: $(BUILD_SPECS_DIR)
@@ -26,8 +27,8 @@ $(BUILD_SPECS_DIR): $(STATUS_FLAGS_DIR)/build_specs.flag
 
 $(STATUS_FLAGS_DIR)/build_specs.flag: $(srpms) $(BUILD_SRPMS_DIR)
 	# For each SRPM, if it is newer than the spec extract a new copy of the .spec file
-	for srpm in $(srpms); do \
-		srpm_file=$${srpm} && \
+	for srpm in $(srpms_basename); do \
+		srpm_file=$(BUILD_SRPMS_DIR)/$${srpm} && \
 		spec_destination=$(BUILD_SPECS_DIR)/$$(rpm -qp $${srpm_file} --define='with_check 1' --queryformat %{NAME}-%{VERSION}-%{RELEASE}/%{NAME}.spec) && \
 		spec_dir=$$(dirname $${spec_destination}) && \
 		if [ $${srpm_file} -nt $@ -o ! -f $@ ]; then \


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
I keep my repo nested a bit deep in my home directory. Because of this, Make errors out in the `$(STATUS_FLAGS_DIR)/build_specs.flag` target due to the expansion of `$(srpms)`, which contains the full path of each SRPM. Specifically, `sh` does not like having extremely long arguments. So, I modified the loop to only use the basename of each srpm, which keeps the length under `sh`'s comfort level.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change loop in `$(STATUS_FLAGS_DIR)/build_specs.flag` target to use basenames of SRPMs instead of full paths

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Used with local build
