### PR TITLE
[dev] Add static subpackage provides to libseccomp-devel

### DIFF
--- a/SPECS/libseccomp/libseccomp.spec
+++ b/SPECS/libseccomp/libseccomp.spec
@@ -1,13 +1,14 @@
 Summary:       Enhanced seccomp library
 Name:          libseccomp
 Version:       2.4.1
-Release:       2%{?dist}
+Release:       3%{?dist}
 License:       LGPLv2
+Vendor:        Microsoft Corporation
+Distribution:  Mariner
 Group:         System Environment/Libraries
-Url:           https://github.com/seccomp/libseccomp/wiki
+URL:           https://github.com/seccomp/libseccomp/wiki
 Source0:       https://github.com/seccomp/libseccomp/releases/download/v%{version}/%{name}-%{version}.tar.gz
-Vendor:         Microsoft Corporation
-Distribution:   Mariner
+
 %if %{with_check}
 BuildRequires: which
 %endif
@@ -19,10 +20,11 @@ is designed to abstract away the underlying BPF based syscall filter language
 and present a more conventional function-call based filtering interface that
 should be familiar to, and easily adopted by application developers.
 
-%package devel
-Summary:  Development files used to build applications with libseccomp support
-Group:    Development/Libraries
-Provides: pkgconfig(libseccomp)
+%package    devel
+Summary:    Development files used to build applications with libseccomp support
+Group:      Development/Libraries
+Provides:   pkgconfig(libseccomp) = %{version}-%{release}
+Provides:   %{name}-static = %{version}-%{release}
 
 %description devel
 The libseccomp-devel package contains the libraries and header files
@@ -33,18 +35,16 @@ needed for developing secure applications.
 
 %build
 %configure
-make V=1 %{?_smp_mflags}
+%make_build
 
 %install
-rm -rf "%{buildroot}"
-make V=1 DESTDIR="%{buildroot}" install
+%make_install
+find %{buildroot} -type f -name "*.la" -delete -print
 
 %check
-make check
+%make_build check
 
-%post -p /sbin/ldconfig
-
-%postun -p /sbin/ldconfig
+%ldconfig_scriptlets
 
 %files
 %license LICENSE
@@ -57,27 +57,38 @@ make check
 %{_includedir}/seccomp.h
 %{_libdir}/libseccomp.so
 %{_libdir}/libseccomp.a
