### PR TITLE
[dev] Update clang to fix lldb build error

### DIFF
--- a/SPECS/clang/clang.spec
+++ b/SPECS/clang/clang.spec
@@ -3,23 +3,23 @@ Name:           clang
 Version:        8.0.1
 Release:        4%{?dist}
 License:        NCSA
-URL:            https://clang.llvm.org
-Source0:        https://github.com/llvm/llvm-project/releases/download/llvmorg-%{version}/cfe-%{version}.src.tar.xz
-Group:          Development/Tools
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
+Group:          Development/Tools
+URL:            https://clang.llvm.org
+Source0:        https://github.com/llvm/llvm-project/releases/download/llvmorg-%{version}/cfe-%{version}.src.tar.xz
 BuildRequires:  cmake
+BuildRequires:  libxml2-devel
 BuildRequires:  llvm-devel = %{version}
 BuildRequires:  ncurses-devel
-BuildRequires:  zlib-devel
-BuildRequires:  libxml2-devel
 BuildRequires:  python2-devel
+BuildRequires:  zlib-devel
 Requires:       libstdc++-devel
-Requires:       ncurses
-Requires:       llvm
-Requires:       zlib
 Requires:       libxml2
+Requires:       llvm
+Requires:       ncurses
 Requires:       python2
+Requires:       zlib
 
 %description
 The goal of the Clang project is to create a new C based language front-end: C, C++, Objective C/C++, OpenCL C and others for the LLVM compiler. You can get and build the source today.
@@ -42,7 +42,7 @@ export CXXFLAGS="`echo " %{build_cxxflags} " | sed 's/ -g//'`"
 
 mkdir -p build
 cd build
-cmake -DCMAKE_INSTALL_PREFIX=/usr   \
+cmake -DCMAKE_INSTALL_PREFIX=%{_prefix}   \
       -DCMAKE_BUILD_TYPE=Release    \
 	-DLLVM_ENABLE_EH=ON \
 	-DLLVM_ENABLE_RTTI=ON \
@@ -65,6 +65,7 @@ make clang-check
 %clean
 rm -rf %{buildroot}/*
 
+
 %files
 %defattr(-,root,root)
 %license LICENSE.TXT
@@ -82,22 +83,29 @@ rm -rf %{buildroot}/*
 %{_includedir}/*
 
 %changelog
-* Tue Apr 27 2021 Henry Li <lihl@microsoft.com> 8.0.1-4
+* Tue Apr 27 2021 Henry Li <lihl@microsoft.com> - 8.0.1-4
 - Enable eh/rtti, which are required by lldb.
 
 *   Fri Jun 12 2020 Henry Beberman <henry.beberman@microsoft.com> 8.0.1-3
 -   Temporarily disable generation of debug symbols.
+
 *   Sat May 09 00:21:24 PST 2020 Nick Samson <nisamson@microsoft.com> - 8.0.1-2
 -   Added %%license line automatically
+
 *   Tue Mar 17 2020 Henry Beberman <henry.beberman@microsoft.com> 8.0.1-1
 -   Update to 8.0.1. Fix Source0 URL. License verified.
+
 *   Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 6.0.1-2
 -   Initial CBL-Mariner import from Photon (license: Apache2).
+
 *   Thu Aug 09 2018 Srivatsa S. Bhat <srivatsa@csail.mit.edu> 6.0.1-1
 -   Update to version 6.0.1 to get it to build with gcc 7.3
+
 *   Wed Jun 28 2017 Chang Lee <changlee@vmware.com> 4.0.0-2
 -   Updated %check
+
 *   Fri Apr 7 2017 Alexey Makhalov <amakhalov@vmware.com> 4.0.0-1
 -   Version update
+
 *   Wed Jan 11 2017 Xiaolin Li <xiaolinl@vmware.com>  3.9.1-1
 -   Initial build.

--- a/SPECS/clang/clang.spec
+++ b/SPECS/clang/clang.spec
@@ -1,7 +1,7 @@
 Summary:        C, C++, Objective C and Objective C++ front-end for the LLVM compiler.
 Name:           clang
 Version:        8.0.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        NCSA
 URL:            https://clang.llvm.org
 Source0:        https://github.com/llvm/llvm-project/releases/download/llvmorg-%{version}/cfe-%{version}.src.tar.xz
@@ -44,6 +44,8 @@ mkdir -p build
 cd build
 cmake -DCMAKE_INSTALL_PREFIX=/usr   \
       -DCMAKE_BUILD_TYPE=Release    \
+	-DLLVM_ENABLE_EH=ON \
+	-DLLVM_ENABLE_RTTI=ON \
       -Wno-dev ..
 
 make %{?_smp_mflags}
@@ -80,6 +82,9 @@ rm -rf %{buildroot}/*
 %{_includedir}/*
 
 %changelog
+* Tue Apr 27 2021 Henry Li <lihl@microsoft.com> 8.0.1-4
+- Enable eh/rtti, which are required by lldb.
+
 *   Fri Jun 12 2020 Henry Beberman <henry.beberman@microsoft.com> 8.0.1-3
 -   Temporarily disable generation of debug symbols.
 *   Sat May 09 00:21:24 PST 2020 Nick Samson <nisamson@microsoft.com> - 8.0.1-2


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?

Enabling rtti for llvm causes lldb to have build errors of undefined reference to clang-related definitions. Fix the errors by enabling eh and rtti in clang.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Enable eh/rtti, which are required by lldb.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-YYYY-XXXX

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local Build
