### PR TITLE
[dev] Fix location of dbus-glib pkgconfig provides

### DIFF
--- a/SPECS/dbus-glib/dbus-glib.spec
+++ b/SPECS/dbus-glib/dbus-glib.spec
@@ -31,10 +31,10 @@ Headers and static libraries for the D-Bus GLib bindings
 
 %build
 %configure \
-    %if %{with_check}
+%if %{with_check}
     --enable-tests \
     --enable-asserts \
-    %endif
+%endif
     --disable-static \
     --disable-gtk-doc
 %make_build

--- a/SPECS/dbus-glib/dbus-glib.spec
+++ b/SPECS/dbus-glib/dbus-glib.spec
@@ -3,25 +3,25 @@ Name:           dbus-glib
 Version:        0.110
 Release:        4%{?dist}
 License:        AFL OR GPLv2+
+Vendor:         Microsoft Corporation
+Distribution:   Mariner
 Group:          System Environment/Libraries
 URL:            https://dbus.freedesktop.org/doc/dbus-glib/
 Source0:        https://dbus.freedesktop.org/releases/dbus-glib/%{name}-%{version}.tar.gz
-Vendor:         Microsoft Corporation
-Distribution:   Mariner
-BuildRequires:  glib-devel
 BuildRequires:  dbus-devel
-Requires:       glib
+BuildRequires:  glib-devel
 Requires:       dbus
+Requires:       glib
 
 %description
 The D-Bus GLib package contains GLib interfaces to the D-Bus API.
 
-%package    devel
-Summary:    Libraries and headers for the D-Bus GLib bindings
-Requires:   glib-devel
-Requires:   dbus-devel
-Requires:   %{name} = %{version}
-Provides:   pkgconfig(dbus-glib-1)
+%package        devel
+Summary:        Libraries and headers for the D-Bus GLib bindings
+Requires:       %{name} = %{version}
+Requires:       dbus-devel
+Requires:       glib-devel
+Provides:       pkgconfig(dbus-glib-1)
 
 %description devel
 Headers and static libraries for the D-Bus GLib bindings
@@ -70,7 +70,7 @@ Headers and static libraries for the D-Bus GLib bindings
 - License verified- corrected to "AFL OR GPLv2+" from "AFL AND GPLv2+"
 - Fix test suite by compiling unit tests, assertions during %%with_check builds
 - Use configure/make macros
-- Spec linted 
+- Spec linted
 
 * Sat May 09 2020 Nick Samson <nisamson@microsoft.com> - 0.110-3
 - Added %%license line automatically

--- a/SPECS/dbus-glib/dbus-glib.spec
+++ b/SPECS/dbus-glib/dbus-glib.spec
@@ -1,49 +1,52 @@
-Summary:	Glib interfaces to D-Bus API
-Name:		dbus-glib
-Version:	0.110
-Release:        3%{?dist}
-License: 	AFL and GPLv2+
-Group: 		System Environment/Libraries
-Source0:	http://dbus.freedesktop.org/releases/dbus-glib/%{name}-%{version}.tar.gz
-%define sha1 dbus-glib=998b7c762c8f18c906f19fc393bb8712eabe8c97
+Summary:        Glib interfaces to D-Bus API
+Name:           dbus-glib
+Version:        0.110
+Release:        4%{?dist}
+License:        AFL OR GPLv2+
+Group:          System Environment/Libraries
+URL:            https://dbus.freedesktop.org/doc/dbus-glib/
+Source0:        https://dbus.freedesktop.org/releases/dbus-glib/%{name}-%{version}.tar.gz
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
-BuildRequires:	glib-devel
-BuildRequires:	dbus-devel
-Requires:	glib
-Requires:	dbus
-Provides:	pkgconfig(dbus-glib-1)
+BuildRequires:  glib-devel
+BuildRequires:  dbus-devel
+Requires:       glib
+Requires:       dbus
 
 %description
 The D-Bus GLib package contains GLib interfaces to the D-Bus API.
 
-%package devel
-Summary:	Libraries and headers for the D-Bus GLib bindings
-Requires:	glib-devel
-Requires:	dbus-devel
-Requires:	%{name} = %{version}
+%package    devel
+Summary:    Libraries and headers for the D-Bus GLib bindings
+Requires:   glib-devel
+Requires:   dbus-devel
+Requires:   %{name} = %{version}
+Provides:   pkgconfig(dbus-glib-1)
 
 %description devel
 Headers and static libraries for the D-Bus GLib bindings
 
 %prep
