### PR TITLE
CVE fixes for atftp and vim

### DIFF
--- a/SPECS/atftp/atftp.signatures.json
+++ b/SPECS/atftp/atftp.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "atftp-0.7.2.tar.gz": "1ad080674e9f974217b3a703e7356c6c8446dc5e7b2014d0d06e1bfaa11b5041"
+  "atftp-0.7.5.tar.gz": "93c87a4fb18218414e008e01c995dadd231ba4c752d0f894b34416d1e6d3038a"
  }
 }

--- a/SPECS/atftp/atftp.spec
+++ b/SPECS/atftp/atftp.spec
@@ -1,7 +1,7 @@
 Summary:        Advanced Trivial File Transfer Protocol (ATFTP) - TFTP server
 Name:           atftp
-Version:        0.7.2
-Release:        3%{?dist}
+Version:        0.7.5
+Release:        1%{?dist}
 URL:            http://sourceforge.net/projects/atftp
 License:        GPLv2+ and GPLv3+ and LGPLv2+
 Group:          System Environment/Daemons
@@ -131,6 +131,9 @@ fi
 
 
 %changelog
+* Mon Sep 27 2021 Suresh Babu Chalamalasetty <schalam@microsoft.com> - 0.7.5-1
+- Fix CVE-2021-41054 by updating to 0.7.5.
+
 * Sat May 09 2020 Nick Samson <nisamson@microsoft.com> - 0.7.2-3
 - Added %%license line automatically
 

--- a/SPECS/vim/vim.signatures.json
+++ b/SPECS/vim/vim.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "vim-8.1.1667.tar.gz": "9896654b6729f4007222505b52784786441bcafcc7c81ed937255bf5ea250309"
+  "vim-8.2.3441.tar.gz": "3db6c3af32b741c2e618358bbf002cffe9db2ab8d21f9ea277110fce54fec4d2"
  }
 }

--- a/SPECS/vim/vim.spec
+++ b/SPECS/vim/vim.spec
@@ -1,7 +1,7 @@
 %define debug_package %{nil}
 Summary:        Text editor
 Name:           vim
-Version:        8.1.1667
+Version:        8.2.3441
 Release:        1%{?dist}
 License:        Vim
 Vendor:         Microsoft Corporation
@@ -16,7 +16,7 @@ BuildRequires:  ncurses-devel
 %description
 The Vim package contains a powerful text editor.
 
-%package    extra
+%package        extra
 Summary:        Extra files for Vim text editor
 Group:          Applications/Editors
 
@@ -85,99 +85,100 @@ fi
 
 %files extra
 %license README.txt
-%doc %{_datarootdir}/vim/vim81/doc/*
+%doc %{_datarootdir}/vim/vim*/doc/*
 %defattr(-,root,root)
 %{_bindir}/vimtutor
 %{_bindir}/xxd
 %{_mandir}/*/*
