### PR TITLE
Remove shortcuts from ISO installer views

### DIFF
--- a/toolkit/tools/imagegen/attendedinstaller/views/diskview/autopartitionwidget/autopartitionwidget.go
+++ b/toolkit/tools/imagegen/attendedinstaller/views/diskview/autopartitionwidget/autopartitionwidget.go
@@ -248,10 +248,9 @@ func (ap *AutoPartitionWidget) mustUpdateConfiguration(sysConfig *configuration.
 }
 
 func (ap *AutoPartitionWidget) populateBlockDeviceOptions() {
-	for i, disk := range ap.systemDevices {
+	for _, disk := range ap.systemDevices {
 		formattedSize := diskutils.BytesToSizeAndUnit(disk.RawDiskSize)
 		diskRepresentation := fmt.Sprintf("%s - %s @ %s", disk.Model, formattedSize, disk.DevicePath)
-		currentRune := rune(i + 'a')
-		ap.deviceList.AddItem(diskRepresentation, "", currentRune, nil)
+		ap.deviceList.AddItem(diskRepresentation, "", 0, nil)
 	}
 }

--- a/toolkit/tools/imagegen/attendedinstaller/views/installationview/installationview.go
+++ b/toolkit/tools/imagegen/attendedinstaller/views/installationview/installationview.go
@@ -159,8 +159,7 @@ func (iv *InstallationView) populateInstallOptions() (err error) {
 	}
 
 	for _, option := range iv.installOptions {
-		currentRune := rune(iv.optionList.GetItemCount() + 'a')
-		iv.optionList.AddItem(option, "", currentRune, nil)
+		iv.optionList.AddItem(option, "", 0, nil)
 	}
 
 	return

--- a/toolkit/tools/imagegen/attendedinstaller/views/installerview/installerview.go
+++ b/toolkit/tools/imagegen/attendedinstaller/views/installerview/installerview.go
@@ -164,8 +164,7 @@ func (iv *InstallerView) populateInstallerOptions() (err error) {
 	}
 
 	for _, option := range iv.installerOptions {
-		currentRune := rune(iv.optionList.GetItemCount() + 'a')
-		iv.optionList.AddItem(option, "", currentRune, nil)
+		iv.optionList.AddItem(option, "", 0, nil)
 	}
 
 	return


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Remove shortcuts from ISO installer views for improved text-to-speech accessibility

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Removes shortcuts from `AutoPartitionWidget`, `InstallationView`, `InstallerView` views

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Built and ran ISO with full configuration
