### PR TITLE
Unifying `coredns` specs for the sake of automation.

### DIFF
--- a/SPECS/coredns/coredns-1.6.5.spec
+++ b/SPECS/coredns/coredns-1.6.5.spec
@@ -11,8 +11,14 @@ Group:          System Environment/Libraries
 URL:            https://github.com/coredns/coredns
 #Source0:       https://github.com/coredns/coredns/archive/v%%{version}.tar.gz
 Source0:        %{name}-%{version}.tar.gz
-# use go modules from tarball because they cannot be downloaded at build time
-# (build system prevents that)
+# Below is a manually created tarball, no download link.
+# We're using pre-populated Go modules from this tarball, since network is disabled during build time.
+# How to re-build this file:
+#   1. wget https://github.com/coredns/coredns/archive/v%%{version}.tar.gz -O %%{name}-%%{version}.tar.gz
+#   2. tar -xf %%{name}-%%{version}.tar.gz
+#   3. cd %%{name}-%%{version}
+#   4. go mod vendor
+#   5. tar -cf %%{name}-%%{version}-vendor.tar.gz vendor
 Source1:        %{name}-%{version}-vendor.tar.gz
 Patch0:         makefile-buildoption-commitnb-%{version}.patch
 

--- a/SPECS/coredns/coredns-1.6.5.spec
+++ b/SPECS/coredns/coredns-1.6.5.spec
@@ -9,7 +9,7 @@ Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Group:          System Environment/Libraries
 URL:            https://github.com/coredns/coredns
-#Source0:       https://github.com/coredns/coredns/archive/v1.6.5.tar.gz
+#Source0:       https://github.com/coredns/coredns/archive/v%%{version}.tar.gz
 Source0:        %{name}-%{version}.tar.gz
 # use go modules from tarball because they cannot be downloaded at build time
 # (build system prevents that)

--- a/SPECS/coredns/coredns-1.6.7.spec
+++ b/SPECS/coredns/coredns-1.6.7.spec
@@ -9,7 +9,7 @@ Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Group:          System Environment/Libraries
 URL:            https://github.com/coredns/coredns
-#Source0:       https://github.com/coredns/coredns/archive/v1.6.7.tar.gz
+#Source0:       https://github.com/coredns/coredns/archive/v%%{version}.tar.gz
 Source0:        %{name}-%{version}.tar.gz
 # use go modules from tarball because they cannot be downloaded at build time
 # (build system prevents that)

--- a/SPECS/coredns/coredns-1.6.7.spec
+++ b/SPECS/coredns/coredns-1.6.7.spec
@@ -11,8 +11,14 @@ Group:          System Environment/Libraries
 URL:            https://github.com/coredns/coredns
 #Source0:       https://github.com/coredns/coredns/archive/v%%{version}.tar.gz
 Source0:        %{name}-%{version}.tar.gz
-# use go modules from tarball because they cannot be downloaded at build time
-# (build system prevents that)
+# Below is a manually created tarball, no download link.
+# We're using pre-populated Go modules from this tarball, since network is disabled during build time.
+# How to re-build this file:
+#   1. wget https://github.com/coredns/coredns/archive/v%%{version}.tar.gz -O %%{name}-%%{version}.tar.gz
+#   2. tar -xf %%{name}-%%{version}.tar.gz
+#   3. cd %%{name}-%%{version}
+#   4. go mod vendor
+#   5. tar -cf %%{name}-%%{version}-vendor.tar.gz vendor
 Source1:        %{name}-%{version}-vendor.tar.gz
 Patch0:         makefile-buildoption-commitnb.patch
 

--- a/SPECS/coredns/coredns-1.7.0.spec
+++ b/SPECS/coredns/coredns-1.7.0.spec
@@ -9,7 +9,7 @@ Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Group:          System Environment/Libraries
 URL:            https://github.com/coredns/coredns
-#Source0:       https://github.com/coredns/coredns/archive/v1.7.0.tar.gz
+#Source0:       https://github.com/coredns/coredns/archive/v%%{version}.tar.gz
 Source0:        %{name}-%{version}.tar.gz
 # use go modules from tarball because they cannot be downloaded at build time
 # (build system prevents that)

--- a/SPECS/coredns/coredns-1.7.0.spec
+++ b/SPECS/coredns/coredns-1.7.0.spec
@@ -11,8 +11,14 @@ Group:          System Environment/Libraries
 URL:            https://github.com/coredns/coredns
 #Source0:       https://github.com/coredns/coredns/archive/v%%{version}.tar.gz
 Source0:        %{name}-%{version}.tar.gz
-# use go modules from tarball because they cannot be downloaded at build time
-# (build system prevents that)
+# Below is a manually created tarball, no download link.
+# We're using pre-populated Go modules from this tarball, since network is disabled during build time.
+# How to re-build this file:
+#   1. wget https://github.com/coredns/coredns/archive/v%%{version}.tar.gz -O %%{name}-%%{version}.tar.gz
+#   2. tar -xf %%{name}-%%{version}.tar.gz
+#   3. cd %%{name}-%%{version}
+#   4. go mod vendor
+#   5. tar -cf %%{name}-%%{version}-vendor.tar.gz vendor
 Source1:        %{name}-%{version}-vendor.tar.gz
 Patch0:         makefile-buildoption-commitnb.patch
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Minimal change to unify `coredns` specs to simplify automation efforts.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Switched to using macros instead of hard-coded versions in the source URL.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
No.

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- None, minor change in comments.
