### PR TITLE
Patch libjpeg-turbo CVE-2020-17541

### DIFF
--- a/SPECS/libjpeg-turbo/CVE-2020-17541.patch
+++ b/SPECS/libjpeg-turbo/CVE-2020-17541.patch
@@ -1,0 +1,45 @@
+From 6bbc0a3c703f5ea2aecc3a6e60e8ba2935febb82 Mon Sep 17 00:00:00 2001
+From: DRC <information@libjpeg-turbo.org>
+Date: Thu, 5 Dec 2019 13:12:28 -0600
+Subject: [PATCH] Huffman enc.: Fix very rare local buffer overrun
+
+... detected by ASan.  This is a similar issue to the issue that was
+fixed with 402a715f82313384ef4606660c32d8678c79f197.  Apparently it is
+possible to create a malformed JPEG image that exceeds the Huffman
+encoder's 256-byte local buffer when attempting to losslessly tranform
+the image.  That makes sense, given that it was necessary to extend the
+Huffman decoder's local buffer to 512 bytes in order to handle all
+pathological cases (refer to 0463f7c9aad060fcd56e98d025ce16185279e2bc.)
+
+Since this issue affected only lossless transformation, a workflow that
+isn't generally exposed to arbitrary data exploits, and since the
+overrun did not overflow the stack (i.e. it did not result in a segfault
+or other user-visible issue, and valgrind didn't even detect it), it did
+not likely pose a security risk.
+
+Fixes #392
+---
+ jchuff.c     |  4 ++--
+ 1 files changed, 2 insertions(+), 2 deletions(-)
+
+diff -Naur a/jchuff.c b/jchuff.c
+--- a/jchuff.c	2018-07-27 09:47:48.000000000 -0700
++++ b/jchuff.c	2021-06-11 12:13:35.203734046 -0700
+@@ -4,7 +4,7 @@
+  * This file was part of the Independent JPEG Group's software:
+  * Copyright (C) 1991-1997, Thomas G. Lane.
+  * libjpeg-turbo Modifications:
+- * Copyright (C) 2009-2011, 2014-2016, 2018, D. R. Commander.
++ * Copyright (C) 2009-2011, 2014-2016, 2018-2019, D. R. Commander.
+  * Copyright (C) 2015, Matthieu Darbois.
+  * For conditions of distribution and use, see the accompanying README.ijg
+  * file.
+@@ -428,7 +428,7 @@
+  * scanning order-- 1, 8, 16, etc.), then this will produce an encoded block
+  * larger than 200 bytes.
+  */
+-#define BUFSIZE  (DCTSIZE2 * 4)
++#define BUFSIZE (DCTSIZE2 * 8)
+ 
+ #define LOAD_BUFFER() { \
+   if (state->free_in_buffer < BUFSIZE) { \

--- a/SPECS/libjpeg-turbo/libjpeg-turbo.spec
+++ b/SPECS/libjpeg-turbo/libjpeg-turbo.spec
@@ -1,16 +1,16 @@
 Summary:        fork of the original IJG libjpeg which uses SIMD.
 Name:           libjpeg-turbo
 Version:        2.0.0
-Release:        6%{?dist}
+Release:        7%{?dist}
 License:        IJG
 URL:            http://sourceforge.net/projects/libjpeg-turbo
 Group:          System Environment/Libraries
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Source0:        http://downloads.sourceforge.net/libjpeg-turbo/%{name}-%{version}.tar.gz
-%define sha1    libjpeg-turbo=6d74b609294b6bae5a7cde035f7d6b80d60ebb77
 Patch0:         CVE-2018-20330.patch
 Patch1:         CVE-2018-19664.patch
+Patch2:         CVE-2020-17541.patch
 %ifarch x86_64
 BuildRequires:  nasm
 %endif
@@ -26,9 +26,7 @@ Requires:       %{name} = %{version}-%{release}
 It contains the libraries and header files to create applications
 
 %prep
-%setup -q
-%patch0 -p1
-%patch1 -p1
+%autosetup -p1
 
 %build
 mkdir build
@@ -62,9 +60,10 @@ make DESTDIR=%{buildroot} install
 %{_libdir}/pkgconfig/*.pc
 
 %changelog
-* Sat May 09 2020 Nick Samson <nisamson@microsoft.com> - 2.0.0-6
-- Added %%license line automatically
-
+*   Fri Jun 11 2021 Henry Beberman <henry.beberman@microsoft.com> - 2.0.0-7
+-   Patch CVE-2020-17541
+*   Sat May 09 2020 Nick Samson <nisamson@microsoft.com> - 2.0.0-6
+-   Added %%license line automatically
 *   Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 2.0.0-5
 -   Initial CBL-Mariner import from Photon (license: Apache2).
 *   Mon Mar 04 2019 Keerthana K <keerthanak@vmware.com> 2.0.0-4


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Patch libjpeg-turbo CVE-2020-17541

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Patch libjpeg-turbo CVE CVE-2020-17541

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2020-17541

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local Build
