### PR TITLE
[dev] Fix build break caused by bind and man-db

### DIFF
--- a/SPECS/bind/bind.spec
+++ b/SPECS/bind/bind.spec
@@ -9,7 +9,7 @@
 Summary:        Domain Name System software
 Name:           bind
 Version:        9.16.3
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        ISC
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -305,20 +305,20 @@ install -m 640 %{SOURCE5} %{buildroot}%{_localstatedir}/named/named.loopback
 install -m 640 %{SOURCE6} %{buildroot}%{_localstatedir}/named/named.empty
 install -m 640 %{SOURCE7} %{buildroot}%{_sysconfdir}/named.rfc1912.zones
 
-mkdir -p %{buildroot}/%{_lib}/tmpfiles.d
+mkdir -p %{buildroot}/%{_tmpfilesdir}
 cat << EOF >> %{buildroot}/%{_sysconfdir}/named.conf
 zone "." in {
     type master;
     allow-update {none;}; // no DDNS by default
 };
 EOF
-echo "d /run/named 0755 named named - -" > %{buildroot}/%{_lib}/tmpfiles.d/named.conf
+echo "d /run/named 0755 named named - -" > %{buildroot}/%{_tmpfilesdir}/named.conf
 
 # sample bind configuration files for %%doc:
 mkdir -p sample/etc sample/var/named/{data,slaves}
 install -m 644 %{SOURCE8} sample/etc/named.conf
 # Copy default configuration to %%doc to make it usable from system-config-bind
-cp %{buildroot}/%{_lib}/tmpfiles.d/named.conf named.conf.default
+cp %{buildroot}/%{_tmpfilesdir}/named.conf named.conf.default
 install -m 644 %{SOURCE7} sample/etc/named.rfc1912.zones
 install -m 644 %{SOURCE4} %{SOURCE5} %{SOURCE6}  sample/var/named
 install -m 644 %{SOURCE3} sample/var/named/named.ca
