### PR TITLE
Fix CVE-2021-3392 and CVE-2021-3409 in qemu-kvm

### DIFF
--- a/SPECS/qemu-kvm/CVE-2021-3392.patch
+++ b/SPECS/qemu-kvm/CVE-2021-3392.patch
@@ -1,0 +1,25 @@
+CVE-2021-3392 patch adapted from QEMU patch by Prasad J Pandit <pjp@fedoraproject.org>
+
+Link: https://bugzilla.redhat.com/show_bug.cgi?id=1924042
+
+Signed-off-by: Neha Agarwal <nehaagarwal@microsoft.com>
+---
+ hw/scsi/mptsas.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/hw/scsi/mptsas.c b/hw/scsi/mptsas.c
+index f86616544b..adff5b0bf2 100644
+--- a/hw/scsi/mptsas.c
++++ b/hw/scsi/mptsas.c
+@@ -257,8 +257,8 @@ static void mptsas_free_request(MPTSASRequest *req)
+         req->sreq->hba_private = NULL;
+         scsi_req_unref(req->sreq);
+         req->sreq = NULL;
+-        QTAILQ_REMOVE(&s->pending, req, next);
+     }
++    QTAILQ_REMOVE(&s->pending, req, next);
+     qemu_sglist_destroy(&req->qsg);
+     g_free(req);
+ }
+-- 
+2.29.2

