### PR TITLE
Update logrotate and add systemd timer

### DIFF
--- a/SPECS/logrotate/logrotate.signatures.json
+++ b/SPECS/logrotate/logrotate.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "logrotate-3.16.0.tar.gz": "bc6acfd09925045d48b5ff553c24c567cfd5f59d513c4ac34bfb51fa6b79dc8a"
+  "logrotate-3.18.1.tar.gz": "5db8d0d9600a260e5b6dc4498aa7c1a6910a51b611611005f652a4f606d0a23b"
  }
 }

--- a/SPECS/logrotate/logrotate.spec
+++ b/SPECS/logrotate/logrotate.spec
@@ -5,13 +5,11 @@ Release:        1%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
+Group:          System Environment/Base
 URL:            https://github.com/logrotate/logrotate/
 Source0:        https://github.com/%{name}/%{name}/releases/download/%{version}/%{name}-%{version}.tar.gz
-Group:          System Environment/Base
-
 BuildRequires:  popt-devel
 BuildRequires:  systemd-devel
-
 Requires:       popt
 Requires:       systemd
 

--- a/SPECS/logrotate/logrotate.spec
+++ b/SPECS/logrotate/logrotate.spec
@@ -25,8 +25,7 @@ the log file gets to a certain size.
 
 %build
 ./autogen.sh
-./configure \
-   --prefix=%{_prefix}
+./configure --prefix=%{_prefix} --with-state-file-path=%{_localstatedir}/lib/logrotate/logrotate.status
 make %{?_smp_mflags}
 
 # Remove hardening options that are not supported by our current systemd version.

--- a/SPECS/logrotate/logrotate.spec
+++ b/SPECS/logrotate/logrotate.spec
@@ -3,21 +3,21 @@ Name:           logrotate
 Version:        3.18.1
 Release:        1%{?dist}
 License:        GPLv2
+Vendor:         Microsoft Corporation
+Distribution:   Mariner
 URL:            https://github.com/logrotate/logrotate/
 Source0:        https://github.com/%{name}/%{name}/releases/download/%{version}/%{name}-%{version}.tar.gz
 Group:          System Environment/Base
-Vendor:         Microsoft Corporation
-Distribution:   Mariner
 
 BuildRequires:  popt-devel
 BuildRequires:  systemd-devel
 
-Requires:       systemd
 Requires:       popt
+Requires:       systemd
 
 %description
-The logrotate utility is designed to simplify the administration of log 
-files on a system which generates a lot of log files. Logrotate allows 
+The logrotate utility is designed to simplify the administration of log
+files on a system which generates a lot of log files. Logrotate allows
 for the automatic rotation compression, removal and mailing of log files.
 Logrotate can be set to handle a log file daily, weekly, monthly or when
 the log file gets to a certain size.
@@ -33,9 +33,6 @@ make %{?_smp_mflags}
 
 # Remove hardening options that are not supported by our current systemd version.
 sed -i -E '/ProtectClock=true|ProtectHostname=true|ProtectKernelLogs=true/d' examples/logrotate.service
-
-%check
-make -s check
 
 %install
 make DESTDIR=%{buildroot} install
@@ -57,19 +54,19 @@ install -p -m 644 examples/{b,w}tmp %{buildroot}%{_sysconfdir}/logrotate.d/
 %defattr(-,root,root)
 %license COPYING
 %dir %{_sysconfdir}/logrotate.d
+%dir %{_localstatedir}/lib/logrotate
 %{_sbindir}/logrotate
 %{_unitdir}/logrotate.{service,timer}
 %config(noreplace) %{_sysconfdir}/logrotate.conf
 %config(noreplace) %{_sysconfdir}/logrotate.d/{b,w}tmp
 %{_mandir}/man5/logrotate.conf.5.gz
 %{_mandir}/man8/logrotate.8.gz
-%{_localstatedir}/lib/logrotate/logrotate.status
+%ghost %verify(not size md5 mtime) %attr(0644, root, root) %{_localstatedir}/lib/logrotate/logrotate.status
 
 %changelog
 *   Wed Jul 21 2021 Henry Beberman <henry.beberman@microsoft.com> - 3.18.1-1
 -   Update to version 3.18.1
 -   Add default logrotate systemd service and logrotate.conf
--   Add check section
 *   Sat May 09 2020 Nick Samson <nisamson@microsoft.com> - 3.16.0-2
 -   Added %%license line automatically
 *   Fri Apr 24 2020 Pawel Winogrodzki <pawelwi@microsoft.com> 3.16.0-1

--- a/SPECS/logrotate/logrotate.spec
+++ b/SPECS/logrotate/logrotate.spec
@@ -28,6 +28,9 @@ the log file gets to a certain size.
 ./configure --prefix=%{_prefix} --with-state-file-path=%{_localstatedir}/lib/logrotate/logrotate.status
 make %{?_smp_mflags}
 
+# Disable dateext since it can cause rotation to fail if run twice in a day
+sed -i 's/dateext/#dateext/' examples/logrotate.conf
+
 # Remove hardening options that are not supported by our current systemd version.
 sed -i -E '/ProtectClock=true|ProtectHostname=true|ProtectKernelLogs=true/d' examples/logrotate.service
 