-%{_libdir}/libseccomp.la
 %{_libdir}/pkgconfig/libseccomp.pc
 %{_bindir}/scmp_sys_resolver
 %{_mandir}/man1/*
 %{_mandir}/man3/*
 
 %changelog
-* Sat May 09 00:21:43 PST 2020 Nick Samson <nisamson@microsoft.com>
+* Tue Jun 29 2021 Thomas Crain <thcrain@microsoft.com> - 2.4.1-3
+- Provide libseccomp-static from devel subpackage
+- Version the pkgconfig provides
+- Modernize spec with macros
+- Remove libtool archive files
+
+* Sat May 09 2020 Nick Samson <nisamson@microsoft.com> - 2.4.1-2
 - Added %%license line automatically
 
-*   Tue Mar 17 2020 Henry Beberman <henry.beberman@microsoft.com> 2.4.1-1
--   Update to 2.4.1. License verified.
-*   Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 2.3.3-3
--   Initial CBL-Mariner import from Photon (license: Apache2).
-*  Wed Jan 9 2019 Michelle Wang <michellew@vmware.com> 2.3.3-2
--  Fix make check for libseccomp.
-*  Mon Sep 10 2018 Bo Gan <ganb@vmware.com> 2.3.3-1
--  Updated to version 2.3.3.
-*  Tue Apr 11 2017 Harish Udaiya KUmar <hudaiyakumar@vmware.com> 2.3.2-1
--  Updated to version 2.3.2.
-*  Tue May 24 2016 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 2.2.3-2
--  GA - Bump release of all rpms.
-*  Sat Jan 16 2016 Fabio Rapposelli <fabio@vmware.com> - 2.2.3-1
--  First release of the package.
+* Tue Mar 17 2020 Henry Beberman <henry.beberman@microsoft.com> - 2.4.1-1
+- Update to 2.4.1. License verified.
+
+* Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> - 2.3.3-3
+- Initial CBL-Mariner import from Photon (license: Apache2).
+
+* Wed Jan 9 2019 Michelle Wang <michellew@vmware.com> - 2.3.3-2
+- Fix make check for libseccomp.
+
+* Mon Sep 10 2018 Bo Gan <ganb@vmware.com> - 2.3.3-1
+- Updated to version 2.3.3.
+
+* Tue Apr 11 2017 Harish Udaiya KUmar <hudaiyakumar@vmware.com> - 2.3.2-1
+- Updated to version 2.3.2.
+
+* Tue May 24 2016 Priyesh Padmavilasom <ppadmavilasom@vmware.com> - 2.2.3-2
+- GA - Bump release of all rpms.
+
+* Sat Jan 16 2016 Fabio Rapposelli <fabio@vmware.com> - 2.2.3-1
+- First release of the package.

--- a/SPECS/libseccomp/libseccomp.spec
+++ b/SPECS/libseccomp/libseccomp.spec
@@ -1,14 +1,13 @@
-Summary:       Enhanced seccomp library
-Name:          libseccomp
-Version:       2.4.1
-Release:       3%{?dist}
-License:       LGPLv2
-Vendor:        Microsoft Corporation
-Distribution:  Mariner
-Group:         System Environment/Libraries
-URL:           https://github.com/seccomp/libseccomp/wiki
-Source0:       https://github.com/seccomp/libseccomp/releases/download/v%{version}/%{name}-%{version}.tar.gz
-
+Summary:        Enhanced seccomp library
+Name:           libseccomp
+Version:        2.4.1
+Release:        3%{?dist}
+License:        LGPLv2
+Vendor:         Microsoft Corporation
+Distribution:   Mariner
+Group:          System Environment/Libraries
+URL:            https://github.com/seccomp/libseccomp/wiki
+Source0:        https://github.com/seccomp/libseccomp/releases/download/v%{version}/%{name}-%{version}.tar.gz
 %if %{with_check}
 BuildRequires: which
 %endif
@@ -20,13 +19,13 @@ is designed to abstract away the underlying BPF based syscall filter language
 and present a more conventional function-call based filtering interface that
 should be familiar to, and easily adopted by application developers.
 
-%package    devel
-Summary:    Development files used to build applications with libseccomp support
-Group:      Development/Libraries
-Provides:   pkgconfig(libseccomp) = %{version}-%{release}
-Provides:   %{name}-static = %{version}-%{release}
+%package        devel
+Summary:        Development files used to build applications with libseccomp support
+Group:          Development/Libraries
+Provides:       pkgconfig(libseccomp) = %{version}-%{release}
+Provides:       %{name}-static = %{version}-%{release}
 
-%description devel
+%description    devel
 The libseccomp-devel package contains the libraries and header files
 needed for developing secure applications.
 
@@ -48,9 +47,7 @@ find %{buildroot} -type f -name "*.la" -delete -print
 
 %files
 %license LICENSE
-%doc LICENSE
-%doc CREDITS
-%doc README.md
+%doc CREDITS README.md
 %{_libdir}/libseccomp.so.*
 
 %files devel

--- a/SPECS/libseccomp/libseccomp.spec
+++ b/SPECS/libseccomp/libseccomp.spec
@@ -9,7 +9,7 @@ Group:          System Environment/Libraries
 URL:            https://github.com/seccomp/libseccomp/wiki
 Source0:        https://github.com/seccomp/libseccomp/releases/download/v%{version}/%{name}-%{version}.tar.gz
 %if %{with_check}
-BuildRequires: which
+BuildRequires:  which
 %endif
 
 %description


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Some packages expect the existence of a `libseccomp-static` package. Since we ship the static libraries as part of the `devel` subpackage, we should add a `libseccomp-static` provides to the devel subpackage.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add `libseccomp-static` provides to devel subpackage
- Modernize spec with make, ldconfig macros
- Remove libtool archive files

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build of affected package with `RUN_CHECK=y`
