### PR TITLE
[dev] Add devel subpackage to libconfig, update to 1.7.3

### DIFF
--- a/SPECS/libconfig/libconfig.signatures.json
+++ b/SPECS/libconfig/libconfig.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "libconfig-1.7.2.tar.gz": "f67ac44099916ae260a6c9e290a90809e7d782d96cdd462cac656ebc5b685726"
+  "libconfig-1.7.3.tar.gz": "545166d6cac037744381d1e9cc5a5405094e7bfad16a411699bcff40bbb31ee7"
  }
 }

--- a/SPECS/libconfig/libconfig.spec
+++ b/SPECS/libconfig/libconfig.spec
@@ -1,3 +1,6 @@
+%global sover_major 11
+%global sover_minor 1
+
 Summary:        C/C++ configuration file library
 Name:           libconfig
 Version:        1.7.3
@@ -7,7 +10,7 @@ Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Group:          Development/Tools
 URL:            https://hyperrealm.github.io/libconfig/
-Source0:       https://github.com/hyperrealm/%{name}/releases/download/v%{version}/%{name}-%{version}.tar.gz
+Source0:        https://github.com/hyperrealm/%{name}/releases/download/v%{version}/%{name}-%{version}.tar.gz
 BuildRequires:  autoconf
 BuildRequires:  texinfo
 
@@ -43,7 +46,8 @@ cd ..
 %files
 %license COPYING.LIB
 %doc AUTHORS ChangeLog README
-%{_libdir}/libconfig*.so.*
+%{_libdir}/libconfig*.so.%{sover_major}
+%{_libdir}/libconfig*.so.%{sover_major}.%{sover_minor}*
 
 %files devel
 %{_includedir}/libconfig*

--- a/SPECS/libconfig/libconfig.spec
+++ b/SPECS/libconfig/libconfig.spec
@@ -1,32 +1,36 @@
 Summary:        C/C++ configuration file library
 Name:           libconfig
-Version:        1.7.2
-Release:        2%{?dist}
+Version:        1.7.3
+Release:        1%{?dist}
 License:        LGPLv2+
-URL:            https://hyperrealm.github.io/libconfig/
-#Source0:       https://github.com/hyperrealm/%{name}/archive/v%{version}.tar.gz
-Source0:        %{name}-%{version}.tar.gz
-Group:          Development/Tools
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
-
+Group:          Development/Tools
+URL:            https://hyperrealm.github.io/libconfig/
+Source0:       https://github.com/hyperrealm/%{name}/releases/download/v%{version}/%{name}-%{version}.tar.gz
 BuildRequires:  autoconf
 BuildRequires:  texinfo
 
 %description
-Libconfig is a simple library for processing structured configuration files, like this one: test.cfg. This file format is more compact and more readable than XML. And unlike XML, it is type-aware, so it is not necessary to do string parsing in application code.
+Libconfig is a simple library for processing structured configuration files. This file format is more compact and more readable than XML. And unlike XML, it is type-aware, so it is not necessary to do string parsing in application code.
+
+%package        devel
+Summary:        Development libraries and headers for %{name}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+
+%description    devel
+Development libraries and headers for %{name}
 
 %prep
-%setup -q
+%autosetup
 
 %build
-autoreconf
 %configure --disable-static
-make %{?_smp_mflags}
+%make_build
 
 %install
-make DESTDIR=%{buildroot} install
-rm -rf %{buildroot}%{_libdir}/*.la
+%make_install
+find %{buildroot} -type f -name "*.la" -delete -print
 rm -rf %{buildroot}%{_infodir}/dir
 
 %check
@@ -34,31 +38,40 @@ cd ./tests
 ./libconfig_tests # This HAS to be run in the tests directory due to use of relative paths.
 cd ..
 
-%post -p /sbin/ldconfig
-
-%postun -p /sbin/ldconfig
+%ldconfig_scriptlets
 
 %files
-%license LICENSE
-%doc AUTHORS ChangeLog COPYING.LIB README
+%license COPYING.LIB
+%doc AUTHORS ChangeLog README
 %{_libdir}/libconfig*.so.*
+
+%files devel
 %{_includedir}/libconfig*
-%{_libdir}/libconfig*.so
-%{_libdir}/pkgconfig/libconfig*.pc
 %{_infodir}/libconfig.info*
 %{_libdir}/cmake/libconfig*/*.cmake
