### PR TITLE
gRPC: Turn off automatic provides

### DIFF
--- a/SPECS/grpc/grpc.spec
+++ b/SPECS/grpc/grpc.spec
@@ -1,7 +1,7 @@
 Summary:        Open source remote procedure call (RPC) framework
 Name:           grpc
 Version:        1.35.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -20,6 +20,7 @@ Source0:        %{name}-%{version}.tar.gz
 BuildRequires:  git
 BuildRequires:  cmake
 BuildRequires:  gcc
+AutoProv:       no
 
 %description
 gRPC is a modern, open source, high-performance remote procedure call (RPC) framework that can run anywhere. It enables client and server applications to communicate transparently, and simplifies the building of connected systems.
@@ -79,5 +80,8 @@ find %{buildroot} -name '*.cmake' -delete
 %{_bindir}/grpc_*_plugin
 
 %changelog
+* Fri Mar 26 2021 Chris Co <chrco@microsoft.com> - 1.35.0-2
+- Turn off RPM AutoProvides to prevent gRPC from mistakenly providing libz.so
+
 * Mon Mar 08 2021 Neha Agarwal <nehaagarwal@microsoft.com> - 1.35.0-1
 - Original CBL-Mariner version. License Verified.


### PR DESCRIPTION
gRPC appears to be building zlib libraries as part of its included
third party modules. RPM was then dynamically discovering and
automatically providing libz.so.1 shared objects in the gRPC metadata.
So when a different package (i.e., kmod) requires libz.so.1, both
gRPC and zlib RPMs matched equally and tdnf/rpm would select one at
random to install. If gRPC was selected, the tdnf installation would
fail with error code 20.

To prevent this from happening, turn off automatic provides in gRPC
so zlib is always used.

In the future, we may want to consider adjusting the CMAKE flags to
have gRPC autodetect zlib in the build environment instead of use
the third party submodule version.

$ rpm -qp grpc-1.35.0-1.cm1.x86_64.rpm --provides
warning: grpc-1.35.0-1.cm1.x86_64.rpm: Header V4 RSA/SHA256 Signature, key ID 3135ce90: NOKEY
grpc = 1.35.0-1.cm1
grpc(x86-64) = 1.35.0-1.cm1
libaddress_sorting.so.14()(64bit)
libgpr.so.14()(64bit)
libgrpc++.so.1()(64bit)
libgrpc++_alts.so.1()(64bit)
libgrpc++_error_details.so.1()(64bit)
libgrpc++_reflection.so.1()(64bit)
libgrpc++_unsecure.so.1()(64bit)
libgrpc.so.14()(64bit)
libgrpc_plugin_support.so.1()(64bit)
libgrpc_unsecure.so.14()(64bit)
libgrpcpp_channelz.so.1()(64bit)
libprotobuf-lite.so.3.14.0.0()(64bit)
libprotobuf.so.3.14.0.0()(64bit)
libprotoc.so.3.14.0.0()(64bit)
libupb.so.14()(64bit)
libz.so.1()(64bit)
libz.so.1(ZLIB_1.2.0)(64bit)
libz.so.1(ZLIB_1.2.0.2)(64bit)
libz.so.1(ZLIB_1.2.0.8)(64bit)
libz.so.1(ZLIB_1.2.2)(64bit)
libz.so.1(ZLIB_1.2.2.3)(64bit)
libz.so.1(ZLIB_1.2.2.4)(64bit)
libz.so.1(ZLIB_1.2.3.3)(64bit)
libz.so.1(ZLIB_1.2.3.4)(64bit)
libz.so.1(ZLIB_1.2.3.5)(64bit)
libz.so.1(ZLIB_1.2.5.1)(64bit)
libz.so.1(ZLIB_1.2.5.2)(64bit)
libz.so.1(ZLIB_1.2.7.1)(64bit)
libz.so.1(ZLIB_1.2.9)(64bit)

$ rpm -qp zlib-1.2.11-3.cm1.x86_64.rpm --provides
libz.so.1()(64bit)
libz.so.1(ZLIB_1.2.0)(64bit)
libz.so.1(ZLIB_1.2.0.2)(64bit)
libz.so.1(ZLIB_1.2.0.8)(64bit)
libz.so.1(ZLIB_1.2.2)(64bit)
libz.so.1(ZLIB_1.2.2.3)(64bit)
libz.so.1(ZLIB_1.2.2.4)(64bit)
libz.so.1(ZLIB_1.2.3.3)(64bit)
libz.so.1(ZLIB_1.2.3.4)(64bit)
libz.so.1(ZLIB_1.2.3.5)(64bit)
libz.so.1(ZLIB_1.2.5.1)(64bit)
libz.so.1(ZLIB_1.2.5.2)(64bit)
libz.so.1(ZLIB_1.2.7.1)(64bit)
libz.so.1(ZLIB_1.2.9)(64bit)
zlib = 1.2.11-3.cm1
zlib(x86-64) = 1.2.11-3.cm1

$ rpm -qp kmod-25-4.cm1.x86_64.rpm --requires
/sbin/ldconfig
/sbin/ldconfig
libc.so.6()(64bit)
libc.so.6(GLIBC_2.14)(64bit)
libc.so.6(GLIBC_2.17)(64bit)
libc.so.6(GLIBC_2.2.5)(64bit)
libc.so.6(GLIBC_2.3)(64bit)
libc.so.6(GLIBC_2.3.4)(64bit)
libc.so.6(GLIBC_2.4)(64bit)
libc.so.6(GLIBC_2.8)(64bit)
libgcc_s.so.1()(64bit)
libgcc_s.so.1(GCC_3.0)(64bit)
libgcc_s.so.1(GCC_3.3.1)(64bit)
liblzma.so.5()(64bit)
liblzma.so.5(XZ_5.0)(64bit)
libpthread.so.0()(64bit)
libpthread.so.0(GLIBC_2.2.5)(64bit)
libz.so.1()(64bit)
rpmlib(CompressedFileNames) <= 3.0.4-1
rpmlib(FileDigests) <= 4.6.0-1
rpmlib(PayloadFilesHavePrefix) <= 4.0-1
xz

$ rpm -qp grpc-1.35.0-2.cm1.x86_64.rpm --provides
grpc = 1.35.0-2.cm1
grpc(x86-64) = 1.35.0-2.cm1

Signed-off-by: Chris Co <chrco@microsoft.com>

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO


###### Links to CVEs  <!-- optional -->

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local build
