### PR TITLE
Improving toolchain download logs.

### DIFF
--- a/toolkit/scripts/toolchain.mk
+++ b/toolkit/scripts/toolchain.mk
@@ -12,6 +12,9 @@ $(call create_folder,$(SRPMS_DIR))
 
 toolchain_build_dir = $(BUILD_DIR)/toolchain
 toolchain_local_temp = $(BUILD_DIR)/toolchain_temp
+toolchain_logs_dir = $(LOGS_DIR)/toolchain
+toolchain_downloads_logs_dir = $(toolchain_logs_dir)/downloads
+toolchain_log_tail_length = 20
 populated_toolchain_chroot = $(toolchain_build_dir)/populated_toolchain
 toolchain_sources_dir = $(populated_toolchain_chroot)/usr/src/mariner/SOURCES
 populated_toolchain_rpms = $(populated_toolchain_chroot)/usr/src/mariner/RPMS
@@ -33,6 +36,7 @@ toolchain_rpms_buildarch := $(shell grep $(build_arch) $(toolchain_manifest))
 toolchain_rpms_noarch := $(shell grep noarch $(toolchain_manifest))
 
 $(call create_folder,$(toolchain_build_dir))
+$(call create_folder,$(toolchain_downloads_logs_dir))
 $(call create_folder,$(populated_toolchain_chroot))
 
 .PHONY: raw-toolchain toolchain clean-toolchain check-manifests check-aarch64-manifests check-x86_64-manifests
@@ -44,6 +48,7 @@ clean: clean-toolchain
 clean-toolchain:
 	rm -rf $(toolchain_build_dir)
 	rm -rf $(toolchain_local_temp)
+	rm -rf $(toolchain_logs_dir)
 	rm -rf $(STATUS_FLAGS_DIR)/toolchain_local_temp.flag
 	rm -f $(SCRIPTS_DIR)/toolchain/container/toolchain-local-wget-list
 	rm -f $(SCRIPTS_DIR)/toolchain/container/texinfo-perl-fix.patch
@@ -190,17 +195,25 @@ $(toolchain_rpms): $(toolchain_manifest) $(toolchain_local_temp)
 else
 # Download from online package server
 $(toolchain_rpms):
-	mkdir -p $(dir $@) && \
-	cd $(dir $@) && \
+	$(eval rpm_filename := "$(notdir $@)")
+	$(eval rpm_dir := "$(dir $@)")
+	$(eval log_file := "$(toolchain_downloads_logs_dir)/$(rpm_filename).log")
+	@echo "Downloading toolchain RPM: $(rpm_filename)" | tee "$(log_file)" && \
+	mkdir -p $(rpm_dir) && \
+	cd $(rpm_dir) && \
 	for url in $(PACKAGE_URL_LIST); do \
-		wget $${url}/$(notdir $@) \
-			--no-verbose \
+		wget $${url}/$(rpm_filename) \
 			$(if $(TLS_CERT),--certificate=$(TLS_CERT)) \
 			$(if $(TLS_KEY),--private-key=$(TLS_KEY)) \
+			-a $(log_file) \
 			&& \
+		echo "Downloaded toolchain RPM: $(rpm_filename)" | tee -a $(log_file) && \
 		break; \
-	done || $(call print_error,Loop in $@ failed) ; \
-	{ [ -f $@ ] || \
-		$(call print_error,Failed to download toolchain package: $@); }
+	done || { \
+			echo "\nERROR: Failed to download toolchain package: $(rpm_filename)." && \
+			echo "ERROR: Last $(toolchain_log_tail_length) lines from log '$(log_file)':\n" && \
+			tail -n$(toolchain_log_tail_length) $(log_file) | sed 's/^/\t/' && \
+			$(call print_error,\nToolchain download failed. See above errors for more details.) \
+		}
 endif
 endif


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
This PR aims at reducing the noise and confusion around the logs printed during toolchain RPMs download for derivative builds.

**Current successful** download:
```
mkdir -p /home/pawel/CBL-MarinerDemo/toolkit/../build/rpm_cache/cache/x86_64/ && \
cd /home/pawel/CBL-MarinerDemo/toolkit/../build/rpm_cache/cache/x86_64/ && \
for url in https://packages.microsoft.com/cbl-mariner/1.0/prod/base/x86_64/rpms https://packages.microsoft.com/cbl-mariner/1.0/prod/update/x86_64/rpms; do \
        wget ${url}/bash-4.4.18-6.cm1.x86_64.rpm \
                --no-verbose \
                 \
                 \
                && \
        break; \
done || { echo "Loop in /home/pawel/CBL-MarinerDemo/toolkit/../build/rpm_cache/cache/x86_64/bash-4.4.18-6.cm1.x86_64.rpm failed" ; exit 1 ; } ; \
{ [ -f /home/pawel/CBL-MarinerDemo/toolkit/../build/rpm_cache/cache/x86_64/bash-4.4.18-6.cm1.x86_64.rpm ] || \
        { echo "Failed to download toolchain package: /home/pawel/CBL-MarinerDemo/toolkit/../build/rpm_cache/cache/x86_64/bash-4.4.18-6.cm1.x86_64.rpm" ; exit 1 ; }; }
https://packages.microsoft.com/cbl-mariner/1.0/prod/base/x86_64/rpms/bash-4.4.18-6.cm1.x86_64.rpm:
2021-03-06 20:08:32 ERROR 404: Not Found.
2021-03-06 20:08:32 URL:https://packages.microsoft.com/cbl-mariner/1.0/prod/update/x86_64/rpms/bash-4.4.18-6.cm1.x86_64.rpm [1033215/1033215] -> "bash-4.4.18-6.cm1.x86_64.rpm" [1]
```

