### PR TITLE
Fix sodiff's interpretation of final result file

### DIFF
--- a/toolkit/scripts/analysis.mk
+++ b/toolkit/scripts/analysis.mk
@@ -59,6 +59,7 @@ $(SODIFF_REPO_FILE):
 
 sodiff-check: $(BUILT_PACKAGES_FILE) | $(SODIFF_REPO_FILE)
 	<$(BUILT_PACKAGES_FILE) $(SODIFF_SCRIPT) $(RPMS_DIR)/ $(SODIFF_REPO_FILE) $(RELEASE_MAJOR_ID) $(SODIFF_OUTPUT_FOLDER)
-	( file -b $(SODIFF_OUTPUT_FOLDER)/sodiff-summary.txt | grep -q empty ) || ( echo "SRPM files that need to be updated due to sodiff:"; cat $(SODIFF_OUTPUT_FOLDER)/sodiff-summary.txt ; $(call print_error,$@ failed - see $(SODIFF_OUTPUT_FOLDER)/ for a list of failed files.) )
+	[ $(wc -w $(SODIFF_OUTPUT_FOLDER)/sodiff-summary.txt | cut -f1 -d' ')  -eq 0 ] || ( echo "SRPM files that need to be updated due to sodiff:"; cat $(SODIFF_OUTPUT_FOLDER)/sodiff-summary.txt ; $(call print_error,$@ failed - see $(SODIFF_OUTPUT_FOLDER)/ for a list of failed files.) )
 	echo "SODIFF finished - no changes detected."
+
 package-toolkit: $(SODIFF_REPO_FILE)

--- a/toolkit/scripts/analysis.mk
+++ b/toolkit/scripts/analysis.mk
@@ -8,12 +8,19 @@
 
 # Requires DNF on Mariner / yum and yum-utils on Ubuntu.
 
+# A folder with sodiff-related artifacts
 SODIFF_OUTPUT_FOLDER=$(BUILD_DIR)/sodiff
 RPM_BUILD_LOGS_DIR=$(LOGS_DIR)/pkggen/rpmbuilding
+# A CSV file containing a list of "SRPM \t generated RPMs" entries
 BUILD_SUMMARY_FILE=$(SODIFF_OUTPUT_FOLDER)/build-summary.csv
+# A list of packages built during the current run
 BUILT_PACKAGES_FILE=$(SODIFF_OUTPUT_FOLDER)/built-packages.txt
+# Repositories that SODIFF runs the checks against
 SODIFF_REPO_SOURCES="mariner-official-base.repo mariner-official-update.repo mariner-microsoft.repo"
 SODIFF_REPO_FILE=$(SCRIPTS_DIR)/sodiff/sodiff.repo
+# An artifact containing a list of packages that need to be dash-rolled due to their dependency having a new .so version
+SODIFF_SUMMARY_FILE=$(SODIFF_OUTPUT_FOLDER)/sodiff-summary.txt
+# A script doing the sodiff work
 SODIFF_SCRIPT=$(SCRIPTS_DIR)/sodiff/mariner-sodiff.sh
 
 clean: clean-sodiff
@@ -59,7 +66,9 @@ $(SODIFF_REPO_FILE):
 
 sodiff-check: $(BUILT_PACKAGES_FILE) | $(SODIFF_REPO_FILE)
 	<$(BUILT_PACKAGES_FILE) $(SODIFF_SCRIPT) $(RPMS_DIR)/ $(SODIFF_REPO_FILE) $(RELEASE_MAJOR_ID) $(SODIFF_OUTPUT_FOLDER)
-	[ $(wc -w $(SODIFF_OUTPUT_FOLDER)/sodiff-summary.txt | cut -f1 -d' ')  -eq 0 ] || ( echo "SRPM files that need to be updated due to sodiff:"; cat $(SODIFF_OUTPUT_FOLDER)/sodiff-summary.txt ; $(call print_error,$@ failed - see $(SODIFF_OUTPUT_FOLDER)/ for a list of failed files.) )
+	[ ! -f "$(SODIFF_SUMMARY_FILE)" ] \
+	|| [ `$(wc -w $(SODIFF_SUMMARY_FILE) | cut -f1 -d' ')`  -eq 0 ] \
+	|| ( echo "SRPM files that need to be updated due to sodiff:"; cat $(SODIFF_OUTPUT_FOLDER)/sodiff-summary.txt ; $(call print_error,$@ failed - see $(SODIFF_SUMMARY_FILE) for a list of failed files.) )
 	echo "SODIFF finished - no changes detected."
 
 package-toolkit: $(SODIFF_REPO_FILE)

