### PR TITLE
[dev] Fix placement of os-release file in mariner-release

### DIFF
--- a/SPECS/mariner-release/mariner-release.spec
+++ b/SPECS/mariner-release/mariner-release.spec
@@ -16,9 +16,8 @@ BuildArch:      noarch
 Azure CBL-Mariner release files such as yum configs and other %{_sysconfdir}/ release related files
 
 %install
-rm -rf %{buildroot}
 install -d %{buildroot}%{_sysconfdir}
-install -d %{buildroot}/%{_lib}
+install -d %{buildroot}/%{_libdir}
 
 echo "CBL-Mariner %{mariner_release_version}" > %{buildroot}%{_sysconfdir}/mariner-release
 echo "MARINER_BUILD_NUMBER=%{mariner_build_number}" >> %{buildroot}%{_sysconfdir}/mariner-release
@@ -31,7 +30,7 @@ DISTRIB_DESCRIPTION="CBL-Mariner %{mariner_release_version}"
 EOF
 
 version_id=`echo %{mariner_release_version} | grep -o -E '[0-9]+.[0-9]+' | head -1`
-cat > %{buildroot}/%{_lib}/os-release << EOF
+cat > %{buildroot}/%{_libdir}/os-release << EOF
 NAME="Common Base Linux Mariner"
 VERSION="%{mariner_release_version}"
 ID=mariner
@@ -53,21 +52,19 @@ cat > %{buildroot}%{_sysconfdir}/issue.net <<- EOF
 Welcome to CBL-Mariner %{mariner_release_version} (%{_arch}) - Kernel %r (%t)
 EOF
 
-%clean
-rm -rf $RPM_BUILD_ROOT
-
 %files
 %defattr(-,root,root,-)
 %config(noreplace) %{_sysconfdir}/mariner-release
 %config(noreplace) %{_sysconfdir}/lsb-release
-%config(noreplace) /%{_lib}/os-release
+%config(noreplace) %{_libdir}/os-release
 %config(noreplace) %{_sysconfdir}/os-release
 %config(noreplace) %{_sysconfdir}/issue
 %config(noreplace) %{_sysconfdir}/issue.net
 
 %changelog
-* Tue May 18 2021 Jon Slobodzian <joslobo@microsoft.com> - 2.0-1
+* Tue Jul 29 2021 Jon Slobodzian <joslobo@microsoft.com> - 2.0-1
 - Updating version and distrotag for future looking 2.0 branch.  Formatting fixes.
+- Remove %%clean section, buildroot cleaning step (both automatically done by RPM)
 
 * Wed Apr 27 2021 Jon Slobodzian <joslobo@microsoft.com> - 1.0-16
 - Updating version for April update

--- a/SPECS/mariner-release/mariner-release.spec
+++ b/SPECS/mariner-release/mariner-release.spec
@@ -62,7 +62,7 @@ EOF
 %config(noreplace) %{_sysconfdir}/issue.net
 
 %changelog
-* Tue Jul 29 2021 Jon Slobodzian <joslobo@microsoft.com> - 2.0-1
+* Thu Jul 29 2021 Jon Slobodzian <joslobo@microsoft.com> - 2.0-1
 - Updating version and distrotag for future looking 2.0 branch.  Formatting fixes.
 - Remove %%clean section, buildroot cleaning step (both automatically done by RPM)
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
A previous change to mariner-release in #1118 caused the `os-release` file to reside in the `/lib` folder. This broke the image builds, as the `/lib` folder created by mariner-release conflicted with the `/lib` folder created by the filesystem package. To fix this, we revert that specific change.

Release number can stay the same, as we have not released the previous changes anywhere.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Move `os-release` back to `/usr/lib`
- Remove %%clean section, buildroot cleaning step from the spec (both are automatically added by RPM)

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local image build with new mariner-release version