--- a/SPECS/logrotate/logrotate.spec
+++ b/SPECS/logrotate/logrotate.spec
@@ -1,56 +1,77 @@
 Summary:        Logrotate
 Name:           logrotate
-Version:        3.16.0
-Release:        2%{?dist}
+Version:        3.18.1
+Release:        1%{?dist}
 License:        GPLv2
 URL:            https://github.com/logrotate/logrotate/
-#Source0:       %{url}/archive/%{version}.tar.gz
-Source0:        %{name}-%{version}.tar.gz
+Source0:        https://github.com/%{name}/%{name}/releases/download/%{version}/%{name}-%{version}.tar.gz
 Group:          System Environment/Base
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 
 BuildRequires:  popt-devel
+BuildRequires:  systemd-devel
 
-Requires:   popt
+Requires:       systemd
+Requires:       popt
 
 %description
-The logrotate utility is designed to simplify the administration of log files on a system which generates a lot of log files. Logrotate allows for the automatic rotation compression, removal and mailing of log files. Logrotate can be set to handle a log file daily, weekly, monthly or when the log file gets to a certain size.
+The logrotate utility is designed to simplify the administration of log 
+files on a system which generates a lot of log files. Logrotate allows 
+for the automatic rotation compression, removal and mailing of log files.
+Logrotate can be set to handle a log file daily, weekly, monthly or when
+the log file gets to a certain size.
 
 %prep
-%setup -q
+%autosetup -p1
 
 %build
 ./autogen.sh
 ./configure \
    --prefix=%{_prefix}
-# logrotate code has misleading identation and GCC 6.3 does not like it.
-make %{?_smp_mflags} CFLAGS="-Wno-error=misleading-indentation -g -O2"
+make %{?_smp_mflags}
+
+# Remove hardening options that are not supported by our current systemd version.
+sed -i -E '/ProtectClock=true|ProtectHostname=true|ProtectKernelLogs=true/d' examples/logrotate.service
+
+%check
+make -s check
 
 %install
 make DESTDIR=%{buildroot} install
 install -vd %{buildroot}%{_sysconfdir}/logrotate.d
-install -vd %{buildroot}%{_sysconfdir}/cron.daily
 install -vd %{buildroot}%{_localstatedir}/lib/logrotate
+install -vd %{buildroot}%{_unitdir}
 touch %{buildroot}%{_localstatedir}/lib/logrotate/logrotate.status
+install -p -m 644 examples/logrotate.conf %{buildroot}%{_sysconfdir}/logrotate.conf
+install -p -m 644 examples/logrotate.{service,timer} %{buildroot}%{_unitdir}/
+install -p -m 644 examples/{b,w}tmp %{buildroot}%{_sysconfdir}/logrotate.d/
 
-%post -p /sbin/ldconfig
+%post
+%systemd_post logrotate.{service,timer}
 
-%postun -p /sbin/ldconfig
+%postun
+%systemd_preun logrotate.{service,timer}
 
 %files
 %defattr(-,root,root)
 %license COPYING
 %dir %{_sysconfdir}/logrotate.d
 %{_sbindir}/logrotate
+%{_unitdir}/logrotate.{service,timer}
+%config(noreplace) %{_sysconfdir}/logrotate.conf
+%config(noreplace) %{_sysconfdir}/logrotate.d/{b,w}tmp
 %{_mandir}/man5/logrotate.conf.5.gz
 %{_mandir}/man8/logrotate.8.gz
-/var/lib/logrotate/logrotate.status
+%{_localstatedir}/lib/logrotate/logrotate.status
 
 %changelog
-* Sat May 09 2020 Nick Samson <nisamson@microsoft.com> - 3.16.0-2
-- Added %%license line automatically
-
+*   Wed Jul 21 2021 Henry Beberman <henry.beberman@microsoft.com> - 3.18.1-1
+-   Update to version 3.18.1
+-   Add default logrotate systemd service and logrotate.conf
+-   Add check section
+*   Sat May 09 2020 Nick Samson <nisamson@microsoft.com> - 3.16.0-2
+-   Added %%license line automatically
 *   Fri Apr 24 2020 Pawel Winogrodzki <pawelwi@microsoft.com> 3.16.0-1
 -   Updated to 3.16.0.
 -   License verified.

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -3805,8 +3805,8 @@
         "type": "other",
         "other": {
           "name": "logrotate",
-          "version": "3.16.0",
-          "downloadUrl": "https://github.com/logrotate/logrotate//archive/3.16.0.tar.gz"
+          "version": "3.18.1",
+          "downloadUrl": "https://github.com/logrotate/logrotate/releases/download/3.18.1/logrotate-3.18.1.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
- Update logrotate to the latest release 3.18.1
- Add a systemd timer to logrotate so that it will run automatically once a day.
- Add a default logrotate configuration that will also run configs in /etc/logrotate.d/

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build
- Tested install and observed timer scheduled and successful execution of logrotate