+%{_libdir}/libconfig*.so
+%{_libdir}/pkgconfig/libconfig*.pc
 
 %changelog
-* Sat May 09 00:21:35 PST 2020 Nick Samson <nisamson@microsoft.com> - 1.7.2-2
+* Tue Jun 29 2021 Thomas Crain <thcrain@microsoft.com> - 1.7.3-1
+- Upgrade to latest release and update license location
+- Use release version of the source tarball
+- Add a devel subpackage
+- Lint spec, modernize with macros
+
+* Sat May 09 2020 Nick Samson <nisamson@microsoft.com> - 1.7.2-2
 - Added %%license line automatically
 
-*   Mon Apr 20 2020 Nick Samson <nisamson@microsoft.com> 1.7.2-1
--   Updated for bug-fixes, changed Source0 to current official sources. URL updated. License verified.
--   Fixes to build script to compile latest version.
--   Added BuildRequires.
-*   Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 1.5-3
--   Initial CBL-Mariner import from Photon (license: Apache2).
-*   Tue May 24 2016 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 1.5-2
--   GA - Bump release of all rpms
-*   Tue Nov 24 2015 Xiaolin Li <xiaolinl@vmware.com> 0.7.2-1
--   Initial build.  First version
+* Mon Apr 20 2020 Nick Samson <nisamson@microsoft.com> - 1.7.2-1
+- Updated for bug-fixes, changed Source0 to current official sources. URL updated. License verified.
+- Fixes to build script to compile latest version.
+- Added BuildRequires.
+
+* Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> - 1.5-3
+- Initial CBL-Mariner import from Photon (license: Apache2).
+
+* Tue May 24 2016 Priyesh Padmavilasom <ppadmavilasom@vmware.com> - 1.5-2
+- GA - Bump release of all rpms
+
+* Tue Nov 24 2015 Xiaolin Li <xiaolinl@vmware.com> - 0.7.2-1
+- Initial build.  First version

--- a/SPECS/libconfig/libconfig.spec
+++ b/SPECS/libconfig/libconfig.spec
@@ -1,6 +1,5 @@
 %global sover_major 11
 %global sover_minor 1
-
 Summary:        C/C++ configuration file library
 Name:           libconfig
 Version:        1.7.3

--- a/SPECS/libstoragemgmt/libstoragemgmt.spec
+++ b/SPECS/libstoragemgmt/libstoragemgmt.spec
@@ -3,10 +3,10 @@ Name:           libstoragemgmt
 Version:        1.8.4
 Release:        8%{?dist}
 License:        LGPLv2+
-URL:            https://github.com/libstorage/libstoragemgmt
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
-Source0:        https://github.com/libstorage/libstoragemgmt/releases/download/%{version}/%{name}-%{version}.tar.gz
+URL:            https://github.com/libstorage/libstoragemgmt
+Source0:        https://github.com/libstorage/%{name}/releases/download/%{version}/%{name}-%{version}.tar.gz
 Patch1:         0001-change-run-dir.patch
 
 BuildRequires:  gcc
@@ -244,112 +244,112 @@ getent passwd libstoragemgmt >/dev/null || \
 %post smis-plugin
 if [ $1 -eq 1 ]; then
     # New install.
-    /usr/bin/systemctl try-restart %{name}.service >/dev/null 2>&1 || :
+    %{_bindir}/systemctl try-restart %{name}.service >/dev/null 2>&1 || :
 fi
 
 %postun smis-plugin
 if [ $1 -eq 0 ]; then
     # Remove
-    /usr/bin/systemctl try-restart %{name}.service >/dev/null 2>&1 || :
+    %{_bindir}/systemctl try-restart %{name}.service >/dev/null 2>&1 || :
 fi
 
 # Need to restart lsmd if plugin is new installed or removed.
 %post netapp-plugin
 if [ $1 -eq 1 ]; then
     # New install.
-    /usr/bin/systemctl try-restart %{name}.service >/dev/null 2>&1 || :
+    %{_bindir}/systemctl try-restart %{name}.service >/dev/null 2>&1 || :
 fi
 
 %postun netapp-plugin
 if [ $1 -eq 0 ]; then
     # Remove
-    /usr/bin/systemctl try-restart %{name}.service >/dev/null 2>&1 || :
+    %{_bindir}/systemctl try-restart %{name}.service >/dev/null 2>&1 || :
 fi
 
 # Need to restart lsmd if plugin is new installed or removed.
 %post targetd-plugin
 if [ $1 -eq 1 ]; then
     # New install.
