### PR TITLE
Making `grpc` use system's `protobuf`.

### DIFF
--- a/SPECS/grpc/grpc.spec
+++ b/SPECS/grpc/grpc.spec
@@ -56,13 +56,13 @@ The grpc-plugins package contains the grpc plugins.
 %build
 mkdir -p cmake/build
 cd cmake/build
-cmake ../.. -DgRPC_INSTALL=ON \
-   -DBUILD_SHARED_LIBS=ON \
-   -DCMAKE_BUILD_TYPE=Release             \
-   -DCMAKE_INSTALL_PREFIX:PATH=%{_prefix} \
-   -DgRPC_CARES_PROVIDER:STRING='package' \
+cmake ../.. -DgRPC_INSTALL=ON                \
+   -DBUILD_SHARED_LIBS=ON                    \
+   -DCMAKE_BUILD_TYPE=Release                \
+   -DCMAKE_INSTALL_PREFIX:PATH=%{_prefix}    \
+   -DgRPC_CARES_PROVIDER:STRING='package'    \
    -DgRPC_PROTOBUF_PROVIDER:STRING='package' \
-   -DgRPC_SSL_PROVIDER:STRING='package'   \
+   -DgRPC_SSL_PROVIDER:STRING='package'      \
    -DgRPC_ZLIB_PROVIDER:STRING='package'
 %make_build
 

