### PR TITLE
Configure /proc with hidepid by default and add doPseudoFsMount to addEntryToFstab

### DIFF
--- a/toolkit/docs/formats/imageconfig.md
+++ b/toolkit/docs/formats/imageconfig.md
@@ -253,7 +253,7 @@ A sample KernelCommandLine enabling a basic IMA mode and passing two additional 
 
 ### HidepidDisabled
 
-An optional flag that removes the `hidepid` option from `/proc`. `Hidepid` prevents proc IDs from being visible to all users.
+An optional flag that removes the `hidepid` option from `/proc`. `Hidepid` prevents proc IDs from being visible to all users. Set this flag if mounting `/proc` in postinstall scripts to ensure the mount options are set correctly.
 
 ### Users
 

--- a/toolkit/docs/formats/imageconfig.md
+++ b/toolkit/docs/formats/imageconfig.md
@@ -251,9 +251,9 @@ A sample KernelCommandLine enabling a basic IMA mode and passing two additional 
 },
 ```
 
-### HidepidDisable
+### HidepidDisabled
 
-An optional flag that removes the hidepid option from /proc. Hidepid prevents proc ids from being visible to all users.
+An optional flag that removes the `hidepid` option from `/proc`. `Hidepid` prevents proc IDs from being visible to all users.
 
 ### Users
 

--- a/toolkit/docs/formats/imageconfig.md
+++ b/toolkit/docs/formats/imageconfig.md
@@ -251,6 +251,10 @@ A sample KernelCommandLine enabling a basic IMA mode and passing two additional 
 },
 ```
 
+### HidepidDisable
+
+An optional flag that removes the hidepid option from /proc. Hidepid prevents proc ids from being visible to all users.
+
 ### Users
 
 Users is an array of user information. The User information is a map of key value pairs.

--- a/toolkit/tools/imagegen/configuration/configuration_test.go
+++ b/toolkit/tools/imagegen/configuration/configuration_test.go
@@ -354,6 +354,7 @@ var expectedConfiguration Config = Config{
 				TmpfsOverlays:                nil,
 				TmpfsOverlaySize:             "20%",
 			},
+			HidepidDisabled: true,
 		},
 		{
 			Name: "BiggerDiskA",

--- a/toolkit/tools/imagegen/configuration/systemconfig.go
+++ b/toolkit/tools/imagegen/configuration/systemconfig.go
@@ -30,6 +30,7 @@ type SystemConfig struct {
 	Encryption         RootEncryption      `json:"Encryption"`
 	RemoveRpmDb        bool                `json:"RemoveRpmDb"`
 	ReadOnlyVerityRoot ReadOnlyVerityRoot  `json:"ReadOnlyVerityRoot"`
+	HidepidDisable     bool                `json:"HidepidDisable"`
 }
 
 // GetRootPartitionSetting returns a pointer to the partition setting describing the disk which
@@ -132,6 +133,8 @@ func (s *SystemConfig) IsValid() (err error) {
 	}
 
 	//Validate Encryption
+
+	//Validate HidepidDisable
 
 	return
 }

--- a/toolkit/tools/imagegen/configuration/systemconfig.go
+++ b/toolkit/tools/imagegen/configuration/systemconfig.go
@@ -30,7 +30,7 @@ type SystemConfig struct {
 	Encryption         RootEncryption      `json:"Encryption"`
 	RemoveRpmDb        bool                `json:"RemoveRpmDb"`
 	ReadOnlyVerityRoot ReadOnlyVerityRoot  `json:"ReadOnlyVerityRoot"`
-	HidepidDisable     bool                `json:"HidepidDisable"`
+	HidepidDisabled    bool                `json:"HidepidDisabled"`
 }
 
 // GetRootPartitionSetting returns a pointer to the partition setting describing the disk which
@@ -134,7 +134,7 @@ func (s *SystemConfig) IsValid() (err error) {
 
 	//Validate Encryption
 
-	//Validate HidepidDisable
+	//Validate HidepidDisabled
 
 	return
 }

