### PR TITLE
[ISO] Fix display update issues in ManualPartitionWidget

### DIFF
--- a/toolkit/tools/imagegen/attendedinstaller/views/diskview/manualpartitionwidget/manualpartitionwidget.go
+++ b/toolkit/tools/imagegen/attendedinstaller/views/diskview/manualpartitionwidget/manualpartitionwidget.go
@@ -310,9 +310,14 @@ func (mp *ManualPartitionWidget) Primitive() tview.Primitive {
 	return mp.pages
 }
 
-// SetSystemDeviceIndex updates the system device used
+// SetSystemDeviceIndex updates the system device used.
+// Panics if the space label cannot be updated.
 func (mp *ManualPartitionWidget) SetSystemDeviceIndex(index int) {
 	mp.deviceIndex = index
+
+	err := mp.updateSpaceLabel()
+	logger.PanicOnError(err, "Failed to update space label")
+
 	mp.flex.SetTitle(fmt.Sprintf(uitext.DiskAdvanceTitleFmt, mp.systemDevices[mp.deviceIndex].DevicePath))
 }
 

--- a/toolkit/tools/imagegen/attendedinstaller/views/diskview/manualpartitionwidget/manualpartitionwidget.go
+++ b/toolkit/tools/imagegen/attendedinstaller/views/diskview/manualpartitionwidget/manualpartitionwidget.go
@@ -255,6 +255,7 @@ func (mp *ManualPartitionWidget) HandleInput(event *tcell.EventKey) *tcell.Event
 			return tcell.NewEventKey(tcell.KeyTab, 0, tcell.ModNone)
 		case tcell.KeyEsc:
 			mp.pages.HidePage(addPartitionPage)
+			mp.refreshTitle()
 		}
 	} else {
 		// The front page is the partition table


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Fixes two bugs in the ManualPartitionWidget section of the ISO installer. 

The first bug concerns a disk size associated with the wrong disk showing up in the "space left" display field. This was due to a missing display update call when changing the selected disk.

The second bug concerns the incorrect title being shown on the partition table screen when navigating back from the partition addition page.. This was due to a missing title refresh call when processing escape key input in the partition addition page.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Refresh the title of the ManualPartitionWidget when using the escape key to go from the partition addition page to the partition table page.
- Update the "space left" field when changing ManualPartitionWidget's selected disk.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Validated UI changes on a local test setup
