### PR TITLE
Make chronyd not listen on UDP port by default

### DIFF
--- a/SPECS/chrony/chrony.spec
+++ b/SPECS/chrony/chrony.spec
@@ -4,7 +4,7 @@
 
 Name:           chrony
 Version:        3.5.1
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        An NTP client/server
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -91,6 +91,8 @@ cat >> chrony.conf << EOF
 
 # Setting larger 'maxdistance' to tolerate time.windows.com delay
 maxdistance 16.0
+# Disable listening on UDP port (leaving only Unix socket interface).
+cmdport 0
 EOF
 
 touch -r examples/chrony.conf.example2 examples/chrony-wait.service chrony.conf
@@ -201,6 +203,9 @@ systemctl start chronyd.service
 %dir %attr(-,chrony,chrony) %{_localstatedir}/log/chrony
 
 %changelog
+* Wed Jun 23 2021 Mateusz Malisz <mamalisz@microsoft.com> - 3.5.1-5
+- Make chronyd not listen on UDP port by default.
+
 * Tue Apr 13 2021 Rachel Menge <rachelmenge@microsoft.com> - 3.5.1-4
 - Bump release to rebuild with new nettle (3.7.2)
 


### PR DESCRIPTION

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
This change makes chronyd not listen on UDP port by default. The behavior can be overridden by a config change.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Make chronyd not listen on UDP port.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
NO

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build
