### PR TITLE
[cross] cross-toolchain: Add ExclusiveArch

### DIFF
--- a/SPECS-CROSS/binutils_cross/binutils_cross.spec
+++ b/SPECS-CROSS/binutils_cross/binutils_cross.spec
@@ -58,6 +58,7 @@ URL:            http://www.gnu.org/software/binutils
 Group:          System Environment/Base
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
+ExclusiveArch:  x86_64
 Source0:        http://ftp.gnu.org/gnu/binutils/binutils-%{version}.tar.xz
 
 

--- a/SPECS-CROSS/cross-gcc/cross-gcc.spec
+++ b/SPECS-CROSS/cross-gcc/cross-gcc.spec
@@ -65,6 +65,7 @@ BuildRequires:  %{_cross_name}-glibc-bootstrap2
 BuildRequires:  %{_cross_name}-gcc-bootstrap3
 BuildRequires:  grep
 AutoReqProv:    no
+ExclusiveArch:  x86_64
 Conflicts:      %{_cross_name}-gcc-bootstrap
 Conflicts:      %{_cross_name}-gcc-bootstrap2
 Conflicts:      %{_cross_name}-gcc-bootstrap3

--- a/SPECS-CROSS/gcc-bootstrap_cross/gcc-bootstrap2_cross.spec
+++ b/SPECS-CROSS/gcc-bootstrap_cross/gcc-bootstrap2_cross.spec
@@ -72,6 +72,7 @@ BuildRequires:  %{_cross_name}-binutils
 BuildRequires:  %{_cross_name}-kernel-headers
 BuildRequires:  %{_cross_name}-glibc-bootstrap
 AutoReqProv:    no
+ExclusiveArch:  x86_64
 Conflicts:      %{_cross_name}-cross-gcc
 #%%if %%{with_check}
 #BuildRequires:  autogen

--- a/SPECS-CROSS/gcc-bootstrap_cross/gcc-bootstrap3_cross.spec
+++ b/SPECS-CROSS/gcc-bootstrap_cross/gcc-bootstrap3_cross.spec
@@ -72,6 +72,7 @@ BuildRequires:  %{_cross_name}-binutils
 BuildRequires:  %{_cross_name}-kernel-headers
 BuildRequires:  %{_cross_name}-glibc-bootstrap2
 AutoReqProv:    no
+ExclusiveArch:  x86_64
 Conflicts:      %{_cross_name}-cross-gcc
 Conflicts:      %{_cross_name}-gcc-bootstrap
 Conflicts:      %{_cross_name}-gcc-bootstrap2

--- a/SPECS-CROSS/gcc-bootstrap_cross/gcc-bootstrap_cross.spec
+++ b/SPECS-CROSS/gcc-bootstrap_cross/gcc-bootstrap_cross.spec
@@ -68,6 +68,7 @@ Patch1:         CVE-2019-15847.nopatch
 BuildRequires:  %{_cross_name}-binutils
 BuildRequires:  %{_cross_name}-kernel-headers
 AutoReqProv:    no
+ExclusiveArch:  x86_64
 Conflicts:      %{_cross_name}-cross-gcc
 #%%if %%{with_check}
 #BuildRequires:  autogen

--- a/SPECS-CROSS/glibc-bootstrap_cross/glibc-bootstrap2_cross.spec
+++ b/SPECS-CROSS/glibc-bootstrap_cross/glibc-bootstrap2_cross.spec
@@ -88,6 +88,7 @@ BuildRequires:  %{_cross_name}-gcc-bootstrap
 BuildRequires:  %{_cross_name}-gcc-bootstrap2
 BuildRequires:  perl(File::Find)
 AutoReqProv:    no
+ExclusiveArch:  x86_64
 Conflicts:      %{_cross_name}-glibc
 Conflicts:      %{_cross_name}-glibc-bootstrap2
 Conflicts:      %{_cross_name}-cross-gcc

--- a/SPECS-CROSS/glibc-bootstrap_cross/glibc-bootstrap_cross.spec
+++ b/SPECS-CROSS/glibc-bootstrap_cross/glibc-bootstrap_cross.spec
@@ -86,6 +86,7 @@ BuildRequires:  %{_cross_name}-binutils
 BuildRequires:  %{_cross_name}-kernel-headers
 BuildRequires:  %{_cross_name}-gcc-bootstrap
 AutoReqProv:    no
+ExclusiveArch:  x86_64
 Conflicts:      %{_cross_name}-glibc
 Conflicts:      %{_cross_name}-glibc-bootstrap
 Conflicts:      %{_cross_name}-cross-gcc


### PR DESCRIPTION
When running the build packages on the cross specs folder, the
cross toolchain packages are flagged as buildable for the target
arch. However, we do not want to have these packages build for
the target arch.

So add the ExclusiveArch field.

Signed-off-by: Chris Co <chrco@microsoft.com>