### PR TITLE
diskutils: Add partprobe after partition creation

### DIFF
--- a/.github/workflows/quickstart_1.0.yml
+++ b/.github/workflows/quickstart_1.0.yml
@@ -30,7 +30,7 @@ jobs:
       run: |
         # Golang and docker are already installed on the agent
         sudo apt-get update
-        sudo apt -y install make tar wget curl rpm qemu-utils genisoimage pigz
+        sudo apt -y install make tar wget curl rpm qemu-utils genisoimage pigz parted
 
     - name: Download SRPMS
       run: |
@@ -58,7 +58,7 @@ jobs:
       run: |
         # Golang and docker are already installed on the agent
         sudo apt-get update
-        sudo apt -y install make tar wget curl rpm qemu-utils genisoimage pigz
+        sudo apt -y install make tar wget curl rpm qemu-utils genisoimage pigz parted
 
     - name: ISO Quick Start
       run: |
@@ -85,7 +85,7 @@ jobs:
       run: |
         # Golang and docker are already installed on the agent
         sudo apt-get update
-        sudo apt -y install make tar wget curl rpm qemu-utils genisoimage pigz
+        sudo apt -y install make tar wget curl rpm qemu-utils genisoimage pigz parted
 
     - name: VHDX Quick Start
       run: |

--- a/toolkit/docs/building/prerequisites.md
+++ b/toolkit/docs/building/prerequisites.md
@@ -11,7 +11,7 @@ sudo add-apt-repository ppa:longsleep/golang-backports
 sudo apt-get update
 
 # Install required dependencies.
-sudo apt -y install make tar wget curl rpm qemu-utils golang-1.15-go genisoimage python-minimal bison gawk
+sudo apt -y install make tar wget curl rpm qemu-utils golang-1.15-go genisoimage python-minimal bison gawk parted
 
 # Recommended but not required: `pigz` for faster compression operations.
 sudo apt -y install pigz

--- a/toolkit/tools/imagegen/diskutils/diskutils.go
+++ b/toolkit/tools/imagegen/diskutils/diskutils.go
@@ -398,7 +398,19 @@ func CreateSinglePartition(diskDevPath string, partitionNumber int, partitionTab
 			return "", err
 		}
 	}
-
+	// Update kernel partition table information
+	//
+	// There can be a timing issue where partition creation finishes but the
+	// devtmpfs files are not populated in time for partition initialization.
+	// So to deal with this, we call partprobe here to query and flush the
+	// partition table information, which should enforce that the devtmpfs
+	// files are created when partprobe returns control.
+	stdout, stderr, err := shell.Execute("partprobe", "-s", diskDevPath)
+	if err != nil {
+		logger.Log.Warnf("Failed to execute partprobe: %v", stderr)
+		return "", err
+	}
+	logger.Log.Debugf(stdout)
 	return InitializeSinglePartition(diskDevPath, partitionNumber, partitionTableType, partition)
 }
 

--- a/toolkit/tools/imagegen/diskutils/diskutils.go
+++ b/toolkit/tools/imagegen/diskutils/diskutils.go
@@ -417,7 +417,7 @@ func CreateSinglePartition(diskDevPath string, partitionNumber int, partitionTab
 		logger.Log.Warnf("Failed to execute partprobe: %v", stderr)
 		return "", err
 	}
-	logger.Log.Debugf(stdout)
+	logger.Log.Debugf("Partprobe -s returned: %s", stdout)
 	return InitializeSinglePartition(diskDevPath, partitionNumber, partitionTableType, partition)
 }
 

--- a/toolkit/tools/imagegen/diskutils/diskutils.go
+++ b/toolkit/tools/imagegen/diskutils/diskutils.go
@@ -376,9 +376,9 @@ func CreatePartitions(diskDevPath string, disk configuration.Disk, rootEncryptio
 // CreateSinglePartition creates a single partition based on the partition config
 func CreateSinglePartition(diskDevPath string, partitionNumber int, partitionTableType string, partition configuration.Partition) (partDevPath string, err error) {
 	const (
-		fillToEndOption = "100%"
-		mibFmt          = "%dMiB"
-		timeout         = "5"
+		fillToEndOption  = "100%"
+		mibFmt           = "%dMiB"
+		timeoutInSeconds = "5"
 	)
 	start := partition.Start
 	end := partition.End
@@ -412,7 +412,7 @@ func CreateSinglePartition(diskDevPath string, partitionNumber int, partitionTab
 	// with other cooperating processes. The important part is it will block
 	// if the fd is busy, and then execute the command. Adding a timeout
 	// to prevent us from possibly waiting forever.
-	stdout, stderr, err := shell.Execute("flock", "--timeout", timeout, diskDevPath, "partprobe", "-s", diskDevPath)
+	stdout, stderr, err := shell.Execute("flock", "--timeout", timeoutInSeconds, diskDevPath, "partprobe", "-s", diskDevPath)
 	if err != nil {
 		logger.Log.Warnf("Failed to execute partprobe: %v", stderr)
 		return "", err


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
* diskutils: Add partprobe after partition creation

There can be a timing issue where partition creation finishes but the
devtmpfs files are not populated in time for partition initialization.
So to deal with this, we call partprobe here to query and flush the
partition table information, which should enforce that the devtmpfs
files are created when partprobe returns control.

* diskutils: invoke partprobe with flock

Added flock because "partprobe -s" apparently doesn't always block.
flock is part of the util-linux package and helps to synchronize access
with other cooperating processes. The important part is it will block
if the fd is busy, and then execute the command. Adding a 5 second timeout
to prevent us from possibly waiting forever.

Signed-off-by: Chris Co <chrco@microsoft.com>

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->

###### Links to CVEs  <!-- optional -->

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
Local build. Tested in QEMU environment where timing issue was occurring.
Also tested on most recent 1.0-dev branch where VHDX image builds started exhibiting this issue.
