### PR TITLE
Add support for grep -P

### DIFF
--- a/SPECS/grep/grep-3.1-glibc-2.28-fix.patch
+++ b/SPECS/grep/grep-3.1-glibc-2.28-fix.patch
@@ -1,0 +1,38 @@
+diff --git a/tests/Makefile.am b/tests/Makefile.am
+index 66fb461..c6e96e4 100644
+--- a/tests/Makefile.am
++++ b/tests/Makefile.am
+@@ -55,10 +55,6 @@ XFAIL_TESTS = triple-backref
+ # FIXME-2015: Remove this once the gnulib bug is fixed.
+ if USE_INCLUDED_REGEX
+ XFAIL_TESTS += equiv-classes
+-else
+-# The backslash-alt test fails for glibc, which needs to be fixed.
+-# FIXME-2015: Remove this once the glibc bug is fixed.
+-XFAIL_TESTS += backref-alt
+ endif
+ 
+ TESTS =						\
+diff --git a/tests/Makefile.in b/tests/Makefile.in
+index 55c72d0..04e64af 100644
+--- a/tests/Makefile.in
++++ b/tests/Makefile.in
+@@ -108,9 +108,6 @@ check_PROGRAMS = get-mb-cur-max$(EXEEXT)
+ # The included matcher needs to be fixed.
+ # FIXME-2015: Remove this once the gnulib bug is fixed.
+ @USE_INCLUDED_REGEX_TRUE@am__append_1 = equiv-classes
+-# The backslash-alt test fails for glibc, which needs to be fixed.
+-# FIXME-2015: Remove this once the glibc bug is fixed.
+-@USE_INCLUDED_REGEX_FALSE@am__append_2 = backref-alt
+ subdir = tests
+ ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
+ am__aclocal_m4_deps = $(top_srcdir)/m4/00gnulib.m4 \
+@@ -1408,7 +1405,7 @@ LDADD = ../lib/libgreputils.a $(LIBINTL) ../lib/libgreputils.a
+ # matcher (i.e., with glibc) and with the included matcher.
+ # Both matchers need to be fixed.
+ # FIXME-2015: Remove this once the glibc and gnulib bugs are fixed.
+-XFAIL_TESTS = triple-backref $(am__append_1) $(am__append_2)
++XFAIL_TESTS = triple-backref $(am__append_1)
+ TESTS = \
+   backref					\
+   backref-alt					\

--- a/SPECS/grep/grep-3.31-help-align.patch
+++ b/SPECS/grep/grep-3.31-help-align.patch
@@ -1,0 +1,31 @@
+diff --git a/src/grep.c b/src/grep.c
+index a2de03d..fd1b3a9 100644
+--- a/src/grep.c
++++ b/src/grep.c
+@@ -1962,17 +1962,20 @@ Output control:\n\
+   -D, --devices=ACTION      how to handle devices, FIFOs and sockets;\n\
+                             ACTION is 'read' or 'skip'\n\
+   -r, --recursive           like --directories=recurse\n\
+-  -R, --dereference-recursive  likewise, but follow all symlinks\n\
++  -R, --dereference-recursive\n\
++                            likewise, but follow all symlinks\n\
+ "));
+       printf (_("\
+-      --include=FILE_PATTERN  search only files that match FILE_PATTERN\n\
+-      --exclude=FILE_PATTERN  skip files and directories matching\
++      --include=FILE_PATTERN\n\
++                            search only files that match FILE_PATTERN\n\
++      --exclude=FILE_PATTERN\n\
++                            skip files and directories matching\
+  FILE_PATTERN\n\
+       --exclude-from=FILE   skip files matching any file pattern from FILE\n\
+-      --exclude-dir=PATTERN  directories that match PATTERN will be skipped.\n\
++      --exclude-dir=PATTERN directories that match PATTERN will be skipped.\n\
+ "));
+       printf (_("\
+-  -L, --files-without-match  print only names of FILEs with no selected lines\n\
++  -L, --files-without-match print only names of FILEs with no selected lines\n\
+   -l, --files-with-matches  print only names of FILEs with selected lines\n\
+   -c, --count               print only a count of selected lines per FILE\n\
+   -T, --initial-tab         make tabs line up (if needed)\n\
+   

--- a/SPECS/grep/grep-3.31-man-fix-gs.patch
+++ b/SPECS/grep/grep-3.31-man-fix-gs.patch
@@ -1,0 +1,61 @@
+diff --git a/doc/grep.in.1 b/doc/grep.in.1
+index 40c9586..a4e89eb 100644
+--- a/doc/grep.in.1
++++ b/doc/grep.in.1
+@@ -335,7 +335,7 @@ Print
+ .I NUM
+ lines of trailing context after matching lines.
+ Places a line containing a group separator
+-.RB ( \-\^\- )
++.RB "(described under " \-\^\-group\-separator )
+ between contiguous groups of matches.
+ With the
+ .B \-o
+@@ -348,7 +348,7 @@ Print
+ .I NUM
+ lines of leading context before matching lines.
+ Places a line containing a group separator
+-.RB ( \-\^\- )
++.RB "(described under " \-\^\-group\-separator )
+ between contiguous groups of matches.
+ With the
+ .B \-o
+@@ -361,13 +361,24 @@ Print
+ .I NUM
+ lines of output context.
+ Places a line containing a group separator
+-.RB ( \-\^\- )
++.RB "(described under " \-\^\-group\-separator )
+ between contiguous groups of matches.
+ With the
+ .B \-o
+ or
+ .B \-\^\-only\-matching
+ option, this has no effect and a warning is given.
++.TP
++.BI \-\^\-group\-separator= SEP
++Use
++.I SEP
++as a group separator. By default
++.I SEP
++is double hyphen
++.RB ( \-\^\- ).
++.TP
++.B \-\^\-no\-group-separator
++Use empty string as a group separator.
+ .SS "File and Directory Selection"
+ .TP
+ .BR \-a ", " \-\^\-text
+diff --git a/src/grep.c b/src/grep.c
+index 8d22aec..a2de03d 100644
+--- a/src/grep.c
++++ b/src/grep.c
+@@ -1986,6 +1986,8 @@ Context control:\n\
+ "));
+       printf (_("\
+   -NUM                      same as --context=NUM\n\
++      --group-separator=SEP use SEP as a group separator\n\
++      --no-group-separator  use empty string as a group separator\n\
+       --color[=WHEN],\n\
+       --colour[=WHEN]       use markers to highlight the matching strings;\n\
+                             WHEN is 'always', 'never', or 'auto'\n\


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Add support for Perl regular expressions in grep ("grep -P")
Previously running "grep -P" on Mariner would result in:
grep: support for the -P option is not compiled into this --disable-perl-regexp binary

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Compile grep --without-included-regex and include pcre-devel package when building
- Skip expected "pcre-jitstack" test failure. Note this is the same error as https://bugs.gentoo.org/569816
- Add patch files from Fedora regarding "backref-alt" test, as well as patch files for grep help text and manpage

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build with RUN_CHECK=y. Pipeline build:
