### PR TITLE
Fix logic errors in runliveinstaller script

### DIFF
--- a/toolkit/resources/imageconfigs/additionalfiles/iso_initrd/root/runliveinstaller
+++ b/toolkit/resources/imageconfigs/additionalfiles/iso_initrd/root/runliveinstaller
@@ -28,9 +28,10 @@ else
     done
 fi
 
+CONFIG_ROOT=$ISO_ROOT/config
 
 # Restrict speakup use to attended installs
-if [[ -f "$CONFIG_ROOT/unattended_config.json" ]]; then
+if [[ ! -f "$CONFIG_ROOT/unattended_config.json" ]]; then
     # FIXME(thcrain-msft)
     # This is a loop of silence to keep the default audio device alive
     # This is a temporary workaround that is needed for VirtualBox,
@@ -47,11 +48,6 @@ if [[ -f "$CONFIG_ROOT/unattended_config.json" ]]; then
     systemctl enable espeakup
     systemctl start espeakup
 fi
-
-
-
-
-CONFIG_ROOT=$ISO_ROOT/config
 
 cd /installer
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Fix logic bugs regarding espeakup instantiation in `runliveinstaller`. These were caught previously in code review, but the fixing commit was not pushed to the remote branch.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Make sure $CONFIG_ROOT is defined before use
- Negate test for unattended configuration

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local test
