### PR TITLE
[dev] Use GitHub source tarball for swig

### DIFF
--- a/SPECS/swig/swig.signatures.json
+++ b/SPECS/swig/swig.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "swig-4.0.2.tar.gz": "d53be9730d8d58a16bf0cbd1f8ac0c0c3e1090573168bfa151b01eb47fa906fc"
+  "swig-4.0.2.tar.gz": "b5f43d5f94c57ede694ffe5e805acc5a3a412387d7f97dcf290d06c46335cb0b"
  }
 }

--- a/SPECS/swig/swig.spec
+++ b/SPECS/swig/swig.spec
@@ -1,12 +1,13 @@
 Summary:        Connects C/C++/Objective C to some high-level programming languages
 Name:           swig
 Version:        4.0.2
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv3+ AND BSD
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 URL:            https://swig.sourceforge.net/
-Source0:        https://downloads.sourceforge.net/project/swig/swig/swig-%{version}/swig-%{version}.tar.gz
+#Source0:       https://github.com/swig/swig/archive/refs/tags/v%{version}.tar.gz
+Source0:        %{name}-%{version}.tar.gz
 BuildRequires:  pcre-devel
 Requires:       pcre
 
@@ -20,29 +21,28 @@ interpreted programming environments, systems integration, and as a
 tool for building user interfaces
 
 %prep
-%setup -q -n swig-%{version}
+%autosetup
 
 %build
 ./autogen.sh
 
 %configure \
-	--without-ocaml \
- 	--without-java \
- 	--without-r \
- 	--without-go
+    --without-ocaml \
+    --without-java \
+    --without-r \
+    --without-go
 
-make %{?_smp_mflags}
+%make_build
 
 %install
-
-make DESTDIR=%{buildroot} install
+%make_install
 
 # Enable ccache-swig by default, if ccache is installed.
 mkdir -p %{buildroot}%{_libdir}/ccache
 ln -fs ../../bin/ccache-swig %{buildroot}%{_libdir}/ccache/swig
 
 %check
-make %{?_smp_mflags} check
+%make_build check
 
 %files
 %license LICENSE LICENSE-GPL LICENSE-UNIVERSITIES
@@ -51,31 +51,35 @@ make %{?_smp_mflags} check
 %{_libdir}/ccache
 
 %changelog
+* Thu Aug 05 2021 Thomas Crain <thcrain@microsoft.com> - 4.0.2-2
+- Switch source URL to GitHub version
+- Lint spec
+
 * Mon Mar 15 2021 Henry Li <lihl@microsoft.com> - 4.0.2-1
 - Upgrade to version 4.0.2. License Verified.
 - Correct licensing.
 - Remove sha1 define
 
-* Sat May 09 00:21:36 PST 2020 Nick Samson <nisamson@microsoft.com> - 3.0.12-4
+* Sat May 09 2020 Nick Samson <nisamson@microsoft.com> - 3.0.12-4
 - Added %%license line automatically
 
-*   Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 3.0.12-3
--   Initial CBL-Mariner import from Photon (license: Apache2).
+* Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 3.0.12-3
+- Initial CBL-Mariner import from Photon (license: Apache2).
 
-*       Tue May 02 2017 Vinay Kulkarni <kulkarniv@vmware.com> 3.0.12-2
--       Correct the license.
+* Tue May 02 2017 Vinay Kulkarni <kulkarniv@vmware.com> 3.0.12-2
+- Correct the license.
 
-*       Wed Apr 12 2017 Vinay Kulkarni <kulkarniv@vmware.com> 3.0.12-1
--       Update to version 3.0.12
+* Wed Apr 12 2017 Vinay Kulkarni <kulkarniv@vmware.com> 3.0.12-1
+- Update to version 3.0.12
 
-*       Tue Oct 04 2016 ChangLee <changlee@vmware.com> 3.0.8-3
--       Modified %check
+* Tue Oct 04 2016 ChangLee <changlee@vmware.com> 3.0.8-3
+- Modified %check
 