-    /usr/bin/systemctl try-restart %{name}.service >/dev/null 2>&1 || :
+    %{_bindir}/systemctl try-restart %{name}.service >/dev/null 2>&1 || :
 fi
 
 %postun targetd-plugin
 if [ $1 -eq 0 ]; then
     # Remove
-    /usr/bin/systemctl try-restart %{name}.service >/dev/null 2>&1 || :
+    %{_bindir}/systemctl try-restart %{name}.service >/dev/null 2>&1 || :
 fi
 
 # Need to restart lsmd if plugin is new installed or removed.
 %post nstor-plugin
 if [ $1 -eq 1 ]; then
     # New install.
-    /usr/bin/systemctl try-restart %{name}.service >/dev/null 2>&1 || :
+    %{_bindir}/systemctl try-restart %{name}.service >/dev/null 2>&1 || :
 fi
 
 %postun nstor-plugin
 if [ $1 -eq 0 ]; then
     # Remove
-    /usr/bin/systemctl try-restart %{name}.service >/dev/null 2>&1 || :
+    %{_bindir}/systemctl try-restart %{name}.service >/dev/null 2>&1 || :
 fi
 
 # Need to restart lsmd if plugin is new installed or removed.
 %post megaraid-plugin
 if [ $1 -eq 1 ]; then
     # New install.
-    /usr/bin/systemctl try-restart %{name}.service >/dev/null 2>&1 || :
+    %{_bindir}/systemctl try-restart %{name}.service >/dev/null 2>&1 || :
 fi
 %postun megaraid-plugin
 if [ $1 -eq 0 ]; then
     # Remove
-    /usr/bin/systemctl try-restart %{name}.service >/dev/null 2>&1 || :
+    %{_bindir}/systemctl try-restart %{name}.service >/dev/null 2>&1 || :
 fi
 
 # Need to restart lsmd if plugin is new installed or removed.
 %post hpsa-plugin
 if [ $1 -eq 1 ]; then
     # New install.
-    /usr/bin/systemctl try-restart %{name}.service >/dev/null 2>&1 || :
+    %{_bindir}/systemctl try-restart %{name}.service >/dev/null 2>&1 || :
 fi
 %postun hpsa-plugin
 if [ $1 -eq 0 ]; then
     # Remove
-    /usr/bin/systemctl try-restart %{name}.service >/dev/null 2>&1 || :
+    %{_bindir}/systemctl try-restart %{name}.service >/dev/null 2>&1 || :
 fi
 
 # Need to restart lsmd if plugin is new installed or removed.
 %post arcconf-plugin
 if [ $1 -eq 1 ]; then
     # New install.
-    /usr/bin/systemctl try-restart %{name}.service >/dev/null 2>&1 || :
+    %{_bindir}/systemctl try-restart %{name}.service >/dev/null 2>&1 || :
 fi
 %postun arcconf-plugin
 if [ $1 -eq 0 ]; then
     # Remove
-    /usr/bin/systemctl try-restart %{name}.service >/dev/null 2>&1 || :
+    %{_bindir}/systemctl try-restart %{name}.service >/dev/null 2>&1 || :
 fi
 
 # Need to restart lsmd if plugin is new installed or removed.
 %post nfs-plugin
 if [ $1 -eq 1 ]; then
     # New install.
-    /usr/bin/systemctl try-restart %{name}.service >/dev/null 2>&1 || :
+    %{_bindir}/systemctl try-restart %{name}.service >/dev/null 2>&1 || :
 fi
 %postun nfs-plugin
 if [ $1 -eq 0 ]; then
     # Remove
-    /usr/bin/systemctl try-restart %{name}.service >/dev/null 2>&1 || :
+    %{_bindir}/systemctl try-restart %{name}.service >/dev/null 2>&1 || :
 fi
 
 # Need to restart lsmd if plugin is new installed or removed.
 %post local-plugin
 if [ $1 -eq 1 ]; then
     # New install.
-    /usr/bin/systemctl try-restart %{name}.service >/dev/null 2>&1 || :
+    %{_bindir}/systemctl try-restart %{name}.service >/dev/null 2>&1 || :
 fi
 %postun local-plugin
 if [ $1 -eq 0 ]; then
     # Remove
