### PR TITLE
diskutils: add more robust handling of disk/partition operations

### DIFF
--- a/toolkit/tools/imagegen/diskutils/diskutils.go
+++ b/toolkit/tools/imagegen/diskutils/diskutils.go
@@ -485,7 +485,10 @@ func InitializeSinglePartition(diskDevPath string, partitionNumber int, partitio
 		}
 		if flagToSet != "" {
 			args = append(args, flagToSet, "on")
-			_, stderr, err := shell.Execute("flock", "--timeout", timeoutInSeconds, diskDevPath, "parted", args...)
+			// Golang does not allow mixing of variadic and regular arguments. So add all of the flock args to
+			// the overall arg slice and pass that to execute
+			args = append([]string{"--timeout", timeoutInSeconds, diskDevPath, "parted"}, args...)
+			_, stderr, err := shell.Execute("flock", args...)
 			if err != nil {
 				logger.Log.Warnf("Failed to set flag (%s) using parted: %v", flagToSet, stderr)
 			}


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
This change has two parts:

* diskutils: always flock disk/partition operations

Parted can't be trusted to fully complete all disk operations by
the time it returns control. So add flock to every disk or partition
operation.

Also add a flock partprobe -s command after parted commands but before
any other non-parted command could run.

* diskutils: add retry logic

Partition creation and dynamic /dev file generation are still racing and all
the "fixes" that supposedly prevent these timing issues are just not
sufficient to fully solve the problem. So add retry logic to deal with
this problem. Not ideal but also not worth wasting any more cycles on this.

Signed-off-by: Chris Co <chrco@microsoft.com>

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
local build, pipeline build