### PR TITLE
[dev] Upgrade protobuf to 3.17.3, protobuf-c to 1.4.0 and add compatibility provides

### DIFF
--- a/SPECS/protobuf-c/protobuf-c.signatures.json
+++ b/SPECS/protobuf-c/protobuf-c.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "protobuf-c-1.3.1.tar.gz": "5eeec797d7ff1d4b1e507925a1780fad5dd8dd11163203d8832e5a9f20a79b08"
+  "protobuf-c-1.4.0.tar.gz": "26d98ee9bf18a6eba0d3f855ddec31dbe857667d269bc0b6017335572f85bbcb"
  }
 }

--- a/SPECS/protobuf-c/protobuf-c.spec
+++ b/SPECS/protobuf-c/protobuf-c.spec
@@ -1,24 +1,20 @@
 Summary:        Google's data interchange format - C implementation
 Name:           protobuf-c
-Version:        1.3.1
-Release:        4%{?dist}
+Version:        1.4.0
+Release:        1%{?dist}
 License:        BSD-3-Clause
 Group:          Development/Libraries
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 URL:            https://github.com/protobuf-c/protobuf-c
-Source0:        https://github.com/protobuf-c/protobuf-c/releases/download/v%{version}/%{name}-%{version}.tar.gz
-%define         sha1 protobuf-c=37cbb1e8dc07d8819328f2cac9aec757c8d51756
-BuildRequires:  protobuf >= 2.6.0
-BuildRequires:  protobuf-devel >= 2.6.0
-BuildRequires:  autoconf
-BuildRequires:  automake
-BuildRequires:  libtool
+Source0:        %{url}/releases/download/v%{version}/%{name}-%{version}.tar.gz
+BuildRequires:  pkgconfig(protobuf) >= 2.6.0
 BuildRequires:  libstdc++
 BuildRequires:  curl
 BuildRequires:  make
 BuildRequires:  unzip
 Requires:       protobuf
+Provides:       %{name}-compiler = %{version}-%{release}
 
 %description
 Protocol Buffers (a.k.a., protobuf) are Google's language-neutral, platform-neutral, extensible mechanism for serializing structured data. You can find protobuf's documentation on the Google Developers site. This is the C implementation.
@@ -26,7 +22,7 @@ Protocol Buffers (a.k.a., protobuf) are Google's language-neutral, platform-neut
 %package        devel
 Summary:        Development files for protobuf
 Group:          Development/Libraries
-Requires:       protobuf-c = %{version}-%{release}
+Requires:       %{name} = %{version}-%{release}
 
 %description    devel
 The protobuf-c-devel package contains libraries and header files for
@@ -35,37 +31,38 @@ developing applications that use protobuf-c.
 %package        static
 Summary:        protobuf-c static lib
 Group:          Development/Libraries
-Requires:       protobuf-c = %{version}-%{release}
+Requires:       %{name} = %{version}-%{release}
 
 %description    static
 The protobuf-c-static package contains static protobuf-c libraries.
 
 %prep
-%setup
-autoreconf -iv
+%autosetup
 
 %build
 %configure --disable-silent-rules
-make %{?_smp_mflags}
+%make_build
 
 %install
-make DESTDIR=%{buildroot} install
+%make_install
+find %{buildroot} -type f -name "*.la" -delete -print
 
-%post   -p /sbin/ldconfig
-%postun -p /sbin/ldconfig
+%check
+%make_build check
+
+%ldconfig_scriptlets
 
 %files
 %defattr(-,root,root)
 %license LICENSE
 %{_bindir}/protoc-c
-%{_libdir}/libprotobuf-c.so.*
 %{_bindir}/protoc-gen-c
