### PR TITLE
Updating `maven` to version 3.8.1 to fix CVE-2021-26291.

### DIFF
--- a/SPECS/maven/maven.signatures.json
+++ b/SPECS/maven/maven.signatures.json
@@ -1,8 +1,8 @@
 {
  "Signatures": {
   "apache-maven-3.8.1-bin.tar.gz": "b98a1905eb554d07427b2e5509ff09bd53e2f1dd7a0afa38384968b113abef02",
-  "apache-maven-3.8.1-licenses.tar.gz": "ea19a15b3bc742db3b25ce02471ece7d5b88b57466a757401f851e878fac2993",
-  "apache-maven-3.8.1-m2.tar.gz": "9c3e13af5daae082d13d73a1191b7319f84c6db671c48607723c79dae3bd2ded",
+  "apache-maven-3.8.1-licenses.tar.gz": "0159eb2952ee4e971664566630063b5492aa15d6b797a1b5588116822be18885",
+  "apache-maven-3.8.1-m2.tar.gz": "638929d4a6bc97d526a733e610b9231c6bb76ff5f29d45ca094ba5941b4bed4e",
   "apache-maven-3.8.1-src.tar.gz": "86dc0df5950bb22dedcab326499531ee9c155016c9a7a3d3f33315becb0c71b1"
  }
 }

--- a/SPECS/maven/maven.signatures.json
+++ b/SPECS/maven/maven.signatures.json
@@ -1,8 +1,8 @@
 {
  "Signatures": {
-  "apache-maven-3.5.4-bin.tar.gz": "ce50b1c91364cb77efe3776f756a6d92b76d9038b0a0782f7d53acf1e997a14d",
-  "apache-maven-3.5.4-licenses.tar.gz": "233c7d392a6267d586e81970ebd4d792b24e743d728e419fc8c4854b3a80e4da",
-  "apache-maven-3.5.4-m2.tar.gz": "da84471232c52c29edd7b2056de9be415f3605a01ebdc6f41529ec6eca82df95",
-  "apache-maven-3.5.4-src.tar.gz": "f3ba1f1b24bbd4c345174ac616d40e26e72dad6022d56317d3ff6f7dd003e2f5"
+  "apache-maven-3.8.1-bin.tar.gz": "b98a1905eb554d07427b2e5509ff09bd53e2f1dd7a0afa38384968b113abef02",
+  "apache-maven-3.8.1-licenses.tar.gz": "233c7d392a6267d586e81970ebd4d792b24e743d728e419fc8c4854b3a80e4da",
+  "apache-maven-3.8.1-m2.tar.gz": "da84471232c52c29edd7b2056de9be415f3605a01ebdc6f41529ec6eca82df95",
+  "apache-maven-3.8.1-src.tar.gz": "86dc0df5950bb22dedcab326499531ee9c155016c9a7a3d3f33315becb0c71b1"
  }
 }

--- a/SPECS/maven/maven.signatures.json
+++ b/SPECS/maven/maven.signatures.json
@@ -1,8 +1,8 @@
 {
  "Signatures": {
   "apache-maven-3.8.1-bin.tar.gz": "b98a1905eb554d07427b2e5509ff09bd53e2f1dd7a0afa38384968b113abef02",
-  "apache-maven-3.8.1-licenses.tar.gz": "233c7d392a6267d586e81970ebd4d792b24e743d728e419fc8c4854b3a80e4da",
-  "apache-maven-3.8.1-m2.tar.gz": "da84471232c52c29edd7b2056de9be415f3605a01ebdc6f41529ec6eca82df95",
+  "apache-maven-3.8.1-licenses.tar.gz": "ea19a15b3bc742db3b25ce02471ece7d5b88b57466a757401f851e878fac2993",
+  "apache-maven-3.8.1-m2.tar.gz": "9c3e13af5daae082d13d73a1191b7319f84c6db671c48607723c79dae3bd2ded",
   "apache-maven-3.8.1-src.tar.gz": "86dc0df5950bb22dedcab326499531ee9c155016c9a7a3d3f33315becb0c71b1"
  }
 }

