### PR TITLE
Fix majority of broken mysql package tests

### DIFF
--- a/SPECS/mysql/mysql.spec
+++ b/SPECS/mysql/mysql.spec
@@ -1,7 +1,7 @@
 Summary:        MySQL.
 Name:           mysql
 Version:        8.0.26
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2 with exceptions AND LGPLv2 AND BSD
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -13,7 +13,14 @@ BuildRequires:  cmake
 BuildRequires:  libtirpc-devel
 BuildRequires:  openssl-devel
 BuildRequires:  rpcsvc-proto-devel
+BuildRequires:  tzdata
 BuildRequires:  zlib-devel
+%if %{with_check}
+BuildRequires:  net-tools
+BuildRequires:  sudo
+BuildRequires:  shadow-utils
+%endif
+Requires:       tzdata
 
 %description
 MySQL is a free, widely used SQL engine. It can be used as a fast database as well as a rock-solid DBMS using a modular engine architecture.
@@ -47,7 +54,10 @@ cmake . \
 %make_install
 
 %check
-%make_build test
+# Test suite has multiple failures when run as root
+chmod g+w . -R
+useradd test -G root -m
+sudo -u test %make_build CTEST_OUTPUT_ON_FAILURE=1 test
 
 %files
 %defattr(-,root,root)
@@ -75,6 +85,11 @@ cmake . \
 %{_libdir}/pkgconfig/mysqlclient.pc
 
 %changelog
+* Mon Aug 30 2021 Thomas Crain <thcrain@microsoft.com> - 8.0.26-2
+- Fix majority of package test failures by adding necessary requirements and running tests as non-root
+- Add missing tzdata runtime requirement
+- Add better log outputs for failed %%check tests
+
 * Tue Jul 27 2021 Thomas Crain <thcrain@microsoft.com> - 8.0.26-1
 - Upgrade to 8.0.26 to fix 31 CVEs
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
The upgrade to the latest version of `mysql` in #1198 enabled more tests than we were previously running. Some of these tests fail for various reasons- missing check-time requirements, being run under root user, etc. This PR fixes most of the newly failing tests.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add missing `tzdata` build/runtime dependency, additional check-time dependencies
- Run tests as a non-root user
- Add better test failure logging

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local package build with `RUN_CHECK=y`
