### PR TITLE
kernel: Add patch to revert a cdrom eject commit

### DIFF
--- a/SPECS-SIGNED/kernel-signed/kernel-signed.spec
+++ b/SPECS-SIGNED/kernel-signed/kernel-signed.spec
@@ -10,7 +10,7 @@
 Summary:        Signed Linux Kernel for %{buildarch} systems
 Name:           kernel-signed-%{buildarch}
 Version:        5.10.52.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -146,6 +146,9 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %endif
 
 %changelog
+* Fri Jul 30 2021 Chris Co <chrco@microsoft.com> - 5.10.52.1-2
+- Bump release number to match kernel release
+
 * Tue Jul 20 2021 Rachel Menge <rachelmenge@microsoft.com> - 5.10.52.1-1
 - Update source to 5.10.52.1
 

--- a/SPECS/hyperv-daemons/0001-Revert-scsi-sr-Return-appropriate-error-code-when-di.patch
+++ b/SPECS/hyperv-daemons/0001-Revert-scsi-sr-Return-appropriate-error-code-when-di.patch
@@ -1,0 +1,29 @@
+From 92e4056768992185cf0850822045aff207c0bd40 Mon Sep 17 00:00:00 2001
+From: Chris Co <chrco@microsoft.com>
+Date: Fri, 30 Jul 2021 19:04:15 +0000
+Subject: [PATCH] Revert "scsi: sr: Return appropriate error code when disk is
+ ejected"
+
+This reverts commit f77f97238496aeab597d573aa1703441626da999.
+
+Signed-off-by: Chris Co <chrco@microsoft.com>
+---
+ drivers/scsi/sr.c | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/drivers/scsi/sr.c b/drivers/scsi/sr.c
+index 726b7048a767..c231c9d9847e 100644
+--- a/drivers/scsi/sr.c
++++ b/drivers/scsi/sr.c
+@@ -220,8 +220,6 @@ static unsigned int sr_get_events(struct scsi_device *sdev)
+ 		return DISK_EVENT_EJECT_REQUEST;
+ 	else if (med->media_event_code == 2)
+ 		return DISK_EVENT_MEDIA_CHANGE;
+-	else if (med->media_event_code == 3)
+-		return DISK_EVENT_EJECT_REQUEST;
+ 	return 0;
+ }
+ 
+-- 
+2.17.1
+

--- a/SPECS/hyperv-daemons/hyperv-daemons.spec
+++ b/SPECS/hyperv-daemons/hyperv-daemons.spec
@@ -9,7 +9,7 @@
 Summary:        Hyper-V daemons suite
 Name:           hyperv-daemons
 Version:        5.10.52.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -27,6 +27,7 @@ Source102:      hypervvss.rules
 # HYPERV FCOPY DAEMON
 Source201:      hypervfcopyd.service
 Source202:      hypervfcopy.rules
+Patch0:         0001-Revert-scsi-sr-Return-appropriate-error-code-when-di.patch
 BuildRequires:  gcc
 Requires:       hypervfcopyd = %{version}-%{release}
 Requires:       hypervkvpd = %{version}-%{release}
@@ -104,6 +105,7 @@ Contains tools and scripts useful for Hyper-V guests.
 
 %prep
 %setup -q -n CBL-Mariner-Linux-Kernel-rolling-lts-mariner-%{version}
+%patch0 -p1
 
 %build
 pushd tools/hv
@@ -219,6 +221,9 @@ fi
 %{_sbindir}/lsvmbus
 
 %changelog
+* Fri Jul 30 2021 Chris Co <chrco@microsoft.com> - 5.10.52.1-2
+- Add patch to fix CDROM eject errors
+
 * Tue Jul 20 2021 Rachel Menge <rachelmenge@microsoft.com> - 5.10.52.1-1
 - Update source to 5.10.52.1
 

--- a/SPECS/kernel-headers/0001-Revert-scsi-sr-Return-appropriate-error-code-when-di.patch
+++ b/SPECS/kernel-headers/0001-Revert-scsi-sr-Return-appropriate-error-code-when-di.patch
@@ -1,0 +1,29 @@
+From 92e4056768992185cf0850822045aff207c0bd40 Mon Sep 17 00:00:00 2001
+From: Chris Co <chrco@microsoft.com>
+Date: Fri, 30 Jul 2021 19:04:15 +0000
+Subject: [PATCH] Revert "scsi: sr: Return appropriate error code when disk is
+ ejected"
+
+This reverts commit f77f97238496aeab597d573aa1703441626da999.
+
+Signed-off-by: Chris Co <chrco@microsoft.com>
+---
+ drivers/scsi/sr.c | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/drivers/scsi/sr.c b/drivers/scsi/sr.c
+index 726b7048a767..c231c9d9847e 100644
+--- a/drivers/scsi/sr.c
++++ b/drivers/scsi/sr.c
+@@ -220,8 +220,6 @@ static unsigned int sr_get_events(struct scsi_device *sdev)
+ 		return DISK_EVENT_EJECT_REQUEST;
+ 	else if (med->media_event_code == 2)
+ 		return DISK_EVENT_MEDIA_CHANGE;
+-	else if (med->media_event_code == 3)
+-		return DISK_EVENT_EJECT_REQUEST;
+ 	return 0;
+ }
+ 
+-- 
+2.17.1
+

