### PR TITLE
Moving `license_map.py` script to toolkit and updating its functionality.

### DIFF
--- a/.github/workflows/check-license-map.yml
+++ b/.github/workflows/check-license-map.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Run license map checking script
         run: |
-          python3 ./SPECS/LICENSES-AND-NOTICES/data/license_map.py \
+          python3 ./toolkit/scripts/licenses/license_map.py \
           ./SPECS/LICENSES-AND-NOTICES/data/licenses.json \
           ./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md \
           ./SPECS \

--- a/toolkit/scripts/licenses/license_map.py
+++ b/toolkit/scripts/licenses/license_map.py
@@ -51,17 +51,20 @@ def get_missing_specs(spec_directories, license_collection):
     return specs_not_in_json, specs_not_in_dir
 
 
-def main(input_filename, output_filename, spec_directories):
+def main(input_filename, output_filename, spec_directories, only_update):
     with open(input_filename, 'r') as input_file:
         license_collection = deserialize_json(input_file)
-
-    specs_not_in_json, specs_not_in_dir = get_missing_specs(spec_directories, license_collection)
 
     with open(output_filename, 'r') as output_file:
         old_content = output_file.read()
     new_content = generate_markdown(license_collection)
     with open(output_filename, 'w') as output_file:
         output_file.write(new_content)
+
+    if only_update:
+        return
+
+    specs_not_in_json, specs_not_in_dir = get_missing_specs(spec_directories, license_collection)
 
     if len(specs_not_in_json) or len(specs_not_in_dir) or old_content != new_content:
         if len(specs_not_in_json):
@@ -83,8 +86,9 @@ def main(input_filename, output_filename, spec_directories):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Processes spec license data, find missing entries, and regenerate license map file.')
-    parser.add_argument('input_filename', type=Path, help='Path to data file with license data')
-    parser.add_argument('output_filename', type=Path, help='Path to license map markdown file')
-    parser.add_argument('spec_directories', type=Path, nargs='+', help='Directories containing specs')
+    parser.add_argument('input_filename', type=Path, help='Path to data file with license data.')
+    parser.add_argument('output_filename', type=Path, help='Path to license map markdown file.')
+    parser.add_argument('spec_directories', type=Path, nargs='+', help='Directories containing specs.')
+    parser.add_argument('--only_update', help='Does not perform a check, only updates the markdown file according to the input JSON.', action='store_true')
     p = parser.parse_args()
-    main(p.input_filename, p.output_filename, p.spec_directories)
+    main(p.input_filename, p.output_filename, p.spec_directories, p.only_update)


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Updating the `license_map.py` script to allow markdown updates without running a check at the same time. These checks are not required for automated package updates and the error code returned in case of a licenses JSON outdated for unrelated reasons is confusing to use in the automation scripts.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Added the `--only_update` flag to the `license_map.py` script.
- Moved the `licesense_map.py` script into the `toolkit/scripts/licenses` directory next to other scripts.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
No.

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local script run.
