### PR TITLE
[dev] Fix build breaks due to Python2 toolchain removal

### DIFF
--- a/SPECS-SIGNED/grub2-efi-binary-signed/grub2-efi-binary-signed.spec
+++ b/SPECS-SIGNED/grub2-efi-binary-signed/grub2-efi-binary-signed.spec
@@ -10,7 +10,7 @@
 Summary:        Signed GRand Unified Bootloader for %{buildarch} systems
 Name:           grub2-efi-binary-signed-%{buildarch}
 Version:        2.06~rc1
-Release:        4%{?dist}
+Release:        5%{?dist}
 License:        GPLv3+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -54,6 +54,9 @@ cp %{SOURCE1} %{buildroot}/boot/efi/EFI/BOOT/%{grubefiname}
 /boot/efi/EFI/BOOT/%{grubefiname}
 
 %changelog
+* Tue May 25 2021 Thomas Crain <thcrain@microsoft.com> - 2.06~rc1-5
+- Update release to be aligned with unsigned version
+
 * Fri Apr 16 2021 Chris Co <chrco@microsoft.com> - 2.06~rc1-4
 - Commonize to one spec instead of having a spec per arch
 - Define a new grub2-efi-binary subpackage which contains the signed collateral

--- a/SPECS/grub2/grub2.spec
+++ b/SPECS/grub2/grub2.spec
@@ -6,7 +6,7 @@
 Summary:        GRand Unified Bootloader
 Name:           grub2
 Version:        2.06~rc1
-Release:        4%{?dist}
+Release:        5%{?dist}
 License:        GPLv3+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -110,6 +110,7 @@ tar -zxf gnulib-%{gnulibversion}.tar.gz
 mv gnulib-%{gnulibversion} gnulib
 
 %build
+export PYTHON=%{python3}
 ./bootstrap --no-git --gnulib-srcdir=./gnulib
 %ifarch x86_64
 mkdir build-for-pc
@@ -270,6 +271,9 @@ cp $GRUB_MODULE_SOURCE $EFI_BOOT_DIR/$GRUB_MODULE_NAME
 %endif
 
 %changelog
+* Tue May 25 2021 Thomas Crain <thcrain@microsoft.com> - 2.06~rc1-5
+- Explicitly specify python 3 as the python interpreter for bootstrapping
+
 * Fri Apr 16 2021 Chris Co <chrco@microsoft.com> - 2.06~rc1-4
 - Bump version to match grub-efi-binary-signed spec
 

--- a/SPECS/libxml2/libxml2.spec
+++ b/SPECS/libxml2/libxml2.spec
@@ -1,5 +1,3 @@
-%{!?python2_sitelib: %define python2_sitelib %(python2 -c "from distutils.sysconfig import get_python_lib;print(get_python_lib())")}
-%{!?python3_sitelib: %define python3_sitelib %(python3 -c "from distutils.sysconfig import get_python_lib;print(get_python_lib())")}
 Summary:        Libxml2
 Name:           libxml2
 Version:        2.9.10
@@ -13,8 +11,6 @@ Source0:        ftp://xmlsoft.org/libxml2/%{name}-%{version}.tar.gz
 Patch0:         CVE-2019-20388.patch
 Patch1:         CVE-2020-7595.patch
 Patch2:         CVE-2020-24977.patch
-BuildRequires:  python2-devel
-BuildRequires:  python2-libs
 BuildRequires:  python3-devel
 Provides:       pkgconfig(libxml-2.0) = %{version}-%{release}
 Provides:       %{name}-tools = %{version}-%{release}
@@ -22,17 +18,6 @@ Provides:       libxml-tools = %{version}-%{release}
 
 %description
 The libxml2 package contains libraries and utilities used for parsing XML files.
-
-%package python
-Summary:        The libxml2 python module
-Group:          Development/Languages/Python
-Requires:       %{name} = %{version}
-Requires:       python2
-Requires:       python2-libs
-Requires:       python-xml
-
-%description    python
-The libxml2 python module
 
 %package -n     python3-libxml2
 Summary:        Python 3 bindings for libxml2.
