### PR TITLE
[dev] Cleaning SRPM expansion console output

### DIFF
--- a/toolkit/scripts/srpm_expand.mk
+++ b/toolkit/scripts/srpm_expand.mk
@@ -10,6 +10,10 @@ $(call create_folder,$(BUILD_SPECS_DIR))
 
 srpms = $(shell find $(BUILD_SRPMS_DIR)/ -type f -name '*.src.rpm')
 srpms_basename = $(foreach srpm,$(srpms),$(notdir $(srpm)))
+srpm_expand_logs_dir = $(LOGS_DIR)/srpm_expand
+srpm_expand_log = $(srpm_expand_logs_dir)/srpm_expand.log
+
+$(call create_folder, $(srpm_expand_logs_dir))
 
 .PHONY: expand-specs clean-expand-specs
 expand-specs: $(BUILD_SPECS_DIR)
@@ -28,15 +32,16 @@ $(BUILD_SPECS_DIR): $(STATUS_FLAGS_DIR)/build_specs.flag
 
 # For each SRPM, if it is newer than the spec extract a new copy of the .spec file
 $(STATUS_FLAGS_DIR)/build_specs.flag: $(srpms) $(BUILD_SRPMS_DIR)
-	# For each SRPM, if it is newer than the spec extract a new copy of the .spec file
+	@echo "Extracting new or updated SRPMs from \"$(BUILD_SRPMS_DIR)\"." | tee $(srpm_expand_log) && \
 	for srpm in $(srpms_basename); do \
 		srpm_file=$(BUILD_SRPMS_DIR)/$${srpm} && \
-		spec_destination=$(BUILD_SPECS_DIR)/$$(rpm -qp $${srpm_file} --define='with_check 1' --queryformat %{NAME}-%{VERSION}-%{RELEASE}/%{NAME}.spec) && \
-		spec_dir=$$(dirname $${spec_destination}) && \
-		if [ $${srpm_file} -nt $@ -o ! -f $@ ]; then \
-			mkdir -p $${spec_dir} && \
-			echo extracting $${spec_destination} && \
-			cd $${spec_dir} && rpm2cpio $${srpm_file} | cpio -idvu || $(call print_error,Failed to expand $${srpm_file}) ; \
-		fi || $(call print_error,If in $@ failed) ; \
-	done || $(call print_error,Loop in $@ failed) ; \
+		spec_destination=$(BUILD_SPECS_DIR)/$$(rpm -qp $$srpm_file --define='with_check 1' --queryformat %{NAME}-%{VERSION}-%{RELEASE}/%{NAME}.spec) && \
+		spec_dir=$$(dirname $$spec_destination) && \
+		if [ ! -f $@ -o $$srpm -nt $@ ]; then \
+			echo "Extracting \"$$srpm_file\" to \"$$spec_dir\"." | tee -a $(srpm_expand_log) && \
+			mkdir -p $$spec_dir && \
+			cd $$spec_dir && \
+			rpm2cpio $$srpm_file | cpio -idvu 2>>$(srpm_expand_log) || $(call print_error,Failed to expand "$$srpm".); \
+		fi \
+	done || $(call print_error,Checking for spec updates failed. See above errors and "$(srpm_expand_log)" for more details.); \
 	touch $@

--- a/toolkit/scripts/srpm_pack.mk
+++ b/toolkit/scripts/srpm_pack.mk
@@ -65,7 +65,7 @@ $(STATUS_FLAGS_DIR)/build_toolchain_srpms.flag: $(STATUS_FLAGS_DIR)/build_srpms.
 	@touch $@
 else
 $(STATUS_FLAGS_DIR)/build_srpms.flag: $(chroot_worker) $(local_specs) $(local_spec_dirs) $(SPECS_DIR) $(go-srpmpacker)
-	GODEBUG=x509ignoreCN=0 $(go-srpmpacker) \
+	$(go-srpmpacker) \
 		--dir=$(SPECS_DIR) \
 		--output-dir=$(BUILD_SRPMS_DIR) \
 		--source-url=$(SOURCE_URL) \
@@ -78,11 +78,11 @@ $(STATUS_FLAGS_DIR)/build_srpms.flag: $(chroot_worker) $(local_specs) $(local_sp
 		--worker-tar=$(chroot_worker) \
 		$(if $(filter y,$(RUN_CHECK)),--run-check) \
 		--log-file=$(LOGS_DIR)/pkggen/srpms/srpmpacker.log \
-		--log-level=$(LOG_LEVEL)
+		--log-level=$(LOG_LEVEL) && \
 	touch $@
 
 $(STATUS_FLAGS_DIR)/build_toolchain_srpms.flag: $(toolchain_spec_list) $(go-srpmpacker)
-	GODEBUG=x509ignoreCN=0 $(go-srpmpacker) \
+	$(go-srpmpacker) \
 		--dir=$(SPECS_DIR) \
 		--output-dir=$(BUILD_SRPMS_DIR) \
 		--source-url=$(SOURCE_URL) \
@@ -95,6 +95,6 @@ $(STATUS_FLAGS_DIR)/build_toolchain_srpms.flag: $(toolchain_spec_list) $(go-srpm
 		--pack-list=$(toolchain_spec_list) \
 		$(if $(filter y,$(RUN_CHECK)),--run-check) \
 		--log-file=$(LOGS_DIR)/toolchain/srpms/toolchain_srpmpacker.log \
-		--log-level=$(LOG_LEVEL)
+		--log-level=$(LOG_LEVEL) && \
 	touch $@
 endif

--- a/toolkit/scripts/toolchain.mk
+++ b/toolkit/scripts/toolchain.mk
@@ -204,7 +204,7 @@ $(toolchain_rpms): $(TOOLCHAIN_MANIFEST) $(toolchain_local_temp)
 else
 # Download from online package server
 $(toolchain_rpms):
-	rpm_filename="$(notdir $@)" && \
+	@rpm_filename="$(notdir $@)" && \
 	rpm_dir="$(dir $@)" && \
 	log_file="$(toolchain_downloads_logs_dir)/$$rpm_filename.log" && \
 	echo "Downloading toolchain RPM: $$rpm_filename" | tee "$$log_file" && \


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
This is a port of applicable changes from #765 to the 2.0 branch. In particular, this cleans up SRPM expansion logs by excluding long filepath outputs and cpio outputs.

From the original PR: 
This PR aims at reducing the noise and confusion around the logs printed during RPMs builds.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- See #765 for a detailed list of changes.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local test runs touching affected parts of the toolkit
