### PR TITLE
[dev] `binutils`: adding `libiberty` library and header

### DIFF
--- a/SPECS/UI-cairo/UI-cairo.spec
+++ b/SPECS/UI-cairo/UI-cairo.spec
@@ -11,7 +11,7 @@
 Summary:        A 2D graphics library (UI libs dependent)
 Name:           UI-cairo
 Version:        1.16.0
-Release:        12%{?dist}
+Release:        13%{?dist}
 # The sources for 'cairo' itself are available under the (LGPLv2 OR MPLv1.1) license.
 # Test code and fonts are available under either the MIT or Public Domain license.
 # The 'cairo-trace' tools are released under the GPLv3 license - 'License' tag added separately for that subpackage.
@@ -149,6 +149,7 @@ This package contains tools for working with the cairo graphics library.
     --disable-gl \
     --disable-gtk-doc \
     --disable-static \
+    --disable-symbol-lookup \
     --enable-ft \
     --enable-gobject \
     --enable-pdf \
@@ -223,6 +224,9 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %{_libdir}/cairo/
 
 %changelog
+* Thu Sep 16 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.16.0-13
+- Disabling "symbol-lookup" feature due to compilation errors.
+
 * Thu Jun 10 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.16.0-12
 - Added missing 'Conflicts' for all 'cairo' subpackges.
 

--- a/SPECS/binutils/binutils.spec
+++ b/SPECS/binutils/binutils.spec
@@ -46,11 +46,8 @@ find %{buildroot} -type f -name "*.la" -delete -print
 rm -rf %{buildroot}%{_infodir}
 %find_lang %{name} --all-name
 
-# Rebuild libiberty.a with -fPIC.
-#%make_build -C libiberty clean
-#%make_build CFLAGS="$CFLAGS -g -fPIC" -C libiberty
-#install -m 644 libiberty/libiberty.a %{buildroot}%{_libdir}
-#install -m 644 include/libiberty.h %{buildroot}%{_includedir}
+install -m 644 libiberty/libiberty.a %{buildroot}%{_libdir}
+install -m 644 include/libiberty.h %{buildroot}%{_includedir}
 
 %check
 sed -i 's/testsuite/ /g' gold/Makefile
@@ -131,7 +128,7 @@ sed -i 's/testsuite/ /g' gold/Makefile
 
 %changelog
 * Tue Sep 14 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 2.36.1-3
-- Adding 'libiberty' libs using Fedora 32 (license: MIT) spec for guidance.
+- Adding 'libiberty' lib and header.
 
 * Tue Aug 24 2021 Thomas Crain <thcrain@microsoft.com> - 2.36.1-2
 - Add patch from Fedora 34 (license: MIT) to export demangle.h from libiberty sources

--- a/SPECS/binutils/binutils.spec
+++ b/SPECS/binutils/binutils.spec
@@ -1,7 +1,7 @@
 Summary:        Contains a linker, an assembler, and other tools
 Name:           binutils
 Version:        2.36.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        GPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -10,6 +10,8 @@ URL:            https://www.gnu.org/software/binutils
 Source0:        https://ftp.gnu.org/gnu/binutils/%{name}-%{version}.tar.xz
 # Patch Source: https://src.fedoraproject.org/rpms/binutils/blob/f34/f/binutils-export-demangle.h.patch
 Patch0:         export-demangle-header.patch
+
+Provides:       bundled(libiberty)
 
 %description
 The Binutils package contains a linker, an assembler,
@@ -28,13 +30,13 @@ for handling compiled objects.
 
 %build
 %configure \
+    --disable-silent-rules \
+    --disable-werror    \
     --enable-gold       \
     --enable-ld=default \
     --enable-plugins    \
     --enable-shared     \
-    --disable-werror    \
-    --with-system-zlib  \
-    --disable-silent-rules
+    --with-system-zlib
 
 %make_build tooldir=%{_prefix}
 
@@ -43,6 +45,12 @@ for handling compiled objects.
 find %{buildroot} -type f -name "*.la" -delete -print
 rm -rf %{buildroot}%{_infodir}
 %find_lang %{name} --all-name
+
+# Rebuild libiberty.a with -fPIC.
+#%make_build -C libiberty clean
+#%make_build CFLAGS="$CFLAGS -g -fPIC" -C libiberty
+#install -m 644 libiberty/libiberty.a %{buildroot}%{_libdir}
+#install -m 644 include/libiberty.h %{buildroot}%{_includedir}
 
 %check
 sed -i 's/testsuite/ /g' gold/Makefile
@@ -94,22 +102,21 @@ sed -i 's/testsuite/ /g' gold/Makefile
 %{_libdir}/libopcodes-%{version}.so
 
 %files devel
-%{_includedir}/plugin-api.h
-%{_includedir}/symcat.h
-%{_includedir}/bfd.h
 %{_includedir}/ansidecl.h
-%{_includedir}/bfdlink.h
-%{_includedir}/dis-asm.h
 %{_includedir}/bfd_stdint.h
-%{_includedir}/diagnostics.h
+%{_includedir}/bfd.h
+%{_includedir}/bfdlink.h
 %{_includedir}/ctf-api.h
 %{_includedir}/ctf.h
 %{_includedir}/demangle.h
-%{_libdir}/libbfd.a
-%{_libdir}/libopcodes.a
-%{_libdir}/libbfd.so
-%{_libdir}/libopcodes.so
+%{_includedir}/diagnostics.h
+%{_includedir}/dis-asm.h
+%{_includedir}/libiberty.h
+%{_includedir}/plugin-api.h
+%{_includedir}/symcat.h
 %{_libdir}/bfd-plugins/libdep.so
