### PR TITLE
Add MountIdentifier key to PartitionSetting struct

### DIFF
--- a/toolkit/docs/formats/imageconfig.md
+++ b/toolkit/docs/formats/imageconfig.md
@@ -102,6 +102,38 @@ A sample PartitionSettings entry, designating an EFI and a root partitions:
 ],
 ```
 
+A PartitionSetting may set a `MountIdentifier` to control how a partition is identified in the `fstab` file. The supported options are `uuid`, `partuuid`, and `partlabel`. If the `MountIdentifier` is omitted `partuuid` will be selected by default.
+
+`partlabel` may not be used with `mbr` disks, and requires the `Name` key in the corresponding `Partition` be populated. An example with the rootfs mounted via `PARTLABEL=my_rootfs`, but the boot mount using the default `PARTUUID=<PARTUUID>`:
+``` json
+"Partitions": [
+    
+    ...
+    
+    {
+        "ID": "rootfs",
+        "Name": "my_rootfs",
+        "Start": 9,
+        "End": 0,
+        "FsType": "ext4"
+    }
+]
+```
+``` json
+"PartitionSettings": [
+    {
+        "ID": "boot",
+        "MountPoint": "/boot/efi",
+        "MountOptions" : "umask=0077"
+    },
+    {
+        "ID": "rootfs",
+        "MountPoint": "/",
+        "MountIdentifier": "partlabel"
+    }
+],
+```
+
 It is possible to use `PartitionSettings` to configure diff disk image creation. Two types of diffs are possible.
 `rdiff` and `overlay` diff.
 

--- a/toolkit/tools/imagegen/configuration/mountidentifier.go
+++ b/toolkit/tools/imagegen/configuration/mountidentifier.go
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Parser for the image builder's configuration schemas.
+
+package configuration
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// MountIdentifier indicates how a partition should be identified in the fstab file
+type MountIdentifier string
+
+//label
+const (
+	// MountIdentifierUuid mounts this partition via the filesystem UUID
+	MountIdentifierUuid MountIdentifier = "uuid"
+	// MountIdentifierPartUuid mounts this partition via the GPT/MBR PARTUUID
+	MountIdentifierPartUuid MountIdentifier = "partuuid"
+	// MountIdentifierPartLabel mounts this partition via the GPT PARTLABEL
+	MountIdentifierPartLabel MountIdentifier = "partlabel"
+
+	// There is not a clear way to set arbitrary partitions via a device path (ie /dev/sda1)
+	// so we do not support those.
+
+	// We currently do not set filesystem LABELS, so those are also not useful here.
+
+	MountIdentifierDefault MountIdentifier = MountIdentifierPartUuid
+	MountIdentifierNone    MountIdentifier = ""
+)
+
+func (m MountIdentifier) String() string {
+	return fmt.Sprint(string(m))
+}
+
+// GetValidMountIdentifiers returns a list of all the supported mount identifiers
+func (m *MountIdentifier) GetValidMountIdentifiers() (types []MountIdentifier) {
+	return []MountIdentifier{
+		MountIdentifierUuid,
+		MountIdentifierPartUuid,
+		MountIdentifierPartLabel,
+		MountIdentifierNone,
+	}
+}
+
+func GetDefaultMountIdentifier() (defaultVal MountIdentifier) {
+	return MountIdentifierDefault
+}
+
+// IsValid returns an error if the PartitionFlag is not valid
+func (m *MountIdentifier) IsValid() (err error) {
+	for _, valid := range m.GetValidMountIdentifiers() {
+		if *m == valid {
+			return
+		}
+	}
+	return fmt.Errorf("invalid value for Mount Identifier (%s)", m)
+}
+
+// UnmarshalJSON Unmarshals an MountIdentifier entry
+func (m *MountIdentifier) UnmarshalJSON(b []byte) (err error) {
+	// Use an intermediate type which will use the default JSON unmarshal implementation
+	type IntermediateTypeMountIdentifier MountIdentifier
+
+	// Populate non-standard default
+	*m = GetDefaultMountIdentifier()
+
+	err = json.Unmarshal(b, (*IntermediateTypeMountIdentifier)(m))
+	if err != nil {
+		return fmt.Errorf("failed to parse [MountIdentifier]: %w", err)
+	}
+
+	// Now validate the resulting unmarshaled object
+	err = m.IsValid()
+	if err != nil {
+		return fmt.Errorf("failed to parse [MountIdentifier]: %w", err)
+	}
+	return
+}

--- a/toolkit/tools/imagegen/configuration/mountidentifier_test.go
+++ b/toolkit/tools/imagegen/configuration/mountidentifier_test.go
@@ -1,0 +1,78 @@
+// Copyright Microsoft Corporation.
+// Licensed under the MIT License.
+
+package configuration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestMain found in configuration_test.go.
+
+var (
+	validMountIdentifiers = []MountIdentifier{
+		MountIdentifier("uuid"),
+		MountIdentifier("partuuid"),
+		MountIdentifier("partlabel"),
+		MountIdentifier(""),
+	}
+	invalidMountIdentifier     = MountIdentifier("not_a_behavior")
+	validMountIdentifierJSON   = `"uuid"`
+	invalidMountIdentifierJSON = `1234`
+)
+
+func TestShouldSucceedValidMountIdentifiersMatch_MountIdentifier(t *testing.T) {
+	var identifier MountIdentifier
+	assert.Equal(t, len(validMountIdentifiers), len(identifier.GetValidMountIdentifiers()))
+
+	for _, mountIdentifier := range validMountIdentifiers {
+		found := false
+		for _, validMountIdentifier := range identifier.GetValidMountIdentifiers() {
+			if mountIdentifier == validMountIdentifier {
+				found = true
+			}
+		}
+		assert.True(t, found)
+	}
+}
+
+func TestShouldSucceedParsingValidIdentifiers_MountIdentifier(t *testing.T) {
+	for _, validIdentifier := range validMountIdentifiers {
+		var checkedIdentifier MountIdentifier
+
+		assert.NoError(t, validIdentifier.IsValid())
+		err := remarshalJSON(validIdentifier, &checkedIdentifier)
+		assert.NoError(t, err)
+		assert.Equal(t, validIdentifier, checkedIdentifier)
+	}
+}
+
+func TestShouldFailParsingInvalidMountIdentifier_MountIdentifier(t *testing.T) {
+	var checkedIdentifier MountIdentifier
+
+	err := invalidMountIdentifier.IsValid()
+	assert.Error(t, err)
+	assert.Equal(t, "invalid value for Mount Identifier (not_a_behavior)", err.Error())
+
+	err = remarshalJSON(invalidMountIdentifier, &checkedIdentifier)
+	assert.Error(t, err)
+	assert.Equal(t, "failed to parse [MountIdentifier]: invalid value for Mount Identifier (not_a_behavior)", err.Error())
+}
+
+func TestShouldSucceedParsingValidJSON_MountIdentifier(t *testing.T) {
+	var checkedIdentifier MountIdentifier
+
+	err := marshalJSONString(validMountIdentifierJSON, &checkedIdentifier)
+	assert.NoError(t, err)
+	assert.Equal(t, validMountIdentifiers[0], checkedIdentifier)
+}
+
+func TestShouldFailParsingInvalidJSON_MountIdentifier(t *testing.T) {
+	var checkedIdentifier MountIdentifier
+
+	err := marshalJSONString(invalidMountIdentifierJSON, &checkedIdentifier)
+	assert.Error(t, err)
+	assert.Equal(t, "failed to parse [MountIdentifier]: json: cannot unmarshal number into Go value of type configuration.IntermediateTypeMountIdentifier", err.Error())
+}

--- a/toolkit/tools/imagegen/configuration/partition.go
+++ b/toolkit/tools/imagegen/configuration/partition.go
@@ -42,13 +42,10 @@ func (p *Partition) HasFlag(flag PartitionFlag) bool {
 // for any non-ASCII characters
 // header (72 bytes of UTF-16)
 func nameCheck(name string) (err error) {
-	const (
-		maxLength = 36
-	)
+	const maxLength = 36
 
 	encodedString := utf16.Encode([]rune(name))
 	stringLengthWithNull := len(encodedString) + 1
-	//maxChar := utf16.Encode([]rune("\uFFFF"))
 
 	for pos, char := range name {
 		if char > unicode.MaxASCII {

--- a/toolkit/tools/imagegen/configuration/partition.go
+++ b/toolkit/tools/imagegen/configuration/partition.go
@@ -8,6 +8,7 @@ package configuration
 import (
 	"encoding/json"
 	"fmt"
+	"unicode/utf16"
 )
 
 // Partition defines the size, name and file system type
@@ -36,6 +37,20 @@ func (p *Partition) HasFlag(flag PartitionFlag) bool {
 	return false
 }
 
+// nameSizeCheck makes sure the Name can fit in the alloted space in the GPT
+// header (72 bytes of UTF-16)
+func nameSizeCheck(name string) (err error) {
+	const maxLength = 36
+
+	encodedString := utf16.Encode([]rune(name))
+	stringLengthWithNull := len(encodedString) + 1
+
+	if stringLengthWithNull > maxLength {
+		return fmt.Errorf("[Name] is too long, GPT header can hold only 72 bytes of UTF-16 (35 normal characters + null) while (%s) needs %d bytes", name, stringLengthWithNull*2)
+	}
+	return
+}
+
 // IsValid returns an error if the Partition is not valid
 func (p *Partition) IsValid() (err error) {
 	for _, f := range p.Flags {
@@ -43,6 +58,12 @@ func (p *Partition) IsValid() (err error) {
 			return
 		}
 	}
+
+	err = nameSizeCheck(p.Name)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/toolkit/tools/imagegen/configuration/partition.go
+++ b/toolkit/tools/imagegen/configuration/partition.go
@@ -8,6 +8,7 @@ package configuration
 import (
 	"encoding/json"
 	"fmt"
+	"unicode"
 	"unicode/utf16"
 )
 
@@ -37,13 +38,23 @@ func (p *Partition) HasFlag(flag PartitionFlag) bool {
 	return false
 }
 
-// nameSizeCheck makes sure the Name can fit in the alloted space in the GPT
+// nameCheck makes sure the Name can fit in the alloted space in the GPT, and since parted works best with ASCII we check
+// for any non-ASCII characters
 // header (72 bytes of UTF-16)
-func nameSizeCheck(name string) (err error) {
-	const maxLength = 36
+func nameCheck(name string) (err error) {
+	const (
+		maxLength = 36
+	)
 
 	encodedString := utf16.Encode([]rune(name))
 	stringLengthWithNull := len(encodedString) + 1
+	//maxChar := utf16.Encode([]rune("\uFFFF"))
+
+	for pos, char := range name {
+		if char > unicode.MaxASCII {
+			return fmt.Errorf("[Name] (%s) contains a non-ASCII character '%c' at position (%d)", name, char, pos)
+		}
+	}
 
 	if stringLengthWithNull > maxLength {
 		return fmt.Errorf("[Name] is too long, GPT header can hold only 72 bytes of UTF-16 (35 normal characters + null) while (%s) needs %d bytes", name, stringLengthWithNull*2)
@@ -59,7 +70,7 @@ func (p *Partition) IsValid() (err error) {
 		}
 	}
 
-	err = nameSizeCheck(p.Name)
+	err = nameCheck(p.Name)
 	if err != nil {
 		return err
 	}

--- a/toolkit/tools/imagegen/configuration/partition_test.go
+++ b/toolkit/tools/imagegen/configuration/partition_test.go
@@ -81,28 +81,19 @@ func TestShouldFailLongNormalName_Partition(t *testing.T) {
 	assert.Equal(t, "failed to parse [Partition]: [Name] is too long, GPT header can hold only 72 bytes of UTF-16 (35 normal characters + null) while (abcdefghijklmnopqrstuvwxyz0123456789) needs 74 bytes", err.Error())
 }
 
-func TestShouldPassShortSymbolName_Partition(t *testing.T) {
+func TestShouldFailSymbolName_Partition(t *testing.T) {
 	var checkedPartition Partition
-	shortSymbolNamePartition := validPartition
-	shortSymbolNamePartition.Name = "1👌2🤣3🤢ab~52*^&%$6"
+	symbolNamePartition := validPartition
+	symbolNamePartition.Name = "( •_•)>⌐■~■"
 
-	err := remarshalJSON(shortSymbolNamePartition, &checkedPartition)
-	assert.NoError(t, err)
-}
-
-func TestShouldFailLongSymbolName_Partition(t *testing.T) {
-	var checkedPartition Partition
-	longSymbolNamePartition := validPartition
-
-	longSymbolNamePartition.Name = "1🤷‍♂️2@3( •_•)>⌐■~■ab~52(⌐■_■)67👩‍💻"
-
-	err := longSymbolNamePartition.IsValid()
+	err := symbolNamePartition.IsValid()
 	assert.Error(t, err)
-	assert.Equal(t, "[Name] is too long, GPT header can hold only 72 bytes of UTF-16 (35 normal characters + null) while (1🤷\u200d♂️2@3( •_•)>⌐■~■ab~52(⌐■_■)67👩\u200d💻) needs 78 bytes", err.Error())
+	assert.Equal(t, "[Name] (( •_•)>⌐■~■) contains a non-ASCII character '•' at position (2)", err.Error())
 
-	err = remarshalJSON(longSymbolNamePartition, &checkedPartition)
+	err = remarshalJSON(symbolNamePartition, &checkedPartition)
 	assert.Error(t, err)
-	assert.Equal(t, "failed to parse [Partition]: [Name] is too long, GPT header can hold only 72 bytes of UTF-16 (35 normal characters + null) while (1🤷\u200d♂️2@3( •_•)>⌐■~■ab~52(⌐■_■)67👩\u200d💻) needs 78 bytes", err.Error())
+	assert.Equal(t, "failed to parse [Partition]: [Name] (( •_•)>⌐■~■) contains a non-ASCII character '•' at position (2)", err.Error())
+
 }
 
 func TestShouldFailParsingInvalidFlag_Partition(t *testing.T) {

--- a/toolkit/tools/imagegen/configuration/partition_test.go
+++ b/toolkit/tools/imagegen/configuration/partition_test.go
@@ -46,6 +46,65 @@ func TestShouldFailFindingBadFlag_Partition(t *testing.T) {
 	assert.False(t, validPartition.HasFlag("notaflag"))
 }
 
+func TestShouldPassEmptyName_Partition(t *testing.T) {
+	var checkedPartition Partition
+	emptyNamePartition := validPartition
+
+	emptyNamePartition.Name = ""
+
+	err := remarshalJSON(emptyNamePartition, &checkedPartition)
+	assert.NoError(t, err)
+}
+
+func TestShouldPassMaxLengthName_Partition(t *testing.T) {
+	var checkedPartition Partition
+	maxNamePartition := validPartition
+
+	maxNamePartition.Name = "abcdefghijklmnopqrstuvwxyz012345678"
+
+	err := remarshalJSON(maxNamePartition, &checkedPartition)
+	assert.NoError(t, err)
+}
+
+func TestShouldFailLongNormalName_Partition(t *testing.T) {
+	var checkedPartition Partition
+	longNamePartition := validPartition
+
+	longNamePartition.Name = "abcdefghijklmnopqrstuvwxyz0123456789"
+
+	err := longNamePartition.IsValid()
+	assert.Error(t, err)
+	assert.Equal(t, "[Name] is too long, GPT header can hold only 72 bytes of UTF-16 (35 normal characters + null) while (abcdefghijklmnopqrstuvwxyz0123456789) needs 74 bytes", err.Error())
+
+	err = remarshalJSON(longNamePartition, &checkedPartition)
+	assert.Error(t, err)
+	assert.Equal(t, "failed to parse [Partition]: [Name] is too long, GPT header can hold only 72 bytes of UTF-16 (35 normal characters + null) while (abcdefghijklmnopqrstuvwxyz0123456789) needs 74 bytes", err.Error())
+}
+
+func TestShouldPassShortSymbolName_Partition(t *testing.T) {
+	var checkedPartition Partition
+	shortSymbolNamePartition := validPartition
+	shortSymbolNamePartition.Name = "1👌2🤣3🤢ab~52*^&%$6"
+
+	err := remarshalJSON(shortSymbolNamePartition, &checkedPartition)
+	assert.NoError(t, err)
+}
+
+func TestShouldFailLongSymbolName_Partition(t *testing.T) {
+	var checkedPartition Partition
+	longSymbolNamePartition := validPartition
+
+	longSymbolNamePartition.Name = "1🤷‍♂️2@3( •_•)>⌐■~■ab~52(⌐■_■)67👩‍💻"
+
+	err := longSymbolNamePartition.IsValid()
+	assert.Error(t, err)
+	assert.Equal(t, "[Name] is too long, GPT header can hold only 72 bytes of UTF-16 (35 normal characters + null) while (1🤷\u200d♂️2@3( •_•)>⌐■~■ab~52(⌐■_■)67👩\u200d💻) needs 78 bytes", err.Error())
+
+	err = remarshalJSON(longSymbolNamePartition, &checkedPartition)
+	assert.Error(t, err)
+	assert.Equal(t, "failed to parse [Partition]: [Name] is too long, GPT header can hold only 72 bytes of UTF-16 (35 normal characters + null) while (1🤷\u200d♂️2@3( •_•)>⌐■~■ab~52(⌐■_■)67👩\u200d💻) needs 78 bytes", err.Error())
+}
+
 func TestShouldFailParsingInvalidFlag_Partition(t *testing.T) {
 	var checkedPartition Partition
 	invalidPartition := validPartition

--- a/toolkit/tools/imagegen/configuration/partitionsetting.go
+++ b/toolkit/tools/imagegen/configuration/partitionsetting.go
@@ -12,12 +12,23 @@ import (
 
 // PartitionSetting holds the mounting information for each partition.
 type PartitionSetting struct {
-	RemoveDocs       bool   `json:"RemoveDocs"`
-	ID               string `json:"ID"`
-	MountOptions     string `json:"MountOptions"`
-	MountPoint       string `json:"MountPoint"`
-	OverlayBaseImage string `json:"OverlayBaseImage"`
-	RdiffBaseImage   string `json:"RdiffBaseImage"`
+	RemoveDocs       bool            `json:"RemoveDocs"`
+	ID               string          `json:"ID"`
+	MountIdentifier  MountIdentifier `json:"MountIdentifier"`
+	MountOptions     string          `json:"MountOptions"`
+	MountPoint       string          `json:"MountPoint"`
+	OverlayBaseImage string          `json:"OverlayBaseImage"`
+	RdiffBaseImage   string          `json:"RdiffBaseImage"`
+}
+
+var defaultPartitionSetting PartitionSetting = PartitionSetting{
+	MountIdentifier: GetDefaultMountIdentifier(),
+}
+
+// GetDefaultPartitionSetting returns a copy of the default partition setting
+func GetDefaultPartitionSetting() (defaultVal PartitionSetting) {
+	defaultVal = defaultPartitionSetting
+	return defaultVal
 }
 
 // IsValid returns an error if the PartitionSetting is not valid
@@ -29,6 +40,10 @@ func (p *PartitionSetting) IsValid() (err error) {
 func (p *PartitionSetting) UnmarshalJSON(b []byte) (err error) {
 	// Use an intermediate type which will use the default JSON unmarshal implementation
 	type IntermediateTypePartitionSetting PartitionSetting
+
+	// Populate non-standard default values
+	*p = GetDefaultPartitionSetting()
+
 	err = json.Unmarshal(b, (*IntermediateTypePartitionSetting)(p))
 	if err != nil {
 		return fmt.Errorf("failed to parse [PartitionSetting]: %w", err)

--- a/toolkit/tools/imagegen/configuration/partitionsetting_test.go
+++ b/toolkit/tools/imagegen/configuration/partitionsetting_test.go
@@ -13,17 +13,26 @@ import (
 
 var (
 	validPartitionSetting PartitionSetting = PartitionSetting{
-		ID:         "testing",
-		MountPoint: "/",
+		ID:              "testing",
+		MountPoint:      "/",
+		MountIdentifier: GetDefaultMountIdentifier(),
 	}
 	invalidvalidPartitionSettingJSON = `{"RemoveDocs": 1234}`
 )
 
 func TestShouldSucceedParsingDefaultPartitionSetting_PartitionSetting(t *testing.T) {
-	var checkedPartitionSetting PartitionSetting
+	var (
+		checkedPartitionSetting PartitionSetting
+		defaultPartitionSetting PartitionSetting = PartitionSetting{
+			MountIdentifier: GetDefaultMountIdentifier(),
+		}
+	)
 	err := marshalJSONString("{}", &checkedPartitionSetting)
 	assert.NoError(t, err)
-	assert.Equal(t, PartitionSetting{}, checkedPartitionSetting)
+	assert.Equal(t, defaultPartitionSetting, checkedPartitionSetting)
+
+	// Check the non-standard default values are correct
+	assert.Equal(t, "partuuid", checkedPartitionSetting.MountIdentifier.String())
 }
 
 func TestShouldSucceedParsingValidPartitionSetting_PartitionSetting(t *testing.T) {

--- a/toolkit/tools/imagegen/configuration/systemconfig.go
+++ b/toolkit/tools/imagegen/configuration/systemconfig.go
@@ -38,7 +38,19 @@ type SystemConfig struct {
 func (s *SystemConfig) GetRootPartitionSetting() (rootPartitionSetting *PartitionSetting) {
 	for i, p := range s.PartitionSettings {
 		if p.MountPoint == "/" {
-			// We want to refernce the actual object in the slice
+			// We want to reference the actual object in the slice
+			return &s.PartitionSettings[i]
+		}
+	}
+	return nil
+}
+
+// GetMountpointPartitionSetting will search the system configuration for the partition setting
+// corresponding to a mount point.
+func (s *SystemConfig) GetMountpointPartitionSetting(mountPoint string) (partitionSetting *PartitionSetting) {
+	for i, p := range s.PartitionSettings {
+		if p.MountPoint == mountPoint {
+			// We want to reference the actual object in the slice
 			return &s.PartitionSettings[i]
 		}
 	}

--- a/toolkit/tools/imagegen/configuration/systemconfig_test.go
+++ b/toolkit/tools/imagegen/configuration/systemconfig_test.go
@@ -164,8 +164,8 @@ func TestShouldFailToParsingMultipleSameMounts_SystemConfig(t *testing.T) {
 
 	badPartitionSettingsConfig := validSystemConfig
 	badPartitionSettingsConfig.PartitionSettings = []PartitionSetting{
-		{MountPoint: "/"},
-		{MountPoint: "/"},
+		{MountPoint: "/", MountIdentifier: GetDefaultMountIdentifier()},
+		{MountPoint: "/", MountIdentifier: GetDefaultMountIdentifier()},
 	}
 
 	err := badPartitionSettingsConfig.IsValid()
@@ -182,8 +182,8 @@ func TestShouldSucceedParsingMultipleSameEmptyMounts_SystemConfig(t *testing.T) 
 
 	emptyPartitionSettingsConfig := validSystemConfig
 	emptyPartitionSettingsConfig.PartitionSettings = []PartitionSetting{
-		{MountPoint: ""},
-		{MountPoint: ""},
+		{MountPoint: "", MountIdentifier: GetDefaultMountIdentifier()},
+		{MountPoint: "", MountIdentifier: GetDefaultMountIdentifier()},
 	}
 
 	err := emptyPartitionSettingsConfig.IsValid()

--- a/toolkit/tools/imagegen/configuration/testdata/test_configuration.json
+++ b/toolkit/tools/imagegen/configuration/testdata/test_configuration.json
@@ -194,12 +194,14 @@
             "PartitionSettings": [
                 {
                     "ID": "MyBootA",
-                    "MountPoint": "/boot"
+                    "MountPoint": "/boot",
+                    "MountIdentifier": "uuid"
                 },
                 {
                     "ID": "MyRootfsA",
                     "MountPoint": "/",
-                    "RemoveDocs": true
+                    "RemoveDocs": true,
+                    "MountIdentifier": "uuid"
                 },
                 {
                     "ID": "SharedData",


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge.

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Allow the user to decide how to identify devices to be mounted in the `fstab`: `UUID`, `PARTUUID`, or `PARTLABEL`. To preserve backwards compatibility `PARTUUID` is selected by default if the key is left unset.

Future PR will update `imager` to respect these configs.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add `[MountIdentifier]` key to `[PartitionSetting]`
  - May be one of: `uuid`, `partuuid`, `partlabel`
  - Default value if unset it `partuuid`
- ~**NOTE:** `configuration_test.go` is heavily dependent on #1440. Instead of teasing the changes apart I left the file as the union of both change sets here. A rebase will be needed once that PR is complete to get the tests passing.~ Fixed

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local builds