### PR TITLE
[dev] Update python dependencies in alsa-lib to use python3

### DIFF
--- a/SPECS/alsa-lib/alsa-lib.spec
+++ b/SPECS/alsa-lib/alsa-lib.spec
@@ -48,6 +48,7 @@ make DESTDIR=%{buildroot} install
 %changelog
 * Wed May 26 2021 Thomas Crain <thcrain@microsoft.com> - 1.2.2-2
 - Replace python2 dependencies with python3
+- License verified
 
 * Thu May 28 2020 Andrew Phelps <anphel@microsoft.com> - 1.2.2-1
 - Update to version 1.2.2 to fix CVE-2009-0035

--- a/SPECS/alsa-lib/alsa-lib.spec
+++ b/SPECS/alsa-lib/alsa-lib.spec
@@ -1,16 +1,16 @@
 Summary:        ALSA library
 Name:           alsa-lib
 Version:        1.2.2
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        LGPLv2+
-URL:            https://alsa-project.org
-Group:          Applications/Internet
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
+Group:          Applications/Internet
+URL:            https://alsa-project.org
 Source0:        https://www.alsa-project.org/files/pub/lib/%{name}-%{version}.tar.bz2
-BuildRequires:  python2-devel
-BuildRequires:  python2-libs
-Requires:       python2
+BuildRequires:  python3-devel
+BuildRequires:  python3-libs
+Requires:       python3
 
 %description
 The ALSA Library package contains the ALSA library used by programs
@@ -19,6 +19,7 @@ The ALSA Library package contains the ALSA library used by programs
 %package        devel
 Summary:        Header and development files
 Requires:       %{name} = %{version}
+
 %description    devel
 It contains the libraries and header files to create applications
 
@@ -45,13 +46,20 @@ make DESTDIR=%{buildroot} install
 %{_includedir}/*
 
 %changelog
-* Thu May 28 2020 Andrew Phelps <anphel@microsoft.com> 1.2.2-1
+* Wed May 26 2021 Thomas Crain <thcrain@microsoft.com> - 1.2.2-2
+- Replace python2 dependencies with python3
+
+* Thu May 28 2020 Andrew Phelps <anphel@microsoft.com> - 1.2.2-1
 - Update to version 1.2.2 to fix CVE-2009-0035
-* Sat May 09 2020 Nick Samson <nisamson@microsoft.com> 1.1.9-2
+
+* Sat May 09 2020 Nick Samson <nisamson@microsoft.com> - 1.1.9-2
 - Added %%license line automatically
-* Mon Mar 16 2020 Andrew Phelps <anphel@microsoft.com> 1.1.9-1
+
+* Mon Mar 16 2020 Andrew Phelps <anphel@microsoft.com> - 1.1.9-1
 - Update to version 1.1.9. License verified.
-* Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 1.1.7-2
+
+* Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> - 1.1.7-2
 - Initial CBL-Mariner import from Photon (license: Apache2).
-* Mon Dec 10 2018 Alexey Makhalov <amakhalov@vmware.com> 1.1.7-1
+
+* Mon Dec 10 2018 Alexey Makhalov <amakhalov@vmware.com> - 1.1.7-1
 - initial version, moved from Vivace

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -1,6 +1,6 @@
-alsa-lib-1.2.2-1.cm1.aarch64.rpm
-alsa-lib-debuginfo-1.2.2-1.cm1.aarch64.rpm
-alsa-lib-devel-1.2.2-1.cm1.aarch64.rpm
+alsa-lib-1.2.2-2.cm1.aarch64.rpm
+alsa-lib-debuginfo-1.2.2-2.cm1.aarch64.rpm
+alsa-lib-devel-1.2.2-2.cm1.aarch64.rpm
 asciidoc-9.1.0-1.cm1.noarch.rpm
 autoconf-2.69-11.cm1.noarch.rpm
 automake-1.16.1-3.cm1.noarch.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -1,6 +1,6 @@
-alsa-lib-1.2.2-1.cm1.x86_64.rpm
-alsa-lib-debuginfo-1.2.2-1.cm1.x86_64.rpm
-alsa-lib-devel-1.2.2-1.cm1.x86_64.rpm
+alsa-lib-1.2.2-2.cm1.x86_64.rpm
+alsa-lib-debuginfo-1.2.2-2.cm1.x86_64.rpm
+alsa-lib-devel-1.2.2-2.cm1.x86_64.rpm
 asciidoc-9.1.0-1.cm1.noarch.rpm
 autoconf-2.69-11.cm1.noarch.rpm
 automake-1.16.1-3.cm1.noarch.rpm


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Update alsa-lib to have a build-time requirement on python3 instead of python2

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Update alsa-lib to have a build-time requirement on python3 instead of python2

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
**YES**

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- N/A