+%{_libdir}/libbfd.a
+%{_libdir}/libbfd.so
 %{_libdir}/libctf-nobfd.a
 %{_libdir}/libctf-nobfd.so
 %{_libdir}/libctf-nobfd.so.0
@@ -118,8 +125,14 @@ sed -i 's/testsuite/ /g' gold/Makefile
 %{_libdir}/libctf.so
 %{_libdir}/libctf.so.0
 %{_libdir}/libctf.so.0.*
+%{_libdir}/libiberty.a
+%{_libdir}/libopcodes.a
+%{_libdir}/libopcodes.so
 
 %changelog
+* Tue Sep 14 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 2.36.1-3
+- Adding 'libiberty' libs using Fedora 32 (license: MIT) spec for guidance.
+
 * Tue Aug 24 2021 Thomas Crain <thcrain@microsoft.com> - 2.36.1-2
 - Add patch from Fedora 34 (license: MIT) to export demangle.h from libiberty sources
 - Lint spec

--- a/SPECS/cairo/cairo.spec
+++ b/SPECS/cairo/cairo.spec
@@ -1,7 +1,7 @@
 Summary:        A 2D graphics library.
 Name:           cairo
 Version:        1.17.4
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        LGPLv2 OR MPLv1.1
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -69,7 +69,8 @@ It contains the libraries and header files to create applications
         --enable-xlib-xrender=no \
         --enable-gobject \
         CFLAGS="-O3 -fPIC" \
-        --disable-static
+        --disable-static \
+        --disable-symbol-lookup
 make %{?_smp_mflags}
 
 %install
@@ -103,6 +104,9 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %{_libdir}/pkgconfig/*.pc
 
 %changelog
+* Thu Sep 16 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.17.4-2
+- Disabling "symbol-lookup" feature due to compilation errors.
+
 * Fri Mar 26 2021 Thomas Crain <thcrain@microsoft.com> - 1.17.4-1
 - Merge the following releases from 1.0 to dev branch
 - niontive@microsoft.com, 1.16.0-5: Fix CVE-2018-19876

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -12,8 +12,8 @@ zlib-devel-1.2.11-5.cm2.aarch64.rpm
 file-5.38-2.cm2.aarch64.rpm
 file-devel-5.38-2.cm2.aarch64.rpm
 file-libs-5.38-2.cm2.aarch64.rpm
-binutils-2.36.1-2.cm2.aarch64.rpm
-binutils-devel-2.36.1-2.cm2.aarch64.rpm
+binutils-2.36.1-3.cm2.aarch64.rpm
+binutils-devel-2.36.1-3.cm2.aarch64.rpm
 gmp-6.1.2-5.cm2.aarch64.rpm
 gmp-devel-6.1.2-5.cm2.aarch64.rpm
 mpfr-4.0.1-3.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -12,8 +12,8 @@ zlib-devel-1.2.11-5.cm2.x86_64.rpm
 file-5.38-2.cm2.x86_64.rpm
 file-devel-5.38-2.cm2.x86_64.rpm
 file-libs-5.38-2.cm2.x86_64.rpm
-binutils-2.36.1-2.cm2.x86_64.rpm
-binutils-devel-2.36.1-2.cm2.x86_64.rpm
+binutils-2.36.1-3.cm2.x86_64.rpm
+binutils-devel-2.36.1-3.cm2.x86_64.rpm
 gmp-6.1.2-5.cm2.x86_64.rpm
 gmp-devel-6.1.2-5.cm2.x86_64.rpm
 mpfr-4.0.1-3.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -12,9 +12,9 @@ bash-4.4.18-7.cm2.aarch64.rpm
 bash-debuginfo-4.4.18-7.cm2.aarch64.rpm
 bash-devel-4.4.18-7.cm2.aarch64.rpm
 bash-lang-4.4.18-7.cm2.aarch64.rpm
-binutils-2.36.1-2.cm2.aarch64.rpm
-binutils-debuginfo-2.36.1-2.cm2.aarch64.rpm
-binutils-devel-2.36.1-2.cm2.aarch64.rpm
+binutils-2.36.1-3.cm2.aarch64.rpm
+binutils-debuginfo-2.36.1-3.cm2.aarch64.rpm
+binutils-devel-2.36.1-3.cm2.aarch64.rpm
 bison-3.1-4.cm2.aarch64.rpm
 bison-debuginfo-3.1-4.cm2.aarch64.rpm
 bzip2-1.0.6-16.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -12,9 +12,9 @@ bash-4.4.18-7.cm2.x86_64.rpm
 bash-debuginfo-4.4.18-7.cm2.x86_64.rpm
 bash-devel-4.4.18-7.cm2.x86_64.rpm
 bash-lang-4.4.18-7.cm2.x86_64.rpm
-binutils-2.36.1-2.cm2.x86_64.rpm
-binutils-debuginfo-2.36.1-2.cm2.x86_64.rpm
-binutils-devel-2.36.1-2.cm2.x86_64.rpm
+binutils-2.36.1-3.cm2.x86_64.rpm
+binutils-debuginfo-2.36.1-3.cm2.x86_64.rpm
+binutils-devel-2.36.1-3.cm2.x86_64.rpm
 bison-3.1-4.cm2.x86_64.rpm
 bison-debuginfo-3.1-4.cm2.x86_64.rpm
 bzip2-1.0.6-16.cm2.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

Adding the `libiberty` components to `binutils` to satisfy common requirements.

I've also updated `cairo` and `UI-cairo` builds. The new header and library triggers a build of the `symbol-lookup` feature, which fails to compile due to errors. Disabling that feature until required.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Extended `binutils` with `libiberty`.
- Disabled `symbol-lookup` feature in `cairo` and `UI-cairo`.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
Yes.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local package build.
- Pipeline toolchain build.