### PR TITLE
[dev] Ensure RUN_CHECK Make flag and with_check RPM define match

### DIFF
--- a/SPECS/pygobject3/pygobject3.spec
+++ b/SPECS/pygobject3/pygobject3.spec
@@ -1,6 +1,6 @@
 Name:           pygobject3
 Version:        3.36.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Python bindings for GObject Introspection
 
 License:        LGPLv2+
@@ -14,12 +14,12 @@ BuildRequires:  gobject-introspection-devel
 BuildRequires:  meson
 BuildRequires:  python3-devel
 BuildRequires:  python3-cairo-devel
-%if %{with_check}
+BuildRequires:  glib-schemas
 BuildRequires:  python-setuptools
 BuildRequires:  python3-setuptools
+%if %{with_check}
 BuildRequires:  gobject-introspection-python
 BuildRequires:  python3-test
-BuildRequires:  glib-schemas
 BuildRequires:  dbus
 BuildRequires:  curl-devel
 BuildRequires:  openssl-devel
@@ -94,6 +94,9 @@ python3 setup.py test
 %{_libdir}/pkgconfig/pygobject-3.0.pc
 
 %changelog
+* Fri May 14 2021 Thomas Crain <thcrain@microsoft.com> - 3.36.1-3
+- Move python setuptools and glib schemas to non-check BuildRequires
+
 * Thu Feb 04 2021 Joe Schmitt <joschmit@microsoft.com> - 3.36.1-2
 - Initial CBL-Mariner import from Fedora 32 (license: MIT).
 - License verified.

