### PR TITLE
Fixing CVE-2021-32066 in `ruby`

### DIFF
--- a/SPECS/ruby/CVE-2021-32066.patch
+++ b/SPECS/ruby/CVE-2021-32066.patch
@@ -13,10 +13,10 @@ Co-authored-by: Shugo Maeda <shugo@ruby-lang.org>
  3 files changed, 39 insertions(+), 2 deletions(-)
 
 diff --git a/lib/net/imap.rb b/lib/net/imap.rb
-index 720acbc86d0b4..94ef78198f6db 100644
+index 1c7e89b..91df89b 100644
 --- a/lib/net/imap.rb
 +++ b/lib/net/imap.rb
-@@ -1216,12 +1216,14 @@ def get_tagged_response(tag, cmd)
+@@ -1215,12 +1215,14 @@ module Net
        end
        resp = @tagged_responses.delete(tag)
        case resp.name
@@ -32,7 +32,7 @@ index 720acbc86d0b4..94ef78198f6db 100644
        end
      end
  
-@@ -3717,6 +3719,10 @@ class BadResponseError < ResponseError
+@@ -3716,6 +3718,10 @@ module Net
      class ByeResponseError < ResponseError
      end
  
@@ -44,10 +44,10 @@ index 720acbc86d0b4..94ef78198f6db 100644
      RESPONSE_ERRORS["NO"] = NoResponseError
      RESPONSE_ERRORS["BAD"] = BadResponseError
 diff --git a/test/net/imap/test_imap.rb b/test/net/imap/test_imap.rb
-index 33b305e116591..0ce0eb67bae3e 100644
+index 936f4e0..217b611 100644
 --- a/test/net/imap/test_imap.rb
 +++ b/test/net/imap/test_imap.rb
-@@ -127,6 +127,16 @@ def test_starttls
+@@ -127,6 +127,16 @@ class IMAPTest < Test::Unit::TestCase
          imap.disconnect
        end
      end
@@ -63,8 +63,8 @@ index 33b305e116591..0ce0eb67bae3e 100644
 +    end
    end
  
-   def start_server
-@@ -784,6 +794,27 @@ def starttls_test
+   def test_unexpected_eof
+@@ -762,6 +772,27 @@ EOF
      end
    end
  
@@ -93,16 +93,16 @@ index 33b305e116591..0ce0eb67bae3e 100644
      return TCPServer.new(server_addr, 0)
    end
 diff --git a/version.h b/version.h
-index f41251e06e6b5..959011c7ac2c6 100644
+index 1c491eb..2f4fcdf 100644
 --- a/version.h
 +++ b/version.h
-@@ -2,7 +2,7 @@
- # define RUBY_VERSION_MINOR RUBY_API_VERSION_MINOR
- #define RUBY_VERSION_TEENY 4
- #define RUBY_RELEASE_DATE RUBY_RELEASE_YEAR_STR"-"RUBY_RELEASE_MONTH_STR"-"RUBY_RELEASE_DAY_STR
--#define RUBY_PATCHLEVEL 190
-+#define RUBY_PATCHLEVEL 191
+@@ -1,6 +1,6 @@
+ #define RUBY_VERSION "2.6.7"
+ #define RUBY_RELEASE_DATE "2021-04-05"
+-#define RUBY_PATCHLEVEL 197
++#define RUBY_PATCHLEVEL 198
  
  #define RUBY_RELEASE_YEAR 2021
- #define RUBY_RELEASE_MONTH 7
- 
+ #define RUBY_RELEASE_MONTH 4
+-- 
+2.17.1

