### PR TITLE
Patch several CVEs in Rust

### DIFF
--- a/SPECS/azure-iotedge/azure-iotedge.spec
+++ b/SPECS/azure-iotedge/azure-iotedge.spec
@@ -1,7 +1,7 @@
 Summary:        Azure IoT Edge Security Daemon
 Name:           azure-iotedge
 Version:        1.1.0
-Release:        3%{?dist}
+Release:        4%{?dist}
 
 # A buildable azure-iotedge environments needs functioning submodules that do not work from the archive download
 # To recreate the tar.gz run the following
@@ -166,6 +166,9 @@ echo "==========================================================================
 %doc %{_docdir}/iotedge-%{version}/trademark
 
 %changelog
+* Mon Apr 26 2021 Thomas Crain <thcrain@microsoft.com> - 1.1.0-4
+- Bump release to rebuild with rust 1.47.0-3 (security update)
+
 * Tue Apr 20 2021 Thomas Crain <thcrain@microsoft.com> - 1.1.0-3
 - Bump release to rebuild with rust 1.47.0-2 (security update)
 

--- a/SPECS/cloud-hypervisor/cloud-hypervisor.spec
+++ b/SPECS/cloud-hypervisor/cloud-hypervisor.spec
@@ -50,6 +50,9 @@ install -D -m755 target/release/vhost_user_net %{buildroot}%{_libdir}/cloud-hype
 %exclude %{_libdir}/debug
 
 %changelog
+* Mon Apr 26 2021 Thomas Crain <thcrain@microsoft.com> - 0.6.0-7
+- Bump release to rebuild with rust 1.47.0-3 (security update)
+
 * Tue Apr 20 2021 Thomas Crain <thcrain@microsoft.com> - 0.6.0-6
 - Bump release to rebuild with rust 1.47.0-2 (security update)
 

--- a/SPECS/cloud-hypervisor/cloud-hypervisor.spec
+++ b/SPECS/cloud-hypervisor/cloud-hypervisor.spec
@@ -1,7 +1,7 @@
 Summary:        A Rust-VMM based cloud hypervisor from Intel
 Name:           cloud-hypervisor
 Version:        0.6.0
-Release:        6%{?dist}
+Release:        7%{?dist}
 License:        ASL 2.0 or BSD
 URL:            https://github.com/cloud-hypervisor/cloud-hypervisor
 Group:          Development/Tools

--- a/SPECS/rpm-ostree/rpm-ostree.spec
+++ b/SPECS/rpm-ostree/rpm-ostree.spec
@@ -1,7 +1,7 @@
 Summary:        Commit RPMs to an OSTree repository
 Name:           rpm-ostree
 Version:        2019.3