-%{_datarootdir}/vim/vim81/autoload/*
-%{_datarootdir}/vim/vim81/bugreport.vim
-%{_datarootdir}/vim/vim81/colors/*
+%{_datarootdir}/vim/vim*/autoload/*
+%{_datarootdir}/vim/vim*/bugreport.vim
+%{_datarootdir}/vim/vim*/colors/*
 %{_datarootdir}/applications/gvim.desktop
 %{_datarootdir}/applications/vim.desktop
 %{_datarootdir}/icons/hicolor/48x48/apps/gvim.png
 %{_datarootdir}/icons/locolor/16x16/apps/gvim.png
 %{_datarootdir}/icons/locolor/32x32/apps/gvim.png
-%{_datarootdir}/vim/vim81/defaults.vim
-%{_datarootdir}/vim/vim81/pack/dist/opt/*
-%exclude %{_datarootdir}/vim/vim81/colors/desert.vim
-%{_datarootdir}/vim/vim81/compiler/*
-%{_datarootdir}/vim/vim81/delmenu.vim
-%{_datarootdir}/vim/vim81/evim.vim
-%{_datarootdir}/vim/vim81/filetype.vim
-%{_datarootdir}/vim/vim81/ftoff.vim
-%{_datarootdir}/vim/vim81/ftplugin.vim
-%{_datarootdir}/vim/vim81/ftplugin/*
-%{_datarootdir}/vim/vim81/ftplugof.vim
-%{_datarootdir}/vim/vim81/gvimrc_example.vim
-%{_datarootdir}/vim/vim81/indent.vim
-%{_datarootdir}/vim/vim81/indent/*
-%{_datarootdir}/vim/vim81/indoff.vim
-%{_datarootdir}/vim/vim81/keymap/*
-%{_datarootdir}/vim/vim81/macros/*
-%{_datarootdir}/vim/vim81/menu.vim
-%{_datarootdir}/vim/vim81/mswin.vim
-%{_datarootdir}/vim/vim81/optwin.vim
-%{_datarootdir}/vim/vim81/plugin/*
-%{_datarootdir}/vim/vim81/synmenu.vim
-%{_datarootdir}/vim/vim81/vimrc_example.vim
-%{_datarootdir}/vim/vim81/print/*
-%{_datarootdir}/vim/vim81/scripts.vim
-%{_datarootdir}/vim/vim81/spell/*
-%{_datarootdir}/vim/vim81/syntax/*
-%exclude %{_datarootdir}/vim/vim81/syntax/syntax.vim
-%{_datarootdir}/vim/vim81/tools/*
-%{_datarootdir}/vim/vim81/tutor/*
-%{_datarootdir}/vim/vim81/lang/*.vim
-%doc %{_datarootdir}/vim/vim81/lang/*.txt
-%lang(af) %{_datarootdir}/vim/vim81/lang/af/LC_MESSAGES/vim.mo
-%lang(ca) %{_datarootdir}/vim/vim81/lang/ca/LC_MESSAGES/vim.mo
-%lang(cs) %{_datarootdir}/vim/vim81/lang/cs/LC_MESSAGES/vim.mo
-%lang(de) %{_datarootdir}/vim/vim81/lang/de/LC_MESSAGES/vim.mo
-%lang(eb_GB) %{_datarootdir}/vim/vim81/lang/en_GB/LC_MESSAGES/vim.mo
-%lang(eo) %{_datarootdir}/vim/vim81/lang/eo/LC_MESSAGES/vim.mo
-%lang(es) %{_datarootdir}/vim/vim81/lang/es/LC_MESSAGES/vim.mo
-%lang(fi) %{_datarootdir}/vim/vim81/lang/fi/LC_MESSAGES/vim.mo
-%lang(fr) %{_datarootdir}/vim/vim81/lang/fr/LC_MESSAGES/vim.mo
-%lang(ga) %{_datarootdir}/vim/vim81/lang/ga/LC_MESSAGES/vim.mo
-%lang(it) %{_datarootdir}/vim/vim81/lang/it/LC_MESSAGES/vim.mo
-%lang(ja) %{_datarootdir}/vim/vim81/lang/ja/LC_MESSAGES/vim.mo
-%lang(ko.UTF-8) %{_datarootdir}/vim/vim81/lang/ko.UTF-8/LC_MESSAGES/vim.mo
-%lang(ko) %{_datarootdir}/vim/vim81/lang/ko/LC_MESSAGES/vim.mo
-%lang(nb) %{_datarootdir}/vim/vim81/lang/nb/LC_MESSAGES/vim.mo
-%lang(no) %{_datarootdir}/vim/vim81/lang/no/LC_MESSAGES/vim.mo
-%lang(pl) %{_datarootdir}/vim/vim81/lang/pl/LC_MESSAGES/vim.mo
-%lang(pt_BR) %{_datarootdir}/vim/vim81/lang/pt_BR/LC_MESSAGES/vim.mo
-%lang(ru) %{_datarootdir}/vim/vim81/lang/ru/LC_MESSAGES/vim.mo
-%lang(sk) %{_datarootdir}/vim/vim81/lang/sk/LC_MESSAGES/vim.mo
-%lang(sv) %{_datarootdir}/vim/vim81/lang/sv/LC_MESSAGES/vim.mo
-%lang(uk) %{_datarootdir}/vim/vim81/lang/uk/LC_MESSAGES/vim.mo
-%lang(da) %{_datarootdir}/vim/vim81/lang/da/LC_MESSAGES/vim.mo
-%lang(lv) %{_datarootdir}/vim/vim81/lang/lv/LC_MESSAGES/vim.mo
-%lang(sr) %{_datarootdir}/vim/vim81/lang/sr/LC_MESSAGES/vim.mo
-%lang(vi) %{_datarootdir}/vim/vim81/lang/vi/LC_MESSAGES/vim.mo
-%lang(zh_CN.UTF-8) %{_datarootdir}/vim/vim81/lang/zh_CN.UTF-8/LC_MESSAGES/vim.mo
-%lang(zh_CN) %{_datarootdir}/vim/vim81/lang/zh_CN/LC_MESSAGES/vim.mo
-%lang(zh_TW.UTF-8) %{_datarootdir}/vim/vim81/lang/zh_TW.UTF-8/LC_MESSAGES/vim.mo
-%lang(zh_TW) %{_datarootdir}/vim/vim81/lang/zh_TW/LC_MESSAGES/vim.mo
-%lang(cs.cp1250) %{_datarootdir}/vim/vim81/lang/cs.cp1250/LC_MESSAGES/vim.mo
-%lang(ja.euc-jp) %{_datarootdir}/vim/vim81/lang/ja.euc-jp/LC_MESSAGES/vim.mo
-%lang(ja.sjis) %{_datarootdir}/vim/vim81/lang/ja.sjis/LC_MESSAGES/vim.mo
-%lang(nl) %{_datarootdir}/vim/vim81/lang/nl/LC_MESSAGES/vim.mo
-%lang(pl.UTF-8) %{_datarootdir}/vim/vim81/lang/pl.UTF-8/LC_MESSAGES/vim.mo
-%lang(pl.cp1250) %{_datarootdir}/vim/vim81/lang/pl.cp1250/LC_MESSAGES/vim.mo
-%lang(ru.cp1251) %{_datarootdir}/vim/vim81/lang/ru.cp1251/LC_MESSAGES/vim.mo
-%lang(sk.cp1250) %{_datarootdir}/vim/vim81/lang/sk.cp1250/LC_MESSAGES/vim.mo
-%lang(uk.cp1251) %{_datarootdir}/vim/vim81/lang/uk.cp1251/LC_MESSAGES/vim.mo
-%lang(zh_CN.cp936) %{_datarootdir}/vim/vim81/lang/zh_CN.cp936/LC_MESSAGES/vim.mo
+%{_datarootdir}/vim/vim*/defaults.vim
+%{_datarootdir}/vim/vim*/pack/dist/opt/*
+%exclude %{_datarootdir}/vim/vim*/colors/desert.vim
+%{_datarootdir}/vim/vim*/compiler/*
+%{_datarootdir}/vim/vim*/delmenu.vim
+%{_datarootdir}/vim/vim*/evim.vim
+%{_datarootdir}/vim/vim*/filetype.vim
+%{_datarootdir}/vim/vim*/ftoff.vim
+%{_datarootdir}/vim/vim*/ftplugin.vim
+%{_datarootdir}/vim/vim*/ftplugin/*
+%{_datarootdir}/vim/vim*/ftplugof.vim
+%{_datarootdir}/vim/vim*/gvimrc_example.vim
+%{_datarootdir}/vim/vim*/indent.vim
+%{_datarootdir}/vim/vim*/indent/*
+%{_datarootdir}/vim/vim*/indoff.vim
+%{_datarootdir}/vim/vim*/keymap/*
+%{_datarootdir}/vim/vim*/macros/*
+%{_datarootdir}/vim/vim*/menu.vim
+%{_datarootdir}/vim/vim*/mswin.vim
+%{_datarootdir}/vim/vim*/optwin.vim
+%{_datarootdir}/vim/vim*/plugin/*
+%{_datarootdir}/vim/vim*/synmenu.vim
+%{_datarootdir}/vim/vim*/vimrc_example.vim
+%{_datarootdir}/vim/vim*/print/*
+%{_datarootdir}/vim/vim*/scripts.vim
+%{_datarootdir}/vim/vim*/spell/*
+%{_datarootdir}/vim/vim*/syntax/*
+%exclude %{_datarootdir}/vim/vim*/syntax/syntax.vim
+%{_datarootdir}/vim/vim*/tools/*
+%{_datarootdir}/vim/vim*/tutor/*
+%{_datarootdir}/vim/vim*/lang/*.vim
+%doc %{_datarootdir}/vim/vim*/lang/*.txt
+%lang(af) %{_datarootdir}/vim/vim*/lang/af/LC_MESSAGES/vim.mo
+%lang(ca) %{_datarootdir}/vim/vim*/lang/ca/LC_MESSAGES/vim.mo
+%lang(cs) %{_datarootdir}/vim/vim*/lang/cs/LC_MESSAGES/vim.mo
+%lang(de) %{_datarootdir}/vim/vim*/lang/de/LC_MESSAGES/vim.mo
+%lang(eb_GB) %{_datarootdir}/vim/vim*/lang/en_GB/LC_MESSAGES/vim.mo
+%lang(eo) %{_datarootdir}/vim/vim*/lang/eo/LC_MESSAGES/vim.mo
+%lang(es) %{_datarootdir}/vim/vim*/lang/es/LC_MESSAGES/vim.mo
+%lang(fi) %{_datarootdir}/vim/vim*/lang/fi/LC_MESSAGES/vim.mo
+%lang(fr) %{_datarootdir}/vim/vim*/lang/fr/LC_MESSAGES/vim.mo
+%lang(ga) %{_datarootdir}/vim/vim*/lang/ga/LC_MESSAGES/vim.mo
+%lang(it) %{_datarootdir}/vim/vim*/lang/it/LC_MESSAGES/vim.mo
+%lang(ja) %{_datarootdir}/vim/vim*/lang/ja/LC_MESSAGES/vim.mo
+%lang(ko.UTF-8) %{_datarootdir}/vim/vim*/lang/ko.UTF-8/LC_MESSAGES/vim.mo
+%lang(ko) %{_datarootdir}/vim/vim*/lang/ko/LC_MESSAGES/vim.mo
+%lang(nb) %{_datarootdir}/vim/vim*/lang/nb/LC_MESSAGES/vim.mo
+%lang(no) %{_datarootdir}/vim/vim*/lang/no/LC_MESSAGES/vim.mo
+%lang(pl) %{_datarootdir}/vim/vim*/lang/pl/LC_MESSAGES/vim.mo
+%lang(pt_BR) %{_datarootdir}/vim/vim*/lang/pt_BR/LC_MESSAGES/vim.mo
+%lang(ru) %{_datarootdir}/vim/vim*/lang/ru/LC_MESSAGES/vim.mo
+%lang(sk) %{_datarootdir}/vim/vim*/lang/sk/LC_MESSAGES/vim.mo
+%lang(sv) %{_datarootdir}/vim/vim*/lang/sv/LC_MESSAGES/vim.mo
+%lang(uk) %{_datarootdir}/vim/vim*/lang/uk/LC_MESSAGES/vim.mo
+%lang(da) %{_datarootdir}/vim/vim*/lang/da/LC_MESSAGES/vim.mo
+%lang(lv) %{_datarootdir}/vim/vim*/lang/lv/LC_MESSAGES/vim.mo
+%lang(sr) %{_datarootdir}/vim/vim*/lang/sr/LC_MESSAGES/vim.mo
+%lang(tr) %{_datarootdir}/vim/vim*/lang/tr/LC_MESSAGES/vim.mo
+%lang(vi) %{_datarootdir}/vim/vim*/lang/vi/LC_MESSAGES/vim.mo
+%lang(zh_CN.UTF-8) %{_datarootdir}/vim/vim*/lang/zh_CN.UTF-8/LC_MESSAGES/vim.mo
+%lang(zh_CN) %{_datarootdir}/vim/vim*/lang/zh_CN/LC_MESSAGES/vim.mo
+%lang(zh_TW.UTF-8) %{_datarootdir}/vim/vim*/lang/zh_TW.UTF-8/LC_MESSAGES/vim.mo
+%lang(zh_TW) %{_datarootdir}/vim/vim*/lang/zh_TW/LC_MESSAGES/vim.mo
+%lang(cs.cp1250) %{_datarootdir}/vim/vim*/lang/cs.cp1250/LC_MESSAGES/vim.mo
+%lang(ja.euc-jp) %{_datarootdir}/vim/vim*/lang/ja.euc-jp/LC_MESSAGES/vim.mo
+%lang(ja.sjis) %{_datarootdir}/vim/vim*/lang/ja.sjis/LC_MESSAGES/vim.mo
+%lang(nl) %{_datarootdir}/vim/vim*/lang/nl/LC_MESSAGES/vim.mo
+%lang(pl.UTF-8) %{_datarootdir}/vim/vim*/lang/pl.UTF-8/LC_MESSAGES/vim.mo
+%lang(pl.cp1250) %{_datarootdir}/vim/vim*/lang/pl.cp1250/LC_MESSAGES/vim.mo
+%lang(ru.cp1251) %{_datarootdir}/vim/vim*/lang/ru.cp1251/LC_MESSAGES/vim.mo
+%lang(sk.cp1250) %{_datarootdir}/vim/vim*/lang/sk.cp1250/LC_MESSAGES/vim.mo
+%lang(uk.cp1251) %{_datarootdir}/vim/vim*/lang/uk.cp1251/LC_MESSAGES/vim.mo
+%lang(zh_CN.cp936) %{_datarootdir}/vim/vim*/lang/zh_CN.cp936/LC_MESSAGES/vim.mo
 
 %files
 %defattr(-,root,root)
 %license README.txt
 %config(noreplace) %{_sysconfdir}/vimrc
