### PR TITLE
Add CVE-2021-3470 for redis and CVE-2021-30004 for wpa_supplicant

### DIFF
--- a/SPECS/redis/CVE-2021-3470.patch
+++ b/SPECS/redis/CVE-2021-3470.patch
@@ -1,0 +1,14 @@
+diff --git a/src/zmalloc.c b/src/zmalloc.c
+index dd655620ca69..972db79d7ab7 100644
+--- a/src/zmalloc.c
++++ b/src/zmalloc.c
+@@ -177,9 +177,6 @@ void *zrealloc(void *ptr, size_t size) {
+ size_t zmalloc_size(void *ptr) {
+     void *realptr = (char*)ptr-PREFIX_SIZE;
+     size_t size = *((size_t*)realptr);
+-    /* Assume at least that all the allocations are padded at sizeof(long) by
+-     * the underlying allocator. */
+-    if (size&(sizeof(long)-1)) size += sizeof(long)-(size&(sizeof(long)-1));
+     return size+PREFIX_SIZE;
+ }
+ size_t zmalloc_usable(void *ptr) {

--- a/SPECS/redis/redis.spec
+++ b/SPECS/redis/redis.spec
@@ -1,7 +1,7 @@
 Summary:        advanced key-value store
 Name:           redis
 Version:        5.0.5
-Release:        6%{?dist}
+Release:        7%{?dist}
 License:        BSD
 URL:            https://redis.io/
 Group:          Applications/Databases
@@ -13,6 +13,7 @@ Patch1:         CVE-2020-14147.patch
 Patch2:         disable_active_defrag_big_keys.patch
 # CVE-2021-21309 affects 32-bit executables only. Mariner always builds with -m64 and does not support 32-bit architectures.
 Patch3:         CVE-2021-21309.nopatch
+Patch4:         CVE-2021-3470.patch
 
 BuildRequires:  gcc
 BuildRequires:  systemd
@@ -87,6 +88,8 @@ exit 0
 %config(noreplace) %attr(0640, %{name}, %{name}) %{_sysconfdir}/redis.conf
 
 %changelog
+* Fri Apr 09 2021 Suresh Babu Chalamalasetty <schalam@microsoft.com> 5.0.5-7
+- Add patch for CVE-2021-3470
 * Thu Mar 11 2021 Mateusz Malisz <mamalisz@microsoft.com> 5.0.5-6
 - Add nopatch for CVE-2021-21309.
 * Wed Mar 03 2021 Andrew Phelps <anphel@microsoft.com> 5.0.5-5

--- a/SPECS/wpa_supplicant/CVE-2021-30004.patch
+++ b/SPECS/wpa_supplicant/CVE-2021-30004.patch
@@ -1,0 +1,114 @@
+From a0541334a6394f8237a4393b7372693cd7e96f15 Mon Sep 17 00:00:00 2001
+From: Jouni Malinen <j@w1.fi>
+Date: Sat, 13 Mar 2021 18:19:31 +0200
+Subject: ASN.1: Validate DigestAlgorithmIdentifier parameters
+
+The supported hash algorithms do not use AlgorithmIdentifier parameters.
+However, there are implementations that include NULL parameters in
+addition to ones that omit the parameters. Previous implementation did
+not check the parameters value at all which supported both these cases,
+but did not reject any other unexpected information.
+
+Use strict validation of digest algorithm parameters and reject any
+unexpected value when validating a signature. This is needed to prevent
+potential forging attacks.
+
+Signed-off-by: Jouni Malinen <j@w1.fi>
+---
+ src/tls/pkcs1.c  | 21 +++++++++++++++++++++
+ src/tls/x509v3.c | 20 ++++++++++++++++++++
+ 2 files changed, 41 insertions(+)
+
+diff --git a/src/tls/pkcs1.c b/src/tls/pkcs1.c
+index bbdb0d7..5761dfe 100644
+--- a/src/tls/pkcs1.c
++++ b/src/tls/pkcs1.c
+@@ -244,6 +244,8 @@ int pkcs1_v15_sig_ver(struct crypto_public_key *pk,
+ 		os_free(decrypted);
+ 		return -1;
+ 	}
++	wpa_hexdump(MSG_MSGDUMP, "PKCS #1: DigestInfo",
++		    hdr.payload, hdr.length);
+ 
+ 	pos = hdr.payload;
+ 	end = pos + hdr.length;
+@@ -265,6 +267,8 @@ int pkcs1_v15_sig_ver(struct crypto_public_key *pk,
+ 		os_free(decrypted);
+ 		return -1;
+ 	}
++	wpa_hexdump(MSG_MSGDUMP, "PKCS #1: DigestAlgorithmIdentifier",
++		    hdr.payload, hdr.length);
+ 	da_end = hdr.payload + hdr.length;
+ 
+ 	if (asn1_get_oid(hdr.payload, hdr.length, &oid, &next)) {
+@@ -273,6 +277,23 @@ int pkcs1_v15_sig_ver(struct crypto_public_key *pk,
+ 		os_free(decrypted);
+ 		return -1;
+ 	}
++	wpa_hexdump(MSG_MSGDUMP, "PKCS #1: Digest algorithm parameters",
++		    next, da_end - next);
++
++	/*
++	 * RFC 5754: The correct encoding for the SHA2 algorithms would be to
++	 * omit the parameters, but there are implementation that encode these
++	 * as a NULL element. Allow these two cases and reject anything else.
++	 */
++	if (da_end > next &&
++	    (asn1_get_next(next, da_end - next, &hdr) < 0 ||
++	     !asn1_is_null(&hdr) ||
++	     hdr.payload + hdr.length != da_end)) {
++		wpa_printf(MSG_DEBUG,
++			   "PKCS #1: Unexpected digest algorithm parameters");
++		os_free(decrypted);
++		return -1;
++	}
+ 
+ 	if (!asn1_oid_equal(&oid, hash_alg)) {
+ 		char txt[100], txt2[100];
+diff --git a/src/tls/x509v3.c b/src/tls/x509v3.c
+index a8944dd..df337ec 100644
+--- a/src/tls/x509v3.c
++++ b/src/tls/x509v3.c
+@@ -1964,6 +1964,7 @@ int x509_check_signature(struct x509_certificate *issuer,
+ 		os_free(data);
+ 		return -1;
+ 	}
++	wpa_hexdump(MSG_MSGDUMP, "X509: DigestInfo", hdr.payload, hdr.length);
+ 
+ 	pos = hdr.payload;
+ 	end = pos + hdr.length;
+@@ -1985,6 +1986,8 @@ int x509_check_signature(struct x509_certificate *issuer,
+ 		os_free(data);
+ 		return -1;
+ 	}
++	wpa_hexdump(MSG_MSGDUMP, "X509: DigestAlgorithmIdentifier",
++		    hdr.payload, hdr.length);
+ 	da_end = hdr.payload + hdr.length;
+ 
+ 	if (asn1_get_oid(hdr.payload, hdr.length, &oid, &next)) {
+@@ -1992,6 +1995,23 @@ int x509_check_signature(struct x509_certificate *issuer,
+ 		os_free(data);
+ 		return -1;
+ 	}
++	wpa_hexdump(MSG_MSGDUMP, "X509: Digest algorithm parameters",
++		    next, da_end - next);
++
++	/*
++	 * RFC 5754: The correct encoding for the SHA2 algorithms would be to
++	 * omit the parameters, but there are implementation that encode these
++	 * as a NULL element. Allow these two cases and reject anything else.
++	 */
++	if (da_end > next &&
++	    (asn1_get_next(next, da_end - next, &hdr) < 0 ||
++	     !asn1_is_null(&hdr) ||
++	     hdr.payload + hdr.length != da_end)) {
++		wpa_printf(MSG_DEBUG,
++			   "X509: Unexpected digest algorithm parameters");
++		os_free(data);
++		return -1;
++	}
+ 
+ 	if (x509_sha1_oid(&oid)) {
+ 		if (signature->oid.oid[6] != 5 /* sha-1WithRSAEncryption */) {
+-- 
+cgit v0.12

--- a/SPECS/wpa_supplicant/wpa_supplicant.spec
+++ b/SPECS/wpa_supplicant/wpa_supplicant.spec
@@ -1,7 +1,7 @@
 Summary:        WPA client
 Name:           wpa_supplicant
 Version:        2.9
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        BSD
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -11,6 +11,7 @@ Source0:        https://w1.fi/releases/%{name}-%{version}.tar.gz
 Patch0:         CVE-2019-16275.patch
 Patch1:         CVE-2021-0326.patch
 Patch2:         CVE-2021-27803.patch
+Patch3:         CVE-2021-30004.patch
 BuildRequires:  libnl3-devel
 BuildRequires:  openssl-devel
 Requires:       libnl3
@@ -98,6 +99,9 @@ EOF
 %{_sysconfdir}/wpa_supplicant/wpa_supplicant-wlan0.conf
 
 %changelog
+* Fri Apr 09 2021 Suresh Babu Chalamalasetty <schalam@microsoft.com> - 2.9-4
+- Add patch for CVE-2021-30004
+
 * Mon Mar 08 2021 Thomas Crain <thcrain@microsoft.com> - 2.9-3
 - Add patch for CVE-2021-0326 and CVE-2021-27803
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Adding CVE-2021-3470 for redis and CVE-2021-30004 for wpa_supplicant.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change
Add CVE-2021-3470
- Change
Add CVE-2021-30004

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
YES
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-30004
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=2021-3470 

###### Test Methodology
Locally built both redis and wpa_supplicant packages with CVEs.
