### PR TITLE
Add dependabot configuration file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "07:00"
+      timezone: "America/Los_Angeles"
+    reviewers:
+      - "microsoft/cbl-mariner-devs"
+    target-branch: "1.0-dev"
+
+  - package-ecosystem: "gomod"
+    directory: "toolkit/tools"
+    schedule:
+      interval: "daily"
+      time: "07:00"
+      timezone: "America/Los_Angeles"
+    reviewers:
+      - "microsoft/cbl-mariner-devs"
+    target-branch: "1.0-dev"


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Dependabot is a useful tool to keep dependencies up-to-date. However, the default settings don't reflect our repository's workflow with respect to default reviewer sets and target branches (e.g. we don't PR against the default branch, usually). This PR sets up a configuration file to allow the tools to work better for us.

This PR is against the 1.0-dev branch, and will be cherry-picked into 1.0 after being merged.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Run dependency checks daily at 7AM Redmond time 
- Use `microsoft/cbl-mariner-devs` group as a default reviewer for dependabot PRs
- Change dependabot target branch to `1.0-dev`
- Run checks against our go modules and our github actions

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- The configuration file was validated using the tool's [configuration validator](https://dependabot.com/docs/config-file/validator/).
