### PR TITLE
patch moby-containerd to resolve CVE-2021-32760 (#1153)

### DIFF
--- a/SPECS/moby-containerd/CVE-2021-32760.patch
+++ b/SPECS/moby-containerd/CVE-2021-32760.patch
@@ -1,0 +1,79 @@
+From 45e9ebe3c91b258ad7489baaea3a1f6e0b42ceb4 Mon Sep 17 00:00:00 2001
+From: Derek McGowan <derek@mcg.dev>
+Date: Tue, 6 Jul 2021 12:37:54 -0700
+Subject: [PATCH] [release/1.4] Use chmod path for checking symlink
+
+Signed-off-by: Derek McGowan <derek@mcg.dev>
+---
+ archive/tar_test.go | 35 +++++++++++++++++++++++++++++++++++
+ archive/tar_unix.go |  2 +-
+ 2 files changed, 36 insertions(+), 1 deletion(-)
+
+diff --git a/archive/tar_test.go b/archive/tar_test.go
+index 568f5a95f..8ffd3f221 100644
+--- a/archive/tar_test.go
++++ b/archive/tar_test.go
+@@ -243,6 +243,11 @@ func TestBreakouts(t *testing.T) {
+ 		return nil
+ 	}
+ 	errFileDiff := errors.New("files differ")
++	td, err := ioutil.TempDir("", "test-breakouts-")
++	if err != nil {
++		t.Fatal(err)
++	}
++	defer os.RemoveAll(td)
+ 
+ 	isSymlinkFile := func(f string) func(string) error {
+ 		return func(root string) error {
+@@ -744,6 +749,36 @@ func TestBreakouts(t *testing.T) {
+ 			// resolution ends up just removing etc
+ 			validator: fileNotExists("etc/passwd"),
+ 		},
++		{
++
++			name: "HardlinkSymlinkChmod",
++			w: func() tartest.WriterToTar {
++				p := filepath.Join(td, "perm400")
++				if err := ioutil.WriteFile(p, []byte("..."), 0400); err != nil {
++					t.Fatal(err)
++				}
++				ep := filepath.Join(td, "also-exists-outside-root")
++				if err := ioutil.WriteFile(ep, []byte("..."), 0640); err != nil {
++					t.Fatal(err)
++				}
++
++				return tartest.TarAll(
++					tc.Symlink(p, ep),
++					tc.Link(ep, "sketchylink"),
++				)
++			}(),
++			validator: func(string) error {
++				p := filepath.Join(td, "perm400")
++				fi, err := os.Lstat(p)
++				if err != nil {
++					return err
++				}
++				if perm := fi.Mode() & os.ModePerm; perm != 0400 {
++					return errors.Errorf("%s perm changed from 0400 to %04o", p, perm)
++				}
++				return nil
++			},
++		},
+ 	}
+ 
+ 	for _, bo := range breakouts {
+diff --git a/archive/tar_unix.go b/archive/tar_unix.go
+index 6e89d2fdb..c22e79bf2 100644
+--- a/archive/tar_unix.go
++++ b/archive/tar_unix.go
+@@ -113,7 +113,7 @@ func handleTarTypeBlockCharFifo(hdr *tar.Header, path string) error {
+ 
+ func handleLChmod(hdr *tar.Header, path string, hdrInfo os.FileInfo) error {
+ 	if hdr.Typeflag == tar.TypeLink {
+-		if fi, err := os.Lstat(hdr.Linkname); err == nil && (fi.Mode()&os.ModeSymlink == 0) {
++		if fi, err := os.Lstat(path); err == nil && (fi.Mode()&os.ModeSymlink == 0) {
+ 			if err := os.Chmod(path, hdrInfo.Mode()); err != nil && !os.IsNotExist(err) {
+ 				return err
+ 			}
+-- 
+2.32.0

--- a/SPECS/moby-containerd/moby-containerd.spec
+++ b/SPECS/moby-containerd/moby-containerd.spec
@@ -3,7 +3,7 @@
 Summary: Industry-standard container runtime
 Name: moby-containerd
 Version: 1.4.4+azure
-Release: 1%{?dist}
+Release: 2%{?dist}
 License: ASL 2.0
 Group: Tools/Container
 
@@ -17,6 +17,7 @@ Source1: containerd.service
 Source2: containerd.toml
 Source3: NOTICE
 Source4: LICENSE
+Patch0:  CVE-2021-32760.patch
 URL: https://www.containerd.io
 Vendor: Microsoft Corporation
 Distribution: Mariner
@@ -69,6 +70,7 @@ used directly by developers or end-users.
 
 %prep
 %setup -q -n %{name}-%{version} -c
+%patch0 -p1
 mkdir -p %{OUR_GOPATH}/src/github.com/containerd
 ln -sfT %{_topdir}/BUILD/%{name}-%{version} %{OUR_GOPATH}/src/github.com/containerd/containerd
 
@@ -133,6 +135,8 @@ fi
 %{_mandir}/*/*
 
 %changelog
+* Mon Jul 19 2021 Neha Agarwal <nehaagarwal@microsoft.com> 1.4.4+azure-2
+- CVE-2021-32760 fix
 * Mon Jul 12 2021 Andrew Phelps <anphel@microsoft.com> 1.4.4+azure-1
 - Update to version 1.4.4+azure
 * Tue Jun 08 2021 Henry Beberman <henry.beberman@microsoft.com> 1.3.4+azure-3


### PR DESCRIPTION
Cherry Pick CVE-2021-32760