-%{_datarootdir}/vim/vim81/syntax/syntax.vim
-%{_datarootdir}/vim/vim81/rgb.txt
-%{_datarootdir}/vim/vim81/colors/desert.vim
+%{_datarootdir}/vim/vim*/syntax/syntax.vim
+%{_datarootdir}/vim/vim*/rgb.txt
+%{_datarootdir}/vim/vim*/colors/desert.vim
 %{_bindir}/ex
 %{_bindir}/vi
 %{_bindir}/view
@@ -187,6 +188,9 @@ fi
 %{_bindir}/vimdiff
 
 %changelog
+* Mon Sep 27 2021 Suresh Babu Chalamalasetty <schalam@microsoft.com> - 8.2.3441-1
+- Fix CVE-2021-3778 and update to version 8.2.3441.
+
 * Fri Oct 30 2020 Pawel Winogrodzki <pawelwi@microsoft.com> - 8.1.1667-1
 - Fix CVE-2019-20807 by updating to 8.1.1667.
 

--- a/SPECS/vim/vim.spec
+++ b/SPECS/vim/vim.spec
@@ -189,7 +189,7 @@ fi
 
 %changelog
 * Mon Sep 27 2021 Suresh Babu Chalamalasetty <schalam@microsoft.com> - 8.2.3441-1
