### PR TITLE
kernel: Update to 5.10.57.1 (#1279)

### DIFF
--- a/SPECS-SIGNED/kernel-signed/kernel-signed.spec
+++ b/SPECS-SIGNED/kernel-signed/kernel-signed.spec
@@ -9,8 +9,8 @@
 %define uname_r %{version}-%{release}
 Summary:        Signed Linux Kernel for %{buildarch} systems
 Name:           kernel-signed-%{buildarch}
-Version:        5.10.52.1
-Release:        3%{?dist}
+Version:        5.10.57.1
+Release:        1%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -146,6 +146,9 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %endif
 
 %changelog
+* Thu Aug 12 2021 Rachel Menge <rachelmenge@microsoft.com> - 5.10.57.1-1
+- Update source to 5.10.57.1
+
 * Tue Aug 03 2021 Chris Co <chrco@microsoft.com> - 5.10.52.1-3
 - Bump release number to match kernel release
 

--- a/SPECS/hyperv-daemons/hyperv-daemons.signatures.json
+++ b/SPECS/hyperv-daemons/hyperv-daemons.signatures.json
@@ -7,6 +7,6 @@
   "hypervkvpd.service": "25339871302f7a47e1aecfa9fc2586c78bc37edb98773752f0a5dec30f0ed3a1",
   "hypervvss.rules": "94cead44245ef6553ab79c0bbac8419e3ff4b241f01bcec66e6f508098cbedd1",
   "hypervvssd.service": "22270d9f0f23af4ea7905f19c1d5d5495e40c1f782cbb87a99f8aec5a011078d",
-  "kernel-5.10.52.1.tar.gz": "7fd3e7779e20f6ec6ddaa8c4b78a713a15b13860730e5b7e624ae27b304363b3"
+  "kernel-5.10.57.1.tar.gz": "51dbaa5781b36bfc53e2054bb54631d4c50946bea0de27a9bbf2c8f45ba37eb3"
  }
 }

--- a/SPECS/hyperv-daemons/hyperv-daemons.spec
+++ b/SPECS/hyperv-daemons/hyperv-daemons.spec
@@ -8,8 +8,8 @@
 %global udev_prefix 70
 Summary:        Hyper-V daemons suite
 Name:           hyperv-daemons
-Version:        5.10.52.1
-Release:        3%{?dist}
+Version:        5.10.57.1
+Release:        1%{?dist}
 License:        GPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -223,6 +223,9 @@ fi
 %{_sbindir}/lsvmbus
 
 %changelog
+* Thu Aug 12 2021 Rachel Menge <rachelmenge@microsoft.com> - 5.10.57.1-1
+- Update source to 5.10.57.1
+
 * Tue Aug 03 2021 Chris Co <chrco@microsoft.com> - 5.10.52.1-3
 - Add patch to fix VDSO in HyperV
 

--- a/SPECS/kernel-headers/kernel-headers.signatures.json
+++ b/SPECS/kernel-headers/kernel-headers.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "kernel-5.10.52.1.tar.gz": "7fd3e7779e20f6ec6ddaa8c4b78a713a15b13860730e5b7e624ae27b304363b3"
+  "kernel-5.10.57.1.tar.gz": "51dbaa5781b36bfc53e2054bb54631d4c50946bea0de27a9bbf2c8f45ba37eb3"
  }
 }

--- a/SPECS/kernel-headers/kernel-headers.spec
+++ b/SPECS/kernel-headers/kernel-headers.spec
@@ -1,7 +1,7 @@
 Summary:        Linux API header files
 Name:           kernel-headers