-Release:        8%{?dist}
+Release:        9%{?dist}
 License:        LGPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -161,6 +161,9 @@ make check
 %{_datadir}/gir-1.0/*-1.0.gir
 
 %changelog
+* Mon Apr 26 2021 Thomas Crain <thcrain@microsoft.com> - 2019-3.9
+- Bump release to rebuild with rust 1.47.0-3 (security update)
+
 * Tue Apr 20 2021 Thomas Crain <thcrain@microsoft.com> - 2019.3-8
 - Bump release to rebuild with rust 1.47.0-2 (security update)
 

--- a/SPECS/rust/CVE-2020-36317.patch
+++ b/SPECS/rust/CVE-2020-36317.patch
@@ -1,0 +1,111 @@
+From 4588490cdceb407fd5754045d173be7ea381b794 Mon Sep 17 00:00:00 2001
+From: Thomas Crain <thcrain@microsoft.com>
+Date: Mon, 26 Apr 2021 12:40:04 -0500
+Subject: [PATCH 1/6] Patch CVE-2020-36317
+
+Backporting the following to 1.47.0:
+https://github.com/rust-lang/rust/pull/78499
+https://github.com/rust-lang/rust/pull/82554
+---
+ library/alloc/src/string.rs   | 37 ++++++++++++++++++++++-------------
+ library/alloc/tests/string.rs | 15 ++++++++++++++
+ 2 files changed, 38 insertions(+), 14 deletions(-)
+
+diff --git a/library/alloc/src/string.rs b/library/alloc/src/string.rs
+index 05690e19d23..9387f4edde3 100644
+--- a/library/alloc/src/string.rs
++++ b/library/alloc/src/string.rs
+@@ -1231,35 +1231,44 @@ impl String {
+     where
+         F: FnMut(char) -> bool,
+     {
++        struct SetLenOnDrop<'a> {
++            s: &'a mut String,
++            idx: usize,
++            del_bytes: usize,
++        }
++
++        impl<'a> Drop for SetLenOnDrop<'a> {
++            fn drop(&mut self) {
++                let new_len = self.idx - self.del_bytes;
++                debug_assert!(new_len <= self.s.len());
++                unsafe { self.s.vec.set_len(new_len) };
++            }
++        }
++
+         let len = self.len();
+-        let mut del_bytes = 0;
+-        let mut idx = 0;
++        let mut guard = SetLenOnDrop { s: self, idx: 0, del_bytes: 0 };
+ 
+-        while idx < len {
+-            let ch = unsafe { self.get_unchecked(idx..len).chars().next().unwrap() };
++        while guard.idx < len {
++            let ch = unsafe { guard.s.get_unchecked(guard.idx..len).chars().next().unwrap() };
+             let ch_len = ch.len_utf8();
+ 
+             if !f(ch) {
+-                del_bytes += ch_len;
+-            } else if del_bytes > 0 {
++                guard.del_bytes += ch_len;
++            } else if guard.del_bytes > 0 {
+                 unsafe {
+                     ptr::copy(
+-                        self.vec.as_ptr().add(idx),
+-                        self.vec.as_mut_ptr().add(idx - del_bytes),
++                        guard.s.vec.as_ptr().add(guard.idx),
++                        guard.s.vec.as_mut_ptr().add(guard.idx - guard.del_bytes),
+                         ch_len,
+                     );
+                 }
+             }
+ 
+             // Point idx to the next char
+-            idx += ch_len;
++            guard.idx += ch_len;
+         }
+ 
+-        if del_bytes > 0 {
+-            unsafe {
+-                self.vec.set_len(len - del_bytes);
+-            }
+-        }
++        drop(guard);
+     }
+ 
+     /// Inserts a character into this `String` at a byte position.
+diff --git a/library/alloc/tests/string.rs b/library/alloc/tests/string.rs
+index d38655af78c..61587987172 100644
+--- a/library/alloc/tests/string.rs
++++ b/library/alloc/tests/string.rs
+@@ -1,6 +1,7 @@
+ use std::borrow::Cow;
+ use std::collections::TryReserveError::*;
+ use std::mem::size_of;
++use std::panic;
+ 
+ pub trait IntoCow<'a, B: ?Sized>
+ where
+@@ -374,6 +375,20 @@ fn test_retain() {
+ 
+     s.retain(|_| false);
+     assert_eq!(s, "");
++
++    let mut s = String::from("0è0");
++    let _ = panic::catch_unwind(panic::AssertUnwindSafe(|| {
++        let mut count = 0;
++        s.retain(|_| {
++            count += 1;
++            match count {
++                1 => false,
++                2 => true,
++                _ => panic!(),
++            }
++        });
++    }));
++    assert!(std::str::from_utf8(s.as_bytes()).is_ok());
+ }
+ 
+ #[test]
+-- 
+2.25.1

--- a/SPECS/rust/CVE-2020-36323.patch
+++ b/SPECS/rust/CVE-2020-36323.patch
@@ -1,0 +1,142 @@
+From 358bf9bf74dc7ce040e9be8232057d2904ba4fd9 Mon Sep 17 00:00:00 2001
+From: Thomas Crain <thcrain@microsoft.com>
+Date: Mon, 26 Apr 2021 14:28:30 -0500
+Subject: [PATCH] Fix CVE-2020-36323
+
+Backported to 1.47.0:
+https://github.com/rust-lang/rust/pull/81728
+---
+ library/alloc/src/str.rs   | 44 ++++++++++++++++++++++----------------
+ library/alloc/tests/str.rs | 30 ++++++++++++++++++++++++++
+ 2 files changed, 55 insertions(+), 19 deletions(-)
+
+diff --git a/library/alloc/src/str.rs b/library/alloc/src/str.rs
+index 339592728ac..7e55f2fa579 100644
+--- a/library/alloc/src/str.rs
++++ b/library/alloc/src/str.rs
+@@ -90,8 +90,8 @@ impl<S: Borrow<str>> Join<&str> for [S] {
+     }
+ }
+ 
+-macro_rules! spezialize_for_lengths {
+-    ($separator:expr, $target:expr, $iter:expr; $($num:expr),*) => {
++macro_rules! specialize_for_lengths {
++    ($separator:expr, $target:expr, $iter:expr; $($num:expr),*) => {{
+         let mut target = $target;
+         let iter = $iter;
+         let sep_bytes = $separator;
+@@ -102,7 +102,8 @@ macro_rules! spezialize_for_lengths {
+                 $num => {
+                     for s in iter {
+                         copy_slice_and_advance!(target, sep_bytes);
+-                        copy_slice_and_advance!(target, s.borrow().as_ref());
++                        let content_bytes = s.borrow().as_ref();
++                        copy_slice_and_advance!(target, content_bytes);
+                     }
+                 },
+             )*
+@@ -110,11 +111,13 @@ macro_rules! spezialize_for_lengths {
+                 // arbitrary non-zero size fallback
+                 for s in iter {
+                     copy_slice_and_advance!(target, sep_bytes);
+-                    copy_slice_and_advance!(target, s.borrow().as_ref());
++                    let content_bytes = s.borrow().as_ref();
++                    copy_slice_and_advance!(target, content_bytes);
+                 }
+             }
+         }
+-    };
++        target
++    }}
+ }
+ 
+ macro_rules! copy_slice_and_advance {
+@@ -153,30 +156,33 @@ where
+     // if the `len` calculation overflows, we'll panic
+     // we would have run out of memory anyway and the rest of the function requires
+     // the entire Vec pre-allocated for safety
+-    let len = sep_len
++    let reserved_len = sep_len
+         .checked_mul(iter.len())
+         .and_then(|n| {
+             slice.iter().map(|s| s.borrow().as_ref().len()).try_fold(n, usize::checked_add)
+         })
+         .expect("attempt to join into collection with len > usize::MAX");
+ 
+-    // crucial for safety
+-    let mut result = Vec::with_capacity(len);
+-    assert!(result.capacity() >= len);
++    // prepare an uninitialized buffer
++    let mut result = Vec::with_capacity(reserved_len);
++    debug_assert!(result.capacity() >= reserved_len);
+ 
+     result.extend_from_slice(first.borrow().as_ref());
+ 
+     unsafe {
+-        {
+-            let pos = result.len();
+-            let target = result.get_unchecked_mut(pos..len);
+-
+-            // copy separator and slices over without bounds checks
+-            // generate loops with hardcoded offsets for small separators
+-            // massive improvements possible (~ x2)
+-            spezialize_for_lengths!(sep, target, iter; 0, 1, 2, 3, 4);
+-        }
+-        result.set_len(len);
++        let pos = result.len();
++        let target = result.get_unchecked_mut(pos..reserved_len);
++
++        // copy separator and slices over without bounds checks
++        // generate loops with hardcoded offsets for small separators
++        // massive improvements possible (~ x2)
++        let remain = specialize_for_lengths!(sep, target, iter; 0, 1, 2, 3, 4);
++
++        // A weird borrow implementation may return different
++        // slices for the length calculation and the actual copy.
++        // Make sure we don't expose uninitialized bytes to the caller.
++        let result_len = reserved_len - remain.len();
++        result.set_len(result_len);
+     }
+     result
+ }
+diff --git a/library/alloc/tests/str.rs b/library/alloc/tests/str.rs
+index b20cf076aca..5a3190103c3 100644
+--- a/library/alloc/tests/str.rs
++++ b/library/alloc/tests/str.rs
+@@ -1921,3 +1921,33 @@ fn different_str_pattern_forwarding_lifetimes() {
+ 
+     foo::<&str>("x");
+ }
++
++#[test]
++fn test_join_isue_80335() {
++    use core::{borrow::Borrow, cell::Cell};
++
++    struct WeirdBorrow {
++        state: Cell<bool>,
++    }
++
++    impl Default for WeirdBorrow {
++        fn default() -> Self {
++            WeirdBorrow { state: Cell::new(false) }
++        }
++    }
++
++    impl Borrow<str> for WeirdBorrow {
++        fn borrow(&self) -> &str {
++            let state = self.state.get();
++            if state {
++                "0"
++            } else {
++                self.state.set(true);
++                "123456"
++            }
++        }
++    }
++
++    let arr: [WeirdBorrow; 3] = Default::default();
++    test_join!("0-0-0", arr, "-");
++}
+-- 
+2.25.1
+

--- a/SPECS/rust/CVE-2021-28875.patch
+++ b/SPECS/rust/CVE-2021-28875.patch
@@ -1,0 +1,58 @@
+From 4095a00f08f855366c60ae00040edc1a5e64dd7c Mon Sep 17 00:00:00 2001
+From: Thomas Crain <thcrain@microsoft.com>
+Date: Mon, 26 Apr 2021 12:42:46 -0500
+Subject: [PATCH 2/6] Patch CVE-2021-28875
+
+Backport to 1.47.0 from:
+https://github.com/rust-lang/rust/pull/80895
+---
+ library/std/src/io/mod.rs | 23 ++++++++++-------------
+ 1 file changed, 10 insertions(+), 13 deletions(-)
+
+diff --git a/library/std/src/io/mod.rs b/library/std/src/io/mod.rs
+index 462b696db40..0a3be236ac9 100644
+--- a/library/std/src/io/mod.rs
++++ b/library/std/src/io/mod.rs
+@@ -362,7 +362,6 @@ where
+ {
+     let start_len = buf.len();
+     let mut g = Guard { len: buf.len(), buf };
+-    let ret;
+     loop {
+         if g.len == g.buf.len() {
+             unsafe {
+@@ -380,22 +379,20 @@ where
+                 r.initializer().initialize(&mut g.buf[g.len..]);
+             }
+         }
+-
+-        match r.read(&mut g.buf[g.len..]) {
+-            Ok(0) => {
+-                ret = Ok(g.len - start_len);
+-                break;
++        let buf = &mut g.buf[g.len..];
++        match r.read(buf) {
++            Ok(0) => return Ok(g.len - start_len),
++            Ok(n) => {
++                // We can't allow bogus values from read. If it is too large, the returned vec could have its length
++                // set past its capacity, or if it overflows the vec could be shortened which could create an invalid
++                // string if this is called via read_to_string.
++                assert!(n <= buf.len());
++                g.len += n;
+             }
+-            Ok(n) => g.len += n,
+             Err(ref e) if e.kind() == ErrorKind::Interrupted => {}
+-            Err(e) => {
+-                ret = Err(e);
+-                break;
+-            }
++            Err(e) => return Err(e),
+         }
+     }
+-
+-    ret
+ }
+ 
+ pub(crate) fn default_read_vectored<F>(read: F, bufs: &mut [IoSliceMut<'_>]) -> Result<usize>
+-- 
+2.25.1

--- a/SPECS/rust/CVE-2021-28876.patch
+++ b/SPECS/rust/CVE-2021-28876.patch
@@ -1,0 +1,34 @@
+From adb9ae35768ccf0a457693950d5b128d8de2372f Mon Sep 17 00:00:00 2001
+From: Thomas Crain <thcrain@microsoft.com>
+Date: Mon, 26 Apr 2021 13:41:49 -0500
+Subject: [PATCH 4/6] Fix CVE-2021-28876
+
+Backport to 1.47.0:
+https://github.com/rust-lang/rust/pull/81741
+---
+ library/core/src/iter/adapters/zip.rs | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/library/core/src/iter/adapters/zip.rs b/library/core/src/iter/adapters/zip.rs
+index cde4d8f3c06..8a9f4b8af1e 100644
+--- a/library/core/src/iter/adapters/zip.rs
++++ b/library/core/src/iter/adapters/zip.rs
+@@ -201,12 +201,13 @@ where
+                 Some((self.a.__iterator_get_unchecked(i), self.b.__iterator_get_unchecked(i)))
+             }
+         } else if A::may_have_side_effect() && self.index < self.a.size() {
++            let i = self.index;
++            self.index += 1;
+             // match the base implementation's potential side effects
+-            // SAFETY: we just checked that `self.index` < `self.a.len()`
++            // SAFETY: we just checked that `i` < `self.a.len()`
+             unsafe {
+-                self.a.__iterator_get_unchecked(self.index);
++                self.a.__iterator_get_unchecked(i);
+             }
+-            self.index += 1;
+             None
+         } else {
+             None
+-- 
+2.25.1

--- a/SPECS/rust/CVE-2021-28877.patch
+++ b/SPECS/rust/CVE-2021-28877.patch
@@ -1,0 +1,53 @@
+From a297d4e6d60244482b6889111080a461bd474426 Mon Sep 17 00:00:00 2001
+From: Thomas Crain <thcrain@microsoft.com>
+Date: Mon, 26 Apr 2021 13:38:46 -0500
+Subject: [PATCH 3/6] Patch CVE-2021-28877
+
+Backported to 1.47.0:
+https://github.com/rust-lang/rust/pull/80670/files
+---
+ library/core/src/iter/adapters/zip.rs |  1 +
+ library/core/tests/iter.rs            | 18 ++++++++++++++++++
+ 2 files changed, 19 insertions(+)
+
+diff --git a/library/core/src/iter/adapters/zip.rs b/library/core/src/iter/adapters/zip.rs
+index 581ac6e0d82..cde4d8f3c06 100644
+--- a/library/core/src/iter/adapters/zip.rs
++++ b/library/core/src/iter/adapters/zip.rs
+@@ -289,6 +289,7 @@ where
+ 
+     #[inline]
+     unsafe fn get_unchecked(&mut self, idx: usize) -> <Self as Iterator>::Item {
++        let idx = self.index + idx;
+         // SAFETY: the caller must uphold the contract for
+         // `Iterator::get_unchecked`.
+         unsafe { (self.a.__iterator_get_unchecked(idx), self.b.__iterator_get_unchecked(idx)) }
+diff --git a/library/core/tests/iter.rs b/library/core/tests/iter.rs
+index 00e3972c42f..803dc5d1698 100644
+--- a/library/core/tests/iter.rs
++++ b/library/core/tests/iter.rs
+@@ -3222,3 +3222,21 @@ fn test_flatten_non_fused_inner() {
+     assert_eq!(iter.next(), Some(1));
+     assert_eq!(iter.next(), None);
+ }
++
++#[test]
++fn test_zip_trusted_random_access_composition() {
++    let a = [0, 1, 2, 3, 4];
++    let b = a;
++    let c = a;
++
++    let a = a.iter().copied();
++    let b = b.iter().copied();
++    let mut c = c.iter().copied();
++    c.next();
++
++    let mut z1 = a.zip(b);
++    assert_eq!(z1.next().unwrap(), (0, 0));
++
++    let mut z2 = z1.zip(c);
++    assert_eq!(z2.next().unwrap(), ((1, 1), 1));
++}
+\ No newline at end of file
+-- 
+2.25.1

--- a/SPECS/rust/CVE-2021-28878.patch
+++ b/SPECS/rust/CVE-2021-28878.patch
@@ -1,0 +1,106 @@
+From a461afc27b43155dcf16430bc071682466011501 Mon Sep 17 00:00:00 2001
+From: Thomas Crain <thcrain@microsoft.com>
+Date: Mon, 26 Apr 2021 13:49:28 -0500
+Subject: [PATCH 6/6] Fix CVE-2021-28878
+
+Backported to 1.47.0:
+https://github.com/rust-lang/rust/pull/82292
+---
+ library/core/src/iter/adapters/zip.rs | 13 +++++++++----
+ library/core/tests/iter.rs            | 23 +++++++++++++++++++++++
+ 2 files changed, 32 insertions(+), 4 deletions(-)
+
+diff --git a/library/core/src/iter/adapters/zip.rs b/library/core/src/iter/adapters/zip.rs
+index e480bf2bc28..79f22583e5d 100644
+--- a/library/core/src/iter/adapters/zip.rs
++++ b/library/core/src/iter/adapters/zip.rs
+@@ -16,9 +16,10 @@ use super::super::{DoubleEndedIterator, ExactSizeIterator, FusedIterator, Iterat
+ pub struct Zip<A, B> {
+     a: A,
+     b: B,
+-    // index and len are only used by the specialized version of zip
++    // index, len and a_len are only used by the specialized version of zip
+     index: usize,
+     len: usize,
++    a_len: usize,
+ }
+ impl<A: Iterator, B: Iterator> Zip<A, B> {
+     pub(in super::super) fn new(a: A, b: B) -> Zip<A, B> {
+@@ -113,6 +114,7 @@ where
+             b,
+             index: 0, // unused
+             len: 0,   // unused
++            a_len: 0, // unused
+         }
+     }
+ 
+@@ -187,8 +189,9 @@ where
+     B: TrustedRandomAccess + Iterator,
+ {
+     fn new(a: A, b: B) -> Self {
+-        let len = cmp::min(a.size(), b.size());
+-        Zip { a, b, index: 0, len }
++        let a_len = a.size();
++        let len = cmp::min(a_len, b.size());
++        Zip { a, b, index: 0, len, a_len }
+     }
+ 
+     #[inline]
+@@ -200,7 +203,7 @@ where
+             unsafe {
+                 Some((self.a.__iterator_get_unchecked(i), self.b.__iterator_get_unchecked(i)))
+             }
+-        } else if A::may_have_side_effect() && self.index < self.a.size() {
++        } else if A::may_have_side_effect() && self.index < self.a_len {
+             let i = self.index;
+             self.index += 1;
+             self.len += 1;
+@@ -267,6 +270,7 @@ where
+                     for _ in 0..sz_a - self.len {
+                         self.a.next_back();
+                     }
++                    self.a_len = self.len;
+                 }
+                 let sz_b = self.b.size();
+                 if b_side_effect && sz_b > self.len {
+@@ -278,6 +282,7 @@ where
+         }
+         if self.index < self.len {
+             self.len -= 1;
++            self.a_len -= 1;
+             let i = self.len;
+             // SAFETY: `i` is smaller than the previous value of `self.len`,
+             // which is also smaller than or equal to `self.a.len()` and `self.b.len()`
+diff --git a/library/core/tests/iter.rs b/library/core/tests/iter.rs
+index 913764894ec..bbadb5820e9 100644
+--- a/library/core/tests/iter.rs
++++ b/library/core/tests/iter.rs
+@@ -3260,3 +3260,26 @@ fn test_issue_82282() {
+         panic!();
+     }
+ }
++
++#[test]
++fn test_issue_82291() {
++    use std::cell::Cell;
++
++    let mut v1 = [()];
++    let v2 = [()];
++
++    let called = Cell::new(0);
++
++    let mut zip = v1
++        .iter_mut()
++        .map(|r| {
++            called.set(called.get() + 1);
++            r
++        })
++        .zip(&v2);
++
++    zip.next_back();
++    assert_eq!(called.get(), 1);
++    zip.next();
++    assert_eq!(called.get(), 1);
++}
+-- 
+2.25.1

--- a/SPECS/rust/CVE-2021-28879.patch
+++ b/SPECS/rust/CVE-2021-28879.patch
@@ -1,28 +1,28 @@
-From 1e43823ef5bc19f8ffa60539f8dc93868d6cc1ef Mon Sep 17 00:00:00 2001
+From 173e9c1d6dc4195e9223d6c1f7fe95017c12fd9f Mon Sep 17 00:00:00 2001
 From: Thomas Crain <thcrain@microsoft.com>
-Date: Sun, 25 Apr 2021 13:14:28 -0500
-Subject: [PATCH] Fix CVE-2021-28879
+Date: Mon, 26 Apr 2021 13:44:39 -0500
+Subject: [PATCH 5/6] Fix CVE-2021-28879
 
-Backported from https://github.com/rust-lang/rust/pull/82289/files
-
+Backport to 1.47.0:
+https://github.com/rust-lang/rust/pull/82289
 ---
  library/core/src/iter/adapters/zip.rs |  3 ++-
- library/core/tests/iter.rs            | 20 ++++++++++++++++++++
- 2 files changed, 22 insertions(+), 1 deletion(-)
+ library/core/tests/iter.rs            | 22 +++++++++++++++++++++-
+ 2 files changed, 23 insertions(+), 2 deletions(-)
 
 diff --git a/library/core/src/iter/adapters/zip.rs b/library/core/src/iter/adapters/zip.rs
-index 581ac6e0d82..95bb16325ef 100644
+index 8a9f4b8af1e..e480bf2bc28 100644
 --- a/library/core/src/iter/adapters/zip.rs
 +++ b/library/core/src/iter/adapters/zip.rs
-@@ -201,6 +201,7 @@ where
-                 Some((self.a.__iterator_get_unchecked(i), self.b.__iterator_get_unchecked(i)))
-             }
+@@ -203,6 +203,7 @@ where
          } else if A::may_have_side_effect() && self.index < self.a.size() {
+             let i = self.index;
+             self.index += 1;
 +            self.len += 1;
              // match the base implementation's potential side effects
-             // SAFETY: we just checked that `self.index` < `self.a.len()`
+             // SAFETY: we just checked that `i` < `self.a.len()`
              unsafe {
-@@ -262,7 +263,7 @@ where
+@@ -263,7 +264,7 @@ where
              if sz_a != sz_b {
                  let sz_a = self.a.size();
                  if a_side_effect && sz_a > self.len {
@@ -32,13 +32,17 @@ index 581ac6e0d82..95bb16325ef 100644
                      }
                  }
 diff --git a/library/core/tests/iter.rs b/library/core/tests/iter.rs
-index 00e3972c42f..94787931994 100644
+index 803dc5d1698..913764894ec 100644
 --- a/library/core/tests/iter.rs
 +++ b/library/core/tests/iter.rs
-@@ -1882,6 +1882,26 @@ fn test_double_ended_zip() {
-     assert_eq!(it.next(), None);
- }
+@@ -3239,4 +3239,24 @@ fn test_zip_trusted_random_access_composition() {
  
+     let mut z2 = z1.zip(c);
+     assert_eq!(z2.next().unwrap(), ((1, 1), 1));
+-}
+\ No newline at end of file
++}
++
 +#[test]
 +fn test_issue_82282() {
 +    fn overflowed_zip(arr: &[i32]) -> impl Iterator<Item = (i32, &())> {
@@ -58,9 +62,6 @@ index 00e3972c42f..94787931994 100644
 +        panic!();
 +    }
 +}
-+
- #[test]
- fn test_double_ended_filter() {
-     let xs = [1, 2, 3, 4, 5, 6];
 -- 
 2.25.1
+

--- a/SPECS/rust/rust.spec
+++ b/SPECS/rust/rust.spec
@@ -3,7 +3,7 @@
 Summary:        Rust Programming Language
 Name:           rust
 Version:        1.47.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        ASL 2.0 AND MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -17,7 +17,13 @@ Source4:        https://static.rust-lang.org/dist/2020-08-27/rust-std-1.46.0-x86
 Source5:        https://static.rust-lang.org/dist/2020-08-27/cargo-0.47.0-aarch64-unknown-linux-gnu.tar.gz
 Source6:        https://static.rust-lang.org/dist/2020-08-27/rustc-1.46.0-aarch64-unknown-linux-gnu.tar.gz
 Source7:        https://static.rust-lang.org/dist/2020-08-27/rust-std-1.46.0-aarch64-unknown-linux-gnu.tar.gz
-Patch0:         CVE-2021-28879.patch
+Patch0:         CVE-2020-36317.patch
+Patch1:         CVE-2021-28875.patch
+Patch2:         CVE-2021-28877.patch
+Patch3:         CVE-2021-28876.patch
+Patch4:         CVE-2021-28879.patch
+Patch5:         CVE-2021-28878.patch
+Patch6:         CVE-2020-36323.patch
 
 BuildRequires:  binutils
 BuildRequires:  cmake
@@ -104,6 +110,10 @@ rm %{buildroot}%{_docdir}/%{name}/*.old
 %{_sysconfdir}/bash_completion.d/cargo
 
 %changelog
+* Mon Apr 26 2021 Thomas Crain <thcrain@microsoft.com> - 1.47.0-3
+- Patch CVE-2020-36317, CVE-2021-28875, CVE-2021-28876, CVE-2021-28877, CVE-2021-28878
+- Redo patch for CVE-2021-28879 with regards to patches listed above
+
 * Mon Apr 19 2021 Thomas Crain <thcrain@microsoft.com> - 1.47.0-2
 - Patch CVE-2021-28879
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Adds patches for several High/Critical CVEs in Rust 1.47.0

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Address listed CVEs
- Bump versions of packages that build using Rust

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2020-36317
- https://nvd.nist.gov/vuln/detail/CVE-2020-36323
- https://nvd.nist.gov/vuln/detail/CVE-2020-28875
- https://nvd.nist.gov/vuln/detail/CVE-2020-28876
- https://nvd.nist.gov/vuln/detail/CVE-2020-28877
- https://nvd.nist.gov/vuln/detail/CVE-2020-28878
- https://nvd.nist.gov/vuln/detail/CVE-2020-28879

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local build
