### PR TITLE
add bios-grub partition flag

### DIFF
--- a/toolkit/tools/imagegen/configuration/partitionflag.go
+++ b/toolkit/tools/imagegen/configuration/partitionflag.go
@@ -20,6 +20,8 @@ const (
 	PartitionFlagGrub PartitionFlag = "grub"
 	// PartitionFlagBiosGrub indicates this is a bios grub boot partition
 	PartitionFlagBiosGrub PartitionFlag = "bios_grub"
+	// PartitionFlagBiosGrubLegacy indicates this is a bios grub boot partition. Needed to preserve legacy config behavior.
+	PartitionFlagBiosGrubLegacy PartitionFlag = "bios-grub"
 	// PartitionFlagBoot indicates this is a boot partition
 	PartitionFlagBoot PartitionFlag = "boot"
 	// PartitionFlagDeviceMapperRoot indicates this partition will be used for a device mapper root device
@@ -37,6 +39,7 @@ func (p *PartitionFlag) GetValidPartitionFlags() (types []PartitionFlag) {
 		PartitionFlagESP,
 		PartitionFlagGrub,
 		PartitionFlagBiosGrub,
+		PartitionFlagBiosGrubLegacy,
 		PartitionFlagBoot,
 		PartitionFlagDeviceMapperRoot,
 	}

--- a/toolkit/tools/imagegen/configuration/partitionflag_test.go
+++ b/toolkit/tools/imagegen/configuration/partitionflag_test.go
@@ -16,6 +16,7 @@ var (
 		PartitionFlag("esp"),
 		PartitionFlag("grub"),
 		PartitionFlag("bios_grub"),
+		PartitionFlag("bios-grub"),
 		PartitionFlag("boot"),
 		PartitionFlag("dmroot"),
 	}

--- a/toolkit/tools/imagegen/diskutils/diskutils.go
+++ b/toolkit/tools/imagegen/diskutils/diskutils.go
@@ -453,7 +453,7 @@ func InitializeSinglePartition(diskDevPath string, partitionNumber int, partitio
 		switch flag {
 		case configuration.PartitionFlagESP:
 			flagToSet = "esp"
-		case configuration.PartitionFlagGrub, configuration.PartitionFlagBiosGrub:
+		case configuration.PartitionFlagGrub, configuration.PartitionFlagBiosGrub, configuration.PartitionFlagBiosGrubLegacy:
 			flagToSet = "bios_grub"
 		case configuration.PartitionFlagBoot:
 			flagToSet = "boot"


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
When we released the initial tools, "bios-grub" was a valid partition
Flag in the image configuration JSON. At some point, it got dropped
in favor of "bios_grub". However calamares GUI ISO installer produces
config files with the original "bios-grub" flag. So this change
restores the "bios-grub" flag as a legacy option. We still prefer
users to use "bios_grub" going forward.

Signed-off-by: Chris Co <chrco@microsoft.com>

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->

###### Links to CVEs  <!-- optional -->

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
Local build. Tested GUI ISO install on Gen1 