### PR TITLE
Fix CVE-2021-33503, CVE-2021-3445, CVE-2021-3546

### DIFF
--- a/SPECS/libdnf/CVE-2021-3445.patch
+++ b/SPECS/libdnf/CVE-2021-3445.patch
@@ -1,0 +1,92 @@
+diff --git a/libdnf/dnf-keyring.cpp b/libdnf/dnf-keyring.cpp
+index 99e7e6e..fd0fc5d 100644
+--- a/libdnf/dnf-keyring.cpp
++++ b/libdnf/dnf-keyring.cpp
+@@ -34,6 +34,8 @@
+ #include <glib.h>
+ #include <rpm/rpmlib.h>
+ #include <rpm/rpmts.h>
++#include <rpm/rpmlog.h>
++#include <rpm/rpmcli.h>
+ 
+ #include "dnf-types.h"
+ #include "dnf-keyring.h"
+@@ -210,6 +212,26 @@ dnf_keyring_add_public_keys(rpmKeyring keyring, GError **error)
+     return TRUE;
+ }
+ 
++static int
++rpmcliverifysignatures_log_handler_cb(rpmlogRec rec, rpmlogCallbackData data)
++{
++    GString **string =(GString **) data;
++
++    /* create string if required */
++    if (*string == NULL)
++        *string = g_string_new("");
++
++    /* if text already exists, join them */
++    if ((*string)->len > 0)
++        g_string_append(*string, ": ");
++    g_string_append(*string, rpmlogRecMessage(rec));
++
++    /* remove the trailing /n which rpm does */
++    if ((*string)->len > 0)
++        g_string_truncate(*string,(*string)->len - 1);
++    return 0;
++}
++
+ /**
+  * dnf_keyring_check_untrusted_file:
+  */
+@@ -226,6 +248,10 @@ dnf_keyring_check_untrusted_file(rpmKeyring keyring,
+     rpmtd td = NULL;
+     rpmts ts = NULL;
+ 
++    char *path = g_strdup(filename);
++    char *path_array[2] = {path, NULL};
++    g_autoptr(GString) rpm_error = NULL;
++
+     /* open the file for reading */
+     fd = Fopen(filename, "r.fdio");
+     if (fd == NULL) {
+@@ -246,9 +272,27 @@ dnf_keyring_check_untrusted_file(rpmKeyring keyring,
+         goto out;
+     }
+ 
+-    /* we don't want to abort on missing keys */
+     ts = rpmtsCreate();
+-    rpmtsSetVSFlags(ts, _RPMVSF_NOSIGNATURES);
++
++    if (rpmtsSetKeyring(ts, keyring) < 0) {
++        g_set_error_literal(error, DNF_ERROR, DNF_ERROR_INTERNAL_ERROR, "failed to set keyring");
++        goto out;
++    }
++    rpmtsSetVfyLevel(ts, RPMSIG_SIGNATURE_TYPE);
++    rpmlogSetCallback(rpmcliverifysignatures_log_handler_cb, &rpm_error);
++
++    // rpm doesn't provide any better API call than rpmcliVerifySignatures (which is for CLI):
++    // - use path_array as input argument
++    // - gather logs via callback because we don't want to print anything if check is successful
++    if (rpmcliVerifySignatures(ts, (char * const*) path_array)) {
++        g_set_error(error,
++                DNF_ERROR,
++                DNF_ERROR_GPG_SIGNATURE_INVALID,
++                "%s could not be verified.\n%s",
++                filename,
++                (rpm_error ? rpm_error->str : "UNKNOWN ERROR"));
++        goto out;
++    }
+ 
+     /* read in the file */
+     rc = rpmReadPackageFile(ts, fd, filename, &hdr);
+@@ -312,6 +356,10 @@ dnf_keyring_check_untrusted_file(rpmKeyring keyring,
+     g_debug("%s has been verified as trusted", filename);
+     ret = TRUE;
+ out:
++    rpmlogSetCallback(NULL, NULL);
++
++    if (path != NULL)
++        g_free(path);
+     if (dig != NULL)
+         pgpFreeDig(dig);
+     if (td != NULL) {

--- a/SPECS/libdnf/libdnf.spec
+++ b/SPECS/libdnf/libdnf.spec
@@ -7,7 +7,7 @@
 
 Name:           libdnf
 Version:        %{libdnf_major_version}.%{libdnf_minor_version}.%{libdnf_micro_version}
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Library providing simplified C and Python API to libsolv.
 License:        LGPLv2+
 Vendor:         Microsoft Corporation
@@ -15,6 +15,7 @@ Distribution:   Mariner
 URL:            https://github.com/rpm-software-management/libdnf
 #Source0:       %{url}/archive/%{version}.tar.gz
 Source0:        %{name}-%{version}.tar.gz
+Patch0:         CVE-2021-3445.patch
 
 BuildRequires:  cmake
 BuildRequires:  gcc
@@ -85,7 +86,7 @@ Requires:       python3-%{name} = %{version}-%{release}
 Python 3 bindings for the hawkey library.
 
 %prep
-%setup -q
+%autosetup -p1
 
 %build
 # Allows cmake to find libsolv.
@@ -176,6 +177,9 @@ popd
 %{python3_sitelib}/hawkey/
 
 %changelog
+* Tue Jul 06 2021 Henry Li <lihl@microsoft.com> 0.43.1-2
+- Patch CVE-2021-3445
+
 * Mon Aug 17 2020 Emre Girgin <mrgirgin@microsoft.com> 0.43.1-1
 - Updating to version 0.43.1.
 

--- a/SPECS/python-urllib3/python-urllib3.signatures.json
+++ b/SPECS/python-urllib3/python-urllib3.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "urllib3-1.25.9.tar.gz": "1f1bef30176d8361ba8ae0728316e76f5ec8fc1f336c5352165211b2cb0a53f7"
+  "urllib3-1.26.5.tar.gz": "d40bb01b73e82b8eee60e27c72c5f497be16191ee18c6a0e2549605aff1ba426"
  }
 }

--- a/SPECS/python-urllib3/python-urllib3.spec
+++ b/SPECS/python-urllib3/python-urllib3.spec
@@ -2,7 +2,7 @@
 %{!?python3_sitelib: %define python3_sitelib %(python3 -c "from distutils.sysconfig import get_python_lib;print(get_python_lib())")}
 Summary:        A powerful, sanity-friendly HTTP client for Python.
 Name:           python-urllib3
-Version:        1.25.9
+Version:        1.26.5
 Release:        1%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
@@ -98,6 +98,9 @@ ulimit -n $nofiles
 %{python3_sitelib}/*
 
 %changelog
+* Tue Jul 06 2021 Henry Li <lihl@microsoft.com> - 1.26.5-1
+- Update to version 1.26.5
+
 * Wed Dec 23 2020 Rachel Menge <rachelmenge@microsoft.com> - 1.25.9-1
 - Updated to version 1.25.9
 

--- a/SPECS/qemu-kvm/CVE-2021-3546.patch
+++ b/SPECS/qemu-kvm/CVE-2021-3546.patch
@@ -1,0 +1,32 @@
+If 'virgl_cmd_get_capset' set 'max_size' to 0,
+the 'virgl_renderer_fill_caps' will write the data after the 'resp'.
+This patch avoid this by checking the returned 'max_size'.
+
+virtio-gpu fix: abd7f08b23 ("display: virtio-gpu-3d: check
+virgl capabilities max_size")
+
+Fixes: CVE-2021-3546
+Reported-by: Li Qiang <liq3ea@163.com>
+Reviewed-by: Prasad J Pandit <pjp@fedoraproject.org>
+Signed-off-by: Li Qiang <liq3ea@163.com>
+---
+ contrib/vhost-user-gpu/virgl.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/contrib/vhost-user-gpu/virgl.c b/contrib/vhost-user-gpu/virgl.c
+index a16a311d80..7172104b19 100644
+--- a/contrib/vhost-user-gpu/virgl.c
++++ b/contrib/vhost-user-gpu/virgl.c
+@@ -177,6 +177,10 @@ virgl_cmd_get_capset(VuGpu *g,
+ 
+     virgl_renderer_get_cap_set(gc.capset_id, &max_ver,
+                                &max_size);
++    if (!max_size) {
++        cmd->error = VIRTIO_GPU_RESP_ERR_INVALID_PARAMETER;
++        return;
++    }
+     resp = g_malloc0(sizeof(*resp) + max_size);
+ 
+     resp->hdr.type = VIRTIO_GPU_RESP_OK_CAPSET;
+-- 
+2.25.1

--- a/SPECS/qemu-kvm/qemu-kvm.spec
+++ b/SPECS/qemu-kvm/qemu-kvm.spec
@@ -1,7 +1,7 @@
 Summary:        QEMU is a machine emulator and virtualizer
 Name:           qemu-kvm
 Version:        4.2.0
-Release:        33%{?dist}
+Release:        34%{?dist}
 License:        GPLv2 AND GPLv2+ AND CC-BY AND BSD
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -54,6 +54,7 @@ Patch35:        CVE-2021-20181.patch
 Patch36:        CVE-2021-20221.patch
 Patch37:        CVE-2021-3527.patch
 Patch38:        CVE-2020-27661.nopatch
+Patch39:        CVE-2021-3546.patch
 
 BuildRequires:  alsa-lib-devel
 BuildRequires:  glib-devel
@@ -117,6 +118,7 @@ This package provides a command line tool for manipulating disk images.
 %patch35 -p1
 %patch36 -p1
 %patch37 -p1
+%patch39 -p1
 
 # Remove invalid flag exposed by binutils 2.36.1
 sed -i "/LDFLAGS_NOPIE/d" configure
@@ -216,6 +218,9 @@ fi
 %{_bindir}/qemu-nbd
 
 %changelog
+* Tue Jul 06 2021 Henry Li <lihl@microsoft.com> - 4.2.0-34
+- Patch CVE-2021-3546
+
 * Tue Jun 22 2021 Suresh Babu Chalamalasetty <schalam@microsoft.com> - 4.2.0-33
 - Mark CVE-2020-27661 as nopatch
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -6395,7 +6395,7 @@
         "type": "other",
         "other": {
           "name": "python-urllib3",
-          "version": "1.25.9",
+          "version": "1.26.5",
           "downloadUrl": "https://github.com/shazow/urllib3/archive/1.25.9/urllib3-1.25.9.tar.gz"
         }
       }

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -2665,8 +2665,8 @@
         "type": "other",
         "other": {
           "name": "libdnf",
-          "version": "0.39.1",
-          "downloadUrl": "https://github.com/rpm-software-management/libdnf/archive/0.39.1.tar.gz"
+          "version": "0.43.1",
+          "downloadUrl": "https://github.com/rpm-software-management/libdnf/archive/0.43.1.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
- Update python-urllib3 to version 1.26.5 and resolve CVE-2021-33503
- Fix CVE-2021-3546
- Fix CVE-2021-3445
- Fix incorrect versioning for libdnf in cgmanifest

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Update to version 1.26.5
- Patch CVE-2021-3546
- Patch CVE-2021-3445

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
NO

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2021-33503
- https://nvd.nist.gov/vuln/detail/CVE-2021-3445
- https://nvd.nist.gov/vuln/detail/CVE-2021-3546

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local Build
