### PR TITLE
python-sphinx: Add missing runtime dependency on setuptools

### DIFF
--- a/SPECS/python-sphinx/python-sphinx.spec
+++ b/SPECS/python-sphinx/python-sphinx.spec
@@ -1,49 +1,46 @@
 %{!?python2_sitelib: %define python2_sitelib %(python2 -c "from distutils.sysconfig import get_python_lib;print(get_python_lib())")}
 %{!?python3_sitelib: %define python3_sitelib %(python3 -c "from distutils.sysconfig import get_python_lib;print(get_python_lib())")}
-
-Summary:       Python documentation generator
-Name:          python-sphinx
-Version:       1.7.9
-Release:       11%{?dist}
-Group:         Development/Tools
-License:       BSD
-URL:           https://www.sphinx-doc.org
-Vendor:        Microsoft Corporation
-Distribution:  Mariner
+Summary:        Python documentation generator
+Name:           python-sphinx
+Version:        1.7.9
+Release:        12%{?dist}
+License:        BSD
+Vendor:         Microsoft Corporation
+Distribution:   Mariner
+Group:          Development/Tools
+URL:            https://www.sphinx-doc.org
 #Source0:      https://github.com/sphinx-doc/sphinx/archive/v%{version}.tar.gz
-Source0:       Sphinx-%{version}.tar.gz
-
-BuildRequires: python2
-BuildRequires: python2-libs
-BuildRequires: python2-devel
-BuildRequires: python-setuptools
-BuildRequires: babel
-BuildRequires: python-docutils
-BuildRequires: python-jinja2
-BuildRequires: python-pygments
-BuildRequires: python-six
-BuildRequires: python-sphinx-theme-alabaster
-BuildRequires: python-imagesize
-BuildRequires: python-requests
-BuildRequires: python-snowballstemmer
-BuildRequires: pytest
-BuildRequires: python-typing
-BuildRequires: python-pip
-
-Requires:      python2
-Requires:      python2-libs
-Requires:      babel
-Requires:      python-docutils
-Requires:      python-jinja2
-Requires:      python-pygments
-Requires:      python-six
-Requires:      python-sphinx-theme-alabaster
-Requires:      python-imagesize
-Requires:      python-requests
-Requires:      python-snowballstemmer
-Requires:      python-typing
-Requires:      python2-sphinxcontrib-websupport
-
+Source0:        Sphinx-%{version}.tar.gz
+BuildRequires:  babel
+BuildRequires:  pytest
+BuildRequires:  python-docutils
+BuildRequires:  python-imagesize
+BuildRequires:  python-jinja2
+BuildRequires:  python-pip
+BuildRequires:  python-pygments
+BuildRequires:  python-requests
+BuildRequires:  python-setuptools
+BuildRequires:  python-six
+BuildRequires:  python-snowballstemmer
+BuildRequires:  python-sphinx-theme-alabaster
+BuildRequires:  python-typing
+BuildRequires:  python2
+BuildRequires:  python2-devel
+BuildRequires:  python2-libs
+Requires:       babel
+Requires:       python-docutils
+Requires:       python-imagesize
+Requires:       python-jinja2
+Requires:       python-pygments
+Requires:       python-requests
+Requires:       python-setuptools
+Requires:       python-six
+Requires:       python-snowballstemmer
+Requires:       python-sphinx-theme-alabaster
+Requires:       python-typing
+Requires:       python2
+Requires:       python2-libs
+Requires:       python2-sphinxcontrib-websupport
 BuildArch:      noarch
 
 %description
@@ -55,34 +52,34 @@ documentation, but has now been cleaned up in the hope that it will be
 useful to many other projects.
 
 %package -n    python3-sphinx
-Summary:       Python documentation generator
-BuildRequires: python3
-BuildRequires: python3-devel
-BuildRequires: python3-babel
-BuildRequires: python3-docutils
-BuildRequires: python3-jinja2
-BuildRequires: python3-pygments
-BuildRequires: python3-six
-BuildRequires: python3-sphinx-theme-alabaster
-BuildRequires: python3-imagesize
-BuildRequires: python3-requests
-BuildRequires: python3-snowballstemmer
-BuildRequires: python3-pytest
-BuildRequires: python3-setuptools
-BuildRequires: python3-xml
-
-Requires:      python3
-Requires:      python3-libs
-Requires:      python3-babel
-Requires:      python3-docutils
-Requires:      python3-jinja2
-Requires:      python3-pygments
-Requires:      python3-six
-Requires:      python3-sphinx-theme-alabaster
-Requires:      python3-imagesize
-Requires:      python3-requests
-Requires:      python3-snowballstemmer
-Requires:      python3-sphinxcontrib-websupport
+Summary:        Python documentation generator
+BuildRequires:  python3
+BuildRequires:  python3-babel
+BuildRequires:  python3-devel
+BuildRequires:  python3-docutils
+BuildRequires:  python3-imagesize
+BuildRequires:  python3-jinja2
+BuildRequires:  python3-pygments
+BuildRequires:  python3-pytest
+BuildRequires:  python3-requests
+BuildRequires:  python3-setuptools
+BuildRequires:  python3-six
+BuildRequires:  python3-snowballstemmer
+BuildRequires:  python3-sphinx-theme-alabaster
+BuildRequires:  python3-xml
+Requires:       python3
+Requires:       python3-babel
+Requires:       python3-docutils
+Requires:       python3-imagesize
+Requires:       python3-jinja2
+Requires:       python3-libs
+Requires:       python3-pygments
+Requires:       python3-requests
+Requires:       python3-setuptools
+Requires:       python3-six
+Requires:       python3-snowballstemmer
+Requires:       python3-sphinx-theme-alabaster
+Requires:       python3-sphinxcontrib-websupport
 
 %description -n python3-sphinx
 