--- a/toolkit/scripts/sodiff/mariner-sodiff.sh
+++ b/toolkit/scripts/sodiff/mariner-sodiff.sh
@@ -68,9 +68,8 @@ done
 2>/dev/null cat "$sodiff_out_dir"/require* | sort -u > "$sodiff_out_dir"/sodiff-intermediate-summary.txt
 
 rm "$sodiff_out_dir"/sodiff-summary.txt
-touch "$sodiff_out_dir"/sodiff-summary.txt
-# Remove packages that have been dash-rolled already.
 
+# Remove packages that have been dash-rolled already.
 echo "$pkgs" > "$sodiff_out_dir/sodiff-built-packages.txt"
 for package in $( cat "$sodiff_out_dir"/sodiff-intermediate-summary.txt ); do
     # Remove version and release

--- a/toolkit/scripts/sodiff/mariner-sodiff.sh
+++ b/toolkit/scripts/sodiff/mariner-sodiff.sh
@@ -43,7 +43,7 @@ for rpmpackage in $pkgs; do
     for sofile in $package_provides; do
         # Query local metadata for provides
         sos_found=$( $DNF_COMMAND repoquery $common_options --whatprovides $sofile | wc -l )
-        if [[ $sos_found -eq 0 ]] ; then
+        if [[ "$sos_found" -eq 0 ]] ; then
             # SO file not found, meaning this might be a new .SO
             # or a new version of a preexisting .SO.
             # Check if the previous version exists in the database.
@@ -67,7 +67,7 @@ done
 # Obtain a list of unique packages to be updated
 2>/dev/null cat "$sodiff_out_dir"/require* | sort -u > "$sodiff_out_dir"/sodiff-intermediate-summary.txt
 
-rm "$sodiff_out_dir"/sodiff-summary.txt
+rm -f "$sodiff_out_dir"/sodiff-summary.txt
 
 # Remove packages that have been dash-rolled already.
 echo "$pkgs" > "$sodiff_out_dir/sodiff-built-packages.txt"

--- a/toolkit/scripts/sodiff/mariner-sodiff.sh
+++ b/toolkit/scripts/sodiff/mariner-sodiff.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -x
 
 # Required binaries:
 # rpm and dnf on Mariner
@@ -43,7 +43,7 @@ for rpmpackage in $pkgs; do
     for sofile in $package_provides; do
         # Query local metadata for provides
         sos_found=$( $DNF_COMMAND repoquery $common_options --whatprovides $sofile | wc -l )
-        if [[ "$sos_found" -eq 0 ]] ; then
+        if [ "$sos_found" -eq 0 ] ; then
             # SO file not found, meaning this might be a new .SO
             # or a new version of a preexisting .SO.
             # Check if the previous version exists in the database.
@@ -54,7 +54,7 @@ for rpmpackage in $pkgs; do
             # check for generic .so in the repo
             sos_found=$( $DNF_COMMAND repoquery $common_options --whatprovides "${sofile_no_ver}*" | wc -l )
 
-            if ! [[ $sos_found -eq 0 ]] ; then
+            if ! [ "$sos_found" -eq 0 ] ; then
                 # Generic version of SO was found.
                 # This means it's a new version of a preexisting SO.
                 # Log which packages depend on this functionality

--- a/toolkit/scripts/sodiff/mariner-sodiff.sh
+++ b/toolkit/scripts/sodiff/mariner-sodiff.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash
 
 # Required binaries:
 # rpm and dnf on Mariner


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Current mechanism to parse final output of sodiff did not work. Changed to one based on word-count.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change sodiff detection mechanism to a more foolproof method.


###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build