-    /usr/bin/systemctl try-restart %{name}.service >/dev/null 2>&1 || :
+    %{_bindir}/systemctl try-restart %{name}.service >/dev/null 2>&1 || :
 fi
 
 %files

--- a/SPECS/libstoragemgmt/libstoragemgmt.spec
+++ b/SPECS/libstoragemgmt/libstoragemgmt.spec
@@ -1,19 +1,14 @@
-%{!?python3_sitelib: %define python3_sitelib %(python3 -c "from distutils.sysconfig import get_python_lib;print(get_python_lib())")}
-
-%bcond_with     test
-
 Summary:        Storage array management library
 Name:           libstoragemgmt
 Version:        1.8.4
-Release:        7%{?dist}
+Release:        8%{?dist}
 License:        LGPLv2+
 URL:            https://github.com/libstorage/libstoragemgmt
-Vendor:         Microsoft
+Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Source0:        https://github.com/libstorage/libstoragemgmt/releases/download/%{version}/%{name}-%{version}.tar.gz
 Patch1:         0001-change-run-dir.patch
 
-Requires:       python3-%{name}
 BuildRequires:  gcc
 BuildRequires:  autoconf
 BuildRequires:  automake
@@ -27,20 +22,19 @@ BuildRequires:  openssl-devel
 BuildRequires:  glib-devel
 BuildRequires:  systemd
 BuildRequires:  bash-completion
-BuildRequires:  libconfig
+BuildRequires:  libconfig-devel
 BuildRequires:  systemd-devel
 BuildRequires:  procps-ng
 BuildRequires:  sqlite-devel
 BuildRequires:  python3-six
 BuildRequires:  python3-devel
 BuildRequires:  python3-pywbem
-
 %{?systemd_requires}
 BuildRequires:  systemd 
 BuildRequires:  systemd-devel
-
 BuildRequires:  chrpath
 BuildRequires:  valgrind
+Requires:       python3-%{name}
 
 %description
 The libStorageMgmt library will provide a vendor agnostic open source storage
@@ -209,8 +203,6 @@ plugin selection for locally managed storage.
 %make_build
 
 %install
-rm -rf %{buildroot}
-
 %make_install
 
 find %{buildroot} -name '*.la' -exec rm -f {} ';'
@@ -222,14 +214,12 @@ install -m 644 tools/udev/90-scsi-ua.rules \
 install -m 755 tools/udev/scan-scsi-target \
     %{buildroot}/%{_udevrulesdir}/../scan-scsi-target
 
-%if 0%{with test}
 %check
 if ! make check
 then
   cat test-suite.log || true
   exit 1
 fi
-%endif
 
 %pre
 getent group libstoragemgmt >/dev/null || groupadd -r libstoragemgmt
@@ -536,6 +526,10 @@ fi
 %{_mandir}/man1/local_lsmplugin.1*
 
 %changelog
+* Tue Jun 29 2021 Thomas Crain <thcrain@microsoft.com> - 1.8.4-8
+- Use libconfig-devel at build-time instead of libconfig
+- Remove %%bcond_with test line
+
 * Wed Mar 10 2021 Thomas Crain <thcrain@microsoft.com> - 1.8.4-7
 - Remove manual placement of bash-completion file, now that this package has bash-completion.pc available to it
 

--- a/SPECS/lldpad/lldpad.spec
+++ b/SPECS/lldpad/lldpad.spec
@@ -19,7 +19,6 @@ Requires:       libconfig
 Requires:       libnl3
 Requires:       systemd
 
-
 %description
 The lldpad package comes with utilities to manage an LLDP interface with support for reading and configuring TLVs. TLVs and interfaces are individual controlled allowing flexible configuration for TX only, RX only, or TX/RX modes per TLV.
 

