### PR TITLE
 Updating `uclibc-ng` to version 1.0.37 to fix CVE-2021-27419.

### DIFF
--- a/SPECS/uclibc-ng/uclibc-ng.signatures.json
+++ b/SPECS/uclibc-ng/uclibc-ng.signatures.json
@@ -1,6 +1,6 @@
 {
  "Signatures": {
-  "uClibc-ng-1.0.36.tar.xz": "010f40841669809422e01b47e7169d49c61bf3382f493c2571a8a96634ed300c",
+  "uClibc-ng-1.0.37.tar.xz": "b2b815d20645cf604b99728202bf3ecb62507ce39dfa647884b4453caf86212c",
   "uClibc.config": "5cd0bebdcc29597e6abdcfcbb0d7309633dd843b273b0baca718e6d5f2fb0f1f"
  }
 }

--- a/SPECS/uclibc-ng/uclibc-ng.spec
+++ b/SPECS/uclibc-ng/uclibc-ng.spec
@@ -3,7 +3,7 @@
 %global debug_package %{nil}
 Summary:        C library for embedded Linux
 Name:           uclibc-ng
-Version:        1.0.36
+Version:        1.0.37
 Release:        1%{?dist}
 License:        LGPLv2
 Vendor:         Microsoft Corporation
@@ -81,6 +81,9 @@ rm -rf  %{buildroot}/include/
 %{_libdir}/uClibc
 
 %changelog
+* Wed May 05 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.0.37-1
+- Updating to version 1.0.37 to fix CVE-2021-27419.
+
 * Thu Oct 15 2020 Mateusz Malisz <mamalisz@microsoft.com> - 1.0.36-1
 - Initial CBL-Mariner import from Fedora 32 (license: MIT)
 - License Verified

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -6895,8 +6895,8 @@
         "type": "other",
         "other": {
           "name": "uclibc-ng",
-          "version": "1.0.36",
-          "downloadUrl": "https://downloads.uclibc-ng.org/releases/1.0.36/uClibc-ng-1.0.36.tar.xz"
+          "version": "1.0.37",
+          "downloadUrl": "https://downloads.uclibc-ng.org/releases/1.0.37/uClibc-ng-1.0.37.tar.xz"
         }
       }
     },

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -2004,16 +2004,6 @@
       "component": {
         "type": "other",
         "other": {
-          "name": "jsonbuilder",
-          "version": "0.2.1",
-          "downloadUrl": "https://github.com/microsoft/jsonbuilder/archive/v0.2.1.tar.gz"
-        }
-      }
-    },
-    {
-      "component": {
-        "type": "other",
-        "other": {
           "name": "json-glib",
           "version": "1.4.4",
           "downloadUrl": "https://ftp.gnome.org/pub/GNOME/sources/json-glib/1.4/json-glib-1.4.4.tar.xz"


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

Updating `uclibc-ng` to version 1.0.37 to fix CVE-2021-27419.

See [MSRC blog entry](https://msrc-blog.microsoft.com/2021/04/29/badalloc-memory-allocation-vulnerabilities-could-affect-wide-range-of-iot-and-ot-devices-in-industrial-medical-and-enterprise-networks/) and section 3.2.18 from [CISA's web page](https://us-cert.cisa.gov/ics/advisories/icsa-21-119-04) for more details.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Updated `uclibc-ng` to version 1.0.37 to fix CVE-2021-27419.
- Removed a duplicate in `cgmanifest.json`.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
No.

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2021-27419

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local package build.
