### PR TITLE
Making 'keepalived' link against latest 'net-snmp' libraries.

### DIFF
--- a/SPECS/keepalived/keepalived.spec
+++ b/SPECS/keepalived/keepalived.spec
@@ -1,28 +1,30 @@
 Summary:        HA monitor built upon LVS, VRRP and services poller
 Name:           keepalived
 Version:        2.0.10
-Release:        5%{?dist}
+Release:        6%{?dist}
 License:        GPLv2
-URL:            https://www.keepalived.org/
-Group:          Applications/System
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
+Group:          Applications/System
+URL:            https://www.keepalived.org/
 #Note.          We currently use alternate source location.  Preferred original is here:  https://www.keepalived.org/software/keepalived-%{version}.tar.gz
 #Source0:       https://github.com/acassen/keepalived/archive/v%{version}.zip
 Source0:        %{name}-%{version}.zip
 Source1:        %{name}.service
 
-BuildRequires:  openssl-devel
+BuildRequires:  ipset-devel
 BuildRequires:  iptables-devel
 BuildRequires:  libmnl-devel
-BuildRequires:  ipset-devel
-BuildRequires:  libnl3-devel
 BuildRequires:  libnfnetlink-devel
+BuildRequires:  libnl3-devel
 BuildRequires:  net-snmp-devel
+BuildRequires:  openssl-devel
 BuildRequires:  systemd
 BuildRequires:  unzip
-Requires:       systemd
+
 Requires:       libnl3-devel
+Requires:       net-snmp
+Requires:       systemd
 
 %description
 The main goal of the keepalived project is to add a strong & robust keepalive
@@ -88,19 +90,30 @@ fi
 %{_mandir}/man8/%{name}.8*
 
 %changelog
-*   Sat May 09 2020 Nick Samson <nisamson@microsoft.com> 2.0.10-5
--   Added %%license line automatically
-*   Thu Apr 30 2020 Nicolas Ontiveros <niontive@microsoft.com> 2.0.10-4
--   Rename libnl to libnl3.
-*   Mon Apr 13 2020 Jon Slobodzian <joslobo@microsoft.com> 2.0.10-3
--   Verified license. Removed sha1. Fixed Source0 URL. URL to https. dded note about alternate source location.
-*   Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 2.0.10-2
--   Initial CBL-Mariner import from Photon (license: Apache2).
-*   Fri Feb 15 2019 Ashwin H <ashwinh@vmware.com> 2.0.10-1
--   Updated to version 2.0.10
-*   Wed Sep 12 2018 Ankit Jain <ankitja@vmware.com> 2.0.7-1
--   Updated to version 2.0.7
-*   Fri Jun 23 2017 Xiaolin Li <xiaolinl@vmware.com> 1.3.5-2
--   Add iptables-devel to BuildRequires
-*   Thu Apr 06 2017 Dheeraj Shetty <dheerajs@vmware.com> 1.3.5-1
--   Initial build.  First version
+* Thu Apr 15 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 2.0.10-6
+- Adding an explicit run-time dependency on 'net-snmp'.
+- Bumping up release number to link against newer version of 'net-snmp' libraries.
+
+* Sat May 09 2020 Nick Samson <nisamson@microsoft.com> - 2.0.10-5
+- Added %%license line automatically
+
+* Thu Apr 30 2020 Nicolas Ontiveros <niontive@microsoft.com> 2.0.10-4
+- Rename libnl to libnl3.
+
+* Mon Apr 13 2020 Jon Slobodzian <joslobo@microsoft.com> 2.0.10-3
+- Verified license. Removed sha1. Fixed Source0 URL. URL to https. dded note about alternate source location.
+
+* Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 2.0.10-2
+- Initial CBL-Mariner import from Photon (license: Apache2).
+
+* Fri Feb 15 2019 Ashwin H <ashwinh@vmware.com> 2.0.10-1
+- Updated to version 2.0.10
+
+* Wed Sep 12 2018 Ankit Jain <ankitja@vmware.com> 2.0.7-1
+- Updated to version 2.0.7
+
+* Fri Jun 23 2017 Xiaolin Li <xiaolinl@vmware.com> 1.3.5-2
+- Add iptables-devel to BuildRequires
+
+* Thu Apr 06 2017 Dheeraj Shetty <dheerajs@vmware.com> 1.3.5-1
+- Initial build.  First version


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

As part of a CVE fix, a recent update to `net-snmp` changed its shared libraries' version from 35 to 40 and we missed updating other binaries linking against `net-snmp`, so they now use the newer libs and don't force the users to stay on the outdated version.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Bump release number of `keepalived` to produce a newer package compiled against the latest version of `net-snmp` libraries.
- Ran a spec linter for `keepalived`.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
No.

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- None, just a release number change.
