### PR TITLE
Fix build break due to file dependency in python-pexpect

### DIFF
--- a/SPECS/python-pexpect/python-pexpect.spec
+++ b/SPECS/python-pexpect/python-pexpect.spec
@@ -3,7 +3,7 @@
 Summary:        Unicode-aware Pure Python Expect-like module
 Name:           python-%{modname}
 Version:        4.8.0
-Release:        8%{?dist}
+Release:        9%{?dist}
 License:        ISC
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -84,10 +84,11 @@ TRAVIS=true py.test-3 --verbose
 %{python3_sitelib}/%{modname}-*.egg-info
 
 %changelog
+* Tue May 11 2021 Thomas Crain <thcrain@microsoft.com> - 4.8.0-9
+- Remove /usr/bin/man dependency, replace with check-time man-db dependency
+
 * Mon May 10 2021 Thomas Crain <thcrain@microsoft.com> - 4.8.0-8
 - Initial CBL-Mariner import from Fedora 34 (license: MIT)
-- Ensure check-time requirements are specified as such
-- Remove Fedora macro-based Python build machinery
 - License verified
 
 * Wed Jan 27 2021 Fedora Release Engineering <releng@fedoraproject.org> - 4.8.0-7

--- a/SPECS/python-pexpect/python-pexpect.spec
+++ b/SPECS/python-pexpect/python-pexpect.spec
@@ -9,9 +9,9 @@ Vendor:         Microsoft Corporation
 Distribution:   Mariner
 URL:            https://github.com/pexpect/pexpect
 Source0:        %{url}/archive/%{version}/%{modname}-%{version}.tar.gz
-BuildRequires:  %{_bindir}/man
 BuildArch:      noarch
 %if %{with_check}
+BuildRequires:  man-db
 BuildRequires:  openssl
 %endif
 
@@ -86,6 +86,8 @@ TRAVIS=true py.test-3 --verbose
 %changelog
 * Mon May 10 2021 Thomas Crain <thcrain@microsoft.com> - 4.8.0-8
 - Initial CBL-Mariner import from Fedora 34 (license: MIT)
+- Ensure check-time requirements are specified as such
+- Remove Fedora macro-based Python build machinery
 - License verified
 
 * Wed Jan 27 2021 Fedora Release Engineering <releng@fedoraproject.org> - 4.8.0-7


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Dependency on `/usr/bin/man` in `python-pexpect` package caused dependency resolution in pipeline build 91482 to fail, since man-db is not in the toolchain. Dynamic dependencies are unable to be resolved from non-toolchain packages in 1.0. I tested the build in a derivative previously, which caused this failure to be missed.

NOTE: Not bumping package release, as an official version has never been built. 

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change file requirement on `/usr/bin/man` to `man-db`, and make requirement check-time in python-pexpect

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local build