--- a/SPECS/ruby/CVE-2021-32066.patch
+++ b/SPECS/ruby/CVE-2021-32066.patch
@@ -1,0 +1,108 @@
+From a21a3b7d23704a01d34bd79d09dc37897e00922a Mon Sep 17 00:00:00 2001
+From: Yusuke Endoh <mame@ruby-lang.org>
+Date: Wed, 7 Jul 2021 12:06:44 +0900
+Subject: [PATCH] Fix StartTLS stripping vulnerability
+
+Reported by Alexandr Savca in https://hackerone.com/reports/1178562
+
+Co-authored-by: Shugo Maeda <shugo@ruby-lang.org>
+---
+ lib/net/imap.rb            |  8 +++++++-
+ test/net/imap/test_imap.rb | 31 +++++++++++++++++++++++++++++++
+ version.h                  |  2 +-
+ 3 files changed, 39 insertions(+), 2 deletions(-)
+
+diff --git a/lib/net/imap.rb b/lib/net/imap.rb
+index 720acbc86d0b4..94ef78198f6db 100644
+--- a/lib/net/imap.rb
++++ b/lib/net/imap.rb
+@@ -1216,12 +1216,14 @@ def get_tagged_response(tag, cmd)
+       end
+       resp = @tagged_responses.delete(tag)
+       case resp.name
++      when /\A(?:OK)\z/ni
++        return resp
+       when /\A(?:NO)\z/ni
+         raise NoResponseError, resp
+       when /\A(?:BAD)\z/ni
+         raise BadResponseError, resp
+       else
+-        return resp
++        raise UnknownResponseError, resp
+       end
+     end
+ 
+@@ -3717,6 +3719,10 @@ class BadResponseError < ResponseError
+     class ByeResponseError < ResponseError
+     end
+ 
++    # Error raised upon an unknown response from the server.
++    class UnknownResponseError < ResponseError
++    end
++
+     RESPONSE_ERRORS = Hash.new(ResponseError)
+     RESPONSE_ERRORS["NO"] = NoResponseError
+     RESPONSE_ERRORS["BAD"] = BadResponseError
+diff --git a/test/net/imap/test_imap.rb b/test/net/imap/test_imap.rb
+index 33b305e116591..0ce0eb67bae3e 100644
+--- a/test/net/imap/test_imap.rb
++++ b/test/net/imap/test_imap.rb
+@@ -127,6 +127,16 @@ def test_starttls
+         imap.disconnect
+       end
+     end
++
++    def test_starttls_stripping
++      starttls_stripping_test do |port|
++        imap = Net::IMAP.new("localhost", :port => port)
++        assert_raise(Net::IMAP::UnknownResponseError) do
++          imap.starttls(:ca_file => CA_FILE)
++        end
++        imap
++      end
++    end
+   end
+ 
+   def start_server
+@@ -784,6 +794,27 @@ def starttls_test
+     end
+   end
+ 
++  def starttls_stripping_test
++    server = create_tcp_server
++    port = server.addr[1]
++    start_server do
++      sock = server.accept
++      begin
++        sock.print("* OK test server\r\n")
++        sock.gets
++        sock.print("RUBY0001 BUG unhandled command\r\n")
++      ensure
++        sock.close
++        server.close
++      end
++    end
++    begin
++      imap = yield(port)
++    ensure
++      imap.disconnect if imap && !imap.disconnected?
++    end
++  end
++
+   def create_tcp_server
+     return TCPServer.new(server_addr, 0)
+   end
+diff --git a/version.h b/version.h
+index f41251e06e6b5..959011c7ac2c6 100644
+--- a/version.h
++++ b/version.h
+@@ -2,7 +2,7 @@
+ # define RUBY_VERSION_MINOR RUBY_API_VERSION_MINOR
+ #define RUBY_VERSION_TEENY 4
+ #define RUBY_RELEASE_DATE RUBY_RELEASE_YEAR_STR"-"RUBY_RELEASE_MONTH_STR"-"RUBY_RELEASE_DAY_STR
+-#define RUBY_PATCHLEVEL 190
++#define RUBY_PATCHLEVEL 191
+ 
+ #define RUBY_RELEASE_YEAR 2021
+ #define RUBY_RELEASE_MONTH 7
+ 

--- a/SPECS/ruby/ruby.spec
+++ b/SPECS/ruby/ruby.spec
@@ -1,13 +1,14 @@
 Summary:        Ruby
 Name:           ruby
 Version:        2.6.7
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        (Ruby OR BSD) AND Public Domain AND MIT AND CC0 AND zlib AND UCD
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Group:          System Environment/Security
 URL:            https://www.ruby-lang.org/en/
 Source0:        https://cache.ruby-lang.org/pub/ruby/2.6/%{name}-%{version}.tar.xz
+Patch0:         CVE-2021-32066.patch
 BuildRequires:  openssl-devel
 BuildRequires:  readline
 BuildRequires:  readline-devel
@@ -61,6 +62,9 @@ sudo -u test make test TESTS="-v"
 %{_mandir}/man5/*
 
 %changelog
+* Wed Aug 11 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 2.6.7-2
+- Patching CVE-2021-32066.
+
 * Mon May 03 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 2.6.7-1
 - Updating to version 2.6.7 to fix CVE-2021-28965.
 - Updated the "%%files" section to display shared lib's version.


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

Adding a patch to fix CVE-2021-32066 in `ruby`.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Patched CVE-2021-32066 in `ruby`.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2021-32066

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local package build with `RUN_CHECK=y`. All tests passed.
