### PR TITLE
Add nopatch for CVE-2021-21309 for redis

### DIFF
--- a/SPECS/redis/redis.spec
+++ b/SPECS/redis/redis.spec
@@ -1,7 +1,7 @@
 Summary:        advanced key-value store
 Name:           redis
 Version:        5.0.5
-Release:        5%{?dist}
+Release:        6%{?dist}
 License:        BSD
 URL:            https://redis.io/
 Group:          Applications/Databases
@@ -11,6 +11,9 @@ Source0:        https://download.redis.io/releases/%{name}-%{version}.tar.gz
 Patch0:         redis-conf.patch
 Patch1:         CVE-2020-14147.patch
 Patch2:         disable_active_defrag_big_keys.patch
+# CVE-2021-21309 affects 32-bit executables only. Mariner always builds with -m64 and does not support 32-bit architectures.
+Patch3:         CVE-2021-21309.nopatch
+
 BuildRequires:  gcc
 BuildRequires:  systemd
 BuildRequires:  make
@@ -84,6 +87,8 @@ exit 0
 %config(noreplace) %attr(0640, %{name}, %{name}) %{_sysconfdir}/redis.conf
 
 %changelog
+* Thu Mar 11 2021 Mateusz Malisz <mamalisz@microsoft.com> 5.0.5-6
+- Add nopatch for CVE-2021-21309.
 * Wed Mar 03 2021 Andrew Phelps <anphel@microsoft.com> 5.0.5-5
 - Add patch to remove an unreliable test. License verified.
 * Fri Oct 23 2020 Henry Li <lihl@microsoft.com> 5.0.5-4


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
CVE-2021-21309 affects only 32-bit redis executables. Mariner does not support nor build executables on any 32-bit system. Additionally we append flags such as -m64 to ensure 64-bit executables.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add nopatch for CVE-2021-21309

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2021-21309

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: 74857
