### PR TITLE
[dev] Fix rsyslog.d and product_uuid permissions

### DIFF
--- a/SPECS/WALinuxAgent/WALinuxAgent.spec
+++ b/SPECS/WALinuxAgent/WALinuxAgent.spec
@@ -1,7 +1,7 @@
 Summary:        The Windows Azure Linux Agent
 Name:           WALinuxAgent
 Version:        2.2.54.2
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -48,6 +48,8 @@ mkdir -p  %{buildroot}/%{_localstatedir}/log
 mkdir -p -m 0700 %{buildroot}/%{_sharedstatedir}/waagent
 mkdir -p %{buildroot}/%{_localstatedir}/log
 touch %{buildroot}/%{_localstatedir}/log/waagent.log
+install -vdm 755 %{buildroot}/%{_sysconfdir}/udev/rules.d
+install -m 644 config/99-azure-product-uuid.rules %{buildroot}/%{_sysconfdir}/udev/rules.d
 # python refers to python2 version on CBL-Mariner hence update to use python3
 sed -i 's,#!/usr/bin/env python,#!/usr/bin/python3,' %{buildroot}%{_bindir}/waagent
 sed -i 's,#!/usr/bin/env python,#!/usr/bin/python3,' %{buildroot}%{_bindir}/waagent2.0
@@ -67,6 +69,7 @@ python3 setup.py check && python3 setup.py test
 
 %files
 %{_libdir}/systemd/system/*
+%{_sysconfdir}/udev/rules.d/*
 %defattr(0644,root,root,0755)
 %license LICENSE.txt
 %attr(0755,root,root) %{_bindir}/waagent
@@ -77,6 +80,9 @@ python3 setup.py check && python3 setup.py test
 %{python3_sitelib}/*
 
 %changelog
+* Thu Sep 16 2021 Henry Beberman <henry.beberman@microsoft.com> - 2.2.54.2-3
+- Include the 99-azure-product-uuid udev rule.
+
 * Tue Aug 17 2021 Thomas Crain <thcrain@microsoft.com> - 2.2.54.2-2
 - Fix incorrect %%{_lib} macro usage
 

--- a/SPECS/rsyslog/rsyslog.spec
+++ b/SPECS/rsyslog/rsyslog.spec
@@ -1,8 +1,7 @@
-%define sha1    rsyslog=7541e3cf6facbab19792ff8d9d7f4cd3fbb1c634
 Summary:        Rocket-fast system for log processing
 Name:           rsyslog
 Version:        8.37.0
-Release:        6%{?dist}
+Release:        7%{?dist}
 License:        GPLv3+ AND ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -114,6 +113,7 @@ sed -i 's/libsystemd-journal/libsystemd/' configure
 install -vd %{buildroot}%{_libdir}/systemd/system/
 install -vd %{buildroot}%{_sysconfdir}/systemd/journald.conf.d/
 install -vd %{buildroot}%{_docdir}/%{name}/html
+install -vdm 755 %{buildroot}/%{_sysconfdir}/rsyslog.d
 rm -f %{buildroot}/lib/systemd/system/rsyslog.service
 install -p -m 644 %{SOURCE1} %{buildroot}%{_libdir}/systemd/system/
 install -p -m 644 %{SOURCE2} %{buildroot}%{_sysconfdir}/systemd/journald.conf.d/
@@ -146,11 +146,15 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %{_libdir}/systemd/system/rsyslog.service
 %{_sysconfdir}/systemd/journald.conf.d/*
 %{_sysconfdir}/rsyslog.conf
+%dir %attr(0755, root, root) %{_sysconfdir}/rsyslog.d
 
 %files doc
 %doc %{_docdir}/%{name}/html
 
 %changelog
+* Thu Sep 16 2021 Henry Beberman <henry.beberman@microsoft.com> - 8.37.0-7
+- Add /etc/rsyslog.d directory.
+
 * Mon Jul 19 2021 Thomas Crain <thcrain@microsoft.com> - 8.37.0-6
 - Add html documentation subpackage from upstream-provided tarball
 - Enable various features and add the corresponding provides for subpackages from other distros:


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Fixing permissions on /etc/rsyslog.d and /sys/devices/virtual/dmi/id/product_uuid to improve compat with AMA and ASA VM extensions.
Porting 1.0-dev fix into dev: https://github.com/microsoft/CBL-Mariner/pull/1413

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Create /etc/rsyslog.d explicitly with correct permissions in the rsyslog package
- Add product_uuid permission udev rule to WALinuxAgent package

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
- Local Build
