### PR TITLE
kernel: Add patch to fix VDSO in HyperV

### DIFF
--- a/SPECS-SIGNED/kernel-signed/kernel-signed.spec
+++ b/SPECS-SIGNED/kernel-signed/kernel-signed.spec
@@ -10,7 +10,7 @@
 Summary:        Signed Linux Kernel for %{buildarch} systems
 Name:           kernel-signed-%{buildarch}
 Version:        5.10.52.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -146,6 +146,9 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %endif
 
 %changelog
+* Tue Aug 03 2021 Chris Co <chrco@microsoft.com> - 5.10.52.1-3
+- Bump release number to match kernel release
+
 * Fri Jul 30 2021 Chris Co <chrco@microsoft.com> - 5.10.52.1-2
 - Bump release number to match kernel release
 

--- a/SPECS/hyperv-daemons/0001-clocksource-drivers-hyper-v-Re-enable-VDSO_CLOCKMODE.patch
+++ b/SPECS/hyperv-daemons/0001-clocksource-drivers-hyper-v-Re-enable-VDSO_CLOCKMODE.patch
@@ -1,0 +1,63 @@
+From d1921ccf2f197a9e1699f2b35890f06dc4105500 Mon Sep 17 00:00:00 2001
+From: Vitaly Kuznetsov <vkuznets@redhat.com>
+Date: Thu, 13 May 2021 09:32:46 +0200
+Subject: [PATCH] clocksource/drivers/hyper-v: Re-enable VDSO_CLOCKMODE_HVCLOCK
+ on X86
+
+Mohammed reports (https://bugzilla.kernel.org/show_bug.cgi?id=213029)
+the commit e4ab4658f1cf ("clocksource/drivers/hyper-v: Handle vDSO
+differences inline") broke vDSO on x86. The problem appears to be that
+VDSO_CLOCKMODE_HVCLOCK is an enum value in 'enum vdso_clock_mode' and
+'#ifdef VDSO_CLOCKMODE_HVCLOCK' branch evaluates to false (it is not
+a define).
+
+Use a dedicated HAVE_VDSO_CLOCKMODE_HVCLOCK define instead.
+
+Fixes: e4ab4658f1cf ("clocksource/drivers/hyper-v: Handle vDSO differences inline")
+Reported-by: Mohammed Gamal <mgamal@redhat.com>
+Suggested-by: Thomas Gleixner <tglx@linutronix.de>
+Signed-off-by: Vitaly Kuznetsov <vkuznets@redhat.com>
+Signed-off-by: Thomas Gleixner <tglx@linutronix.de>
+Reviewed-by: Michael Kelley <mikelley@microsoft.com>
+Link: https://lore.kernel.org/r/20210513073246.1715070-1-vkuznets@redhat.com
+---
+ arch/x86/include/asm/vdso/clocksource.h | 2 ++
+ drivers/clocksource/hyperv_timer.c      | 4 ++--
+ 2 files changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/arch/x86/include/asm/vdso/clocksource.h b/arch/x86/include/asm/vdso/clocksource.h
+index 119ac8612d89..136e5e57cfe1 100644
+--- a/arch/x86/include/asm/vdso/clocksource.h
++++ b/arch/x86/include/asm/vdso/clocksource.h
+@@ -7,4 +7,6 @@
+ 	VDSO_CLOCKMODE_PVCLOCK,	\
+ 	VDSO_CLOCKMODE_HVCLOCK
+ 
++#define HAVE_VDSO_CLOCKMODE_HVCLOCK
++
+ #endif /* __ASM_VDSO_CLOCKSOURCE_H */
+diff --git a/drivers/clocksource/hyperv_timer.c b/drivers/clocksource/hyperv_timer.c
+index ba17faa92597..5d08f5f58a6b 100644
+--- a/drivers/clocksource/hyperv_timer.c
++++ b/drivers/clocksource/hyperv_timer.c
+@@ -419,7 +419,7 @@ static void resume_hv_clock_tsc(struct clocksource *arg)
+ 	hv_set_register(HV_REGISTER_REFERENCE_TSC, tsc_msr);
+ }
+ 
+-#ifdef VDSO_CLOCKMODE_HVCLOCK
++#ifdef HAVE_VDSO_CLOCKMODE_HVCLOCK
+ static int hv_cs_enable(struct clocksource *cs)
+ {
+ 	vclocks_set_used(VDSO_CLOCKMODE_HVCLOCK);
+@@ -435,7 +435,7 @@ static struct clocksource hyperv_cs_tsc = {
+ 	.flags	= CLOCK_SOURCE_IS_CONTINUOUS,
+ 	.suspend= suspend_hv_clock_tsc,
+ 	.resume	= resume_hv_clock_tsc,
+-#ifdef VDSO_CLOCKMODE_HVCLOCK
++#ifdef HAVE_VDSO_CLOCKMODE_HVCLOCK
+ 	.enable = hv_cs_enable,
+ 	.vdso_clock_mode = VDSO_CLOCKMODE_HVCLOCK,
+ #else
+-- 
+2.17.1
+

--- a/SPECS/hyperv-daemons/hyperv-daemons.spec
+++ b/SPECS/hyperv-daemons/hyperv-daemons.spec
@@ -9,7 +9,7 @@
 Summary:        Hyper-V daemons suite
 Name:           hyperv-daemons
 Version:        5.10.52.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        GPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -28,6 +28,7 @@ Source102:      hypervvss.rules
 Source201:      hypervfcopyd.service
 Source202:      hypervfcopy.rules
 Patch0:         0001-Revert-scsi-sr-Return-appropriate-error-code-when-di.patch
+Patch1:         0001-clocksource-drivers-hyper-v-Re-enable-VDSO_CLOCKMODE.patch
 BuildRequires:  gcc
 Requires:       hypervfcopyd = %{version}-%{release}
 Requires:       hypervkvpd = %{version}-%{release}
@@ -106,6 +107,7 @@ Contains tools and scripts useful for Hyper-V guests.
 %prep
 %setup -q -n CBL-Mariner-Linux-Kernel-rolling-lts-mariner-%{version}
 %patch0 -p1
+%patch1 -p1
 
 %build
 pushd tools/hv
@@ -221,6 +223,9 @@ fi
 %{_sbindir}/lsvmbus
 
 %changelog
+* Tue Aug 03 2021 Chris Co <chrco@microsoft.com> - 5.10.52.1-3
+- Add patch to fix VDSO in HyperV
+
 * Fri Jul 30 2021 Chris Co <chrco@microsoft.com> - 5.10.52.1-2
 - Add patch to fix CDROM eject errors
 

--- a/SPECS/kernel-headers/0001-clocksource-drivers-hyper-v-Re-enable-VDSO_CLOCKMODE.patch
+++ b/SPECS/kernel-headers/0001-clocksource-drivers-hyper-v-Re-enable-VDSO_CLOCKMODE.patch
@@ -1,0 +1,63 @@
+From d1921ccf2f197a9e1699f2b35890f06dc4105500 Mon Sep 17 00:00:00 2001
+From: Vitaly Kuznetsov <vkuznets@redhat.com>
+Date: Thu, 13 May 2021 09:32:46 +0200
+Subject: [PATCH] clocksource/drivers/hyper-v: Re-enable VDSO_CLOCKMODE_HVCLOCK
+ on X86
+
+Mohammed reports (https://bugzilla.kernel.org/show_bug.cgi?id=213029)
+the commit e4ab4658f1cf ("clocksource/drivers/hyper-v: Handle vDSO
+differences inline") broke vDSO on x86. The problem appears to be that
+VDSO_CLOCKMODE_HVCLOCK is an enum value in 'enum vdso_clock_mode' and
+'#ifdef VDSO_CLOCKMODE_HVCLOCK' branch evaluates to false (it is not
+a define).
+
+Use a dedicated HAVE_VDSO_CLOCKMODE_HVCLOCK define instead.
+
+Fixes: e4ab4658f1cf ("clocksource/drivers/hyper-v: Handle vDSO differences inline")
+Reported-by: Mohammed Gamal <mgamal@redhat.com>
+Suggested-by: Thomas Gleixner <tglx@linutronix.de>
+Signed-off-by: Vitaly Kuznetsov <vkuznets@redhat.com>
+Signed-off-by: Thomas Gleixner <tglx@linutronix.de>
+Reviewed-by: Michael Kelley <mikelley@microsoft.com>
+Link: https://lore.kernel.org/r/20210513073246.1715070-1-vkuznets@redhat.com
+---
+ arch/x86/include/asm/vdso/clocksource.h | 2 ++
+ drivers/clocksource/hyperv_timer.c      | 4 ++--
+ 2 files changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/arch/x86/include/asm/vdso/clocksource.h b/arch/x86/include/asm/vdso/clocksource.h
+index 119ac8612d89..136e5e57cfe1 100644
+--- a/arch/x86/include/asm/vdso/clocksource.h
++++ b/arch/x86/include/asm/vdso/clocksource.h
+@@ -7,4 +7,6 @@
+ 	VDSO_CLOCKMODE_PVCLOCK,	\
+ 	VDSO_CLOCKMODE_HVCLOCK
+ 
++#define HAVE_VDSO_CLOCKMODE_HVCLOCK
++
+ #endif /* __ASM_VDSO_CLOCKSOURCE_H */
+diff --git a/drivers/clocksource/hyperv_timer.c b/drivers/clocksource/hyperv_timer.c
+index ba17faa92597..5d08f5f58a6b 100644
+--- a/drivers/clocksource/hyperv_timer.c
++++ b/drivers/clocksource/hyperv_timer.c
+@@ -419,7 +419,7 @@ static void resume_hv_clock_tsc(struct clocksource *arg)
+ 	hv_set_register(HV_REGISTER_REFERENCE_TSC, tsc_msr);
+ }
+ 
+-#ifdef VDSO_CLOCKMODE_HVCLOCK
++#ifdef HAVE_VDSO_CLOCKMODE_HVCLOCK
+ static int hv_cs_enable(struct clocksource *cs)
+ {
+ 	vclocks_set_used(VDSO_CLOCKMODE_HVCLOCK);
+@@ -435,7 +435,7 @@ static struct clocksource hyperv_cs_tsc = {
+ 	.flags	= CLOCK_SOURCE_IS_CONTINUOUS,
+ 	.suspend= suspend_hv_clock_tsc,
+ 	.resume	= resume_hv_clock_tsc,
+-#ifdef VDSO_CLOCKMODE_HVCLOCK
++#ifdef HAVE_VDSO_CLOCKMODE_HVCLOCK
+ 	.enable = hv_cs_enable,
+ 	.vdso_clock_mode = VDSO_CLOCKMODE_HVCLOCK,
+ #else
+-- 
+2.17.1
+

--- a/SPECS/kernel-headers/kernel-headers.spec
+++ b/SPECS/kernel-headers/kernel-headers.spec
@@ -1,7 +1,7 @@
 Summary:        Linux API header files
 Name:           kernel-headers
 Version:        5.10.52.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -10,6 +10,7 @@ URL:            https://github.com/microsoft/CBL-Mariner-Linux-Kernel
 #Source0:       https://github.com/microsoft/CBL-Mariner-Linux-Kernel/archive/rolling-lts/mariner/%%{version}.tar.gz
 Source0:        kernel-%{version}.tar.gz
 Patch0:         0001-Revert-scsi-sr-Return-appropriate-error-code-when-di.patch
+Patch1:         0001-clocksource-drivers-hyper-v-Re-enable-VDSO_CLOCKMODE.patch
 BuildArch:      noarch
 
 %description
@@ -18,6 +19,7 @@ The Linux API Headers expose the kernel's API for use by Glibc.
 %prep
 %setup -q -n CBL-Mariner-Linux-Kernel-rolling-lts-mariner-%{version}
 %patch0 -p1
+%patch1 -p1
 
 %build
 make mrproper
@@ -37,6 +39,9 @@ cp -rv usr/include/* /%{buildroot}%{_includedir}
 %{_includedir}/*
 
 %changelog
+* Tue Aug 03 2021 Chris Co <chrco@microsoft.com> - 5.10.52.1-3
+- Add patch to fix VDSO in HyperV
+
 * Fri Jul 30 2021 Chris Co <chrco@microsoft.com> - 5.10.52.1-2
 - Add patch to fix CDROM eject errors
 

--- a/SPECS/kernel-hyperv/0001-clocksource-drivers-hyper-v-Re-enable-VDSO_CLOCKMODE.patch
+++ b/SPECS/kernel-hyperv/0001-clocksource-drivers-hyper-v-Re-enable-VDSO_CLOCKMODE.patch
@@ -1,0 +1,63 @@
+From d1921ccf2f197a9e1699f2b35890f06dc4105500 Mon Sep 17 00:00:00 2001
+From: Vitaly Kuznetsov <vkuznets@redhat.com>
+Date: Thu, 13 May 2021 09:32:46 +0200
+Subject: [PATCH] clocksource/drivers/hyper-v: Re-enable VDSO_CLOCKMODE_HVCLOCK
+ on X86
+
+Mohammed reports (https://bugzilla.kernel.org/show_bug.cgi?id=213029)
+the commit e4ab4658f1cf ("clocksource/drivers/hyper-v: Handle vDSO
+differences inline") broke vDSO on x86. The problem appears to be that
+VDSO_CLOCKMODE_HVCLOCK is an enum value in 'enum vdso_clock_mode' and
+'#ifdef VDSO_CLOCKMODE_HVCLOCK' branch evaluates to false (it is not
+a define).
+
+Use a dedicated HAVE_VDSO_CLOCKMODE_HVCLOCK define instead.
+
+Fixes: e4ab4658f1cf ("clocksource/drivers/hyper-v: Handle vDSO differences inline")
+Reported-by: Mohammed Gamal <mgamal@redhat.com>
+Suggested-by: Thomas Gleixner <tglx@linutronix.de>
+Signed-off-by: Vitaly Kuznetsov <vkuznets@redhat.com>
+Signed-off-by: Thomas Gleixner <tglx@linutronix.de>
+Reviewed-by: Michael Kelley <mikelley@microsoft.com>
+Link: https://lore.kernel.org/r/20210513073246.1715070-1-vkuznets@redhat.com
+---
+ arch/x86/include/asm/vdso/clocksource.h | 2 ++
+ drivers/clocksource/hyperv_timer.c      | 4 ++--
+ 2 files changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/arch/x86/include/asm/vdso/clocksource.h b/arch/x86/include/asm/vdso/clocksource.h
+index 119ac8612d89..136e5e57cfe1 100644
+--- a/arch/x86/include/asm/vdso/clocksource.h
++++ b/arch/x86/include/asm/vdso/clocksource.h
+@@ -7,4 +7,6 @@
+ 	VDSO_CLOCKMODE_PVCLOCK,	\
+ 	VDSO_CLOCKMODE_HVCLOCK
+ 
++#define HAVE_VDSO_CLOCKMODE_HVCLOCK
++
+ #endif /* __ASM_VDSO_CLOCKSOURCE_H */
+diff --git a/drivers/clocksource/hyperv_timer.c b/drivers/clocksource/hyperv_timer.c
+index ba17faa92597..5d08f5f58a6b 100644
+--- a/drivers/clocksource/hyperv_timer.c
++++ b/drivers/clocksource/hyperv_timer.c
+@@ -419,7 +419,7 @@ static void resume_hv_clock_tsc(struct clocksource *arg)
+ 	hv_set_register(HV_REGISTER_REFERENCE_TSC, tsc_msr);
+ }
+ 
+-#ifdef VDSO_CLOCKMODE_HVCLOCK
++#ifdef HAVE_VDSO_CLOCKMODE_HVCLOCK
+ static int hv_cs_enable(struct clocksource *cs)
+ {
+ 	vclocks_set_used(VDSO_CLOCKMODE_HVCLOCK);
+@@ -435,7 +435,7 @@ static struct clocksource hyperv_cs_tsc = {
+ 	.flags	= CLOCK_SOURCE_IS_CONTINUOUS,
+ 	.suspend= suspend_hv_clock_tsc,
+ 	.resume	= resume_hv_clock_tsc,
+-#ifdef VDSO_CLOCKMODE_HVCLOCK
++#ifdef HAVE_VDSO_CLOCKMODE_HVCLOCK
+ 	.enable = hv_cs_enable,
+ 	.vdso_clock_mode = VDSO_CLOCKMODE_HVCLOCK,
+ #else
+-- 
+2.17.1
+

--- a/SPECS/kernel-hyperv/kernel-hyperv.spec
+++ b/SPECS/kernel-hyperv/kernel-hyperv.spec
@@ -4,7 +4,7 @@
 Summary:        Linux Kernel optimized for Hyper-V
 Name:           kernel-hyperv
 Version:        5.10.52.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -16,6 +16,7 @@ Source1:        config
 Source2:        sha512hmac-openssl.sh
 Source3:        cbl-mariner-ca-20210127.pem
 Patch0:         0001-Revert-scsi-sr-Return-appropriate-error-code-when-di.patch
+Patch1:         0001-clocksource-drivers-hyper-v-Re-enable-VDSO_CLOCKMODE.patch
 BuildRequires:  audit-devel
 BuildRequires:  bash
 BuildRequires:  bc
@@ -92,6 +93,7 @@ This package contains the 'perf' performance analysis tools for Linux kernel.
 %prep
 %setup -q -n CBL-Mariner-Linux-Kernel-rolling-lts-mariner-%{version}
 %patch0 -p1
+%patch1 -p1
 
 %build
 make mrproper
@@ -269,6 +271,9 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %{_libdir}/perf/include/bpf/*
 
 %changelog
+* Tue Aug 03 2021 Chris Co <chrco@microsoft.com> - 5.10.52.1-3
+- Add patch to fix VDSO in HyperV
+
 * Fri Jul 30 2021 Chris Co <chrco@microsoft.com> - 5.10.52.1-2
 - Add patch to fix CDROM eject errors
 

--- a/SPECS/kernel/0001-clocksource-drivers-hyper-v-Re-enable-VDSO_CLOCKMODE.patch
+++ b/SPECS/kernel/0001-clocksource-drivers-hyper-v-Re-enable-VDSO_CLOCKMODE.patch
@@ -1,0 +1,63 @@
+From d1921ccf2f197a9e1699f2b35890f06dc4105500 Mon Sep 17 00:00:00 2001
+From: Vitaly Kuznetsov <vkuznets@redhat.com>
+Date: Thu, 13 May 2021 09:32:46 +0200
+Subject: [PATCH] clocksource/drivers/hyper-v: Re-enable VDSO_CLOCKMODE_HVCLOCK
+ on X86
+
+Mohammed reports (https://bugzilla.kernel.org/show_bug.cgi?id=213029)
+the commit e4ab4658f1cf ("clocksource/drivers/hyper-v: Handle vDSO
+differences inline") broke vDSO on x86. The problem appears to be that
+VDSO_CLOCKMODE_HVCLOCK is an enum value in 'enum vdso_clock_mode' and
+'#ifdef VDSO_CLOCKMODE_HVCLOCK' branch evaluates to false (it is not
+a define).
+
+Use a dedicated HAVE_VDSO_CLOCKMODE_HVCLOCK define instead.
+
+Fixes: e4ab4658f1cf ("clocksource/drivers/hyper-v: Handle vDSO differences inline")
+Reported-by: Mohammed Gamal <mgamal@redhat.com>
+Suggested-by: Thomas Gleixner <tglx@linutronix.de>
+Signed-off-by: Vitaly Kuznetsov <vkuznets@redhat.com>
+Signed-off-by: Thomas Gleixner <tglx@linutronix.de>
+Reviewed-by: Michael Kelley <mikelley@microsoft.com>
+Link: https://lore.kernel.org/r/20210513073246.1715070-1-vkuznets@redhat.com
+---
+ arch/x86/include/asm/vdso/clocksource.h | 2 ++
+ drivers/clocksource/hyperv_timer.c      | 4 ++--
+ 2 files changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/arch/x86/include/asm/vdso/clocksource.h b/arch/x86/include/asm/vdso/clocksource.h
+index 119ac8612d89..136e5e57cfe1 100644
+--- a/arch/x86/include/asm/vdso/clocksource.h
++++ b/arch/x86/include/asm/vdso/clocksource.h
+@@ -7,4 +7,6 @@
+ 	VDSO_CLOCKMODE_PVCLOCK,	\
+ 	VDSO_CLOCKMODE_HVCLOCK
+ 
++#define HAVE_VDSO_CLOCKMODE_HVCLOCK
++
+ #endif /* __ASM_VDSO_CLOCKSOURCE_H */
+diff --git a/drivers/clocksource/hyperv_timer.c b/drivers/clocksource/hyperv_timer.c
+index ba17faa92597..5d08f5f58a6b 100644
+--- a/drivers/clocksource/hyperv_timer.c
++++ b/drivers/clocksource/hyperv_timer.c
+@@ -419,7 +419,7 @@ static void resume_hv_clock_tsc(struct clocksource *arg)
+ 	hv_set_register(HV_REGISTER_REFERENCE_TSC, tsc_msr);
+ }
+ 
+-#ifdef VDSO_CLOCKMODE_HVCLOCK
++#ifdef HAVE_VDSO_CLOCKMODE_HVCLOCK
+ static int hv_cs_enable(struct clocksource *cs)
+ {
+ 	vclocks_set_used(VDSO_CLOCKMODE_HVCLOCK);
+@@ -435,7 +435,7 @@ static struct clocksource hyperv_cs_tsc = {
+ 	.flags	= CLOCK_SOURCE_IS_CONTINUOUS,
+ 	.suspend= suspend_hv_clock_tsc,
+ 	.resume	= resume_hv_clock_tsc,
+-#ifdef VDSO_CLOCKMODE_HVCLOCK
++#ifdef HAVE_VDSO_CLOCKMODE_HVCLOCK
+ 	.enable = hv_cs_enable,
+ 	.vdso_clock_mode = VDSO_CLOCKMODE_HVCLOCK,
+ #else
+-- 
+2.17.1
+

--- a/SPECS/kernel/kernel.spec
+++ b/SPECS/kernel/kernel.spec
@@ -4,7 +4,7 @@
 Summary:        Linux Kernel
 Name:           kernel
 Version:        5.10.52.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -17,6 +17,7 @@ Source2:        config_aarch64
 Source3:        sha512hmac-openssl.sh
 Source4:        cbl-mariner-ca-20210127.pem
 Patch0:         0001-Revert-scsi-sr-Return-appropriate-error-code-when-di.patch
+Patch1:         0001-clocksource-drivers-hyper-v-Re-enable-VDSO_CLOCKMODE.patch
 # Kernel CVEs are addressed by moving to a newer version of the stable kernel.
 # Since kernel CVEs are filed against the upstream kernel version and not the
 # stable kernel version, our automated tooling will still flag the CVE as not
@@ -281,6 +282,7 @@ This package contains common device tree blobs (dtb)
 %prep
 %setup -q -n CBL-Mariner-Linux-Kernel-rolling-lts-mariner-%{version}
 %patch0 -p1
+%patch1 -p1
 
 %build
 make mrproper
@@ -511,6 +513,9 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %endif
 
 %changelog
+* Tue Aug 03 2021 Chris Co <chrco@microsoft.com> - 5.10.52.1-3
+- Add patch to fix VDSO in HyperV
+
 * Fri Jul 30 2021 Chris Co <chrco@microsoft.com> - 5.10.52.1-2
 - Add patch to fix CDROM eject errors
 

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -1,5 +1,5 @@
 filesystem-1.1-7.cm1.aarch64.rpm
-kernel-headers-5.10.52.1-2.cm1.noarch.rpm
+kernel-headers-5.10.52.1-3.cm1.noarch.rpm
 glibc-2.28-19.cm1.aarch64.rpm
 glibc-devel-2.28-19.cm1.aarch64.rpm
 glibc-i18n-2.28-19.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -1,5 +1,5 @@
 filesystem-1.1-7.cm1.x86_64.rpm
-kernel-headers-5.10.52.1-2.cm1.noarch.rpm
+kernel-headers-5.10.52.1-3.cm1.noarch.rpm
 glibc-2.28-19.cm1.x86_64.rpm
 glibc-devel-2.28-19.cm1.x86_64.rpm
 glibc-i18n-2.28-19.cm1.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -158,7 +158,7 @@ json-c-debuginfo-0.14-3.cm1.aarch64.rpm
 json-c-devel-0.14-3.cm1.aarch64.rpm
 kbd-2.0.4-5.cm1.aarch64.rpm
 kbd-debuginfo-2.0.4-5.cm1.aarch64.rpm
-kernel-headers-5.10.52.1-2.cm1.noarch.rpm
+kernel-headers-5.10.52.1-3.cm1.noarch.rpm
 kmod-25-4.cm1.aarch64.rpm
 kmod-debuginfo-25-4.cm1.aarch64.rpm
 kmod-devel-25-4.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -158,7 +158,7 @@ json-c-debuginfo-0.14-3.cm1.x86_64.rpm
 json-c-devel-0.14-3.cm1.x86_64.rpm
 kbd-2.0.4-5.cm1.x86_64.rpm
 kbd-debuginfo-2.0.4-5.cm1.x86_64.rpm
-kernel-headers-5.10.52.1-2.cm1.noarch.rpm
+kernel-headers-5.10.52.1-3.cm1.noarch.rpm
 kmod-25-4.cm1.x86_64.rpm
 kmod-debuginfo-25-4.cm1.x86_64.rpm
 kmod-devel-25-4.cm1.x86_64.rpm


### PR DESCRIPTION
Our validation found that clock_gettime(CONFIG_REALTIME, &start) was
taking orders of magnitude longer to complete than before. This was due
to the following upstream commit e4ab4658f1cf which, while not
backported to the LTS stable trees, was backported into our specific
kernel source as part of our ARM64 support.

This change applies the upstream commit 3486d2c9be65 which fixes the
VDSO regression.

cherry-pick of 9cb978e0a4f3340bbc83073279028e7238b3fbf0 to 1.0

Signed-off-by: Chris Co <chrco@microsoft.com>