### PR TITLE
Fix two bugs in cross gcc package

### DIFF
--- a/SPECS-CROSS/cross-gcc/cross-gcc.spec
+++ b/SPECS-CROSS/cross-gcc/cross-gcc.spec
@@ -72,6 +72,7 @@ Conflicts:      %{_cross_name}-gcc-bootstrap3
 Conflicts:      %{_cross_name}-glibc-bootstrap
 Conflicts:      %{_cross_name}-glibc-bootstrap2
 Conflicts:      %{_cross_name}-kernel-headers
+Requires:       libmpc
 
 %description
 Bundle of all files needed to cross compile with gcc including: gcc, glibc, binutils, kernel headers.
@@ -142,6 +143,13 @@ install -D %{_cross_name}-file_manifest.txt %{buildroot}/%{_cross_prefix}/%{_cro
 
 # %%post   -p /sbin/ldconfig
 # %%postun -p /sbin/ldconfig
+
+%post 
+
+# Create a symlink from sysroot/usr/include to sysroot/include
+# The GCC toolchain will look for header files under sysroot/usr/include
+mkdir -p %{_cross_sysroot}/usr
+ln -s "../include" %{_cross_sysroot}/usr
 
 %files -f %{_cross_name}-file_manifest.txt
 %defattr(-,root,root)

--- a/SPECS-CROSS/cross-gcc/cross-gcc.spec
+++ b/SPECS-CROSS/cross-gcc/cross-gcc.spec
@@ -132,6 +132,11 @@ for source_file in $(cat %{_cross_name}-file_manifest_with_dirs.txt | sort --uni
 done
 install -D %{_cross_name}-file_manifest.txt %{buildroot}/%{_cross_prefix}/%{_cross_name}-file_manifest.txt
 
+# Create a symlink from sysroot/usr/include to sysroot/include
+# The GCC toolchain will look for header files under sysroot/usr/include
+mkdir -p %{buildroot}/%{_cross_sysroot}/usr
+ln -s "../include" %{buildroot}/%{_cross_sysroot}/usr
+
 # Turning off so we don't get ldconfig errors for crossarch packages
 # Add the /opt/cross libs to the ldcache
 # mkdir -p %%{buildroot}%%{_sysconfdir}/ld.so.conf.d/
@@ -144,18 +149,12 @@ install -D %{_cross_name}-file_manifest.txt %{buildroot}/%{_cross_prefix}/%{_cro
 # %%post   -p /sbin/ldconfig
 # %%postun -p /sbin/ldconfig
 
-%post 
-
-# Create a symlink from sysroot/usr/include to sysroot/include
-# The GCC toolchain will look for header files under sysroot/usr/include
-mkdir -p %{_cross_sysroot}/usr
-ln -s "../include" %{_cross_sysroot}/usr
-
 %files -f %{_cross_name}-file_manifest.txt
 %defattr(-,root,root)
 %license licenses/*
 #%%{_sysconfdir}/ld.so.conf.d/%%{name}.conf
 %{_cross_prefix}/%{_cross_name}-file_manifest.txt
+%{_cross_sysroot}/usr
 
 %changelog
 * Tue Feb 23 2021 Daniel McIlvaney <damcilva@microsoft.com> - 0.1.0-1


### PR DESCRIPTION
This change fixes two bugs in the cross gcc package:

1. Missing `libmpc` dependency

    `libmpc` is needed when running the cross gcc package. A `Requires: libmpc` dependency was added to the cross gcc spec file to make sure that it's installed when the cross gcc package is installed. 

    Testing in a Mariner container: Verified by trying to install the cross gcc package without the `libmpc` package installed. The installation failed. I then installed the libmpc package and tried installing the cross gcc package. The installation passed and gcc was able to find libmpc.

2. sysroot include headers not being found by cross gcc

   The cross gcc tools were unable to find the sysroot include headers when gcc was invoked. Using the `-E -Wp,-v -` flags when invoking gcc, I found the header include paths it was searching and saw that there was a missing symlink when comparing the output. The symlink is now created during the %post step of the cross gcc package. 

   Testing in a Mariner container: Verified that headers under the sysroot/include path are now found when compiling a small C++ program.