### PR TITLE
Fix failing test for espeak-ng

### DIFF
--- a/SPECS/espeak-ng/espeak-ng.spec
+++ b/SPECS/espeak-ng/espeak-ng.spec
@@ -1,7 +1,7 @@
 Summary:        Compact text-to-speech synthesizer
 Name:           espeak-ng
 Version:        1.50
-Release:        1%{?dist}
+Release:        2%{?dist}
 # Apache2 license applies only to Android APK code- does not apply here
 # BSD license applies only to Windows code- does not apply here
 License:        GPLv3 AND Unicode
@@ -9,7 +9,8 @@ Vendor:         Microsoft Corporation
 Distribution:   Mariner
 URL:            https://github.com/espeak-ng/espeak-ng
 Source0:        https://github.com/%{name}/%{name}/releases/download/%{version}/%{name}-%{version}.tgz
-Patch0:         tests-newline-fixes.patch
+Patch0:         tests-fix-greek-letter-variants.patch
+Patch1:         tests-newline-fixes.patch
 BuildRequires:  alsa-lib-devel
 BuildRequires:  autoconf
 BuildRequires:  automake
@@ -73,6 +74,10 @@ make check
 %{_libdir}/*.so
 
 %changelog
+* Fri Mar 05 2021 Thomas Crain <thcrain@microsoft.com> - 1.50-2
+- Add tests-fix-greek-letter-variants.patch to address failing test
+- Adjust tests-newline-fixes.patch to account for new patch
+
 * Fri Feb 05 2021 Thomas Crain <thcrain@microsoft.com> - 1.50-1
 - Original version for CBL-Mariner (license: MIT)
 - License verified

--- a/SPECS/espeak-ng/tests-fix-greek-letter-variants.patch
+++ b/SPECS/espeak-ng/tests-fix-greek-letter-variants.patch
@@ -1,0 +1,47 @@
+From 00c37d667f58e5a36853eb9ac08b09567a150704 Mon Sep 17 00:00:00 2001
+From: "Reece H. Dunn" <msclrhd@gmail.com>
+Date: Wed, 4 Dec 2019 07:41:21 +0000
+Subject: [PATCH] grc: add Greek variant letter form support; fixes
+ pronunciation of the test
+
+---
+ dictsource/grc_rules              | 12 ++++++++++++
+ tests/language-pronunciation.test |  2 +-
+ 2 files changed, 13 insertions(+), 1 deletion(-)
+
+diff --git a/dictsource/grc_rules b/dictsource/grc_rules
+index 94b0c6ca2..cd1f3054c 100644
+--- a/dictsource/grc_rules
++++ b/dictsource/grc_rules
+@@ -52,6 +52,18 @@ u	υ
+ y	υ
+ w	ω // (long o; not standard transliteration but may be easier to type
+ 
++// replace variant letter forms with their standard equivalents
++ϐ	β    // U+03d0
++ϑ	θ    // U+03d1
++ϒ	υ    // U+03d2
++ϕ	φ    // U+03d5
++ϖ	π    // U+03d6
++ϰ	κ    // U+03f0
++ϱ	ρ    // U+03f1
++ϲ	ς    // U+03f2
++ϴ	θ    // U+03f4
++ϵ	ε    // U+03f5
++Ϲ	ς    // U+03f9
+ 
+ // alpha
+ ά	ὰ    // tonos
+diff --git a/tests/language-pronunciation.test b/tests/language-pronunciation.test
+index c6db1f261..b46df44da 100755
+--- a/tests/language-pronunciation.test
++++ b/tests/language-pronunciation.test
+@@ -50,7 +50,7 @@ test_phonemes fr "Latn" "byv'e d@- s@- (en)w'Iski(fr) k@ l@- patr'O~ Z'yZ fam'Y\
+ test_phonemes ga "Latn" "d'u@skIl; 'i:@s@ 'u:rva#k n@ h'o:iQ\"@ b'anIh@ p'o:r 'e:v@ ,0g@s 'A:a#v" "D’fhuascail Íosa Úrmhac na hÓighe Beannaithe pór Éava agus Ádhaimh"
+ test_phonemes gd "Latn" "m'us d'a:g_:_: k;'E:d;'u:n@ R'O:b 'i: l^'e 'ob" "Mus d’fhàg Cèit-Ùna ròp Ì le ob."
+ test_phonemes gn "Latn" "m,aym'a_| ,yByp'o**a_| o'u k'o_| yB'y_| 'a**i_| ,in^ap,yty_!y**'e h'a_| ,ete'i~Sa t,eko**,uBiS,a**eNd'a h'a_| ,akat'uap,e J^,eQu,e**ek'ope\nh'a_| ,ikat'u **up'i_| ,oik,ua'a n^et'eBa h'a_| ,an^et,e_!yB'a\n,ipo**'a~Ba h'a_| ,iBa'iBa\nt,ekoteB'e~ p,eheNgu'eiS,a_| ,oik'o_| ,on^oNd,iBeku'e**a" "Mayma yvypóra ou ko yvy ári iñapyty'yre ha eteĩcha tecoruvicharendá ha acatúape jeguerekópe; ha ikatu rupi oikuaa ñetéva ha añete'yva, iporãva ha ivaíva, tekotevẽ pehenguéicha oiko oñondivekuéra."
+-test_phonemes grc "Grek" "hoI_: d'e_: f_: 'o_: 'i_: n_: 'i_: l'et@_|_|f_|_:_: 'e_: s_: h'u:toI_: hoI_: s'yn_: k'admOI:_: 'a_: p_: 'i_: l'et@_|_|f_|_:_: 'o_: m_: 'e_: n_: 'o_: 'i_: es'E:gag,on_: d_: 'i_: d_: 'a_: s_: l'et@_|_|f_|_:_: 'a_: l_: 'i_: 'a_: 'es_: tu:s_: ell'E:nas_: 'aI_: d'E:_: 'aI_: gR'ammat,a_:\n'o_: 'y_: l'et@_|_|f_|_:_: e'onta_: pR'in_: ell'E:si_: h'O:s_: em'oI_: d_: 'o_: l'et@_|_|f_|_:_: 'e_: 'e_: 'i_: n_:\npR'O:ta_: m'en_: t'oIsi_: 'aI_: h'apant,es_: xR'eO:nt,aI_: f_: 'o_: 'i_: n_: 'i_: l'et@_|_|f_|_:_: 'e_: s_:\nmet'a_: d'e_: xR'onu:_: pRob'aInont,os_: h'ama_: tEI:_: O:n'EI:_: met'ebal,on_: 'aI_: ton_: l'et@_|_|f_|_:_: 'y_: l'et@_|_|d_|_:_: m_: 'o_: n_: tO:n_: gRamm'atO:n_:" "Οἱ δὲ Φοίνιϰες οὗτοι οἱ σὺν Κάδμῳ ἀπιϰόμενοι.. ἐσήγαγον διδασϰάλια ἐς τοὺς ῞Ελληνας ϰαὶ δὴ ϰαὶ γράμματα, οὐϰ ἐόντα πρὶν ῞Ελλησι ὡς ἐμοὶ δοϰέειν, πρῶτα μὲν τοῖσι ϰαὶ ἅπαντες χρέωνται Φοίνιϰες· μετὰ δὲ χρόνου προβαίνοντος ἅμα τῇ ϕωνῇ μετέβαλον ϰαὶ τὸν ϱυϑμὸν τῶν γραμμάτων."
++test_phonemes grc "Grek" "hoI_: d'e_: f'oInik,es_: h'u:toI_: hoI_: s'yn_: k'admOI:_: ,apik'omen,oI_: es'E:gag,on_: d,idask'ali;,a_: 'es_: tu:s_: ell'E:nas_: k'aI_: d'E:_: k'aI_: gR'ammat,a_:\n'u:k_: e'onta_: pR'in_: ell'E:si_: h'O:s_: em'oI_: dok'ee:n_:\npR'O:ta_: m'en_: t'oIsi_: k'aI_: h'apant,es_: xR'eO:nt,aI_: f'oInik,es_:\nmet'a_: d'e_: xR'onu:_: pRob'aInont,os_: h'ama_: tEI:_: fO:n'EI:_: met'ebal,on_: k'aI_: ton_: RyTm'on_: tO:n_: gRamm'atO:n_:" "Οἱ δὲ Φοίνιϰες οὗτοι οἱ σὺν Κάδμῳ ἀπιϰόμενοι.. ἐσήγαγον διδασϰάλια ἐς τοὺς ῞Ελληνας ϰαὶ δὴ ϰαὶ γράμματα, οὐϰ ἐόντα πρὶν ῞Ελλησι ὡς ἐμοὶ δοϰέειν, πρῶτα μὲν τοῖσι ϰαὶ ἅπαντες χρέωνται Φοίνιϰες· μετὰ δὲ χρόνου προβαίνοντος ἅμα τῇ ϕωνῇ μετέβαλον ϰαὶ τὸν ϱυϑμὸν τῶν γραμμάτων."
+ test_phonemes gu "Gujr" "d@*'e:k vj@kt'Ine: S,IkS@n.'Vno: Vd#'Ika:r c#'e:\no:c#'a:mV~ 'o:c#u~ pr,a:t#m'Ik 'Vne: pa:j'a:na: t,@bk:a:'o:mV~ SIkS'Vn. m@p#'Vt r@2H'e:Se:\npr,a:t#m'Ik SIkS'Vn. p#,@*JIj'a:t r@2H'e:Se:\nwIS'e:s. w,Ig#a:v,Is.@j'@k 'Vne: vj,@vs'a:ji SIkS'Vn. s,a:ma:nj'@t@H ,Up@l'Vbd# r@2H'e:Se: 'Vne: j,o:gj@t'a:na: d#o:r'Vn. p'Vr 'Uc: SIkS'Vn. pr'a:pt k,@rv'a:no: s@rv'Vne: s@m'a:n Vd#'Ika:r r@2H'e:Se:" "દરેક વ્યક્તિને શિક્ષણનો અધિકાર છે. ઓછામાં ઓછું પ્રાથમિક અને પાયાના તબક્કાઓમાં શિક્ષણ મફત રહેશે. પ્રાથમિક શિક્ષણ ફરજિયાત રહેશે. વિશેષ વિઘાવિષયક અને વ્યવસાયી શિક્ષણ સામાન્યતઃ ઉપલબ્ધ રહેશે અને યોગ્યતાના ધોરણ પર ઉચ્ચ શિક્ષણ પ્રાપ્ત કરવાનો સર્વને સમાન અધિકાર રહેશે."
+ test_phonemes hi "Deva" "r'Is.Ij,o~ ko: s@t'a:ne: v'a:le: d'Us.t. r'a:kS@s,o~ ke: r'a:Ja: r'a:v@n. ka: s,@rv@n'a:S k'Vrn,e: v'a:le: v,Is.n.Uvt'a:r b#,@gv'a:n Sri*'a:m\nVj'o:d#ja: ke: m,aha:*'a:J d'VS@*,@t# ke: b'Vr.e: s@p'Utr@- t#e:" "ऋषियों को सताने वाले दुष्ट राक्षसों के राजा रावण का सर्वनाश करने वाले विष्णुवतार भगवान श्रीराम, अयोध्या के महाराज दशरथ के बड़े सपुत्र थे।"
+ test_phonemes hy "Armn"  "k@rn'am ,apak'i ut'el j'ev ints'i ,anhang'ist tS#@n'er" "Կրնամ ապակի ուտել և ինծի անհանգիստ չըներ։"

--- a/SPECS/espeak-ng/tests-newline-fixes.patch
+++ b/SPECS/espeak-ng/tests-newline-fixes.patch
@@ -17,7 +17,7 @@ From: https://github.com/espeak-ng/espeak-ng/commit/171e8a4e09588b123e1707b10073
  2 files changed, 195 insertions(+), 62 deletions(-)
 
 diff --git a/tests/language-pronunciation.test b/tests/language-pronunciation.test
-index c6db1f2..825917a 100755
+index b46df44da..825917a9b 100755
 --- a/tests/language-pronunciation.test
 +++ b/tests/language-pronunciation.test
 @@ -24,94 +24,223 @@ test_phonemes() {
@@ -94,7 +94,7 @@ index c6db1f2..825917a 100755
  test_phonemes ga "Latn" "d'u@skIl; 'i:@s@ 'u:rva#k n@ h'o:iQ\"@ b'anIh@ p'o:r 'e:v@ ,0g@s 'A:a#v" "D’fhuascail Íosa Úrmhac na hÓighe Beannaithe pór Éava agus Ádhaimh"
  test_phonemes gd "Latn" "m'us d'a:g_:_: k;'E:d;'u:n@ R'O:b 'i: l^'e 'ob" "Mus d’fhàg Cèit-Ùna ròp Ì le ob."
 -test_phonemes gn "Latn" "m,aym'a_| ,yByp'o**a_| o'u k'o_| yB'y_| 'a**i_| ,in^ap,yty_!y**'e h'a_| ,ete'i~Sa t,eko**,uBiS,a**eNd'a h'a_| ,akat'uap,e J^,eQu,e**ek'ope\nh'a_| ,ikat'u **up'i_| ,oik,ua'a n^et'eBa h'a_| ,an^et,e_!yB'a\n,ipo**'a~Ba h'a_| ,iBa'iBa\nt,ekoteB'e~ p,eheNgu'eiS,a_| ,oik'o_| ,on^oNd,iBeku'e**a" "Mayma yvypóra ou ko yvy ári iñapyty'yre ha eteĩcha tecoruvicharendá ha acatúape jeguerekópe; ha ikatu rupi oikuaa ñetéva ha añete'yva, iporãva ha ivaíva, tekotevẽ pehenguéicha oiko oñondivekuéra."
--test_phonemes grc "Grek" "hoI_: d'e_: f_: 'o_: 'i_: n_: 'i_: l'et@_|_|f_|_:_: 'e_: s_: h'u:toI_: hoI_: s'yn_: k'admOI:_: 'a_: p_: 'i_: l'et@_|_|f_|_:_: 'o_: m_: 'e_: n_: 'o_: 'i_: es'E:gag,on_: d_: 'i_: d_: 'a_: s_: l'et@_|_|f_|_:_: 'a_: l_: 'i_: 'a_: 'es_: tu:s_: ell'E:nas_: 'aI_: d'E:_: 'aI_: gR'ammat,a_:\n'o_: 'y_: l'et@_|_|f_|_:_: e'onta_: pR'in_: ell'E:si_: h'O:s_: em'oI_: d_: 'o_: l'et@_|_|f_|_:_: 'e_: 'e_: 'i_: n_:\npR'O:ta_: m'en_: t'oIsi_: 'aI_: h'apant,es_: xR'eO:nt,aI_: f_: 'o_: 'i_: n_: 'i_: l'et@_|_|f_|_:_: 'e_: s_:\nmet'a_: d'e_: xR'onu:_: pRob'aInont,os_: h'ama_: tEI:_: O:n'EI:_: met'ebal,on_: 'aI_: ton_: l'et@_|_|f_|_:_: 'y_: l'et@_|_|d_|_:_: m_: 'o_: n_: tO:n_: gRamm'atO:n_:" "Οἱ δὲ Φοίνιϰες οὗτοι οἱ σὺν Κάδμῳ ἀπιϰόμενοι.. ἐσήγαγον διδασϰάλια ἐς τοὺς ῞Ελληνας ϰαὶ δὴ ϰαὶ γράμματα, οὐϰ ἐόντα πρὶν ῞Ελλησι ὡς ἐμοὶ δοϰέειν, πρῶτα μὲν τοῖσι ϰαὶ ἅπαντες χρέωνται Φοίνιϰες· μετὰ δὲ χρόνου προβαίνοντος ἅμα τῇ ϕωνῇ μετέβαλον ϰαὶ τὸν ϱυϑμὸν τῶν γραμμάτων."
+-test_phonemes grc "Grek" "hoI_: d'e_: f'oInik,es_: h'u:toI_: hoI_: s'yn_: k'admOI:_: ,apik'omen,oI_: es'E:gag,on_: d,idask'ali;,a_: 'es_: tu:s_: ell'E:nas_: k'aI_: d'E:_: k'aI_: gR'ammat,a_:\n'u:k_: e'onta_: pR'in_: ell'E:si_: h'O:s_: em'oI_: dok'ee:n_:\npR'O:ta_: m'en_: t'oIsi_: k'aI_: h'apant,es_: xR'eO:nt,aI_: f'oInik,es_:\nmet'a_: d'e_: xR'onu:_: pRob'aInont,os_: h'ama_: tEI:_: fO:n'EI:_: met'ebal,on_: k'aI_: ton_: RyTm'on_: tO:n_: gRamm'atO:n_:" "Οἱ δὲ Φοίνιϰες οὗτοι οἱ σὺν Κάδμῳ ἀπιϰόμενοι.. ἐσήγαγον διδασϰάλια ἐς τοὺς ῞Ελληνας ϰαὶ δὴ ϰαὶ γράμματα, οὐϰ ἐόντα πρὶν ῞Ελλησι ὡς ἐμοὶ δοϰέειν, πρῶτα μὲν τοῖσι ϰαὶ ἅπαντες χρέωνται Φοίνιϰες· μετὰ δὲ χρόνου προβαίνοντος ἅμα τῇ ϕωνῇ μετέβαλον ϰαὶ τὸν ϱυϑμὸν τῶν γραμμάτων."
 -test_phonemes gu "Gujr" "d@*'e:k vj@kt'Ine: S,IkS@n.'Vno: Vd#'Ika:r c#'e:\no:c#'a:mV~ 'o:c#u~ pr,a:t#m'Ik 'Vne: pa:j'a:na: t,@bk:a:'o:mV~ SIkS'Vn. m@p#'Vt r@2H'e:Se:\npr,a:t#m'Ik SIkS'Vn. p#,@*JIj'a:t r@2H'e:Se:\nwIS'e:s. w,Ig#a:v,Is.@j'@k 'Vne: vj,@vs'a:ji SIkS'Vn. s,a:ma:nj'@t@H ,Up@l'Vbd# r@2H'e:Se: 'Vne: j,o:gj@t'a:na: d#o:r'Vn. p'Vr 'Uc: SIkS'Vn. pr'a:pt k,@rv'a:no: s@rv'Vne: s@m'a:n Vd#'Ika:r r@2H'e:Se:" "દરેક વ્યક્તિને શિક્ષણનો અધિકાર છે. ઓછામાં ઓછું પ્રાથમિક અને પાયાના તબક્કાઓમાં શિક્ષણ મફત રહેશે. પ્રાથમિક શિક્ષણ ફરજિયાત રહેશે. વિશેષ વિઘાવિષયક અને વ્યવસાયી શિક્ષણ સામાન્યતઃ ઉપલબ્ધ રહેશે અને યોગ્યતાના ધોરણ પર ઉચ્ચ શિક્ષણ પ્રાપ્ત કરવાનો સર્વને સમાન અધિકાર રહેશે."
 -test_phonemes hi "Deva" "r'Is.Ij,o~ ko: s@t'a:ne: v'a:le: d'Us.t. r'a:kS@s,o~ ke: r'a:Ja: r'a:v@n. ka: s,@rv@n'a:S k'Vrn,e: v'a:le: v,Is.n.Uvt'a:r b#,@gv'a:n Sri*'a:m\nVj'o:d#ja: ke: m,aha:*'a:J d'VS@*,@t# ke: b'Vr.e: s@p'Utr@- t#e:" "ऋषियों को सताने वाले दुष्ट राक्षसों के राजा रावण का सर्वनाश करने वाले विष्णुवतार भगवान श्रीराम, अयोध्या के महाराज दशरथ के बड़े सपुत्र थे।"
 +test_phonemes gn "Latn" "m,aym'a_| ,yByp'o**a_| o'u k'o_| yB'y_| 'a**i_| ,in^ap,yty_!y**'e h'a_| ,ete'i~Sa t,eko**,uBiS,a**eNd'a h'a_| ,akat'uap,e J^,eQu,e**ek'ope
@@ -306,7 +306,7 @@ index c6db1f2..825917a 100755
  ##### Fallback to other languages in different scripts (language switch).
  
 diff --git a/tests/translate.test b/tests/translate.test
-index 31cda43..729e445 100755
+index 31cda438f..729e445e6 100755
 --- a/tests/translate.test
 +++ b/tests/translate.test
 @@ -43,7 +43,11 @@ test_phonemes en-GB-x-gbcwmd "aI 'av" "I have"


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Initial addition of espeak-ng was missing a fix for the `language-pronunciation` test regarding Greek letters. This adds that in

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add missing greek letter patch
- Change other patch to account for new patch

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local build with RUN_CHECK=y