--- a/toolkit/tools/imagegen/configuration/testdata/test_configuration.json
+++ b/toolkit/tools/imagegen/configuration/testdata/test_configuration.json
@@ -186,7 +186,8 @@
             "RemoveRpmDb": false,
             "ReadOnlyVerityRoot": {
                 "Enable": false
-            }
+            },
+            "HidepidDisabled": true
         },
         {
             "Name": "BiggerDiskA",

--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -775,7 +775,7 @@ func updateFstab(installRoot string, installMap, mountPointToFsTypeMap, mountPoi
 	}
 
 	if hidepidEnable {
-		err = addEntryToFstab(installRoot, "/proc", "proc", "proc","rw,nosuid,nodev,noexec,relatime,hidepid=2", true)
+		err = addEntryToFstab(installRoot, "/proc", "proc", "proc", "rw,nosuid,nodev,noexec,relatime,hidepid=2", true)
 		if err != nil {
 			return
 		}

--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -373,8 +373,9 @@ func PackageNamesFromConfig(config configuration.Config) (packageList []*pkgjson
 // - mountPointToMountArgsMap is a map of mountpoints to mount options
 // - isRootFS specifies if the installroot is either backed by a directory (rootfs) or a raw disk
 // - encryptedRoot stores information about the encrypted root device if root encryption is enabled
-//- diffDiskBuild is a flag that denotes whether this is a diffdisk build or not
-func PopulateInstallRoot(installChroot *safechroot.Chroot, packagesToInstall []string, config configuration.SystemConfig, installMap, mountPointToFsTypeMap, mountPointToMountArgsMap map[string]string, isRootFS bool, encryptedRoot diskutils.EncryptedRootDevice, diffDiskBuild bool) (err error) {
+// - diffDiskBuild is a flag that denotes whether this is a diffdisk build or not
+// - hidepidEnable is a flag that denotes whether /proc will be mounted with the hidepid option
+func PopulateInstallRoot(installChroot *safechroot.Chroot, packagesToInstall []string, config configuration.SystemConfig, installMap, mountPointToFsTypeMap, mountPointToMountArgsMap map[string]string, isRootFS bool, encryptedRoot diskutils.EncryptedRootDevice, diffDiskBuild, hidepidEnable bool) (err error) {
 	const (
 		filesystemPkg = "filesystem"
 	)
@@ -446,7 +447,7 @@ func PopulateInstallRoot(installChroot *safechroot.Chroot, packagesToInstall []s
 
 	if !isRootFS {
 		// Configure system files
-		err = configureSystemFiles(installChroot, hostname, installMap, mountPointToFsTypeMap, mountPointToMountArgsMap, encryptedRoot)
+		err = configureSystemFiles(installChroot, hostname, installMap, mountPointToFsTypeMap, mountPointToMountArgsMap, encryptedRoot, hidepidEnable)
 		if err != nil {
 			return
 		}
@@ -599,7 +600,7 @@ func initializeTdnfConfiguration(installRoot string) (err error) {
 	return
 }
 
-func configureSystemFiles(installChroot *safechroot.Chroot, hostname string, installMap, mountPointToFsTypeMap, mountPointToMountArgsMap map[string]string, encryptedRoot diskutils.EncryptedRootDevice) (err error) {
+func configureSystemFiles(installChroot *safechroot.Chroot, hostname string, installMap, mountPointToFsTypeMap, mountPointToMountArgsMap map[string]string, encryptedRoot diskutils.EncryptedRootDevice, hidepidEnable bool) (err error) {
 	// Update hosts file
 	err = updateHosts(installChroot.RootDir(), hostname)
 	if err != nil {
@@ -607,7 +608,7 @@ func configureSystemFiles(installChroot *safechroot.Chroot, hostname string, ins
 	}
 
 	// Update fstab
-	err = updateFstab(installChroot.RootDir(), installMap, mountPointToFsTypeMap, mountPointToMountArgsMap)
+	err = updateFstab(installChroot.RootDir(), installMap, mountPointToFsTypeMap, mountPointToMountArgsMap, hidepidEnable)
 	if err != nil {
 		return
 	}
@@ -761,21 +762,28 @@ func updateInitramfsForEncrypt(installChroot *safechroot.Chroot) (err error) {
 	return
 }
 
-func updateFstab(installRoot string, installMap, mountPointToFsTypeMap, mountPointToMountArgsMap map[string]string) (err error) {
+func updateFstab(installRoot string, installMap, mountPointToFsTypeMap, mountPointToMountArgsMap map[string]string, hidepidEnable bool) (err error) {
 	ReportAction("Configuring fstab")
 
 	for mountPoint, devicePath := range installMap {
 		if mountPoint != "" && devicePath != NullDevice {
-			err = addEntryToFstab(installRoot, mountPoint, devicePath, mountPointToFsTypeMap[mountPoint], mountPointToMountArgsMap[mountPoint])
+			err = addEntryToFstab(installRoot, mountPoint, devicePath, mountPointToFsTypeMap[mountPoint], mountPointToMountArgsMap[mountPoint], false)
 			if err != nil {
 				return
 			}
 		}
 	}
+
+	if hidepidEnable {
+		err = addEntryToFstab(installRoot, "/proc", "proc", "proc","rw,nosuid,nodev,noexec,relatime,hidepid=2", true)
+		if err != nil {
+			return
+		}
+	}
 	return
 }
 
-func addEntryToFstab(installRoot, mountPoint, devicePath, fsType, mountArgs string) (err error) {
+func addEntryToFstab(installRoot, mountPoint, devicePath, fsType, mountArgs string, doPseudoFsMount bool) (err error) {
 	const (
 		uuidPrefix       = "UUID="
 		fstabPath        = "/etc/fstab"
@@ -807,6 +815,8 @@ func addEntryToFstab(installRoot, mountPoint, devicePath, fsType, mountArgs stri
 		device = devicePath
 	} else if diskutils.IsReadOnlyDevice(devicePath) {
 		device = devicePath
+	} else if doPseudoFsMount {
+		device = devicePath
 	} else {
 		uuid, err := GetUUID(devicePath)
 		if err != nil {
@@ -821,6 +831,8 @@ func addEntryToFstab(installRoot, mountPoint, devicePath, fsType, mountArgs stri
 	pass := defaultPass
 	if mountPoint == rootfsMountPoint {
 		pass = rootPass
+	} else if doPseudoFsMount {
+		pass = disablePass
 	}
 
 	// Construct fstab entry and append to fstab file

--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -374,8 +374,8 @@ func PackageNamesFromConfig(config configuration.Config) (packageList []*pkgjson
 // - isRootFS specifies if the installroot is either backed by a directory (rootfs) or a raw disk
 // - encryptedRoot stores information about the encrypted root device if root encryption is enabled
 // - diffDiskBuild is a flag that denotes whether this is a diffdisk build or not
-// - hidepidEnable is a flag that denotes whether /proc will be mounted with the hidepid option
-func PopulateInstallRoot(installChroot *safechroot.Chroot, packagesToInstall []string, config configuration.SystemConfig, installMap, mountPointToFsTypeMap, mountPointToMountArgsMap map[string]string, isRootFS bool, encryptedRoot diskutils.EncryptedRootDevice, diffDiskBuild, hidepidEnable bool) (err error) {
+// - hidepidEnabled is a flag that denotes whether /proc will be mounted with the hidepid option
+func PopulateInstallRoot(installChroot *safechroot.Chroot, packagesToInstall []string, config configuration.SystemConfig, installMap, mountPointToFsTypeMap, mountPointToMountArgsMap map[string]string, isRootFS bool, encryptedRoot diskutils.EncryptedRootDevice, diffDiskBuild, hidepidEnabled bool) (err error) {
 	const (
 		filesystemPkg = "filesystem"
 	)
@@ -447,7 +447,7 @@ func PopulateInstallRoot(installChroot *safechroot.Chroot, packagesToInstall []s
 
 	if !isRootFS {
 		// Configure system files
-		err = configureSystemFiles(installChroot, hostname, installMap, mountPointToFsTypeMap, mountPointToMountArgsMap, encryptedRoot, hidepidEnable)
+		err = configureSystemFiles(installChroot, hostname, installMap, mountPointToFsTypeMap, mountPointToMountArgsMap, encryptedRoot, hidepidEnabled)
 		if err != nil {
 			return
 		}
@@ -600,7 +600,7 @@ func initializeTdnfConfiguration(installRoot string) (err error) {
 	return
 }
 
-func configureSystemFiles(installChroot *safechroot.Chroot, hostname string, installMap, mountPointToFsTypeMap, mountPointToMountArgsMap map[string]string, encryptedRoot diskutils.EncryptedRootDevice, hidepidEnable bool) (err error) {
+func configureSystemFiles(installChroot *safechroot.Chroot, hostname string, installMap, mountPointToFsTypeMap, mountPointToMountArgsMap map[string]string, encryptedRoot diskutils.EncryptedRootDevice, hidepidEnabled bool) (err error) {
 	// Update hosts file
 	err = updateHosts(installChroot.RootDir(), hostname)
 	if err != nil {
@@ -608,7 +608,7 @@ func configureSystemFiles(installChroot *safechroot.Chroot, hostname string, ins
 	}
 
 	// Update fstab
-	err = updateFstab(installChroot.RootDir(), installMap, mountPointToFsTypeMap, mountPointToMountArgsMap, hidepidEnable)
+	err = updateFstab(installChroot.RootDir(), installMap, mountPointToFsTypeMap, mountPointToMountArgsMap, hidepidEnabled)
 	if err != nil {
 		return
 	}
@@ -762,20 +762,23 @@ func updateInitramfsForEncrypt(installChroot *safechroot.Chroot) (err error) {
 	return
 }
 
-func updateFstab(installRoot string, installMap, mountPointToFsTypeMap, mountPointToMountArgsMap map[string]string, hidepidEnable bool) (err error) {
+func updateFstab(installRoot string, installMap, mountPointToFsTypeMap, mountPointToMountArgsMap map[string]string, hidepidEnabled bool) (err error) {
+	const (
+		doPseudoFsMount = true
+	)
 	ReportAction("Configuring fstab")
 
 	for mountPoint, devicePath := range installMap {
 		if mountPoint != "" && devicePath != NullDevice {
-			err = addEntryToFstab(installRoot, mountPoint, devicePath, mountPointToFsTypeMap[mountPoint], mountPointToMountArgsMap[mountPoint], false)
+			err = addEntryToFstab(installRoot, mountPoint, devicePath, mountPointToFsTypeMap[mountPoint], mountPointToMountArgsMap[mountPoint], !doPseudoFsMount)
 			if err != nil {
 				return
 			}
 		}
 	}
 
-	if hidepidEnable {
-		err = addEntryToFstab(installRoot, "/proc", "proc", "proc", "rw,nosuid,nodev,noexec,relatime,hidepid=2", true)
+	if hidepidEnabled {
+		err = addEntryToFstab(installRoot, "/proc", "proc", "proc", "rw,nosuid,nodev,noexec,relatime,hidepid=2", doPseudoFsMount)
 		if err != nil {
 			return
 		}
@@ -811,11 +814,7 @@ func addEntryToFstab(installRoot, mountPoint, devicePath, fsType, mountArgs stri
 
 	// Get the block device
 	var device string
-	if diskutils.IsEncryptedDevice(devicePath) {
-		device = devicePath
-	} else if diskutils.IsReadOnlyDevice(devicePath) {
-		device = devicePath
-	} else if doPseudoFsMount {
+	if diskutils.IsEncryptedDevice(devicePath) || diskutils.IsReadOnlyDevice(devicePath) || doPseudoFsMount {
 		device = devicePath
 	} else {
 		uuid, err := GetUUID(devicePath)

--- a/toolkit/tools/imager/imager.go
+++ b/toolkit/tools/imager/imager.go
@@ -481,11 +481,8 @@ func buildImage(mountPointMap, mountPointToFsTypeMap, mountPointToMountArgsMap m
 		setupChrootPackages = append(setupChrootPackages, toolingPackage.Name)
 	}
 
-	logger.Log.Infof("HidepidDisabled is %v.", systemConfig.HidepidDisable)
-	hidepidEnable := true
-	if systemConfig.HidepidDisable {
-		hidepidEnable = false
-	}
+	logger.Log.Infof("HidepidDisabled is %v.", systemConfig.HidepidDisabled)
+	hidepidEnabled := !systemConfig.HidepidDisabled
 
 	if systemConfig.ReadOnlyVerityRoot.Enable {
 		// We will need the veritysetup package (and its dependencies) to manage the verity disk, add them to our
@@ -514,7 +511,7 @@ func buildImage(mountPointMap, mountPointToFsTypeMap, mountPointToMountArgsMap m
 	defer installChroot.Close(leaveChrootOnDisk)
 
 	// Populate image contents
-	err = installutils.PopulateInstallRoot(installChroot, packagesToInstall, systemConfig, installMap, mountPointToFsTypeMap, mountPointToMountArgsMap, isRootFS, encryptedRoot, diffDiskBuild, hidepidEnable)
+	err = installutils.PopulateInstallRoot(installChroot, packagesToInstall, systemConfig, installMap, mountPointToFsTypeMap, mountPointToMountArgsMap, isRootFS, encryptedRoot, diffDiskBuild, hidepidEnabled)
 	if err != nil {
 		err = fmt.Errorf("failed to populate image contents: %s", err)
 		return

--- a/toolkit/tools/imager/imager.go
+++ b/toolkit/tools/imager/imager.go
@@ -481,6 +481,12 @@ func buildImage(mountPointMap, mountPointToFsTypeMap, mountPointToMountArgsMap m
 		setupChrootPackages = append(setupChrootPackages, toolingPackage.Name)
 	}
 
+	logger.Log.Infof("HidepidDisabled is %v.", systemConfig.HidepidDisable)
+	hidepidEnable := true
+	if systemConfig.HidepidDisable {
+		hidepidEnable = false
+	}
+
 	if systemConfig.ReadOnlyVerityRoot.Enable {
 		// We will need the veritysetup package (and its dependencies) to manage the verity disk, add them to our
 		// image setup environment (setuproot chroot or live installer).
@@ -508,7 +514,7 @@ func buildImage(mountPointMap, mountPointToFsTypeMap, mountPointToMountArgsMap m
 	defer installChroot.Close(leaveChrootOnDisk)
 
 	// Populate image contents
-	err = installutils.PopulateInstallRoot(installChroot, packagesToInstall, systemConfig, installMap, mountPointToFsTypeMap, mountPointToMountArgsMap, isRootFS, encryptedRoot, diffDiskBuild)
+	err = installutils.PopulateInstallRoot(installChroot, packagesToInstall, systemConfig, installMap, mountPointToFsTypeMap, mountPointToMountArgsMap, isRootFS, encryptedRoot, diffDiskBuild, hidepidEnable)
 	if err != nil {
 		err = fmt.Errorf("failed to populate image contents: %s", err)
 		return


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
`Hidepid` is a mount option that prevents proc ids from being visible to all users. Without it, a non-privileged user can see all process identifiers (PIDs) and can `cat` the pid to see which process is involved.

Therefore, set ` hidepid` by default and allow users to opt out using the `HidepidDisable` config option. In order for these options to persist, the mount point is added to the fstab file. 

Since `/proc` is a pseudo file system, an argument was added to `addEntryToFstab` that specifies whether the mountpoint relates to a pseudo file system (such as /proc, /sys). This argument allows `device` to be set to the given path and the `pass num` be set to `0` since fsck checking does not apply to pseudo filesystems.  

Test with following commands
To see pids (with hidepid will only show those associated with your user unless privileged)
`ls -ld /proc/[0-9]*`

To see updated fstab file
`cat /etc/fstab`

To see /proc options
`mount | grep ^proc`

References:
https://linux-audit.com/linux-system-hardening-adding-hidepid-to-proc/
https://www.iezzi.ch/process-hiding-hidepid-capabilities-of-procfs/ 

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Added bool json config option "HidepidDisable". When set to true, proc is not mounted with the hidepid option and is not added to the fstab file. This results in hidepid being set by default
- Updated updateFstab to check if hidepid is enabled. If so, calls addEntryToFstab 
- Updated addEntryToFstab to check if using pseudo filesystem mount and if so, to disable pass and use given device
- Updated documentation

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO


###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- local build (x86, vhdx in hyper-v)
