### PR TITLE
Updated zeromq to 4.3.4 to address CVE-2021-20236

### DIFF
--- a/SPECS/zeromq/zeromq.signatures.json
+++ b/SPECS/zeromq/zeromq.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "libzmq-4.3.2.tar.gz": "02ecc88466ae38cf2c8d79f09cfd2675ba299a439680b64ade733e26a349edeb"
+  "zeromq-4.3.4.tar.gz": "c593001a89f5a85dd2ddf564805deb860e02471171b3f204944857336295c3e5"
  }
 }

--- a/SPECS/zeromq/zeromq.spec
+++ b/SPECS/zeromq/zeromq.spec
@@ -2,11 +2,11 @@ Summary:        library for fast, message-based applications
 Name:           zeromq
 Version:        4.3.4
 Release:        1%{?dist}
-URL:            https://www.zeromq.org
 License:        LGPLv3+
-Group:          System Environment/Libraries
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
+Group:          System Environment/Libraries
+URL:            https://www.zeromq.org
 Source0:        https://github.com/zeromq/libzmq/releases/download/v%{version}/zeromq-%{version}.tar.gz
 Requires:       libstdc++
 
@@ -18,13 +18,15 @@ queues, multiple messaging patterns, message filtering (subscriptions), seamless
 access to multiple transport protocols and more.
 
 %package    devel
-Summary:    Header and development files for zeromq
-Requires:   %{name} = %{version}
+Summary:        Header and development files for zeromq
+Requires:       %{name} = %{version}
+
 %description    devel
 It contains the libraries and header files to create applications
 
 %prep
 %autosetup -n zeromq-%{version} -p1
+
 %build
 ./autogen.sh
 ./configure \
@@ -36,7 +38,7 @@ make %{?_smp_mflags}
 
 %install
 make DESTDIR=%{buildroot} install
-find %{buildroot}%{_libdir} -name '*.la' -delete
+find %{buildroot} -type f -name "*.la" -delete -print
 
 %check
 make check
@@ -57,20 +59,26 @@ make check
 %{_includedir}/
 
 %changelog
-*   Thu Jun 03 2021 Nick Samson <nisamson@microsoft.com> - 4.3.4-1
--   Upgraded to 4.3.4 to address CVE-2021-20236, updated URL
+* Thu Jun 03 2021 Nick Samson <nisamson@microsoft.com> - 4.3.4-1
+- Upgraded to 4.3.4 to address CVE-2021-20236, updated URL
+
 * Sat May 09 2020 Nick Samson <nisamson@microsoft.com> - 4.3.2-2
 - Added %%license line automatically
 
 *   Wed Mar 18 2020 Henry Beberman <henry.beberman@microsoft.com> 4.3.2-1
 -   Update to 4.3.2. Source0 URL fixed. License verified.
+
 *   Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 4.2.3-2
 -   Initial CBL-Mariner import from Photon (license: Apache2).
+
 *   Thu Sep 13 2018 Siju Maliakkal <smaliakkal@vmware.com> 4.2.3-1
 -   Updated to latest version
+
 *   Fri Sep 15 2017 Bo Gan <ganb@vmware.com> 4.1.4-3
 -   Remove devpts mount
+
 *   Mon Aug 07 2017 Chang Lee <changlee@vmware.com> 4.1.4-2
 -   Fixed %check
+
 *   Thu Apr 13 2017 Dheeraj Shetty <dheerajs@vmware.com> 4.1.4-1
 -   Initial build. First version

--- a/SPECS/zeromq/zeromq.spec
+++ b/SPECS/zeromq/zeromq.spec
@@ -1,13 +1,13 @@
 Summary:        library for fast, message-based applications
 Name:           zeromq
-Version:        4.3.2
-Release:        2%{?dist}
+Version:        4.3.4
+Release:        1%{?dist}
 URL:            https://www.zeromq.org
 License:        LGPLv3+
 Group:          System Environment/Libraries
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
-Source0:        https://github.com/zeromq/libzmq/archive/v%{version}/libzmq-%{version}.tar.gz
+Source0:        https://github.com/zeromq/libzmq/releases/download/v%{version}/zeromq-%{version}.tar.gz
 Requires:       libstdc++
 
 %description
@@ -24,12 +24,13 @@ Requires:   %{name} = %{version}
 It contains the libraries and header files to create applications
 
 %prep
-%setup -q -n libzmq-%{version}
+%autosetup -n zeromq-%{version} -p1
 %build
 ./autogen.sh
 ./configure \
     --prefix=%{_prefix} \
     --with-libsodium=no \
+    --without-docs \
     --disable-static
 make %{?_smp_mflags}
 
@@ -56,6 +57,8 @@ make check
 %{_includedir}/
 
 %changelog
+*   Thu Jun 03 2021 Nick Samson <nisamson@microsoft.com> - 4.3.4-1
+-   Upgraded to 4.3.4 to address CVE-2021-20236, updated URL
 * Sat May 09 00:20:47 PST 2020 Nick Samson <nisamson@microsoft.com> - 4.3.2-2
 - Added %%license line automatically
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -7625,8 +7625,8 @@
         "type": "other",
         "other": {
           "name": "zeromq",
-          "version": "4.3.2",
-          "downloadUrl": "https://github.com/zeromq/libzmq/archive/v4.3.2/libzmq-4.3.2.tar.gz"
+          "version": "4.3.4",
+          "downloadUrl": "https://github.com/zeromq/libzmq/releases/download/v4.3.4/zeromq-4.3.4.tar.gz"
         }
       }
     },


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Fixes critical CVE in zeromq.

###### Change Log  <!-- REQUIRED -->
Fixes critical CVE-2021-20236 

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2021-20236

###### Test Methodology
- Local build with `RUN_CHECK=y` ticked
