### PR TITLE
Fix libcurl issue in python-pycurl tests

### DIFF
--- a/SPECS/python-pycurl/python-pycurl.spec
+++ b/SPECS/python-pycurl/python-pycurl.spec
@@ -5,7 +5,7 @@
 
 Name:           python-pycurl
 Version:        7.43.0.2
-Release:        6%{?dist}
+Release:        7%{?dist}
 Summary:        A Python interface to libcurl
 Group:          Development/Languages
 License:        LGPLv2+ or MIT
@@ -13,17 +13,20 @@ URL:            http://pycurl.sourceforge.net/
 Source0:        https://dl.bintray.com/pycurl/pycurl/pycurl-%{version}.tar.gz
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
+Patch0:         skip-incompatible-libcurl-tests.patch
 BuildRequires:  openssl-devel
 BuildRequires:  python2-devel
 BuildRequires:  python2-libs
 BuildRequires:  curl-devel
-
 BuildRequires:  python3
 BuildRequires:  python3-devel
 BuildRequires:  python3-libs
 %if %{with_check}
-BuildRequires: python-setuptools, vsftpd, curl-libs
-BuildRequires: python3-setuptools, python3-xml
+BuildRequires:  python-setuptools
+BuildRequires:  vsftpd
+BuildRequires:  curl-libs
+BuildRequires:  python3-setuptools
+BuildRequires:  python3-xml
 %endif
 
 %description
@@ -60,6 +63,7 @@ Documentation and examples for pycurl
 
 %prep
 %setup -q -n pycurl-%{version}
