### PR TITLE
`cronie`: splitting into subpackages

### DIFF
--- a/SPECS/cronie/cronie.spec
+++ b/SPECS/cronie/cronie.spec
@@ -169,8 +169,6 @@ make %{?_smp_mflags} check
 * Tue Aug 24 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.5.2-7
 - Splitting package into "cronie-anacron" and "cronie-noanacron".
 - Package changes are an import from Fedora 32 (license: MIT).
-- Adding "Provides: cronie-anacron" for compatibility reasons.
-- Moving "dailyjobs" to separate "*-noanachron" subpackage.
 
 * Mon Aug 23 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.5.2-6
 - Adding "Provides: anacron" for compatibility reasons.

--- a/SPECS/cronie/cronie.spec
+++ b/SPECS/cronie/cronie.spec
@@ -2,21 +2,21 @@ Summary:        Cron Daemon
 Name:           cronie
 Version:        1.5.2
 Release:        7%{?dist}
-License:        GPLv2+ and MIT and BSD and ISC
+License:        GPLv2+ AND MIT AND BSD AND ISC
+Vendor:         Microsoft Corporation
+Distribution:   Mariner
+Group:          System Environment/Base
 URL:            https://github.com/cronie-crond/cronie
 Source0:        https://github.com/cronie-crond/cronie/releases/download/cronie-%{version}/cronie-%{version}.tar.gz
 Source1:        run-parts.sh
-Group:          System Environment/Base
-Vendor:         Microsoft Corporation
-Distribution:   Mariner
 
 BuildRequires:  libselinux-devel
 BuildRequires:  pam-devel
 BuildRequires:  systemd
 
-Requires:       systemd
 Requires:       libselinux
 Requires:       pam
+Requires:       systemd
 
 %description
 Cronie contains the standard UNIX daemon crond that runs specified programs at
@@ -25,14 +25,14 @@ has security and configuration enhancements like the ability to use pam and
 SELinux.
 
 %package anacron
-Summary:   Utility for running regular jobs
+Summary:        Utility for running regular jobs
 
-Provides:  dailyjobs = %{version}-%{release}
-Provides:  anacron = 2.4
-Obsoletes: anacron <= 2.3
-
+Requires:       %{name} = %{version}-%{release}
 Requires(post): coreutils
-Requires:  %{name} = %{version}-%{release}
+
+Provides:       dailyjobs = %{version}-%{release}
+Provides:       anacron = 2.4
+Obsoletes:      anacron <= 2.3
 
 %description anacron
 Anacron is part of cronie that is used for running jobs with regular
@@ -46,11 +46,11 @@ powered off and it also allows randomizing the time of the job execution
 for better utilization of resources shared among multiple systems.
 
 %package noanacron
-Summary:   Utility for running simple regular jobs in old cron style
+Summary:        Utility for running simple regular jobs in old cron style
 
-Provides:  dailyjobs = %{version}-%{release}
+Requires:       %{name} = %{version}-%{release}
 
-Requires:  %{name} = %{version}-%{release}
+Provides:       dailyjobs = %{version}-%{release}
 
 %description noanacron
 Old style of running {hourly,daily,weekly,monthly}.jobs without anacron. No
@@ -61,10 +61,11 @@ extra features.
 sed -i 's/^\s*auth\s*include\s*password-auth$/auth       include    system-auth/g;
      s/^\s*account\s*include\s*password-auth$/account    include    system-account/g;
      s/^\s*session\s*include\s*password-auth$/session    include    system-session/g;' pam/crond
+
 %build
 ./configure \
     --prefix=%{_prefix} \
-    --sysconfdir=/etc   \
+    --sysconfdir=%{_sysconfdir}   \
     --localstatedir=/var\
     --with-pam          \
     --with-selinux      \
@@ -72,6 +73,7 @@ sed -i 's/^\s*auth\s*include\s*password-auth$/auth       include    system-auth/
     --enable-pie        \
     --enable-relro
 make %{?_smp_mflags}
+
 %install
 make DESTDIR=%{buildroot} install
 install -vdm700 %{buildroot}%{_localstatedir}/spool/cron
@@ -94,10 +96,10 @@ install -vm644 contrib/anacrontab %{buildroot}%{_sysconfdir}/anacrontab
 
 touch %{buildroot}%{_sysconfdir}/cron.deny
 
-install -vdm755 %{buildroot}/var/spool/anacron
-touch %{buildroot}/var/spool/anacron/cron.daily
-touch %{buildroot}/var/spool/anacron/cron.weekly
-touch %{buildroot}/var/spool/anacron/cron.monthly
+install -vdm755 %{buildroot}%{_var}/spool/anacron
+touch %{buildroot}%{_var}/spool/anacron/cron.daily
+touch %{buildroot}%{_var}/spool/anacron/cron.weekly
+touch %{buildroot}%{_var}/spool/anacron/cron.monthly
 
 install -m755  %{SOURCE1} %{buildroot}/%{_bindir}/run-parts
 
@@ -153,7 +155,7 @@ make %{?_smp_mflags} check
 %{_sbindir}/anacron
 %attr(0755,root,root) %{_sysconfdir}/cron.hourly/0anacron
 %config(noreplace) %{_sysconfdir}/anacrontab
-%dir /var/spool/anacron
+%dir %{_var}/spool/anacron
 %ghost %attr(0600,root,root) %{_localstatedir}/spool/anacron/cron.daily
 %ghost %attr(0600,root,root) %{_localstatedir}/spool/anacron/cron.monthly
 %ghost %attr(0600,root,root) %{_localstatedir}/spool/anacron/cron.weekly
