### PR TITLE
Package bash-completion files properly in packages that autodetect directory from pkg-config

### DIFF
--- a/SPECS/dnf/dnf.spec
+++ b/SPECS/dnf/dnf.spec
@@ -4,7 +4,7 @@
 Summary:        Python 3 version of the DNF package manager.
 Name:           dnf
 Version:        4.2.18
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        GPLv2+ OR GPL
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -86,7 +86,7 @@ ctest -VV
 
 %files -f %{name}.lang
 %{_bindir}/%{name}
-%{_sysconfdir}/bash_completion.d/dnf
+%{_datadir}/bash-completion/completions/dnf
 %{_unitdir}/%{name}-makecache.service
 %{_unitdir}/%{name}-makecache.timer
 
@@ -138,6 +138,9 @@ ctest -VV
 %{python3_sitelib}/%{name}/automatic
 
 %changelog
+* Wed Mar 10 2021 Thomas Crain <thcrain@microsoft.com> - 4.2.18-4
+- Use modern bash-completion directory, now that dnf can auto-detect it based on bash-completion.pc
+
 * Tue Nov 03 2020 Ruying Chen <v-ruyche@microsoft.com> - 4.2.18-3
 - Systemd supports merged /usr. Update with corresponding file locations and macros.
 

--- a/SPECS/libstoragemgmt/libstoragemgmt.spec
+++ b/SPECS/libstoragemgmt/libstoragemgmt.spec
@@ -5,7 +5,7 @@
 Summary:        Storage array management library
 Name:           libstoragemgmt
 Version:        1.8.4
-Release:        6%{?dist}
+Release:        7%{?dist}
 License:        LGPLv2+
 URL:            https://github.com/libstorage/libstoragemgmt
 Vendor:         Microsoft
@@ -221,9 +221,6 @@ install -m 644 tools/udev/90-scsi-ua.rules \
     %{buildroot}/%{_udevrulesdir}/90-scsi-ua.rules
 install -m 755 tools/udev/scan-scsi-target \
     %{buildroot}/%{_udevrulesdir}/../scan-scsi-target
-
-mkdir -p %{buildroot}/%{_datadir}/bash-completion/completions/
-mv %{buildroot}/etc/bash_completion.d/lsmcli %{buildroot}/%{_datadir}/bash-completion/completions/
 
 %if 0%{with test}
 %check
@@ -539,6 +536,9 @@ fi
 %{_mandir}/man1/local_lsmplugin.1*
 
 %changelog
+* Wed Mar 10 2021 Thomas Crain <thcrain@microsoft.com> - 1.8.4-7
+- Remove manual placement of bash-completion file, now that this package has bash-completion.pc available to it
+
 * Fri Aug 21 2020 Thomas Crain <thcrain@microsoft.com> 1.8.4-6
 - Initial CBL-Mariner version imported from Fedora 33 (license: MIT)
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Package bash-completion files properly in packages that autodetect directory from pkg-config

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Use proper bash-completion dir in dnf, libstoragemgmt

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO


###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Build of affected packages
