### PR TITLE
Fix libpng random test failure

### DIFF
--- a/SPECS/libpng/libpng-fix-pngtest-random-failures.patch
+++ b/SPECS/libpng/libpng-fix-pngtest-random-failures.patch
@@ -1,0 +1,94 @@
+Add upstream patch to fix the following random test error.
+    "FAIL: tests/pngtest"
+Patch comes from: https://github.com/glennrp/libpng/commit/72fa126446460347a504f3d9b90f24aed1365595
+
+
+diff -ruN a/Makefile.am b/Makefile.am
+--- a/Makefile.am	2021-03-05 15:51:50.996269641 -0800
++++ b/Makefile.am	2021-03-05 15:58:47.711103516 -0800
+@@ -59,8 +59,7 @@
+ # Generally these are single line shell scripts to run a test with a particular
+ # set of parameters:
+ TESTS =\
+-   tests/pngtest\
+-   tests/pngtest-badpngs\
++   tests/pngtest-all\
+    tests/pngvalid-gamma-16-to-8 tests/pngvalid-gamma-alpha-mode\
+    tests/pngvalid-gamma-background tests/pngvalid-gamma-expand16-alpha-mode\
+    tests/pngvalid-gamma-expand16-background\
+diff -ruN a/Makefile.in b/Makefile.in
+--- a/Makefile.in	2021-03-05 15:51:56.072247998 -0800
++++ b/Makefile.in	2021-03-05 16:20:34.141504371 -0800
+@@ -736,8 +736,7 @@
+ # Generally these are single line shell scripts to run a test with a particular
+ # set of parameters:
+ TESTS = \
+-   tests/pngtest\
+-   tests/pngtest-badpngs\
++   tests/pngtest-all\
+    tests/pngvalid-gamma-16-to-8 tests/pngvalid-gamma-alpha-mode\
+    tests/pngvalid-gamma-background tests/pngvalid-gamma-expand16-alpha-mode\
+    tests/pngvalid-gamma-expand16-background\
+@@ -1578,16 +1577,9 @@
+ 	        am__force_recheck=am--force-recheck \
+ 	        TEST_LOGS="$$log_list"; \
+ 	exit $$?
+-tests/pngtest.log: tests/pngtest
+-	@p='tests/pngtest'; \
+-	b='tests/pngtest'; \
+-	$(am__check_pre) $(LOG_DRIVER) --test-name "$$f" \
+-	--log-file $$b.log --trs-file $$b.trs \
+-	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
+-	"$$tst" $(AM_TESTS_FD_REDIRECT)
+-tests/pngtest-badpngs.log: tests/pngtest-badpngs
+-	@p='tests/pngtest-badpngs'; \
+-	b='tests/pngtest-badpngs'; \
++tests/pngtest-all.log: tests/pngtest-all
++	@p='tests/pngtest-all'; \
++	b='tests/pngtest-all'; \
+ 	$(am__check_pre) $(LOG_DRIVER) --test-name "$$f" \
+ 	--log-file $$b.log --trs-file $$b.trs \
+ 	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
+diff -ruN a/tests/pngtest b/tests/pngtest
+--- a/tests/pngtest	2021-03-05 15:52:16.180164597 -0800
++++ b/tests/pngtest	1969-12-31 16:00:00.000000000 -0800
+@@ -1,2 +0,0 @@
+-#!/bin/sh
+-exec ./pngtest --strict ${srcdir}/pngtest.png
+diff -ruN a/tests/pngtest-all b/tests/pngtest-all
+--- a/tests/pngtest-all	1969-12-31 16:00:00.000000000 -0800
++++ b/tests/pngtest-all	2021-03-05 15:56:44.159342792 -0800
+@@ -0,0 +1,16 @@
++#!/bin/sh
++
++# normal execution
++
++./pngtest --strict ${srcdir}/pngtest.png
++
++# various crashers
++# using --relaxed because some come from fuzzers that don't maintain CRC's
++
++./pngtest --relaxed ${srcdir}/contrib/testpngs/crashers/badcrc.png
++./pngtest --relaxed ${srcdir}/contrib/testpngs/crashers/badadler.png
++./pngtest --xfail ${srcdir}/contrib/testpngs/crashers/bad_iCCP.png
++./pngtest --xfail ${srcdir}/contrib/testpngs/crashers/empty_ancillary_chunks.png
++./pngtest --xfail ${srcdir}/contrib/testpngs/crashers/huge_*_chunk.png \
++    ${srcdir}/contrib/testpngs/crashers/huge_*safe_to_copy.png
++./pngtest --xfail ${srcdir}/contrib/testpngs/crashers/huge_IDAT.png
+diff -ruN a/tests/pngtest-badpngs b/tests/pngtest-badpngs
+--- a/tests/pngtest-badpngs	2021-03-05 15:52:49.056035782 -0800
++++ b/tests/pngtest-badpngs	1969-12-31 16:00:00.000000000 -0800
+@@ -1,13 +0,0 @@
+-#!/bin/sh
+-
+-# various crashers
+-# using --relaxed because some come from fuzzers that don't maintain CRC's
+-
+-./pngtest --relaxed ${srcdir}/contrib/testpngs/crashers/badcrc.png
+-./pngtest --relaxed ${srcdir}/contrib/testpngs/crashers/badadler.png
+-./pngtest --xfail ${srcdir}/contrib/testpngs/crashers/bad_iCCP.png
+-./pngtest --xfail ${srcdir}/contrib/testpngs/crashers/empty_ancillary_chunks.png
+-./pngtest --xfail ${srcdir}/contrib/testpngs/crashers/huge_*_chunk.png \
+-    ${srcdir}/contrib/testpngs/crashers/huge_*safe_to_copy.png
+-
+-exec ./pngtest --xfail ${srcdir}/contrib/testpngs/crashers/huge_IDAT.png