+%patch0 -p1
 rm -f doc/*.xml_validity
 #chmod a-x examples/*
 
@@ -118,6 +122,8 @@ rm -rf %{buildroot}
 %doc COPYING-LGPL COPYING-MIT RELEASE-NOTES.rst ChangeLog README.rst examples doc tests
 
 %changelog
+*   Wed Jun 16 2021 Andrew Phelps <anphel@microsoft.com> 7.43.0-2-7
+-   Add patch to fix libcurl package test issue
 *   Wed Mar 03 2021 Andrew Phelps <anphel@microsoft.com> 7.43.0.2-6
 -   Disable unreliable multi_timer_test
 *   Wed Jan 20 2021 Andrew Phelps <anphel@microsoft.com> 7.43.0.2-5

--- a/SPECS/python-pycurl/python-pycurl.spec
+++ b/SPECS/python-pycurl/python-pycurl.spec
@@ -122,7 +122,7 @@ rm -rf %{buildroot}
 %doc COPYING-LGPL COPYING-MIT RELEASE-NOTES.rst ChangeLog README.rst examples doc tests
 
 %changelog
-*   Wed Jun 16 2021 Andrew Phelps <anphel@microsoft.com> 7.43.0-2-7
+*   Wed Jun 16 2021 Andrew Phelps <anphel@microsoft.com> 7.43.0.2-7
 -   Add patch to fix libcurl package test issue
 *   Wed Mar 03 2021 Andrew Phelps <anphel@microsoft.com> 7.43.0.2-6
 -   Disable unreliable multi_timer_test

--- a/SPECS/python-pycurl/skip-incompatible-libcurl-tests.patch
+++ b/SPECS/python-pycurl/skip-incompatible-libcurl-tests.patch
@@ -1,0 +1,76 @@
+diff -urN a/tests/failonerror_test.py b/tests/failonerror_test.py
+--- a/tests/failonerror_test.py	2021-06-16 13:54:20.634340403 -0700
++++ b/tests/failonerror_test.py	2021-06-16 13:56:19.337945639 -0700
+@@ -21,6 +21,8 @@
+     # not sure what the actual min is but 7.26 is too old
+     # and does not include status text, only the status code
+     @util.min_libcurl(7, 38, 0)
++    # no longer supported by libcurl: https://github.com/curl/curl/issues/6615
++    @util.removed_in_libcurl(7, 75, 0)
+     def test_failonerror(self):
+         self.curl.setopt(pycurl.URL, 'http://%s:8380/status/403' % localhost)
+         sio = util.BytesIO()
+@@ -41,6 +43,8 @@
+     # not sure what the actual min is but 7.26 is too old
+     # and does not include status text, only the status code
+     @util.min_libcurl(7, 38, 0)
++    # no longer supported by libcurl: https://github.com/curl/curl/issues/6615
++    @util.removed_in_libcurl(7, 75, 0)
+     def test_failonerror_status_line_invalid_utf8_python2(self):
+         self.curl.setopt(pycurl.URL, 'http://%s:8380/status_invalid_utf8' % localhost)
+         sio = util.BytesIO()
+@@ -61,6 +65,8 @@
+     # not sure what the actual min is but 7.26 is too old
+     # and does not include status text, only the status code
+     @util.min_libcurl(7, 38, 0)
++    # no longer supported by libcurl: https://github.com/curl/curl/issues/6615
++    @util.removed_in_libcurl(7, 75, 0)
+     def test_failonerror_status_line_invalid_utf8_python3(self):
+         self.curl.setopt(pycurl.URL, 'http://%s:8380/status_invalid_utf8' % localhost)
+         sio = util.BytesIO()
+diff -urN a/tests/option_constants_test.py b/tests/option_constants_test.py
+--- a/tests/option_constants_test.py	2021-06-16 13:54:32.058302421 -0700
++++ b/tests/option_constants_test.py	2021-06-16 13:57:26.629721761 -0700
+@@ -164,9 +164,16 @@
+     def test_sslversion_options(self):
+         curl = pycurl.Curl()
+         curl.setopt(curl.SSLVERSION, curl.SSLVERSION_DEFAULT)
++        curl.setopt(curl.SSLVERSION, curl.SSLVERSION_TLSv1)
++        curl.close()
++
++    # SSLVERSION_SSLv* return CURLE_BAD_FUNCTION_ARGUMENT with curl-7.77.0
++    @util.removed_in_libcurl(7, 77, 0)
++    @util.only_ssl
++    def test_legacy_sslversion_options(self):
++        curl = pycurl.Curl()
+         curl.setopt(curl.SSLVERSION, curl.SSLVERSION_SSLv2)
+         curl.setopt(curl.SSLVERSION, curl.SSLVERSION_SSLv3)
+-        curl.setopt(curl.SSLVERSION, curl.SSLVERSION_TLSv1)
+         curl.close()
+ 
+     @util.min_libcurl(7, 34, 0)
+diff -urN a/tests/util.py b/tests/util.py
+--- a/tests/util.py	2021-06-16 13:54:05.910389353 -0700
++++ b/tests/util.py	2021-06-16 13:58:05.345592928 -0700
+@@ -122,6 +122,21 @@
+ 
+     return decorator
+ 
++def removed_in_libcurl(major, minor, patch):
++    import nose.plugins.skip
++
++    def decorator(fn):
++        @functools.wraps(fn)
++        def decorated(*args, **kwargs):
++            if not pycurl_version_less_than(major, minor, patch):
++                raise nose.plugins.skip.SkipTest('libcurl >= %d.%d.%d' % (major, minor, patch))
++
++            return fn(*args, **kwargs)
++
++        return decorated
++
++    return decorator
++
+ def only_ssl(fn):
+     import nose.plugins.skip
+     import pycurl


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Fix python-pycurl package tests, which were broken by the curl 7.76 package update.
Errors seen:
                                "FAIL: test_failonerror (tests.failonerror_test.FailonerrorTest)"
                                "pycurl.error: (22, 'The requested URL returned error: 403')"
                                "FAIL: test_failonerror_status_line_invalid_utf8_python3 (tests.failonerror_test.FailonerrorTest)"
                                "pycurl.error: (22, 'The requested URL returned error: 555')"

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add patch to python-pycurl to fix package tests. Patch is based on upstream fix: https://github.com/pycurl/pycurl/pull/689
- Cleanup python-pycurl spec

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local package build with RUN_CHECK=y
