### PR TITLE
disable debuginfo due to size

### DIFF
--- a/SPECS/ceph/ceph.spec
+++ b/SPECS/ceph/ceph.spec
@@ -1,7 +1,10 @@
+#disable debuginfo because ceph-debuginfo rpm is too large
+%define debug_package %{nil}
+
 Summary:        User space components of the Ceph file system
 Name:           ceph
 Version:        16.2.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        LGPLv2 and LGPLv3 and CC-BY-SA and GPLv2 and Boost and BSD and MIT and Public Domain and GPLv3 and ASL-2.0
 URL:            https://ceph.io/
 Vendor:         Microsoft Corporation
@@ -52,10 +55,6 @@ Source0:        https://download.ceph.com/tarballs/%{name}-%{version}.tar.gz
 %{!?python3_version: %global python3_version 3}
 %{!?python3_sitelib: %global python3_sitelib %(python3 -c "from distutils.sysconfig import get_python_lib;print(get_python_lib())")}
 %define python3_sitearch %(python3 -c "from distutils.sysconfig import get_python_lib; import sys; sys.stdout.write(get_python_lib(1))")
-
-
-# disable dwz which compresses the debuginfo
-%global _find_debuginfo_dwz_opts %{nil}
 
 
 #################################################################################
@@ -1796,6 +1795,9 @@ exit 0
 %config %{_sysconfdir}/prometheus/ceph/ceph_default_alerts.yml
 
 %changelog
+*   Thu Jun 17 2021 Neha Agarwal <nehaagarwal@microsoft.com> 16.2.0-2
+-   Disable debuginfo because ceph-debuginfo rpm is too large
+
 *   Fri May 21 2021 Neha Agarwal <nehaagarwal@microsoft.com> 16.2.0-1
 -   Update package version to fix CVE-2020-25660, CVE-2020-25678 and CVE-2020-27781
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
disable debuginfo because ceph-debuginfo rpm is too large

###### Change Log  <!-- REQUIRED -->
- dwz is currently not available in 1.0-dev (available in dev), but Fedora is moving away from it. Compressing debuginfo using dwz was disabled in the original Fedora spec for ceph. Disabling ceph-debuginfo rpm for the time being.

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Associated issues  <!-- optional -->
- https://microsoft.visualstudio.com/OS/_workitems/edit/28918515

###### Links to CVEs  <!-- optional -->
- None

###### Test Methodology
- Local build. Verified that ceph-debuginfo rpm doesn't get produced.
