### PR TITLE
installutils: Fix generation of SSH user directories when keys not provided

### DIFF
--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -1332,9 +1332,16 @@ func provisionUserSSHCerts(installChroot *safechroot.Chroot, user configuration.
 	const squashErrors = false
 	const authorizedKeysTempFilePerms = 0644
 	const authorizedKeysTempFile = "/tmp/authorized_keys"
+	const sshDirectoryPermission = "0700"
+
+	// Skip user SSH directory generation when not provided with public keys
+	// Let SSH handle the creation of this folder on its first use
+	if len(user.SSHPubKeyPaths) == 0 {
+		return
+	}
 
 	userSSHKeyDir := filepath.Join(homeDir, ".ssh")
-	authorizedKeysFile := filepath.Join(homeDir, ".ssh/authorized_keys")
+	authorizedKeysFile := filepath.Join(userSSHKeyDir, "authorized_keys")
 
 	exists, err = file.PathExists(authorizedKeysTempFile)
 	if err != nil {
@@ -1399,34 +1406,30 @@ func provisionUserSSHCerts(installChroot *safechroot.Chroot, user configuration.
 		return
 	}
 
-	if len(user.SSHPubKeyPaths) != 0 {
-		const sshDirectoryPermission = "0700"
-
-		// Change ownership of the folder to belong to the user and their primary group
-		err = installChroot.UnsafeRun(func() (err error) {
-			// Find the primary group of the user
-			stdout, stderr, err := shell.Execute("id", "-g", user.Name)
-			if err != nil {
-				logger.Log.Warnf(stderr)
-				return
-			}
-
-			primaryGroup := strings.TrimSpace(stdout)
-			logger.Log.Debugf("Primary group for user (%s) is (%s)", user.Name, primaryGroup)
-
-			ownership := fmt.Sprintf("%s:%s", user.Name, primaryGroup)
-			err = shell.ExecuteLive(squashErrors, "chown", "-R", ownership, userSSHKeyDir)
-			if err != nil {
-				return
-			}
-
-			err = shell.ExecuteLive(squashErrors, "chmod", "-R", sshDirectoryPermission, userSSHKeyDir)
+	// Change ownership of the folder to belong to the user and their primary group
+	err = installChroot.UnsafeRun(func() (err error) {
+		// Find the primary group of the user
+		stdout, stderr, err := shell.Execute("id", "-g", user.Name)
+		if err != nil {
+			logger.Log.Warnf(stderr)
 			return
-		})
+		}
 
+		primaryGroup := strings.TrimSpace(stdout)
+		logger.Log.Debugf("Primary group for user (%s) is (%s)", user.Name, primaryGroup)
+
+		ownership := fmt.Sprintf("%s:%s", user.Name, primaryGroup)
+		err = shell.ExecuteLive(squashErrors, "chown", "-R", ownership, userSSHKeyDir)
 		if err != nil {
 			return
 		}
+
+		err = shell.ExecuteLive(squashErrors, "chmod", "-R", sshDirectoryPermission, userSSHKeyDir)
+		return
+	})
+
+	if err != nil {
+		return
 	}
 
 	return


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
When `installutils` processes a user's provided SSH public keys, it creates the `$HOME/.ssh/authorized_keys` file regardless of whether the user provided any public keys. However, due to an error in our code, we only gave the user's SSH directory the proper permissions if keys were provided in the system configuration. This means that when a user is configured without keys, that user would need to fix the SSH directory permissions manually at a later date.

Since `ssh` handles the creation of a user's SSH directory when not present, we choose to skip generation of the SSH directory and the authorized keys file entirely when public keys are not provided for a user.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Do not create a user's `$HOME/.ssh` directory or a user's `$HOME/.ssh/authorized_keys` file when public keys are not provided as part of the system configuration.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- Fixes #1308 

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local ISO build and installation using configurations with and without user SSH keys.