@@ -116,8 +113,6 @@ python2 setup.py install --prefix=%{_prefix} --root=%{buildroot}
 %check
 make -k check |& tee %{_specdir}/%{name}-check-log || %{nocheck}
 
-%clean
-
 %files
 %defattr(-,root,root)
 %license LICENSE
@@ -140,45 +135,65 @@ make -k check |& tee %{_specdir}/%{name}-check-log || %{nocheck}
 %{python3_sitelib}/*
 
 %changelog
+* Mon Jun 14 2021 Tom Fay <tomfay@microsoft.com> - 1.7.9-12
+- Add python*-setuptools as a runtime dependency.
+- Clean spec.
+
 *   Fri Aug 21 2020 Thomas Crain <thcrain@microsoft.com> 1.7.9-11
 -   Add sphinx-*-3 binary symlinks for Fedora compatibility
 -   Add Requires: python(2/3)-sphinxcontrib-websupport
 -   Correct license shortname
 -   License verified
+
 *   Tue Jun 02 2020 Jon Slobodzian <joslobo@microsoft.com> 1.7.9-10
 -   Add python-typing back.
+
 *   Sat May 09 2020 Nick Samson <nisamson@microsoft.com> 1.7.9-9
 -   Added %%license line automatically
+
 *   Thu Apr 30 2020 Emre Girgin <mrgirgin@microsoft.com> 1.7.9-8
 -   Renaming python-pytest to pytest
+
 *   Wed Apr 29 2020 Emre Girgin <mrgirgin@microsoft.com> 1.7.9-7
 -   Renaming python-babel to babel
+
 *   Wed Apr 29 2020 Emre Girgin <mrgirgin@microsoft.com> 1.7.9-6
 -   Renaming python-Pygments to python-pygments
+
 *   Tue Apr 28 2020 Emre Girgin <mrgirgin@microsoft.com> 1.7.9-5
 -   Renaming python-alabaster to python-sphinx-theme-alabaster
+
 *   Mon Apr 13 2020 Nicolas Ontiveros <niontive@microsoft.com> 1.7.9-4
 -   Remove python-typing from BuildRequires and Requires.
+
 *   Tue Apr 07 2020 Joe Schmitt <joschmit@microsoft.com> 1.7.9-3
 -   Update URL.
 -   Update Source0 with valid URL.
 -   Remove sha1 macro.
 -   License verified.
+
 *   Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 1.7.9-2
 -   Initial CBL-Mariner import from Photon (license: Apache2).
+
 *   Sun Sep 09 2018 Tapas Kundu <tkundu@vmware.com> 1.7.9-1
 -   Update to version 1.7.9
+
 *   Wed Jun 07 2017 Xiaolin Li <xiaolinl@vmware.com> 1.5.3-5
 -   Add python3-setuptools and python3-xml to python3 sub package Buildrequires.
+
 *   Thu Jun 01 2017 Dheeraj Shetty <dheerajs@vmware.com> 1.5.3-4
 -   Keep the original python2 scripts and rename the python3 scripts
+
 *   Wed Apr 26 2017 Dheeraj Shetty <dheerajs@vmware.com> 1.5.3-3
 -   BuildRequires and Requires python-babel, python-docutils, python-jinja2,
     python-Pygments, python-six, python-alabaster, python-imagesize,
     python-requests and python-snowballstemmer. Adding python3 version
+
 *   Tue Apr 25 2017 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 1.5.3-2
 -   Fix arch
+
 *   Thu Mar 30 2017 Sarah Choi <sarahc@vmware.com> 1.5.3-1
 -   Upgrade version to 1.5.3
+
 *   Fri Dec 16 2016 Dheeraj Shetty <dheerajs@vmware.com> 1.5.1-1
 -   Initial


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?

I was building a package that has a build dependency on python3-sphinx and discovered that python3-sphinx has an undeclared runtime dependency on python3-setuptools.

A minimal repro is `docker run cblmariner.azurecr.io/base/core:1.0.20210430 bash -c "tdnf install -y python3-sphinx && sphinx-build-3"`.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change Add python*-setuptools as a runtime dependency to python*-sphinx

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**