-- Fix CVE-2021-3778 and update to version 8.2.3441.
+- Fix CVE-2021-3778 and CVE-2021-3796 CVEs by updating to 8.2.3441.
 
 * Fri Oct 30 2020 Pawel Winogrodzki <pawelwi@microsoft.com> - 8.1.1667-1
 - Fix CVE-2019-20807 by updating to 8.1.1667.

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -135,8 +135,8 @@
         "type": "other",
         "other": {
           "name": "atftp",
-          "version": "0.7.2",
-          "downloadUrl": "http://sourceforge.net/projects/atftp/files/latest/download/atftp-0.7.2.tar.gz"
+          "version": "0.7.5",
+          "downloadUrl": "http://sourceforge.net/projects/atftp/files/latest/download/atftp-0.7.5.tar.gz"
         }
       }
     },
@@ -8555,8 +8555,8 @@
         "type": "other",
         "other": {
           "name": "vim",
-          "version": "8.1.1667",
-          "downloadUrl": "https://github.com/vim/vim/archive/v8.1.1667.tar.gz"
+          "version": "8.2.3441",
+          "downloadUrl": "https://github.com/vim/vim/archive/v8.2.3441.tar.gz"
         }
       }
     },


### PR DESCRIPTION
CVE fixes for atftp and vim.
1. Fix CVE-2021-3778 and CVE-2021-3796 CVEs by updating to vim version 8.2.3441
2. Fix CVE-2021-41054 by updating to atftp version to 0.7.5

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
 CVE fixes for atftp and vim.
1. Fix CVE-2021-3778 and CVE-2021-3796 CVEs by updating to vim version 8.2.3441
2. Fix CVE-2021-41054 by updating to atftp version to 0.7.5

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change
  Fix CVE-2021-3778 and CVE-2021-3796 CVEs by updating to vim version 8.2.3441
- Change
  Fix CVE-2021-41054 by updating to atftp version to 0.7.5


###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
-  https://nvd.nist.gov/vuln/detail/CVE-2021-3778
-  https://nvd.nist.gov/vuln/detail/CVE-2021-3796
-  https://nvd.nist.gov/vuln/detail/CVE-2021-41054

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build.