--- a/SPECS/maven/maven.spec
+++ b/SPECS/maven/maven.spec
@@ -19,7 +19,7 @@ URL:            https://maven.apache.org/
 Source0:        https://archive.apache.org/dist/maven/maven-3/%{version}/source/apache-%{name}-%{version}-src.tar.gz
 # Using pre-compiled binaries because 'maven' requires itself during build-time.
 Source1:        https://archive.apache.org/dist/maven/maven-3/%{version}/binaries/apache-%{name}-%{version}-bin.tar.gz
-# In order to re-generate these sources after a version update switch "sources_generation" to 1
+# In order to re-generate these sources after a version update, switch "sources_generation" to 1
 # and make sure network is enabled during the build. The tarballs will be inside the built 'maven-cached-sources' subpackage.
 %if ! 0%{?sources_generation}
 Source2:        %{m2_cache_tarball_name}

--- a/SPECS/maven/maven.spec
+++ b/SPECS/maven/maven.spec
@@ -98,6 +98,8 @@ echo "Compressing cached licenses."
 tar -C apache-maven -cpvz -f %{licenses_tarball_name} target/licenses/lib
 mv %{licenses_tarball_name} %{buildroot}%{_prefix}
 
+rm %{buildroot}%{_prefix}/boot/plexus-classworlds.license
+
 %endif
 
 mkdir -p %{buildroot}%{_datadir}/java/maven

--- a/SPECS/maven/maven.spec
+++ b/SPECS/maven/maven.spec
@@ -17,12 +17,14 @@ Distribution:   Mariner
 Group:          Applications/System
 URL:            https://maven.apache.org/
 Source0:        https://archive.apache.org/dist/maven/maven-3/%{version}/source/apache-%{name}-%{version}-src.tar.gz
+# Using pre-compiled binaries because 'maven' requires itself during build-time.
 Source1:        https://archive.apache.org/dist/maven/maven-3/%{version}/binaries/apache-%{name}-%{version}-bin.tar.gz
+# In order to re-generate these sources after a version update switch "sources_generation" to 1
+# and make sure network is enabled during the build. The tarballs will be inside the built 'maven-cached-sources' subpackage.
 %if ! 0%{?sources_generation}
 Source2:        %{m2_cache_tarball_name}
 Source3:        %{licenses_tarball_name}
 %endif
-# Note: this license tarball will need to be regenerated if this package is upgraded by running: apache-maven/src/main/appended-resources/META-INF/LICENSE.vm
 BuildRequires:  ant
 BuildRequires:  openjdk8
 BuildRequires:  openjre8

--- a/SPECS/maven/maven.spec
+++ b/SPECS/maven/maven.spec
@@ -1,28 +1,25 @@
 Summary:        Apache Maven
 Name:           maven
-Version:        3.5.4
-Release:        13%{?dist}
+Version:        3.8.1
+Release:        1%{?dist}
 License:        ASL 2.0
-URL:            https://maven.apache.org/
-Group:          Applications/System
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
+Group:          Applications/System
+URL:            https://maven.apache.org/
 Source0:        https://archive.apache.org/dist/maven/maven-3/%{version}/source/apache-%{name}-%{version}-src.tar.gz
 Source1:        https://archive.apache.org/dist/maven/maven-3/%{version}/binaries/apache-%{name}-%{version}-bin.tar.gz
 Source2:        apache-%{name}-%{version}-m2.tar.gz
 Source3:        apache-%{name}-%{version}-licenses.tar.gz
 # Note: this license tarball will need to be regenerated if this package is upgraded by running: apache-maven/src/main/appended-resources/META-INF/LICENSE.vm
-
 BuildRequires:  ant
-BuildRequires:  openjre8
 BuildRequires:  openjdk8
+BuildRequires:  openjre8
 BuildRequires:  wget >= 1.15
+Requires:       %{_bindir}/which
 Requires:       openjre8
-Requires:       /usr/bin/which
 
-%define _prefix /var/opt/apache-%{name}
-%define _bindir %{_prefix}/bin
-%define _libdir %{_prefix}/lib
+%define _prefix %{_var}/opt/apache-%{name}
 
 %description
 The Maven package contains binaries for a build system
@@ -30,9 +27,9 @@ The Maven package contains binaries for a build system
 %prep
 # Setup mvn binary
 tar xf %{SOURCE1} --no-same-owner