--- a/SPECS/lldpad/lldpad.spec
+++ b/SPECS/lldpad/lldpad.spec
@@ -1,17 +1,16 @@
-Summary:    Intel LLDP Agent
-Name:       lldpad
-Version:    1.0.1
-Release:    17%{?dist}
-License:    GPLv2
-URL:        https://github.com/intel/openlldp
-#Source0:    https://github.com/intel/openlldp/archive/v%{version}.tar.gz
-Source0:    %{name}-%{version}.pkgupdate.tar.gz
-Patch0: remove-lldp-ethertype-use-linux-5.3-header-instead.patch
-Group:      System Environment/Daemons
+Summary:        Intel LLDP Agent
+Name:           lldpad
+Version:        1.0.1
+Release:        18%{?dist}
+License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
-
-BuildRequires: libconfig
+Group:          System Environment/Daemons
+URL:            https://github.com/intel/openlldp
+#Source0:       https://github.com/intel/openlldp/archive/v%%{version}.tar.gz
+Source0:        %{name}-%{version}.pkgupdate.tar.gz
+Patch0:         remove-lldp-ethertype-use-linux-5.3-header-instead.patch
+BuildRequires: libconfig-devel
 BuildRequires: libnl3-devel
 BuildRequires: readline-devel
 BuildRequires: systemd
@@ -32,17 +31,17 @@ sed -i "s/u8 arglen;/u8 arglen = 0;/g" lldp_util.c
 %build
 ./bootstrap.sh
 %configure --disable-static
-make %{?_smp_mflags}
+%make_build
 
 %install
-make DESTDIR=%{buildroot} install
+%make_install
 find %{buildroot} -name '*.la' -exec rm -f {} ';'
 mkdir -p %{buildroot}/lib/systemd/system
 mkdir -p %{buildroot}%{_sharedstatedir}/%{name}
 mv %{buildroot}/%{_libdir}/systemd/system/lldpad.service \
-   	%{buildroot}/lib/systemd/system/lldpad.service
+    %{buildroot}/lib/systemd/system/lldpad.service
 mv %{buildroot}/%{_libdir}/systemd/system/lldpad.socket  \
-	%{buildroot}/lib/systemd/system/lldpad.socket
+    %{buildroot}/lib/systemd/system/lldpad.socket
 
 %preun
 %systemd_preun lldpad.socket
@@ -69,42 +68,62 @@ mv %{buildroot}/%{_libdir}/systemd/system/lldpad.socket  \
 
 
 %changelog
