### PR TITLE
Fixing older toolkit builds. Ignoring 'BuildRequires' on pre-installed packages.

### DIFF
--- a/toolkit/tools/cgmanifest.json
+++ b/toolkit/tools/cgmanifest.json
@@ -31,6 +31,15 @@
             "Component": {
                 "Type": "Go",
                 "Go": {
+                    "Name": "github.com/deckarep/golang-set",
+                    "Version": "v1.7.1"
+                }
+            }
+        },
+        {
+            "Component": {
+                "Type": "Go",
+                "Go": {
                     "Name": "github.com/gdamore/tcell",
                     "Version": "v1.3.0"
                 }

--- a/toolkit/tools/go.mod
+++ b/toolkit/tools/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
 	github.com/bendahl/uinput v1.4.0
 	github.com/cavaliercoder/go-cpio v0.0.0-20180626203310-925f9528c45e
+	github.com/deckarep/golang-set v1.7.1
 	github.com/gdamore/tcell v1.3.0
 	github.com/klauspost/compress v1.10.5 // indirect
 	github.com/klauspost/pgzip v1.2.3

--- a/toolkit/tools/go.sum
+++ b/toolkit/tools/go.sum
@@ -12,6 +12,8 @@ github.com/cavaliercoder/go-cpio v0.0.0-20180626203310-925f9528c45e/go.mod h1:oD
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/deckarep/golang-set v1.7.1 h1:SCQV0S6gTtp6itiFrTqI+pfmJ4LN85S1YzhDf9rTHJQ=
+github.com/deckarep/golang-set v1.7.1/go.mod h1:93vsz/8Wt4joVM7c2AVqh+YRMiUSc14yDtF28KmMOgQ=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/gdamore/encoding v1.0.0 h1:+7OoQ1Bc6eTm5niUzBa0Ctsh6JbMW6Ra+YNuAtDBdko=
 github.com/gdamore/encoding v1.0.0/go.mod h1:alR0ol34c49FCSBLjhosxzcPHQbf2trDkoo5dl+VrEg=

--- a/toolkit/tools/internal/rpm/rpm.go
+++ b/toolkit/tools/internal/rpm/rpm.go
@@ -132,6 +132,15 @@ func DefaultDefines() map[string]string {
 	}
 }
 
+// GetInstalledPackages returns a string list of all packages installed on the system
+// in the "[name]-[version]-[release].[distribution].[architecture]" format.
+// Example: tdnf-2.1.0-4.cm1.x86_64
+func GetInstalledPackages() (result []string, err error) {
+	const queryArg = "-qa"
+
+	return executeRpmCommand(rpmProgram, queryArg)
+}
+
 // QuerySPEC queries a SPEC file with queryFormat. Returns the output split by line and trimmed.
 func QuerySPEC(specFile, sourceDir, queryFormat string, defines map[string]string, extraArgs ...string) (result []string, err error) {
 	const queryArg = "-q"

--- a/toolkit/tools/internal/safechroot/safechroot.go
+++ b/toolkit/tools/internal/safechroot/safechroot.go
@@ -513,7 +513,8 @@ func (c *Chroot) restoreRoot(originalRoot, originalWd *os.File) {
 func (c *Chroot) createMountPoints(allMountPoints []*MountPoint) (err error) {
 	for _, mountPoint := range allMountPoints {
 		fullPath := filepath.Join(c.rootDir, mountPoint.target)
-		logger.Log.Debugf("Mounting (%s)", fullPath)
+		logger.Log.Debugf("Mounting: source: (%s), target: (%s), fstype: (%s), flags: (%#x), data: (%s)",
+			mountPoint.source, fullPath, mountPoint.fstype, mountPoint.flags, mountPoint.data)
 
 		err = os.MkdirAll(fullPath, os.ModePerm)
 		if err != nil {

--- a/toolkit/tools/internal/sliceutils/sliceutils.go
+++ b/toolkit/tools/internal/sliceutils/sliceutils.go
@@ -3,6 +3,9 @@
 
 package sliceutils
 
+// NotFound value is returned by Find(), if a given value is not present in the slice.
+const NotFound = -1
+
 // Find returns an index of the first occurrence of thing in slice, or -1 if it does not appear in the slice.
 func Find(slice []string, thing string) int {
 	for i := range slice {
@@ -10,7 +13,7 @@ func Find(slice []string, thing string) int {
 			return i
 		}
 	}
-	return -1
+	return NotFound
 }
 
 // FindMatches returns a new slice keeping only these elements from slice that matcher returned true for.

--- a/toolkit/tools/pkgworker/pkgworker.go
+++ b/toolkit/tools/pkgworker/pkgworker.go
@@ -327,7 +327,7 @@ func installBuildRequires(buildRequires []string) (err error) {
 		return
 	}
 
-	logger.Log.Debugf("Will install the following built-time package requirements: %v", buildRequires)
+	logger.Log.Debugf("Will install the following build-time package requirements: %v", buildRequires)
 
 	defaultArgs := []string{"install", "-y"}
 	installArgs := append(defaultArgs, buildRequires...)

--- a/toolkit/tools/pkgworker/pkgworker.go
+++ b/toolkit/tools/pkgworker/pkgworker.go
@@ -271,7 +271,7 @@ func installBuildRequires(defines map[string]string, runCheck bool) (err error) 
 			stdout string
 		)
 
-		defaultArgs := []string{"install", "-y"}
+		defaultArgs := []string{"install", "-y", "--allowerasing"}
 		installArgs := make([]string, 0, len(buildRequires)+len(defaultArgs))
 
 		installArgs = append(installArgs, defaultArgs...)

--- a/toolkit/tools/pkgworker/pkgworker.go
+++ b/toolkit/tools/pkgworker/pkgworker.go
@@ -324,7 +324,7 @@ func installBuildRequires(buildRequires []string) (err error) {
 	)
 
 	if len(buildRequires) == 0 {
-		logger.Log.Debug("Build-time package requirements already satisfied. Skipping insallation step.")
+		logger.Log.Debug("Build-time package requirements already satisfied. Skipping installation step.")
 		return
 	}
 

--- a/toolkit/tools/pkgworker/pkgworker.go
+++ b/toolkit/tools/pkgworker/pkgworker.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	mapset "github.com/deckarep/golang-set"
 	"gopkg.in/alecthomas/kingpin.v2"
 	"microsoft.com/pkggen/internal/exe"
 	"microsoft.com/pkggen/internal/file"
@@ -55,9 +56,11 @@ var (
 )
 
 var (
-	greaterThanOrEqualRegex = regexp.MustCompile(` '?>='? [^ ]*`)
-	equalToRegex            = regexp.MustCompile(` '?='? `)
-	lessThanOrEqualToRegex  = regexp.MustCompile(` '?<='? `)
+	installedPackageNameRegex = regexp.MustCompile(`^(.+)(-[^-]+-[^-]+)`)
+	brPackageNameRegex        = regexp.MustCompile(`^[^\s]+`)
+	greaterThanOrEqualRegex   = regexp.MustCompile(` '?>='? [^ ]*`)
+	equalToRegex              = regexp.MustCompile(` '?='? `)
+	lessThanOrEqualToRegex    = regexp.MustCompile(` '?<='? `)
 )
 
 func main() {
@@ -162,7 +165,7 @@ func buildSRPMInChroot(chrootDir, rpmDirPath, workerTar, srpmFile, repoFile, rpm
 }
 
 func buildRPMFromSRPMInChroot(srpmFile string, runCheck bool, defines map[string]string) (err error) {
-	// Convert /localrpms into a repository that a package manager can use
+	// Convert /localrpms into a repository that a package manager can use.
 	err = rpmrepomanager.CreateRepo(chrootLocalRpmsDir)
 	if err != nil {
 		return
@@ -174,8 +177,14 @@ func buildRPMFromSRPMInChroot(srpmFile string, runCheck bool, defines map[string
 		return
 	}
 
-	// Query and install the build requirements for this SRPM
-	err = installBuildRequires(defines, runCheck)
+	// Find build requirements still not installed on the system.
+	missingBuildRequires, err := findMissingBuildRequires(defines, runCheck)
+	if err != nil {
+		return
+	}
+
+	// Install the missing build requirements for this SRPM.
+	err = installBuildRequires(missingBuildRequires)
 	if err != nil {
 		return
 	}
@@ -236,17 +245,13 @@ func moveBuiltRPMs(rpmOutDir, dstDir string) (builtRPMs []string, err error) {
 	return
 }
 
-func installBuildRequires(defines map[string]string, runCheck bool) (err error) {
-	// Query the BuildRequires fields from this spec and turn them into an array of PackageVersions
+func findMissingBuildRequires(defines map[string]string, runCheck bool) (missingBuildRequires []string, err error) {
 	const (
-		emptyQueryFormat        = ""
-		caCertificatesPackage   = "ca-certificates"
-		unresolvedOutputPrefix  = "No package"
-		unresolvedOutputPostfix = "available"
-		alreadyInstalledPostfix = "is already installed."
-		noMatchingPackagesErr   = "Error(1011) : No matching packages"
+		caCertificatesPackage = "ca-certificates"
+		emptyQueryFormat      = ""
+		packageNameMatchIndex = 1
 	)
-	// Find the SPEC file extracted from the SRPM
+
 	specDir := filepath.Join(chrootRpmBuildRoot, "SPECS")
 	allSpecFiles, err := ioutil.ReadDir(specDir)
 	if err != nil {
@@ -254,7 +259,7 @@ func installBuildRequires(defines map[string]string, runCheck bool) (err error) 
 	}
 
 	if len(allSpecFiles) != 1 {
-		return fmt.Errorf("unexpected number of SPEC files extracted, wanted (1) and found (%d)", len(allSpecFiles))
+		return missingBuildRequires, fmt.Errorf("unexpected number of SPEC files extracted, wanted (1) and found (%d)", len(allSpecFiles))
 	}
 
 	specFile := filepath.Join(specDir, allSpecFiles[0].Name())
@@ -265,65 +270,95 @@ func installBuildRequires(defines map[string]string, runCheck bool) (err error) 
 		return
 	}
 
-	if runCheck || len(buildRequires) > 0 {
-		var (
-			stderr string
-			stdout string
-		)
+	logger.Log.Debugf("List of all 'BuildRequires': %v", buildRequires)
 
-		defaultArgs := []string{"install", "-y", "--allowerasing"}
-		installArgs := make([]string, 0, len(buildRequires)+len(defaultArgs))
+	installedPackages, err := rpm.GetInstalledPackages()
+	if err != nil {
+		return
+	}
 
-		installArgs = append(installArgs, defaultArgs...)
+	logger.Log.Debugf("List of all installed packages: %v", installedPackages)
 
-		for _, pkg := range buildRequires {
-			// Replace version conditionals with tdnf friendly version:
-			// - replace >= with "latest" (no version)
-			// - replace = and <= with the exact version
-			buildReq := greaterThanOrEqualRegex.ReplaceAllString(pkg, "")
-			buildReq = equalToRegex.ReplaceAllString(buildReq, "-")
-			buildReq = lessThanOrEqualToRegex.ReplaceAllString(buildReq, "-")
+	installedPackagesSet := mapset.NewSet()
+	for _, installedPackage := range installedPackages {
+		installedPackage = installedPackageNameRegex.FindStringSubmatch(installedPackage)[packageNameMatchIndex]
+		installedPackagesSet.Add(installedPackage)
+	}
 
-			// Add each package to the installArgs
-			installArgs = append(installArgs, strings.TrimSpace(buildReq))
+	for _, singleBuildRequires := range buildRequires {
+		// Replace version conditionals with tdnf friendly version:
+		// - replace >= with "latest" (no version)
+		// - replace = and <= with the exact version
+		packageNameWithVersion := greaterThanOrEqualRegex.ReplaceAllString(singleBuildRequires, "")
+		packageNameWithVersion = equalToRegex.ReplaceAllString(packageNameWithVersion, "-")
+		packageNameWithVersion = lessThanOrEqualToRegex.ReplaceAllString(packageNameWithVersion, "-")
+		packageNameWithVersion = strings.TrimSpace(packageNameWithVersion)
+
+		packageName := brPackageNameRegex.FindString(singleBuildRequires)
+		if !installedPackagesSet.Contains(packageName) {
+			logger.Log.Debugf("Found a 'BuildRequires' to install: %s", packageNameWithVersion)
+			missingBuildRequires = append(missingBuildRequires, packageNameWithVersion)
 		}
+	}
 
-		if runCheck {
-			logger.Log.Debug("Adding the 'ca-certificates' package - needed for package tests.")
+	if runCheck {
+		logger.Log.Debug("Adding the 'ca-certificates' package - needed for package tests.")
 
-			installArgs = append(installArgs, caCertificatesPackage)
-		}
+		missingBuildRequires = append(missingBuildRequires, caCertificatesPackage)
+	}
 
-		stdout, stderr, err = shell.Execute("tdnf", installArgs...)
-		if err != nil {
-			logger.Log.Warnf("Failed to install build requirements. stderr: %s\nstdout: %s", stderr, stdout)
-			// TDNF will output an error if all packages are already installed.
-			// Ignore it iff there is no other error present in stderr.
-			splitStderr := strings.Split(stderr, "\n")
-			for _, line := range splitStderr {
-				trimmedLine := strings.TrimSpace(line)
-				if trimmedLine == "" {
-					continue
-				}
+	return
+}
 
-				if !strings.HasSuffix(trimmedLine, alreadyInstalledPostfix) && trimmedLine != noMatchingPackagesErr {
-					return fmt.Errorf(trimmedLine)
-				}
+func installBuildRequires(buildRequires []string) (err error) {
+	const (
+		noMatchingPackagesErr   = "Error(1011) : No matching packages"
+		unresolvedOutputPrefix  = "No package"
+		unresolvedOutputPostfix = "available"
+	)
+
+	var (
+		stderr string
+		stdout string
+	)
+
+	if len(buildRequires) == 0 {
+		logger.Log.Debug("Build-time package requirements already satisfied. Skipping insallation step.")
+		return
+	}
+
+	logger.Log.Debugf("Will install the following built-time package requirements: %v", buildRequires)
+
+	defaultArgs := []string{"install", "-y"}
+	installArgs := append(defaultArgs, buildRequires...)
+
+	stdout, stderr, err = shell.Execute("tdnf", installArgs...)
+	if err != nil {
+		logger.Log.Warnf("Failed to install build requirements. stderr: %s\nstdout: %s", stderr, stdout)
+		// Save only the relevant stderr in the error returned by the function.
+		splitStderr := strings.Split(stderr, "\n")
+		for _, line := range splitStderr {
+			trimmedLine := strings.TrimSpace(line)
+			if (trimmedLine == "") ||
+				(trimmedLine == noMatchingPackagesErr) {
+				continue
 			}
+
+			return fmt.Errorf(trimmedLine)
 		}
+	}
 
-		if err == nil {
-			// TDNF will ignore unavailable packages that have been requested to be installed without reporting an error code.
-			// Search the stdout of TDNF for such a failure and warn the user.
-			// This may happen if a SPEC requires the the path to a tool (e.g. /bin/cp), so mark it as a warning for now.
-			splitStdout := strings.Split(stdout, "\n")
-			for _, line := range splitStdout {
-				trimmedLine := strings.TrimSpace(line)
+	if err == nil {
+		// TDNF will ignore unavailable packages that have been requested to be installed without reporting an error code.
+		// Search the stdout of TDNF for such a failure and warn the user.
+		// This may happen if a SPEC requires the the path to a tool (e.g. /bin/cp), so mark it as a warning for now.
+		splitStdout := strings.Split(stdout, "\n")
+		for _, line := range splitStdout {
+			trimmedLine := strings.TrimSpace(line)
 
-				// If a package was not available, update err
-				if strings.HasPrefix(trimmedLine, unresolvedOutputPrefix) && strings.HasSuffix(trimmedLine, unresolvedOutputPostfix) {
-					logger.Log.Warnf("Unable to install buildrequires: %s", trimmedLine)
-				}
+			// If a package was not available, update err
+			if strings.HasPrefix(trimmedLine, unresolvedOutputPrefix) && strings.HasSuffix(trimmedLine, unresolvedOutputPostfix) {
+				logger.Log.Warnf("Unable to install buildrequires: %s", trimmedLine)
 			}
 		}
 	}
@@ -344,7 +379,7 @@ func removeLibArchivesFromSystem() (err error) {
 
 		// Skip directories that are meant for device files and kernel virtual filesystems.
 		// These will not contain .la files and are mounted into the safechroot from the host.
-		if info.IsDir() && sliceutils.Find(dirsToExclude, path) != -1 {
+		if info.IsDir() && sliceutils.Find(dirsToExclude, path) != sliceutils.NotFound {
 			return filepath.SkipDir
 		}
 

--- a/toolkit/tools/pkgworker/pkgworker.go
+++ b/toolkit/tools/pkgworker/pkgworker.go
@@ -56,10 +56,10 @@ var (
 )
 
 var (
-	installedPackageNameRegex = regexp.MustCompile(`^(.+)(-[^-]+-[^-]+)`)
 	brPackageNameRegex        = regexp.MustCompile(`^[^\s]+`)
-	greaterThanOrEqualRegex   = regexp.MustCompile(` '?>='? [^ ]*`)
 	equalToRegex              = regexp.MustCompile(` '?='? `)
+	greaterThanOrEqualRegex   = regexp.MustCompile(` '?>='? [^ ]*`)
+	installedPackageNameRegex = regexp.MustCompile(`^(.+)(-[^-]+-[^-]+)`)
 	lessThanOrEqualToRegex    = regexp.MustCompile(` '?<='? `)
 )
 
@@ -252,6 +252,7 @@ func findMissingBuildRequires(defines map[string]string, runCheck bool) (missing
 		packageNameMatchIndex = 1
 	)
 
+	// Find the SPEC file extracted from the SRPM
 	specDir := filepath.Join(chrootRpmBuildRoot, "SPECS")
 	allSpecFiles, err := ioutil.ReadDir(specDir)
 	if err != nil {
@@ -313,8 +314,8 @@ func findMissingBuildRequires(defines map[string]string, runCheck bool) (missing
 func installBuildRequires(buildRequires []string) (err error) {
 	const (
 		noMatchingPackagesErr   = "Error(1011) : No matching packages"
-		unresolvedOutputPrefix  = "No package"
 		unresolvedOutputPostfix = "available"
+		unresolvedOutputPrefix  = "No package"
 	)
 
 	var (


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

We've recently discovered an issue, where releasing a new version/release of a package, which is part of the pre-installed set of worker chroot packages, would break derivatives using older versions of the toolkit. The reason behind bug, was `tdnf install` finding a newer version of the package, but refusing to install it, since the same package (but with an older version) was already present inside the chroot.

We want to make sure derivatives build with the versions of the packages provided by the toolkit they are using and **not** silently update the packages without their knowledge. This is an initial step bringing us closer to that goal, where we remove any pre-installed packages from the `tdnf install` command. A final, long-term solution potentially supporting scenarios like downgrading packages, if a specific **older** versions is required explicitly in the derivative's spec is out of scope for this change.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Started ignoring pre-installed packages found in spec's `BuildRequires`.
- Added the `github.com/deckarep/golang-set` Go module.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
No.

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local package builds of the [CBL-MarinerDemo](https://github.com/microsoft/CBL-MarinerDemo) repo with an older toolkit (except for the code changes from this PR).
