### PR TITLE
Fixing parsing the packages JSON.

### DIFF
--- a/toolkit/tools/internal/pkgjson/pkgjson.go
+++ b/toolkit/tools/internal/pkgjson/pkgjson.go
@@ -25,7 +25,7 @@ var (
 	// Examples:
 	//	gcc ->       "gcc" "" ""
 	//	gcc=9.1.0 -> "gcc" "=" "1.9.0"
-	packageWithVersionRegex = regexp.MustCompile(`^([^<>=]+)([<>=]+)?(.*)?$`)
+	packageWithVersionRegex = regexp.MustCompile(`^\s*([^><=\s]+)\s*(?:((?:[<>]=)|(?:[<>=]))\s*([^<>=\s]+))?\s*$`)
 )
 
 // PackageRepo contains an array of SRPMs and relational dependencies

--- a/toolkit/tools/internal/pkgjson/pkgjson.go
+++ b/toolkit/tools/internal/pkgjson/pkgjson.go
@@ -5,11 +5,27 @@ package pkgjson
 
 import (
 	"fmt"
+	"regexp"
 
 	"microsoft.com/pkggen/internal/versioncompare"
 
 	"microsoft.com/pkggen/internal/jsonutils"
 	"microsoft.com/pkggen/internal/logger"
+)
+
+const (
+	packageWithVersionNameIndex       = 1
+	packageWithVersionConditionIndex  = 2
+	packageWithVersionVersionIndex    = 3
+	packageWithVersionExpectedMatches = 4
+)
+
+var (
+	// Regular expression to correctly split a string with the package name and an optional version constraint.
+	// Examples:
+	//	gcc ->       "gcc" "" ""
+	//	gcc=9.1.0 -> "gcc" "=" "1.9.0"
+	packageWithVersionRegex = regexp.MustCompile(`^([^<>=]+)([<>=]+)?(.*)?$`)
 )
 
 // PackageRepo contains an array of SRPMs and relational dependencies
@@ -32,10 +48,6 @@ type PackageVerInterval struct {
 	UpperBound     *versioncompare.TolerantVersion // Upper bound on the range of valid versions
 	LowerInclusive bool                            // Does the lower bound actually include the indicated version (< vs <=)
 	UpperInclusive bool                            // Does the upper bound actually include the indicated version (< vs <=)
-}
-
-func (pkgVer *PackageVer) String() string {
-	return fmt.Sprintf("%s:C:'%s'V:'%s',C2:'%s'V2:'%s'", pkgVer.Name, pkgVer.Condition, pkgVer.Version, pkgVer.SCondition, pkgVer.SVersion)
 }
 
 // Package is a representation of a package with name and version information
@@ -157,6 +169,30 @@ func (pkgVer *PackageVer) Interval() (interval PackageVerInterval, err error) {
 	}
 
 	return
+}
+
+// String prints the contents of the given PackageVer struct.
+func (pkgVer *PackageVer) String() string {
+	return fmt.Sprintf("%s:C:'%s'V:'%s',C2:'%s'V2:'%s'", pkgVer.Name, pkgVer.Condition, pkgVer.Version, pkgVer.SCondition, pkgVer.SVersion)
+}
+
+// PackagesListEntryToPackageVer converts an entry from the packages list JSON into an instance of PackageVer.
+// The entries may contain only the name of the package or also include a single package version constraint.
+// Examples:
+//		- "gcc"
+//		- "gcc=9.1.0"
+func PackagesListEntryToPackageVer(packageString string) (pkgVer *PackageVer, err error) {
+	matches := packageWithVersionRegex.FindStringSubmatch(packageString)
+	if len(matches) != packageWithVersionExpectedMatches {
+		err = fmt.Errorf("packages list entry \"%s\" does not match the '[name][optional_condition][optional_version]' format", packageString)
+		return
+	}
+
+	return &PackageVer{
+		Name:      matches[packageWithVersionNameIndex],
+		Condition: matches[packageWithVersionConditionIndex],
+		Version:   matches[packageWithVersionVersionIndex],
+	}, err
 }
 
 // String outputs an interval in interval notation

--- a/toolkit/tools/internal/pkgjson/pkgjson_test.go
+++ b/toolkit/tools/internal/pkgjson/pkgjson_test.go
@@ -434,8 +434,43 @@ func TestShouldCorrectlyConvertPackageNameWithLesserVersionConstraint(t *testing
 	assert.Equal(t, "9.1.0", packageVer.Version)
 }
 
