### PR TITLE
Joslobo/cp mariner release for offcycle back to 10dev

### DIFF
--- a/SPECS/mariner-release/mariner-release.spec
+++ b/SPECS/mariner-release/mariner-release.spec
@@ -1,7 +1,7 @@
 Summary:       CBL-Mariner release files
 Name:          mariner-release
 Version:       1.0
-Release:       20%{?dist}
+Release:       21%{?dist}
 License:       MIT
 Group:         System Environment/Base
 URL:           https://aka.ms/cbl-mariner
@@ -67,6 +67,8 @@ rm -rf $RPM_BUILD_ROOT
 %config(noreplace) /etc/issue.net
 
 %changelog
+*   Thu Aug 19 2021 Jon Slobodzian <joslobo@microsoft.com> - 1.0-21
+-   Off-cycle update for Kernel CVE's
 *   Fri Jul 23 2021 Jon Slobodzian <joslobo@microsoft.com> - 1.0-20
 -   Updating version for July update
 *   Fri Jun 25 2021 Andrew Phelps <anphel@microsoft.com> - 1.0-19

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -58,7 +58,7 @@ findutils-lang-4.6.0-7.cm1.aarch64.rpm
 gettext-0.19.8.1-4.cm1.aarch64.rpm
 gzip-1.9-5.cm1.aarch64.rpm
 make-4.2.1-5.cm1.aarch64.rpm
-mariner-release-1.0-20.cm1.noarch.rpm
+mariner-release-1.0-21.cm1.noarch.rpm
 patch-2.7.6-7.cm1.aarch64.rpm
 util-linux-2.32.1-5.cm1.aarch64.rpm
 util-linux-devel-2.32.1-5.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -58,7 +58,7 @@ findutils-lang-4.6.0-7.cm1.x86_64.rpm
 gettext-0.19.8.1-4.cm1.x86_64.rpm
 gzip-1.9-5.cm1.x86_64.rpm
 make-4.2.1-5.cm1.x86_64.rpm
-mariner-release-1.0-20.cm1.noarch.rpm
+mariner-release-1.0-21.cm1.noarch.rpm
 patch-2.7.6-7.cm1.x86_64.rpm
 util-linux-2.32.1-5.cm1.x86_64.rpm
 util-linux-devel-2.32.1-5.cm1.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -266,7 +266,7 @@ m4-debuginfo-1.4.18-4.cm1.aarch64.rpm
 make-4.2.1-5.cm1.aarch64.rpm
 make-debuginfo-4.2.1-5.cm1.aarch64.rpm
 mariner-check-macros-1.0-4.cm1.noarch.rpm
-mariner-release-1.0-20.cm1.noarch.rpm
+mariner-release-1.0-21.cm1.noarch.rpm
 mariner-repos-1.0-14.cm1.noarch.rpm
 mariner-repos-extras-1.0-14.cm1.noarch.rpm
 mariner-repos-extras-preview-1.0-14.cm1.noarch.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -266,7 +266,7 @@ m4-debuginfo-1.4.18-4.cm1.x86_64.rpm
 make-4.2.1-5.cm1.x86_64.rpm
 make-debuginfo-4.2.1-5.cm1.x86_64.rpm
 mariner-check-macros-1.0-4.cm1.noarch.rpm
-mariner-release-1.0-20.cm1.noarch.rpm
+mariner-release-1.0-21.cm1.noarch.rpm
 mariner-repos-1.0-14.cm1.noarch.rpm
 mariner-repos-extras-1.0-14.cm1.noarch.rpm
 mariner-repos-extras-preview-1.0-14.cm1.noarch.rpm


### PR DESCRIPTION
This merge pulls the mariner-release changes for an off-cycle build of CBL-Mariner from the 1.0 branch back to the 1.0-dev branch to resynchronize the content.