@@ -184,37 +186,53 @@ make %{?_smp_mflags} check
 
 * Tue Apr 28 2020 Emre Girgin <mrgirgin@microsoft.com> 1.5.2-2
 - Renaming Linux-PAM to pam
+
 * Wed Mar 18 2020 Nicolas Ontiveros <niontive@microsoft.com> 1.5.2-1
 - Update to 1.5.2. License verified.
+
 * Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 1.5.1-2
 - Initial CBL-Mariner import from Photon (license: Apache2).
+
 * Mon Apr 24 2017 Bo Gan <ganb@vmware.com> 1.5.1-1
 - Update to 1.5.1
+
 * Wed Dec 07 2016 Xiaolin Li <xiaolinl@vmware.com> 1.5.0-13
 - BuildRequires Linux-PAM-devel
+
 * Wed Oct 05 2016 ChangLee <changlee@vmware.com> 1.5.0-12
 - Modified %check
+
 * Mon Aug 29 2016 Divya Thaluru <dthaluru@vmware.com>  1.5.0-11
 - Fixed pam configuration for crond
+
 * Thu Aug 4 2016 Divya Thaluru <dthaluru@vmware.com>  1.5.0-10
 - Added logic to not replace conf files in upgrade scenario
+
 * Tue May 24 2016 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 1.5.0-9
 - GA - Bump release of all rpms
+
 * Tue May 3 2016 Divya Thaluru <dthaluru@vmware.com>  1.5.0-8
 - Fixing spec file to handle rpm upgrade scenario correctly
+
 * Thu Mar 24 2016 Xiaolin Li <xiaolinl@vmware.com>  1.5.0-7
 - Add run-parts command.
+
 * Fri Mar 04 2016 Anish Swaminathan <anishs@vmware.com>  1.5.0-6
 - Add folders to sysconfdir.
+
 * Mon Feb 08 2016 Anish Swaminathan <anishs@vmware.com>  1.5.0-5
 - Change default sysconfdir.
+
 * Thu Dec 10 2015 Xiaolin Li <xiaolinl@vmware.com>  1.5.0-4
 - Add systemd to Requires and BuildRequires.
 - Use systemctl to enable/disable service.
+
 * Mon Nov 30 2015 Xiaolin Li <xiaolinl@vmware.com> 1.5.0-3
 - Symlink cron.service to crond.service.
 - And move the /usr/etc/pam.d/crond to /etc/pam.d/crond
+
 * Thu Nov 12 2015 Xiaolin Li <xiaolinl@vmware.com> 1.5.0-2
 - Add crond to systemd service.
+
 * Wed Jun 17 2015 Divya Thaluru <dthaluru@vmware.com> 1.5.0-1
 - Initial build. First version

--- a/SPECS/sysstat/sysstat.spec
+++ b/SPECS/sysstat/sysstat.spec
@@ -1,7 +1,7 @@
 Summary:        The Sysstat package contains utilities to monitor system performance and usage activity
 Name:           sysstat
 Version:        12.3.3
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        GPLv2
 URL:            http://sebastien.godard.pagesperso-orange.fr/
 Group:          Development/Debuggers
@@ -10,9 +10,9 @@ Distribution:   Mariner
 #Source0:       https://github.com/%{name}/%{name}/archive/v%{version}.tar.gz
 Source0:        %{name}-%{version}.tar.gz
 
-BuildRequires:  cronie
+BuildRequires:  cronie-anacron
 
-Requires:       cronie
+Requires:       cronie-anacron
 
 %description
  The Sysstat package contains utilities to monitor system performance and usage activity. Sysstat contains the sar utility, common to many commercial Unixes, and tools you can schedule via cron to collect and historize performance and activity data.
@@ -57,6 +57,9 @@ rm -rf %{buildroot}/*
 
 
 %changelog
+* Tue Aug 24 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 12.3.3-2
+- Updating dependencies from "cronie" to "cronie-anacron" after splitting of "cronie".
+
 * Mon Nov 16 2020 Pawel Winogrodzki <pawelwi@microsoft.com> - 12.3.3-2
 - Removing %%check section as the package doesn't have a test suite.
 

--- a/toolkit/imageconfigs/packagelists/core-packages-image-aarch64.json
+++ b/toolkit/imageconfigs/packagelists/core-packages-image-aarch64.json
@@ -3,7 +3,7 @@
         "shim-unsigned",
         "grub2-efi-binary",
         "ca-certificates",
-        "cronie",
+        "cronie-anacron",
         "logrotate",
         "core-packages-base-image",
         "initramfs"

--- a/toolkit/imageconfigs/packagelists/core-packages-image.json
+++ b/toolkit/imageconfigs/packagelists/core-packages-image.json
@@ -3,7 +3,7 @@
         "shim",
         "grub2-efi-binary",
         "ca-certificates",
-        "cronie",
+        "cronie-anacron",
         "logrotate",
         "core-packages-base-image",
         "initramfs"


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

The split is more in-line with what users expect in terms of package names and their content. It also allows to use a smaller `cronie-noanacron` package, if needed.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Split `cronie` into `cronie`, `cronie-anacron`, and `cronie-noanacron`.
- Added `Provides: dailyjobs`.
- Updated one spec depending on `cronie`.
- Updated package lists to use `cronie-anacron`.
- Basic spec linting for `cronie`.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build of `cronie` and `sysstat`.