@@ -383,7 +383,6 @@ fi;
 %{_libdir}/named/*.so
 %config(noreplace) %verify(not md5 size mtime) %{_sysconfdir}/sysconfig/named
 %config(noreplace) %{_sysconfdir}/logrotate.d/named
-%{_tmpfilesdir}/named.conf
 %{_sbindir}/named-journalprint
 %{_sbindir}/named-checkconf
 %{_bindir}/named-rrchecker
@@ -479,9 +478,6 @@ fi;
 %{_libdir}/libdns-pkcs11.so
 %{_libdir}/libns-pkcs11.so
 
-%files license
-%license COPYRIGHT LICENSE
-
 %files dnssec-utils
 %{_sbindir}/dnssec*
 %exclude %{_sbindir}/dnssec*pkcs11
@@ -498,10 +494,10 @@ fi;
 %config(noreplace) %{_sysconfdir}/named-chroot.files
 %{_libexecdir}/setup-named-chroot.sh
 %defattr(0664,root,named,-)
-%ghost %{dev(c,1,3)} %verify(not mtime) %{chroot_prefix}/dev/null
-%ghost %{dev(c,1,8)} %verify(not mtime) %{chroot_prefix}/dev/random
-%ghost %{dev(c,1,9)} %verify(not mtime) %{chroot_prefix}/dev/urandom
-%ghost %{dev(c,1,5)} %verify(not mtime) %{chroot_prefix}/dev/zero
+%ghost %dev(c,1,3) %verify(not mtime) %{chroot_prefix}/dev/null
+%ghost %dev(c,1,8) %verify(not mtime) %{chroot_prefix}/dev/random
+%ghost %dev(c,1,9) %verify(not mtime) %{chroot_prefix}/dev/urandom
+%ghost %dev(c,1,5) %verify(not mtime) %{chroot_prefix}/dev/zero
 %defattr(0640,root,named,0750)
 %dir %{chroot_prefix}
 %dir %{chroot_prefix}/dev
@@ -545,9 +541,13 @@ fi;
 %{_mandir}/man8/named-compilezone.8*
 %{_mandir}/man8/named-nzd2nzf.8*
 %{_sysconfdir}/*
-%{_lib}/tmpfiles.d/named.conf
+%{_tmpfilesdir}/named.conf
 
 %changelog
+* Thu May 13 2021 Henry Li <lihl@microsoft.com> - 9.16.3-4
+- Fix file path error caused by linting
+- Remove named.conf from main package, which is already provided by bind-utils
+
 * Mon May 03 2021 Henry Li <lihl@microsoft.com> - 9.16.3-3
 - Add bind, bind-devel, bind-libs, bind-license, bind-pkcs11, bind-pkcs11-libs,
   bind-pkcs11-utils, bind-pkcs11-devel, bind-dnssec-utils, bind-dnssec-doc,

--- a/SPECS/bind/bind.spec
+++ b/SPECS/bind/bind.spec
@@ -546,6 +546,7 @@ fi;
 %changelog
 * Thu May 13 2021 Henry Li <lihl@microsoft.com> - 9.16.3-4
 - Fix file path error caused by linting
+- Remove duplicate %files section for bind-license
 - Remove named.conf from main package, which is already provided by bind-utils
 
 * Mon May 03 2021 Henry Li <lihl@microsoft.com> - 9.16.3-3

--- a/SPECS/man-db/man-db.spec
+++ b/SPECS/man-db/man-db.spec
@@ -45,7 +45,7 @@ find %{buildroot}%{_libdir} -name '*.la' -delete
 %find_lang %{name} --all-name
 
 # remove zsoelim man page - part of groff package
-rm $RPM_BUILD_ROOT%{_datadir}/man/man1/zsoelim.1
+rm %{buildroot}%{_datadir}/man/man1/zsoelim.1
 
 %check
 getent group man >/dev/null || groupadd -r man

--- a/SPECS/man-db/man-db.spec
+++ b/SPECS/man-db/man-db.spec
@@ -1,7 +1,7 @@
 Summary:        Programs for finding and viewing man pages
 Name:           man-db
 Version:        2.8.4
-Release:        6%{?dist}
+Release:        7%{?dist}
 License:        GPLv2+
 URL:            https://nongnu.org/man-db
 Group:          Applications/System
@@ -44,6 +44,9 @@ make DESTDIR=%{buildroot} install
 find %{buildroot}%{_libdir} -name '*.la' -delete
 %find_lang %{name} --all-name
 
+# remove zsoelim man page - part of groff package
+rm $RPM_BUILD_ROOT%{_datadir}/man/man1/zsoelim.1
+
 %check
 getent group man >/dev/null || groupadd -r man
 getent passwd man >/dev/null || useradd -c "man" -d /var/cache/man -g man \
@@ -77,6 +80,9 @@ fi
 %{_libdir}/tmpfiles.d/man-db.conf
 
 %changelog
+* Thu May 13 2021 Henry Li <lihl@microsoft.com> 2.8.4-7
+- Remove zsoelim man page, which is provided by groff
+
 *   Mon Sep 28 2020 Ruying Chen <v-ruyche@microsoft.com> 2.8.4-6
 -   Add explicit provide for "man"
 *   Sat May 09 2020 Nick Samson <nisamson@microsoft.com> 2.8.4-5


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Fix the build break caused by bind and man-db.

Fix certain file paths in bind.spec which are incorrectly replaced after applying the linter and removed duplicate contents detected in the spec.

sudo failed to build because both groff and man-db provided the same file: zsoelim man due to a recent change in groff. Remove the conflict file from man-db since groff is the right place to provide this file.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->

bind:
- Fix file path error caused by linting
- Remove duplicate %files section for bind-license
- Remove named.conf from main package, which is already provided by bind-utils

man-db:
-Remove zsoelim man page, which is provided by groff


###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-YYYY-XXXX

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local build