--- a/toolkit/scripts/pkggen.mk
+++ b/toolkit/scripts/pkggen.mk
@@ -71,6 +71,7 @@ $(specs_file): $(chroot_worker) $(BUILD_SPECS_DIR) $(build_specs) $(build_spec_d
 		--rpm-dir $(RPMS_DIR) \
 		--dist-tag $(DIST_TAG) \
 		--worker-tar $(chroot_worker) \
+		$(if $(filter y,$(RUN_CHECK)),--run-check) \
 		$(logging_command) \
 		--output $@
 

--- a/toolkit/scripts/srpm_pack.mk
+++ b/toolkit/scripts/srpm_pack.mk
@@ -76,6 +76,7 @@ $(STATUS_FLAGS_DIR)/build_srpms.flag: $(chroot_worker) $(local_specs) $(local_sp
 		--build-dir=$(BUILD_DIR)/SRPM_packaging \
 		--signature-handling=$(SRPM_FILE_SIGNATURE_HANDLING) \
 		--worker-tar=$(chroot_worker) \
+		$(if $(filter y,$(RUN_CHECK)),--run-check) \
 		--log-file=$(LOGS_DIR)/pkggen/srpms/srpmpacker.log \
 		--log-level=$(LOG_LEVEL)
 	touch $@
@@ -92,6 +93,7 @@ $(STATUS_FLAGS_DIR)/build_toolchain_srpms.flag: $(toolchain_spec_list) $(go-srpm
 		--build-dir=$(BUILD_DIR)/SRPM_packaging \
 		--signature-handling=$(SRPM_FILE_SIGNATURE_HANDLING) \
 		--pack-list=$(toolchain_spec_list) \
+		$(if $(filter y,$(RUN_CHECK)),--run-check) \
 		--log-file=$(LOGS_DIR)/toolchain/srpms/toolchain_srpmpacker.log \
 		--log-level=$(LOG_LEVEL)
 	touch $@

--- a/toolkit/tools/internal/rpm/rpm.go
+++ b/toolkit/tools/internal/rpm/rpm.go
@@ -127,11 +127,15 @@ func executeRpmCommand(program string, args ...string) (results []string, err er
 }
 
 // DefaultDefines returns a new map of default defines that can be used during RPM queries.
-func DefaultDefines() map[string]string {
-	const defaultWithCheck = "1"
+func DefaultDefines(runCheck bool) map[string]string {
+	// "with_check" definition should align with the RUN_CHECK Make variable whenever possible
+	withCheckSetting := "0"
+	if runCheck {
+		withCheckSetting = "1"
+	}
 
 	return map[string]string{
-		WithCheckDefine: defaultWithCheck,
+		WithCheckDefine: withCheckSetting,
 	}
 }
 

--- a/toolkit/tools/pkgworker/pkgworker.go
+++ b/toolkit/tools/pkgworker/pkgworker.go
@@ -68,7 +68,7 @@ func main() {
 	srpmName := strings.TrimSuffix(filepath.Base(*srpmFile), ".src.rpm")
 	chrootDir := filepath.Join(*workDir, srpmName)
 
-	defines := rpm.DefaultDefines()
+	defines := rpm.DefaultDefines(*runCheck)
 	defines[rpm.DistTagDefine] = *distTag
 	defines[rpm.DistroReleaseVersionDefine] = *distroReleaseVersion
 	defines[rpm.DistroBuildNumberDefine] = *distroBuildNumber

--- a/toolkit/tools/specreader/specreader.go
+++ b/toolkit/tools/specreader/specreader.go
@@ -46,6 +46,7 @@ var (
 	rpmsDir   = app.Flag("rpm-dir", "Directory containing built RPMs.").Required().ExistingDir()
 	distTag   = app.Flag("dist-tag", "The distribution tag the SPEC will be built with.").Required().String()
 	workerTar = app.Flag("worker-tar", "Full path to worker_chroot.tar.gz.  If this argument is empty, specs will be parsed in the host environment.").ExistingFile()
+	runCheck  = app.Flag("run-check", "Run the check during package build").Bool()
 	logFile   = exe.LogFileFlag(app)
 	logLevel  = exe.LogLevelFlag(app)
 )
@@ -254,7 +255,7 @@ func readSpecWorker(requests <-chan string, results chan<- *parseResult, cancel 
 
 	defer wg.Done()
 
-	defines := rpm.DefaultDefines()
+	defines := rpm.DefaultDefines(*runCheck)
 	defines[rpm.DistTagDefine] = distTag
 
 	for specfile := range requests {

--- a/toolkit/tools/specreader/specreader.go
+++ b/toolkit/tools/specreader/specreader.go
@@ -46,7 +46,7 @@ var (
 	rpmsDir   = app.Flag("rpm-dir", "Directory containing built RPMs.").Required().ExistingDir()
 	distTag   = app.Flag("dist-tag", "The distribution tag the SPEC will be built with.").Required().String()
 	workerTar = app.Flag("worker-tar", "Full path to worker_chroot.tar.gz.  If this argument is empty, specs will be parsed in the host environment.").ExistingFile()
-	runCheck  = app.Flag("run-check", "Run the check during package build").Bool()
+	runCheck  = app.Flag("run-check", "Whether or not to run the spec file's check section during package build.").Bool()
 	logFile   = exe.LogFileFlag(app)
 	logLevel  = exe.LogLevelFlag(app)
 )
@@ -60,13 +60,13 @@ func main() {
 		logger.Log.Panicf("Value in --workers must be greater than zero. Found %d", *workers)
 	}
 
-	err := parseSPECsWrapper(*buildDir, *specsDir, *rpmsDir, *srpmsDir, *distTag, *output, *workerTar, *workers)
+	err := parseSPECsWrapper(*buildDir, *specsDir, *rpmsDir, *srpmsDir, *distTag, *output, *workerTar, *workers, *runCheck)
 	logger.PanicOnError(err)
 }
 
 // parseSPECsWrapper wraps parseSPECs to conditionally run it inside a chroot.
 // If workerTar is non-empty, parsing will occur inside a chroot, otherwise it will run on the host system.
-func parseSPECsWrapper(buildDir, specsDir, rpmsDir, srpmsDir, distTag, outputFile, workerTar string, workers int) (err error) {
+func parseSPECsWrapper(buildDir, specsDir, rpmsDir, srpmsDir, distTag, outputFile, workerTar string, workers int, runCheck bool) (err error) {
 	var (
 		chroot      *safechroot.Chroot
 		packageRepo *pkgjson.PackageRepo
@@ -83,7 +83,7 @@ func parseSPECsWrapper(buildDir, specsDir, rpmsDir, srpmsDir, distTag, outputFil
 
 	doParse := func() error {
 		var parseError error
-		packageRepo, parseError = parseSPECs(specsDir, rpmsDir, srpmsDir, distTag, workers)
+		packageRepo, parseError = parseSPECs(specsDir, rpmsDir, srpmsDir, distTag, workers, runCheck)
 		return parseError
 	}
 
@@ -160,7 +160,7 @@ func createChroot(workerTar, buildDir, specsDir, srpmsDir string) (chroot *safec
 }
 
 // parseSPECs will parse all specs in specsDir and return a summary of the SPECs.
-func parseSPECs(specsDir, rpmsDir, srpmsDir, distTag string, workers int) (packageRepo *pkgjson.PackageRepo, err error) {
+func parseSPECs(specsDir, rpmsDir, srpmsDir, distTag string, workers int, runCheck bool) (packageRepo *pkgjson.PackageRepo, err error) {
 	var (
 		packageList []*pkgjson.Package
 		wg          sync.WaitGroup
@@ -186,7 +186,7 @@ func parseSPECs(specsDir, rpmsDir, srpmsDir, distTag string, workers int) (packa
 	// Start the workers now so they begin working as soon as a new job is buffered.
 	for i := 0; i < workers; i++ {
 		wg.Add(1)
-		go readSpecWorker(requests, results, cancel, &wg, distTag, rpmsDir, srpmsDir)
+		go readSpecWorker(requests, results, cancel, &wg, distTag, rpmsDir, srpmsDir, runCheck)
 	}
 
 	for _, specFile := range specFiles {
@@ -246,7 +246,7 @@ func sortPackages(packageRepo *pkgjson.PackageRepo) {
 // readspec is a goroutine that takes a full filepath to a spec file and scrapes it into the Specdef structure
 // Concurrency is limited by the size of the semaphore channel passed in. Too many goroutines at once can deplete
 // available filehandles.
-func readSpecWorker(requests <-chan string, results chan<- *parseResult, cancel <-chan struct{}, wg *sync.WaitGroup, distTag, rpmsDir, srpmsDir string) {
+func readSpecWorker(requests <-chan string, results chan<- *parseResult, cancel <-chan struct{}, wg *sync.WaitGroup, distTag, rpmsDir, srpmsDir string, runCheck bool) {
 	const (
 		emptyQueryFormat      = ``
 		querySrpm             = `%{NAME}-%{VERSION}-%{RELEASE}.src.rpm`
@@ -255,7 +255,7 @@ func readSpecWorker(requests <-chan string, results chan<- *parseResult, cancel 
 
 	defer wg.Done()
 
-	defines := rpm.DefaultDefines(*runCheck)
+	defines := rpm.DefaultDefines(runCheck)
 	defines[rpm.DistTagDefine] = distTag
 
 	for specfile := range requests {

--- a/toolkit/tools/srpmpacker/srpmpacker.go
+++ b/toolkit/tools/srpmpacker/srpmpacker.go
@@ -106,6 +106,7 @@ var (
 	buildDir     = app.Flag("build-dir", "Directory to store temporary files while building.").Default(defaultBuildDir).String()
 	distTag      = app.Flag("dist-tag", "The distribution tag SRPMs will be built with.").Required().String()
 	packListFile = app.Flag("pack-list", "Path to a list of SPECs to pack. If empty will pack all SPECs.").ExistingFile()
+	runCheck     = app.Flag("run-check", "Run the check during package build").Bool()
 
 	workers          = app.Flag("workers", "Number of concurrent goroutines to parse with.").Default(defaultWorkerCount).Int()
 	repackAll        = app.Flag("repack", "Rebuild all SRPMs, even if already built.").Bool()
@@ -456,7 +457,7 @@ func specsToPackWorker(requests <-chan string, results chan<- *specState, cancel
 		containingDir := filepath.Dir(specFile)
 
 		// Find the SRPM that this SPEC will produce.
-		defines := rpm.DefaultDefines()
+		defines := rpm.DefaultDefines(*runCheck)
 		defines[rpm.DistTagDefine] = distTag
 
 		// Allow the user to configure if the SPEC sources are in a nested 'SOURCES' directory.
@@ -705,7 +706,7 @@ func packSingleSPEC(specFile, srpmFile, signaturesFile, buildDir, outDir, distTa
 	// This will only contain signatures that have either been validated or updated by this tool.
 	currentSignatures := make(map[string]string)
 
-	defines := rpm.DefaultDefines()
+	defines := rpm.DefaultDefines(*runCheck)
 	if distTag != "" {
 		defines[rpm.DistTagDefine] = distTag
 	}

--- a/toolkit/tools/srpmpacker/srpmpacker.go
+++ b/toolkit/tools/srpmpacker/srpmpacker.go
@@ -106,7 +106,7 @@ var (
 	buildDir     = app.Flag("build-dir", "Directory to store temporary files while building.").Default(defaultBuildDir).String()
 	distTag      = app.Flag("dist-tag", "The distribution tag SRPMs will be built with.").Required().String()
 	packListFile = app.Flag("pack-list", "Path to a list of SPECs to pack. If empty will pack all SPECs.").ExistingFile()
-	runCheck     = app.Flag("run-check", "Run the check during package build").Bool()
+	runCheck     = app.Flag("run-check", "Whether or not to run the spec file's check section during package build.").Bool()
 
 	workers          = app.Flag("workers", "Number of concurrent goroutines to parse with.").Default(defaultWorkerCount).Int()
 	repackAll        = app.Flag("repack", "Rebuild all SRPMs, even if already built.").Bool()
@@ -177,7 +177,7 @@ func main() {
 	packList, err := parsePackListFile(*packListFile)
 	logger.PanicOnError(err)
 
-	err = createAllSRPMsWrapper(*specsDir, *distTag, *buildDir, *outDir, *workerTar, *workers, *nestedSourcesDir, *repackAll, packList, templateSrcConfig)
+	err = createAllSRPMsWrapper(*specsDir, *distTag, *buildDir, *outDir, *workerTar, *workers, *nestedSourcesDir, *repackAll, *runCheck, packList, templateSrcConfig)
 	logger.PanicOnError(err)
 }
 
@@ -210,7 +210,7 @@ func parsePackListFile(packListFile string) (packList []string, err error) {
 
 // createAllSRPMsWrapper wraps createAllSRPMs to conditionally run it inside a chroot.
 // If workerTar is non-empty, packing will occur inside a chroot, otherwise it will run on the host system.
-func createAllSRPMsWrapper(specsDir, distTag, buildDir, outDir, workerTar string, workers int, nestedSourcesDir, repackAll bool, packList []string, templateSrcConfig sourceRetrievalConfiguration) (err error) {
+func createAllSRPMsWrapper(specsDir, distTag, buildDir, outDir, workerTar string, workers int, nestedSourcesDir, repackAll, runCheck bool, packList []string, templateSrcConfig sourceRetrievalConfiguration) (err error) {
 	var chroot *safechroot.Chroot
 	originalOutDir := outDir
 	if workerTar != "" {
@@ -223,7 +223,7 @@ func createAllSRPMsWrapper(specsDir, distTag, buildDir, outDir, workerTar string
 	}
 
 	doCreateAll := func() error {
-		return createAllSRPMs(specsDir, distTag, buildDir, outDir, workers, nestedSourcesDir, repackAll, packList, templateSrcConfig)
+		return createAllSRPMs(specsDir, distTag, buildDir, outDir, workers, nestedSourcesDir, repackAll, runCheck, packList, templateSrcConfig)
 	}
 
 	if chroot != nil {
@@ -249,7 +249,7 @@ func createAllSRPMsWrapper(specsDir, distTag, buildDir, outDir, workerTar string
 }
 
 // createAllSRPMs will find all SPEC files in specsDir and pack SRPMs for them if needed.
-func createAllSRPMs(specsDir, distTag, buildDir, outDir string, workers int, nestedSourcesDir, repackAll bool, packList []string, templateSrcConfig sourceRetrievalConfiguration) (err error) {
+func createAllSRPMs(specsDir, distTag, buildDir, outDir string, workers int, nestedSourcesDir, repackAll, runCheck bool, packList []string, templateSrcConfig sourceRetrievalConfiguration) (err error) {
 	logger.Log.Infof("Finding all SPEC files")
 
 	specFiles, err := findSPECFiles(specsDir, packList)
@@ -257,7 +257,7 @@ func createAllSRPMs(specsDir, distTag, buildDir, outDir string, workers int, nes
 		return
 	}
 
-	specStates, err := calculateSPECsToRepack(specFiles, distTag, outDir, nestedSourcesDir, repackAll, workers)
+	specStates, err := calculateSPECsToRepack(specFiles, distTag, outDir, nestedSourcesDir, repackAll, runCheck, workers)
 	if err != nil {
 		return
 	}
@@ -366,7 +366,7 @@ func createChroot(workerTar, buildDir, outDir, specsDir string) (chroot *safechr
 // calculateSPECsToRepack will check which SPECs should be packed.
 // If the resulting SRPM does not exist, or is older than a modification to
 // one of the files used by the SPEC then it is repacked.
-func calculateSPECsToRepack(specFiles []string, distTag, outDir string, nestedSourcesDir, repackAll bool, workers int) (states []*specState, err error) {
+func calculateSPECsToRepack(specFiles []string, distTag, outDir string, nestedSourcesDir, repackAll, runCheck bool, workers int) (states []*specState, err error) {
 	var wg sync.WaitGroup
 
 	requests := make(chan string, len(specFiles))
@@ -378,7 +378,7 @@ func calculateSPECsToRepack(specFiles []string, distTag, outDir string, nestedSo
 	// Start the workers now so they begin working as soon as a new job is buffered.
 	for i := 0; i < workers; i++ {
 		wg.Add(1)
-		go specsToPackWorker(requests, results, cancel, &wg, distTag, outDir, nestedSourcesDir, repackAll)
+		go specsToPackWorker(requests, results, cancel, &wg, distTag, outDir, nestedSourcesDir, repackAll, runCheck)
 	}
 
 	for _, specFile := range specFiles {
@@ -428,7 +428,7 @@ func calculateSPECsToRepack(specFiles []string, distTag, outDir string, nestedSo
 }
 
 // specsToPackWorker will process a channel of spec files that should be checked if packing is needed.
-func specsToPackWorker(requests <-chan string, results chan<- *specState, cancel <-chan struct{}, wg *sync.WaitGroup, distTag, outDir string, nestedSourcesDir, repackAll bool) {
+func specsToPackWorker(requests <-chan string, results chan<- *specState, cancel <-chan struct{}, wg *sync.WaitGroup, distTag, outDir string, nestedSourcesDir, repackAll, runCheck bool) {
 	const (
 		queryFormat         = `%{NAME}-%{VERSION}-%{RELEASE}.src.rpm`
 		queryExclusiveArch  = "%{ARCH}\n[%{EXCLUSIVEARCH}]\n"
@@ -457,7 +457,7 @@ func specsToPackWorker(requests <-chan string, results chan<- *specState, cancel
 		containingDir := filepath.Dir(specFile)
 
 		// Find the SRPM that this SPEC will produce.
-		defines := rpm.DefaultDefines(*runCheck)
+		defines := rpm.DefaultDefines(runCheck)
 		defines[rpm.DistTagDefine] = distTag
 
 		// Allow the user to configure if the SPEC sources are in a nested 'SOURCES' directory.


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
I noticed that in the 1.0->dev merge, in non-check builds, we were rebuilding RPMs which have `with_check`-gated build requirements that were not in the toolchain (namely Python3 with tzdata/iana-etc). 

Further investigation revealed that in our package graph, we always added these gated build requirements regardless of the value of the `RUN_CHECK`. These non-toolchain build requirements were then built, which caused the cached toolchain package to be invalidated because one of its requirements was built instead of cached.

Additionally, during package builds, we pulled in the gated build requirements regardless of the value of RUN_CHECK.

This is all because our default defines that we pass to RPM set `with_check=1` blindly. I added an argument to `rpm.DefaultDefines` to force all callers to respect the value of RUN_CHECK and set the `with_check` define accordingly.  

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Fix placement of BuildRequires in pygobject3
- Add `runCheck` argument to `rpm.DefaultDefines` function to force callers to consider keeping the two in sync.
- Add `--run-check` flag to `specreader`, `srpmpacker` tools, and update their Make invocations accordingly

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
Somewhat- this bug can cause toolchain packages to be rebuilt during the regular package build. Fixing this bug means we shouldn't need to rebuild any toolchain packages in this fashion.

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local build, manual inspection of the package graph to validate change had intended effect
