### PR TITLE
Thcrain/corrosion

### DIFF
--- a/SPECS/rust/CVE-2021-28879.patch
+++ b/SPECS/rust/CVE-2021-28879.patch
@@ -1,30 +1,3 @@
-<<<<<<< HEAD
-From 1e43823ef5bc19f8ffa60539f8dc93868d6cc1ef Mon Sep 17 00:00:00 2001
-From: Thomas Crain <thcrain@microsoft.com>
-Date: Sun, 25 Apr 2021 13:14:28 -0500
-Subject: [PATCH] Fix CVE-2021-28879
-
-Backported from https://github.com/rust-lang/rust/pull/82289/files
-
----
- library/core/src/iter/adapters/zip.rs |  3 ++-
- library/core/tests/iter.rs            | 20 ++++++++++++++++++++
- 2 files changed, 22 insertions(+), 1 deletion(-)
-
-diff --git a/library/core/src/iter/adapters/zip.rs b/library/core/src/iter/adapters/zip.rs
-index 581ac6e0d82..95bb16325ef 100644
---- a/library/core/src/iter/adapters/zip.rs
-+++ b/library/core/src/iter/adapters/zip.rs
-@@ -201,6 +201,7 @@ where
-                 Some((self.a.__iterator_get_unchecked(i), self.b.__iterator_get_unchecked(i)))
-             }
-         } else if A::may_have_side_effect() && self.index < self.a.size() {
-+            self.len += 1;
-             // match the base implementation's potential side effects
-             // SAFETY: we just checked that `self.index` < `self.a.len()`
-             unsafe {
-@@ -262,7 +263,7 @@ where
-=======
 From 173e9c1d6dc4195e9223d6c1f7fe95017c12fd9f Mon Sep 17 00:00:00 2001
 From: Thomas Crain <thcrain@microsoft.com>
 Date: Mon, 26 Apr 2021 13:44:39 -0500
@@ -50,7 +23,6 @@ index 8a9f4b8af1e..e480bf2bc28 100644
              // SAFETY: we just checked that `i` < `self.a.len()`
              unsafe {
 @@ -263,7 +264,7 @@ where
->>>>>>> 1.0-dev
              if sz_a != sz_b {
                  let sz_a = self.a.size();
                  if a_side_effect && sz_a > self.len {
@@ -60,15 +32,6 @@ index 8a9f4b8af1e..e480bf2bc28 100644
                      }
                  }
 diff --git a/library/core/tests/iter.rs b/library/core/tests/iter.rs
-<<<<<<< HEAD
-index 00e3972c42f..94787931994 100644
---- a/library/core/tests/iter.rs
-+++ b/library/core/tests/iter.rs
-@@ -1882,6 +1882,26 @@ fn test_double_ended_zip() {
-     assert_eq!(it.next(), None);
- }
- 
-=======
 index 803dc5d1698..913764894ec 100644
 --- a/library/core/tests/iter.rs
 +++ b/library/core/tests/iter.rs
@@ -80,7 +43,6 @@ index 803dc5d1698..913764894ec 100644
 \ No newline at end of file
 +}
 +
->>>>>>> 1.0-dev
 +#[test]
 +fn test_issue_82282() {
 +    fn overflowed_zip(arr: &[i32]) -> impl Iterator<Item = (i32, &())> {
@@ -100,15 +62,6 @@ index 803dc5d1698..913764894ec 100644
 +        panic!();
 +    }
 +}
-<<<<<<< HEAD
-+
- #[test]
- fn test_double_ended_filter() {
-     let xs = [1, 2, 3, 4, 5, 6];
--- 
-2.25.1
-=======
 -- 
 2.25.1
 
->>>>>>> 1.0-dev


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Merge artifacts were left in a file from the April Update. Reverted this file to the one present and tested from 1.0-dev.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- `git checkout 1.0-dev -- SPECS/rust/CVE-2021-28879.patch`


###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- N/A, this is the version of the patch that has already been tested and built since 4/26
