### PR TITLE
Adding CBL-Mariner .repo files to the toolkit.

### DIFF
--- a/toolkit/scripts/toolkit.mk
+++ b/toolkit/scripts/toolkit.mk
@@ -12,11 +12,14 @@ toolkit_component_extra_files = \
 	$(PROJECT_ROOT)/LICENSES-AND-NOTICES/LICENSE.md \
 	$(toolkit_root)/.gitignore
 
+mariner_repos_dir = $(SPECS_DIR)/mariner-repos
+
 # Outputs
 toolkit_version   = $(RELEASE_VERSION)-$(build_arch)
 toolkit_archive   = $(OUT_DIR)/toolkit-$(toolkit_version).tar.gz
 toolkit_remove_archive = $(OUT_DIR)/toolkit-*.tar.gz
 toolkit_build_dir = $(BUILD_DIR)/toolkit
+toolkit_repos_dir = $(toolkit_build_dir)/repos
 toolkit_tools_dir = $(toolkit_build_dir)/tools/toolkit_bins
 toolkit_release_file = $(toolkit_build_dir)/version.txt
 
@@ -30,8 +33,10 @@ clean-package-toolkit:
 package-toolkit: go-tools
 	rm -rf $(toolkit_build_dir) && \
 	mkdir -p $(toolkit_build_dir) && \
+	mkdir -p $(toolkit_repos_dir) && \
 	mkdir -p $(toolkit_tools_dir) && \
 	cp -r $(toolkit_root)/* $(toolkit_build_dir) && \
+	cp $(mariner_repos_dir)/*.repo $(toolkit_repos_dir) && \
 	cp $(toolkit_component_extra_files) $(toolkit_build_dir) && \
 	cp $(go_tool_targets) $(toolkit_tools_dir) && \
 	echo "$(toolkit_version)" > $(toolkit_release_file) && \


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

Adding the .repo files to the toolkit, so that clients have them available if they'd like to build their packages/images with non-default CBL-Mariner RPMs more easily.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add all CBL-Mariner .repo files to the toolkit.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
No.

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local run of `make package-toolkit REBUILD_TOOLS=y` and checking the content of the resulting tarball.
