### PR TITLE
Update dnsmasq to 2.85 to fix CVE-2021-3348

### DIFF
--- a/SPECS/dnsmasq/dnsmasq.signatures.json
+++ b/SPECS/dnsmasq/dnsmasq.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "dnsmasq-2.84.tar.xz": "603195c64b73137609b07e1024ae0b37f652b2f5fe467dce66985b3d1850050c"
+  "dnsmasq-2.85.tar.xz": "ad98d3803df687e5b938080f3d25c628fe41c878752d03fbc6199787fee312fa"
  }
 }

--- a/SPECS/dnsmasq/dnsmasq.spec
+++ b/SPECS/dnsmasq/dnsmasq.spec
@@ -1,6 +1,6 @@
 Summary:        DNS proxy with integrated DHCP server
 Name:           dnsmasq
-Version:        2.84
+Version:        2.85
 Release:        1%{?dist}
 License:        GPLv2 or GPLv3
 Group:          System Environment/Daemons
@@ -69,46 +69,67 @@ rm -rf %{buildroot}
 %config  /usr/share/dnsmasq/trust-anchors.conf
 
 %changelog
-*   Thu Jan 28 2021 Henry Li <lihl@microsoft.com> 2.84-1
--   Upgrade to version 2.84
--   Fix CVE-2020-25683, CVE-2020-25686, CVE-2020-25687
--   Remove Patch CVE-2019-14834
--   Use autosetup
-*   Thu Jun 18 2020 Pawel Winogrodzki <pawelwi@microsoft.com> 2.79-11
--   Removing runtime dependency on a specific kernel package.
-*   Thu Jun 11 2020 Christopher Co <chrco@microsoft.com> - 2.79-10
--   Remove KERNEL_VERSION macro from BuildRequires
-*   Thu May 21 2020 Ruying Chen <v-ruyche@microsoft.com> - 2.79-9
--   Fix CVE-2019-14834
-*   Sat May 09 00:21:16 PST 2020 Nick Samson <nisamson@microsoft.com> - 2.79-8
--   Added %%license line automatically
-*   Thu Apr 30 2020 Emre Girgin <mrgirgin@microsoft.com> 2.79-7
--   Renaming linux-api-headers to kernel-headers
-*   Tue Apr 28 2020 Emre Girgin <mrgirgin@microsoft.com> 2.79-6
--   Renaming linux to kernel
-*   Thu Apr 09 2020 Pawel Winogrodzki <pawelwi@microsoft.com> 2.79-5
--   Fixed "Source0" tag.
--   Removed "%%define sha1".
-*   Mon Mar 23 2020 Christopher Co <chrco@microsoft.com> 2.79-4
--   Remove KERNEL_RELEASE macro from required packages
-*   Wed Jan 08 2020 Christopher Co <chrco@microsoft.com> 2.79-3
--   Fix missing SIOCGSTAMP ioctl definition due to linux 5.2 header refactor
--   Verified License
-*   Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 2.79-2
--   Initial CBL-Mariner import from Photon (license: Apache2).
-*   Mon Sep 10 2018 Ajay Kaher <akaher@vmware.com> 2.79-1
--   Upgrading to version 2.79
-*   Tue Feb 13 2018 Xiaolin Li <xiaolinl@vmware.com> 2.76-5
--   Fix CVE-2017-15107
-*   Mon Nov 13 2017 Vinay Kulkarni <kulkarniv@vmware.com> 2.76-4
--   Always restart dnsmasq service on exit
-*   Wed Oct 11 2017 Alexey Makhalov <amakhalov@vmware.com> 2.76-3
--   Fix CVE-2017-13704
-*   Wed Sep 27 2017 Alexey Makhalov <amakhalov@vmware.com> 2.76-2
--   Fix CVE-2017-14491..CVE-2017-14496
-*   Sun Nov 27 2016 Vinay Kulkarni <kulkarniv@vmware.com> 2.76-1
--   Upgrade to 2.76 to address CVE-2015-8899
-*   Tue May 24 2016 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 2.75-2
--   GA - Bump release of all rpms
-*   Mon Apr 18 2016 Xiaolin Li <xiaolinl@vmware.com> 2.75-1
--   Initial version
+* Fri Apr 23 2021 Thomas Crain <thcrain@microsoft.com> - 2.85-1
+- Upgrade to version 2.85 to fix  CVE-2021-3348
+
+* Thu Jan 28 2021 Henry Li <lihl@microsoft.com> - 2.84-1
+- Upgrade to version 2.84
+- Fix CVE-2020-25683, CVE-2020-25686, CVE-2020-25687
+- Remove Patch CVE-2019-14834
+- Use autosetup
+
+* Thu Jun 18 2020 Pawel Winogrodzki <pawelwi@microsoft.com> - 2.79-11
+- Removing runtime dependency on a specific kernel package.
+
+* Thu Jun 11 2020 Christopher Co <chrco@microsoft.com> - 2.79-10
+- Remove KERNEL_VERSION macro from BuildRequires
+
+* Thu May 21 2020 Ruying Chen <v-ruyche@microsoft.com> - 2.79-9
+- Fix CVE-2019-14834
+
+* Sat May 09 2020 Nick Samson <nisamson@microsoft.com> - 2.79-8
+- Added %%license line automatically
+
+* Thu Apr 30 2020 Emre Girgin <mrgirgin@microsoft.com> - 2.79-7
+- Renaming linux-api-headers to kernel-headers
+
+* Tue Apr 28 2020 Emre Girgin <mrgirgin@microsoft.com> - 2.79-6
+- Renaming linux to kernel
+
+* Thu Apr 09 2020 Pawel Winogrodzki <pawelwi@microsoft.com> - 2.79-5
+- Fixed "Source0" tag.
+- Removed "%%define sha1".
+
+* Mon Mar 23 2020 Christopher Co <chrco@microsoft.com> - 2.79-4
+- Remove KERNEL_RELEASE macro from required packages
+
+* Wed Jan 08 2020 Christopher Co <chrco@microsoft.com> - 2.79-3
+- Fix missing SIOCGSTAMP ioctl definition due to linux 5.2 header refactor
+- Verified License
+
+* Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> - 2.79-2
+- Initial CBL-Mariner import from Photon (license: Apache2).
+
+* Mon Sep 10 2018 Ajay Kaher <akaher@vmware.com> - 2.79-1
+- Upgrading to version 2.79
+
+* Tue Feb 13 2018 Xiaolin Li <xiaolinl@vmware.com> - 2.76-5
+- Fix CVE-2017-15107
+
+* Mon Nov 13 2017 Vinay Kulkarni <kulkarniv@vmware.com> - 2.76-4
+- Always restart dnsmasq service on exit
+
+* Wed Oct 11 2017 Alexey Makhalov <amakhalov@vmware.com> - 2.76-3
+- Fix CVE-2017-13704
+
+* Wed Sep 27 2017 Alexey Makhalov <amakhalov@vmware.com> - 2.76-2
+- Fix CVE-2017-14491..CVE-2017-14496
+
+* Sun Nov 27 2016 Vinay Kulkarni <kulkarniv@vmware.com> - 2.76-1
+- Upgrade to 2.76 to address CVE-2015-8899
+
+* Tue May 24 2016 Priyesh Padmavilasom <ppadmavilasom@vmware.com> - 2.75-2
+- GA - Bump release of all rpms
+
+* Mon Apr 18 2016 Xiaolin Li <xiaolinl@vmware.com> - 2.75-1
+- Initial version

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -945,8 +945,8 @@
         "type": "other",
         "other": {
           "name": "dnsmasq",
-          "version": "2.84",
-          "downloadUrl": "http://www.thekelleys.org.uk/dnsmasq/dnsmasq-2.84.tar.xz"
+          "version": "2.85",
+          "downloadUrl": "http://www.thekelleys.org.uk/dnsmasq/dnsmasq-2.85.tar.xz"
         }
       }
     },


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Update dnsmasq to 2.85 to fix CVE-2021-3348

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Update dnsmasq to 2.85

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2021-3348

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local build