-mv ./apache-maven-3.5.4 /var/opt/
-ln -sfvn apache-maven-3.5.4 /var/opt/apache-maven
-ln -sfv /var/opt/apache-maven/bin/mvn /usr/bin/mvn
+mv ./apache-maven-3.5.4 %{_var}/opt/
+ln -sfvn apache-maven-3.5.4 %{_var}/opt/apache-maven
+ln -sfv %{_var}/opt/apache-maven/bin/mvn %{_bindir}/mvn
 # Setup maven .m2 cache directory
 mkdir /root/.m2
 pushd /root/.m2
@@ -44,7 +41,7 @@ popd
 rm -v apache-maven/src/main/appended-resources/META-INF/LICENSE.vm
 pushd apache-maven
 tar xf %{SOURCE3} --no-same-owner
-cp -v ./target/licenses/lib/* /var/opt/apache-maven/lib
+cp -v ./target/licenses/lib/* %{_var}/opt/apache-maven/lib
 popd
 
 %clean
@@ -53,7 +50,7 @@ rm -rf %{buildroot}
 %build
 MAVEN_DIST_DIR=%{buildroot}%{_prefix}
 
-export JAVA_HOME=$(find /usr/lib/jvm -name "OpenJDK*")
+export JAVA_HOME=$(find %{_lib}/jvm -name "OpenJDK*")
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$(find $JAVA_HOME/lib -name "jli")
 
 sed -i 's/www.opensource/opensource/g' DEPENDENCIES
@@ -97,70 +94,103 @@ done
 %exclude %{_libdir}/jansi-native
 
 %changelog
-* Sat May 09 00:21:30 PST 2020 Nick Samson <nisamson@microsoft.com> - 3.5.4-13
+* Wed May 05 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 3.8.1-1
+- Updating to version 3.8.1 to fix CVE-2021-26291.
+
+* Sat May 09 2020 Nick Samson <nisamson@microsoft.com> - 3.5.4-13
 - Added %%license line automatically
 
-*   Thu Apr 30 2020 Emre Girgin <mrgirgin@microsoft.com> 3.5.4-12
--   Renaming apache-ant to ant
-*   Thu Apr 30 2020 Emre Girgin <mrgirgin@microsoft.com> 3.5.4-11
--   Renaming apache-maven to maven
-*   Wed Apr 29 2020 Nicolas Guibourge <nicolasg@microsoft.com> 3.5.4-10
--   Add path to libjli.so in LD_LIBRARY_PATH and skip test while building
-*   Thu Apr 23 2020 Andrew Phelps <anphel@microsoft.com> 3.5.4-9
--   Replace downloaded license files with new source tarball.
-*   Thu Apr 16 2020 Nick Samson <nisamson@microsoft.com> 3.5.4-8
--   Updated Source0, License info to use Fedora guidelines. Signature verified.
-*   Fri Apr 10 2020 Andrew Phelps <anphel@microsoft.com> 3.5.4-7
--   Support building offline for CDPX.
-*   Wed Apr 01 2020 Andrew Phelps <anphel@microsoft.com> 3.5.4-6
--   Support building standalone by adding mvn binary. License verified.
-*   Wed Feb 12 2020 Andrew Phelps <anphel@microsoft.com> 3.5.4-5
--   Remove ExtraBuildRequires
-*   Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 3.5.4-4
--   Initial CBL-Mariner import from Photon (license: Apache2).
-*   Mon Nov 05 2018 Alexey Makhalov <amakhalov@vmware.com> 3.5.4-3
--   Removed dependency on JAVA8_VERSION macro
-*   Mon Oct 29 2018 Alexey Makhalov <amakhalov@vmware.com> 3.5.4-2
--   Use ExtraBuildRequires
-*   Tue Sep 18 2018 Ankit Jain <ankitja@vmware.com> 3.5.4-1
--   Updated apache-maven to version 3.5.4
-*   Fri Oct 13 2017 Alexey Makhalov <amakhalov@vmware.com> 3.5.0-5
--   Remove BuildArch
-*   Mon Sep 18 2017 Alexey Makhalov <amakhalov@vmware.com> 3.5.0-4
--   Requires /usr/bin/which
-*   Mon Jun 19 2017 Divya Thaluru <dthaluru@vmware.com> 3.5.0-3
--   Removed dependency on ANT_HOME
--   Removed apache-maven profile file
--   Removed version from directory path
-*   Thu May 18 2017 Harish Udaiya Kumar <hudaiyakumar@vmware.com> 3.5.0-2
--   Renamed openjdk to openjdk8
-*   Mon Apr 24 2017 Harish Udaiya Kumar <hudaiyakumar@vmware.com> 3.5.0-1
--   Updated apache-maven to version 3.5.0
-*   Fri Mar 31 2017 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 3.3.9-8
--   use java rpm macros to determine versions
-*   Wed Dec 21 2016 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 3.3.9-7
--   Updated JAVA_HOME path to point to latest JDK.
-*   Thu Oct 27 2016 Alexey Makhalov <amakhalov@vmware.com> 3.3.9-6
--   Fix build issue - unable to fetch opensource.org/.../mit-license.php
-*   Tue Oct 04 2016 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 3.3.9-5
--   Updated JAVA_HOME path to point to latest JDK.
-*   Tue May 24 2016 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 3.3.9-4
--   GA - Bump release of all rpms
-*   Fri May 20 2016 Divya Thaluru <dthaluru@vmware.com> 3.3.9-3
--   Updated JAVA_HOME path to point to latest JDK.
-*   Tue Mar 01 2016 Harish Udaiya Kumar <hudaiyakumar@vmware.com> 3.3.9-2
--   Updated the apache-ant version to 1.9.6
-*   Fri Feb 26 2016 Kumar Kaushik <kaushikk@vmware.com> 3.3.9-2
--   Updated JAVA_HOME path to point to latest JDK.
-*   Thu Jan 21 2016 Xiaolin Li <xiaolinl@vmware.com> 3.3.9-1
--   Updated to version 3.3.9
-*   Tue Jan 5 2016 Xiaolin Li <xiaolinl@vmware.com> 3.3.3-4
--   Increase build timeout from 600000 to 1200000
-*   Mon Nov 16 2015 Sharath George <sharathg@vmware.com> 3.3.3-3
--   Change path to /var/opt.
-*   Wed Sep 16 2015 Harish Udaiya Kumar <hudaiyakumar@vmware.com> 3.3.3-2
--   Updated dependencies after repackaging openjdk.
-*   Thu Jul 9 2015     Sarah Choi<sarahc@vmware.com> 3.3.3-1
--   Add a script to set environment variables for MAVEN
-*   Fri May 22 2015 Sriram Nambakam <snambakam@vmware.com> 1.9.4
--   Initial build.    First version
+* Thu Apr 30 2020 Emre Girgin <mrgirgin@microsoft.com> - 3.5.4-12
+- Renaming apache-ant to ant
+
+* Thu Apr 30 2020 Emre Girgin <mrgirgin@microsoft.com> - 3.5.4-11
+- Renaming apache-maven to maven
+
+* Wed Apr 29 2020 Nicolas Guibourge <nicolasg@microsoft.com> - 3.5.4-10
+- Add path to libjli.so in LD_LIBRARY_PATH and skip test while building
+
+* Thu Apr 23 2020 Andrew Phelps <anphel@microsoft.com> - 3.5.4-9
+- Replace downloaded license files with new source tarball.
+
+* Thu Apr 16 2020 Nick Samson <nisamson@microsoft.com> - 3.5.4-8
+- Updated Source0, License info to use Fedora guidelines. Signature verified.
+
+* Fri Apr 10 2020 Andrew Phelps <anphel@microsoft.com> - 3.5.4-7
+- Support building offline for CDPX.
+
+* Wed Apr 01 2020 Andrew Phelps <anphel@microsoft.com> - 3.5.4-6
+- Support building standalone by adding mvn binary. License verified.
+
+* Wed Feb 12 2020 Andrew Phelps <anphel@microsoft.com> - 3.5.4-5
+- Remove ExtraBuildRequires
+
+* Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> - 3.5.4-4
+- Initial CBL-Mariner import from Photon (license: Apache2).
+
+* Mon Nov 05 2018 Alexey Makhalov <amakhalov@vmware.com> - 3.5.4-3
+- Removed dependency on JAVA8_VERSION macro
+
+* Mon Oct 29 2018 Alexey Makhalov <amakhalov@vmware.com> - 3.5.4-2
+- Use ExtraBuildRequires
+
+* Tue Sep 18 2018 Ankit Jain <ankitja@vmware.com> - 3.5.4-1
+- Updated apache-maven to version 3.5.4
+
+* Fri Oct 13 2017 Alexey Makhalov <amakhalov@vmware.com> - 3.5.0-5
+- Remove BuildArch
+
+* Mon Sep 18 2017 Alexey Makhalov <amakhalov@vmware.com> - 3.5.0-4
+- Requires /usr/bin/which
+
+* Mon Jun 19 2017 Divya Thaluru <dthaluru@vmware.com> - 3.5.0-3
+- Removed dependency on ANT_HOME
+- Removed apache-maven profile file
+- Removed version from directory path
+
+* Thu May 18 2017 Harish Udaiya Kumar <hudaiyakumar@vmware.com> - 3.5.0-2
+- Renamed openjdk to openjdk8
+
+* Mon Apr 24 2017 Harish Udaiya Kumar <hudaiyakumar@vmware.com> - 3.5.0-1
+- Updated apache-maven to version 3.5.0
+
+* Fri Mar 31 2017 Priyesh Padmavilasom <ppadmavilasom@vmware.com> - 3.3.9-8
+- use java rpm macros to determine versions
+
+* Wed Dec 21 2016 Priyesh Padmavilasom <ppadmavilasom@vmware.com> - 3.3.9-7
+- Updated JAVA_HOME path to point to latest JDK.
+
+* Thu Oct 27 2016 Alexey Makhalov <amakhalov@vmware.com> - 3.3.9-6
+- Fix build issue - unable to fetch opensource.org/.../mit-license.php
+
+* Tue Oct 04 2016 Priyesh Padmavilasom <ppadmavilasom@vmware.com> - 3.3.9-5
+- Updated JAVA_HOME path to point to latest JDK.
+
+* Tue May 24 2016 Priyesh Padmavilasom <ppadmavilasom@vmware.com> - 3.3.9-4
+- GA - Bump release of all rpms
+
+* Fri May 20 2016 Divya Thaluru <dthaluru@vmware.com> - 3.3.9-3
+- Updated JAVA_HOME path to point to latest JDK.
+
+* Tue Mar 01 2016 Harish Udaiya Kumar <hudaiyakumar@vmware.com> - 3.3.9-2
+- Updated the apache-ant version to 1.9.6
+
+* Fri Feb 26 2016 Kumar Kaushik <kaushikk@vmware.com> - 3.3.9-2
+- Updated JAVA_HOME path to point to latest JDK.
+
+* Thu Jan 21 2016 Xiaolin Li <xiaolinl@vmware.com> - 3.3.9-1
+- Updated to version 3.3.9
+
+* Tue Jan 5 2016 Xiaolin Li <xiaolinl@vmware.com> - 3.3.3-4
+- Increase build timeout from 600000 to 1200000
+
+* Mon Nov 16 2015 Sharath George <sharathg@vmware.com> - 3.3.3-3
+- Change path to /var/opt.
+
+* Wed Sep 16 2015 Harish Udaiya Kumar <hudaiyakumar@vmware.com> - 3.3.3-2
+- Updated dependencies after repackaging openjdk.
+
+* Thu Jul 9 2015     Sarah Choi<sarahc@vmware.com> - 3.3.3-1
+- Add a script to set environment variables for MAVEN
+
+* Fri May 22 2015 Sriram Nambakam <snambakam@vmware.com> - 1.9.4
+- Initial build.    First version

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -3375,8 +3375,8 @@
         "type": "other",
         "other": {
           "name": "maven",
-          "version": "3.5.4",
-          "downloadUrl": "https://archive.apache.org/dist/maven/maven-3/3.5.4/source/apache-maven-3.5.4-src.tar.gz"
+          "version": "3.8.1",
+          "downloadUrl": "https://archive.apache.org/dist/maven/maven-3/3.8.1/source/apache-maven-3.8.1-src.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge
---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

Updating `maven` to version 3.8.1 to fix CVE-2021-26291.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Updating `maven` to version 3.8.1.
- Added a conditionally built `maven-cached-sources` subpackage to simplify future updates.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
No.

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2021-26291

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local package build.
