### PR TITLE
diskutils: add clearer error when no disk found

### DIFF
--- a/toolkit/tools/imagegen/diskutils/diskutils.go
+++ b/toolkit/tools/imagegen/diskutils/diskutils.go
@@ -507,6 +507,11 @@ func SystemBlockDevices() (systemDevices []SystemBlockDevice, err error) {
 		logger.Log.Warn(stderr)
 		return
 	}
+	if len(rawDiskOutput) == 0 {
+		err = fmt.Errorf("no supported disks found")
+		logger.Log.Errorf("%s", err)
+		return
+	}
 
 	bytes := []byte(rawDiskOutput)
 	err = json.Unmarshal(bytes, &blockDevices)


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Our ISO installer, via diskutils, checks to see if there are valid disks
to install to before proceeding. If we boot the ISO on hardware where
the installer cannot find any disks, the installer panics with a very cryptic
error message:
    PANI[0000] unexpected end of JSON input

This message leads people to believe that the error is with their
imageconfig JSON file, but in reality, the JSON referenced here is
from the output of our lsblk command. We use lsblk to see if the
system has any disks we can install to and we get this output in JSON
format. So in the case where no supported disk is found, we end up
feeding an empty JSON input into the json.Unmarshal() and we get
this panic message.

So add a check to make sure the output from lsblk isn't empty
before we feed it to the json.Unmarshal(). Now if no supported disks
are found, you should get the following error message:
    ERRO[0000] no supported disks found
    PANI[0000] no supported disks found

Signed-off-by: Chris Co <chrco@microsoft.com>

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->

###### Links to CVEs  <!-- optional -->

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
Local build