@@ -94,10 +79,6 @@ rm -rf %{buildroot}/*
 %{_datadir}/aclocal/*
 %{_datadir}/gtk-doc/*
 %{_mandir}/man1/*
-
-%files python
-%defattr(-,root,root)
-%{python2_sitelib}/*
 
 %files -n python3-libxml2
 %defattr(-,root,root)

--- a/SPECS/libxml2/libxml2.spec
+++ b/SPECS/libxml2/libxml2.spec
@@ -94,6 +94,9 @@ rm -rf %{buildroot}/*
 %changelog
 * Fri May 21 2021 Nick Samson <nisamson@microsoft.com> - 2.9.10-8
 - Added explicit requirement on python xml library
+- Remove requirement on python2
+- Remove libxml2-python subpackage
+
 * Fri Mar 26 2021 Thomas Crain <thcrain@microsoft.com> - 2.9.10-7
 - Merge the following releases from 1.0 to dev branch
 - v-ruyche@microsoft.com, 2.9.10-3: Patch CVE-2020-24977.

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -229,7 +229,6 @@ libtool-debuginfo-2.4.6-7.cm1.aarch64.rpm
 libxml2-2.9.10-8.cm1.aarch64.rpm
 libxml2-debuginfo-2.9.10-8.cm1.aarch64.rpm
 libxml2-devel-2.9.10-8.cm1.aarch64.rpm
-libxml2-python-2.9.10-8.cm1.aarch64.rpm
 libxslt-1.1.34-4.cm1.aarch64.rpm
 libxslt-debuginfo-1.1.34-4.cm1.aarch64.rpm
 libxslt-devel-1.1.34-4.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -575,7 +575,7 @@ tdnf-devel-2.1.0-7.cm1.x86_64.rpm
 tdnf-plugin-repogpgcheck-2.1.0-7.cm1.x86_64.rpm
 tdnf-python-2.1.0-7.cm1.x86_64.rpm
 texinfo-6.5-8.cm1.x86_64.rpm
-texinfo-debuginfo-6.5-8.cm1.x8p6_64.rpm
+texinfo-debuginfo-6.5-8.cm1.x86_64.rpm
 unzip-6.0-19.cm1.x86_64.rpm
 unzip-debuginfo-6.0-19.cm1.x86_64.rpm
 util-linux-2.36.1-3.cm1.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -229,7 +229,6 @@ libtool-debuginfo-2.4.6-7.cm1.x86_64.rpm
 libxml2-2.9.10-8.cm1.x86_64.rpm
 libxml2-debuginfo-2.9.10-8.cm1.x86_64.rpm
 libxml2-devel-2.9.10-8.cm1.x86_64.rpm
-libxml2-python-2.9.10-8.cm1.x86_64.rpm
 libxslt-1.1.34-4.cm1.x86_64.rpm
 libxslt-debuginfo-1.1.34-4.cm1.x86_64.rpm
 libxslt-devel-1.1.34-4.cm1.x86_64.rpm
@@ -576,7 +575,7 @@ tdnf-devel-2.1.0-7.cm1.x86_64.rpm
 tdnf-plugin-repogpgcheck-2.1.0-7.cm1.x86_64.rpm
 tdnf-python-2.1.0-7.cm1.x86_64.rpm
 texinfo-6.5-8.cm1.x86_64.rpm
-texinfo-debuginfo-6.5-8.cm1.x86_64.rpm
+texinfo-debuginfo-6.5-8.cm1.x8p6_64.rpm
 unzip-6.0-19.cm1.x86_64.rpm
 unzip-debuginfo-6.0-19.cm1.x86_64.rpm
 util-linux-2.36.1-3.cm1.x86_64.rpm

--- a/toolkit/resources/manifests/package/update_manifests.sh
+++ b/toolkit/resources/manifests/package/update_manifests.sh
@@ -81,7 +81,6 @@ remove_packages_for_pkggen_core () {
     sed -i '/libselinux-utils/d' $TmpPkgGen
     sed -i '/libsepol-devel/d' $TmpPkgGen
     sed -i '/libsolv-tools/d' $TmpPkgGen
-    sed -i '/libxml2-python/d' $TmpPkgGen
     sed -i '/libxslt/d' $TmpPkgGen
     sed -i '/Linux-PAM/d' $TmpPkgGen
     sed -i '/lua-devel/d' $TmpPkgGen

--- a/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
+++ b/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
@@ -316,6 +316,7 @@ chroot_and_install_rpms python3
 
 # openjdk needs fontconfig to build, which needs libxml
 build_rpm_in_chroot_no_install libxml2
+copy_rpm_subpackage python3-libxml2
 chroot_and_install_rpms libxml2
 chroot_and_install_rpms expat
 chroot_and_install_rpms freetype
@@ -409,6 +410,8 @@ build_rpm_in_chroot_no_install libsolv
 # glib needs perl-XML-Parser, python3-xml, gtk-doc, meson, libselinux
 chroot_and_install_rpms perl-XML-Parser
 
+# itstool needs python3-libxml2
+chroot_and_install_rpms python3-libxml2
 build_rpm_in_chroot_no_install itstool
 
 # gtk-doc needs itstool

--- a/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
+++ b/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
@@ -314,7 +314,7 @@ rm -vf $FINISHED_RPM_DIR/python3*debuginfo*.rpm
 chroot_and_install_rpms python3
 
 
-# openjdk needs fontconfig to build, which needs libxml2
+# openjdk needs fontconfig to build, which needs libxml
 build_rpm_in_chroot_no_install libxml2
 chroot_and_install_rpms libxml2
 chroot_and_install_rpms expat
@@ -408,10 +408,6 @@ build_rpm_in_chroot_no_install libsolv
 
 # glib needs perl-XML-Parser, python3-xml, gtk-doc, meson, libselinux
 chroot_and_install_rpms perl-XML-Parser
-
-# itstool needs python3-libxml2
-# python3-libxml2 is built by building libxml2
-chroot_and_install_rpms python3-libxml2
 
 build_rpm_in_chroot_no_install itstool
 

--- a/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
+++ b/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
@@ -314,7 +314,7 @@ rm -vf $FINISHED_RPM_DIR/python3*debuginfo*.rpm
 chroot_and_install_rpms python3
 
 
-# openjdk needs fontconfig to build, which needs libxml
+# openjdk needs fontconfig to build, which needs libxml2
 build_rpm_in_chroot_no_install libxml2
 chroot_and_install_rpms libxml2
 chroot_and_install_rpms expat
@@ -408,6 +408,10 @@ build_rpm_in_chroot_no_install libsolv
 
 # glib needs perl-XML-Parser, python3-xml, gtk-doc, meson, libselinux
 chroot_and_install_rpms perl-XML-Parser
+
+# itstool needs python3-libxml2
+# python3-libxml2 is built by building libxml2
+chroot_and_install_rpms python3-libxml2
 
 build_rpm_in_chroot_no_install itstool
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Python2 buildrequires in libxml2 were causing rebuilds of toolchain packages in the regular package build phase. Additionally, grub2 failed to build due to the absence of python2.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Explicitly use python3 when bootstrapping grub2
- Remove libxml2-python package

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
**YES**

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: 95478