-%setup -q
-%build
-./configure \
-	--prefix=%{_prefix} \
-	--sysconfdir=%{_sysconfdir} \
-        --disable-static \
-	--disable-gtk-doc
+%autosetup
 
-make %{?_smp_mflags}
+%build
+%configure \
+    %if %{with_check}
+    --enable-tests \
+    --enable-asserts \
+    %endif
+    --disable-static \
+    --disable-gtk-doc
+%make_build
+
 %install
-make DESTDIR=%{buildroot} install
+%make_install
 
 %check
-make %{?_smp_mflags} check
+%make_build check
 
-%post	-p /sbin/ldconfig
-%postun	-p /sbin/ldconfig
+%ldconfig_scriptlets
+
 %files
 %defattr(-,root,root)
 %license COPYING
@@ -61,27 +64,40 @@ make %{?_smp_mflags} check
 %{_libdir}/*.so
 %{_libdir}/pkgconfig/*.pc
 
-
-
 %changelog
-* Sat May 09 00:21:38 PST 2020 Nick Samson <nisamson@microsoft.com> - 0.110-3
+* Thu Jun 17 2021 Thomas Crain <thcrain@microsoft.com> - 0.110-4
+- Move pkgconfig(dbus-glib-1) provides to the devel package from the base package
+- License verified- corrected to "AFL OR GPLv2+" from "AFL AND GPLv2+"
+- Fix test suite by compiling unit tests, assertions during %%with_check builds
+- Use configure/make macros
+- Spec linted 
+
+* Sat May 09 2020 Nick Samson <nisamson@microsoft.com> - 0.110-3
 - Added %%license line automatically
 
-*   Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 0.110-2
--   Initial CBL-Mariner import from Photon (license: Apache2).
-*	Mon Sep 10 2018 Ajay Kaher <akaher@vmware.com> 0.110-1
--       Upgraded to 0.110
-*       Wed May 03 2017 Bo Gan <ganb@vmware.com> 0.108-1
--       Update to 0.108
-*       Wed Oct 05 2016 ChangLee <changlee@vmware.com> 0.106-5
--       Modified %check
-*	Tue May 24 2016 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 0.106-4
--	GA - Bump release of all rpms
-*   Mon Feb 22 2016 XIaolin Li <xiaolinl@vmware.com> 0.106-1
--   Updated to version 0.106
-*   	Thu Jan 28 2016 Anish Swaminathan <anishs@vmware.com> 0.104-3
--   	Add requires to dbus-glib-devel
-* 	Tue Sep 22 2015 Harish Udaiya Kumar <hudaiyakumar@vmware.com> 0.104-2
--	Updated build requires after creating devel package for dbus
-*	Tue Jun 23 2015 Divya Thaluru <dthaluru@vmware.com> 0.104-1
--	Initial build.
+* Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> - 0.110-2
+- Initial CBL-Mariner import from Photon (license: Apache2).
+
+* Mon Sep 10 2018 Ajay Kaher <akaher@vmware.com> - 0.110-1
+- Upgraded to 0.110
+
+* Wed May 03 2017 Bo Gan <ganb@vmware.com> - 0.108-1
+- Update to 0.108
+
+* Wed Oct 05 2016 ChangLee <changlee@vmware.com> - 0.106-5
+- Modified %check
+
+* Tue May 24 2016 Priyesh Padmavilasom <ppadmavilasom@vmware.com> - 0.106-4
+- GA - Bump release of all rpms
+
+* Mon Feb 22 2016 XIaolin Li <xiaolinl@vmware.com> - 0.106-1
+- Updated to version 0.106
+
+* Thu Jan 28 2016 Anish Swaminathan <anishs@vmware.com> - 0.104-3
+- Add requires to dbus-glib-devel
+
+* Tue Sep 22 2015 Harish Udaiya Kumar <hudaiyakumar@vmware.com> - 0.104-2
+- Updated build requires after creating devel package for dbus
+
+* Tue Jun 23 2015 Divya Thaluru <dthaluru@vmware.com> - 0.104-1
+- Initial build.


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
`dbus-glib` has a provides of `pkgconfig(dbus-glib-1)` on the base package, but the pkgconfig file is in the `devel` subpackage. This PR fixes that, as well as various fixes to the spec and the package tests.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Move `pkgconfig(dbus-glib-1)` provides to the devel package from the base package
- License verified- corrected to "AFL OR GPLv2+" from "AFL AND GPLv2+"
- Fix test suite by compiling unit tests, assertions during `%with_check` builds
- Use configure/make macros
- Spec linted 

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build of affected packages
