### PR TITLE
Update libwebp to 1.0.3, fixing CVEs. (#987)

### DIFF
--- a/SPECS/libwebp/libwebp.signatures.json
+++ b/SPECS/libwebp/libwebp.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "libwebp-1.0.0.tar.gz": "c5c5ebf979543ac1f3348df8f6245262abd787a147b9632c880d92bfc38dbbeb"
+  "libwebp-1.0.3.tar.gz": "082d114bcb18a0e2aafc3148d43367c39304f86bf18ba0b2e766447e111a4a91"
  }
 }

--- a/SPECS/libwebp/libwebp.spec
+++ b/SPECS/libwebp/libwebp.spec
@@ -1,54 +1,53 @@
 Summary:        Library to encode and decode webP format images
 Name:           libwebp
-Version:        1.0.0
-Release:        4%{?dist}
+Version:        1.0.3
+Release:        1%{?dist}
 License:        BSD
-URL:            https://webmproject.org/
-Group:          System Environment/Libraries
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
+Group:          System Environment/Libraries
+URL:            https://webmproject.org/
 #Source0:       https://github.com/webmproject/%{name}/archive/v%{version}.tar.gz
 Source0:        %{name}-%{version}.tar.gz
 
-BuildRequires:	libjpeg-turbo-devel
-BuildRequires:	libtiff-devel
-BuildRequires:	libpng-devel
-Requires:	libjpeg-turbo
-Requires:	libtiff
-Requires:	libpng
+BuildRequires:  libjpeg-turbo-devel
+BuildRequires:  libpng-devel
+BuildRequires:  libtiff-devel
+Requires:       libjpeg-turbo
+Requires:       libpng
+Requires:       libtiff
+
 %description
 The libwebp package contains a library and support programs to encode and decode images in WebP format.
 
-%package	devel
-Summary:	Header and development files
-Requires:	%{name} = %{version}-%{release}
-%description	devel
+%package        devel
+Summary:        Header and development files
+Requires:       %{name} = %{version}-%{release}
+%description    devel
 It contains the libraries and header files to create applications
 
 %prep
 %setup -q
+
 %build
 ./autogen.sh
 
 ./configure \
-	--prefix=%{_prefix} \
-	--enable-libwebpmux \
-	--enable-libwebpdemux \
-	--enable-libwebpdecoder \
-	--enable-libwebpextras  \
-	--enable-swap-16bit-csp \
-	--disable-static
+        --prefix=%{_prefix} \
+        --enable-libwebpmux \
+        --enable-libwebpdemux \
+        --enable-libwebpdecoder \
+        --enable-libwebpextras  \
+        --enable-swap-16bit-csp \
+        --disable-static
 make %{?_smp_mflags}
 
 %install
 make DESTDIR=%{buildroot} install
-find %{buildroot} -name '*.la' -delete
+find %{buildroot} -type f -name '*.la' -delete -print
 
-%post
-/sbin/ldconfig
-
-%postun
-/sbin/ldconfig
+%post -p /sbin/ldconfig
+%postun -p /sbin/ldconfig
 
 %files
 %defattr(-,root,root)
@@ -64,16 +63,23 @@ find %{buildroot} -name '*.la' -delete
 %{_libdir}/pkgconfig/*.pc
 
 %changelog
-* Sat May 09 00:21:21 PST 2020 Nick Samson <nisamson@microsoft.com> - 1.0.0-4
-- Added %%license line automatically
+* Tue May 25 2021 Mateusz Malisz <mamalisz@microsoft.com> - 1.0.3-1
+- Update to version 1.0.3
+
+*   Sat May 09 2020 Nick Samson <nisamson@microsoft.com> 1.0.0-4
+-   Added %%license line automatically
 
 *   Mon Apr 13 2020 Jon Slobodzian <joslobo@microsoft.com> 1.0.0-3
 -   Verified license. Removed sha1. Fixed Source0 URL comment.  Fixed formatting. URL to https.
+
 *   Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 1.0.0-2
 -   Initial CBL-Mariner import from Photon (license: Apache2).
+
 *   Wed Sep 12 2018 Keerthana K <keerthanak@vmware.com> 1.0.0-1
 -   Update to version 1.0.0
+
 *   Thu Apr 06 2017 Kumar Kaushik <kaushikk@vmware.com> 0.6.0-1
 -   Upgrading version to 0.6.0
+
 *   Wed Jul 27 2016 Divya Thaluru <dthaluru@vmware.com> 0.5.1-1
 -   Initial version

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -3045,8 +3045,8 @@
         "type": "other",
         "other": {
           "name": "libwebp",
-          "version": "1.0.0",
-          "downloadUrl": "https://github.com/webmproject/libwebp/archive/v1.0.0.tar.gz"
+          "version": "1.0.3",
+          "downloadUrl": "https://github.com/webmproject/libwebp/archive/v1.0.3.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Update libwebp to 1.0.3 to fix various CVEs. This is a commit picked from the 1.0-dev branch.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Update libwebp to 1.0.3

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO


###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2018-25009
- https://nvd.nist.gov/vuln/detail/CVE-2018-25010
- https://nvd.nist.gov/vuln/detail/CVE-2018-25011
- https://nvd.nist.gov/vuln/detail/CVE-2018-25012
- https://nvd.nist.gov/vuln/detail/CVE-2018-25013
- https://nvd.nist.gov/vuln/detail/CVE-2018-25014
- https://nvd.nist.gov/vuln/detail/CVE-2020-36329
- https://nvd.nist.gov/vuln/detail/CVE-2020-36330
- https://nvd.nist.gov/vuln/detail/CVE-2020-36331

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local build
