### PR TITLE
Update default sshd_config to match other distros

### DIFF
--- a/SPECS/openssh/openssh.spec
+++ b/SPECS/openssh/openssh.spec
@@ -2,7 +2,7 @@
 Summary:        Free version of the SSH connectivity tools
 Name:           openssh
 Version:        8.5p1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        BSD
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -70,23 +70,16 @@ tar xf %{SOURCE1} --no-same-owner
     --with-maintype=man \
     --enable-strip=no \
     --with-kerberos5=%{_prefix}
-make
+%make_build
 
 %install
-[ %{buildroot} != "/"] && rm -rf %{buildroot}/*
-make DESTDIR=%{buildroot} install
+%make_install
 install -vdm755 %{buildroot}%{_sharedstatedir}/sshd
 
-cat <<EOF >>%{buildroot}%{_sysconfdir}/ssh/sshd_config
-AllowTcpForwarding no
-ClientAliveCountMax 2
-Compression no
-#MaxSessions 2
-TCPKeepAlive no
-AllowAgentForwarding no
-PermitRootLogin no
-UsePAM yes
-EOF
+sed -i 's/#UsePAM no/UsePAM yes/' %{buildroot}%{_sysconfdir}/ssh/sshd_config
+sed -i 's/#PrintMotd yes/PrintMotd no/' %{buildroot}%{_sysconfdir}/ssh/sshd_config
+sed -i 's/#PermitUserEnvironment no/PermitUserEnvironment no/' %{buildroot}%{_sysconfdir}/ssh/sshd_config
+sed -i 's/#ClientAliveInterval 0/ClientAliveInterval 120/' %{buildroot}%{_sysconfdir}/ssh/sshd_config
 
 #   Install daemon script
 pushd blfs-systemd-units-%{systemd_units_rel}
@@ -189,6 +182,9 @@ rm -rf %{buildroot}/*
 %{_mandir}/man8/ssh-sk-helper.8.gz
 
 %changelog
+* Fri Mar 12 2021 Henry Beberman <henry.beberman@microsoft.com> - 8.5p1-2
+- Update default sshd_config to align more closely with other cloud images
+
 * Thu Mar 11 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 8.5p1-1
 - Updating to 8.5p1 to patch CVE-2021-28041.
 - Added "TEST_SSH_UNSAFE_PERMISSIONS=1" to enable running more tests.

--- a/SPECS/openssh/openssh.spec
+++ b/SPECS/openssh/openssh.spec
@@ -77,6 +77,7 @@ tar xf %{SOURCE1} --no-same-owner
 install -vdm755 %{buildroot}%{_sharedstatedir}/sshd
 
 sed -i 's/#UsePAM no/UsePAM yes/' %{buildroot}%{_sysconfdir}/ssh/sshd_config
+sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin no/' %{buildroot}%{_sysconfdir}/ssh/sshd_config
 sed -i 's/#PrintMotd yes/PrintMotd no/' %{buildroot}%{_sysconfdir}/ssh/sshd_config
 sed -i 's/#PermitUserEnvironment no/PermitUserEnvironment no/' %{buildroot}%{_sysconfdir}/ssh/sshd_config
 sed -i 's/#ClientAliveInterval 0/ClientAliveInterval 120/' %{buildroot}%{_sysconfdir}/ssh/sshd_config


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Under the current default sshd_config settings SSH connections to Azure VMs are timing out after a period of user inactivity. This behavior does not occur on other images available on the platform. In order to fix this I've updated the default settings we're toggling in the sshd_config to more closely match those other distros. I've also reworked how we're setting values in sshd_config to do it in place instead with sed of blobbing them onto the end.

Additionally I cleaned up a little non-idiomatic spec syntax in favor of macros.

###### Change Log  <!-- REQUIRED -->
- Add the following changes to sshd_config
  - Set PrintMotd to no
  - Set PermitUserEnvironment to no
  - Set ClientAliveInterval to 120
  - Set UsePAM to yes
- Remove the following customization from sshd_config
  - AllowTcpForwarding no (now defaulting to yes) 
  - ClientAliveCountMax 2 (now defaulting to 3)
  - Compression no (now defaulting to yes)
  - TCPKeepAlive no (now defaulting to yes)
  - AllowAgentForwarding no (now defaulting to yes)
  - PermitRootLogin no (now defaulting to without-password)

Under these new settings password logins should still be available to non-root users. Deployments that have customized sshd_config will not be forced to take the configuration update because its packaged as %config(noreplace)

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
**NO**


###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Full Local package and image build
- Can SSH to local VM with password using our existing meta-user-data.iso
- Can SSH to Azure VM when its created with a password (Azure cloud-init explicitly sets PasswordAuthentication yes)
- Can SSH to Azure VM when its created with an SSH pubkey (Azure cloud-init explicitly sets PasswordAuthentication no)