### PR TITLE
Add partition and disk config validation

### DIFF
--- a/toolkit/scripts/tools.mk
+++ b/toolkit/scripts/tools.mk
@@ -103,7 +103,7 @@ go-fmt-all:
 # Formats the test coverage for the tools
 .PHONY: $(BUILD_DIR)/tools/all_tools.coverage
 $(BUILD_DIR)/tools/all_tools.coverage: $(shell find $(TOOLS_DIR)/ -type f -name '*.go')
-	cd $(TOOLS_DIR) && go test -covermode=atomic -coverprofile=$@ ./...
+	cd $(TOOLS_DIR) && go test -coverpkg=./... -covermode=atomic -coverprofile=$@ ./...
 $(test_coverage_report): $(BUILD_DIR)/tools/all_tools.coverage
 	cd $(TOOLS_DIR) && go tool cover -html=$(BUILD_DIR)/tools/all_tools.coverage -o $@
 go-test-coverage: $(test_coverage_report)

--- a/toolkit/tools/imagegen/configuration/configuration_test.go
+++ b/toolkit/tools/imagegen/configuration/configuration_test.go
@@ -65,6 +65,12 @@ func TestShouldErrorForMissingFile(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestShouldSucceedReturnNilDiskForBadPartition(t *testing.T) {
+	badPartition := Partition{ID: "NOT_A_REAL_ID"}
+	diskPart := expectedConfiguration.GetDiskContainingPartition(&badPartition)
+	assert.Nil(t, diskPart)
+}
+
 func TestShouldFailForUntaggedEncryptionDeviceMapperRoot(t *testing.T) {
 	var checkedConfig Config
 	testConfig := expectedConfiguration
@@ -87,28 +93,24 @@ func TestShouldFailForUntaggedEncryptionDeviceMapperRoot(t *testing.T) {
 	assert.Equal(t, "failed to parse [Config]: a config in [SystemConfigs] enables a device mapper based root (Encryption or Read-Only), but partitions are miss-configured: [Partition] 'MyRootfs' must include 'dmroot' device mapper root flag in [Flags] for [SystemConfig] 'SmallerDisk's root partition since it uses [ReadOnlyVerityRoot] or [Encryption]", err.Error())
 }
 
-func TestShouldFailDeviceMapperWithNoRootDisks(t *testing.T) {
-	var checkedConfig Config
-	testConfig := expectedConfiguration
-
-	// Clear the disks, add one empty one
-	testConfig.Disks = []Disk{{}}
-
-	err := testConfig.IsValid()
-	assert.Error(t, err)
-	assert.Equal(t, "a config in [SystemConfigs] enables a device mapper based root (Encryption or Read-Only), but partitions are miss-configured: can't find a [Disk] [Partition] to match with [PartitionSetting] 'MyRootfs'", err.Error())
-
-	err = remarshalJSON(testConfig, &checkedConfig)
-	assert.Error(t, err)
-	assert.Equal(t, "failed to parse [Config]: a config in [SystemConfigs] enables a device mapper based root (Encryption or Read-Only), but partitions are miss-configured: can't find a [Disk] [Partition] to match with [PartitionSetting] 'MyRootfs'", err.Error())
-}
-
 func TestShouldFailDeviceMapperWithNoRootPartitions(t *testing.T) {
 	var checkedConfig Config
 	testConfig := expectedConfiguration
 
 	// Clear the partitions, then add a missmatching one
 	testConfig.SystemConfigs = append([]SystemConfig{}, testConfig.SystemConfigs...)
+	testConfig.Disks = append([]Disk{}, expectedConfiguration.Disks...)
+	testConfig.Disks[0].Partitions = []Partition{
+		{
+			ID: "NotRoot",
+			Flags: []PartitionFlag{
+				"dmroot",
+			},
+			Start:  uint64(0),
+			End:    uint64(1024),
+			FsType: "ext4",
+		},
+	}
 	testConfig.SystemConfigs[0].PartitionSettings = []PartitionSetting{{ID: "NotRoot", MountPoint: "/not/root"}}
 
 	err := testConfig.IsValid()
@@ -126,26 +128,41 @@ func TestShouldFailDeviceMapperWithMultipleRoots(t *testing.T) {
 	testConfig := expectedConfiguration
 
 	// Copy the root partition settings
-	ExtraDmRoot := Partition{
-		ID: "MySecondRootfs",
-		Flags: []PartitionFlag{
-			"dmroot",
+	ExtraDmRoots := []Partition{
+		{
+			ID: "MyRootfs",
+			Flags: []PartitionFlag{
+				"dmroot",
+			},
+			Start:  uint64(0),
+			End:    uint64(1024),
+			FsType: "ext4",
+		}, {
+			ID: "MySecondRootfs",
+			Flags: []PartitionFlag{
+				"dmroot",
+			},
+			Start:  uint64(1024),
+			End:    uint64(2048),
+			FsType: "ext4",
 		},
-		Start:  uint64(1024),
-		End:    uint64(2048),
-		FsType: "ext4",
 	}
-	ExtraPartitionSetting := PartitionSetting{
-		ID:         "MySecondRootfs",
-		MountPoint: "/OtherRoot",
+	ExtraPartitionSettings := []PartitionSetting{
+		{
+			ID:         "MyRootfs",
+			MountPoint: "/",
+		}, {
+			ID:         "MySecondRootfs",
+			MountPoint: "/OtherRoot",
+		},
 	}
 
 	// Copy the disks, then add the extra partition
 	testConfig.Disks = append([]Disk{}, expectedConfiguration.Disks...)
-	testConfig.Disks[0].Partitions = append(testConfig.Disks[0].Partitions, ExtraDmRoot)
+	testConfig.Disks[0].Partitions = ExtraDmRoots
 	// Copy the partition settings, then add the extra partition setting
 	testConfig.SystemConfigs = append([]SystemConfig{}, expectedConfiguration.SystemConfigs[0])
-	testConfig.SystemConfigs[0].PartitionSettings = append(testConfig.SystemConfigs[0].PartitionSettings, ExtraPartitionSetting)
+	testConfig.SystemConfigs[0].PartitionSettings = ExtraPartitionSettings
 
 	err := testConfig.IsValid()
 	assert.Error(t, err)
@@ -156,6 +173,59 @@ func TestShouldFailDeviceMapperWithMultipleRoots(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, "failed to parse [Config]: a config in [SystemConfigs] enables a device mapper based root (Encryption or Read-Only), but partitions are miss-configured: [SystemConfig] 'SmallerDisk' includes two (or more) device mapper root [PartitionSettings] 'MyRootfs' and 'MySecondRootfs', include only one", err.Error())
 
+}
+
+func TestShouldFailDuplicatedIDs(t *testing.T) {
+	var checkedConfig Config
+	testConfig := expectedConfiguration
+
+	// Copy the disks, then add some duplicate IDs
+	// First on the same disk
+	testConfig.Disks = append([]Disk{}, expectedConfiguration.Disks...)
+	testConfig.Disks[0].Partitions = append([]Partition{}, expectedConfiguration.Disks[0].Partitions...)
+	testConfig.Disks[0].Partitions = append(testConfig.Disks[0].Partitions, Partition{ID: "duplicatedID"})
+	testConfig.Disks[0].Partitions = append(testConfig.Disks[0].Partitions, Partition{ID: "duplicatedID"})
+
+	err := testConfig.IsValid()
+	assert.Error(t, err)
+	assert.Equal(t, "invalid [Config]: a [Partition] on a [Disk] '0' shares an ID 'duplicatedID' with another partition (on disk '0')", err.Error())
+
+	err = remarshalJSON(testConfig, &checkedConfig)
+	assert.Error(t, err)
+	assert.Equal(t, "failed to parse [Config]: invalid [Config]: a [Partition] on a [Disk] '0' shares an ID 'duplicatedID' with another partition (on disk '0')", err.Error())
+
+	// Reset the config, then try across disks
+	testConfig.Disks = append([]Disk{}, expectedConfiguration.Disks...)
+	testConfig.Disks[0].Partitions = append([]Partition{}, expectedConfiguration.Disks[0].Partitions...)
+	testConfig.Disks[1].Partitions = append([]Partition{}, expectedConfiguration.Disks[1].Partitions...)
+	testConfig.Disks[0].Partitions = append(testConfig.Disks[0].Partitions, Partition{ID: "duplicatedID"})
+	testConfig.Disks[1].Partitions = append(testConfig.Disks[1].Partitions, Partition{ID: "duplicatedID"})
+
+	err = testConfig.IsValid()
+	assert.Error(t, err)
+	assert.Equal(t, "invalid [Config]: a [Partition] on a [Disk] '0' shares an ID 'duplicatedID' with another partition (on disk '1')", err.Error())
+
+	err = remarshalJSON(testConfig, &checkedConfig)
+	assert.Error(t, err)
+	assert.Equal(t, "failed to parse [Config]: invalid [Config]: a [Partition] on a [Disk] '0' shares an ID 'duplicatedID' with another partition (on disk '1')", err.Error())
+}
+
+func TestShouldFailMissingPartition(t *testing.T) {
+	var checkedConfig Config
+	testConfig := expectedConfiguration
+
+	testConfig.Disks = append([]Disk{}, expectedConfiguration.Disks...)
+	testConfig.SystemConfigs = append([]SystemConfig{}, expectedConfiguration.SystemConfigs...)
+	testConfig.SystemConfigs[0].PartitionSettings = append([]PartitionSetting{}, expectedConfiguration.SystemConfigs[0].PartitionSettings...)
+	testConfig.SystemConfigs[0].PartitionSettings[0].ID = "NOT_AN_ID"
+
+	err := testConfig.IsValid()
+	assert.Error(t, err)
+	assert.Equal(t, "invalid [Config]: [SystemConfig] 'SmallerDisk' mounts a [Partition] 'NOT_AN_ID' which has no corresponding partition on a [Disk]", err.Error())
+
+	err = remarshalJSON(testConfig, &checkedConfig)
+	assert.Error(t, err)
+	assert.Equal(t, "failed to parse [Config]: invalid [Config]: [SystemConfig] 'SmallerDisk' mounts a [Partition] 'NOT_AN_ID' which has no corresponding partition on a [Disk]", err.Error())
 }
 
 var expectedConfiguration Config = Config{

--- a/toolkit/tools/imagegen/configuration/verityerrorbehavior_test.go
+++ b/toolkit/tools/imagegen/configuration/verityerrorbehavior_test.go
@@ -23,7 +23,7 @@ var (
 	invalidVerityErrorBehaviorJSON = `1234`
 )
 
-func TestShouldSucceedValidImaPoliciesMatch_VerityErrorBehavior(t *testing.T) {
+func TestShouldSucceedValidVerityErrorBehaviorsMatch_VerityErrorBehavior(t *testing.T) {
 	var behavior VerityErrorBehavior
 	assert.Equal(t, len(validVerityErrorBehaviors), len(behavior.GetValidVerityErrorBehaviors()))
 
@@ -38,7 +38,7 @@ func TestShouldSucceedValidImaPoliciesMatch_VerityErrorBehavior(t *testing.T) {
 	}
 }
 
-func TestShouldSucceedParsingValidPolicies_VerityErrorBehavior(t *testing.T) {
+func TestShouldSucceedParsingValidErrorBehaviors_VerityErrorBehavior(t *testing.T) {
 	for _, validErrorBehavior := range validVerityErrorBehaviors {
 		var checkedBehavior VerityErrorBehavior
 
@@ -49,7 +49,7 @@ func TestShouldSucceedParsingValidPolicies_VerityErrorBehavior(t *testing.T) {
 	}
 }
 
-func TestShouldFailParsingInvalidErrorBehavoir_VerityErrorBehavior(t *testing.T) {
+func TestShouldFailParsingInvalidErrorBehavior_VerityErrorBehavior(t *testing.T) {
 	var checkedBehavior VerityErrorBehavior
 
 	err := invalidVerityErrorBehavior.IsValid()


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
We did not catch several invalid configurations:
- We did not check if a `PartitionSetting` actually referred to a disk `partition` which existed.
- We did not check if multiple disk `partition`s shared an ID

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add `checkForMissingDiskPartitions()` to `configuration.go:IsValid()` to make sure all `PartitionSettings` have a matching partition listed in `Disks`
- Add `checkDuplicatePartitionIDs()` to `configuration.go:IsValid()`  to find duplicated entries in `Disks`.
- Improve how we generate code coverage (union all tests together when calculating coverage, for example we did not include the coverage from testing `ConfigurationValidator` in our coverage report for `Configuration`. Now we should get coverage data for our entire set of tests together.
- Fix some typos in the verityerrorbehavior unit tests (they function names refered to IMA Policies still).

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Tested against all default configs
- Successfully built core images locally.