-*   Thu Jun 18 2020 Pawel Winogrodzki <pawelwi@microsoft.com> 1.0.1-17
--   Removing runtime dependency on a specific kernel package.
-*   Thu Jun 11 2020 Christopher Co <chrco@microsoft.com> - 1.0.1-16
--   Remove KERNEL_VERSION macro from BuildRequires
-*   Sat May 09 2020 Nick Samson <nisamson@microsoft.com> - 1.0.1-15
--   Added %%license line automatically
-*   Thu Apr 30 2020 Emre Girgin <mrgirgin@microsoft.com> 1.0.1-14
--   Renaming linux-api-headers to kernel-headers
-*   Thu Apr 30 2020 Nicolas Ontiveros <niontive@microsoft.com> 1.0.1-13
--   Rename libnl to libnl3.
-*   Tue Apr 28 2020 Emre Girgin <mrgirgin@microsoft.com> 1.0.1-12
--   Renaming linux to kernel
-*   Tue Apr 07 2020 Eric Li <eli@microsoft.com> 1.0.1-11
--   Fix Source0 URL and add Source0: comment to the working link. Verified license.
-*   Wed Mar 25 2020 Henry Beberman <henry.beberman@microsoft.com> 1.0.1-10
--   Disable warnings to build with GCC9. Fix Source0 URL.
-*   Mon Mar 23 2020 Christopher Co <chrco@microsoft.com> 1.0.1-9
--   Remove KERNEL_RELEASE macro from required packages
-*   Thu Jan 09 2020 Christopher Co <chrco@microsoft.com> 1.0.1-8
--   Update to work with Linux 5.4.23 kernel and headers
--   Add patch to remove duplicate LLDP ethertype which was added to Linux headers in 5.3
--   Updated URL
--   Verified License
-*   Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 1.0.1-7
--   Initial CBL-Mariner import from Photon (license: Apache2).
-*   Mon Aug 13 2018 Srivatsa S. Bhat <srivatsa@csail.mit.edu> 1.0.1-6
--   Suppress build warnings with gcc 7.3
-*   Wed May 25 2016 Anish Swaminathan <anishs@vmware.com> 1.0.1-5
--   Add required folder for service to start
-*   Tue May 24 2016 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 1.0.1-4
--   GA - Bump release of all rpms
-*   Thu May 05 2016 Kumar Kaushik <kaushikk@vmware.com>  1.0.1-3
--   Adding support in pre/post/un scripts for upgrade.
-*   Thu Dec 10 2015 Xiaolin Li <xiaolinl@vmware.com>  1.0.1-2
--   Add systemd to Requires and BuildRequires.
--   The source is based on git://open-lldp.org/open-lldp commit 036e314
--   Use systemctl to enable/disable service.
-*   Tue Nov 24 2015 Xiaolin Li <xiaolinl@vmware.com> 1.0.1-1
--   Initial build.  First version
+* Tue Jun 29 2021 Thomas Crain <thcrain@microsoft.com> - 1.0.1-18
+- Use libconfig-devel at build-time, rather than libconfig
+- Lint spec, modernize with macros
+
+* Thu Jun 18 2020 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.0.1-17
+- Removing runtime dependency on a specific kernel package.
+
+* Thu Jun 11 2020 Christopher Co <chrco@microsoft.com> - 1.0.1-16
+- Remove KERNEL_VERSION macro from BuildRequires
+
+* Sat May 09 2020 Nick Samson <nisamson@microsoft.com> - 1.0.1-15
+- Added %%license line automatically
+
+* Thu Apr 30 2020 Emre Girgin <mrgirgin@microsoft.com> - 1.0.1-14
+- Renaming linux-api-headers to kernel-headers
+
+* Thu Apr 30 2020 Nicolas Ontiveros <niontive@microsoft.com> - 1.0.1-13
+- Rename libnl to libnl3.
+
+* Tue Apr 28 2020 Emre Girgin <mrgirgin@microsoft.com> - 1.0.1-12
+- Renaming linux to kernel
+
+* Tue Apr 07 2020 Eric Li <eli@microsoft.com> - 1.0.1-11
+- Fix Source0 URL and add Source0: comment to the working link. Verified license.
+
+* Wed Mar 25 2020 Henry Beberman <henry.beberman@microsoft.com> - 1.0.1-10
+- Disable warnings to build with GCC9. Fix Source0 URL.
+
+* Mon Mar 23 2020 Christopher Co <chrco@microsoft.com> - 1.0.1-9
+- Remove KERNEL_RELEASE macro from required packages
+
+* Thu Jan 09 2020 Christopher Co <chrco@microsoft.com> - 1.0.1-8
+- Update to work with Linux 5.4.23 kernel and headers
+- Add patch to remove duplicate LLDP ethertype which was added to Linux headers in 5.3
+- Updated URL
+- Verified License
+
+* Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> - 1.0.1-7
+- Initial CBL-Mariner import from Photon (license: Apache2).
+
+* Mon Aug 13 2018 Srivatsa S. Bhat <srivatsa@csail.mit.edu> - 1.0.1-6
+- Suppress build warnings with gcc 7.3
+
+* Wed May 25 2016 Anish Swaminathan <anishs@vmware.com> - 1.0.1-5
+- Add required folder for service to start
+
+* Tue May 24 2016 Priyesh Padmavilasom <ppadmavilasom@vmware.com> - 1.0.1-4
+- GA - Bump release of all rpms
+
+* Thu May 05 2016 Kumar Kaushik <kaushikk@vmware.com> - 1.0.1-3
+- Adding support in pre/post/un scripts for upgrade.
+
+* Thu Dec 10 2015 Xiaolin Li <xiaolinl@vmware.com> - 1.0.1-2
+- Add systemd to Requires and BuildRequires.
+- The source is based on git://open-lldp.org/open-lldp commit 036e314
+- Use systemctl to enable/disable service.
+
+* Tue Nov 24 2015 Xiaolin Li <xiaolinl@vmware.com> - 1.0.1-1
+- Initial build.  First version

--- a/SPECS/lldpad/lldpad.spec
+++ b/SPECS/lldpad/lldpad.spec
@@ -10,14 +10,15 @@ URL:            https://github.com/intel/openlldp
 #Source0:       https://github.com/intel/openlldp/archive/v%%{version}.tar.gz
 Source0:        %{name}-%{version}.pkgupdate.tar.gz
 Patch0:         remove-lldp-ethertype-use-linux-5.3-header-instead.patch