--- a/SPECS/grpc/grpc.spec
+++ b/SPECS/grpc/grpc.spec
@@ -75,19 +75,13 @@ find %{buildroot} -name '*.cmake' -delete
 %files
 %license LICENSE
 %{_libdir}/*.so.*
-%{_lib64dir}/*.so.*
 %{_datadir}/grpc/roots.pem
-%exclude %{_datadir}/pkgconfig/zlib.pc
-%exclude %{_bindir}/acountry
-%exclude %{_bindir}/ahost
-%exclude %{_bindir}/adig
 
 %files devel
 %{_includedir}/*
 %{_libdir}/*.so
 %{_lib64dir}/*.so
 %{_libdir}/pkgconfig/*.pc
-%{_lib64dir}/pkgconfig/*.pc
 
 %files plugins
 %license LICENSE

--- a/SPECS/grpc/grpc.spec
+++ b/SPECS/grpc/grpc.spec
@@ -1,7 +1,7 @@
 Summary:        Open source remote procedure call (RPC) framework
 Name:           grpc
 Version:        1.35.0
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -17,16 +17,18 @@ Source0:        %{name}-%{version}.tar.gz
 #  popd
 #  sudo mv grpc grpc-%{version}
 #  sudo tar -cvf grpc-%{version}.tar.gz grpc-%{version}/
-BuildRequires:  git
 BuildRequires:  c-ares-devel
 BuildRequires:  cmake
 BuildRequires:  gcc
-BuildRequires:  zlib-devel
+BuildRequires:  git
 BuildRequires:  openssl-devel
+BuildRequires:  protobuf-devel
+BuildRequires:  zlib-devel
 
-Requires:       zlib
-Requires:       openssl
 Requires:       c-ares
+Requires:       openssl
+Requires:       protobuf
+Requires:       zlib
 
 %description
 gRPC is a modern, open source, high-performance remote procedure call (RPC) framework that can run anywhere. It enables client and server applications to communicate transparently, and simplifies the building of connected systems.
@@ -34,6 +36,7 @@ gRPC is a modern, open source, high-performance remote procedure call (RPC) fram
 %package devel
 Summary:        Development files for grpc
 Requires:       %{name} = %{version}-%{release}
+Requires:       protobuf-devel
 
 %description devel
 The grpc-devel package contains the header files and libraries
@@ -57,9 +60,10 @@ cmake ../.. -DgRPC_INSTALL=ON \
    -DBUILD_SHARED_LIBS=ON \
    -DCMAKE_BUILD_TYPE=Release             \
    -DCMAKE_INSTALL_PREFIX:PATH=%{_prefix} \
-   -DgRPC_ZLIB_PROVIDER:STRING='package'  \
+   -DgRPC_CARES_PROVIDER:STRING='package' \
+   -DgRPC_PROTOBUF_PROVIDER:STRING='package' \
    -DgRPC_SSL_PROVIDER:STRING='package'   \
-   -DgRPC_CARES_PROVIDER:STRING='package' 
+   -DgRPC_ZLIB_PROVIDER:STRING='package'
 %make_build
 
 %install
@@ -77,7 +81,6 @@ find %{buildroot} -name '*.cmake' -delete
 %exclude %{_bindir}/acountry
 %exclude %{_bindir}/ahost
 %exclude %{_bindir}/adig
-%exclude %{_bindir}/protoc*
 
 %files devel
 %{_includedir}/*
@@ -91,6 +94,9 @@ find %{buildroot} -name '*.cmake' -delete
 %{_bindir}/grpc_*_plugin
 
 %changelog
+* Mon Jun 21 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.35.0-4
+- Switch to system package for protobuf dependency.
+
 * Wed Apr 28 2021 Nick Samson <nick.samson@microsoft.com> - 1.35.0-3
 - Switch to system package for c-ares dependency.
 

--- a/SPECS/protobuf/protobuf.signatures.json
+++ b/SPECS/protobuf/protobuf.signatures.json
@@ -1,5 +1,6 @@
 {
  "Signatures": {
-  "protobuf-3.14.0.tar.gz": "d0f5f605d0d656007ce6c8b5a82df3037e1d8fe8b121ed42e536f569dec16113"
+  "protobuf-3.14.0.tar.gz": "d0f5f605d0d656007ce6c8b5a82df3037e1d8fe8b121ed42e536f569dec16113",
+  "protobuf-3.14.0-m2.tar.gz": "205cd04bea8506bdf512cd7918cc7907aa81ed145d848cd5e0e890adff35b3fd"
  }
 }

--- a/SPECS/protobuf/protobuf.signatures.json
+++ b/SPECS/protobuf/protobuf.signatures.json
@@ -1,6 +1,6 @@
 {
  "Signatures": {
   "protobuf-3.14.0.tar.gz": "d0f5f605d0d656007ce6c8b5a82df3037e1d8fe8b121ed42e536f569dec16113",
-  "protobuf-3.14.0-m2.tar.gz": "205cd04bea8506bdf512cd7918cc7907aa81ed145d848cd5e0e890adff35b3fd"
+  "protobuf-3.14.0-m2.tar.gz": "cde3be31710f80bfd594f652fcb28c43afefb16f70a15895086ff5f386b555aa"
  }
 }

--- a/SPECS/protobuf/protobuf.signatures.json
+++ b/SPECS/protobuf/protobuf.signatures.json
@@ -1,6 +1,5 @@
 {
  "Signatures": {
-  "protobuf-3.6.1.tar.gz": "3d4e589d81b2006ca603c1ab712c9715a76227293032d05b26fca603f90b3f5b",
-  "protobuf-m2-3.6.1.tar.gz": "205cd04bea8506bdf512cd7918cc7907aa81ed145d848cd5e0e890adff35b3fd"
+  "protobuf-3.14.0.tar.gz": "d0f5f605d0d656007ce6c8b5a82df3037e1d8fe8b121ed42e536f569dec16113"
  }
 }

--- a/SPECS/protobuf/protobuf.spec
+++ b/SPECS/protobuf/protobuf.spec
@@ -3,16 +3,15 @@
 
 Summary:        Google's data interchange format
 Name:           protobuf
-Version:        3.6.1
-Release:        8%{?dist}
+Version:        3.14.0
+Release:        1%{?dist}
 License:        BSD
 Group:          Development/Libraries
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 URL:            https://developers.google.com/protocol-buffers/
-#Source0:       https://github.com/protocolbuffers/protobuf/archive/v%{version}.tar.gz
+#Source0:       https://github.com/protocolbuffers/protobuf/archive/v%%{version}/%%{name}-%%{version}-all.tar.gz
 Source0:        protobuf-%{version}.tar.gz
-Source1:        protobuf-m2-%{version}.tar.gz
 
 BuildRequires:  autoconf
 BuildRequires:  automake
@@ -84,10 +83,6 @@ Requires:       openjre8 >= 1.8.0.45
 This contains protobuf java package.
 
 %prep
-mkdir /root/.m2
-pushd /root/.m2
-tar xf %{SOURCE1} --no-same-owner
-popd
 %setup
 autoreconf -iv
 
@@ -157,6 +152,9 @@ popd
 %{_libdir}/java/protobuf/*.jar
 
 %changelog
+* Mon Jun 21 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 3.14.0-1
+- Updating to version 3.14.0 to satisfy requirements from 'grpc' and 'collectd'.
+
 * Sat May 09 2020 Nick Samson <nisamson@microsoft.com> - 3.6.1-8
 - Added %%license line automatically
 

--- a/SPECS/protobuf/protobuf.spec
+++ b/SPECS/protobuf/protobuf.spec
@@ -1,6 +1,14 @@
 %{!?python2_sitelib: %global python2_sitelib %(python2 -c "from distutils.sysconfig import get_python_lib;print(get_python_lib())")}
 %{!?python3_sitelib: %global python3_sitelib %(python3 -c "from distutils.sysconfig import get_python_lib;print(get_python_lib())")}
 
+# Switch "sources_generation" to 1 when running a package build to generate cached sources for regular builds.
+%define sources_generation 0
+%define m2_cache_tarball_name %{name}-%{version}-m2.tar.gz
+
+%if ! 0%{?sources_generation}
+%define offline_build -o
+%endif
+
 Summary:        Google's data interchange format
 Name:           protobuf
 Version:        3.14.0
@@ -12,6 +20,11 @@ Distribution:   Mariner
 URL:            https://developers.google.com/protocol-buffers/
 #Source0:       https://github.com/protocolbuffers/protobuf/archive/v%%{version}/%%{name}-%%{version}-all.tar.gz
 Source0:        protobuf-%{version}.tar.gz
+# In order to re-generate this source after a version update, switch "sources_generation" to 1
+# and make sure network is enabled during the build. The tarballs will be inside the built 'maven-cached-sources' subpackage.
+%if ! 0%{?sources_generation}
+Source1:        %{m2_cache_tarball_name}
+%endif
 
 BuildRequires:  autoconf
 BuildRequires:  automake
@@ -23,6 +36,18 @@ BuildRequires:  unzip
 
 %description
 Protocol Buffers (a.k.a., protobuf) are Google's language-neutral, platform-neutral, extensible mechanism for serializing structured data. You can find protobuf's documentation on the Google Developers site.
+
+%if 0%{?sources_generation}
+
+%package cached-sources
+Summary:    NOT TO BE USED AS REGULAR PACKAGE! REQUIRES NETWORK ACCESS!
+
+%description cached-sources
+%{summary}
+This is an artificial package to ease generation of cached sources for
+the regular builds when the "sources_generation" macro is set to 0.
+
+%endif
 
 %package        devel
 Summary:        Development files for protobuf
@@ -83,6 +108,17 @@ Requires:       openjre8 >= 1.8.0.45
 This contains protobuf java package.
 
 %prep
+
+%if ! 0%{?sources_generation}
+
+# Setup maven .m2 cache directory
+mkdir /root/.m2
+pushd /root/.m2
+tar xf %{SOURCE1} --no-same-owner
+popd
+
+%endif
+
 %setup
 autoreconf -iv
 
@@ -96,10 +132,23 @@ python2 setup.py build
 python3 setup.py build
 popd
 pushd java
-mvn package -o
+mvn package %{?offline_build}
 popd
 
 %install
+%if 0%{?sources_generation}
+
+echo "Compressing cached repositories."
+tar --sort=name \
+    --mtime="2021-04-26 00:00Z" \
+    --owner=0 --group=0 --numeric-owner \
+    --pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime \
+    -C /root/.m2 \
+    -cpvz -f %{m2_cache_tarball_name} repository
+mv /root/.m2/%{m2_cache_tarball_name} %{buildroot}%{_prefix}
+
+%endif
+
 export JAVA_HOME=$(find /usr/lib/jvm -name "OpenJDK*")
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$(find $JAVA_HOME/lib -name "jli")
 make DESTDIR=%{buildroot} install
@@ -124,6 +173,13 @@ popd
 %{_libdir}/libprotobuf-lite.so.*
 %{_libdir}/libprotobuf.so.*
 %{_libdir}/libprotoc.so.*
+
+%if 0%{?sources_generation}
+
+%files cached-sources
+%{_prefix}/%{m2_cache_tarball_name}
+
+%endif
 
 %files devel
 %defattr(-,root,root)
@@ -154,6 +210,7 @@ popd
 %changelog
 * Mon Jun 21 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 3.14.0-1
 - Updating to version 3.14.0 to satisfy requirements from 'grpc' and 'collectd'.
+- Adding steps for re-building Maven cache.
 
 * Sat May 09 2020 Nick Samson <nisamson@microsoft.com> - 3.6.1-8
 - Added %%license line automatically

--- a/SPECS/protobuf/protobuf.spec
+++ b/SPECS/protobuf/protobuf.spec
@@ -9,6 +9,10 @@
 %define offline_build -o
 %endif
 
+%if ! %{with_check}
+%define skip_tests -DskipTests
+%endif
+
 Summary:        Google's data interchange format
 Name:           protobuf
 Version:        3.14.0
@@ -134,7 +138,7 @@ python3 setup.py build
 popd
 
 pushd java
-mvn package %{?offline_build}
+mvn package %{?offline_build} %{?skip_tests}
 popd
 
 %install
@@ -146,7 +150,7 @@ python2 setup.py install --prefix=%{_prefix} --root=%{buildroot}
 python3 setup.py install --prefix=%{_prefix} --root=%{buildroot}
 popd
 pushd java
-mvn install %{?offline_build}
+mvn install %{?offline_build} %{?skip_tests}
 install -vdm755 %{buildroot}%{_libdir}/java/protobuf
 install -vm644 core/target/protobuf-java-%{version}.jar %{buildroot}%{_libdir}/java/protobuf
 install -vm644 util/target/protobuf-java-util-%{version}.jar %{buildroot}%{_libdir}/java/protobuf

--- a/SPECS/protobuf/protobuf.spec
+++ b/SPECS/protobuf/protobuf.spec
@@ -9,10 +9,6 @@
 %define offline_build -o
 %endif
 
-%if (! %{with_check}) && (! 0%{?sources_generation})
-%define skip_tests -DskipTests
-%endif
-
 Summary:        Google's data interchange format
 Name:           protobuf
 Version:        3.14.0
@@ -138,7 +134,7 @@ python3 setup.py build
 popd
 
 pushd java
-mvn package %{?offline_build} %{?skip_tests}
+mvn package %{?offline_build}
 popd
 
 %install

--- a/SPECS/protobuf/protobuf.spec
+++ b/SPECS/protobuf/protobuf.spec
@@ -146,10 +146,10 @@ python2 setup.py install --prefix=%{_prefix} --root=%{buildroot}
 python3 setup.py install --prefix=%{_prefix} --root=%{buildroot}
 popd
 pushd java
-mvn install -o
+mvn install %{?offline_build}
 install -vdm755 %{buildroot}%{_libdir}/java/protobuf
-install -vm644 core/target/protobuf-java-3.6.1.jar %{buildroot}%{_libdir}/java/protobuf
-install -vm644 util/target/protobuf-java-util-3.6.1.jar %{buildroot}%{_libdir}/java/protobuf
+install -vm644 core/target/protobuf-java-%{version}.jar %{buildroot}%{_libdir}/java/protobuf
+install -vm644 util/target/protobuf-java-util-%{version}.jar %{buildroot}%{_libdir}/java/protobuf
 popd
 
 %if 0%{?sources_generation}

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -4735,8 +4735,8 @@
         "type": "other",
         "other": {
           "name": "protobuf",
-          "version": "3.6.1",
-          "downloadUrl": "https://github.com/protocolbuffers/protobuf/archive/v3.6.1.tar.gz"
+          "version": "3.14.0",
+          "downloadUrl": "https://github.com/protocolbuffers/protobuf/archive/v3.14.0/protobuf-3.14.0-all.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

It looks like by default `grpc` build and published its own libraries for `protobuf`, which end up conflicting with the ones we provide through the `protobuf` package. This updated `grpc` to use that package instead.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Switched `grpc` to using system's `protobuf`.
- Updated 'protobuf' to version 3.14.0 to satisfy dependencies from `grpc` and `collectd`.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local package build.