-func TestShouldFailToConvertInvalidPackageListEntry(t *testing.T) {
+func TestShouldCorrectlyConvertPackageNameWithAllowedWhitespaces(t *testing.T) {
+	packageVer, err := PackagesListEntryToPackageVer("  gcc-devel\t\t< 9.1.0    ")
+
+	assert.NoError(t, err)
+	assert.Equal(t, "gcc-devel", packageVer.Name)
+	assert.Equal(t, "<", packageVer.Condition)
+	assert.Equal(t, "", packageVer.SCondition)
+	assert.Equal(t, "", packageVer.SVersion)
+	assert.Equal(t, "9.1.0", packageVer.Version)
+}
+
+func TestShouldFailToConvertPackageListEntryStartingWithInvalidCharacter(t *testing.T) {
 	_, err := PackagesListEntryToPackageVer("=gcc-devel")
+
+	assert.Error(t, err)
+}
+
+func TestShouldFailToConvertPackageListEntryWithInvalidComparison(t *testing.T) {
+	_, err := PackagesListEntryToPackageVer("gcc-devel=>9.1.0")
+
+	assert.Error(t, err)
+}
+
+func TestShouldFailToConvertPackageListEntryWithWhitespacesInComparison(t *testing.T) {
+	_, err := PackagesListEntryToPackageVer("gcc-devel< =9.1.0")
+
+	assert.Error(t, err)
+}
+
+func TestShouldFailToConvertPackageListEntryWithWhitespacesInName(t *testing.T) {
+	_, err := PackagesListEntryToPackageVer("gcc devel")
+
+	assert.Error(t, err)
+}
+
+func TestShouldFailToConvertPackageListEntryWithWhitespacesInVersion(t *testing.T) {
+	_, err := PackagesListEntryToPackageVer("gcc-devel<9 1.0")
 
 	assert.Error(t, err)
 }

--- a/toolkit/tools/internal/pkgjson/pkgjson_test.go
+++ b/toolkit/tools/internal/pkgjson/pkgjson_test.go
@@ -451,6 +451,12 @@ func TestShouldFailToConvertPackageListEntryStartingWithInvalidCharacter(t *test
 	assert.Error(t, err)
 }
 
+func TestShouldFailToConvertPackageListEntryWithIncompleteComparison(t *testing.T) {
+	_, err := PackagesListEntryToPackageVer("gcc-devel=")
+
+	assert.Error(t, err)
+}
+
 func TestShouldFailToConvertPackageListEntryWithInvalidComparison(t *testing.T) {
 	_, err := PackagesListEntryToPackageVer("gcc-devel=>9.1.0")
 

--- a/toolkit/tools/internal/pkgjson/pkgjson_test.go
+++ b/toolkit/tools/internal/pkgjson/pkgjson_test.go
@@ -367,3 +367,75 @@ func TestIntervalCompareWithHigherExclusion(t *testing.T) {
 	assert.Equal(t, -1, intervalLow.Compare(&intervalHigh))
 	assert.Equal(t, 1, intervalHigh.Compare(&intervalLow))
 }
+
+func TestShouldCorrectlyConvertPackageNameWithoutVersionConstraints(t *testing.T) {
+	packageVer, err := PackagesListEntryToPackageVer("gcc-devel")
+
+	assert.NoError(t, err)
+	assert.Equal(t, "gcc-devel", packageVer.Name)
+	assert.Equal(t, "", packageVer.Condition)
+	assert.Equal(t, "", packageVer.SCondition)
+	assert.Equal(t, "", packageVer.SVersion)
+	assert.Equal(t, "", packageVer.Version)
+}
+
+func TestShouldCorrectlyConvertPackageNameWithEqualsVersionConstraint(t *testing.T) {
+	packageVer, err := PackagesListEntryToPackageVer("gcc-devel=9.1.0")
+
+	assert.NoError(t, err)
+	assert.Equal(t, "gcc-devel", packageVer.Name)
+	assert.Equal(t, "=", packageVer.Condition)
+	assert.Equal(t, "", packageVer.SCondition)
+	assert.Equal(t, "", packageVer.SVersion)
+	assert.Equal(t, "9.1.0", packageVer.Version)
+}
+
+func TestShouldCorrectlyConvertPackageNameWithGreaterEqualsVersionConstraint(t *testing.T) {
+	packageVer, err := PackagesListEntryToPackageVer("gcc-devel>=9.1.0")
+
+	assert.NoError(t, err)
+	assert.Equal(t, "gcc-devel", packageVer.Name)
+	assert.Equal(t, ">=", packageVer.Condition)
+	assert.Equal(t, "", packageVer.SCondition)
+	assert.Equal(t, "", packageVer.SVersion)
+	assert.Equal(t, "9.1.0", packageVer.Version)
+}
+
+func TestShouldCorrectlyConvertPackageNameWithGreaterVersionConstraint(t *testing.T) {
+	packageVer, err := PackagesListEntryToPackageVer("gcc-devel>9.1.0")
+
+	assert.NoError(t, err)
+	assert.Equal(t, "gcc-devel", packageVer.Name)
+	assert.Equal(t, ">", packageVer.Condition)
+	assert.Equal(t, "", packageVer.SCondition)
+	assert.Equal(t, "", packageVer.SVersion)
+	assert.Equal(t, "9.1.0", packageVer.Version)
+}
+
+func TestShouldCorrectlyConvertPackageNameWithLesserEqualsVersionConstraint(t *testing.T) {
+	packageVer, err := PackagesListEntryToPackageVer("gcc-devel<=9.1.0")
+
+	assert.NoError(t, err)
+	assert.Equal(t, "gcc-devel", packageVer.Name)
+	assert.Equal(t, "<=", packageVer.Condition)
+	assert.Equal(t, "", packageVer.SCondition)
+	assert.Equal(t, "", packageVer.SVersion)
+	assert.Equal(t, "9.1.0", packageVer.Version)
+}
+
+func TestShouldCorrectlyConvertPackageNameWithLesserVersionConstraint(t *testing.T) {
+	packageVer, err := PackagesListEntryToPackageVer("gcc-devel<9.1.0")
+
+	assert.NoError(t, err)
+	assert.Equal(t, "gcc-devel", packageVer.Name)
+	assert.Equal(t, "<", packageVer.Condition)
+	assert.Equal(t, "", packageVer.SCondition)
+	assert.Equal(t, "", packageVer.SVersion)
+	assert.Equal(t, "9.1.0", packageVer.Version)
+}
+
+func TestShouldFailToConvertInvalidPackageListEntry(t *testing.T) {
+	_, err := PackagesListEntryToPackageVer("=gcc-devel")
+
+	assert.Error(t, err)
+}


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

When reading packages from our packages JSON we didn't split the package name from its version constraint (if present). This change fixes that.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Made sure we correctly split the package names inside the packages JSONs into separate `Name`, `Condition`, and `Version` parts.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
No.

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
-Local image build.