-Version:        5.10.52.1
-Release:        3%{?dist}
+Version:        5.10.57.1
+Release:        1%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -39,6 +39,9 @@ cp -rv usr/include/* /%{buildroot}%{_includedir}
 %{_includedir}/*
 
 %changelog
+* Thu Aug 12 2021 Rachel Menge <rachelmenge@microsoft.com> - 5.10.57.1-1
+- Update source to 5.10.57.1
+
 * Tue Aug 03 2021 Chris Co <chrco@microsoft.com> - 5.10.52.1-3
 - Add patch to fix VDSO in HyperV
 

--- a/SPECS/kernel-hyperv/config
+++ b/SPECS/kernel-hyperv/config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86_64 5.10.52.1 Kernel Configuration
+# Linux/x86_64 5.10.57.1 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (GCC) 9.1.0"
 CONFIG_CC_IS_GCC=y

--- a/SPECS/kernel-hyperv/kernel-hyperv.signatures.json
+++ b/SPECS/kernel-hyperv/kernel-hyperv.signatures.json
@@ -1,8 +1,8 @@
 {
  "Signatures": {
   "cbl-mariner-ca-20210127.pem": "82363cb44e786353936abc2e2d62d9325cacf2d9e9a8ebaf4221ea30a9e0cd7b",
-  "config": "8ca79d2ce0e8d2555caabe8a92c56d97578e5b9c7a2843a933b5239df09ff206",
-  "kernel-5.10.52.1.tar.gz": "7fd3e7779e20f6ec6ddaa8c4b78a713a15b13860730e5b7e624ae27b304363b3",
+  "config": "c0fca8aa92b4663f96d2f04d418791c7a75e4b2b9f875bbc67c69baf14449248",
+  "kernel-5.10.57.1.tar.gz": "51dbaa5781b36bfc53e2054bb54631d4c50946bea0de27a9bbf2c8f45ba37eb3",
   "sha512hmac-openssl.sh": "02ab91329c4be09ee66d759e4d23ac875037c3b56e5a598e32fd1206da06a27f"
  }
 }

--- a/SPECS/kernel-hyperv/kernel-hyperv.spec
+++ b/SPECS/kernel-hyperv/kernel-hyperv.spec
@@ -3,8 +3,8 @@
 %define uname_r %{version}-%{release}
 Summary:        Linux Kernel optimized for Hyper-V
 Name:           kernel-hyperv
-Version:        5.10.52.1
-Release:        3%{?dist}
+Version:        5.10.57.1
+Release:        1%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -271,6 +271,9 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %{_libdir}/perf/include/bpf/*
 
 %changelog
+* Thu Aug 12 2021 Rachel Menge <rachelmenge@microsoft.com> - 5.10.57.1-1
+- Update source to 5.10.57.1
+
 * Tue Aug 03 2021 Chris Co <chrco@microsoft.com> - 5.10.52.1-3
 - Add patch to fix VDSO in HyperV
 

--- a/SPECS/kernel/CVE-2020-25639.nopatch
+++ b/SPECS/kernel/CVE-2020-25639.nopatch
@@ -1,0 +1,3 @@
+CVE-2020-25639 - already patched in 5.10.57.1 stable kernel
+Upstream: eaba3b28401f50e22d64351caa8afe8d29509f27
+Stable: e3fcff9f45aa82dacad26e5828598340d2742f47

--- a/SPECS/kernel/CVE-2021-28691.nopatch
+++ b/SPECS/kernel/CVE-2021-28691.nopatch
@@ -1,0 +1,3 @@
+CVE-2021-28691 - already patched in 5.10.57.1 stable kernel
+Upstream: 107866a8eb0b664675a260f1ba0655010fac1e08
+Stable: 6b53db8c4c14b4e7256f058d202908b54a7b85b4

--- a/SPECS/kernel/CVE-2021-29657.nopatch
+++ b/SPECS/kernel/CVE-2021-29657.nopatch
@@ -1,0 +1,3 @@
+CVE-2021-29657 - already patched in 5.10.57.1 stable kernel
+Upstream: a58d9166a756a0f4a6618e4f593232593d6df134
+Stable: 5f6625f5cd5c593fae05a6ce22b406166bc796b8

--- a/SPECS/kernel/CVE-2021-34556.nopatch
+++ b/SPECS/kernel/CVE-2021-34556.nopatch
@@ -1,0 +1,6 @@
+CVE-2021-34556 - already patched in 5.10.57.1 stable kernel
+Upstream: f5e81d1117501546b7be050c5fbafa6efd2c722c
+Stable:  bea9e2fd180892eba2574711b05b794f1d0e7b73
+
+Upstream: 2039f26f3aca5b0e419b98f65dd36481337b86ee
+Stable: 0e9280654aa482088ee6ef3deadef331f5ac5fb0

--- a/SPECS/kernel/CVE-2021-35477.nopatch
+++ b/SPECS/kernel/CVE-2021-35477.nopatch
@@ -1,0 +1,6 @@
+CVE-2021-35477 - already patched in 5.10.57.1 stable kernel
+Upstream: f5e81d1117501546b7be050c5fbafa6efd2c722c
+Stable:  bea9e2fd180892eba2574711b05b794f1d0e7b73
+
+Upstream: 2039f26f3aca5b0e419b98f65dd36481337b86ee
+Stable: 0e9280654aa482088ee6ef3deadef331f5ac5fb0

--- a/SPECS/kernel/CVE-2021-3564.nopatch
+++ b/SPECS/kernel/CVE-2021-3564.nopatch
@@ -1,0 +1,3 @@
+CVE-2021-3564 - already patched in 5.10.57.1 stable kernel
+Upstream: 6a137caec23aeb9e036cdfd8a46dd8a366460e5d
+Stable: 3795007c8dfc8bca176529bfeceb17c6f4ef7e44

--- a/SPECS/kernel/CVE-2021-3655.nopatch
+++ b/SPECS/kernel/CVE-2021-3655.nopatch
@@ -1,0 +1,3 @@
+CVE-2021-3655 - already patched in 5.10.57.1 stable kernel
+Upstream: 0c5dc070ff3d6246d22ddd931f23a6266249e3db
+Stable: d4dbef7046e24669278eba4455e9e8053ead6ba0

--- a/SPECS/kernel/CVE-2021-3679.nopatch
+++ b/SPECS/kernel/CVE-2021-3679.nopatch
@@ -1,0 +1,3 @@
+CVE-2021-3679 - already patched in 5.10.57.1 stable kernel
+Upstream:  67f0d6d9883c13174669f88adac4f0ee656cc16a
+Stable: 757bdba8026be19b4f447487695cd0349a648d9e

--- a/SPECS/kernel/CVE-2021-37576.nopatch
+++ b/SPECS/kernel/CVE-2021-37576.nopatch
@@ -1,0 +1,3 @@
+CVE-2021-37576 - already patched in 5.10.57.1 stable kernel
+Upstream: f62f3c20647ebd5fb6ecb8f0b477b9281c44c10a
+Stable: c1fbdf0f3c26004a2803282fdc1c35086908a99e

--- a/SPECS/kernel/CVE-2021-38160.nopatch
+++ b/SPECS/kernel/CVE-2021-38160.nopatch
@@ -1,0 +1,3 @@
+CVE-2021-38160 - already patched in 5.10.57.1 stable kernel
+Upstream: d00d8da5869a2608e97cfede094dfc5e11462a46
+Stable: f6ec306b93dc600a0ab3bb2693568ef1cc5f7f7a

--- a/SPECS/kernel/CVE-2021-38198.nopatch
+++ b/SPECS/kernel/CVE-2021-38198.nopatch
@@ -1,0 +1,3 @@
+CVE-2021-38198 - already patched in 5.10.57.1 stable kernel
+Upstream: b1bd5cba3306691c771d558e94baa73e8b0b96b7
+Stable: 6b6ff4d1f349cb35a7c7d2057819af1b14f80437

--- a/SPECS/kernel/CVE-2021-38199.nopatch
+++ b/SPECS/kernel/CVE-2021-38199.nopatch
@@ -1,0 +1,3 @@
+CVE-2021-38199 - already patched in 5.10.57.1 stable kernel
+Upstream: dd99e9f98fbf423ff6d365b37a98e8879170f17c
+Stable: ff4023d0194263a0827c954f623c314978cf7ddd

--- a/SPECS/kernel/CVE-2021-38200.nopatch
+++ b/SPECS/kernel/CVE-2021-38200.nopatch
@@ -1,0 +1,4 @@
+CVE-2021-38200 - Introducing commit not in stable tree. 
+Mariner also does not support powerpc. No fix necessary at this time.
+Upstream introducing commit - 2ca13a4cc56c920a6c9fc8ee45d02bccacd7f46c
+Upstream fix commit - 60b7ed54a41b550d50caf7f2418db4a7e75b5bdc

--- a/SPECS/kernel/CVE-2021-38201.nopatch
+++ b/SPECS/kernel/CVE-2021-38201.nopatch
@@ -1,0 +1,3 @@
+CVE-2021-38201 - Introducing commit not in stable tree. No fix necessary at this time.
+Upstream introducing commit - 8d86e373b0ef52d091ced9583ffbb33ad2771576
+Upstream fix commit - 6d1c0f3d28f98ea2736128ed3e46821496dc3a8c

--- a/SPECS/kernel/CVE-2021-38202.nopatch
+++ b/SPECS/kernel/CVE-2021-38202.nopatch
@@ -1,0 +1,3 @@
+CVE-2021-38202 - Introducing commit not in stable tree. No fix necessary at this time.
+Upstream introducing commit - 6019ce0742ca55d3e45279a19b07d1542747a098
+Upstream fix commit - 7b08cf62b1239a4322427d677ea9363f0ab677c6

--- a/SPECS/kernel/CVE-2021-38203.nopatch
+++ b/SPECS/kernel/CVE-2021-38203.nopatch
@@ -1,0 +1,3 @@
+CVE-2021-38200 - Introducing commit not in stable tree. No fix necessary at this time.
+Upstream introducing commit - eafa4fd0ad06074da8be4e28ff93b4dca9ffa407
+Upstream fix commit - 1cb3db1cf383a3c7dbda1aa0ce748b0958759947

--- a/SPECS/kernel/CVE-2021-38204.nopatch
+++ b/SPECS/kernel/CVE-2021-38204.nopatch
@@ -1,0 +1,3 @@
+CVE-2021-38204 - already patched in 5.10.57.1 stable kernel
+Upstream: b5fdf5c6e6bee35837e160c00ac89327bdad031b
+Stable: 7af54a4e221e5619a87714567e2258445dc35435

--- a/SPECS/kernel/CVE-2021-38206.nopatch
+++ b/SPECS/kernel/CVE-2021-38206.nopatch
@@ -1,0 +1,3 @@
+CVE-2021-38206 - already patched in 5.10.57.1 stable kernel
+Upstream: bddc0c411a45d3718ac535a070f349be8eca8d48
+Stable: f74df6e086083dc435f7500bdbc86b05277d17af

--- a/SPECS/kernel/CVE-2021-38207.nopatch
+++ b/SPECS/kernel/CVE-2021-38207.nopatch
@@ -1,0 +1,3 @@
+CVE-2021-38207 - already patched in 5.10.57.1 stable kernel
+Upstream: c364df2489b8ef2f5e3159b1dff1ff1fdb16040d
+Stable: cfe403f209b11fad123a882100f0822a52a7630f

--- a/SPECS/kernel/CVE-2021-38208.nopatch
+++ b/SPECS/kernel/CVE-2021-38208.nopatch
@@ -1,0 +1,3 @@
+CVE-2021-38208 - already patched in 5.10.57.1 stable kernel
+Upstream: 4ac06a1e013cf5fdd963317ffd3b968560f33bba
+Stable: 48ee0db61c8299022ec88c79ad137f290196cac2

--- a/SPECS/kernel/CVE-2021-38209.nopatch
+++ b/SPECS/kernel/CVE-2021-38209.nopatch
@@ -1,0 +1,3 @@
+CVE-2021-38209 - already patched in 5.10.57.1 stable kernel
+Upstream: 2671fa4dc0109d3fb581bc3078fdf17b5d9080f6
+Stable: d3598eb3915cc0c0d8cab42f4a6258ff44c4033e

--- a/SPECS/kernel/config
+++ b/SPECS/kernel/config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86_64 5.10.52.1 Kernel Configuration
+# Linux/x86_64 5.10.57.1 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (GCC) 9.1.0"
 CONFIG_CC_IS_GCC=y

--- a/SPECS/kernel/config_aarch64
+++ b/SPECS/kernel/config_aarch64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 5.10.52.1 Kernel Configuration
+# Linux/arm64 5.10.57.1 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (GCC) 9.1.0"
 CONFIG_CC_IS_GCC=y

--- a/SPECS/kernel/kernel.signatures.json
+++ b/SPECS/kernel/kernel.signatures.json
@@ -1,9 +1,9 @@
 {
  "Signatures": {
   "cbl-mariner-ca-20210127.pem": "82363cb44e786353936abc2e2d62d9325cacf2d9e9a8ebaf4221ea30a9e0cd7b",
-  "config": "6eb66708f4cd1faf77e4ed9bdd805fcc73e78ed6297009ef3eef0e36895343fb",
-  "config_aarch64": "a6ccb3944a151a577292022ffeba42afbce8eeb73480e8888967477a10d7c008",
-  "kernel-5.10.52.1.tar.gz": "7fd3e7779e20f6ec6ddaa8c4b78a713a15b13860730e5b7e624ae27b304363b3",
+  "config": "c5e5479a4f215904825109c28c0a7d18f75b8d8b73b4fa708fcd24db4a047f39",
+  "config_aarch64": "fd7bb6a6d8af54b6b69e1f6fa33d31dddde301d0687a7b6828dba8a8ed52aa85",
+  "kernel-5.10.57.1.tar.gz": "51dbaa5781b36bfc53e2054bb54631d4c50946bea0de27a9bbf2c8f45ba37eb3",
   "sha512hmac-openssl.sh": "02ab91329c4be09ee66d759e4d23ac875037c3b56e5a598e32fd1206da06a27f"
  }
 }

--- a/SPECS/kernel/kernel.spec
+++ b/SPECS/kernel/kernel.spec
@@ -3,8 +3,8 @@
 %define uname_r %{version}-%{release}
 Summary:        Linux Kernel
 Name:           kernel
-Version:        5.10.52.1
-Release:        3%{?dist}
+Version:        5.10.57.1
+Release:        1%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -181,6 +181,31 @@ Patch1147:      CVE-2021-34693.nopatch
 Patch1148:      CVE-2021-33624.nopatch
 Patch1149:      CVE-2021-35039.nopatch
 Patch1150:      CVE-2021-33909.nopatch
+Patch1151:      CVE-2021-37576.nopatch
+Patch1152:      CVE-2021-34556.nopatch
+Patch1153:      CVE-2021-35477.nopatch
+Patch1154:      CVE-2021-28691.nopatch
+Patch1155:      CVE-2021-3564.nopatch
+Patch1156:      CVE-2020-25639.nopatch
+Patch1157:      CVE-2021-29657.nopatch
+Patch1158:      CVE-2021-38199.nopatch
+# CVE-2021-38201 - Introducing commit not in stable tree. No fix necessary at this time.
+Patch1159:      CVE-2021-38201.nopatch
+# CVE-2021-38202  - Introducing commit not in stable tree. No fix necessary at this time.
+Patch1160:      CVE-2021-38202.nopatch
+Patch1161:      CVE-2021-38207.nopatch
+Patch1162:      CVE-2021-38204.nopatch
+Patch1163:      CVE-2021-38206.nopatch
+Patch1164:      CVE-2021-38208.nopatch
+# CVE-2021-38200 - Introducing commit not in stable tree / powerpc not supported.
+Patch1165:      CVE-2021-38200.nopatch
+# CVE-2021-38203 - Introducing commit not in stable tree. No fix necessary at this time.
+Patch1166:      CVE-2021-38203.nopatch
+Patch1167:      CVE-2021-38160.nopatch
+Patch1168:      CVE-2021-3679.nopatch
+Patch1169:      CVE-2021-38198.nopatch
+Patch1170:      CVE-2021-38209.nopatch
+Patch1171:      CVE-2021-3655.nopatch
 BuildRequires:  audit-devel
 BuildRequires:  bash
 BuildRequires:  bc
@@ -513,6 +538,15 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %endif
 
 %changelog
+* Thu Aug 12 2021 Rachel Menge <rachelmenge@microsoft.com> - 5.10.57.1-1
+- Update source to 5.10.57.1
+- Address CVE-2021-37576, CVE-2021-34556, CVE-2021-35477, CVE-2021-28691,
+  CVE-2021-3564, CVE-2020-25639, CVE-2021-29657, CVE-2021-38199,
+  CVE-2021-38201, CVE-2021-38202, CVE-2021-38207, CVE-2021-38204,
+  CVE-2021-38206, CVE-2021-38208, CVE-2021-38200, CVE-2021-38203,
+  CVE-2021-38160, CVE-2021-3679, CVE-2021-38198, CVE-2021-38209,
+  CVE-2021-3655
+
 * Tue Aug 03 2021 Chris Co <chrco@microsoft.com> - 5.10.52.1-3
 - Add patch to fix VDSO in HyperV
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -1985,8 +1985,8 @@
         "type": "other",
         "other": {
           "name": "hyperv-daemons",
-          "version": "5.10.52.1",
-          "downloadUrl": "https://github.com/microsoft/CBL-Mariner-Linux-Kernel/archive/rolling-lts/mariner/5.10.52.1.tar.gz"
+          "version": "5.10.57.1",
+          "downloadUrl": "https://github.com/microsoft/CBL-Mariner-Linux-Kernel/archive/rolling-lts/mariner/5.10.57.1.tar.gz"
         }
       }
     },
@@ -2315,8 +2315,8 @@
         "type": "other",
         "other": {
           "name": "kernel",
-          "version": "5.10.52.1",
-          "downloadUrl": "https://github.com/microsoft/CBL-Mariner-Linux-Kernel/archive/rolling-lts/mariner/5.10.52.1.tar.gz"
+          "version": "5.10.57.1",
+          "downloadUrl": "https://github.com/microsoft/CBL-Mariner-Linux-Kernel/archive/rolling-lts/mariner/5.10.57.1.tar.gz"
         }
       }
     },
@@ -2325,8 +2325,8 @@
         "type": "other",
         "other": {
           "name": "kernel-headers",
-          "version": "5.10.52.1",
-          "downloadUrl": "https://github.com/microsoft/CBL-Mariner-Linux-Kernel/archive/rolling-lts/mariner/5.10.52.1.tar.gz"
+          "version": "5.10.57.1",
+          "downloadUrl": "https://github.com/microsoft/CBL-Mariner-Linux-Kernel/archive/rolling-lts/mariner/5.10.57.1.tar.gz"
         }
       }
     },
@@ -2335,8 +2335,8 @@
         "type": "other",
         "other": {
           "name": "kernel-hyperv",
-          "version": "5.10.52.1",
-          "downloadUrl": "https://github.com/microsoft/CBL-Mariner-Linux-Kernel/archive/rolling-lts/mariner/5.10.52.1.tar.gz"
+          "version": "5.10.57.1",
+          "downloadUrl": "https://github.com/microsoft/CBL-Mariner-Linux-Kernel/archive/rolling-lts/mariner/5.10.57.1.tar.gz"
         }
       }
     },

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -1,5 +1,5 @@
 filesystem-1.1-7.cm1.aarch64.rpm
-kernel-headers-5.10.52.1-3.cm1.noarch.rpm
+kernel-headers-5.10.57.1-1.cm1.noarch.rpm
 glibc-2.28-19.cm1.aarch64.rpm
 glibc-devel-2.28-19.cm1.aarch64.rpm
 glibc-i18n-2.28-19.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -1,5 +1,5 @@
 filesystem-1.1-7.cm1.x86_64.rpm
-kernel-headers-5.10.52.1-3.cm1.noarch.rpm
+kernel-headers-5.10.57.1-1.cm1.noarch.rpm
 glibc-2.28-19.cm1.x86_64.rpm
 glibc-devel-2.28-19.cm1.x86_64.rpm
 glibc-i18n-2.28-19.cm1.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -158,7 +158,7 @@ json-c-debuginfo-0.14-3.cm1.aarch64.rpm
 json-c-devel-0.14-3.cm1.aarch64.rpm
 kbd-2.0.4-5.cm1.aarch64.rpm
 kbd-debuginfo-2.0.4-5.cm1.aarch64.rpm
-kernel-headers-5.10.52.1-3.cm1.noarch.rpm
+kernel-headers-5.10.57.1-1.cm1.noarch.rpm
 kmod-25-4.cm1.aarch64.rpm
 kmod-debuginfo-25-4.cm1.aarch64.rpm
 kmod-devel-25-4.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -158,7 +158,7 @@ json-c-debuginfo-0.14-3.cm1.x86_64.rpm
 json-c-devel-0.14-3.cm1.x86_64.rpm
 kbd-2.0.4-5.cm1.x86_64.rpm
 kbd-debuginfo-2.0.4-5.cm1.x86_64.rpm
-kernel-headers-5.10.52.1-3.cm1.noarch.rpm
+kernel-headers-5.10.57.1-1.cm1.noarch.rpm
 kmod-25-4.cm1.x86_64.rpm
 kmod-debuginfo-25-4.cm1.x86_64.rpm
 kmod-devel-25-4.cm1.x86_64.rpm

--- a/toolkit/scripts/toolchain/container/Dockerfile
+++ b/toolkit/scripts/toolchain/container/Dockerfile
@@ -68,7 +68,7 @@ COPY [ "./toolchain-md5sums", \
 WORKDIR $LFS/sources
 RUN wget -nv --no-clobber --timeout=30 --no-check-certificate --continue --input-file=$LFS/tools/toolchain-local-wget-list --directory-prefix=$LFS/sources; exit 0
 RUN wget -nv --no-clobber --timeout=30 --continue --input-file=$LFS/tools/toolchain-remote-wget-list --directory-prefix=$LFS/sources; exit 0
-RUN wget -nv --no-clobber --timeout=30 --continue https://github.com/microsoft/CBL-Mariner-Linux-Kernel/archive/rolling-lts/mariner/5.10.52.1.tar.gz -O kernel-5.10.52.1.tar.gz --directory-prefix=$LFS/sources; exit 0
+RUN wget -nv --no-clobber --timeout=30 --continue https://github.com/microsoft/CBL-Mariner-Linux-Kernel/archive/rolling-lts/mariner/5.10.57.1.tar.gz -O kernel-5.10.57.1.tar.gz --directory-prefix=$LFS/sources; exit 0
 USER root
 RUN /tools/toolchain-jdk8-wget.sh; exit 0
 RUN md5sum -c $LFS/tools/toolchain-md5sums && \

--- a/toolkit/scripts/toolchain/container/toolchain-md5sums
+++ b/toolkit/scripts/toolchain/container/toolchain-md5sums
@@ -59,7 +59,7 @@ bc62e7df6f75357b6dd1ec34600dbeaf  jdk8u212-b04-langtools.tar.bz2
 d0272e7a6107c64dae62b80ca7ec65e2  jdk8u212-b04-nashorn.tar.bz2
 befd51c2b53a442e1fa6644bba89a95a  jdk8u212-b04.tar.bz2
 94afc90c1f7bef4a27fdd59ece39c878  kbproto-1.0.7.tar.bz2
-a983fcd3083df9e3d28cc27b49d9bc2a  kernel-5.10.52.1.tar.gz
+a852d50d1128755160a138fccdbd6592  kernel-5.10.57.1.tar.gz
 d953ed6b47694dadf0e6042f8f9ff451  libarchive-3.4.2.tar.gz
 968ac4d42a1a71754313527be2ab5df3  libcap-2.26.tar.xz
 ba983eba5a9f05d152a0725b8e863151  libdmx-1.1.3.tar.bz2

--- a/toolkit/scripts/toolchain/container/toolchain_build_in_chroot.sh
+++ b/toolkit/scripts/toolchain/container/toolchain_build_in_chroot.sh
@@ -57,14 +57,14 @@ set -e
 #
 cd /sources
 
-echo Linux-5.10.52.1 API Headers
-tar xf kernel-5.10.52.1.tar.gz
-pushd CBL-Mariner-Linux-Kernel-rolling-lts-mariner-5.10.52.1
+echo Linux-5.10.57.1 API Headers
+tar xf kernel-5.10.57.1.tar.gz
+pushd CBL-Mariner-Linux-Kernel-rolling-lts-mariner-5.10.57.1
 make mrproper
 make headers
 cp -rv usr/include/* /usr/include
 popd
-rm -rf CBL-Mariner-Linux-Kernel-rolling-lts-mariner-5.10.52.1
+rm -rf CBL-Mariner-Linux-Kernel-rolling-lts-mariner-5.10.57.1
 touch /logs/status_kernel_headers_complete
 
 echo 6.8. Man-pages-5.02

--- a/toolkit/scripts/toolchain/container/toolchain_build_temp_tools.sh
+++ b/toolkit/scripts/toolchain/container/toolchain_build_temp_tools.sh
@@ -113,14 +113,14 @@ rm -rf gcc-9.1.0
 
 touch $LFS/logs/temptoolchain/status_gcc_pass1_complete
 
-echo Linux-5.10.52.1 API Headers
-tar xf kernel-5.10.52.1.tar.gz
-pushd CBL-Mariner-Linux-Kernel-rolling-lts-mariner-5.10.52.1
+echo Linux-5.10.57.1 API Headers
+tar xf kernel-5.10.57.1.tar.gz
+pushd CBL-Mariner-Linux-Kernel-rolling-lts-mariner-5.10.57.1
 make mrproper
 make headers
 cp -rv usr/include/* /tools/include
 popd
-rm -rf CBL-Mariner-Linux-Kernel-rolling-lts-mariner-5.10.52.1
+rm -rf CBL-Mariner-Linux-Kernel-rolling-lts-mariner-5.10.57.1
 
 touch $LFS/logs/temptoolchain/status_kernel_headers_complete
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
- Cherry-pick from 1.0-dev (#1279) 

* Update kernel to 5.10.57.1
* Add cve and fix changelog
* Add additional CVEs
* Even more CVEs


###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Cherry-pick from 1.0-dev

Tested vhdx locally
Pipeline: 121487