### PR TITLE
srpmpacker: Change warning to error when duplicate source files detected

### DIFF
--- a/toolkit/tools/srpmpacker/srpmpacker.go
+++ b/toolkit/tools/srpmpacker/srpmpacker.go
@@ -627,8 +627,8 @@ func hydrateFromLocalSource(fileHydrationState map[string]bool, newSourceDir str
 		}
 
 		if isHydrated {
-			logger.Log.Warnf("Duplicate matching file found at (%s), skipping", path)
-			return nil
+			err = fmt.Errorf("Unable to process duplicate matching file (%s)", path)
+			return err
 		}
 
 		if !skipSignatureHandling {


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?

When duplicate filenames are included as sources for a SPEC file, the srpmpacker tool, which does not support this, was producing a warning message:
"WARN[0000] Duplicate matching file found at (/data2/vsts/_work/16/s/SPECS/foo/SOURCES/src/CMakeLists.txt), skipping"

Instead of silently proceeding with source files that are not hash verified, this PR changes to an error that will stop the build, and require the duplicate file to be removed/renamed.
"WARN[0008] Error hydrating from local source directory (/data2/vsts/_work/16/s/SPECS/foo): Unable to process duplicate matching file (/data2/vsts/_work/16/s/SPECS/foo/SOURCES/src/CMakeLists.txt) "

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change srpmpacker warning to error

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local toolkit rebuild
sudo make go-tools REBUILD_TOOLS=y
- Local package build
time sudo make build-packages PACKAGE_BUILD_LIST="foo" PACKAGE_REBUILD_LIST="foo" REBUILD_TOOLS=y SOURCE_URL=https://cblmarinerstorage.blob.core.windows.net/sources/core REBUILD_DEP_CHAINS=n CONFIG_FILE= RUN_CHECK=n PACKAGE_IGNORE_LIST="gcc openjdk8"
