### PR TITLE
Update version of ceph and python-rsa to fix CVEs

### DIFF
--- a/SPECS/ceph/ceph.signatures.json
+++ b/SPECS/ceph/ceph.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "ceph-15.2.4.tar.gz": "5d51297d5f0358f6fc386ecf3d6e3093a044ef4714ed6c0f0d13af90c96dc54b"
+  "ceph-16.2.0.tar.gz": "dfeee542536607220dc2ca49f47c41127c8562dea234a886625e0f7ee1524904"
  }
 }

--- a/SPECS/ceph/ceph.spec
+++ b/SPECS/ceph/ceph.spec
@@ -1,6 +1,6 @@
 Summary:        User space components of the Ceph file system
 Name:           ceph
-Version:        15.2.4
+Version:        16.2.0
 Release:        1%{?dist}
 License:        LGPLv2 and LGPLv3 and CC-BY-SA and GPLv2 and Boost and BSD and MIT and Public Domain and GPLv3 and ASL-2.0
 URL:            https://ceph.io/
@@ -69,14 +69,17 @@ Requires(post): binutils
 Requires:       systemd
 
 BuildRequires:  cryptsetup
+BuildRequires:  cryptsetup-devel
 BuildRequires:  expat-devel
 BuildRequires:  fuse-devel
 BuildRequires:  gcc
 BuildRequires:  gdbm
 BuildRequires:  gperf
+BuildRequires:  icu-devel
 BuildRequires:  keyutils-devel
 BuildRequires:  leveldb-devel > 1.2
 BuildRequires:  libaio-devel
+BuildRequires:  lua-devel
 BuildRequires:  util-linux-libs
 BuildRequires:  libcap-ng-devel
 BuildRequires:  curl-devel
@@ -942,7 +945,6 @@ install -m 0644 -D udev/50-rbd.rules %{buildroot}%{_udevrulesdir}/50-rbd.rules
 
 # sudoers.d
 install -m 0600 -D sudoers.d/ceph-osd-smartctl %{buildroot}%{_sysconfdir}/sudoers.d/ceph-osd-smartctl
-install -m 0600 -D sudoers.d/cephadm %{buildroot}%{_sysconfdir}/sudoers.d/cephadm
 
 #set up placeholder directories
 mkdir -p %{buildroot}%{_sysconfdir}/ceph
@@ -1053,7 +1055,6 @@ exit 0
 %files -n cephadm
 %{_sbindir}/cephadm
 %{_mandir}/man8/cephadm.8*
-%{_sysconfdir}/sudoers.d/cephadm
 %attr(0700,cephadm,cephadm) %dir %{_sharedstatedir}/cephadm
 %attr(0700,cephadm,cephadm) %dir %{_sharedstatedir}/cephadm/.ssh
 %attr(0600,cephadm,cephadm) %{_sharedstatedir}/cephadm/.ssh/authorized_keys
@@ -1070,6 +1071,8 @@ exit 0
 %{_bindir}/ceph-syn
 %{_bindir}/cephfs-data-scan
 %{_bindir}/cephfs-journal-tool
+%{_bindir}/cephfs-mirror
+%{_bindir}/cephfs-top
 %{_bindir}/cephfs-table-tool
 %{_bindir}/rados
 %{_bindir}/radosgw-admin
@@ -1078,6 +1081,8 @@ exit 0
 %{_bindir}/rbd-replay-many
 %{_bindir}/rbdmap
 %{_sbindir}/mount.ceph
+%{_unitdir}/cephfs-mirror@.service
+%{_unitdir}/cephfs-mirror.target
 %if %{with lttng}
 %{_bindir}/rbd-replay-prep
 %endif
@@ -1100,6 +1105,9 @@ exit 0
 %{_mandir}/man8/rbd-replay-many.8*
 %{_mandir}/man8/rbd-replay-prep.8*
 %{_mandir}/man8/rgw-orphan-list.8*
