### PR TITLE
Patch CVE-2021-0326, CVE-2021-27803 in wpa_supplicant

### DIFF
--- a/SPECS/wpa_supplicant/CVE-2021-0326.patch
+++ b/SPECS/wpa_supplicant/CVE-2021-0326.patch
@@ -1,0 +1,39 @@
+From 947272febe24a8f0ea828b5b2f35f13c3821901e Mon Sep 17 00:00:00 2001
+From: Jouni Malinen <jouni@codeaurora.org>
+Date: Mon, 9 Nov 2020 11:43:12 +0200
+Subject: [PATCH] P2P: Fix copying of secondary device types for P2P group
+ client
+
+Parsing and copying of WPS secondary device types list was verifying
+that the contents is not too long for the internal maximum in the case
+of WPS messages, but similar validation was missing from the case of P2P
+group information which encodes this information in a different
+attribute. This could result in writing beyond the memory area assigned
+for these entries and corrupting memory within an instance of struct
+p2p_device. This could result in invalid operations and unexpected
+behavior when trying to free pointers from that corrupted memory.
+
+Credit to OSS-Fuzz: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=27269
+Fixes: e57ae6e19edf ("P2P: Keep track of secondary device types for peers")
+Signed-off-by: Jouni Malinen <jouni@codeaurora.org>
+
+Source: https://w1.fi/security/2020-2/0001-P2P-Fix-copying-of-secondary-device-types-for-P2P-gr.patch
+---
+ src/p2p/p2p.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/p2p/p2p.c b/src/p2p/p2p.c
+index 74b7b52ae05c..5cbfc217fc1f 100644
+--- a/src/p2p/p2p.c
++++ b/src/p2p/p2p.c
+@@ -453,6 +453,8 @@ static void p2p_copy_client_info(struct p2p_device *dev,
+ 	dev->info.config_methods = cli->config_methods;
+ 	os_memcpy(dev->info.pri_dev_type, cli->pri_dev_type, 8);
+ 	dev->info.wps_sec_dev_type_list_len = 8 * cli->num_sec_dev_types;
++	if (dev->info.wps_sec_dev_type_list_len > WPS_SEC_DEV_TYPE_MAX_LEN)
++		dev->info.wps_sec_dev_type_list_len = WPS_SEC_DEV_TYPE_MAX_LEN;
+ 	os_memcpy(dev->info.wps_sec_dev_type_list, cli->sec_dev_types,
+ 		  dev->info.wps_sec_dev_type_list_len);
+ }
+-- 
+2.25.1

