### PR TITLE
Removing unused run-time requirement from `glusterfs-thin-arbiter`.

### DIFF
--- a/SPECS/glusterfs/glusterfs.spec
+++ b/SPECS/glusterfs/glusterfs.spec
@@ -545,7 +545,6 @@ License:        GPLv2 OR LGPLv3+
 
 Requires:       %{name}%{?_isa} = %{version}-%{release}
 Requires:       %{name}-libs%{?_isa} = %{version}-%{release}
-Requires:       %{name}-server%{?_isa} = %{version}-%{release}
 
 %description thin-arbiter
 This package provides a tie-breaker functionality to GlusterFS
@@ -1232,6 +1231,7 @@ exit 0
 - Removed conditions that don't apply in CBL0Mariner.
 - Disabled Python byte compilation.
 - Using '%%make*' macros for building and installation.
+- Removing invalid run-time requires from 'thin-arbiter' to 'server'.
 - License verified.
 
 * Tue Mar 09 2021  Henry Li <lihl[at]microsoft.com> - 7.9-2


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

Removing unused run-time requirement from `glusterfs-thin-arbiter`. The subpackage is not using the `glusterfs-server` subpackage and the build fails due to that dependency, when one builds with the `glusterfs-server` subpackage and its dependencies disabled. Which is what we do for CBL-Mariner at the moment.

We haven't had a successful build since the changes in this spec were introduced, thus I'm not updating the release and treating this a part of the changes for the current release.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Removed unused run-time requirement from `glusterfs-thin-arbiter`.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local package build.