+%{_libdir}/libprotobuf-c.so.1*
 
 %files devel
 %defattr(-,root,root)
 %{_includedir}/*
 %{_libdir}/pkgconfig/*
-%{_libdir}/libprotobuf-c.la
 %{_libdir}/libprotobuf-c.so
 
 %files static
@@ -73,7 +70,14 @@ make DESTDIR=%{buildroot} install
 %{_libdir}/libprotobuf-c.a
 
 %changelog
-* Sat May 09 00:21:08 PST 2020 Nick Samson <nisamson@microsoft.com> - 1.3.1-4
+* Fri Jul 23 2021 Thomas Crain <thcrain@microsoft.com> - 1.4.0-1
+- Upgrade to latest upstream version
+- Version
+- Add check section
+- Remove libtool archives from devel subpackage
+- Lint spec
+
+* Sat May 09 2020 Nick Samson <nisamson@microsoft.com> - 1.3.1-4
 - Added %%license line automatically
 
 *   Fri Mar 03 2020 Jon Slobodzian <joslobo@microsoft.com> 1.20.2-3

--- a/SPECS/protobuf-c/protobuf-c.spec
+++ b/SPECS/protobuf-c/protobuf-c.spec
@@ -3,16 +3,17 @@ Name:           protobuf-c
 Version:        1.4.0
 Release:        1%{?dist}
 License:        BSD-3-Clause
-Group:          Development/Libraries
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
+Group:          Development/Libraries
 URL:            https://github.com/protobuf-c/protobuf-c
 Source0:        %{url}/releases/download/v%{version}/%{name}-%{version}.tar.gz
-BuildRequires:  pkgconfig(protobuf) >= 2.6.0
-BuildRequires:  libstdc++
 BuildRequires:  curl
+BuildRequires:  libstdc++
 BuildRequires:  make
+BuildRequires:  pkg-config
 BuildRequires:  unzip
+BuildRequires:  pkgconfig(protobuf) >= 2.6.0
 Requires:       protobuf
 Provides:       %{name}-compiler = %{version}-%{release}
 
@@ -72,7 +73,6 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %changelog
 * Fri Jul 23 2021 Thomas Crain <thcrain@microsoft.com> - 1.4.0-1
 - Upgrade to latest upstream version
-- Version
 - Add check section
 - Remove libtool archives from devel subpackage
 - Lint spec
@@ -80,13 +80,17 @@ find %{buildroot} -type f -name "*.la" -delete -print
 * Sat May 09 2020 Nick Samson <nisamson@microsoft.com> - 1.3.1-4
 - Added %%license line automatically
 
-*   Fri Mar 03 2020 Jon Slobodzian <joslobo@microsoft.com> 1.20.2-3
--   Fixed Source URL. Verified license. Fixed URL. Fixed Source URL.
-*   Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 1.3.1-2
--   Initial CBL-Mariner import from Photon (license: Apache2).
-*   Wed Sep 19 2018 Tapas Kundu <tkundu@vmware.com> 1.3.1-1
--   Updated to release 1.3.1
-*   Thu Mar 30 2017 Vinay Kulkarni <kulkarniv@vmware.com> 1.2.1-2
--   Fix protobuf-c-static requires
-*   Sat Mar 18 2017 Vinay Kulkarni <kulkarniv@vmware.com> 1.2.1-1
--   Initial packaging for Photon
+* Fri Mar 03 2020 Jon Slobodzian <joslobo@microsoft.com> - 1.20.2-3
+- Fixed Source URL. Verified license. Fixed URL. Fixed Source URL.
+
+* Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> - 1.3.1-2
+- Initial CBL-Mariner import from Photon (license: Apache2).
+
+* Wed Sep 19 2018 Tapas Kundu <tkundu@vmware.com> - 1.3.1-1
+- Updated to release 1.3.1
+
+* Thu Mar 30 2017 Vinay Kulkarni <kulkarniv@vmware.com> - 1.2.1-2
+- Fix protobuf-c-static requires
+
+* Sat Mar 18 2017 Vinay Kulkarni <kulkarniv@vmware.com> - 1.2.1-1
+- Initial packaging for Photon

--- a/SPECS/protobuf/protobuf.signatures.json
+++ b/SPECS/protobuf/protobuf.signatures.json
@@ -1,6 +1,5 @@
 {
  "Signatures": {
-  "protobuf-3.6.1.tar.gz": "3d4e589d81b2006ca603c1ab712c9715a76227293032d05b26fca603f90b3f5b",
-  "protobuf-m2-3.6.1.tar.gz": "205cd04bea8506bdf512cd7918cc7907aa81ed145d848cd5e0e890adff35b3fd"
+  "protobuf-all-3.17.3.tar.gz": "77ad26d3f65222fd96ccc18b055632b0bfedf295cb748b712a98ba1ac0b704b2"
  }
 }

--- a/SPECS/protobuf/protobuf.spec
+++ b/SPECS/protobuf/protobuf.spec
@@ -1,24 +1,19 @@
-%{!?python2_sitelib: %global python2_sitelib %(python2 -c "from distutils.sysconfig import get_python_lib;print(get_python_lib())")}
-%{!?python3_sitelib: %global python3_sitelib %(python3 -c "from distutils.sysconfig import get_python_lib;print(get_python_lib())")}
 Summary:        Google's data interchange format
 Name:           protobuf
-Version:        3.6.1
-Release:        9%{?dist}
+Version:        3.17.3
+Release:        1%{?dist}
 License:        BSD
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Group:          Development/Libraries
 URL:            https://developers.google.com/protocol-buffers/
-#Source0:       https://github.com/protocolbuffers/protobuf/archive/v%{version}.tar.gz
-Source0:        protobuf-%{version}.tar.gz
-Source1:        protobuf-m2-%{version}.tar.gz
-BuildRequires:  autoconf
-BuildRequires:  automake
+Source0:        https://github.com/protocolbuffers/protobuf/releases/download/v%{version}/%{name}-all-%{version}.tar.gz
 BuildRequires:  curl
 BuildRequires:  libstdc++
-BuildRequires:  libtool
 BuildRequires:  make
 BuildRequires:  unzip
+Provides:       %{name}-compiler = %{version}-%{release}
+Provides:       %{name}-lite = %{version}-%{release}
 
 %description
 Protocol Buffers (a.k.a., protobuf) are Google's language-neutral, platform-neutral, extensible mechanism for serializing structured data. You can find protobuf's documentation on the Google Developers site.
@@ -26,7 +21,8 @@ Protocol Buffers (a.k.a., protobuf) are Google's language-neutral, platform-neut
 %package        devel
 Summary:        Development files for protobuf
 Group:          Development/Libraries
-Requires:       protobuf = %{version}-%{release}
+Requires:       %{name} = %{version}-%{release}
+Provides:       %{name}-lite-devel = %{version}-%{release}
 
 %description    devel
 The protobuf-devel package contains libraries and header files for
@@ -35,26 +31,13 @@ developing applications that use protobuf.
 %package        static
 Summary:        protobuf static lib
 Group:          Development/Libraries
-Requires:       protobuf = %{version}-%{release}
+Requires:       %{name} = %{version}-%{release}
+Provides:       %{name}-lite-static = %{version}-%{release}
 
 %description    static
 The protobuf-static package contains static protobuf libraries.
 
-%package        python
-Summary:        protobuf python lib
-Group:          Development/Libraries
-BuildRequires:  python-setuptools
-BuildRequires:  python2
-BuildRequires:  python2-devel
-BuildRequires:  python2-libs
-Requires:       protobuf = %{version}-%{release}
-Requires:       python2
-Requires:       python2-libs
-
-%description    python
-This contains protobuf python libraries.
-
-%package        python3
+%package -n     python3-%{name}
 Summary:        protobuf python3 lib
 Group:          Development/Libraries
 BuildRequires:  python3
@@ -62,46 +45,39 @@ BuildRequires:  python3-devel
 BuildRequires:  python3-libs
 BuildRequires:  python3-setuptools
 BuildRequires:  python3-xml
-Requires:       protobuf = %{version}-%{release}
+Requires:       %{name} = %{version}-%{release}
 Requires:       python3
 Requires:       python3-libs
+Provides:       %{name}-python3 = %{version}-%{release}
 
-%description    python3
+%description -n python3-%{name}
 This contains protobuf python3 libraries.
 
 %prep
-mkdir /root/.m2
-pushd /root/.m2
-tar xf %{SOURCE1} --no-same-owner
-popd
-%setup -q
-autoreconf -iv
+%autosetup
 
 %build
 %configure --disable-silent-rules
-make %{?_smp_mflags}
+%make_build
 pushd python
-python2 setup.py build
-python3 setup.py build
+%py3_build
 popd
 
 %install
-make DESTDIR=%{buildroot} install
+%make_install
 pushd python
-python2 setup.py install --prefix=%{_prefix} --root=%{buildroot}
-python3 setup.py install --prefix=%{_prefix} --root=%{buildroot}
+%py3_install
 popd
 
-%post   -p /sbin/ldconfig
-%postun -p /sbin/ldconfig
+%ldconfig_scriptlets
 
 %files
 %defattr(-,root,root)
 %license LICENSE
 %{_bindir}/protoc
-%{_libdir}/libprotobuf-lite.so.*
-%{_libdir}/libprotobuf.so.*
-%{_libdir}/libprotoc.so.*
+%{_libdir}/libprotobuf-lite.so.28*
+%{_libdir}/libprotobuf.so.28*
+%{_libdir}/libprotoc.so.28*
 
 %files devel
 %defattr(-,root,root)
@@ -120,13 +96,18 @@ popd
 %{_libdir}/libprotobuf.a
 %{_libdir}/libprotoc.a
 
-%files python
-%{python2_sitelib}/*
-
-%files python3
+%files -n python3-%{name}
 %{python3_sitelib}/*
 
 %changelog
+* Fri Jul 23 2021 Thomas Crain <thcrain@microsoft.com. - 3.17.3-1
+- Upgrade to latest upstream version, using upstream release tarball
+- Add soname version to %%file packaging
+- Remove protobuf-m2-%{version}.tar.gz source tarball (no longer needed with java removal)
+- Change python3 subpackage name to python3-protobuf, to match Mariner naming conventions
+- Remove python 2 subpackage
+- Lint spec
+
 * Mon Dec 07 2020 Joe Schmitt <joschmit@microsoft.com> - 3.6.1-9
 - Remove java subpackage.
 

--- a/SPECS/protobuf/protobuf.spec
+++ b/SPECS/protobuf/protobuf.spec
@@ -100,7 +100,7 @@ popd
 %{python3_sitelib}/*
 
 %changelog
-* Fri Jul 23 2021 Thomas Crain <thcrain@microsoft.com. - 3.17.3-1
+* Fri Jul 23 2021 Thomas Crain <thcrain@microsoft.com> - 3.17.3-1
 - Upgrade to latest upstream version, using upstream release tarball
 - Add soname version to %%file packaging
 - Remove protobuf-m2-%{version}.tar.gz source tarball (no longer needed with java removal)

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -4935,8 +4935,8 @@
         "type": "other",
         "other": {
           "name": "protobuf",
-          "version": "3.6.1",
-          "downloadUrl": "https://github.com/protocolbuffers/protobuf/archive/v3.6.1.tar.gz"
+          "version": "3.7.3",
+          "downloadUrl": "https://github.com/protocolbuffers/protobuf/releases/download/v3.7.3/protobuf-all-3.7.3.tar.gz"
         }
       }
     },
@@ -4945,8 +4945,8 @@
         "type": "other",
         "other": {
           "name": "protobuf-c",
-          "version": "1.3.1",
-          "downloadUrl": "https://github.com/protobuf-c/protobuf-c/releases/download/v1.3.1/protobuf-c-1.3.1.tar.gz"
+          "version": "1.4.0",
+          "downloadUrl": "https://github.com/protobuf-c/protobuf-c/releases/download/v1.4.0/protobuf-c-1.4.0.tar.gz"
         }
       }
     },

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -4935,8 +4935,8 @@
         "type": "other",
         "other": {
           "name": "protobuf",
-          "version": "3.7.3",
-          "downloadUrl": "https://github.com/protocolbuffers/protobuf/releases/download/v3.7.3/protobuf-all-3.7.3.tar.gz"
+          "version": "3.17.3",
+          "downloadUrl": "https://github.com/protocolbuffers/protobuf/releases/download/v3.17.3/protobuf-all-3.17.3.tar.gz"
         }
       }
     },


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Our protobuf and protobuf-c packages are out-of-date. We upgrade those to the latest versions. Additionally, linting performed and compatibility provides added as appropriate.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- `protobuf`: Upgrade to 3.17.3. Lint spec. Remove python2 subpackage. Rename python3 subpackage to python3-protobuf. 
- `protobuf-c`: Upgrade to 1.4.0. Lint spec. Add compiler subpackage provide to base package. Add compiler, lite, lite-devel, lite-static subpackage provides to appropriate packages.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build of affected packages