-BuildRequires: libconfig-devel
-BuildRequires: libnl3-devel
-BuildRequires: readline-devel
-BuildRequires: systemd
-BuildRequires: kernel-headers
-Requires:      systemd
-Requires:      libconfig
-Requires:      libnl3
+BuildRequires:  kernel-headers
+BuildRequires:  libconfig-devel
+BuildRequires:  libnl3-devel
+BuildRequires:  readline-devel
+BuildRequires:  systemd
+Requires:       libconfig
+Requires:       libnl3
+Requires:       systemd
+
 
 %description
 The lldpad package comes with utilities to manage an LLDP interface with support for reading and configuring TLVs. TLVs and interfaces are individual controlled allowing flexible configuration for TX only, RX only, or TX/RX modes per TLV.
@@ -35,7 +36,7 @@ sed -i "s/u8 arglen;/u8 arglen = 0;/g" lldp_util.c
 
 %install
 %make_install
-find %{buildroot} -name '*.la' -exec rm -f {} ';'
+find %{buildroot} -type f -name "*.la" -delete -print
 mkdir -p %{buildroot}/lib/systemd/system
 mkdir -p %{buildroot}%{_sharedstatedir}/%{name}
 mv %{buildroot}/%{_libdir}/systemd/system/lldpad.service \
@@ -45,9 +46,11 @@ mv %{buildroot}/%{_libdir}/systemd/system/lldpad.socket  \
 
 %preun
 %systemd_preun lldpad.socket
+
 %post
 /sbin/ldconfig
 %systemd_post lldpad.socket
+
 %postun
 /sbin/ldconfig
 %systemd_postun_with_restart lldpad.socket