--- a/SPECS/libpng/libpng.spec
+++ b/SPECS/libpng/libpng.spec
@@ -1,7 +1,7 @@
 Summary:        contains libraries for reading and writing PNG files.
 Name:           libpng
 Version:        1.6.37
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        zlib
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -9,6 +9,7 @@ Group:          System Environment/Libraries
 # The site does NOT have an HTTPS cert available.
 URL:            http://www.libpng.org/
 Source0:        https://downloads.sourceforge.net/libpng/%{name}-%{version}.tar.xz
+Patch0:         libpng-fix-pngtest-random-failures.patch
 
 %description
 The libpng package contains libraries used by other programs for reading and writing PNG files. The PNG format was designed as a replacement for GIF and, to a lesser extent, TIFF, with many improvements and extensions and lack of patent problems.
@@ -26,6 +27,7 @@ It contains the libraries and header files to create applications
 
 %prep
 %setup -q
+%patch0 -p1
 
 %build
 %configure
@@ -35,6 +37,7 @@ make %{?_smp_mflags}
 make DESTDIR=%{buildroot} install
 
 %check
+chmod +x ./tests/pngtest-all
 make %{?_smp_mflags} -k check
 
 %post -p /sbin/ldconfig
@@ -59,6 +62,9 @@ make %{?_smp_mflags} -k check
 %{_mandir}/man3/*
 
 %changelog
+* Fri Mar 05 2021 Andrew Phelps <anphel@microsoft.com> - 1.6.38-4
+- Add upstream patch to fix random test failure with pngtest.
+
 * Tue Jan 19 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.6.37-3
 - Moved "Provides" for "pkgconfig(*)" to the correct (-devel) subpackage.
 

--- a/SPECS/libpng/libpng.spec
+++ b/SPECS/libpng/libpng.spec
@@ -16,9 +16,7 @@ The libpng package contains libraries used by other programs for reading and wri
 
 %package    devel
 Summary:        Header and development files
-
 Requires:       %{name} = %{version}-%{release}
-
 Provides:       pkgconfig(libpng) = %{version}-%{release}
 Provides:       pkgconfig(libpng16) = %{version}-%{release}
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Add patch to fix random test failure in libpng

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add libpng test patch

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
YES
**NO**

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local package build with RUN_CHECK=y
