### PR TITLE
[dev] Improving logging of blocking packages.

### DIFF
--- a/toolkit/docs/how_it_works/3_package_building.md
+++ b/toolkit/docs/how_it_works/3_package_building.md
@@ -75,6 +75,8 @@ The graph contains several types of nodes, with various states. As the graph is 
 >
 > `StateBuild`: Should be built
 >
+> `StateBuildError`: Package had all of its dependencies satisfied but failed to build for other reasons.
+>
 > `StateUpToDate`: Package is already available locally
 
 #### TypeRun

--- a/toolkit/tools/graphanalytics/graphanalytics.go
+++ b/toolkit/tools/graphanalytics/graphanalytics.go
@@ -275,7 +275,7 @@ func printReversedMap(data map[string][]string, valueDescription string, maxResu
 // printMap will sort and print the largest entries, using the valueDescription in the format.
 func printMap(data map[string][]string, valueDescription string, maxResults int) {
 	const inverse = false
-	pairList := sortMap(data, false)
+	pairList := sortMap(data, inverse)
 	printSlice(pairList, valueDescription, maxResults)
 }
 

--- a/toolkit/tools/graphanalytics/graphanalytics.go
+++ b/toolkit/tools/graphanalytics/graphanalytics.go
@@ -283,7 +283,7 @@ func sortMap(mapToSort map[string][]string, inverse bool) (pairList []mapPair) {
 	return
 }
 
-// insertIfMissing appens a value to the key in a map if it is not present.
+// insertIfMissing appends a value to the key in a map if it is not present.
 //
 // Will alter data.
 func insertIfMissing(data map[string][]string, key string, value string) {

--- a/toolkit/tools/graphanalytics/graphanalytics.go
+++ b/toolkit/tools/graphanalytics/graphanalytics.go
@@ -194,8 +194,8 @@ func printIndirectlyClosestToBeingUnblocked(pkgGraph *pkggraph.PkgGraph, maxResu
 
 			dependency := n.(*pkggraph.PkgNode)
 
-			// Only consider unresolved build nodes.
-			if dependency.State != pkggraph.StateUnresolved && dependency.State != pkggraph.StateBuild {
+			// Only consider unresolved or failed build nodes.
+			if dependency.State != pkggraph.StateUnresolved && dependency.State != pkggraph.StateBuildError {
 				return
 			}
 

--- a/toolkit/tools/graphanalytics/graphanalytics.go
+++ b/toolkit/tools/graphanalytics/graphanalytics.go
@@ -292,7 +292,7 @@ func insertIfMissing(data map[string][]string, key string, value string) {
 	}
 }
 
-// insertIfMissingLastPathNode appens a value to the key in a map if it is not present.
+// insertIfMissingLastPathNode appends a value to the key in a map if it is not present.
 // The function compares last nodes of each stored path with the last node of the new path
 // and inserts the new path only if it introduces a new last node.
 //

--- a/toolkit/tools/graphanalytics/graphanalytics.go
+++ b/toolkit/tools/graphanalytics/graphanalytics.go
@@ -205,7 +205,7 @@ func printIndirectlyClosestToBeingUnblocked(pkgGraph *pkggraph.PkgGraph, maxResu
 			dependencyPath, _ := graphpath.AStar(node, dependency, pkgGraph, graphpath.NullHeuristic)
 			dependencyPathNodes, _ := dependencyPath.To(dependency.ID())
 
-			insertIfMissingPkgNode(srpmsBlockedByPaths, pkgSRPM, dependencyPathNodes)
+			insertIfMissingLastPathNode(srpmsBlockedByPaths, pkgSRPM, dependencyPathNodes)
 
 			return
 		})
@@ -284,6 +284,7 @@ func sortMap(mapToSort map[string][]string, inverse bool) (pairList []mapPair) {
 }
 
 // insertIfMissing appens a value to the key in a map if it is not present.
+//
 // Will alter data.
 func insertIfMissing(data map[string][]string, key string, value string) {
 	if sliceutils.Find(data[key], value, sliceutils.StringMatch) == sliceutils.NotFound {
@@ -291,9 +292,12 @@ func insertIfMissing(data map[string][]string, key string, value string) {
 	}
 }
 
-// insertIfMissingPkgNode appens a value to the key in a map if it is not present.
+// insertIfMissingLastPathNode appens a value to the key in a map if it is not present.
+// The function compares last nodes of each stored path with the last node of the new path
+// and inserts the new path only if it introduces a new last node.
+//
 // Will alter data.
-func insertIfMissingPkgNode(data map[string][][]graph.Node, key string, value []graph.Node) {
+func insertIfMissingLastPathNode(data map[string][][]graph.Node, key string, value []graph.Node) {
 	if sliceutils.Find(data[key], value, finalPathNodeSRPMMatch) == sliceutils.NotFound {
 		data[key] = append(data[key], value)
 	}

--- a/toolkit/tools/graphanalytics/graphanalytics.go
+++ b/toolkit/tools/graphanalytics/graphanalytics.go
@@ -192,7 +192,7 @@ func printIndirectlyClosestToBeingUnblocked(pkgGraph *pkggraph.PkgGraph, maxResu
 			dependency := n.(*pkggraph.PkgNode)
 
 			// Only consider unresolved or failed build nodes.
-			if dependency.State != pkggraph.StateUnresolved && dependency.State != pkggraph.StateBuild {
+			if dependency.State != pkggraph.StateUnresolved && dependency.State != pkggraph.StateBuildError {
 				return
 			}
 

--- a/toolkit/tools/internal/pkggraph/pkggraph.go
+++ b/toolkit/tools/internal/pkggraph/pkggraph.go
@@ -34,7 +34,6 @@ const (
 	StateUnknown    NodeState = iota        // Unknown state
 	StateMeta       NodeState = iota        // Meta nodes do not represent actual build artifacts, but additional nodes used for managing dependencies
 	StateBuild      NodeState = iota        // A package from a local SRPM which should be built from source
-	StateBuildError NodeState = iota        // A package from a local SRPM which failed to build
 	StateUpToDate   NodeState = iota        // A local RPM is already built and is available
 	StateUnresolved NodeState = iota        // A dependency is not available locally and must be acquired from a remote repo
 	StateCached     NodeState = iota        // A dependency was not available locally, but is now available in the chache

--- a/toolkit/tools/internal/pkggraph/pkggraph.go
+++ b/toolkit/tools/internal/pkggraph/pkggraph.go
@@ -1224,11 +1224,3 @@ func (g *PkgGraph) removePkgNodeFromLookup(pkgNode *PkgNode) {
 		}
 	}
 }
-
-// PkgNodeMatch is intended to be used with "Find" for slices of strings.
-func PkgNodeMatch(expected, given interface{}) bool {
-	expectedPkgNode := expected.(*PkgNode)
-	givenPkgNode := given.(*PkgNode)
-
-	return expectedPkgNode.nodeID == givenPkgNode.nodeID
-}

--- a/toolkit/tools/internal/pkggraph/pkggraph.go
+++ b/toolkit/tools/internal/pkggraph/pkggraph.go
@@ -31,14 +31,14 @@ type NodeState int
 
 // Valid values for NodeState type
 const (
-	StateUnknown    NodeState = iota        // Unknown state
-	StateMeta       NodeState = iota        // Meta nodes do not represent actual build artifacts, but additional nodes used for managing dependencies
-	StateBuild      NodeState = iota        // A package from a local SRPM which should be built from source
-	StateBuildError NodeState = iota        // A package from a local SRPM which failed to build
-	StateUpToDate   NodeState = iota        // A local RPM is already built and is available
-	StateUnresolved NodeState = iota        // A dependency is not available locally and must be acquired from a remote repo
-	StateCached     NodeState = iota        // A dependency was not available locally, but is now available in the chache
-	StateMAX        NodeState = StateCached // Max allowable state
+	StateUnknown    NodeState = iota            // Unknown state
+	StateMeta       NodeState = iota            // Meta nodes do not represent actual build artifacts, but additional nodes used for managing dependencies
+	StateBuild      NodeState = iota            // A package from a local SRPM which should be built from source
+	StateUpToDate   NodeState = iota            // A local RPM is already built and is available
+	StateUnresolved NodeState = iota            // A dependency is not available locally and must be acquired from a remote repo
+	StateCached     NodeState = iota            // A dependency was not available locally, but is now available in the chache
+	StateBuildError NodeState = iota            // A package from a local SRPM which failed to build
+	StateMAX        NodeState = StateBuildError // Max allowable state
 )
 
 // NodeType indicates the general node type (build, run, goal, remote).
@@ -1223,4 +1223,12 @@ func (g *PkgGraph) removePkgNodeFromLookup(pkgNode *PkgNode) {
 			break
 		}
 	}
+}
+
+// PkgNodeMatch is intended to be used with "Find" for slices of strings.
+func PkgNodeMatch(expected, given interface{}) bool {
+	expectedPkgNode := expected.(*PkgNode)
+	givenPkgNode := given.(*PkgNode)
+
+	return expectedPkgNode.nodeID == givenPkgNode.nodeID
 }

--- a/toolkit/tools/internal/pkggraph/pkggraph.go
+++ b/toolkit/tools/internal/pkggraph/pkggraph.go
@@ -34,6 +34,7 @@ const (
 	StateUnknown    NodeState = iota        // Unknown state
 	StateMeta       NodeState = iota        // Meta nodes do not represent actual build artifacts, but additional nodes used for managing dependencies
 	StateBuild      NodeState = iota        // A package from a local SRPM which should be built from source
+	StateBuildError NodeState = iota        // A package from a local SRPM which failed to build
 	StateUpToDate   NodeState = iota        // A local RPM is already built and is available
 	StateUnresolved NodeState = iota        // A dependency is not available locally and must be acquired from a remote repo
 	StateCached     NodeState = iota        // A dependency was not available locally, but is now available in the chache

--- a/toolkit/tools/internal/pkggraph/pkggraph.go
+++ b/toolkit/tools/internal/pkggraph/pkggraph.go
@@ -34,6 +34,7 @@ const (
 	StateUnknown    NodeState = iota        // Unknown state
 	StateMeta       NodeState = iota        // Meta nodes do not represent actual build artifacts, but additional nodes used for managing dependencies
 	StateBuild      NodeState = iota        // A package from a local SRPM which should be built from source
+	StateBuildError NodeState = iota        // A package from a local SRPM which failed to build
 	StateUpToDate   NodeState = iota        // A local RPM is already built and is available
 	StateUnresolved NodeState = iota        // A dependency is not available locally and must be acquired from a remote repo
 	StateCached     NodeState = iota        // A dependency was not available locally, but is now available in the chache
@@ -106,6 +107,8 @@ func (n NodeState) String() string {
 		return "Meta"
 	case StateBuild:
 		return "Build"
+	case StateBuildError:
+		return "BuildError"
 	case StateUpToDate:
 		return "UpToDate"
 	case StateUnresolved:
@@ -146,6 +149,8 @@ func (n *PkgNode) DOTColor() string {
 		return "aquamarine"
 	case StateBuild:
 		return "gold"
+	case StateBuildError:
+		return "darkorange"
 	case StateUpToDate:
 		return "forestgreen"
 	case StateUnresolved:

--- a/toolkit/tools/internal/pkggraph/pkggraph_test.go
+++ b/toolkit/tools/internal/pkggraph/pkggraph_test.go
@@ -289,6 +289,7 @@ func TestCreateTestGraph(t *testing.T) {
 func TestNodeStateString(t *testing.T) {
 	assert.Equal(t, "Meta", StateMeta.String())
 	assert.Equal(t, "Build", StateBuild.String())
+	assert.Equal(t, "BuildError", StateBuildError.String())
 	assert.Equal(t, "UpToDate", StateUpToDate.String())
 	assert.Equal(t, "Unresolved", StateUnresolved.String())
 	assert.Equal(t, "Cached", StateCached.String())

--- a/toolkit/tools/internal/sliceutils/sliceutils.go
+++ b/toolkit/tools/internal/sliceutils/sliceutils.go
@@ -8,7 +8,7 @@ import "reflect"
 // NotFound value is returned by Find(), if a given value is not present in the slice.
 const NotFound = -1
 
-// Find returns an index of the first occurrence of thing in slice, or -1 if it does not appear in the slice.
+// Find returns an index of the first occurrence of the "searched" argument in slice, or NotFound if it does not appear in the slice.
 func Find(slice interface{}, searched interface{}, cond func(interface{}, interface{}) bool) int {
 	contentValue := reflect.ValueOf(slice)
 

--- a/toolkit/tools/internal/sliceutils/sliceutils.go
+++ b/toolkit/tools/internal/sliceutils/sliceutils.go
@@ -3,16 +3,21 @@
 
 package sliceutils
 
+import "reflect"
+
 // NotFound value is returned by Find(), if a given value is not present in the slice.
 const NotFound = -1
 
 // Find returns an index of the first occurrence of thing in slice, or -1 if it does not appear in the slice.
-func Find(slice []string, thing string) int {
-	for i := range slice {
-		if thing == slice[i] {
+func Find(slice interface{}, searched interface{}, cond func(interface{}, interface{}) bool) int {
+	contentValue := reflect.ValueOf(slice)
+
+	for i := 0; i < contentValue.Len(); i++ {
+		if cond(searched, contentValue.Index(i).Interface()) {
 			return i
 		}
 	}
+
 	return NotFound
 }
 
@@ -25,4 +30,9 @@ func FindMatches(slice []string, isMatch func(string) bool) []string {
 		}
 	}
 	return result
+}
+
+// StringMatch is intended to be used with "Find" for slices of strings.
+func StringMatch(expected, given interface{}) bool {
+	return expected.(string) == given.(string)
 }

--- a/toolkit/tools/pkgworker/pkgworker.go
+++ b/toolkit/tools/pkgworker/pkgworker.go
@@ -309,7 +309,7 @@ func removeLibArchivesFromSystem() (err error) {
 
 		// Skip directories that are meant for device files and kernel virtual filesystems.
 		// These will not contain .la files and are mounted into the safechroot from the host.
-		if info.IsDir() && sliceutils.Find(dirsToExclude, path) != sliceutils.NotFound {
+		if info.IsDir() && sliceutils.Find(dirsToExclude, path, sliceutils.StringMatch) != sliceutils.NotFound {
 			return filepath.SkipDir
 		}
 

--- a/toolkit/tools/scheduler/schedulerutils/buildworker.go
+++ b/toolkit/tools/scheduler/schedulerutils/buildworker.go
@@ -61,11 +61,9 @@ func BuildNodeWorker(channels *BuildChannels, agent buildagents.BuildAgent, grap
 		case pkggraph.TypeBuild:
 			res.UsedCache, res.BuiltFiles, res.LogFile, res.Err = buildBuildNode(req.Node, req.PkgGraph, graphMutex, agent, req.CanUseCache, buildAttempts)
 			if res.Err == nil {
-				for _, node := range req.AncillaryNodes {
-					if node.Type == pkggraph.TypeBuild {
-						node.State = pkggraph.StateUpToDate
-					}
-				}
+				setAncillaryBuildNodesStatus(req, pkggraph.StateUpToDate)
+			} else {
+				setAncillaryBuildNodesStatus(req, pkggraph.StateBuildError)
 			}
 
 		case pkggraph.TypeRun, pkggraph.TypeGoal, pkggraph.TypeRemote, pkggraph.TypePureMeta:
@@ -152,4 +150,13 @@ func buildSRPMFile(agent buildagents.BuildAgent, buildAttempts int, srpmFile str
 	}, buildAttempts, retryDuration)
 
 	return
+}
+
+// setAncillaryBuildNodesStatus sets the NodeState for all of the request's ancillary nodes.
+func setAncillaryBuildNodesStatus(req *BuildRequest, nodeState pkggraph.NodeState) {
+	for _, node := range req.AncillaryNodes {
+		if node.Type == pkggraph.TypeBuild {
+			node.State = nodeState
+		}
+	}
 }

--- a/toolkit/tools/scheduler/schedulerutils/buildworker.go
+++ b/toolkit/tools/scheduler/schedulerutils/buildworker.go
@@ -61,11 +61,9 @@ func BuildNodeWorker(channels *BuildChannels, agent buildagents.BuildAgent, grap
 		case pkggraph.TypeBuild:
 			res.UsedCache, res.BuiltFiles, res.LogFile, res.Err = buildBuildNode(req.Node, req.PkgGraph, graphMutex, agent, req.CanUseCache, buildAttempts)
 			if res.Err == nil {
-				for _, node := range req.AncillaryNodes {
-					if node.Type == pkggraph.TypeBuild {
-						node.State = pkggraph.StateUpToDate
-					}
-				}
+				setAncillaryNodesStatus(req, pkggraph.StateBuild)
+			} else {
+				setAncillaryNodesStatus(req, pkggraph.StateBuildError)
 			}
 
 		case pkggraph.TypeRun, pkggraph.TypeGoal, pkggraph.TypeRemote, pkggraph.TypePureMeta:
@@ -152,4 +150,13 @@ func buildSRPMFile(agent buildagents.BuildAgent, buildAttempts int, srpmFile str
 	}, buildAttempts, retryDuration)
 
 	return
+}
+
+// setAncillaryNodesStatus sets the NodeState for all of the request's ancillary nodes.
+func setAncillaryNodesStatus(req *BuildRequest, nodeState pkggraph.NodeState) {
+	for _, node := range req.AncillaryNodes {
+		if node.Type == pkggraph.TypeBuild {
+			node.State = nodeState
+		}
+	}
 }

--- a/toolkit/tools/scheduler/schedulerutils/buildworker.go
+++ b/toolkit/tools/scheduler/schedulerutils/buildworker.go
@@ -61,9 +61,11 @@ func BuildNodeWorker(channels *BuildChannels, agent buildagents.BuildAgent, grap
 		case pkggraph.TypeBuild:
 			res.UsedCache, res.BuiltFiles, res.LogFile, res.Err = buildBuildNode(req.Node, req.PkgGraph, graphMutex, agent, req.CanUseCache, buildAttempts)
 			if res.Err == nil {
-				setAncillaryNodesStatus(req, pkggraph.StateBuild)
-			} else {
-				setAncillaryNodesStatus(req, pkggraph.StateBuildError)
+				for _, node := range req.AncillaryNodes {
+					if node.Type == pkggraph.TypeBuild {
+						node.State = pkggraph.StateUpToDate
+					}
+				}
 			}
 
 		case pkggraph.TypeRun, pkggraph.TypeGoal, pkggraph.TypeRemote, pkggraph.TypePureMeta:
@@ -150,13 +152,4 @@ func buildSRPMFile(agent buildagents.BuildAgent, buildAttempts int, srpmFile str
 	}, buildAttempts, retryDuration)
 
 	return
-}
-
-// setAncillaryNodesStatus sets the NodeState for all of the request's ancillary nodes.
-func setAncillaryNodesStatus(req *BuildRequest, nodeState pkggraph.NodeState) {
-	for _, node := range req.AncillaryNodes {
-		if node.Type == pkggraph.TypeBuild {
-			node.State = nodeState
-		}
-	}
 }

--- a/toolkit/tools/scheduler/schedulerutils/preparerequest.go
+++ b/toolkit/tools/scheduler/schedulerutils/preparerequest.go
@@ -66,7 +66,7 @@ func canUseCacheForNode(pkgGraph *pkggraph.PkgGraph, node *pkggraph.PkgNode, pac
 
 	// Check if the node corresponds to an entry in packagesToRebuild
 	specName := strings.TrimSuffix(filepath.Base(node.SpecPath), specSuffix)
-	canUseCache = (sliceutils.Find(packagesToRebuild, specName) == -1)
+	canUseCache = (sliceutils.Find(packagesToRebuild, specName, sliceutils.StringMatch) == -1)
 	if !canUseCache {
 		logger.Log.Debugf("Marking (%s) for rebuild per user request", specName)
 		return


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

The change improves how blocking packages are displayed in the logs to include the whole dependency chain, which lead to the conclusion that a particular package is blocking a given SRPM.

Before:
```
level=info msg="136: at-spi2-atk-2.34.2-1.cm1.src.rpm - 2 total unmet dependencies"
level=debug msg="--> gtk3-3.24.28-3.cm1.src.rpm"
level=debug msg="--> pkgconfig(atk-bridge-2.0)"
```

After:
```
level=info msg="136: at-spi2-atk-2.34.2-1.cm1.src.rpm - 1 total unmet dependencies"
level=debug msg="--> pkgconfig(atk-bridge-2.0): gtk2-devel-2.24.32-8.cm1.x86_64.rpm [gtk2-2.24.32-8.cm1.src.rpm] -> gtk2-2.24.32-8.cm1.x86_64.rpm [gtk2-2.24.32-8.cm1.src.rpm] -> gtk-update-icon-cache-3.24.28-3.cm1.x86_64.rpm [gtk3-3.24.28-3.cm1.src.rpm] -> pkgconfig(atk-bridge-2.0)"
```

Note that after the changes there's only one unmet dependency as `gtk3-3.24.28-3.cm1.src.rpm` from the original was actually blocked itself by unresolved `pkgconfig(atk-bridge-2.0)`, so we only keep the "final" blocker.

The change also introduces a new `StateBuildError` node state to distinguish between build nodes, which had attempted to build because they had their dependencies satisfied but failed, and build nodes, which were blocked from building due to missing dependencies.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Changed logging of indirect blocking packages.
- Introduces a new `StateBuildError` node state.
- Modified the `sliceutils.Find` function to work with slices of arbitrary types.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
No.

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local tool runs against graph .dot files from our builds.
- Package build in the pipelines.