**Current unsuccessful** download:
```
mkdir -p /home/pawel/CBL-MarinerDemo/toolkit/../build/rpm_cache/cache/noarch/ && \
cd /home/pawel/CBL-MarinerDemo/toolkit/../build/rpm_cache/cache/noarch/ && \
for url in https://packages.microsoft.com/cbl-mariner/1.0/prod/base/x86_64/rpms https://packages.microsoft.com/cbl-mariner/1.0/prod/update/x86_64/rpms; do \
        wget ${url}/ca-certificates-20200720-12.cm1.noarch.rpm \
                --no-verbose \
                 \
                 \
                && \
        break; \
done || { echo "Loop in /home/pawel/CBL-MarinerDemo/toolkit/../build/rpm_cache/cache/noarch/ca-certificates-20200720-12.cm1.noarch.rpm failed" ; exit 1 ; } ; \
{ [ -f /home/pawel/CBL-MarinerDemo/toolkit/../build/rpm_cache/cache/noarch/ca-certificates-20200720-12.cm1.noarch.rpm ] || \
        { echo "Failed to download toolchain package: /home/pawel/CBL-MarinerDemo/toolkit/../build/rpm_cache/cache/noarch/ca-certificates-20200720-12.cm1.noarch.rpm" ; exit 1 ; }; }
https://packages.microsoft.com/cbl-mariner/1.0/prod/base/x86_64/rpms/ca-certificates-20200720-12.cm1.noarch.rpm:
2021-03-06 20:08:38 ERROR 404: Not Found.
https://packages.microsoft.com/cbl-mariner/1.0/prod/update/x86_64/rpms/ca-certificates-20200720-12.cm1.noarch.rpm:
2021-03-06 20:08:38 ERROR 404: Not Found.
Loop in /home/pawel/CBL-MarinerDemo/toolkit/../build/rpm_cache/cache/noarch/ca-certificates-20200720-12.cm1.noarch.rpm failed
```

These two outputs are extremely hard to tell apart and on top of that both print `ERROR 404: Not Found.` at least once, making it even harder to figure out the source of the problem.

**New successful** download:
```
Downloading toolchain RPM: bash-4.4.18-6.cm1.x86_64.rpm
Downloaded toolchain RPM: bash-4.4.18-6.cm1.x86_64.rpm
```

**New unsuccessful** download:
```
Downloading toolchain RPM: ca-certificates-20200720-12.cm1.noarch.rpm

ERROR: Failed to download toolchain package: ca-certificates-20200720-12.cm1.noarch.rpm.
ERROR: Last 20 lines from log '/home/pawel/CBL-MarinerDemo/toolkit/../build/logs/toolchain/downloads/ca-certificates-20200720-12.cm1.noarch.rpm.log':

        Downloading toolchain RPM: ca-certificates-20200720-12.cm1.noarch.rpm
        --2021-03-06 20:07:02--  https://packages.microsoft.com/cbl-mariner/1.0/prod/base/x86_64/rpms/ca-certificates-20200720-12.cm1.noarch.rpm
        Resolving packages.microsoft.com (packages.microsoft.com)... 13.93.224.173
        Connecting to packages.microsoft.com (packages.microsoft.com)|13.93.224.173|:443... connected.
        HTTP request sent, awaiting response... 404 Not Found
        2021-03-06 20:07:02 ERROR 404: Not Found.

        --2021-03-06 20:07:02--  https://packages.microsoft.com/cbl-mariner/1.0/prod/update/x86_64/rpms/ca-certificates-20200720-12.cm1.noarch.rpm
        Resolving packages.microsoft.com (packages.microsoft.com)... 13.93.224.173
        Connecting to packages.microsoft.com (packages.microsoft.com)|13.93.224.173|:443... connected.
        HTTP request sent, awaiting response... 404 Not Found
        2021-03-06 20:07:02 ERROR 404: Not Found.


Toolchain download failed. See above errors for more details.
```

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Cleaned-up the console output for toolchain RPM downloads.
- Added an additional log file for each toolchain RPM download attempt.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
No.

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local packages build of the [CBL-MarinerDemo](https://github.com/microsoft/CBL-MarinerDemo) repo.