--- a/SPECS/qemu-kvm/CVE-2021-3409.patch
+++ b/SPECS/qemu-kvm/CVE-2021-3409.patch
@@ -1,0 +1,114 @@
+CVE-2021-3392 patch adapted from QEMU patches by Bin Meng <bmeng.cn@gmail.com>
+
+Link: https://bugzilla.redhat.com/show_bug.cgi?id=1928146
+
+Signed-off-by: Neha Agarwal <nehaagarwal@microsoft.com>
+---
+ hw/sd/sdhci.c | 53 ++++++++++++++++++++++++++++++++++++----------------- 
+ 1 file changed, 36 insertions(+), 17 deletions(-)
+
+diff --git a/hw/sd/sdhci.c b/hw/sd/sdhci.c
+index 9acf446..f72d76c 100644
+--- a/hw/sd/sdhci.c
++++ b/hw/sd/sdhci.c
+@@ -316,6 +316,7 @@
+     SDRequest request;
+     uint8_t response[16];
+     int rlen;
++    bool timeout = false;
+
+     s->errintsts = 0;
+     s->acmd12errsts = 0;
+@@ -339,6 +340,7 @@
+             trace_sdhci_response16(s->rspreg[3], s->rspreg[2],
+                                    s->rspreg[1], s->rspreg[0]);
+         } else {
++            timeout = true;
+             trace_sdhci_error("timeout waiting for command response");
+             if (s->errintstsen & SDHC_EISEN_CMDTIMEOUT) {
+                 s->errintsts |= SDHC_EIS_CMDTIMEOUT;
+@@ -359,7 +361,7 @@
+
+     sdhci_update_irq(s);
+
+-    if (s->blksize && (s->cmdreg & SDHC_CMD_DATA_PRESENT)) {
++    if (!timeout && s->blksize && (s->cmdreg & SDHC_CMD_DATA_PRESENT)) {
+         s->data_count = 0;
+         sdhci_data_transfer(s);
+     }
+@@ -776,8 +778,9 @@
+
+         switch (dscr.attr & SDHC_ADMA_ATTR_ACT_MASK) {
+         case SDHC_ADMA_ATTR_ACT_TRAN:  /* data transfer */
+-
++            s->prnsts |= SDHC_DATA_INHIBIT | SDHC_DAT_LINE_ACTIVE;
+             if (s->trnmod & SDHC_TRNS_READ) {
++                s->prnsts |= SDHC_DOING_READ;
+                 while (length) {
+                     if (s->data_count == 0) {
+                         for (n = 0; n < block_size; n++) {
+@@ -807,6 +810,7 @@
+                     }
+                 }
+             } else {
++                s->prnsts |= SDHC_DOING_WRITE;
+                 while (length) {
+                     begin = s->data_count;
+                     if ((length + begin) < block_size) {
+@@ -1117,23 +1121,26 @@
+
+     switch (offset & ~0x3) {
+     case SDHC_SYSAD:
+-        s->sdmasysad = (s->sdmasysad & mask) | value;
+-        MASKED_WRITE(s->sdmasysad, mask, value);
+-        /* Writing to last byte of sdmasysad might trigger transfer */
+-        if (!(mask & 0xFF000000) && TRANSFERRING_DATA(s->prnsts) && s->blkcnt &&
+-                s->blksize && SDHC_DMA_TYPE(s->hostctl1) == SDHC_CTRL_SDMA) {
+-            if (s->trnmod & SDHC_TRNS_MULTI) {
+-                sdhci_sdma_transfer_multi_blocks(s);
+-            } else {
+-                sdhci_sdma_transfer_single_block(s);
++        if (!TRANSFERRING_DATA(s->prnsts)) {
++            s->sdmasysad = (s->sdmasysad & mask) | value;
++            MASKED_WRITE(s->sdmasysad, mask, value);
++            /* Writing to last byte of sdmasysad might trigger transfer */
++            if (!(mask & 0xFF000000) && s->blkcnt && s->blksize &&
++                SDHC_DMA_TYPE(s->hostctl1) == SDHC_CTRL_SDMA) {
++                if (s->trnmod & SDHC_TRNS_MULTI) {
++                    sdhci_sdma_transfer_multi_blocks(s);
++                } else {
++                    sdhci_sdma_transfer_single_block(s);
++                }
+             }
+         }
+         break;
+     case SDHC_BLKSIZE:
+         if (!TRANSFERRING_DATA(s->prnsts)) {
++            uint16_t blksize = s->blksize;
++
+             MASKED_WRITE(s->blksize, mask, value);
+             MASKED_WRITE(s->blkcnt, mask >> 16, value >> 16);
+-        }
+
+         /* Limit block size to the maximum buffer size */
+         if (extract32(s->blksize, 0, 12) > s->buf_maxsz) {
+@@ -1142,6 +1149,17 @@
+                           s->buf_maxsz);
+
+             s->blksize = deposit32(s->blksize, 0, 12, s->buf_maxsz);
++            }
++
++            /*
++             * If the block size is programmed to a different value from
++             * the previous one, reset the data pointer of s->fifo_buffer[]
++             * so that s->fifo_buffer[] can be filled in using the new block
++             * size in the next transfer.
++             */
++            if (blksize != s->blksize) {
++                s->data_count = 0;
++            }
+         }
+
+         break;
+--
+1.8.3.1

--- a/SPECS/qemu-kvm/qemu-kvm.spec
+++ b/SPECS/qemu-kvm/qemu-kvm.spec
@@ -1,7 +1,7 @@
 Summary:        QEMU is a machine emulator and virtualizer
 Name:           qemu-kvm
 Version:        4.2.0
-Release:        28%{?dist}
+Release:        29%{?dist}
 License:        GPLv2 AND GPLv2+ AND CC-BY AND BSD
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -48,6 +48,8 @@ Patch29:        CVE-2020-17380.patch
 Patch30:        CVE-2021-20203.patch
 Patch31:        CVE-2021-20255.patch
 Patch32:        CVE-2021-3416.patch
+Patch33:        CVE-2021-3392.patch
+Patch34:        CVE-2021-3409.patch
 BuildRequires:  alsa-lib-devel
 BuildRequires:  glib-devel
 BuildRequires:  pixman-devel
@@ -105,6 +107,8 @@ This package provides a command line tool for manipulating disk images.
 %patch30 -p1
 %patch31 -p1
 %patch32 -p1
+%patch33 -p1
+%patch34 -p1
 
 %build
 
@@ -201,6 +205,9 @@ fi
 %{_bindir}/qemu-nbd
 
 %changelog
+* Wed Apr 07 2021 Neha Agarwal <nehaagarwal@microsoft.com> - 4.2.0-29
+- Patch CVE-2021-3392 and CVE-2021-3409.
+
 * Tue Mar 30 2021 Neha Agarwal <nehaagarwal@microsoft.com> - 4.2.0-28
 - Patch CVE-2021-3416. Added test modules under check section.
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
Add patch to qemu-kvm to fix CVE-2021-3392 and CVE-2021-3409

###### Change Log  <!-- REQUIRED -->
- Add patch to qemu-kvm to fix CVE-2021-3392 and CVE-2021-3409

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2021-3409
- https://nvd.nist.gov/vuln/detail/CVE-2021-3392

###### Test Methodology
- Local build