### PR TITLE
Update cloud-utils-growpart to 0.32 to fix kver parsing

### DIFF
--- a/SPECS/cloud-utils-growpart/cloud-utils-growpart.signatures.json
+++ b/SPECS/cloud-utils-growpart/cloud-utils-growpart.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "cloud-utils-0.30.tar.gz": "7360dd3d56aca48945a4a1943315f1633f82f3486ca5f065c6746bce274b8aa5"
+  "cloud-utils-0.32.tar.gz": "132255cbda774834695e2912e09b9058d3281a94874be57e48f2f04f4b89ad77"
  }
 }

--- a/SPECS/cloud-utils-growpart/cloud-utils-growpart.spec
+++ b/SPECS/cloud-utils-growpart/cloud-utils-growpart.spec
@@ -1,10 +1,10 @@
 Summary:        Shell script to auto detect free size on disk and grow partition.
 Name:           cloud-utils-growpart
-Version:        0.30
-Release:        6%{?dist}
+Version:        0.32
+Release:        1%{?dist}
 License:        GPLv3
 Group:          System Environment
-Source0:        https://launchpad.net/cloud-utils/trunk/0.3/+download/cloud-utils-%{version}.tar.gz
+Source0:        https://launchpad.net/cloud-utils/trunk/%{version}/+download/cloud-utils-%{version}.tar.gz
 URL:            https://launchpad.net/cloud-utils
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -34,9 +34,10 @@ cp man/growpart.* $RPM_BUILD_ROOT/%{_mandir}/man1/
 %doc %{_mandir}/man1/growpart.*
 
 %changelog
-* Sat May 09 00:21:21 PST 2020 Nick Samson <nisamson@microsoft.com> - 0.30-6
-- Added %%license line automatically
-
+*   Sat Mar 13 2021 Henry Beberman <henry.beberman@microsoft.com> 0.32-1
+-   Update to version 0.32 for more robust parsing of kernel version in growpart
+*   Sat May 09 2020 Nick Samson <nisamson@microsoft.com> 0.30-6
+-   Added %%license line automatically
 *   Tue May 05 2020 Emre Girgin <mrgirgin@microsoft.com> 0.30-5
 -   Renaming cloud-utils to cloud-utils-growpart
 *   Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 0.30-4

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -635,8 +635,8 @@
         "type": "other",
         "other": {
           "name": "cloud-utils-growpart",
-          "version": "0.30",
-          "downloadUrl": "https://launchpad.net/cloud-utils/trunk/0.3/+download/cloud-utils-0.30.tar.gz"
+          "version": "0.32",
+          "downloadUrl": "https://launchpad.net/cloud-utils/trunk/0.32/+download/cloud-utils-0.32.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
With the 5.10.13.1 kernel we're hitting an error in cloud-utils version 0.30 growpart where it doesn't parse kernel versions robustly. This is causing growpart to fail and stopping the rootfs from being resized to fill the remainder of the disk. Updating to cloud-utils version 0.32 fixes the bug.

###### Change Log  <!-- REQUIRED -->
- Update cloud-utils-growpart to version 0.32

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Test Methodology
- Local package build
- Azure VM with this updated cloud-utils-growpart and kernel 5.10.13.1 successfully resizes the rootfs