### PR TITLE
Use pam_pwquality in system-password PAM config

### DIFF
--- a/SPECS/shadow-utils/pam.d/system-password
+++ b/SPECS/shadow-utils/pam.d/system-password
@@ -2,7 +2,7 @@
 
 # use sha512 hash for encryption, use shadow, and try to use any previously
 # defined authentication token (chosen password) set by any prior module
-password  requisite   pam_cracklib.so
+password  requisite   pam_pwquality.so
 password  required    pam_unix.so       sha512 shadow try_first_pass
 
 # End /etc/pam.d/system-password

--- a/SPECS/shadow-utils/shadow-utils.signatures.json
+++ b/SPECS/shadow-utils/shadow-utils.signatures.json
@@ -11,7 +11,7 @@
   "su": "c7f5f066e5e021deae9dd72cc897240cfdef869da33148f19c8d5e13f5bd0510",
   "system-account": "a8295e4780b323cac83ca08c65c8cd47ca26e516d64ed857fd3f4ac1f1a8ccc4",
   "system-auth": "da912d0b5fe0ee9d70403ca88402974f2c24b6dfeb2c8adc037c72297a859590",
-  "system-password": "f3e1667d6e5d7129cfe062e17ce9fc86ea94979bc8fecd592234e7d22c9ddc43",
+  "system-password": "644e12cde448e732edde812abef10f4e16ef0f8d41c0cdf60e3ad30adf37cdeb",
   "system-session": "6f23e44b3af0ac754494aee8a6ce4f3a203020dbff7a6ea5de3b75bad3b2f6ab",
   "useradd-default": "b239b5620f0c23ef901ea19172e60e38322abbe366e04c94d03ca08f5b936125"
  }

--- a/SPECS/shadow-utils/shadow-utils.spec
+++ b/SPECS/shadow-utils/shadow-utils.spec
@@ -1,7 +1,7 @@
 Summary:        Programs for handling passwords in a secure way
 Name:           shadow-utils
 Version:        4.9
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        BSD
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -173,6 +173,7 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %config(noreplace) %{_sysconfdir}/pam.d/*
 
 %files subid
+%license COPYING
 %{_libdir}/libsubid.so.3*
 
 %files subid-devel
@@ -180,6 +181,10 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %{_libdir}/libsubid.so
 
 %changelog
+* Fri Sep 10 2021 Thomas Crain <thcrain@microsoft.com> - 4.9-2
+- Update system-password PAM config to use pam_pwquality.so instead of removed pam_cracklib.so
+- Add license to subid subpackage
+
 * Fri Aug 13 2021 Thomas Crain <thcrain@microsoft.com> - 4.9-1
 - Upgrade to latest upstream version and rebase chkname patch
 - Add upstream patch to deal with libsubid build failure when linking to pam

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -587,10 +587,10 @@ rpm-libs-4.14.2.1-4.cm2.aarch64.rpm
 sed-4.5-3.cm2.aarch64.rpm
 sed-debuginfo-4.5-3.cm2.aarch64.rpm
 sed-lang-4.5-3.cm2.aarch64.rpm
-shadow-utils-4.9-1.cm2.aarch64.rpm
-shadow-utils-debuginfo-4.9-1.cm2.aarch64.rpm
-shadow-utils-subid-4.9-1.cm2.aarch64.rpm
-shadow-utils-subid-devel-4.9-1.cm2.aarch64.rpm
+shadow-utils-4.9-2.cm2.aarch64.rpm
+shadow-utils-debuginfo-4.9-2.cm2.aarch64.rpm
+shadow-utils-subid-4.9-2.cm2.aarch64.rpm
+shadow-utils-subid-devel-4.9-2.cm2.aarch64.rpm
 sqlite-3.34.1-1.cm2.aarch64.rpm
 sqlite-debuginfo-3.34.1-1.cm2.aarch64.rpm
 sqlite-devel-3.34.1-1.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -587,10 +587,10 @@ rpm-libs-4.14.2.1-4.cm2.x86_64.rpm
 sed-4.5-3.cm2.x86_64.rpm
 sed-debuginfo-4.5-3.cm2.x86_64.rpm
 sed-lang-4.5-3.cm2.x86_64.rpm
-shadow-utils-4.9-1.cm2.x86_64.rpm
-shadow-utils-debuginfo-4.9-1.cm2.x86_64.rpm
-shadow-utils-subid-4.9-1.cm2.x86_64.rpm
-shadow-utils-subid-devel-4.9-1.cm2.x86_64.rpm
+shadow-utils-4.9-2.cm2.x86_64.rpm
+shadow-utils-debuginfo-4.9-2.cm2.x86_64.rpm
+shadow-utils-subid-4.9-2.cm2.x86_64.rpm
+shadow-utils-subid-devel-4.9-2.cm2.x86_64.rpm
 sqlite-3.34.1-1.cm2.x86_64.rpm
 sqlite-debuginfo-3.34.1-1.cm2.x86_64.rpm
 sqlite-devel-3.34.1-1.cm2.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
2.0 branch images have been failing to provision using `cloud-init` since the last 1.0 merge. This issue was traced to a `pam` upgrade which removed the pam_cracklib.so library. `shadow-utils` uses that library when setting passwords, and the library's absence caused user provisioning failures. We follow shadow-utils maintainer advice and replace the removed library with `pam_pwquality.so`.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Use `pam_pwquality.so` in system-password PAM config 

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build of core VHD/VHDX images. Was able to setup and login to a user account using cloud-init.