--- a/SPECS/wpa_supplicant/CVE-2021-27803.patch
+++ b/SPECS/wpa_supplicant/CVE-2021-27803.patch
@@ -1,0 +1,51 @@
+From 8460e3230988ef2ec13ce6b69b687e941f6cdb32 Mon Sep 17 00:00:00 2001
+From: Jouni Malinen <jouni@codeaurora.org>
+Date: Tue, 8 Dec 2020 23:52:50 +0200
+Subject: [PATCH] P2P: Fix a corner case in peer addition based on PD Request
+
+p2p_add_device() may remove the oldest entry if there is no room in the
+peer table for a new peer. This would result in any pointer to that
+removed entry becoming stale. A corner case with an invalid PD Request
+frame could result in such a case ending up using (read+write) freed
+memory. This could only by triggered when the peer table has reached its
+maximum size and the PD Request frame is received from the P2P Device
+Address of the oldest remaining entry and the frame has incorrect P2P
+Device Address in the payload.
+
+Fix this by fetching the dev pointer again after having called
+p2p_add_device() so that the stale pointer cannot be used.
+
+Fixes: 17bef1e97a50 ("P2P: Add peer entry based on Provision Discovery Request")
+Signed-off-by: Jouni Malinen <jouni@codeaurora.org>
+
+Source: https://w1.fi/security/2021-1/0001-P2P-Fix-a-corner-case-in-peer-addition-based-on-PD-R.patch
+---
+ src/p2p/p2p_pd.c | 12 +++++-------
+ 1 file changed, 5 insertions(+), 7 deletions(-)
+
+diff --git a/src/p2p/p2p_pd.c b/src/p2p/p2p_pd.c
+index 3994ec03f86b..05fd593494ef 100644
+--- a/src/p2p/p2p_pd.c
++++ b/src/p2p/p2p_pd.c
+@@ -595,14 +595,12 @@ void p2p_process_prov_disc_req(struct p2p_data *p2p, const u8 *sa,
+ 			goto out;
+ 		}
+ 
++		dev = p2p_get_device(p2p, sa);
+ 		if (!dev) {
+-			dev = p2p_get_device(p2p, sa);
+-			if (!dev) {
+-				p2p_dbg(p2p,
+-					"Provision Discovery device not found "
+-					MACSTR, MAC2STR(sa));
+-				goto out;
+-			}
++			p2p_dbg(p2p,
++				"Provision Discovery device not found "
++				MACSTR, MAC2STR(sa));
++			goto out;
+ 		}
+ 	} else if (msg.wfd_subelems) {
+ 		wpabuf_free(dev->info.wfd_subelems);
+-- 
+2.25.1

--- a/SPECS/wpa_supplicant/wpa_supplicant.spec
+++ b/SPECS/wpa_supplicant/wpa_supplicant.spec
@@ -1,7 +1,7 @@
 Summary:        WPA client
 Name:           wpa_supplicant
 Version:        2.9
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        BSD
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -9,6 +9,7 @@ Group:          Applications/Communications
 URL:            https://w1.fi
 Source0:        https://w1.fi/releases/%{name}-%{version}.tar.gz
 Patch0:         CVE-2019-16275.patch
+Patch1:         CVE-2021-27803.patch
 BuildRequires:  libnl3-devel
 BuildRequires:  openssl-devel
 Requires:       libnl3
@@ -18,8 +19,7 @@ Requires:       openssl
 WPA Supplicant is a Wi-Fi Protected Access (WPA) client and IEEE 802.1X supplicant
 
 %prep
-%setup -q
-%patch0 -p1
+%autosetup -p1
 
 %build
 cat > wpa_supplicant/.config << "EOF"
@@ -97,29 +97,32 @@ EOF
 %{_sysconfdir}/wpa_supplicant/wpa_supplicant-wlan0.conf
 
 %changelog
+* Mon Mar 08 2021 Thomas Crain <thcrain@microsoft.com> - 2.9-3
+- Add patch for CVE-2021-27803
+
 * Mon Nov 16 2020 Nicolas Guibourge <nicolasg@microsoft.com> - 2.9-2
 - Change name of CVE-2019-16275 patch.
 
-*   Thu May 14 2020 Henry Beberman <hebeberm@microsoft.com> 2.9-1
--   Update version to 2.9.
--   Add patch for CVE-2019-16275.
+* Thu May 14 2020 Henry Beberman <hebeberm@microsoft.com> - 2.9-1
+- Update version to 2.9.
+- Add patch for CVE-2019-16275.
 
-*   Sat May 09 00:20:37 PST 2020 Nick Samson <nisamson@microsoft.com> - 2.7-4
--   Added %%license line automatically
+* Sat May 09 00:20:37 PST 2020 Nick Samson <nisamson@microsoft.com> - 2.7-4
+- Added %%license line automatically
 
-*   Fri Apr 17 2020 Nicolas Ontiveros <niontive@microsoft.com> 2.7-3
--   Rename libnl to libnl3.
--   Remove sha1 macro.
+* Fri Apr 17 2020 Nicolas Ontiveros <niontive@microsoft.com> - 2.7-3
+- Rename libnl to libnl3.
+- Remove sha1 macro.
 
-*   Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 2.7-2
--   Initial CBL-Mariner import from Photon (license: Apache2).
+* Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> - 2.7-2
+- Initial CBL-Mariner import from Photon (license: Apache2).
 
-*   Thu Jan 3 2019 Michelle Wang <michellew@vmware.com> 2.7-1
--   Update version to 2.7.
+* Thu Jan 3 2019 Michelle Wang <michellew@vmware.com> - 2.7-1
+- Update version to 2.7.
 
-*   Fri Aug 17 2018 Alexey Makhalov <amakhalov@vmware.com> 2.6-2
--   Improve .service file: wait wlanX to appear, run daemon in background.
--   Added skeleton for wlan0 conf file.
+* Fri Aug 17 2018 Alexey Makhalov <amakhalov@vmware.com> - 2.6-2
+- Improve .service file: wait wlanX to appear, run daemon in background.
+- Added skeleton for wlan0 conf file.
 
-*   Tue Nov 14 2017 Alexey Makhalov <amakhalov@vmware.com> 2.6-1
--   Initial build. First version.
+* Tue Nov 14 2017 Alexey Makhalov <amakhalov@vmware.com> - 2.6-1
+- Initial build. First version.

--- a/SPECS/wpa_supplicant/wpa_supplicant.spec
+++ b/SPECS/wpa_supplicant/wpa_supplicant.spec
@@ -9,7 +9,8 @@ Group:          Applications/Communications
 URL:            https://w1.fi
 Source0:        https://w1.fi/releases/%{name}-%{version}.tar.gz
 Patch0:         CVE-2019-16275.patch
-Patch1:         CVE-2021-27803.patch
+Patch1:         CVE-2021-0326.patch
+Patch2:         CVE-2021-27803.patch
 BuildRequires:  libnl3-devel
 BuildRequires:  openssl-devel
 Requires:       libnl3
@@ -98,7 +99,7 @@ EOF
 
 %changelog
 * Mon Mar 08 2021 Thomas Crain <thcrain@microsoft.com> - 2.9-3
-- Add patch for CVE-2021-27803
+- Add patch for CVE-2021-0326 and CVE-2021-27803
 
 * Mon Nov 16 2020 Nicolas Guibourge <nicolasg@microsoft.com> - 2.9-2
 - Change name of CVE-2019-16275 patch.


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Patch CVE-2021-0326, CVE-2021-27803 in wpa_supplicant. We aren't susceptible to either of these, since we don't build with `CONFIG_P2P=y` in our `wpa_supplicant` config, but we might as well add them.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Patch CVE-2021-0326, CVE-2021-27803 in wpa_supplicant

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO


###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2021-0326
- https://nvd.nist.gov/vuln/detail/CVE-2021-27803

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local build of affected packages
