### PR TITLE
Cleaning SRPM expansion and chroot creation console output

### DIFF
--- a/toolkit/Makefile
+++ b/toolkit/Makefile
@@ -45,7 +45,7 @@ TOOL_BINS_DIR    ?= $(toolkit_root)/out/tools
 RESOURCES_DIR    ?= $(toolkit_root)/resources
 SCRIPTS_DIR      ?= $(toolkit_root)/scripts
 
-PROJECT_ROOT     ?= $(toolkit_root)/..
+PROJECT_ROOT     ?= $(realpath $(toolkit_root)/..)
 BUILD_DIR        ?= $(PROJECT_ROOT)/build
 OUT_DIR          ?= $(PROJECT_ROOT)/out
 SPECS_DIR        ?= $(PROJECT_ROOT)/SPECS

--- a/toolkit/scripts/pkggen.mk
+++ b/toolkit/scripts/pkggen.mk
@@ -176,7 +176,7 @@ $(STATUS_FLAGS_DIR)/build-rpms.flag: $(workplan) $(chroot_worker) $(go-pkgworker
 ifeq ($(RUN_CHECK),y)
 	$(warning Make argument 'RUN_CHECK' set to 'y', running package tests. Will add the 'ca-certificates' package and enable networking for package builds.)
 endif
-	rm -f $(LOGS_DIR)/pkggen/failures.txt && \
+	@rm -f $(LOGS_DIR)/pkggen/failures.txt && \
 	$(MAKE) --silent -f $(workplan) go-pkgworker=$(go-pkgworker) CHROOT_DIR=$(CHROOT_DIR) chroot_worker=$(chroot_worker) SRPMS_DIR=$(SRPMS_DIR) RPMS_DIR=$(RPMS_DIR) pkggen_local_repo=$(pkggen_local_repo) LOGS_DIR=$(LOGS_DIR) TOOLCHAIN_MANIFESTS_DIR=$(TOOLCHAIN_MANIFESTS_DIR) GOAL_PackagesToBuild && \
 	{ [ ! -f $(LOGS_DIR)/pkggen/failures.txt ] || \
 		$(call print_error,Failed to build: $$(cat $(LOGS_DIR)/pkggen/failures.txt)); } && \

--- a/toolkit/scripts/srpm_expand.mk
+++ b/toolkit/scripts/srpm_expand.mk
@@ -31,7 +31,7 @@ $(BUILD_SPECS_DIR): $(STATUS_FLAGS_DIR)/build_specs.flag
 
 # For each SRPM, if it is newer than the spec extract a new copy of the .spec file
 $(STATUS_FLAGS_DIR)/build_specs.flag: $(srpms) $(BUILD_SRPMS_DIR)
-	@echo "Extracting new or updated SRPMs from \"$(BUILD_SRPMS_DIR)\"." | tee -a $(srpm_expand_log) && \
+	@echo "Extracting new or updated SRPMs from \"$(BUILD_SRPMS_DIR)\"." | tee $(srpm_expand_log) && \
 	for srpm in $(srpms); do \
 		spec_destination=$(BUILD_SPECS_DIR)/$$(rpm -qp $$srpm --define='with_check 1' --queryformat %{NAME}-%{VERSION}-%{RELEASE}/%{NAME}.spec) && \
 		spec_dir=$$(dirname $$spec_destination) && \

--- a/toolkit/scripts/srpm_expand.mk
+++ b/toolkit/scripts/srpm_expand.mk
@@ -43,5 +43,5 @@ $(STATUS_FLAGS_DIR)/build_specs.flag: $(srpms) $(BUILD_SRPMS_DIR)
 			rpm2cpio $$srpm | cpio -idvu 2>>$(srpm_expand_log) && \
 			echo "Extracted \"$$srpm_filename\"." >> $(srpm_expand_log) || $(call print_error,Failed to expand "$$srpm".); \
 		fi \
-	done || $(call print_error,Checking for spec updates failed. See above errors and "$$srpm_expand_log" for more details.); \
+	done || $(call print_error,Checking for spec updates failed. See above errors and "$(srpm_expand_log)" for more details.); \
 	touch $@

--- a/toolkit/scripts/srpm_expand.mk
+++ b/toolkit/scripts/srpm_expand.mk
@@ -29,14 +29,14 @@ $(BUILD_SPECS_DIR): $(STATUS_FLAGS_DIR)/build_specs.flag
 	@touch $@
 	@echo "Finished updating $@." | tee -a $(srpm_expand_log)
 
+# For each SRPM, if it is newer than the spec extract a new copy of the .spec file
 $(STATUS_FLAGS_DIR)/build_specs.flag: $(srpms) $(BUILD_SRPMS_DIR)
-	@# For each SRPM, if it is newer than the spec extract a new copy of the .spec file
-	@for srpm in $(srpms); do \
+	@echo "Extracting new or updated SRPMs from \"$(BUILD_SRPMS_DIR)\"." | tee -a $(srpm_expand_log) && \
+	for srpm in $(srpms); do \
 		spec_destination=$(BUILD_SPECS_DIR)/$$(rpm -qp $$srpm --define='with_check 1' --queryformat %{NAME}-%{VERSION}-%{RELEASE}/%{NAME}.spec) && \
 		spec_dir=$$(dirname $$spec_destination) && \
 		if [ ! -f $@ -o $$srpm -nt $@ ]; then \
-			echo "Detected a new SRPM \"$$srpm\"." | tee -a $(srpm_expand_log) && \
-			echo "Extracting to \"$$spec_dir\"." | tee -a $(srpm_expand_log) && \
+			echo "Extracting \"$$(basename $$srpm)\" to \"$$spec_dir\"." | tee -a $(srpm_expand_log) && \
 			mkdir -p $$spec_dir && \
 			cd $$spec_dir && \
 			rpm2cpio $$srpm | cpio -idvu 2>>$(srpm_expand_log) || $(call print_error,Failed to expand "$$srpm".) ; \

--- a/toolkit/scripts/srpm_expand.mk
+++ b/toolkit/scripts/srpm_expand.mk
@@ -36,10 +36,12 @@ $(STATUS_FLAGS_DIR)/build_specs.flag: $(srpms) $(BUILD_SRPMS_DIR)
 		spec_destination=$(BUILD_SPECS_DIR)/$$(rpm -qp $$srpm --define='with_check 1' --queryformat %{NAME}-%{VERSION}-%{RELEASE}/%{NAME}.spec) && \
 		spec_dir=$$(dirname $$spec_destination) && \
 		if [ ! -f $@ -o $$srpm -nt $@ ]; then \
-			echo "Extracting \"$$(basename $$srpm)\" to \"$$spec_dir\"." | tee -a $(srpm_expand_log) && \
+			srpm_filename=$$(basename $$srpm) && \
+			echo "Extracting \"$$srpm_filename\" to \"$$spec_dir\"." | tee -a $(srpm_expand_log) && \
 			mkdir -p $$spec_dir && \
 			cd $$spec_dir && \
-			rpm2cpio $$srpm | cpio -idvu 2>>$(srpm_expand_log) || $(call print_error,Failed to expand "$$srpm".) ; \
+			rpm2cpio $$srpm | cpio -idvu 2>>$(srpm_expand_log) && \
+			echo "Extracted \"$$srpm_filename\"." >> $(srpm_expand_log) || $(call print_error,Failed to expand "$$srpm".); \
 		fi \
 	done || $(call print_error,Checking for spec updates failed. See above errors and "$$srpm_expand_log" for more details.); \
 	touch $@

--- a/toolkit/scripts/srpm_expand.mk
+++ b/toolkit/scripts/srpm_expand.mk
@@ -9,6 +9,10 @@ $(call create_folder,$(BUILD_SPECS_DIR))
 ######## SRPM EXPANDING ########
 
 srpms = $(shell find $(BUILD_SRPMS_DIR)/ -type f -name '*.src.rpm')
+srpm_expand_logs_dir = $(LOGS_DIR)/srpm_expand
+srpm_expand_log = $(srpm_expand_logs_dir)/srpm_expand.log
+
+$(call create_folder,$(srpm_expand_logs_dir))
 
 .PHONY: expand-specs clean-expand-specs
 expand-specs: $(BUILD_SPECS_DIR)
@@ -17,26 +21,25 @@ clean: clean-expand-specs
 clean-expand-specs:
 	rm -rf $(BUILD_SPECS_DIR)
 	rm -rf $(STATUS_FLAGS_DIR)/build_specs.flag
+	rm -rf $(srpm_expand_logs_dir)
 
 # The directory freshness is tracked with a status flag. The status flag is only updated when all SPECS have been
 # updated.
 $(BUILD_SPECS_DIR): $(STATUS_FLAGS_DIR)/build_specs.flag
 	@touch $@
-	@echo Finished updating $@
+	@echo "Finished updating $@." | tee -a $(srpm_expand_log)
 
 $(STATUS_FLAGS_DIR)/build_specs.flag: $(srpms) $(BUILD_SRPMS_DIR)
-	# For each SRPM, if it is newer than the spec extract a new copy of the .spec file
-	for srpm in $(srpms); do \
-		srpm_file=$${srpm} && \
-		spec_destination=$(BUILD_SPECS_DIR)/$$(rpm -qp $${srpm_file} --define='with_check 1' --queryformat %{NAME}-%{VERSION}-%{RELEASE}/%{NAME}.spec) && \
-		spec_dir=$$(dirname $${spec_destination}) && \
-		if [ $${srpm_file} -nt $@ -o ! -f $@ ]; then \
-			mkdir -p $${spec_dir} && \
-			echo extracting $${spec_destination} && \
-			cd $${spec_dir} && rpm2cpio $${srpm_file} | cpio -idvu || $(call print_error,Failed to expand $${srpm_file}) ; \
-		fi || $(call print_error,If in $@ failed) ; \
-	done || $(call print_error,Loop in $@ failed) ; \
+	@# For each SRPM, if it is newer than the spec extract a new copy of the .spec file
+	@for srpm in $(srpms); do \
+		spec_destination=$(BUILD_SPECS_DIR)/$$(rpm -qp $$srpm --define='with_check 1' --queryformat %{NAME}-%{VERSION}-%{RELEASE}/%{NAME}.spec) && \
+		spec_dir=$$(dirname $$spec_destination) && \
+		if [ ! -f $@ -o $$srpm -nt $@ ]; then \
+			echo "Detected a new SRPM \"$$srpm\"." | tee -a $(srpm_expand_log) && \
+			echo "Extracting to \"$$spec_dir\"." | tee -a $(srpm_expand_log) && \
+			mkdir -p $$spec_dir && \
+			cd $$spec_dir && \
+			rpm2cpio $$srpm | cpio -idvu 2>>$(srpm_expand_log) || $(call print_error,Failed to expand "$$srpm".) ; \
+		fi \
+	done || $(call print_error,Checking for spec updates failed. See above errors and "$$srpm_expand_log" for more details.); \
 	touch $@
-
-
-

--- a/toolkit/scripts/srpm_pack.mk
+++ b/toolkit/scripts/srpm_pack.mk
@@ -58,7 +58,7 @@ $(STATUS_FLAGS_DIR)/build_srpms.flag: $(local_specs) $(local_spec_dirs) $(SPECS_
 	touch $@
 else
 $(STATUS_FLAGS_DIR)/build_srpms.flag: $(local_specs) $(local_spec_dirs) $(local_sources) $(SPECS_DIR) $(go-srpmpacker)
-	GODEBUG=x509ignoreCN=0 $(go-srpmpacker) \
+	$(go-srpmpacker) \
 		--dir=$(SPECS_DIR) \
 		--output-dir=$(BUILD_SRPMS_DIR) \
 		--source-url=$(SOURCE_URL) \
@@ -69,6 +69,6 @@ $(STATUS_FLAGS_DIR)/build_srpms.flag: $(local_specs) $(local_spec_dirs) $(local_
 		--build-dir=$(BUILD_DIR)/SRPM_packaging \
 		--signature-handling=$(SRPM_FILE_SIGNATURE_HANDLING) \
 		--log-file=$(LOGS_DIR)/pkggen/workplan/intermediate_srpms.log \
-		--log-level=$(LOG_LEVEL)
+		--log-level=$(LOG_LEVEL) && \
 	touch $@
 endif

--- a/toolkit/scripts/toolchain.mk
+++ b/toolkit/scripts/toolchain.mk
@@ -188,31 +188,31 @@ $(toolchain_rpms): $(toolchain_manifest) $(toolchain_local_temp)
 	if [ ! -f $@ -o $(TOOLCHAIN_ARCHIVE) -nt $@ ]; then \
 		echo Extracting RPM $@ from toolchain && \
 		mkdir -p $(dir $@) && \
-		mv $${tempFile} $(dir $@) && \
+		mv $$tempFile $(dir $@) && \
 		touch $@ ; \
 	fi || $(call print_error, $@ failed) && \
 	touch $@
 else
 # Download from online package server
 $(toolchain_rpms):
-	$(eval rpm_filename := "$(notdir $@)")
-	$(eval rpm_dir := "$(dir $@)")
-	$(eval log_file := "$(toolchain_downloads_logs_dir)/$(rpm_filename).log")
-	@echo "Downloading toolchain RPM: $(rpm_filename)" | tee "$(log_file)" && \
-	mkdir -p $(rpm_dir) && \
-	cd $(rpm_dir) && \
+	@rpm_filename="$(notdir $@)" && \
+	rpm_dir="$(dir $@)" && \
+	log_file="$(toolchain_downloads_logs_dir)/$$rpm_filename.log" && \
+	echo "Downloading toolchain RPM: $$rpm_filename" | tee "$$log_file" && \
+	mkdir -p $$rpm_dir && \
+	cd $$rpm_dir && \
 	for url in $(PACKAGE_URL_LIST); do \
-		wget $${url}/$(rpm_filename) \
+		wget $$url/$$rpm_filename \
 			$(if $(TLS_CERT),--certificate=$(TLS_CERT)) \
 			$(if $(TLS_KEY),--private-key=$(TLS_KEY)) \
-			-a $(log_file) \
+			-a $$log_file \
 			&& \
-		echo "Downloaded toolchain RPM: $(rpm_filename)" | tee -a $(log_file) && \
+		echo "Downloaded toolchain RPM: $$rpm_filename" | tee -a $$log_file && \
 		break; \
 	done || { \
-			echo "\nERROR: Failed to download toolchain package: $(rpm_filename)." && \
-			echo "ERROR: Last $(toolchain_log_tail_length) lines from log '$(log_file)':\n" && \
-			tail -n$(toolchain_log_tail_length) $(log_file) | sed 's/^/\t/' && \
+			echo "\nERROR: Failed to download toolchain package: $$rpm_filename." && \
+			echo "ERROR: Last $(toolchain_log_tail_length) lines from log '$$log_file':\n" && \
+			tail -n$(toolchain_log_tail_length) $$log_file | sed 's/^/\t/' && \
 			$(call print_error,\nToolchain download failed. See above errors for more details.) \
 		}
 endif

--- a/toolkit/scripts/toolchain.mk
+++ b/toolkit/scripts/toolchain.mk
@@ -207,7 +207,7 @@ $(toolchain_rpms):
 			$(if $(TLS_KEY),--private-key=$(TLS_KEY)) \
 			-a $$log_file \
 			&& \
-		echo "Downloaded toolchain RPM: $$rpm_filename" | tee -a $$log_file && \
+		echo "Downloaded toolchain RPM: $$rpm_filename" >> $$log_file && \
 		break; \
 	done || { \
 			echo "\nERROR: Failed to download toolchain package: $$rpm_filename." && \


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
This PR aims at reducing the noise and confusion around the logs printed during RPMs builds.

## Simplifying file paths.

Used `realpath` to make file paths shorter and easier to follow.

## Changes to SRPMs expansion output.

We no longer directly print the bash command inside the .mk file, since it mostly produced a long list of file paths without providing any explanation to what is happening. Similarly, we were printing the output from `cpio` listing all extracted files for each SRPM and number of blocks:
```
# For each SRPM, if it is newer than the spec extract a new copy of the .spec file
for srpm in /home/pawel/CBL-Mariner_package_tests2/toolkit/../build/INTERMEDIATE_SRPMS/pyOpenSSL-18.0.0-6.cm1.src.rpm
/home/pawel/CBL-Mariner_package_tests2/toolkit/../build/INTERMEDIATE_SRPMS/ntp-4.2.8p13-3.cm1.src.rpm
/home/pawel/CBL-Mariner_package_tests2/toolkit/../build/INTERMEDIATE_SRPMS/tcpdump-4.9.3-3.cm1.src.rpm
/home/pawel/CBL-Mariner_package_tests2/toolkit/../build/INTERMEDIATE_SRPMS/cairo-1.16.0-5.cm1.src.rpm
/home/pawel/CBL-Mariner_package_tests2/toolkit/../build/INTERMEDIATE_SRPMS/rubygem-fluent-plugin-kafka-0.13.0-1.cm1.src.rpm
/home/pawel/CBL-Mariner_package_tests2/toolkit/../build/INTERMEDIATE_SRPMS/python-pyasn1-0.4.4-3.cm1.src.rpm
/home/pawel/CBL-Mariner_package_tests2/toolkit/../build/INTERMEDIATE_SRPMS/libpwquality-1.4.2-6.cm1.src.rpm
/home/pawel/CBL-Mariner_package_tests2/toolkit/../build/INTERMEDIATE_SRPMS/bridge-utils-1.6-4.cm1.src.rpm
/home/pawel/CBL-Mariner_package_tests2/toolkit/../build/INTERMEDIATE_SRPMS/libxslt-1.1.34-2.cm1.src.rpm
/home/pawel/CBL-Mariner_package_tests2/toolkit/../build/INTERMEDIATE_SRPMS/postgresql-12.6-1.cm1.src.rpm
/home/pawel/CBL-Mariner_package_tests2/toolkit/../build/INTERMEDIATE_SRPMS/intltool-0.51.0-7.cm1.src.rpm
/home/pawel/CBL-Mariner_package_tests2/toolkit/../build/INTERMEDIATE_SRPMS/nfs-utils-2.3.3-8.cm1.src.rpm
(...) do \
        srpm_file=${srpm} && \
        spec_destination=/home/pawel/CBL-Mariner_package_tests2/toolkit/../build/INTERMEDIATE_SPECS/$(rpm -qp ${srpm_file} --define='with_check 1' --queryformat %{NAME}-%{VERSION}-%{RELEASE}/%{NAME}.spec) && \
        spec_dir=$(dirname ${spec_destination}) && \
        if [ ${srpm_file} -nt /home/pawel/CBL-Mariner_package_tests2/toolkit/../build/make_status/build_specs.flag -o ! -f /home/pawel/CBL-Mariner_package_tests2/toolkit/../build/make_status/build_specs.flag ]; then \
                mkdir -p ${spec_dir} && \
                echo extracting ${spec_destination} && \
                cd ${spec_dir} && rpm2cpio ${srpm_file} | cpio -idvu || { echo "Failed to expand ${srpm_file}" ; exit 1 ; } ; \
        fi || { echo "If in /home/pawel/CBL-Mariner_package_tests2/toolkit/../build/make_status/build_specs.flag failed" ; exit 1 ; } ; \
done || { echo "Loop in /home/pawel/CBL-Mariner_package_tests2/toolkit/../build/make_status/build_specs.flag failed" ; exit 1 ; } ; \
Adding RPMS to worker chroot: xz-libs-5.2.4-3.cm1.x86_64.rpm
extracting /data2/vsts_official/_work/8/s/toolkit/../build/INTERMEDIATE_SPECS/libXinerama-1.1.3-2.cm1/libXinerama.spec
Found full path for package xz-libs-5.2.4-3.cm1.x86_64.rpm in /data2/vsts_official/_work/8/s/toolkit/../build/rpm_cache/cache/: (/data2/vsts_official/_work/8/s/toolkit/../build/rpm_cache/cache/x86_64/xz-libs-5.2.4-3.cm1.x86_64.rpm)
libXinerama-1.1.3.tar.bz2
libXinerama.spec
547 blocks
extracting /data2/vsts_official/_work/8/s/toolkit/../build/INTERMEDIATE_SPECS/upower-0.99.7-1.cm1/upower.spec
upower-0.99.7.tar.xz
upower.spec
879 blocks
Adding RPMS to worker chroot: zstd-1.4.4-1.cm1.x86_64.rpm
extracting /data2/vsts_official/_work/8/s/toolkit/../build/INTERMEDIATE_SPECS/lxdm-themes-1-2.cm1/lxdm-themes.spec
Found full path for package zstd-1.4.4-1.cm1.x86_64.rpm in /data2/vsts_official/_work/8/s/toolkit/../build/rpm_cache/cache/: (/data2/vsts_official/_work/8/s/toolkit/../build/rpm_cache/cache/x86_64/zstd-1.4.4-1.cm1.x86_64.rpm)
162422-Shadowplay.tar.gz
162597-Bare-Metal.tar.gz
Shadowplayv2.zip
Windows10-gtk-3.20-1.7.tar.gz
lxdm-themes-1.tar.xz
lxdm-themes.spec
1921 blocks
extracting /data2/vsts_official/_work/8/s/toolkit/../build/INTERMEDIATE_SPECS/xcb-proto-1.13-1.cm1/xcb-proto.spec
xcb-proto-1.13.tar.bz2
xcb-proto.spec
23486 blocks
```


Now:

- We removed the bash commands and made the output more human-readable.
- We only print a line if we've detected a new/updated SRPM, instead of printing a list of all read SRPMs as we did above.
```
Extracting new or updated SRPMs from "/home/pawel/CBL-MarinerCoreUI/build/INTERMEDIATE_SRPMS".
Extracting "marinerui-rpm-macros-1.0.0-1.cm1.src.rpm" to "/home/pawel/CBL-MarinerCoreUI/build/INTERMEDIATE_SPECS/marinerui-rpm-macros-1.0.0-1.cm1".
Extracting "libglvnd-1.3.2-3.cm1.src.rpm" to "/home/pawel/CBL-MarinerCoreUI/build/INTERMEDIATE_SPECS/libglvnd-1.3.2-3.cm1".
Extracting "libXt-1.2.0-3.cm1.src.rpm" to "/home/pawel/CBL-MarinerCoreUI/build/INTERMEDIATE_SPECS/libXt-1.2.0-3.cm1".
Extracting "libinput-1.16.4-2.cm1.src.rpm" to "/home/pawel/CBL-MarinerCoreUI/build/INTERMEDIATE_SPECS/libinput-1.16.4-2.cm1".
```

## Changes to worker chroot's creation logs.

We no longer print the following additional paths, which weren't helpful to the user:
```
Adding RPMS to worker chroot: binutils-2.32-5.cm1.x86_64.rpm
Found full path for package binutils-2.32-5.cm1.x86_64.rpm in /home/pawel/CBL-MarinerCoreUI/toolkit/../build/rpm_cache/cache/: (/home/pawel/CBL-MarinerCoreUI/toolkit/../build/rpm_cache/cache/x86_64/binutils-2.32-5.cm1.x86_64.rpm)
Adding RPMS to worker chroot: binutils-devel-2.32-5.cm1.x86_64.rpm
Found full path for package binutils-devel-2.32-5.cm1.x86_64.rpm in /home/pawel/CBL-MarinerCoreUI/toolkit/../build/rpm_cache/cache/: (/home/pawel/CBL-MarinerCoreUI/toolkit/../build/rpm_cache/cache/x86_64/binutils-devel-2.32-5.cm1.x86_64.rpm)
Adding RPMS to worker chroot: gmp-6.1.2-5.cm1.x86_64.rpm
Found full path for package gmp-6.1.2-5.cm1.x86_64.rpm in /home/pawel/CBL-MarinerCoreUI/toolkit/../build/rpm_cache/cache/: (/home/pawel/CBL-MarinerCoreUI/toolkit/../build/rpm_cache/cache/x86_64/gmp-6.1.2-5.cm1.x86_64.rpm)
Adding RPMS to worker chroot: gmp-devel-6.1.2-5.cm1.x86_64.rpm
Found full path for package gmp-devel-6.1.2-5.cm1.x86_64.rpm in /home/pawel/CBL-MarinerCoreUI/toolkit/../build/rpm_cache/cache/: (/home/pawel/CBL-MarinerCoreUI/toolkit/../build/rpm_cache/cache/x86_64/gmp-devel-6.1.2-5.cm1.x86_64.rpm)
Adding RPMS to worker chroot: mpfr-4.0.1-3.cm1.x86_64.rpm
Found full path for package mpfr-4.0.1-3.cm1.x86_64.rpm in /home/pawel/CBL-MarinerCoreUI/toolkit/../build/rpm_cache/cache/: (/home/pawel/CBL-MarinerCoreUI/toolkit/../build/rpm_cache/cache/x86_64/mpfr-4.0.1-3.cm1.x86_64.rpm)
```

We now dropped the paths and only list the packages being added. We still print error messages, if something goes wrong the same way did so far:
```
Adding RPMS to worker chroot: binutils-2.32-5.cm1.x86_64.rpm
Adding RPMS to worker chroot: binutils-devel-2.32-5.cm1.x86_64.rpm
Adding RPMS to worker chroot: gmp-6.1.2-5.cm1.x86_64.rpm
Adding RPMS to worker chroot: gmp-devel-6.1.2-5.cm1.x86_64.rpm
Adding RPMS to worker chroot: mpfr-4.0.1-3.cm1.x86_64.rpm
```

## Changes to toolchain download logs.

Further shortened the output by not printing a message when a toolchain tarball has finished downloading. Simply printing one line at the beginning of the download seems sufficient to display build progress and what is currently happening. Error messages and logs will still contain the additional line printed once a tarball has finished downloading.

Change from:
```
Downloading toolchain RPM: bash-devel-4.4.18-6.cm1.x86_64.rpm
Downloaded toolchain RPM: alsa-lib-1.2.2-1.cm1.x86_64.rpm
Downloaded toolchain RPM: alsa-lib-devel-1.2.2-1.cm1.x86_64.rpm
Downloading toolchain RPM: binutils-debuginfo-2.32-5.cm1.x86_64.rpm
Downloading toolchain RPM: binutils-devel-2.32-5.cm1.x86_64.rpm
Downloaded toolchain RPM: automake-1.16.1-3.cm1.noarch.rpm
Downloading toolchain RPM: bison-3.1-3.cm1.x86_64.rpm
Downloaded toolchain RPM: asciidoc-8.6.10-4.cm1.noarch.rpm
Downloading toolchain RPM: bison-debuginfo-3.1-3.cm1.x86_64.rpm
Downloaded toolchain RPM: autoconf-2.69-10.cm1.noarch.rpm
Downloaded toolchain RPM: bash-4.4.18-6.cm1.x86_64.rpm
Downloading toolchain RPM: bzip2-1.0.6-15.cm1.x86_64.rpm
Downloading toolchain RPM: bzip2-debuginfo-1.0.6-15.cm1.x86_64.rpm
Downloaded toolchain RPM: alsa-lib-debuginfo-1.2.2-1.cm1.x86_64.rpm
```

To:
```
Downloading toolchain RPM: bash-devel-4.4.18-6.cm1.x86_64.rpm
Downloading toolchain RPM: binutils-debuginfo-2.32-5.cm1.x86_64.rpm
Downloading toolchain RPM: binutils-devel-2.32-5.cm1.x86_64.rpm
Downloading toolchain RPM: bison-3.1-3.cm1.x86_64.rpm
Downloading toolchain RPM: bison-debuginfo-3.1-3.cm1.x86_64.rpm
Downloading toolchain RPM: bzip2-1.0.6-15.cm1.x86_64.rpm
Downloading toolchain RPM: bzip2-debuginfo-1.0.6-15.cm1.x86_64.rpm
```

## Changes to RPMs build logs.

Slight improvement removing the cryptic set of bash commands printed right after we created the workplan and before we start building the first packages.

We had:
```
INFO[0000] Successfully finished converting to format "makefile" - output file "/data2/vsts_official/_work/8/s/toolkit/../build/pkg_artifacts/workplan.mk". 
rm -f /data2/vsts_official/_work/8/s/toolkit/../build/logs/pkggen/failures.txt && \
make --silent -f /data2/vsts_official/_work/8/s/toolkit/../build/pkg_artifacts/workplan.mk go-pkgworker=/data2/vsts_official/_work/8/s/toolkit/out/tools/pkgworker CHROOT_DIR=/data2/vsts_official/_work/8/s/toolkit/../build/worker/chroot chroot_worker=/data2/vsts_official/_work/8/s/toolkit/../build/worker/worker_chroot.tar.gz SRPMS_DIR=/data2/vsts_official/_work/8/s/toolkit/../out/SRPMS RPMS_DIR=/data2/vsts_official/_work/8/s/toolkit/../out/RPMS pkggen_local_repo=/data2/vsts_official/_work/8/s/toolkit/resources/manifests/package/local.repo LOGS_DIR=/data2/vsts_official/_work/8/s/toolkit/../build/logs TOOLCHAIN_MANIFESTS_DIR=/data2/vsts_official/_work/8/s/toolkit/resources/manifests/package GOAL_PackagesToBuild && \
{ [ ! -f /data2/vsts_official/_work/8/s/toolkit/../build/logs/pkggen/failures.txt ] || \
	{ echo "Failed to build: $(cat /data2/vsts_official/_work/8/s/toolkit/../build/logs/pkggen/failures.txt)" ; exit 1 ; }; } && \
touch /data2/vsts_official/_work/8/s/toolkit/../build/make_status/build-rpms.flag
INFO[0000] Building (util-macros-1.19.2-1.cm1.src.rpm)
```

Now:
```
INFO[0000] Successfully finished converting to format "makefile" - output file "/data2/vsts_official/_work/8/s/build/pkg_artifacts/workplan.mk".
INFO[0000] Building (util-macros-1.19.2-1.cm1.src.rpm)
```

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Used `realpath` to make file paths shorter and easier to follow.
- Simplified SRPMs expansion console output.
- Reduced the noise during worker chroot creation.
- Shortened toolchain tarballs download logs.
- Removed printing bash commands starting up the RPMs build process.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
No.

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local packages build of the [CBL-MarinerCoreUI](https://github.com/microsoft/CBL-MarinerCoreUI) repo.
- Local packages build of the [CBL-MarinerDemo](https://github.com/microsoft/CBL-MarinerDemo) repo.
