### PR TITLE
Add rsyslog by default to Mariner cloud images (#1385)

### DIFF
--- a/toolkit/imageconfigs/packagelists/azurevm-packages.json
+++ b/toolkit/imageconfigs/packagelists/azurevm-packages.json
@@ -5,6 +5,7 @@
         "dhcp-client",
         "hyperv-daemons",
         "openssh-server",
+        "rsyslog",
         "WALinuxAgent"
     ]
 }


### PR DESCRIPTION
Add rsyslog by default to Mariner cloud images .

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

What does the PR accomplish, why was it needed?
Most of customers leverages syslog in some form as OS logging standard.
Adding rsyslog feature package by default to Mariner cloud images which is commonly used.

Change Log
Change
Add rsyslog by default to Mariner cloud images
Does this affect the toolchain?
NO

Associated issues
#xxxx
Links to CVEs
https://nvd.nist.gov/vuln/detail/CVE-YYYY-XXXX
Test Methodology
Local validation
