### PR TITLE
Kernel: Update kernel to 5.10.47.1

### DIFF
--- a/SPECS-SIGNED/kernel-signed/kernel-signed.spec
+++ b/SPECS-SIGNED/kernel-signed/kernel-signed.spec
@@ -9,8 +9,8 @@
 %define uname_r %{version}-%{release}
 Summary:        Signed Linux Kernel for %{buildarch} systems
 Name:           kernel-signed-%{buildarch}
-Version:        5.10.42.1
-Release:        4%{?dist}
+Version:        5.10.47.1
+Release:        1%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -146,6 +146,9 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %endif
 
 %changelog
+* Tue Jul 06 2021 Rachel Menge <rachelmenge@microsoft.com> - 5.10.47.1-1
+- Update source to 5.10.47.1
+
 * Wed Jun 30 2021 Chris Co <chrco@microsoft.com> - 5.10.42.1-4
 - Bump release number to match kernel release
 

--- a/SPECS/hyperv-daemons/hyperv-daemons.signatures.json
+++ b/SPECS/hyperv-daemons/hyperv-daemons.signatures.json
@@ -7,6 +7,6 @@
   "hypervkvpd.service": "25339871302f7a47e1aecfa9fc2586c78bc37edb98773752f0a5dec30f0ed3a1",
   "hypervvss.rules": "94cead44245ef6553ab79c0bbac8419e3ff4b241f01bcec66e6f508098cbedd1",
   "hypervvssd.service": "22270d9f0f23af4ea7905f19c1d5d5495e40c1f782cbb87a99f8aec5a011078d",
-  "kernel-5.10.42.1.tar.gz": "47bb149f6ad2fc7d0ad8b31e3fcc0d3b1e5b25069d12f4d1e06dfc0b3c4b32ee"
+  "kernel-5.10.47.1.tar.gz": "617ae94bd39c218e0778af6a564fc57ff86a1896c82fe9a72dab7b37232121b1"
  }
 }

--- a/SPECS/hyperv-daemons/hyperv-daemons.spec
+++ b/SPECS/hyperv-daemons/hyperv-daemons.spec
@@ -8,7 +8,7 @@
 %global udev_prefix 70
 Summary:        Hyper-V daemons suite
 Name:           hyperv-daemons
-Version:        5.10.42.1
+Version:        5.10.47.1
 Release:        1%{?dist}
 License:        GPLv2+
 Vendor:         Microsoft Corporation
@@ -219,6 +219,9 @@ fi
 %{_sbindir}/lsvmbus
 
 %changelog
+* Tue Jul 06 2021 Rachel Menge <rachelmenge@microsoft.com> - 5.10.47.1-1
+- Update source to 5.10.47.1
+
 * Tue Jun 08 2021 Rachel Menge <rachelmenge@microsoft.com> - 5.10.42.1-1
 - Update source to 5.10.42.1
 

--- a/SPECS/kernel-headers/kernel-headers.signatures.json
+++ b/SPECS/kernel-headers/kernel-headers.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "kernel-5.10.42.1.tar.gz": "47bb149f6ad2fc7d0ad8b31e3fcc0d3b1e5b25069d12f4d1e06dfc0b3c4b32ee"
+  "kernel-5.10.47.1.tar.gz": "617ae94bd39c218e0778af6a564fc57ff86a1896c82fe9a72dab7b37232121b1"
  }
 }

--- a/SPECS/kernel-headers/kernel-headers.spec
+++ b/SPECS/kernel-headers/kernel-headers.spec
@@ -1,7 +1,7 @@
 Summary:        Linux API header files
 Name:           kernel-headers