@@ -57,7 +60,7 @@ mv %{buildroot}/%{_libdir}/systemd/system/lldpad.socket  \
 %license COPYING
 %{_sbindir}/*
 %{_libdir}/liblldp_clif.so.*
-/etc/bash_completion.d/*
+%{_sysconfdir}/bash_completion.d/*
 %dir %{_sharedstatedir}/%{name}
 %{_mandir}/man8/*
 %{_includedir}/*
@@ -65,7 +68,6 @@ mv %{buildroot}/%{_libdir}/systemd/system/lldpad.socket  \
 %{_libdir}/liblldp_clif.so
 /lib/systemd/system/lldpad.service
 /lib/systemd/system/lldpad.socket
-
 
 %changelog
 * Tue Jun 29 2021 Thomas Crain <thcrain@microsoft.com> - 1.0.1-18

--- a/SPECS/swupdate/swupdate.spec
+++ b/SPECS/swupdate/swupdate.spec
@@ -1,19 +1,19 @@
 Summary:        Software Update for Embedded Systems
 Name:           swupdate
 Version:        2019.11
-Release:        6%{?dist}
+Release:        7%{?dist}
 License:        GPLv2+
 URL:            https://sbabic.github.io/swupdate/
 Group:          System Environment/Base
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
-#Source0:       https://github.com/sbabic/swupdate/archive/%{version}.tar.gz
+#Source0:       https://github.com/sbabic/swupdate/archive/%%{version}.tar.gz
 Source0:        %{name}-%{version}.tar.gz
 Source1:        .config
 
 BuildRequires:  curl-devel
 BuildRequires:  json-c-devel
-BuildRequires:  libconfig
+BuildRequires:  libconfig-devel
 BuildRequires:  systemd-devel
 BuildRequires:  libarchive-devel
 BuildRequires:  zeromq-devel
@@ -139,6 +139,9 @@ fi
 
 
 %changelog
+* Tue Jun 29 2021 Thomas Crain <thcrain@microsoft.com> - 2019.11-7
+- Use libconfig-devel at build-time, instead of libconfig
+
 *   Fri Sep 25 2020 Emre Girgin <mrgirgin@microsoft.com> 2019.11-6
 -   Disable debug symbol stripping in .config, and create the debuginfo package.
 

--- a/SPECS/swupdate/swupdate.spec
+++ b/SPECS/swupdate/swupdate.spec
@@ -3,42 +3,42 @@ Name:           swupdate
 Version:        2019.11
 Release:        7%{?dist}
 License:        GPLv2+
-URL:            https://sbabic.github.io/swupdate/
-Group:          System Environment/Base
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
+Group:          System Environment/Base
+URL:            https://sbabic.github.io/swupdate/
 #Source0:       https://github.com/sbabic/swupdate/archive/%%{version}.tar.gz
 Source0:        %{name}-%{version}.tar.gz
 Source1:        .config
 
 BuildRequires:  curl-devel
 BuildRequires:  json-c-devel
+BuildRequires:  libarchive-devel
 BuildRequires:  libconfig-devel
 BuildRequires:  systemd-devel
-BuildRequires:  libarchive-devel
 BuildRequires:  zeromq-devel
 Requires:       curl
 Requires:       json-c
+Requires:       libarchive
 Requires:       libconfig
 Requires:       systemd
-Requires:       libarchive
 Requires:       zeromq
 
 %description
 SWUpdate is a Linux Update agent with the goal to provide an efficient and safe way to update an embedded system.
 SWUpdate supports local and remote updates, multiple update strategies.
 
-%package tools
-Summary: swupdate tools
-Group: System Environment/Base
+%package        tools
+Summary:        swupdate tools
+Group:          System Environment/Base
 
-%description tools
+%description    tools
 Supporter tools for SWUpdate
 
-%package devel
-Summary: Development Libraries for swupdate
-Group: Development/Libraries
-Requires: swupdate = %{version}-%{release}
+%package        devel
+Summary:        Development Libraries for swupdate
+Group:          Development/Libraries
+Requires:       swupdate = %{version}-%{release}
 
 %description devel
 This package contains symbolic links, header files,
@@ -142,21 +142,21 @@ fi
 * Tue Jun 29 2021 Thomas Crain <thcrain@microsoft.com> - 2019.11-7
 - Use libconfig-devel at build-time, instead of libconfig
 
-*   Fri Sep 25 2020 Emre Girgin <mrgirgin@microsoft.com> 2019.11-6
--   Disable debug symbol stripping in .config, and create the debuginfo package.
+* Fri Sep 25 2020 Emre Girgin <mrgirgin@microsoft.com> - 2019.11-6
+- Disable debug symbol stripping in .config, and create the debuginfo package.
 
-*   Tue Jun 09 2020 Daniel McIlvaney <damcilva@microsoft.com> 2019.11-5
--   Use Grub on aarch64 systems to abstract firmware (no longer require U-Boot)
+* Tue Jun 09 2020 Daniel McIlvaney <damcilva@microsoft.com> - 2019.11-5
+- Use Grub on aarch64 systems to abstract firmware (no longer require U-Boot)
 
-*   Thu May 28 2020 Emre Girgin <mrgirgin@microsoft.com> 2019.11-4
--   Remove the ifarch clause around Patch0 to unify the SRPM files accross architectures.
+* Thu May 28 2020 Emre Girgin <mrgirgin@microsoft.com> - 2019.11-4
+- Remove the ifarch clause around Patch0 to unify the SRPM files accross architectures.
 
-*   Sat May 09 00:20:47 PST 2020 Nick Samson <nisamson@microsoft.com> - 2019.11-3
--   Added %%license line automatically
+* Sat May 09 2020 Nick Samson <nisamson@microsoft.com> - 2019.11-3
+- Added %%license line automatically
 
-*   Thu Apr 23 2020 Pawel Winogrodzki <pawelwi@microsoft.com> 2019.11-2
--   License verified.
--   Fixed 'Source0' tag.
+* Thu Apr 23 2020 Pawel Winogrodzki <pawelwi@microsoft.com> - 2019.11-2
+- License verified.
+- Fixed 'Source0' tag.
 
-*   Fri Dec 27 2019 Emre Girgin <mrgirgin@microsoft.com> 2019.11-1
--   Original version for CBL-Mariner.
+* Fri Dec 27 2019 Emre Girgin <mrgirgin@microsoft.com> - 2019.11-1
+- Original version for CBL-Mariner.

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -2515,8 +2515,8 @@
         "type": "other",
         "other": {
           "name": "libconfig",
-          "version": "1.7.2",
-          "downloadUrl": "https://github.com/hyperrealm/libconfig/archive/v1.7.2.tar.gz"
+          "version": "1.7.3",
+          "downloadUrl": "https://github.com/hyperrealm/libconfig/releases/download/v1.7.3/libconfig-1.7.3.tar.gz"
         }
       }
     },


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Our `libconfig` package does not follow the traditional base package/devel subpackage pattern that many of our packages follow. This PR updates `libconfig` to version 1.7.3 and gives it a devel subpackage. To match this change, direct dependents on libconfig have had their build-time requirements changed from `libconfig` to `libconfig-devel`.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- `libconfig`: Upgrade to 1.7.3, Add devel subpackage
- `libstoragemgmt`, `lldpad`, `swupdate`: Use `libconfig-devel` at build-time. Address various linting errors.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local check builds of affected packages