--- a/SPECS/kernel-headers/kernel-headers.spec
+++ b/SPECS/kernel-headers/kernel-headers.spec
@@ -1,7 +1,7 @@
 Summary:        Linux API header files
 Name:           kernel-headers
 Version:        5.10.52.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -9,6 +9,7 @@ Group:          System Environment/Kernel
 URL:            https://github.com/microsoft/CBL-Mariner-Linux-Kernel
 #Source0:       https://github.com/microsoft/CBL-Mariner-Linux-Kernel/archive/rolling-lts/mariner/%%{version}.tar.gz
 Source0:        kernel-%{version}.tar.gz
+Patch0:         0001-Revert-scsi-sr-Return-appropriate-error-code-when-di.patch
 BuildArch:      noarch
 
 %description
@@ -16,6 +17,7 @@ The Linux API Headers expose the kernel's API for use by Glibc.
 
 %prep
 %setup -q -n CBL-Mariner-Linux-Kernel-rolling-lts-mariner-%{version}
+%patch0 -p1
 
 %build
 make mrproper
@@ -35,6 +37,9 @@ cp -rv usr/include/* /%{buildroot}%{_includedir}
 %{_includedir}/*
 
 %changelog
+* Fri Jul 30 2021 Chris Co <chrco@microsoft.com> - 5.10.52.1-2
+- Add patch to fix CDROM eject errors
+
 * Tue Jul 20 2021 Rachel Menge <rachelmenge@microsoft.com> - 5.10.52.1-1
 - Update source to 5.10.52.1
 

--- a/SPECS/kernel-hyperv/0001-Revert-scsi-sr-Return-appropriate-error-code-when-di.patch
+++ b/SPECS/kernel-hyperv/0001-Revert-scsi-sr-Return-appropriate-error-code-when-di.patch
@@ -1,0 +1,29 @@
+From 92e4056768992185cf0850822045aff207c0bd40 Mon Sep 17 00:00:00 2001
+From: Chris Co <chrco@microsoft.com>
+Date: Fri, 30 Jul 2021 19:04:15 +0000
+Subject: [PATCH] Revert "scsi: sr: Return appropriate error code when disk is
+ ejected"
+
+This reverts commit f77f97238496aeab597d573aa1703441626da999.
+
+Signed-off-by: Chris Co <chrco@microsoft.com>
+---
+ drivers/scsi/sr.c | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/drivers/scsi/sr.c b/drivers/scsi/sr.c
+index 726b7048a767..c231c9d9847e 100644
+--- a/drivers/scsi/sr.c
++++ b/drivers/scsi/sr.c
+@@ -220,8 +220,6 @@ static unsigned int sr_get_events(struct scsi_device *sdev)
+ 		return DISK_EVENT_EJECT_REQUEST;
+ 	else if (med->media_event_code == 2)
+ 		return DISK_EVENT_MEDIA_CHANGE;
+-	else if (med->media_event_code == 3)
+-		return DISK_EVENT_EJECT_REQUEST;
+ 	return 0;
+ }
+ 
+-- 
+2.17.1
+

--- a/SPECS/kernel-hyperv/kernel-hyperv.spec
+++ b/SPECS/kernel-hyperv/kernel-hyperv.spec
@@ -4,7 +4,7 @@
 Summary:        Linux Kernel optimized for Hyper-V
 Name:           kernel-hyperv
 Version:        5.10.52.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -15,6 +15,7 @@ Source0:        kernel-%{version}.tar.gz
 Source1:        config
 Source2:        sha512hmac-openssl.sh
 Source3:        cbl-mariner-ca-20210127.pem
+Patch0:         0001-Revert-scsi-sr-Return-appropriate-error-code-when-di.patch
 BuildRequires:  audit-devel
 BuildRequires:  bash
 BuildRequires:  bc
@@ -90,6 +91,7 @@ This package contains the 'perf' performance analysis tools for Linux kernel.
 
 %prep
 %setup -q -n CBL-Mariner-Linux-Kernel-rolling-lts-mariner-%{version}
+%patch0 -p1
 
 %build
 make mrproper
@@ -267,6 +269,9 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %{_libdir}/perf/include/bpf/*
 
 %changelog
+* Fri Jul 30 2021 Chris Co <chrco@microsoft.com> - 5.10.52.1-2
+- Add patch to fix CDROM eject errors
+
 * Tue Jul 20 2021 Rachel Menge <rachelmenge@microsoft.com> - 5.10.52.1-1
 - Update source to 5.10.52.1
 

--- a/SPECS/kernel/0001-Revert-scsi-sr-Return-appropriate-error-code-when-di.patch
+++ b/SPECS/kernel/0001-Revert-scsi-sr-Return-appropriate-error-code-when-di.patch
@@ -1,0 +1,29 @@
+From 92e4056768992185cf0850822045aff207c0bd40 Mon Sep 17 00:00:00 2001
+From: Chris Co <chrco@microsoft.com>
+Date: Fri, 30 Jul 2021 19:04:15 +0000
+Subject: [PATCH] Revert "scsi: sr: Return appropriate error code when disk is
+ ejected"
+
+This reverts commit f77f97238496aeab597d573aa1703441626da999.
+
+Signed-off-by: Chris Co <chrco@microsoft.com>
+---
+ drivers/scsi/sr.c | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/drivers/scsi/sr.c b/drivers/scsi/sr.c
+index 726b7048a767..c231c9d9847e 100644
+--- a/drivers/scsi/sr.c
++++ b/drivers/scsi/sr.c
+@@ -220,8 +220,6 @@ static unsigned int sr_get_events(struct scsi_device *sdev)
+ 		return DISK_EVENT_EJECT_REQUEST;
+ 	else if (med->media_event_code == 2)
+ 		return DISK_EVENT_MEDIA_CHANGE;
+-	else if (med->media_event_code == 3)
+-		return DISK_EVENT_EJECT_REQUEST;
+ 	return 0;
+ }
+ 
+-- 
+2.17.1
+

--- a/SPECS/kernel/kernel.spec
+++ b/SPECS/kernel/kernel.spec
@@ -4,7 +4,7 @@
 Summary:        Linux Kernel
 Name:           kernel
 Version:        5.10.52.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -16,6 +16,7 @@ Source1:        config
 Source2:        config_aarch64
 Source3:        sha512hmac-openssl.sh
 Source4:        cbl-mariner-ca-20210127.pem
+Patch0:         0001-Revert-scsi-sr-Return-appropriate-error-code-when-di.patch
 # Kernel CVEs are addressed by moving to a newer version of the stable kernel.
 # Since kernel CVEs are filed against the upstream kernel version and not the
 # stable kernel version, our automated tooling will still flag the CVE as not
@@ -279,6 +280,7 @@ This package contains common device tree blobs (dtb)
 
 %prep
 %setup -q -n CBL-Mariner-Linux-Kernel-rolling-lts-mariner-%{version}
+%patch0 -p1
 
 %build
 make mrproper
@@ -509,6 +511,9 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %endif
 
 %changelog
+* Fri Jul 30 2021 Chris Co <chrco@microsoft.com> - 5.10.52.1-2
+- Add patch to fix CDROM eject errors
+
 * Tue Jul 20 2021 Rachel Menge <rachelmenge@microsoft.com> - 5.10.52.1-1
 - Update source to 5.10.52.1
 - Address CVE-2021-35039, CVE-2021-33909

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -1,5 +1,5 @@
 filesystem-1.1-7.cm1.aarch64.rpm
-kernel-headers-5.10.52.1-1.cm1.noarch.rpm
+kernel-headers-5.10.52.1-2.cm1.noarch.rpm
 glibc-2.28-18.cm1.aarch64.rpm
 glibc-devel-2.28-18.cm1.aarch64.rpm
 glibc-i18n-2.28-18.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -1,5 +1,5 @@
 filesystem-1.1-7.cm1.x86_64.rpm
-kernel-headers-5.10.52.1-1.cm1.noarch.rpm
+kernel-headers-5.10.52.1-2.cm1.noarch.rpm
 glibc-2.28-18.cm1.x86_64.rpm
 glibc-devel-2.28-18.cm1.x86_64.rpm
 glibc-i18n-2.28-18.cm1.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -158,7 +158,7 @@ json-c-debuginfo-0.14-3.cm1.aarch64.rpm
 json-c-devel-0.14-3.cm1.aarch64.rpm
 kbd-2.0.4-5.cm1.aarch64.rpm
 kbd-debuginfo-2.0.4-5.cm1.aarch64.rpm
-kernel-headers-5.10.52.1-1.cm1.noarch.rpm
+kernel-headers-5.10.52.1-2.cm1.noarch.rpm
 kmod-25-4.cm1.aarch64.rpm
 kmod-debuginfo-25-4.cm1.aarch64.rpm
 kmod-devel-25-4.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -158,7 +158,7 @@ json-c-debuginfo-0.14-3.cm1.x86_64.rpm
 json-c-devel-0.14-3.cm1.x86_64.rpm
 kbd-2.0.4-5.cm1.x86_64.rpm
 kbd-debuginfo-2.0.4-5.cm1.x86_64.rpm
-kernel-headers-5.10.52.1-1.cm1.noarch.rpm
+kernel-headers-5.10.52.1-2.cm1.noarch.rpm
 kmod-25-4.cm1.x86_64.rpm
 kmod-debuginfo-25-4.cm1.x86_64.rpm
 kmod-devel-25-4.cm1.x86_64.rpm


### PR DESCRIPTION
Our validation found that cdrom eject is causing a udev event storm and
regressing many performance metrics. Issue isolated to a commit
introduced upstream and backported to stable kernel. Reverting this
commit to mitigate the issue. We will be working with LKML in the
meantime to fix the underlying issue.

cherry-pick of 7474d1b6974e27447a7d594bc77b0d751f2dfbba to 1.0

Signed-off-by: Chris Co <chrco@microsoft.com>