### PR TITLE
Fix qemu CVE-2021-3713

### DIFF
--- a/SPECS/qemu-kvm/CVE-2020-12829.nopatch
+++ b/SPECS/qemu-kvm/CVE-2020-12829.nopatch
@@ -1,5 +1,0 @@
-CVE-2020-12829 affects the sm501 video driver, which is only used for powerpc and SuperH emulation
-CONFIG_SM501 is selected by CONFIG_SAM460EX and CONFIG_R2D (from ppc-softmmu and sh4 targets respectively)
-We only build for the native architecture so we can nopatch this.
-
-This is resolved in qemu >= 5.0

--- a/SPECS/qemu-kvm/CVE-2021-3713.patch
+++ b/SPECS/qemu-kvm/CVE-2021-3713.patch
@@ -1,0 +1,34 @@
+--- a/hw/usb/dev-uas.c	2021-09-13 07:06:33.957673730 -0700
++++ b/hw/usb/dev-uas.c	2021-09-13 07:05:50.160800226 -0700
+@@ -830,6 +830,9 @@
+         }
+         break;
+     case UAS_PIPE_ID_STATUS:
++        if (p->stream > UAS_MAX_STREAMS) {
++            goto err_stream;
++        }
+         if (p->stream) {
+             QTAILQ_FOREACH(st, &uas->results, next) {
+                 if (st->stream == p->stream) {
+@@ -857,6 +860,9 @@
+         break;
+     case UAS_PIPE_ID_DATA_IN:
+     case UAS_PIPE_ID_DATA_OUT:
++        if (p->stream > UAS_MAX_STREAMS) {
++            goto err_stream;
++        }
+         if (p->stream) {
+             req = usb_uas_find_request(uas, p->stream);
+         } else {
+@@ -892,6 +898,11 @@
+         p->status = USB_RET_STALL;
+         break;
+     }
++
++err_stream:
++    error_report("%s: invalid stream %d", __func__, p->stream);
++    p->status = USB_RET_STALL;
++    return;
+ }
+ 
+ static void usb_uas_unrealize(USBDevice *dev, Error **errp)

--- a/SPECS/qemu-kvm/qemu-kvm.spec
+++ b/SPECS/qemu-kvm/qemu-kvm.spec
@@ -1,7 +1,7 @@
 Summary:        QEMU is a machine emulator and virtualizer
 Name:           qemu-kvm
 Version:        4.2.0
-Release:        35%{?dist}
+Release:        36%{?dist}
 License:        GPLv2 AND GPLv2+ AND CC-BY AND BSD
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -13,49 +13,54 @@ Source1:        65-kvm.rules
 Patch0:         CVE-2020-11102.patch
 # This vulnerability is in libslirp source code. And qemu is exposed to it when configured with libslirp.
 # Since Mariner does not have libslirp, it is not applicable.
-Patch1:         CVE-2020-7039.nopatch
-Patch2:         CVE-2020-1711.patch
-Patch3:         CVE-2020-7211.patch
-Patch4:         CVE-2019-20175.patch
-Patch5:         CVE-2020-13659.patch
-Patch6:         CVE-2020-16092.patch
-Patch7:         CVE-2020-15863.patch
-Patch8:         CVE-2020-10702.patch
-Patch9:         CVE-2020-10761.patch
+Patch1:         CVE-2020-1711.patch
+Patch2:         CVE-2020-7211.patch
+Patch3:         CVE-2019-20175.patch
+Patch4:         CVE-2020-13659.patch
+Patch5:         CVE-2020-16092.patch
+Patch6:         CVE-2020-15863.patch
+Patch7:         CVE-2020-10702.patch
+Patch8:         CVE-2020-10761.patch
 # CVE-2020-13253 backported to 4.2.0. Original version: https://github.com/qemu/qemu/commit/790762e5487114341cccc5bffcec4cb3c022c3cd
-Patch10:        CVE-2020-13253.patch
-Patch11:        CVE-2020-13754.patch
-Patch12:        CVE-2020-13800.patch
-Patch13:        CVE-2020-14364.patch
-Patch14:        CVE-2020-13791.patch
+Patch9:        CVE-2020-13253.patch
+Patch10:        CVE-2020-13754.patch
+Patch11:        CVE-2020-13800.patch
+Patch12:        CVE-2020-14364.patch
+Patch13:        CVE-2020-13791.patch
 # CVE-2018-19665 patch never merged upstream, link: https://lists.gnu.org/archive/html/qemu-devel/2018-11/msg03570.html
-Patch15:        CVE-2018-19665.patch
-Patch16:        CVE-2020-13361.patch
-Patch17:        CVE-2020-11869.patch
-Patch18:        CVE-2020-14415.patch
-Patch19:        CVE-2020-15859.patch
-Patch20:        CVE-2020-13362.patch
-Patch21:        CVE-2020-25742.patch
-Patch22:        CVE-2020-25743.patch
-Patch23:        CVE-2020-15469.patch
-Patch24:        CVE-2020-24352.patch
-# CVE-2020-12820 only affects powerpc and SuperH emulation (see .nopatch file for details). Resloved fully in qemu >=5.0.0
-Patch25:        CVE-2020-12829.nopatch
-Patch26:        CVE-2018-12617.patch
-Patch27:        CVE-2020-25723.patch
-Patch28:        CVE-2020-27821.patch
-Patch29:        CVE-2020-17380.patch
-Patch30:        CVE-2021-20203.patch
-Patch31:        CVE-2021-20255.patch
-Patch32:        CVE-2021-3416.patch
-Patch33:        CVE-2021-3392.patch
-Patch34:        CVE-2021-3409.patch
-Patch35:        CVE-2021-20181.patch
-Patch36:        CVE-2021-20221.patch
-Patch37:        CVE-2021-3527.patch
-Patch38:        CVE-2020-27661.nopatch
-Patch39:        CVE-2021-3546.patch
-Patch40:        CVE-2021-3682.patch
+Patch14:        CVE-2018-19665.patch
+Patch15:        CVE-2020-13361.patch
+Patch16:        CVE-2020-11869.patch
+Patch17:        CVE-2020-14415.patch
+Patch18:        CVE-2020-15859.patch
+Patch19:        CVE-2020-13362.patch
+Patch20:        CVE-2020-25742.patch
+Patch21:        CVE-2020-25743.patch
+Patch22:        CVE-2020-15469.patch
+Patch23:        CVE-2020-24352.patch
+Patch24:        CVE-2018-12617.patch
+Patch25:        CVE-2020-25723.patch
+Patch26:        CVE-2020-27821.patch
+Patch27:        CVE-2020-17380.patch
+Patch28:        CVE-2021-20203.patch
+Patch29:        CVE-2021-20255.patch
+Patch30:        CVE-2021-3416.patch
+Patch31:        CVE-2021-3392.patch
+Patch32:        CVE-2021-3409.patch
+Patch33:        CVE-2021-20181.patch
+Patch34:        CVE-2021-20221.patch
+Patch35:        CVE-2021-3527.patch
+Patch36:        CVE-2021-3546.patch
+Patch37:        CVE-2021-3682.patch
+Patch38:        CVE-2021-3713.patch
+
+# Range 1001+ reserved for nopatch files
+Patch1001: CVE-2020-7039.nopatch
+# CVE-2020-12829 affects the sm501 video driver, which is only used for powerpc and SuperH emulation
+# CONFIG_SM501 is selected by CONFIG_SAM460EX and CONFIG_R2D (from ppc-softmmu and sh4 targets respectively). We are not affected because we only build natively.
+# This is resolved in qemu >= 5.0
+Patch1002: CVE-2020-12829.nopatch
+Patch1003: CVE-2020-27661.nopatch
 
 BuildRequires:  alsa-lib-devel
 BuildRequires:  glib-devel
@@ -82,45 +87,7 @@ Requires:       pixman
 This package provides a command line tool for manipulating disk images.
 
 %prep
-%setup -q -n qemu-%{version}
-%patch0 -p1
-%patch2 -p1
-%patch3 -p1
-%patch4 -p1
-%patch5 -p1
-%patch6 -p1
-%patch7 -p1
-%patch8 -p1
-%patch9 -p1
-%patch10 -p1
-%patch11 -p1
-%patch12 -p1
-%patch13 -p1
-%patch14 -p1
-%patch15 -p1
-%patch16 -p1
-%patch17 -p1
-%patch18 -p1
-%patch19 -p1
-%patch20 -p1
-%patch21 -p1
-%patch22 -p1
-%patch23 -p1
-%patch24 -p1
-%patch26 -p1
-%patch27 -p1
-%patch28 -p1
-%patch29 -p1
-%patch30 -p1
-%patch31 -p1
-%patch32 -p1
-%patch33 -p1
-%patch34 -p1
-%patch35 -p1
-%patch36 -p1
-%patch37 -p1
-%patch39 -p1
-%patch40 -p1
+%autosetup -n qemu-%{version} -p1
 
 # Remove invalid flag exposed by binutils 2.36.1
 sed -i "/LDFLAGS_NOPIE/d" configure
@@ -220,6 +187,12 @@ fi
 %{_bindir}/qemu-nbd
 
 %changelog
+* Thu Sep 09 2021 Mateusz Malisz <mamalisz@microsoft.com> - 4.2.0-36
+- Patched CVE-2021-3713
+- Move nopatch files to 1001+ range.
+- Reenable autosetup
+- Move contents of CVE-2020-12829 to this spec and clear the nopatch file.
+
 * Mon Aug 16 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 4.2.0-35
 - Patched CVE-2021-3682.
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
This change fixes qemu CVE-2021-3713. I have also reorganized the patch files to support autopatching, removing some verbosity.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add patch for CVE-2021-3713
- Reorganize patch files to support autopatching

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2021-3713

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build