-*	Tue May 24 2016 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 3.0.8-2
--	GA - Bump release of all rpms
+* Tue May 24 2016 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 3.0.8-2
+- GA - Bump release of all rpms
 
-* 	Tue Feb 23 2016 Anish Swaminathan <anishs@vmware.com>  3.0.8-1
-- 	Upgrade to 3.0.8
+* Tue Feb 23 2016 Anish Swaminathan <anishs@vmware.com>  3.0.8-1
+- Upgrade to 3.0.8
 
-* 	Thu Feb 26 2015 Divya Thaluru <dthaluru@vmware.com> 3.0.5-1
-- 	Initial version
+* Thu Feb 26 2015 Divya Thaluru <dthaluru@vmware.com> 3.0.5-1
+- Initial version

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -7516,18 +7516,8 @@
         "type": "other",
         "other": {
           "name": "swig",
-          "version": "3.0.12",
-          "downloadUrl": "http://downloads.sourceforge.net/project/swig/swig/swig-3.0.12/swig-3.0.12.tar.gz"
-        }
-      }
-    },
-    {
-      "component": {
-        "type": "other",
-        "other": {
-          "name": "swig",
           "version": "4.0.2",
-          "downloadUrl": "https://downloads.sourceforge.net/project/swig/swig/swig-4.0.2/swig-4.0.2.tar.gz"
+          "downloadUrl": "https://github.com/swig/swig/archive/refs/tags/v4.0.2.tar.gz"
         }
       }
     },

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -557,8 +557,8 @@ sqlite-3.34.1-1.cm2.aarch64.rpm
 sqlite-debuginfo-3.34.1-1.cm2.aarch64.rpm
 sqlite-devel-3.34.1-1.cm2.aarch64.rpm
 sqlite-libs-3.34.1-1.cm2.aarch64.rpm
-swig-4.0.2-1.cm2.aarch64.rpm
-swig-debuginfo-4.0.2-1.cm2.aarch64.rpm
+swig-4.0.2-2.cm2.aarch64.rpm
+swig-debuginfo-4.0.2-2.cm2.aarch64.rpm
 systemd-239-40.cm2.aarch64.rpm
 systemd-bootstrap-239-34.cm2.aarch64.rpm
 systemd-bootstrap-debuginfo-239-34.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -557,8 +557,8 @@ sqlite-3.34.1-1.cm2.x86_64.rpm
 sqlite-debuginfo-3.34.1-1.cm2.x86_64.rpm
 sqlite-devel-3.34.1-1.cm2.x86_64.rpm
 sqlite-libs-3.34.1-1.cm2.x86_64.rpm
-swig-4.0.2-1.cm2.x86_64.rpm
-swig-debuginfo-4.0.2-1.cm2.x86_64.rpm
+swig-4.0.2-2.cm2.x86_64.rpm
+swig-debuginfo-4.0.2-2.cm2.x86_64.rpm
 systemd-239-40.cm2.x86_64.rpm
 systemd-bootstrap-239-34.cm2.x86_64.rpm
 systemd-bootstrap-debuginfo-239-34.cm2.x86_64.rpm


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Align the source used in the 2.0 version of `swig` with the source used by the `1.0` branch. 

PR #1236 upgraded the version of swig used by the 1.0 branch to match the version shipped by the dev branch. That PR included a switch to a GitHub-based tarball, which has the same name as the SourceForge-based tarball used in the dev branch. This actually led to the SourceForge-based tarball being overwritten on our source server. Now, this branch's build fails due to a mismatch between the tarballs' checksums. 

For simplicity, we'll just use the GitHub source URL in the dev branch as well. 

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Use GitHub source URL for `swig`
- Lint `swig` spec
- Remove entry for old `swig` version in `cgmanifest.json`

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local toolchain build
