### PR TITLE
Patch CVE-2021-3416 and add tests to qemu-kvm

### DIFF
--- a/SPECS/qemu-kvm/CVE-2021-3416.patch
+++ b/SPECS/qemu-kvm/CVE-2021-3416.patch
@@ -1,0 +1,250 @@
+CVE-2021-3416 patch adapted from QEMU patch by Jason Wang <jasowang@redhat.com>
+
+Link: https://bugzilla.redhat.com/show_bug.cgi?id=1932827
+
+Signed-off-by: Neha Agarwal <nehaagarwal@microsoft.com>
+---
+ include/net/net.h    |  5 +++++
+ include/net/queue.h  |  8 ++++++++
+ net/net.c            | 38 +++++++++++++++++++++++++++++++-------
+ net/queue.c          | 22 ++++++++++++++++++++++
+ hw/net/e1000.c       |  2 +-
+ hw/net/dp8393x.c     |  2 +-
+ hw/net/sungem.c      |  2 +-
+ hw/net/net_tx_pkt.c  |  2 +-
+ hw/net/rtl8139.c     |  2 +-
+ hw/net/pcnet.c       |  2 +-
+ hw/net/lan9118.c     |  2 +-
+
+ 11 files changed, 73 insertions(+), 14 deletions(-)
+
+diff --git a/include/net/net.h b/include/net/net.h
+index 919faca..4f56cae 100644
+--- a/include/net/net.h
++++ b/include/net/net.h
+@@ -144,12 +144,17 @@ void *qemu_get_nic_opaque(NetClientState *nc);
+ void qemu_del_net_client(NetClientState *nc);
+ typedef void (*qemu_nic_foreach)(NICState *nic, void *opaque);
+ void qemu_foreach_nic(qemu_nic_foreach func, void *opaque);
++int qemu_can_receive_packet(NetClientState *nc);
+ int qemu_can_send_packet(NetClientState *nc);
+ ssize_t qemu_sendv_packet(NetClientState *nc, const struct iovec *iov,
+                           int iovcnt);
+ ssize_t qemu_sendv_packet_async(NetClientState *nc, const struct iovec *iov,
+                                 int iovcnt, NetPacketSent *sent_cb);
+ ssize_t qemu_send_packet(NetClientState *nc, const uint8_t *buf, int size);
++ssize_t qemu_receive_packet(NetClientState *nc, const uint8_t *buf, int size);
++ssize_t qemu_receive_packet_iov(NetClientState *nc,
++                                const struct iovec *iov,
++                                int iovcnt);
+ ssize_t qemu_send_packet_raw(NetClientState *nc, const uint8_t *buf, int size);
+ ssize_t qemu_send_packet_async(NetClientState *nc, const uint8_t *buf,
+                                int size, NetPacketSent *sent_cb);
+diff --git a/include/net/queue.h b/include/net/queue.h
+index c0269bb..9f2f289 100644
+--- a/include/net/queue.h
++++ b/include/net/queue.h
+@@ -55,6 +55,14 @@ void qemu_net_queue_append_iov(NetQueue *queue,
+ 
+ void qemu_del_net_queue(NetQueue *queue);
+ 
++ssize_t qemu_net_queue_receive(NetQueue *queue,
++                               const uint8_t *data,
++                               size_t size);
++
++ssize_t qemu_net_queue_receive_iov(NetQueue *queue,
++                                   const struct iovec *iov,
++                                   int iovcnt);
++
+ ssize_t qemu_net_queue_send(NetQueue *queue,
+                             NetClientState *sender,
+                             unsigned flags,
+diff --git a/net/net.c b/net/net.c
+index 77b35ea..edf9b95 100644
+--- a/net/net.c
++++ b/net/net.c
+@@ -529,6 +529,17 @@ int qemu_set_vnet_be(NetClientState *nc, bool is_be)
+ #endif
+ }
+ 
++int qemu_can_receive_packet(NetClientState *nc)
++{
++    if (nc->receive_disabled) {
++        return 0;
++    } else if (nc->info->can_receive &&
++               !nc->info->can_receive(nc)) {
++        return 0;
++    }
++    return 1;
++}
++
+ int qemu_can_send_packet(NetClientState *sender)
+ {
+     int vm_running = runstate_is_running();
+@@ -541,13 +552,7 @@ int qemu_can_send_packet(NetClientState *sender)
+         return 1;
+     }
+ 
+-    if (sender->peer->receive_disabled) {
+-        return 0;
+-    } else if (sender->peer->info->can_receive &&
+-               !sender->peer->info->can_receive(sender->peer)) {
+-        return 0;
+-    }
+-    return 1;
++    return qemu_can_receive_packet(sender->peer);
+ }
+ 
+ static ssize_t filter_receive_iov(NetClientState *nc,
+@@ -680,6 +685,25 @@ ssize_t qemu_send_packet(NetClientState *nc, const uint8_t *buf, int size)
+     return qemu_send_packet_async(nc, buf, size, NULL);
+ }
+ 
++ssize_t qemu_receive_packet(NetClientState *nc, const uint8_t *buf, int size)
++{
++    if (!qemu_can_receive_packet(nc)) {
++        return 0;
++    }
++
++    return qemu_net_queue_receive(nc->incoming_queue, buf, size);
++}
++
++ssize_t qemu_receive_packet_iov(NetClientState *nc, const struct iovec *iov,
++                                int iovcnt)
++{
++    if (!qemu_can_receive_packet(nc)) {
++        return 0;
++    }
++
++    return qemu_net_queue_receive_iov(nc->incoming_queue, iov, iovcnt);
++}
++
+ ssize_t qemu_send_packet_raw(NetClientState *nc, const uint8_t *buf, int size)
+ {
+     return qemu_send_packet_async_with_flags(nc, QEMU_NET_PACKET_FLAG_RAW,
+diff --git a/net/queue.c b/net/queue.c
+index 19e32c8..c872d51 100644
+--- a/net/queue.c
++++ b/net/queue.c
+@@ -182,6 +182,28 @@ static ssize_t qemu_net_queue_deliver_iov(NetQueue *queue,
+     return ret;
+ }
+ 
++ssize_t qemu_net_queue_receive(NetQueue *queue,
++                               const uint8_t *data,
++                               size_t size)
++{
++    if (queue->delivering) {
++        return 0;
++    }
++
++    return qemu_net_queue_deliver(queue, NULL, 0, data, size);
++}
++
++ssize_t qemu_net_queue_receive_iov(NetQueue *queue,
++                                   const struct iovec *iov,
++                                   int iovcnt)
++{
++    if (queue->delivering) {
++        return 0;
++    }
++
++    return qemu_net_queue_deliver_iov(queue, NULL, 0, iov, iovcnt);
++}
++
+ ssize_t qemu_net_queue_send(NetQueue *queue,
+                             NetClientState *sender,
+                             unsigned flags,
+diff --git a/hw/net/e1000.c b/hw/net/e1000.c
+index 4345d86..4f75b44 100644
+--- a/hw/net/e1000.c
++++ b/hw/net/e1000.c
+@@ -546,7 +546,7 @@ e1000_send_packet(E1000State *s, const uint8_t *buf, int size)
+ 
+     NetClientState *nc = qemu_get_queue(s->nic);
+     if (s->phy_reg[PHY_CTRL] & MII_CR_LOOPBACK) {
+-        nc->info->receive(nc, buf, size);
++        qemu_receive_packet(nc, buf, size);
+     } else {
+         qemu_send_packet(nc, buf, size);
+     }
+diff --git a/hw/net/dp8393x.c b/hw/net/dp8393x.c
+index 205c0de..533a830 100644
+--- a/hw/net/dp8393x.c
++++ b/hw/net/dp8393x.c
+@@ -506,7 +506,7 @@ static void dp8393x_do_transmit_packets(dp8393xState *s)
+             s->regs[SONIC_TCR] |= SONIC_TCR_CRSL;
+             if (nc->info->can_receive(nc)) {
+                 s->loopback_packet = 1;
+-                nc->info->receive(nc, s->tx_buffer, tx_len);
++                qemu_receive_packet(nc, s->tx_buffer, tx_len);
+             }
+         } else {
+             /* Transmit packet */
+diff --git a/hw/net/sungem.c b/hw/net/sungem.c
+index 33c3722..3684a4d 100644
+--- a/hw/net/sungem.c
++++ b/hw/net/sungem.c
+@@ -306,7 +306,7 @@ static void sungem_send_packet(SunGEMState *s, const uint8_t *buf,
+     NetClientState *nc = qemu_get_queue(s->nic);
+ 
+     if (s->macregs[MAC_XIFCFG >> 2] & MAC_XIFCFG_LBCK) {
+-        nc->info->receive(nc, buf, size);
++        qemu_receive_packet(nc, buf, size);
+     } else {
+         qemu_send_packet(nc, buf, size);
+     }
+diff --git a/hw/net/net_tx_pkt.c b/hw/net/net_tx_pkt.c
+index da262ed..1f9aa59 100644
+--- a/hw/net/net_tx_pkt.c
++++ b/hw/net/net_tx_pkt.c
+@@ -553,7 +553,7 @@ static inline void net_tx_pkt_sendv(struct NetTxPkt *pkt,
+     NetClientState *nc, const struct iovec *iov, int iov_cnt)
+ {
+     if (pkt->is_loopback) {
+-        nc->info->receive_iov(nc, iov, iov_cnt);
++        qemu_receive_packet_iov(nc, iov, iov_cnt);
+     } else {
+         qemu_sendv_packet(nc, iov, iov_cnt);
+     }
+diff --git a/hw/net/rtl8139.c b/hw/net/rtl8139.c
+index 4675ac8..90b4fc6 100644
+--- a/hw/net/rtl8139.c
++++ b/hw/net/rtl8139.c
+@@ -1795,7 +1795,7 @@ static void rtl8139_transfer_frame(RTL8139State *s, uint8_t *buf, int size,
+         }
+ 
+         DPRINTF("+++ transmit loopback mode\n");
+-        rtl8139_do_receive(qemu_get_queue(s->nic), buf, size, do_interrupt);
++        qemu_receive_packet(qemu_get_queue(s->nic), buf, size);
+ 
+         if (iov) {
+             g_free(buf2);
+diff --git a/hw/net/pcnet.c b/hw/net/pcnet.c
+index f3f18d8..dcd3fc4 100644
+--- a/hw/net/pcnet.c
++++ b/hw/net/pcnet.c
+@@ -1250,7 +1250,7 @@ txagain:
+             if (BCR_SWSTYLE(s) == 1)
+                 add_crc = !GET_FIELD(tmd.status, TMDS, NOFCS);
+             s->looptest = add_crc ? PCNET_LOOPTEST_CRC : PCNET_LOOPTEST_NOCRC;
+-            pcnet_receive(qemu_get_queue(s->nic), s->buffer, s->xmit_pos);
++            qemu_receive_packet(qemu_get_queue(s->nic), s->buffer, s->xmit_pos);
+             s->looptest = 0;
+         } else {
+             if (s->nic) {
+diff --git a/hw/net/lan9118.c b/hw/net/lan9118.c
+index abc7962..6aff424 100644
+--- a/hw/net/lan9118.c
++++ b/hw/net/lan9118.c
+@@ -680,7 +680,7 @@ static void do_tx_packet(lan9118_state *s)
+     /* FIXME: Honor TX disable, and allow queueing of packets.  */
+     if (s->phy_control & 0x4000)  {
+         /* This assumes the receive routine doesn't touch the VLANClient.  */
+-        lan9118_receive(qemu_get_queue(s->nic), s->txp->data, s->txp->len);
++        qemu_receive_packet(qemu_get_queue(s->nic), s->txp->data, s->txp->len);
+     } else {
+         qemu_send_packet(qemu_get_queue(s->nic), s->txp->data, s->txp->len);
+     }
+-- 
+1.8.3.1

--- a/SPECS/qemu-kvm/qemu-kvm.spec
+++ b/SPECS/qemu-kvm/qemu-kvm.spec
@@ -1,7 +1,7 @@
 Summary:        QEMU is a machine emulator and virtualizer
 Name:           qemu-kvm
 Version:        4.2.0
-Release:        27%{?dist}
+Release:        28%{?dist}
 License:        GPLv2 AND GPLv2+ AND CC-BY AND BSD
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -47,6 +47,7 @@ Patch28:        CVE-2020-27821.patch
 Patch29:        CVE-2020-17380.patch
 Patch30:        CVE-2021-20203.patch
 Patch31:        CVE-2021-20255.patch
+Patch32:        CVE-2021-3416.patch
 BuildRequires:  alsa-lib-devel
 BuildRequires:  glib-devel
 BuildRequires:  pixman-devel
@@ -103,6 +104,7 @@ This package provides a command line tool for manipulating disk images.
 %patch29 -p1
 %patch30 -p1
 %patch31 -p1
+%patch32 -p1
 
 %build
 
@@ -138,7 +140,50 @@ ln -sv qemu-system-`uname -m` %{buildroot}%{_bindir}/qemu
 chmod 755 %{buildroot}%{_bindir}/qemu
 
 %check
-# Deliberately empty
+testsPassed=true
+make check-unit
+retVal=$?
+if [ $retVal -ne 0 ]; then
+    testsPassed=false
+fi
+make check-qtest
+retVal=$?
+if [ $retVal -ne 0 ]; then
+    testsPassed=false
+fi
+make check-speed
+retVal=$?
+if [ $retVal -ne 0 ]; then
+    testsPassed=false
+fi
+make check-qapi-schema
+retVal=$?
+if [ $retVal -ne 0 ]; then
+    testsPassed=false
+fi
+make check-block
+retVal=$?
+if [ $retVal -ne 0 ]; then
+    testsPassed=false
+fi
+make check-tcg
+retVal=$?
+if [ $retVal -ne 0 ]; then
+    testsPassed=false
+fi
+make check-softfloat
+retVal=$?
+if [ $retVal -ne 0 ]; then
+    testsPassed=false
+fi
+make check-acceptance
+retVal=$?
+if [ $retVal -ne 0 ]; then
+    testsPassed=false
+fi
+if [ "$testsPassed" = false ] ; then
+    echo 'Some tests failed. Check log for further details'
+fi
 
 %files
 %defattr(-,root,root)
@@ -163,6 +208,9 @@ chmod 755 %{buildroot}%{_bindir}/qemu
 %{_bindir}/qemu-nbd
 
 %changelog
+* Tue Mar 30 2021 Neha Agarwal <nehaagarwal@microsoft.com> - 4.2.0-28
+- Patch CVE-2021-3416. Added test modules under check section.
+
 * Tue Mar 23 2021 Neha Agarwal <nehaagarwal@microsoft.com> - 4.2.0-27
 - Patch CVE-2021-20255
 

--- a/SPECS/qemu-kvm/qemu-kvm.spec
+++ b/SPECS/qemu-kvm/qemu-kvm.spec
@@ -142,47 +142,40 @@ chmod 755 %{buildroot}%{_bindir}/qemu
 %check
 testsPassed=true
 make check-unit
-retVal=$?
-if [ $retVal -ne 0 ]; then
+if [ $? -ne 0 ]; then
     testsPassed=false
 fi
 make check-qtest
-retVal=$?
-if [ $retVal -ne 0 ]; then
+if [ $? -ne 0 ]; then
     testsPassed=false
 fi
 make check-speed
-retVal=$?
-if [ $retVal -ne 0 ]; then
+if [ $? -ne 0 ]; then
     testsPassed=false
 fi
 make check-qapi-schema
-retVal=$?
-if [ $retVal -ne 0 ]; then
+if [ $? -ne 0 ]; then
     testsPassed=false
 fi
 make check-block
-retVal=$?
-if [ $retVal -ne 0 ]; then
+if [ $? -ne 0 ]; then
     testsPassed=false
 fi
 make check-tcg
-retVal=$?
-if [ $retVal -ne 0 ]; then
+if [ $? -ne 0 ]; then
     testsPassed=false
 fi
 make check-softfloat
-retVal=$?
-if [ $retVal -ne 0 ]; then
+if [ $? -ne 0 ]; then
     testsPassed=false
 fi
 make check-acceptance
-retVal=$?
-if [ $retVal -ne 0 ]; then
+if [ $? -ne 0 ]; then
     testsPassed=false
 fi
 if [ "$testsPassed" = false ] ; then
-    echo 'Some tests failed. Check log for further details'
+    echo 'One (or more) tests failed. Check log for further details'
+    (exit 1)
 fi
 
 %files


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
Patch CVE-2021-3416 and add tests to qemu-kvm

###### Change Log  <!-- REQUIRED -->
- Patch CVE-2021-3416. Add test modules under check section.

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2021-3416

###### Test Methodology
- Local build