### PR TITLE
Fix grpc-devel file conflict

### DIFF
--- a/SPECS/grpc/grpc.spec
+++ b/SPECS/grpc/grpc.spec
@@ -81,6 +81,8 @@ find %{buildroot} -name '*.cmake' -delete
 %{_includedir}/grpc
 %{_includedir}/grpc++
 %{_includedir}/grpcpp
+%exclude %{_includedir}/re2/
+
 %{_libdir}/libgpr.so
 %{_libdir}/libgrpc++.so
 %{_libdir}/libgrpc++_alts.so
@@ -93,6 +95,10 @@ find %{buildroot} -name '*.cmake' -delete
 %{_libdir}/libgrpcpp_channelz.so
 %{_libdir}/libupb.so
 %{_libdir}/pkgconfig/*.pc
+%exclude %{_libdir}/libabsl_*
+%exclude %{_libdir}/libaddress_sorting.so
+%exclude %{_libdir}/libre2.so
+%exclude %{_lib64dir}/libre2.so
 
 %files plugins
 %license LICENSE

--- a/SPECS/grpc/grpc.spec
+++ b/SPECS/grpc/grpc.spec
@@ -75,6 +75,7 @@ find %{buildroot} -name '*.cmake' -delete
 %files
 %license LICENSE
 %{_libdir}/*.so.*
+%exclude %{_libdir}/libaddress_sorting.so.*
 %{_datadir}/grpc/roots.pem
 
 %files devel
@@ -82,7 +83,6 @@ find %{buildroot} -name '*.cmake' -delete
 %{_includedir}/grpc++
 %{_includedir}/grpcpp
 %exclude %{_includedir}/re2/
-
 %{_libdir}/libgpr.so
 %{_libdir}/libgrpc++.so
 %{_libdir}/libgrpc++_alts.so

--- a/SPECS/grpc/grpc.spec
+++ b/SPECS/grpc/grpc.spec
@@ -1,7 +1,7 @@
 Summary:        Open source remote procedure call (RPC) framework
 Name:           grpc
 Version:        1.35.0
-Release:        4%{?dist}
+Release:        5%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -78,9 +78,20 @@ find %{buildroot} -name '*.cmake' -delete
 %{_datadir}/grpc/roots.pem
 
 %files devel
-%{_includedir}/*
-%{_libdir}/*.so
-%{_lib64dir}/*.so
+%{_includedir}/grpc
+%{_includedir}/grpc++
+%{_includedir}/grpcpp
+%{_libdir}/libgpr.so
+%{_libdir}/libgrpc++.so
+%{_libdir}/libgrpc++_alts.so
+%{_libdir}/libgrpc++_error_details.so
+%{_libdir}/libgrpc++_reflection.so
+%{_libdir}/libgrpc++_unsecure.so
+%{_libdir}/libgrpc.so
+%{_libdir}/libgrpc_plugin_support.so
+%{_libdir}/libgrpc_unsecure.so
+%{_libdir}/libgrpcpp_channelz.so
+%{_libdir}/libupb.so
 %{_libdir}/pkgconfig/*.pc
 
 %files plugins
@@ -88,6 +99,9 @@ find %{buildroot} -name '*.cmake' -delete
 %{_bindir}/grpc_*_plugin
 
 %changelog
+* Tue Sep 28 2021 Andrew Phelps <anphel@microsoft.com> - 1.35.0-5
+- Explicitly provide grpc-devel files to avoid packaging conflicts with re2-devel.
+
 * Mon Jun 21 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.35.0-4
 - Switch to system package for protobuf dependency.
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
The grpc-devel package pulls in a number of header files that are not part of grpc. This leads to conflicts when installing grpc-devel along with re2-devel (and possibly other packages). I've modified the grpc-devel subpackage to only include the needed grpc-related headers and libraries.

```bash
WARN[0227] file /usr/include/re2/filtered_re2.h from install of re2-devel-20190801-9.cm1.x86_64 conflicts with file from package grpc-devel-1.35.0-4.cm1.x86_64
WARN[0227] file /usr/include/re2/re2.h from install of re2-devel-20190801-9.cm1.x86_64 conflicts with file from package grpc-devel-1.35.0-4.cm1.x86_64
WARN[0227] file /usr/lib/libre2.so from install of re2-devel-20190801-9.cm1.x86_64 conflicts with file from package grpc-devel-1.35.0-4.cm1.x86_64
WARN[0227] Failed to tdnf install: exit status 1. Package name: re2-devel
```

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change grpc-devel files section

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local package build
