### PR TITLE
cloud-utils-growpart: Workaround for timeout

### DIFF
--- a/SPECS/cloud-utils-growpart/cloud-utils-growpart.spec
+++ b/SPECS/cloud-utils-growpart/cloud-utils-growpart.spec
@@ -1,7 +1,7 @@
 Summary:        Shell script to auto detect free size on disk and grow partition.
 Name:           cloud-utils-growpart
 Version:        0.32
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv3
 Group:          System Environment
 Source0:        https://launchpad.net/cloud-utils/trunk/%{version}/+download/cloud-utils-%{version}.tar.gz
@@ -12,6 +12,7 @@ Requires:       gptfdisk
 Requires:       gawk
 Requires:       util-linux
 BuildArch:      noarch
+Patch0:         growpart-remove-flock-disk-locking.patch
 
 %description
 Cloud-utils brings in growpart script. This script is very useful for
@@ -20,6 +21,7 @@ This is generally used by cloud-init for disk space manangement on cloud images.
 
 %prep
 %setup -q -n cloud-utils-%{version}
+%patch0 -p1
 
 %build
 %install
@@ -34,6 +36,8 @@ cp man/growpart.* $RPM_BUILD_ROOT/%{_mandir}/man1/
 %doc %{_mandir}/man1/growpart.*
 
 %changelog
+*   Tue Apr 27 2021 Chris Co <chrco@microsoft.com> - 0.32-2
+-   Add patch to handle unexpected timeout
 *   Sat Mar 13 2021 Henry Beberman <henry.beberman@microsoft.com> 0.32-1
 -   Update to version 0.32 for more robust parsing of kernel version in growpart
 *   Sat May 09 2020 Nick Samson <nisamson@microsoft.com> 0.30-6

--- a/SPECS/cloud-utils-growpart/cloud-utils-growpart.spec
+++ b/SPECS/cloud-utils-growpart/cloud-utils-growpart.spec
@@ -3,16 +3,16 @@ Name:           cloud-utils-growpart
 Version:        0.32
 Release:        2%{?dist}
 License:        GPLv3
-Group:          System Environment
-Source0:        https://launchpad.net/cloud-utils/trunk/%{version}/+download/cloud-utils-%{version}.tar.gz
-URL:            https://launchpad.net/cloud-utils
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
-Requires:       gptfdisk
+Group:          System Environment
+URL:            https://launchpad.net/cloud-utils
+Source0:        https://launchpad.net/cloud-utils/trunk/%{version}/+download/cloud-utils-%{version}.tar.gz
+Patch0:         growpart-remove-flock-disk-locking.patch
 Requires:       gawk
+Requires:       gptfdisk
 Requires:       util-linux
 BuildArch:      noarch
-Patch0:         growpart-remove-flock-disk-locking.patch
 
 %description
 Cloud-utils brings in growpart script. This script is very useful for
@@ -24,6 +24,7 @@ This is generally used by cloud-init for disk space manangement on cloud images.
 %patch0 -p1
 
 %build
+
 %install
 mkdir -p $RPM_BUILD_ROOT/%{_bindir}
 mkdir -p $RPM_BUILD_ROOT/%{_mandir}/man1
@@ -36,20 +37,27 @@ cp man/growpart.* $RPM_BUILD_ROOT/%{_mandir}/man1/
 %doc %{_mandir}/man1/growpart.*
 
 %changelog
-*   Tue Apr 27 2021 Chris Co <chrco@microsoft.com> - 0.32-2
--   Add patch to handle unexpected timeout
-*   Sat Mar 13 2021 Henry Beberman <henry.beberman@microsoft.com> 0.32-1
--   Update to version 0.32 for more robust parsing of kernel version in growpart
-*   Sat May 09 2020 Nick Samson <nisamson@microsoft.com> 0.30-6
--   Added %%license line automatically
-*   Tue May 05 2020 Emre Girgin <mrgirgin@microsoft.com> 0.30-5
--   Renaming cloud-utils to cloud-utils-growpart
-*   Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 0.30-4
--   Initial CBL-Mariner import from Photon (license: Apache2).
--   License verified.
-*   Mon Sep 18 2017 Alexey Makhalov <amakhalov@vmware.com> 0.30-3
--   Requires util-linux or toybox
-*   Tue Apr 25 2017 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 0.30-2
--   Fix arch
-*   Wed Mar 29 2017 Kumar Kaushik <kaushikk@vmware.com> 0.30-1
--   Initial build.  First version
+* Tue Apr 27 2021 Chris Co <chrco@microsoft.com> - 0.32-2
+- Add patch to handle unexpected timeout
+
+* Sat Mar 13 2021 Henry Beberman <henry.beberman@microsoft.com> - 0.32-1
+- Update to version 0.32 for more robust parsing of kernel version in growpart
+
+* Sat May 09 2020 Nick Samson <nisamson@microsoft.com> - 0.30-6
+- Added %%license line automatically
+
+* Tue May 05 2020 Emre Girgin <mrgirgin@microsoft.com> - 0.30-5
+- Renaming cloud-utils to cloud-utils-growpart
+
+* Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> - 0.30-4
+- Initial CBL-Mariner import from Photon (license: Apache2).
+- License verified.
+
+* Mon Sep 18 2017 Alexey Makhalov <amakhalov@vmware.com> - 0.30-3
+- Requires util-linux or toybox
+
+* Tue Apr 25 2017 Priyesh Padmavilasom <ppadmavilasom@vmware.com> - 0.30-2
+- Fix arch
+
+* Wed Mar 29 2017 Kumar Kaushik <kaushikk@vmware.com> - 0.30-1
+- Initial build.  First version