+%{_mandir}/man8/cephfs-mirror.8*
+%{_mandir}/man8/cephfs-top.8*
+%{python3_sitelib}/cephfs_top-*.egg-info
 %dir %{_datadir}/ceph/
 %{_datadir}/ceph/known_hosts_drop.ceph.com
 %{_datadir}/ceph/id_rsa_drop.ceph.com
@@ -1115,6 +1123,8 @@ exit 0
 %{_udevrulesdir}/50-rbd.rules
 %attr(3770,ceph,ceph) %dir %{_localstatedir}/log/ceph/
 %attr(750,ceph,ceph) %dir %{_localstatedir}/lib/ceph/
+%exclude %{_includedir}/libcephsqlite.h
+%exclude %{_libdir}/libcephsqlite.so
 
 %pre common
 CEPH_GROUP_ID=167
@@ -1233,6 +1243,8 @@ fi
 %{_datadir}/ceph/mgr/insights
 %{_datadir}/ceph/mgr/iostat
 %{_datadir}/ceph/mgr/localpool
+%{_datadir}/ceph/mgr/mds_autoscaler
+%{_datadir}/ceph/mgr/mirroring
 %{_datadir}/ceph/mgr/orchestrator
 %{_datadir}/ceph/mgr/osd_perf_query
 %{_datadir}/ceph/mgr/osd_support
@@ -1242,6 +1254,8 @@ fi
 %{_datadir}/ceph/mgr/rbd_support
 %{_datadir}/ceph/mgr/restful
 %{_datadir}/ceph/mgr/selftest
+%{_datadir}/ceph/mgr/snap_schedule
+%{_datadir}/ceph/mgr/stats
 %{_datadir}/ceph/mgr/status
 %{_datadir}/ceph/mgr/telegraf
 %{_datadir}/ceph/mgr/telemetry
@@ -1322,6 +1336,7 @@ fi
 %files fuse
 %{_bindir}/ceph-fuse
 %{_mandir}/man8/ceph-fuse.8*
+%{_mandir}/man8/mount.fuse.ceph.8*
 %{_sbindir}/mount.fuse.ceph
 %{_unitdir}/ceph-fuse@.service
 %{_unitdir}/ceph-fuse.target
@@ -1400,6 +1415,8 @@ fi
 %{_bindir}/radosgw-es
 %{_bindir}/radosgw-object-expirer
 %{_bindir}/rgw-orphan-list
+%{_bindir}/rgw-gap-list
+%{_bindir}/rgw-gap-list-comparator
 %{_libdir}/libradosgw.so*
 %{_mandir}/man8/radosgw.8*
 %dir %{_localstatedir}/lib/ceph/radosgw
@@ -1434,6 +1451,7 @@ fi
 %files osd
 %{_bindir}/ceph-clsinfo
 %{_bindir}/ceph-bluestore-tool
+%{_bindir}/ceph-erasure-code-tool
 %{_bindir}/ceph-objectstore-tool
 %{_bindir}/ceph-osdomap-tool
 %{_bindir}/ceph-osd
@@ -1554,6 +1572,7 @@ fi
 %if %{with lttng}
 %{_libdir}/librbd_tp.so.*
 %endif
+%{_libdir}/ceph/librbd/libceph_*.so*
 
 %post -n librbd1 -p /sbin/ldconfig
 
@@ -1571,7 +1590,6 @@ fi
 
 %files -n librgw2
 %{_libdir}/librgw.so.*
-%{_libdir}/librgw_admin_user.so.*
 %if %{with lttng}
 %{_libdir}/librgw_op_tp.so.*
 %{_libdir}/librgw_rados_tp.so.*
@@ -1584,10 +1602,8 @@ fi
 %files -n librgw-devel
 %dir %{_includedir}/rados
 %{_includedir}/rados/librgw.h
-%{_includedir}/rados/librgw_admin_user.h
 %{_includedir}/rados/rgw_file.h
 %{_libdir}/librgw.so
