### PR TITLE
Enable usergroups by default in shadow-utils

### DIFF
--- a/SPECS/shadow-utils/shadow-utils.spec
+++ b/SPECS/shadow-utils/shadow-utils.spec
@@ -1,7 +1,7 @@
 Summary:        Programs for handling passwords in a secure way
 Name:           shadow-utils
 Version:        4.6
-Release:        10%{?dist}
+Release:        11%{?dist}
 License:        BSD
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -54,9 +54,8 @@ sed -i 's/yes/no/' %{buildroot}%{_sysconfdir}/default/useradd
 ln -s useradd %{buildroot}%{_sbindir}/adduser
 # Use group id 100(users) by default
 sed -i 's/GROUP.*/GROUP=100/' %{buildroot}%{_sysconfdir}/default/useradd
-# Disable usergroups. Use "users" group by default (see /etc/default/useradd)
-# for all nonroot users.
-sed -i 's/USERGROUPS_ENAB.*/USERGROUPS_ENAB no/' %{buildroot}%{_sysconfdir}/login.defs
+# Enable usergroups. Each user will get their own primary group with a name matching their login name
+sed -i 's/USERGROUPS_ENAB.*/USERGROUPS_ENAB yes/' %{buildroot}%{_sysconfdir}/login.defs
 cp etc/{limits,login.access} %{buildroot}%{_sysconfdir}
 for FUNCTION in FAIL_DELAY               \
                 FAILLOG_ENAB             \
@@ -140,6 +139,9 @@ make %{?_smp_mflags} check
 %config(noreplace) %{_sysconfdir}/pam.d/*
 
 %changelog
+* Thu May 20 2021 Thomas Crain <thcrain@microsoft.com> - 4.6-11
+- Enable usergroups for useradd
+
 * Mon Mar 01 2021 Henry Li <lihl@microsoft.com> - 4.6-10
 - Add sym link to adduser from useradd and create the file for adduser
 

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -352,8 +352,8 @@ rpm-libs-4.14.2-11.cm1.aarch64.rpm
 sed-4.5-3.cm1.aarch64.rpm
 sed-debuginfo-4.5-3.cm1.aarch64.rpm
 sed-lang-4.5-3.cm1.aarch64.rpm
-shadow-utils-4.6-10.cm1.aarch64.rpm
-shadow-utils-debuginfo-4.6-10.cm1.aarch64.rpm
+shadow-utils-4.6-11.cm1.aarch64.rpm
+shadow-utils-debuginfo-4.6-11.cm1.aarch64.rpm
 sqlite-3.34.1-1.cm1.aarch64.rpm
 sqlite-debuginfo-3.34.1-1.cm1.aarch64.rpm
 sqlite-devel-3.34.1-1.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -352,8 +352,8 @@ rpm-libs-4.14.2-11.cm1.x86_64.rpm
 sed-4.5-3.cm1.x86_64.rpm
 sed-debuginfo-4.5-3.cm1.x86_64.rpm
 sed-lang-4.5-3.cm1.x86_64.rpm
-shadow-utils-4.6-10.cm1.x86_64.rpm
-shadow-utils-debuginfo-4.6-10.cm1.x86_64.rpm
+shadow-utils-4.6-11.cm1.x86_64.rpm
+shadow-utils-debuginfo-4.6-11.cm1.x86_64.rpm
 sqlite-3.34.1-1.cm1.x86_64.rpm
 sqlite-debuginfo-3.34.1-1.cm1.x86_64.rpm
 sqlite-devel-3.34.1-1.cm1.x86_64.rpm


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
When users are provisioned using `useradd`, and a primary group is not specified with `-g`, the primary group for those users is the `users` group. Using a blanket default group like this is not following best practices. Users created without specified primary groups are able to read each others' files by default.

This problem is due to a bad configuration in the shadow-utils spec. The spec explicitly sets the `USERGROUPS_ENAB` setting in `/etc/login.defs` to `no`. The [useradd man page](https://linux.die.net/man/8/useradd) has a good explanation of how this setting affects the user’s primary group when a primary group is not specified:

“If [-g is] not specified, the behavior of useradd will depend on the USERGROUPS_ENAB variable in /etc/login.defs. If this variable is set to yes (or -U/--user-group is specified on the command line), a group will be created for the user, with the same name as her loginname. If the variable is set to no (or -N/--no-user-group is specified on the command line), useradd will set the primary group of the new user to the value specified by the GROUP variable in /etc/default/useradd, or 100 by default.”

So, we set `USERGROUPS_ENAB` to `yes` in `/etc/login.defs`. This will give each user their own group by default.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Set `USERGROUPS_ENAB` to `yes` in `/etc/login.defs`.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
**YES**

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local build + ISO validation
