### PR TITLE
Fixes for CVE-2020-35521, CVE-2020-35522, CVE-2020-35523, CVE-2020-35524

### DIFF
--- a/SPECS/libtiff/CVE-2020-35522.patch
+++ b/SPECS/libtiff/CVE-2020-35522.patch
@@ -1,0 +1,86 @@
+From 98a254f5b92cea22f5436555ff7fceb12afee84d Mon Sep 17 00:00:00 2001
+From: Thomas Bernard <miniupnp@free.fr>
+Date: Sun, 15 Nov 2020 17:02:51 +0100
+Subject: [PATCH] enforce (configurable) memory limit in tiff2rgba
+
+fixes #207
+fixes #209
+---
+ tools/tiff2rgba.c | 25 +++++++++++++++++++++++--
+ 1 file changed, 23 insertions(+), 2 deletions(-)
+
+diff --git a/tools/tiff2rgba.c b/tools/tiff2rgba.c
+index fbc383aa..764395f6 100644
+--- a/tools/tiff2rgba.c
++++ b/tools/tiff2rgba.c
+@@ -60,6 +60,10 @@ uint32 rowsperstrip = (uint32) -1;
+ int process_by_block = 0; /* default is whole image at once */
+ int no_alpha = 0;
+ int bigtiff_output = 0;
++#define DEFAULT_MAX_MALLOC (256 * 1024 * 1024)
++/* malloc size limit (in bytes)
++ * disabled when set to 0 */
++static tmsize_t maxMalloc = DEFAULT_MAX_MALLOC;
+ 
+ 
+ static int tiffcvt(TIFF* in, TIFF* out);
+@@ -75,8 +79,11 @@ main(int argc, char* argv[])
+ 	extern char *optarg;
+ #endif
+ 
+-	while ((c = getopt(argc, argv, "c:r:t:bn8")) != -1)
++	while ((c = getopt(argc, argv, "c:r:t:bn8M:")) != -1)
+ 		switch (c) {
++			case 'M':
++				maxMalloc = (tmsize_t)strtoul(optarg, NULL, 0) << 20;
++				break;
+ 			case 'b':
+ 				process_by_block = 1;
+ 				break;
+@@ -405,6 +412,12 @@ cvt_whole_image( TIFF *in, TIFF *out )
+ 		  (unsigned long)width, (unsigned long)height);
+         return 0;
+     }
++    if (maxMalloc != 0 && (tmsize_t)pixel_count * (tmsize_t)sizeof(uint32) > maxMalloc) {
++	TIFFError(TIFFFileName(in),
++		  "Raster size " TIFF_UINT64_FORMAT " over memory limit (" TIFF_UINT64_FORMAT "), try -b option.",
++		  (uint64)pixel_count * sizeof(uint32), (uint64)maxMalloc);
++        return 0;
++    }
+ 
+     rowsperstrip = TIFFDefaultStripSize(out, rowsperstrip);
+     TIFFSetField(out, TIFFTAG_ROWSPERSTRIP, rowsperstrip);
+@@ -530,6 +543,13 @@ tiffcvt(TIFF* in, TIFF* out)
+ 	TIFFSetField(out, TIFFTAG_SOFTWARE, TIFFGetVersion());
+ 	CopyField(TIFFTAG_DOCUMENTNAME, stringv);
+ 
++	if (maxMalloc != 0 && TIFFStripSize(in) > maxMalloc)
++	{
++		TIFFError(TIFFFileName(in),
++			  "Strip Size " TIFF_UINT64_FORMAT " over memory limit (" TIFF_UINT64_FORMAT ")",
++			  (uint64)TIFFStripSize(in), (uint64)maxMalloc);
++		return 0;
++	}
+         if( process_by_block && TIFFIsTiled( in ) )
+             return( cvt_by_tile( in, out ) );
+         else if( process_by_block )
+@@ -549,7 +552,7 @@ tiffcvt(TIFF* in, TIFF* out)
+ }
+ 
+ static char* stuff[] = {
+-    "usage: tiff2rgba [-c comp] [-r rows] [-b] [-n] [-8] input... output",
++    "usage: tiff2rgba [-c comp] [-r rows] [-b] [-n] [-8] [-M size] input... output",
+     "where comp is one of the following compression algorithms:",
+     " jpeg\t\tJPEG encoding",
+     " zip\t\tZip/Deflate encoding",
+@@ -551,6 +571,7 @@ static const char* stuff[] = {
+     " -b (progress by block rather than as a whole image)",
+     " -n don't emit alpha component.",
+     " -8 write BigTIFF file instead of ClassicTIFF",
++    " -M set the memory allocation limit in MiB. 0 to disable limit",
+     NULL
+ };
+ 
+-- 
+GitLab
+

--- a/SPECS/libtiff/CVE-2020-35523.patch
+++ b/SPECS/libtiff/CVE-2020-35523.patch
@@ -1,0 +1,50 @@
+From c8d613ef497058fe653c467fc84c70a62a4a71b2 Mon Sep 17 00:00:00 2001
+From: Thomas Bernard <miniupnp@free.fr>
+Date: Tue, 10 Nov 2020 01:54:30 +0100
+Subject: [PATCH] gtTileContig(): check Tile width for overflow
+
+fixes #211
+---
+ libtiff/tif_getimage.c | 17 +++++++++++++----
+ 1 file changed, 13 insertions(+), 4 deletions(-)
+
+diff --git a/libtiff/tif_getimage.c b/libtiff/tif_getimage.c
+index 4da785d3..96ab1460 100644
+--- a/libtiff/tif_getimage.c
++++ b/libtiff/tif_getimage.c
+@@ -29,6 +29,7 @@
+  */
+ #include "tiffiop.h"
+ #include <stdio.h>
++#include <limits.h>
+ 
+ static int gtTileContig(TIFFRGBAImage*, uint32*, uint32, uint32);
+ static int gtTileSeparate(TIFFRGBAImage*, uint32*, uint32, uint32);
+@@ -645,12 +646,20 @@ gtTileContig(TIFFRGBAImage* img, uint32* raster, uint32 w, uint32 h)
+ 
+     flip = setorientation(img);
+     if (flip & FLIP_VERTICALLY) {
+-	    y = h - 1;
+-	    toskew = -(int32)(tw + w);
++        if ((tw + w) > INT_MAX) {
++            TIFFErrorExt(tif->tif_clientdata, TIFFFileName(tif), "%s", "unsupported tile size (too wide)");
++            return (0);
++        }
++        y = h - 1;
++        toskew = -(int32)(tw + w);
+     }
+     else {
+-	    y = 0;
+-	    toskew = -(int32)(tw - w);
++        if (tw > (INT_MAX + w)) {
++            TIFFErrorExt(tif->tif_clientdata, TIFFFileName(tif), "%s", "unsupported tile size (too wide)");
++            return (0);
++        }
++        y = 0;
++        toskew = -(int32)(tw - w);
+     }
+      
+     /*
+-- 
+GitLab
+

--- a/SPECS/libtiff/CVE-2020-35524.patch
+++ b/SPECS/libtiff/CVE-2020-35524.patch
@@ -1,0 +1,39 @@
+From 7be2e452ddcf6d7abca88f41d3761e6edab72b22 Mon Sep 17 00:00:00 2001
+From: Thomas Bernard <miniupnp@free.fr>
+Date: Sat, 14 Nov 2020 12:53:01 +0000
+Subject: [PATCH] tiff2pdf.c: properly calculate datasize when saving to JPEG
+ YCbCr
+
+fixes #220
+---
+ tools/tiff2pdf.c | 14 +++++++++++---
+ 1 file changed, 11 insertions(+), 3 deletions(-)
+
+diff --git a/tools/tiff2pdf.c b/tools/tiff2pdf.c
+index 719811ea..d0b0ede7 100644
+--- a/tools/tiff2pdf.c
++++ b/tools/tiff2pdf.c
+@@ -2087,9 +2087,17 @@ void t2p_read_tiff_size(T2P* t2p, TIFF* input){
+ #endif
+ 		(void) 0;
+ 	}
+-	k = checkMultiply64(TIFFScanlineSize(input), t2p->tiff_length, t2p);
+-	if(t2p->tiff_planar==PLANARCONFIG_SEPARATE){
+-		k = checkMultiply64(k, t2p->tiff_samplesperpixel, t2p);
++#ifdef JPEG_SUPPORT
++	if(t2p->pdf_compression == T2P_COMPRESS_JPEG
++	   && t2p->tiff_photometric == PHOTOMETRIC_YCBCR) {
++		k = checkMultiply64(TIFFNumberOfStrips(input), TIFFStripSize(input), t2p);
++	} else
++#endif
++	{
++		k = checkMultiply64(TIFFScanlineSize(input), t2p->tiff_length, t2p);
++		if(t2p->tiff_planar==PLANARCONFIG_SEPARATE){
++			k = checkMultiply64(k, t2p->tiff_samplesperpixel, t2p);
++		}
+ 	}
+ 	if (k == 0) {
+ 		/* Assume we had overflow inside TIFFScanlineSize */
+-- 
+GitLab
+

--- a/SPECS/libtiff/libtiff.spec
+++ b/SPECS/libtiff/libtiff.spec
@@ -1,15 +1,21 @@
 Summary:        TIFF libraries and associated utilities.
 Name:           libtiff
 Version:        4.1.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        libtiff
 URL:            https://gitlab.com/libtiff/libtiff
 Group:          System Environment/Libraries
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Source0:        https://gitlab.com/libtiff/libtiff/-/archive/v%{version}/libtiff-v%{version}.tar.gz
+# CVE-2020-35522 also covers 35521.
+Patch0: CVE-2020-35521.nopatch
+Patch1: CVE-2020-35522.patch
+Patch2: CVE-2020-35523.patch
+Patch3: CVE-2020-35524.patch
 BuildRequires:  libjpeg-turbo-devel
 Requires:       libjpeg-turbo
+
 %description
 The LibTIFF package contains the TIFF libraries and associated utilities. The libraries are used by many programs for reading and writing TIFF files and the utilities are used for general work with TIFF files.
 
@@ -22,6 +28,11 @@ It contains the libraries and header files to create applications
 
 %prep
 %setup -q -n libtiff-v%{version}
+%patch0 -p1
+%patch1 -p1
+%patch2 -p1
+%patch3 -p1
+
 %build
 sh autogen.sh
 %configure \
@@ -57,6 +68,8 @@ make %{?_smp_mflags} -k check
 %{_datadir}/man/man3/*
 
 %changelog
+*   Fri Mar 19 2021 Jon Slobodzian <joslobo@microsoft.com> - 4.1.0-2
+-   Add patches for CVE-2020-35521, CVE-2020-35522, CVE-2020-35523, CVE-2020-35524
 *   Tue May 26 2020 Ruying Chen <v-ruyche@microsoft.com> - 4.1.0-1
 -   Update to 4.1.0
 *   Wed May 13 2020 Nick Samson <nisamson@microsoft.com> - 4.0.10-6


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Fixes for CVE-2020-35521, CVE-2020-35522, CVE-2020-35523, CVE-2020-35524

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
YES
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2020-35521
- https://nvd.nist.gov/vuln/detail/CVE-2020-35522
- https://nvd.nist.gov/vuln/detail/CVE-2020-35523
- https://nvd.nist.gov/vuln/detail/CVE-2020-35524

###### Test Methodology
Ran self-test
time="2021-03-20T00:54:49-07:00" level=debug msg="============================================================================"
time="2021-03-20T00:54:49-07:00" level=debug msg="Testsuite summary for LibTIFF Software 4.1.0"
time="2021-03-20T00:54:49-07:00" level=debug msg="============================================================================"
**time="2021-03-20T00:54:49-07:00" level=debug msg="# TOTAL: 87"**
**time="2021-03-20T00:54:49-07:00" level=debug msg="# PASS:  87"**
time="2021-03-20T00:54:49-07:00" level=debug msg="# SKIP:  0"
time="2021-03-20T00:54:49-07:00" level=debug msg="# XFAIL: 0"
time="2021-03-20T00:54:49-07:00" level=debug msg="# FAIL:  0"
time="2021-03-20T00:54:49-07:00" level=debug msg="# XPASS: 0"
time="2021-03-20T00:54:49-07:00" level=debug msg="# ERROR: 0"