-%{_libdir}/librgw_admin_user.so
 %if %{with lttng}
 %{_libdir}/librgw_op_tp.so
 %{_libdir}/librgw_rados_tp.so
@@ -1614,6 +1630,7 @@ fi
 %{_includedir}/cephfs/libcephfs.h
 %{_includedir}/cephfs/ceph_ll_client.h
 %{_libdir}/libcephfs.so
+%{_includedir}/cephfs/metrics/Types.h
 
 %files -n python%{python3_pkgversion}-cephfs
 %{python3_sitearch}/cephfs.cpython*.so
@@ -1779,6 +1796,9 @@ exit 0
 %config %{_sysconfdir}/prometheus/ceph/ceph_default_alerts.yml
 
 %changelog
+*   Fri May 21 2021 Neha Agarwal <nehaagarwal@microsoft.com> 16.2.0-1
+-   Update package version to fix CVE-2020-25660, CVE-2020-25678 and CVE-2020-27781
+
 *   Fri Aug 21 2020 Thomas Crain <thcrain@microsoft.com> 15.2.4-1
 -   Initial CBL-Mariner import from Ceph source (license: LGPLv2.1)
 -   License verified

--- a/SPECS/python-rsa/python-rsa.signatures.json
+++ b/SPECS/python-rsa/python-rsa.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "rsa-4.6.tar.gz": "109ea5a66744dd859bf16fe904b8d8b627adafb9408753161e766a92e7d681fa"
+  "rsa-4.7.2.tar.gz": "9d689e6ca1b3038bc82bf8d23e944b6b6037bc02301a574935b2dd946e0353b9"
  }
 }

--- a/SPECS/python-rsa/python-rsa.spec
+++ b/SPECS/python-rsa/python-rsa.spec
@@ -3,7 +3,7 @@
 
 Summary:        Purely Python RSA implementation
 Name:           python-%{pkgname}
-Version:        4.6
+Version:        4.7.2
 Release:        1%{?dist}
 License:        ASL 2.0
 URL:            https://stuvel.eu/software/rsa/
@@ -45,6 +45,9 @@ python3 setup.py install --skip-build --root=%{buildroot}
 %{_bindir}/*
 
 %changelog
+* Fri May 21 2021 Neha Agarwal <nehaagarwal@microsoft.com> - 4.7.2-1
+- Update package version to fix CVE-2020-25658
+
 * Fri Aug 21 2020 Thomas Crain <thcrain@microsoft.com> - 4.6-1
 - Original version for CBL-Mariner
 - License verified

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -725,8 +725,8 @@
         "type": "other",
         "other": {
           "name": "ceph",
-          "version": "15.2.4",
-          "downloadUrl": "https://download.ceph.com/tarballs/ceph-15.2.4.tar.gz"
+          "version": "16.2.0",
+          "downloadUrl": "https://download.ceph.com/tarballs/ceph-16.2.0.tar.gz"
         }
       }
     },
@@ -5725,8 +5725,8 @@
         "type": "other",
         "other": {
           "name": "python-rsa",
-          "version": "4.6",
-          "downloadUrl": "https://pypi.python.org/packages/source/r/rsa/rsa-4.6.tar.gz"
+          "version": "4.7.2",
+          "downloadUrl": "https://pypi.python.org/packages/source/r/rsa/rsa-4.7.2.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Update version of ceph and python-rsa to fix CVEs

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Update ceph version to 16.2.0 to fix CVE-2020-25660, CVE-2020-25678 and CVE-2020-27781
- Update python-rsa version to 4.7.2 to fix CVE-2020-25658

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2020-25658
- https://nvd.nist.gov/vuln/detail/CVE-2020-25660
- https://nvd.nist.gov/vuln/detail/CVE-2020-25678
- https://nvd.nist.gov/vuln/detail/CVE-2020-27781

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local build