-Version:        5.10.42.1
-Release:        4%{?dist}
+Version:        5.10.47.1
+Release:        1%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -35,6 +35,9 @@ cp -rv usr/include/* /%{buildroot}%{_includedir}
 %{_includedir}/*
 
 %changelog
+* Tue Jul 06 2021 Rachel Menge <rachelmenge@microsoft.com> - 5.10.47.1-1
+- Update source to 5.10.47.1
+
 * Wed Jun 30 2021 Chris Co <chrco@microsoft.com> - 5.10.42.1-4
 - Bump release number to match kernel release
 

--- a/SPECS/kernel-hyperv/config
+++ b/SPECS/kernel-hyperv/config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86_64 5.10.42.1 Kernel Configuration
+# Linux/x86_64 5.10.47.1 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (GCC) 9.1.0"
 CONFIG_CC_IS_GCC=y
@@ -3218,7 +3218,6 @@ CONFIG_INTEL_IDMA64=m
 # CONFIG_INTEL_IDXD is not set
 CONFIG_INTEL_IOATDMA=y
 # CONFIG_PLX_DMA is not set
-# CONFIG_XILINX_ZYNQMP_DPDMA is not set
 # CONFIG_QCOM_HIDMA_MGMT is not set
 # CONFIG_QCOM_HIDMA is not set
 CONFIG_DW_DMAC_CORE=y
@@ -3280,7 +3279,6 @@ CONFIG_HYPERV_TIMER=y
 CONFIG_HYPERV_UTILS=m
 CONFIG_HYPERV_BALLOON=m
 CONFIG_DXGKRNL=m
-# CONFIG_DXGKRNL_DEBUG is not set
 # end of Microsoft Hyper-V guest support
 
 # CONFIG_GREYBUS is not set
@@ -4111,6 +4109,7 @@ CONFIG_SYSTEM_TRUSTED_KEYS="certs/mariner.pem"
 # CONFIG_SECONDARY_TRUSTED_KEYRING is not set
 CONFIG_SYSTEM_BLACKLIST_KEYRING=y
 CONFIG_SYSTEM_BLACKLIST_HASH_LIST=""
+# CONFIG_SYSTEM_REVOCATION_LIST is not set
 # end of Certificates for signature checking
 
 CONFIG_BINARY_PRINTF=y

--- a/SPECS/kernel-hyperv/kernel-hyperv.signatures.json
+++ b/SPECS/kernel-hyperv/kernel-hyperv.signatures.json
@@ -1,8 +1,8 @@
 {
  "Signatures": {
   "cbl-mariner-ca-20210127.pem": "82363cb44e786353936abc2e2d62d9325cacf2d9e9a8ebaf4221ea30a9e0cd7b",
-  "config": "da627204951d57b66da73f7f71cb0a9c3236568ecc257ec91fde99e2d0f6310a",
-  "kernel-5.10.42.1.tar.gz": "47bb149f6ad2fc7d0ad8b31e3fcc0d3b1e5b25069d12f4d1e06dfc0b3c4b32ee",
+  "config": "b18f880d3678351b70f6e5841f9a849f6007d2ec113b0dd23faa37501978fbba",
+  "kernel-5.10.47.1.tar.gz": "617ae94bd39c218e0778af6a564fc57ff86a1896c82fe9a72dab7b37232121b1",
   "sha512hmac-openssl.sh": "02ab91329c4be09ee66d759e4d23ac875037c3b56e5a598e32fd1206da06a27f"
  }
 }

--- a/SPECS/kernel-hyperv/kernel-hyperv.spec
+++ b/SPECS/kernel-hyperv/kernel-hyperv.spec
@@ -3,8 +3,8 @@
 %define uname_r %{version}-%{release}
 Summary:        Linux Kernel optimized for Hyper-V
 Name:           kernel-hyperv
-Version:        5.10.42.1
-Release:        4%{?dist}
+Version:        5.10.47.1
+Release:        1%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -267,6 +267,9 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %{_libdir}/perf/include/bpf/*
 
 %changelog
+* Tue Jul 06 2021 Rachel Menge <rachelmenge@microsoft.com> - 5.10.47.1-1
+- Update source to 5.10.47.1
+
 * Wed Jun 30 2021 Chris Co <chrco@microsoft.com> - 5.10.42.1-4
 - Bump release number to match kernel release
 

--- a/SPECS/kernel/CVE-2021-33624.nopatch
+++ b/SPECS/kernel/CVE-2021-33624.nopatch
@@ -1,0 +1,3 @@
+CVE-2021-33624 - already patched in 5.10.47.1 stable kernel
+Upstream: 9183671af6dbf60a1219371d4ed73e23f43b49db
+Stable: 5fc6ed1831ca5a30fb0ceefd5e33c7c689e7627b

--- a/SPECS/kernel/CVE-2021-34693.nopatch
+++ b/SPECS/kernel/CVE-2021-34693.nopatch
@@ -1,0 +1,3 @@
+CVE-2021-34693 - already patched in 5.10.47.1 stable kernel
+Upstream: 5e87ddbe3942e27e939bdc02deb8579b0cbd8ecc
+Stable: acb755be1f7adb204dcedc4d3b204ef098628623

--- a/SPECS/kernel/config
+++ b/SPECS/kernel/config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86_64 5.10.42.1 Kernel Configuration
+# Linux/x86_64 5.10.47.1 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (GCC) 9.1.0"
 CONFIG_CC_IS_GCC=y
@@ -5427,7 +5427,6 @@ CONFIG_INTEL_IDMA64=m
 # CONFIG_INTEL_IDXD is not set
 CONFIG_INTEL_IOATDMA=y
 # CONFIG_PLX_DMA is not set
-# CONFIG_XILINX_ZYNQMP_DPDMA is not set
 # CONFIG_QCOM_HIDMA_MGMT is not set
 # CONFIG_QCOM_HIDMA is not set
 CONFIG_DW_DMAC_CORE=y
@@ -5510,7 +5509,6 @@ CONFIG_HYPERV_TIMER=y
 CONFIG_HYPERV_UTILS=m
 CONFIG_HYPERV_BALLOON=m
 CONFIG_DXGKRNL=m
-# CONFIG_DXGKRNL_DEBUG is not set
 # end of Microsoft Hyper-V guest support
 
 #
@@ -6834,6 +6832,7 @@ CONFIG_SYSTEM_TRUSTED_KEYS="certs/mariner.pem"
 # CONFIG_SECONDARY_TRUSTED_KEYRING is not set
 CONFIG_SYSTEM_BLACKLIST_KEYRING=y
 CONFIG_SYSTEM_BLACKLIST_HASH_LIST=""
+# CONFIG_SYSTEM_REVOCATION_LIST is not set
 # end of Certificates for signature checking
 
 CONFIG_BINARY_PRINTF=y

--- a/SPECS/kernel/config_aarch64
+++ b/SPECS/kernel/config_aarch64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 5.10.42.1 Kernel Configuration
+# Linux/arm64 5.10.47.1 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (GCC) 9.1.0"
 CONFIG_CC_IS_GCC=y
@@ -7564,7 +7564,6 @@ CONFIG_HYPERV_TIMER=y
 CONFIG_HYPERV_UTILS=m
 CONFIG_HYPERV_BALLOON=y
 CONFIG_DXGKRNL=y
-# CONFIG_DXGKRNL_DEBUG is not set
 # end of Microsoft Hyper-V guest support
 
 #
@@ -8984,6 +8983,7 @@ CONFIG_SYSTEM_TRUSTED_KEYS="certs/mariner.pem"
 # CONFIG_SECONDARY_TRUSTED_KEYRING is not set
 CONFIG_SYSTEM_BLACKLIST_KEYRING=y
 CONFIG_SYSTEM_BLACKLIST_HASH_LIST=""
+# CONFIG_SYSTEM_REVOCATION_LIST is not set
 # end of Certificates for signature checking
 
 CONFIG_BINARY_PRINTF=y

--- a/SPECS/kernel/kernel.signatures.json
+++ b/SPECS/kernel/kernel.signatures.json
@@ -1,9 +1,9 @@
 {
  "Signatures": {
   "cbl-mariner-ca-20210127.pem": "82363cb44e786353936abc2e2d62d9325cacf2d9e9a8ebaf4221ea30a9e0cd7b",
-  "config": "cab2dc2e9e22704ef06b7391171fde877852f68faa36f7730bea3cdcc77ab924",
-  "config_aarch64": "a37a74513d5ae83aaf1f58332dd6b0b62de162f7c6a0ccab1b838a53e160a741",
-  "kernel-5.10.42.1.tar.gz": "47bb149f6ad2fc7d0ad8b31e3fcc0d3b1e5b25069d12f4d1e06dfc0b3c4b32ee",
+  "config": "e11f663bfed740ba537fb6a584ced636b303382a2ce43edbd9e61b60917d0393",
+  "config_aarch64": "252c38a191df0c129996e1ef8ecdd150d11c3a32d0f11e7f6f4b36fd5ebce424",
+  "kernel-5.10.47.1.tar.gz": "617ae94bd39c218e0778af6a564fc57ff86a1896c82fe9a72dab7b37232121b1",
   "sha512hmac-openssl.sh": "02ab91329c4be09ee66d759e4d23ac875037c3b56e5a598e32fd1206da06a27f"
  }
 }

--- a/SPECS/kernel/kernel.spec
+++ b/SPECS/kernel/kernel.spec
@@ -3,8 +3,8 @@
 %define uname_r %{version}-%{release}
 Summary:        Linux Kernel
 Name:           kernel
-Version:        5.10.42.1
-Release:        4%{?dist}
+Version:        5.10.47.1
+Release:        1%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -175,6 +175,8 @@ Patch1143:      CVE-2021-3501.nopatch
 Patch1144:      CVE-2021-3506.nopatch
 Patch1145:      CVE-2020-25672.nopatch
 Patch1146:      CVE-2021-33200.nopatch
+Patch1147:      CVE-2021-34693.nopatch
+Patch1148:      CVE-2021-33624.nopatch
 BuildRequires:  audit-devel
 BuildRequires:  bash
 BuildRequires:  bc
@@ -505,6 +507,10 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %endif
 
 %changelog
+* Tue Jul 06 2021 Rachel Menge <rachelmenge@microsoft.com> - 5.10.47.1-1
+- Update source to 5.10.47.1
+- Address CVE-2021-34693, CVE-2021-33624
+
 * Wed Jun 30 2021 Chris Co <chrco@microsoft.com> - 5.10.42.1-4
 - Enable legacy mcelog config
 
@@ -519,11 +525,11 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 - Address CVE-2021-33200
 
 * Thu Jun 03 2021 Rachel Menge <rachelmenge@microsoft.com> - 5.10.37.1-2
-- Address CVE-2020-25672 
+- Address CVE-2020-25672
 
 * Fri May 28 2021 Rachel Menge <rachelmenge@microsoft.com> - 5.10.37.1-1
 - Update source to 5.10.37.1
-- Address CVE-2021-23134, CVE-2021-29155, CVE-2021-31829, CVE-2021-31916, 
+- Address CVE-2021-23134, CVE-2021-29155, CVE-2021-31829, CVE-2021-31916,
   CVE-2021-32399, CVE-2021-33033, CVE-2021-33034, CVE-2021-3483
   CVE-2021-3501, CVE-2021-3506
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -1965,8 +1965,8 @@
         "type": "other",
         "other": {
           "name": "hyperv-daemons",
-          "version": "5.10.42.1",
-          "downloadUrl": "https://github.com/microsoft/CBL-Mariner-Linux-Kernel/archive/rolling-lts/mariner/5.10.42.1.tar.gz"
+          "version": "5.10.47.1",
+          "downloadUrl": "https://github.com/microsoft/CBL-Mariner-Linux-Kernel/archive/rolling-lts/mariner/5.10.47.1.tar.gz"
         }
       }
     },
@@ -2285,8 +2285,8 @@
         "type": "other",
         "other": {
           "name": "kernel",
-          "version": "5.10.42.1",
-          "downloadUrl": "https://github.com/microsoft/CBL-Mariner-Linux-Kernel/archive/rolling-lts/mariner/5.10.42.1.tar.gz"
+          "version": "5.10.47.1",
+          "downloadUrl": "https://github.com/microsoft/CBL-Mariner-Linux-Kernel/archive/rolling-lts/mariner/5.10.47.1.tar.gz"
         }
       }
     },
@@ -2295,8 +2295,8 @@
         "type": "other",
         "other": {
           "name": "kernel-headers",
-          "version": "5.10.42.1",
-          "downloadUrl": "https://github.com/microsoft/CBL-Mariner-Linux-Kernel/archive/rolling-lts/mariner/5.10.42.1.tar.gz"
+          "version": "5.10.47.1",
+          "downloadUrl": "https://github.com/microsoft/CBL-Mariner-Linux-Kernel/archive/rolling-lts/mariner/5.10.47.1.tar.gz"
         }
       }
     },
@@ -2305,8 +2305,8 @@
         "type": "other",
         "other": {
           "name": "kernel-hyperv",
-          "version": "5.10.42.1",
-          "downloadUrl": "https://github.com/microsoft/CBL-Mariner-Linux-Kernel/archive/rolling-lts/mariner/5.10.42.1.tar.gz"
+          "version": "5.10.47.1",
+          "downloadUrl": "https://github.com/microsoft/CBL-Mariner-Linux-Kernel/archive/rolling-lts/mariner/5.10.47.1.tar.gz"
         }
       }
     },

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -1,5 +1,5 @@
 filesystem-1.1-7.cm1.aarch64.rpm
-kernel-headers-5.10.42.1-4.cm1.noarch.rpm
+kernel-headers-5.10.47.1-1.cm1.noarch.rpm
 glibc-2.28-18.cm1.aarch64.rpm
 glibc-devel-2.28-18.cm1.aarch64.rpm
 glibc-i18n-2.28-18.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -1,5 +1,5 @@
 filesystem-1.1-7.cm1.x86_64.rpm
-kernel-headers-5.10.42.1-4.cm1.noarch.rpm
+kernel-headers-5.10.47.1-1.cm1.noarch.rpm
 glibc-2.28-18.cm1.x86_64.rpm
 glibc-devel-2.28-18.cm1.x86_64.rpm
 glibc-i18n-2.28-18.cm1.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -158,7 +158,7 @@ json-c-debuginfo-0.14-3.cm1.aarch64.rpm
 json-c-devel-0.14-3.cm1.aarch64.rpm
 kbd-2.0.4-5.cm1.aarch64.rpm
 kbd-debuginfo-2.0.4-5.cm1.aarch64.rpm
-kernel-headers-5.10.42.1-4.cm1.noarch.rpm
+kernel-headers-5.10.47.1-1.cm1.noarch.rpm
 kmod-25-4.cm1.aarch64.rpm
 kmod-debuginfo-25-4.cm1.aarch64.rpm
 kmod-devel-25-4.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -158,7 +158,7 @@ json-c-debuginfo-0.14-3.cm1.x86_64.rpm
 json-c-devel-0.14-3.cm1.x86_64.rpm
 kbd-2.0.4-5.cm1.x86_64.rpm
 kbd-debuginfo-2.0.4-5.cm1.x86_64.rpm
-kernel-headers-5.10.42.1-4.cm1.noarch.rpm
+kernel-headers-5.10.47.1-1.cm1.noarch.rpm
 kmod-25-4.cm1.x86_64.rpm
 kmod-debuginfo-25-4.cm1.x86_64.rpm
 kmod-devel-25-4.cm1.x86_64.rpm

--- a/toolkit/scripts/toolchain/container/Dockerfile
+++ b/toolkit/scripts/toolchain/container/Dockerfile
@@ -68,7 +68,7 @@ COPY [ "./toolchain-md5sums", \
 WORKDIR $LFS/sources
 RUN wget -nv --no-clobber --timeout=30 --no-check-certificate --continue --input-file=$LFS/tools/toolchain-local-wget-list --directory-prefix=$LFS/sources; exit 0
 RUN wget -nv --no-clobber --timeout=30 --continue --input-file=$LFS/tools/toolchain-remote-wget-list --directory-prefix=$LFS/sources; exit 0
-RUN wget -nv --no-clobber --timeout=30 --continue https://github.com/microsoft/CBL-Mariner-Linux-Kernel/archive/rolling-lts/mariner/5.10.42.1.tar.gz -O kernel-5.10.42.1.tar.gz --directory-prefix=$LFS/sources; exit 0
+RUN wget -nv --no-clobber --timeout=30 --continue https://github.com/microsoft/CBL-Mariner-Linux-Kernel/archive/rolling-lts/mariner/5.10.47.1.tar.gz -O kernel-5.10.47.1.tar.gz --directory-prefix=$LFS/sources; exit 0
 USER root
 RUN /tools/toolchain-jdk8-wget.sh; exit 0
 RUN md5sum -c $LFS/tools/toolchain-md5sums && \

--- a/toolkit/scripts/toolchain/container/toolchain-md5sums
+++ b/toolkit/scripts/toolchain/container/toolchain-md5sums
@@ -59,7 +59,7 @@ bc62e7df6f75357b6dd1ec34600dbeaf  jdk8u212-b04-langtools.tar.bz2
 d0272e7a6107c64dae62b80ca7ec65e2  jdk8u212-b04-nashorn.tar.bz2
 befd51c2b53a442e1fa6644bba89a95a  jdk8u212-b04.tar.bz2
 94afc90c1f7bef4a27fdd59ece39c878  kbproto-1.0.7.tar.bz2
-3955d6482ff5e5b92745ca066c31362e  kernel-5.10.42.1.tar.gz
+09806a906b17f230bf6484881576a51c  kernel-5.10.47.1.tar.gz
 d953ed6b47694dadf0e6042f8f9ff451  libarchive-3.4.2.tar.gz
 968ac4d42a1a71754313527be2ab5df3  libcap-2.26.tar.xz
 ba983eba5a9f05d152a0725b8e863151  libdmx-1.1.3.tar.bz2

--- a/toolkit/scripts/toolchain/container/toolchain_build_in_chroot.sh
+++ b/toolkit/scripts/toolchain/container/toolchain_build_in_chroot.sh
@@ -57,14 +57,14 @@ set -e
 #
 cd /sources
 
-echo Linux-5.10.42.1 API Headers
-tar xf kernel-5.10.42.1.tar.gz
-pushd CBL-Mariner-Linux-Kernel-rolling-lts-mariner-5.10.42.1
+echo Linux-5.10.47.1 API Headers
+tar xf kernel-5.10.47.1.tar.gz
+pushd CBL-Mariner-Linux-Kernel-rolling-lts-mariner-5.10.47.1
 make mrproper
 make headers
 cp -rv usr/include/* /usr/include
 popd
-rm -rf CBL-Mariner-Linux-Kernel-rolling-lts-mariner-5.10.42.1
+rm -rf CBL-Mariner-Linux-Kernel-rolling-lts-mariner-5.10.47.1
 touch /logs/status_kernel_headers_complete
 
 echo 6.8. Man-pages-5.02

--- a/toolkit/scripts/toolchain/container/toolchain_build_temp_tools.sh
+++ b/toolkit/scripts/toolchain/container/toolchain_build_temp_tools.sh
@@ -113,14 +113,14 @@ rm -rf gcc-9.1.0
 
 touch $LFS/logs/temptoolchain/status_gcc_pass1_complete
 
-echo Linux-5.10.42.1 API Headers
-tar xf kernel-5.10.42.1.tar.gz
-pushd CBL-Mariner-Linux-Kernel-rolling-lts-mariner-5.10.42.1
+echo Linux-5.10.47.1 API Headers
+tar xf kernel-5.10.47.1.tar.gz
+pushd CBL-Mariner-Linux-Kernel-rolling-lts-mariner-5.10.47.1
 make mrproper
 make headers
 cp -rv usr/include/* /tools/include
 popd
-rm -rf CBL-Mariner-Linux-Kernel-rolling-lts-mariner-5.10.42.1
+rm -rf CBL-Mariner-Linux-Kernel-rolling-lts-mariner-5.10.47.1
 
 touch $LFS/logs/temptoolchain/status_kernel_headers_complete
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Update kernel to 5.10.47.1

Config changes:
- removed (in x86_64 only) `# CONFIG_XILINX_ZYNQMP_DPDMA is not set` due to removal of dependency on `HAS_IOMEM` & `OF`, 
- removed `# CONFIG_DXGKRNL_DEBUG is not set` as a part of update from the latest upstream code (11e9a539)
- add `# CONFIG_SYSTEM_REVOCATION_LIST is not set`, a new config that depends on `SYSTEM_BLACKLIST_KEYRING` and  `PKCS7_MESSAGE_PARSER` which are currently set. This config provides system-wide ring of revocation certificates.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Update source to 5.10.47.1
- Address CVE-2021-34693, CVE-2021-33624

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2021-34693
- https://nvd.nist.gov/vuln/detail/CVE-2021-33624

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- local build tested in vm
- Pipeline build id x86: 108045
- Pipeline build id ARM: 108415