--- a/SPECS/cloud-utils-growpart/growpart-remove-flock-disk-locking.patch
+++ b/SPECS/cloud-utils-growpart/growpart-remove-flock-disk-locking.patch
@@ -1,0 +1,60 @@
+From 1baf9aed12e35e7c032499081ea1c9887e65626a Mon Sep 17 00:00:00 2001
+From: Chris Co <chrco@microsoft.com>
+Date: Wed, 28 Apr 2021 05:58:02 +0000
+Subject: [PATCH] growpart: remove flock disk locking
+
+Regression identified when using flock disk locking with 5.10 kernel and
+systemd-239. During unlock_disk_and_settle(), udevadm settle will not
+complete and eventually timeout after 2 minutes. When looking at the
+systemd-udevd logs, the daemon crashes and produces the following stack
+trace:
+
+    Stack trace of thread 1531:
+    #0  0x00007fd73d9be405 recvmsg (libpthread.so.0)
+    #1  0x00007fd73dab33b8 udev_monitor_receive_device (libsystemd-shared-239.so)
+    #2  0x0000600347316201 on_uevent (systemd-udevd)
+    #3  0x0000600347316667 on_inotify (systemd-udevd)
+    #4  0x00007fd73dbad6d7 source_dispatch (libsystemd-shared-239.so)
+    #5  0x00007fd73dbaf4e5 sd_event_dispatch (libsystemd-shared-239.so)
+    #6  0x00007fd73dbaf678 sd_event_run (libsystemd-shared-239.so)
+    #7  0x00007fd73dbaf89f sd_event_loop (libsystemd-shared-239.so)
+    #8  0x00006003473132df run (systemd-udevd)
+    #9  0x00007fd73d80e133 __libc_start_main (libc.so.6)
+    #10 0x0000600347313efe _start (systemd-udevd)
+
+The failing behavior appears to be directly linked to the "exec FD"
+actions. A quick way to replicate this issue in the repro environment:
+    exec 9<>$disk
+    exec 9>&-
+    udevadm settle
+
+This patch comments out the initial lock_disk() call, which makes
+unlock_disk_and_settle() return early because ${FLOCK_DISK_FD} is not
+set to a valid FD, avoiding the file descriptor actions that lead to
+the failing behavior.
+
+Note that this change does re-introduce the possibility of udev race
+conditions during the disk operations, effectively reverting this
+behavior to pre-0.32 behavior.
+
+Signed-off-by: Chris Co <chrco@microsoft.com>
+---
+ bin/growpart | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/bin/growpart b/bin/growpart
+index 994b258..90fa016 100755
+--- a/bin/growpart
++++ b/bin/growpart
+@@ -954,7 +954,7 @@ get_resizer "$format" "$resizer" ||
+ 	fail "failed to get a resizer for format '$format'"
+ resizer=$_RET
+ 
+-lock_disk $DISK
++#lock_disk $DISK
+ debug 1 "resizing $PART on $DISK using $resizer"
+ "$resizer"
+ ret=$?
+-- 
+2.17.1
+


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Regression identified when using flock disk locking with 5.10 kernel and
systemd-239. During unlock_disk_and_settle(), udevadm settle will not
complete and eventually timeout after 2 minutes. When looking at the
systemd-udevd logs, the daemon crashes and produces the following stack
trace:

    Stack trace of thread 1531:
    #0  0x00007fd73d9be405 recvmsg (libpthread.so.0)
    #1  0x00007fd73dab33b8 udev_monitor_receive_device (libsystemd-shared-239.so)
    #2  0x0000600347316201 on_uevent (systemd-udevd)
    #3  0x0000600347316667 on_inotify (systemd-udevd)
    #4  0x00007fd73dbad6d7 source_dispatch (libsystemd-shared-239.so)
    #5  0x00007fd73dbaf4e5 sd_event_dispatch (libsystemd-shared-239.so)
    #6  0x00007fd73dbaf678 sd_event_run (libsystemd-shared-239.so)
    #7  0x00007fd73dbaf89f sd_event_loop (libsystemd-shared-239.so)
    #8  0x00006003473132df run (systemd-udevd)
    #9  0x00007fd73d80e133 __libc_start_main (libc.so.6)
    #10 0x0000600347313efe _start (systemd-udevd)

The failing behavior appears to be directly linked to the "exec FD"
actions. A quick way to replicate this issue in the repro environment:
    exec 9<>$disk
    exec 9>&-
    udevadm settle

This patch comments out the initial lock_disk() call, which makes
unlock_disk_and_settle() return early because ${FLOCK_DISK_FD} is not
set to a valid FD, avoiding the file descriptor actions that lead to
the failing behavior.

Note that this change does re-introduce the possibility of udev race
conditions during the disk operations, effectively reverting this
behavior to pre-0.32 behavior.

Signed-off-by: Chris Co <chrco@microsoft.com>

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->

###### Links to CVEs  <!-- optional -->

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local build
