### PR TITLE
Fix dbus-python build issue

### DIFF
--- a/SPECS/dbus-python/dbus-python.spec
+++ b/SPECS/dbus-python/dbus-python.spec
@@ -4,7 +4,7 @@
 Summary:        D-Bus Python Bindings
 Name:           dbus-python
 Version:        1.2.16
-Release:        6%{?dist}
+Release:        7%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -15,9 +15,9 @@ Source0:        http://dbus.freedesktop.org/releases/dbus-python/%{name}-%{versi
 Patch0: 0001-Move-python-modules-to-architecture-specific-directo.patch
 
 BuildRequires: gnupg2
-BuildRequires: glib-devel>=2.42.2
-BuildRequires: dbus>=1.8.6
-BuildRequires: dbus-devel>=1.8.6
+BuildRequires: glib-devel >= 2.42.2
+BuildRequires: dbus >= 1.8.6
+BuildRequires: dbus-devel >= 1.8.6
 %if %{with_check}
 BuildRequires: python3-pip
 %endif
@@ -73,6 +73,9 @@ make check -k || (cat test-suite.log && false)
 %exclude %{_libdir}/python3.7/site-packages/*.la
 
 %changelog
+* Tue Aug 10 2021 Andrew Phelps <anphel@microsoft.com> - 1.2.16-7
+- Add required spaces between BuildRequires version qualifiers.
+
 * Fri Jul 30 2021 Neha Agarwal <nehaagarwal@microsoft.com> - 1.2.16-6
 - Initial CBL-Mariner import from Fedora 34 (license: MIT). License verified.
 - Removed GPG signature, pkgconfig for BuildRequires


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Fix the follow build break from the dbus-python package by adding space between the package name and version number

ERRO[0010] Failed to clone dbus>=1.8.6(,):<ID:6546 Type:Remote State:Unresolved> from '<NO_SRPM_PATH>' in '<NO_REPO>' from RPM repo. Error: No package dbus>=1.8.6 available

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change dbus-python build requires

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local package build
