### PR TITLE
Adding retries to jdk8 tarballs downloads during toolchain builds

### DIFF
--- a/toolkit/scripts/toolchain/container/toolchain-jdk8-wget.sh
+++ b/toolkit/scripts/toolchain/container/toolchain-jdk8-wget.sh
@@ -5,6 +5,7 @@ set -e
 set -x
 
 function download_with_retry {
+  local result
   local retryCount=10
   local sourceTarball="$1"
   local targetTarball="$2"
@@ -13,11 +14,17 @@ function download_with_retry {
     return
   fi
 
-  for ((i=0; i<retryCount; i++)); do
-    if wget -nv --no-clobber --timeout=30 --continue "$sourceTarball" -O "$targetTarball"; then
+  for ((i=1; i<=retryCount; i++)); do
+    result=0
+    if wget -nv --timeout=30 --continue "$sourceTarball" -O "$targetTarball"; then
       break;
+    else
+      result=$?
+      echo "Download attempt $i/$retryCount failed." 1>&2
     fi
   done
+
+  return $result
 }
 
 if [[ -z "$LFS" ]]; then


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Our test community builds are often failing due to download issues while trying to build the jdk8 part of the toolchain. Every now and then we'll get the 500 error, which is gone with the next retry, so I'm adding retry logic to our scripts until we're able to secure a more reliable source of the tarballs.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Added retry logic to jdk8 source tarballs downloads

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
No.

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Internal community build.
