### PR TITLE
[dev] Align rpm-ostree version with our packaging ecosystem

### DIFF
--- a/SPECS/ostree/0001-ostree-Copying-photon-config-to-boot-directory.patch
+++ b/SPECS/ostree/0001-ostree-Copying-photon-config-to-boot-directory.patch
@@ -11,22 +11,20 @@ Signed-off-by: Ankit Jain <ankitja@vmware.com>
 ---
  src/libostree/ostree-sysroot-deploy.c | 70 +++++++++++++++++++++++++++++++++++
  1 file changed, 70 insertions(+)
- mode change 100644 => 100755 src/libostree/ostree-sysroot-deploy.c
 
-diff --git a/src/libostree/ostree-sysroot-deploy.c b/src/libostree/ostree-sysroot-deploy.c
-old mode 100644
-new mode 100755
-index 3ca6c14..0744d7e
---- a/src/libostree/ostree-sysroot-deploy.c
+diff --git a/src/libostree/ostree-sysroot-deploy.c.newold b/src/libostree/ostree-sysroot-deploy.c
+index 6a13a41..976c4b5 100644
+--- a/src/libostree/ostree-sysroot-deploy.c.newold
 +++ b/src/libostree/ostree-sysroot-deploy.c
-@@ -876,12 +876,17 @@ ostree_sysroot_write_origin_file (OstreeSysroot         *sysroot,
+@@ -987,6 +987,7 @@ ostree_sysroot_write_origin_file (OstreeSysroot         *sysroot,
  
  typedef struct {
    int   boot_dfd;
 +  int   ostree_boot_dfd;
    char *kernel_srcpath;
    char *kernel_namever;
-   char *initramfs_srcpath;
+   char *kernel_hmac_srcpath;
+@@ -995,6 +996,10 @@ typedef struct {
    char *initramfs_namever;
    char *devicetree_srcpath;
    char *devicetree_namever;
@@ -37,7 +35,7 @@ index 3ca6c14..0744d7e
    char *bootcsum;
  } OstreeKernelLayout;
  static void
-@@ -894,6 +899,10 @@ _ostree_kernel_layout_free (OstreeKernelLayout *layout)
+@@ -1009,6 +1014,10 @@ _ostree_kernel_layout_free (OstreeKernelLayout *layout)
    g_free (layout->initramfs_namever);
    g_free (layout->devicetree_srcpath);
    g_free (layout->devicetree_namever);
@@ -48,13 +46,13 @@ index 3ca6c14..0744d7e
    g_free (layout->bootcsum);
    g_free (layout);
  }
-@@ -1031,6 +1040,25 @@ get_kernel_from_tree_usrlib_modules (int                  deployment_dfd,
+@@ -1182,6 +1191,26 @@ get_kernel_from_tree_usrlib_modules (OstreeSysroot       *sysroot,
+       ret_layout->kernel_hmac_namever = g_strdup_printf (".%s.hmac", ret_layout->kernel_namever);
+     }
  
-   g_clear_object (&in);
-   glnx_close_fd (&fd);
 +/* Setting the param for Copying Photon Specific config files to sutiable location */
 +  if (!glnx_opendirat (deployment_dfd, "usr/lib/ostree-boot", FALSE, &ret_layout->ostree_boot_dfd, error))
-+	return FALSE;
++       return FALSE;
 +  if (!ot_openat_ignore_enoent (ret_layout->ostree_boot_dfd, "photon.cfg", &fd, error))
 +    return FALSE;
 +  if (fd != -1)
@@ -71,24 +69,24 @@ index 3ca6c14..0744d7e
 +      ret_layout->systemdcfg_namever = g_strdup ("systemd.cfg");
 +    }
 +  glnx_close_fd (&fd);
- 
++
    char hexdigest[OSTREE_SHA256_STRING_LEN+1];
    ot_checksum_get_hexdigest (&checksum, hexdigest, sizeof (hexdigest));
-@@ -1686,6 +1714,35 @@ install_deployment_kernel (OstreeSysroot   *sysroot,
-         }
+   ret_layout->bootcsum = g_strdup (hexdigest);
+@@ -1897,6 +1926,34 @@ install_deployment_kernel (OstreeSysroot   *sysroot,
+       g_ptr_array_add (overlay_initrds, g_steal_pointer (&destpath));
      }
  
-+/* Copying Photon Specific config files to sutiable location */
++  /* Copying Photon Specific config files to sutiable location */
 +  if (kernel_layout->kernelcfg_srcpath)
 +    {
 +      if (!glnx_fstatat_allow_noent (bootcsum_dfd, kernel_layout->kernelcfg_namever, &stbuf, 0, error))
 +        return FALSE;
 +      if (errno == ENOENT)
 +        {
-+          if (!install_into_boot (sepolicy, kernel_layout->ostree_boot_dfd, kernel_layout->kernelcfg_srcpath,
-+							  bootcsum_dfd, kernel_layout->kernelcfg_namever,
-+							  sysroot->debug_flags,
-+							  cancellable, error))
++          if (!install_into_boot (repo, sepolicy, kernel_layout->ostree_boot_dfd, kernel_layout->kernelcfg_srcpath,
++                                                         bootcsum_dfd, kernel_layout->kernelcfg_namever,
++                                                         cancellable, error))
 +            return FALSE;
 +        }
 +    }
@@ -99,37 +97,33 @@ index 3ca6c14..0744d7e
 +        return FALSE;
 +      if (errno == ENOENT)
 +        {
-+          if (!install_into_boot (sepolicy, kernel_layout->ostree_boot_dfd, kernel_layout->systemdcfg_srcpath,
-+							  bootcsum_dfd, kernel_layout->systemdcfg_namever,
-+							  sysroot->debug_flags,
-+							  cancellable, error))
-+	    return FALSE;
++          if (!install_into_boot (repo, sepolicy, kernel_layout->ostree_boot_dfd, kernel_layout->systemdcfg_srcpath,
++                                                         bootcsum_dfd, kernel_layout->systemdcfg_namever,
++                                                         cancellable, error))
++           return FALSE;
 +        }
 +    }
++
 +
    g_autofree char *contents = NULL;
    if (!glnx_fstatat_allow_noent (deployment_dfd, "usr/lib/os-release", &stbuf, 0, error))
      return FALSE;
-@@ -1775,6 +1832,19 @@ install_deployment_kernel (OstreeSysroot   *sysroot,
-       _ostree_kernel_args_replace_take (kargs, g_steal_pointer (&prepare_root_arg));
+@@ -1992,6 +2049,18 @@ install_deployment_kernel (OstreeSysroot   *sysroot,
+       ostree_kernel_args_replace_take (kargs, g_steal_pointer (&prepare_root_arg));
      }
  
 +  if (kernel_layout->systemdcfg_namever)
 +    {
-+      g_autofree char * boot_relpath = g_strconcat ("/", bootcsumdir, "/", kernel_layout->systemdcfg_namever, NULL);
-+      ostree_bootconfig_parser_set (bootconfig, "systemdcfg", boot_relpath);
++      g_autofree char * systemdcfg_boot_relpath = g_strconcat ("/", bootcsumdir, "/", kernel_layout->systemdcfg_namever, NULL);
++      ostree_bootconfig_parser_set (bootconfig, "systemdcfg", systemdcfg_boot_relpath);
 +    }
 +
 +  if (kernel_layout->kernelcfg_namever)
 +    {
-+      g_autofree char * boot_relpath = g_strconcat ("/", bootcsumdir, "/", kernel_layout->kernelcfg_namever, NULL);
-+      ostree_bootconfig_parser_set (bootconfig, "kernelcfg", boot_relpath);
++      g_autofree char * kernelcfg_boot_relpath = g_strconcat ("/", bootcsumdir, "/", kernel_layout->kernelcfg_namever, NULL);
++      ostree_bootconfig_parser_set (bootconfig, "kernelcfg", kernelcfg_boot_relpath);
 +    }
-+
 +
    if (kernel_layout->devicetree_namever)
      {
-       g_autofree char * boot_relpath = g_strconcat ("/", bootcsumdir, "/", kernel_layout->devicetree_namever, NULL);
--- 
-2.7.4
-
+       g_autofree char * dt_boot_relpath = g_strconcat ("/", bootcsumdir, "/", kernel_layout->devicetree_namever, NULL);

--- a/SPECS/ostree/0002-ostree-Adding-load-env-to-menuentry.patch
+++ b/SPECS/ostree/0002-ostree-Adding-load-env-to-menuentry.patch
@@ -9,11 +9,11 @@ to add kernel and systemd commandline parameter
 Signed-off-by: Ajay Kaher <akaher@vmware.com>
 Signed-off-by: Ankit Jain <ankitja@vmware.com>
 ---
- src/libostree/ostree-bootloader-grub2.c | 21 +++++++++++++++++++++
- 1 file changed, 21 insertions(+)
+ src/libostree/ostree-bootloader-grub2.c | 18 ++++++++++++++++++
+ 1 file changed, 18 insertions(+)
 
 diff --git a/src/libostree/ostree-bootloader-grub2.c b/src/libostree/ostree-bootloader-grub2.c
-index ee3ae6f..ad74509 100644
+index 22037f1..53fbfa6 100644
 --- a/src/libostree/ostree-bootloader-grub2.c
 +++ b/src/libostree/ostree-bootloader-grub2.c
 @@ -193,6 +193,8 @@ _ostree_bootloader_grub2_generate_config (OstreeSysroot                 *sysroot
@@ -25,14 +25,11 @@ index ee3ae6f..ad74509 100644
        char *quoted_title = NULL;
        char *uuid = NULL;
        char *quoted_uuid = NULL;
-@@ -217,6 +219,25 @@ _ostree_bootloader_grub2_generate_config (OstreeSysroot                 *sysroot
+@@ -217,6 +219,22 @@ _ostree_bootloader_grub2_generate_config (OstreeSysroot                 *sysroot
        g_string_append (output, grub2_prepare_root_cache);
        g_string_append_c (output, '\n');
  
-+
-+
 +      kernelcfg = ostree_bootconfig_parser_get (config, "kernelcfg");
-+
 +      if(kernelcfg)
 +        {
 +          g_string_append (output, "load_env -f ");

--- a/SPECS/ostree/0003-ostree-converting-osname-to-mariner.patch
+++ b/SPECS/ostree/0003-ostree-converting-osname-to-mariner.patch
@@ -1,15 +1,15 @@
-diff --git a/src/libostree/ostree-sysroot-deploy.c b/src/libostree/ostree-sysroot-deploy.c
-index 0744d7e..634101e 100755
---- a/src/libostree/ostree-sysroot-deploy.c
+diff --git a/src/libostree/ostree-sysroot-deploy.c.old2 b/src/libostree/ostree-sysroot-deploy.c
+index 976c4b5..263e2f5 100644
+--- a/src/libostree/ostree-sysroot-deploy.c.old2
 +++ b/src/libostree/ostree-sysroot-deploy.c
-@@ -1040,15 +1040,15 @@ get_kernel_from_tree_usrlib_modules (int                  deployment_dfd,
+@@ -1191,15 +1191,15 @@ get_kernel_from_tree_usrlib_modules (OstreeSysroot       *sysroot,
+       ret_layout->kernel_hmac_namever = g_strdup_printf (".%s.hmac", ret_layout->kernel_namever);
+     }
  
-   g_clear_object (&in);
-   glnx_close_fd (&fd);
 -/* Setting the param for Copying Photon Specific config files to sutiable location */
 +/* Setting the param for Copying Mariner Specific config files to sutiable location */
    if (!glnx_opendirat (deployment_dfd, "usr/lib/ostree-boot", FALSE, &ret_layout->ostree_boot_dfd, error))
- 	return FALSE;
+        return FALSE;
 -  if (!ot_openat_ignore_enoent (ret_layout->ostree_boot_dfd, "photon.cfg", &fd, error))
 +  if (!ot_openat_ignore_enoent (ret_layout->ostree_boot_dfd, "mariner.cfg", &fd, error))
      return FALSE;
@@ -21,12 +21,12 @@ index 0744d7e..634101e 100755
      }
    glnx_close_fd (&fd);
    if (!ot_openat_ignore_enoent (ret_layout->ostree_boot_dfd, "systemd.cfg", &fd, error))
-@@ -1714,7 +1714,7 @@ install_deployment_kernel (OstreeSysroot   *sysroot,
-         }
+@@ -1926,7 +1926,7 @@ install_deployment_kernel (OstreeSysroot   *sysroot,
+       g_ptr_array_add (overlay_initrds, g_steal_pointer (&destpath));
      }
  
--/* Copying Photon Specific config files to sutiable location */
-+/* Copying Mariner Specific config files to sutiable location */
+-  /* Copying Photon Specific config files to sutiable location */
++  /* Copying Mariner Specific config files to sutiable location */
    if (kernel_layout->kernelcfg_srcpath)
      {
        if (!glnx_fstatat_allow_noent (bootcsum_dfd, kernel_layout->kernelcfg_namever, &stbuf, 0, error))

--- a/SPECS/ostree/dualboot-support.patch
+++ b/SPECS/ostree/dualboot-support.patch
@@ -1,5 +1,5 @@
 diff --git a/src/libostree/ostree-bootloader-grub2.c b/src/libostree/ostree-bootloader-grub2.c
-index ceea682..ee3ae6f 100644
+index 0ef751d..22037f1 100644
 --- a/src/libostree/ostree-bootloader-grub2.c
 +++ b/src/libostree/ostree-bootloader-grub2.c
 @@ -174,6 +174,7 @@ _ostree_bootloader_grub2_generate_config (OstreeSysroot                 *sysroot
@@ -10,7 +10,7 @@ index ceea682..ee3ae6f 100644
  
    g_autoptr(GOutputStream) out_stream = g_unix_output_stream_new (target_fd, FALSE);
  
-@@ -219,10 +220,12 @@ _ostree_bootloader_grub2_generate_config (OstreeSysroot                 *sysroot
+@@ -220,10 +220,12 @@ _ostree_bootloader_grub2_generate_config (OstreeSysroot                 *sysroot
        if (!kernel)
          return glnx_throw (error, "No \"linux\" key in bootloader config");
        g_string_append (output, "linux");
@@ -25,7 +25,7 @@ index ceea682..ee3ae6f 100644
        g_string_append_c (output, ' ');
        g_string_append (output, kernel);
  
-@@ -238,10 +241,12 @@ _ostree_bootloader_grub2_generate_config (OstreeSysroot                 *sysroot
+@@ -239,10 +241,12 @@ _ostree_bootloader_grub2_generate_config (OstreeSysroot                 *sysroot
        if (initrd)
          {
            g_string_append (output, "initrd");
@@ -40,3 +40,4 @@ index ceea682..ee3ae6f 100644
            g_string_append_c (output, ' ');
            g_string_append (output, initrd);
            g_string_append_c (output, '\n');
+

--- a/SPECS/ostree/ostree.signatures.json
+++ b/SPECS/ostree/ostree.signatures.json
@@ -1,6 +1,6 @@
 {
  "Signatures": {
   "91-ostree.preset": "24cdb413163cec872dda583cc55eb070ee1472e6fb1fbf1a4a5e8aeafbeb8b8c",
-  "ostree-2019.2-withsubmodules.tar.gz": "62bb190feefa4256a1e9cecea7e1da6d63a2bd60a40a54270984541dbb91d5e6"
+  "libostree-2021.4.tar.xz": "db5ce01a1606af3466ec77236700f53a63ce20e4984a549d0eaba3f66a3d9361"
  }
 }

--- a/SPECS/ostree/ostree.spec
+++ b/SPECS/ostree/ostree.spec
@@ -157,7 +157,7 @@ install -vdm 755 %{buildroot}%{_sysconfdir}/ostree/remotes.d
 %{_libexecdir}/libostree/grub2*
 
 %changelog
-* Thu Sep 30 2021 Thomas Crain <thcrain@microsoft.com> - 2021.4
+* Thu Sep 30 2021 Thomas Crain <thcrain@microsoft.com> - 2021.4-1
 - Upgrade to latest upstream and rebase patches
 
 * Fri Feb 05 2021 Joe Schmitt <joschmit@microsoft.com> - 2019.2-11

--- a/SPECS/ostree/ostree.spec
+++ b/SPECS/ostree/ostree.spec
@@ -1,16 +1,13 @@
 Summary:        Git for operating system binaries
 Name:           ostree
-Version:        2019.2
-Release:        11%{?dist}
+Version:        2021.4
+Release:        1%{?dist}
 License:        LGPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Group:          Applications/System
 URL:            https://ostree.readthedocs.io/en/latest
-# Manually created Source tar which is equal to
-# Source0 + .git as it requires git hooks at build time
-#Source0:       https://github.com/ostreedev/ostree/releases/download/v2019.2/libostree-2019.2.tar.xz
-Source0:        %{name}-%{version}-withsubmodules.tar.gz
+Source0:        https://github.com/ostreedev/ostree/releases/download/v2021.4/lib%{name}-%{version}.tar.xz
 Source1:        91-ostree.preset
 Patch0:         dualboot-support.patch
 Patch1:         0001-ostree-Copying-photon-config-to-boot-directory.patch
@@ -86,11 +83,7 @@ Requires:       grub2-efi
 GRUB2 integration for OSTree
 
 %prep
-%setup -q
-%patch0 -p1
-%patch1 -p1
-%patch2 -p1
-%patch3 -p1
+%autosetup -p 1 -n lib%{name}-%{version}
 
 %build
 env NOCONFIGURE=1 ./autogen.sh
@@ -164,6 +157,9 @@ install -vdm 755 %{buildroot}%{_sysconfdir}/ostree/remotes.d
 %{_libexecdir}/libostree/grub2*
 
 %changelog
+* Thu Sep 30 2021 Thomas Crain <thcrain@microsoft.com> - 2021.4
+- Upgrade to latest upstream and rebase patches
+
 * Fri Feb 05 2021 Joe Schmitt <joschmit@microsoft.com> - 2019.2-11
 - Replace incorrect %%{_lib} usage with %%{_libdir}
 

--- a/SPECS/rpm-ostree/rpm-ostree-disable-selinux.patch
+++ b/SPECS/rpm-ostree/rpm-ostree-disable-selinux.patch
@@ -1,8 +1,8 @@
 diff --git a/src/app/rpmostree-compose-builtin-rojig.c b/src/app/rpmostree-compose-builtin-rojig.c
-index 02f0e03..10b0059 100644
---- src/app/rpmostree-compose-builtin-rojig.c
-+++ src/app/rpmostree-compose-builtin-rojig.c
-@@ -206,6 +206,7 @@ install_packages (RpmOstreeRojigCompose  *self,
+index 794028a..df315a2 100644
+--- a/src/app/rpmostree-compose-builtin-rojig.c
++++ b/src/app/rpmostree-compose-builtin-rojig.c
+@@ -207,6 +207,7 @@ install_packages (RpmOstreeRojigCompose  *self,
    if (!rpmostree_context_assemble (self->corectx, cancellable, error))
      return FALSE;
  
@@ -10,7 +10,7 @@ index 02f0e03..10b0059 100644
    /* Now reload the policy from the tmproot, and relabel the pkgcache - this
     * is the same thing done in rpmostree_context_commit(). But here we want
     * to ensure our pkgcache labels are accurate, since that will
-@@ -217,7 +218,7 @@ install_packages (RpmOstreeRojigCompose  *self,
+@@ -218,7 +219,7 @@ install_packages (RpmOstreeRojigCompose  *self,
      if (!rpmostree_context_force_relabel (self->corectx, cancellable, error))
        return FALSE;
    }
@@ -20,10 +20,10 @@ index 02f0e03..10b0059 100644
      *out_unmodified = FALSE;
    *out_new_inputhash = g_steal_pointer (&ret_new_inputhash);
 diff --git a/src/app/rpmostree-compose-builtin-tree.c b/src/app/rpmostree-compose-builtin-tree.c
-index a2b6131..96530c1 100644
---- src/app/rpmostree-compose-builtin-tree.c
-+++ src/app/rpmostree-compose-builtin-tree.c
-@@ -287,9 +287,10 @@ install_packages (RpmOstreeTreeComposeContext  *self,
+index bcdc34f..dc8898b 100644
+--- a/src/app/rpmostree-compose-builtin-tree.c
++++ b/src/app/rpmostree-compose-builtin-tree.c
+@@ -302,9 +302,10 @@ install_packages (RpmOstreeTreeComposeContext  *self,
        return FALSE;
    }
  
@@ -35,7 +35,7 @@ index a2b6131..96530c1 100644
    /* For unified core, we have a pkgcache repo. This is auto-created under the cachedir. */
    if (opt_unified_core)
      {
-@@ -397,6 +398,7 @@ install_packages (RpmOstreeTreeComposeContext  *self,
+@@ -435,6 +436,7 @@ install_packages (RpmOstreeTreeComposeContext  *self,
        if (!rpmostree_context_assemble (self->corectx, cancellable, error))
          return FALSE;
  
@@ -43,7 +43,7 @@ index a2b6131..96530c1 100644
        /* Now reload the policy from the tmproot, and relabel the pkgcache - this
         * is the same thing done in rpmostree_context_commit(). But here we want
         * to ensure our pkgcache labels are accurate, since that will
-@@ -410,6 +412,7 @@ install_packages (RpmOstreeTreeComposeContext  *self,
+@@ -448,6 +450,7 @@ install_packages (RpmOstreeTreeComposeContext  *self,
  
        if (!rpmostree_context_force_relabel (self->corectx, cancellable, error))
          return FALSE;
@@ -52,17 +52,18 @@ index a2b6131..96530c1 100644
    else
      {
 diff --git a/src/daemon/rpmostree-sysroot-upgrader.c b/src/daemon/rpmostree-sysroot-upgrader.c
-index 27551a1..95a416f 100644
---- src/daemon/rpmostree-sysroot-upgrader.c
-+++ src/daemon/rpmostree-sysroot-upgrader.c
-@@ -906,13 +906,14 @@ prepare_context_for_assembly (RpmOstreeSysrootUpgrader *self,
+index 45aaf28..d06af6e 100644
+--- a/src/daemon/rpmostree-sysroot-upgrader.c
++++ b/src/daemon/rpmostree-sysroot-upgrader.c
+@@ -922,6 +922,7 @@ prepare_context_for_assembly (RpmOstreeSysrootUpgrader *self,
+   rpmostree_context_configure_from_deployment (self->ctx, self->sysroot,
                                                 self->cfg_merge_deployment);
  
-   /* load the sepolicy to use during import */
 +#ifdef ENABLE_SELINUX
+   /* load the sepolicy to use during import */
    glnx_unref_object OstreeSePolicy *sepolicy = NULL;
    if (!rpmostree_prepare_rootfs_get_sepolicy (self->tmprootfs_dfd, &sepolicy,
-                                               cancellable, error))
+@@ -929,7 +930,7 @@ prepare_context_for_assembly (RpmOstreeSysrootUpgrader *self,
      return FALSE;
  
    rpmostree_context_set_sepolicy (self->ctx, sepolicy);
@@ -72,9 +73,9 @@ index 27551a1..95a416f 100644
      rpmostree_context_set_pkgcache_only (self->ctx, TRUE);
  
 diff --git a/src/daemon/rpmostreed-transaction-livefs.c b/src/daemon/rpmostreed-transaction-livefs.c
-index b8e2a1b..0c881f2 100644
---- src/daemon/rpmostreed-transaction-livefs.c
-+++ src/daemon/rpmostreed-transaction-livefs.c
+index b8e2a1b..28876d0 100644
+--- a/src/daemon/rpmostreed-transaction-livefs.c
++++ b/src/daemon/rpmostreed-transaction-livefs.c
 @@ -189,10 +189,11 @@ copy_new_config_files (OstreeRepo          *repo,
     */
    OstreeRepoCheckoutAtOptions etc_co_opts = { .force_copy = TRUE,
@@ -88,22 +89,23 @@ index b8e2a1b..0c881f2 100644
    glnx_autofd int deployment_etc_dfd = -1;
    if (!glnx_opendirat (new_deployment_dfd, "etc", TRUE, &deployment_etc_dfd, error))
      return FALSE;
-@@ -209,8 +210,10 @@ copy_new_config_files (OstreeRepo          *repo,
+@@ -209,9 +210,10 @@ copy_new_config_files (OstreeRepo          *repo,
        const char *etc_path = path + strlen ("/usr");
  
        etc_co_opts.subpath = path;
 +#ifdef ENABLE_SELINUX
        /* Strip off /usr for selinux labeling */
        etc_co_opts.sepolicy_prefix = etc_path;
+-
 +#endif
- 
        const char *sub_etc_relpath = etc_path + strlen ("/etc/");
        /* We keep track of added subdirectories and skip children of it, since
+        * both the diff and checkout are recursive, but we only need to checkout
 diff --git a/src/libpriv/rpmostree-core.c b/src/libpriv/rpmostree-core.c
-index 1d1b87c..75551f9 100644
---- src/libpriv/rpmostree-core.c
-+++ src/libpriv/rpmostree-core.c
-@@ -804,6 +804,7 @@ rpmostree_context_setup (RpmOstreeContext    *self,
+index 4aedcc4..b413093 100644
+--- a/src/libpriv/rpmostree-core.c
++++ b/src/libpriv/rpmostree-core.c
+@@ -839,6 +839,7 @@ rpmostree_context_setup (RpmOstreeContext    *self,
  
    gboolean selinux;
    g_assert (g_variant_dict_lookup (self->spec->dict, "selinux", "b", &selinux));
@@ -111,7 +113,7 @@ index 1d1b87c..75551f9 100644
    /* Load policy from / if SELinux is enabled, and we haven't already loaded
     * a policy.  This is mostly for the "compose tree" case.
     */
-@@ -828,6 +829,7 @@ rpmostree_context_setup (RpmOstreeContext    *self,
+@@ -863,6 +864,7 @@ rpmostree_context_setup (RpmOstreeContext    *self,
          return glnx_throw (error, "Unable to load SELinux policy from /");
        rpmostree_context_set_sepolicy (self, sepolicy);
      }
@@ -119,7 +121,7 @@ index 1d1b87c..75551f9 100644
  
    return TRUE;
  }
-@@ -2021,10 +2023,12 @@ rpmostree_context_prepare_rojig (RpmOstreeContext *self,
+@@ -2220,10 +2222,12 @@ rpmostree_context_prepare_rojig (RpmOstreeContext *self,
                                   GError          **error)
  {
    self->rojig_pure = TRUE;
@@ -132,7 +134,7 @@ index 1d1b87c..75551f9 100644
    self->rojig_allow_not_found = allow_not_found;
    return rpmostree_context_prepare (self, cancellable, error);
  }
-@@ -2992,7 +2996,9 @@ relabel_in_thread_impl (RpmOstreeContext *self,
+@@ -3205,7 +3209,9 @@ relabel_in_thread_impl (RpmOstreeContext *self,
      ostree_repo_commit_modifier_new (OSTREE_REPO_COMMIT_MODIFIER_FLAGS_CONSUME,
                                         NULL, NULL, NULL);
    ostree_repo_commit_modifier_set_devino_cache (modifier, cache);
@@ -142,7 +144,7 @@ index 1d1b87c..75551f9 100644
  
    g_autoptr(OstreeMutableTree) mtree = ostree_mutable_tree_new ();
    if (!ostree_repo_write_dfd_to_mtree (repo, tmpdir_dfd, pkg_dirname, mtree,
-@@ -3010,6 +3016,7 @@ relabel_in_thread_impl (RpmOstreeContext *self,
+@@ -3223,6 +3229,7 @@ relabel_in_thread_impl (RpmOstreeContext *self,
    if (!ostree_repo_load_commit (repo, commit_csum, &commit_var, NULL, error))
      return FALSE;
  
@@ -150,32 +152,23 @@ index 1d1b87c..75551f9 100644
    /* let's just copy the metadata from the previous commit and only change the
     * rpmostree.sepolicy value */
    g_autoptr(GVariant) meta = g_variant_get_child_value (commit_var, 0);
-@@ -3017,14 +3024,14 @@ relabel_in_thread_impl (RpmOstreeContext *self,
+@@ -3230,6 +3237,7 @@ relabel_in_thread_impl (RpmOstreeContext *self,
  
    g_variant_dict_insert (meta_dict, "rpmostree.sepolicy", "s",
                           ostree_sepolicy_get_csum (self->sepolicy));
--
 +#endif
-+  
+ 
    g_autofree char *new_commit_csum = NULL;
    if (!ostree_repo_write_commit (repo, NULL, "", "",
-                                  g_variant_dict_end (meta_dict),
-                                  OSTREE_REPO_FILE (root), &new_commit_csum,
-                                  cancellable, error))
-     return FALSE;
--
-   /* Compute new content checksum */
-   g_autoptr(GVariant) new_commit = NULL;
-   if (!ostree_repo_load_commit (repo, new_commit_csum, &new_commit, NULL, error))
-@@ -3580,6 +3587,7 @@ add_install (RpmOstreeContext *self,
+@@ -3778,6 +3786,7 @@ add_install (RpmOstreeContext *self,
      return FALSE;
  
-   gboolean sepolicy_matches;
+   gboolean sepolicy_matches = FALSE;
 +#ifdef ENABLE_SELINUX
    if (self->sepolicy)
      {
        if (!commit_has_matching_sepolicy (commit, self->sepolicy, &sepolicy_matches,
-@@ -3589,7 +3597,7 @@ add_install (RpmOstreeContext *self,
+@@ -3787,7 +3796,7 @@ add_install (RpmOstreeContext *self,
        /* We already did any relabeling/reimporting above */
        g_assert (sepolicy_matches);
      }
@@ -184,7 +177,25 @@ index 1d1b87c..75551f9 100644
    if (!checkout_pkg_metadata_by_dnfpkg (self, pkg, cancellable, error))
      return FALSE;
  
-@@ -4425,6 +4433,7 @@ rpmostree_context_commit (RpmOstreeContext      *self,
+@@ -3924,7 +3933,7 @@ rpmostree_core_undo_usretc (int              rootfs_dfd,
+     {
+       *renamed_etc = FALSE;
+     }
+-  
++
+   return TRUE;
+ }
+ 
+@@ -3981,7 +3990,7 @@ process_ostree_layers (RpmOstreeContext *self,
+ {
+   if (!self->treefile_rs)
+     return TRUE;
+-  
++
+   g_auto(GStrv) layers = ror_treefile_get_ostree_layers (self->treefile_rs);
+   g_auto(GStrv) override_layers = ror_treefile_get_ostree_override_layers (self->treefile_rs);
+   const size_t n = (layers ? g_strv_length (layers) : 0) + (override_layers ? g_strv_length (override_layers) : 0);
+@@ -4770,6 +4779,7 @@ rpmostree_context_commit (RpmOstreeContext      *self,
      /* if we're SELinux aware, then reload the final policy from the tmprootfs in case it
       * was changed by a scriptlet; this covers the foobar/foobar-selinux path */
      g_autoptr(OstreeSePolicy) final_sepolicy = NULL;
@@ -192,7 +203,7 @@ index 1d1b87c..75551f9 100644
      if (self->sepolicy)
        {
          if (!rpmostree_prepare_rootfs_get_sepolicy (self->tmprootfs_dfd, &final_sepolicy,
-@@ -4440,6 +4449,7 @@ rpmostree_context_commit (RpmOstreeContext      *self,
+@@ -4785,6 +4795,7 @@ rpmostree_context_commit (RpmOstreeContext      *self,
                         ostree_sepolicy_get_csum (final_sepolicy)) == 0)
            modflags |= OSTREE_REPO_COMMIT_MODIFIER_FLAGS_DEVINO_CANONICAL;
        }
@@ -201,9 +212,9 @@ index 1d1b87c..75551f9 100644
      commit_modifier = ostree_repo_commit_modifier_new (modflags, NULL, NULL, NULL);
      if (final_sepolicy)
 diff --git a/src/libpriv/rpmostree-importer.c b/src/libpriv/rpmostree-importer.c
-index adcc7e9..4dd80d4 100644
---- src/libpriv/rpmostree-importer.c
-+++ src/libpriv/rpmostree-importer.c
+index aa0bb47..4810be2 100644
+--- a/src/libpriv/rpmostree-importer.c
++++ b/src/libpriv/rpmostree-importer.c
 @@ -450,6 +450,7 @@ build_metadata_variant (RpmOstreeImporter *self,
                                          headerGetString (self->hdr, RPMTAG_RELEASE),
                                          headerGetString (self->hdr, RPMTAG_ARCH)));
@@ -221,7 +232,7 @@ index adcc7e9..4dd80d4 100644
    /* let's be nice to our future selves just in case */
    g_variant_builder_add (&metadata_builder, "{sv}", "rpmostree.unpack_version",
                           g_variant_new_uint32 (1));
-@@ -872,7 +873,9 @@ import_rpm_to_repo (RpmOstreeImporter *self,
+@@ -898,7 +899,9 @@ import_rpm_to_repo (RpmOstreeImporter *self,
    else
      {
        ostree_repo_commit_modifier_set_xattr_callback (modifier, xattr_cb, NULL, self);
@@ -232,10 +243,10 @@ index adcc7e9..4dd80d4 100644
  
    OstreeRepoImportArchiveOptions opts = { 0 };
 diff --git a/src/libpriv/rpmostree-postprocess.c b/src/libpriv/rpmostree-postprocess.c
-index d6c7328..72ae916 100644
---- src/libpriv/rpmostree-postprocess.c
-+++ src/libpriv/rpmostree-postprocess.c
-@@ -978,6 +978,7 @@ rpmostree_postprocess_final (int            rootfs_dfd,
+index a3f9cff..f78f9b9 100644
+--- a/src/libpriv/rpmostree-postprocess.c
++++ b/src/libpriv/rpmostree-postprocess.c
+@@ -986,6 +986,7 @@ rpmostree_postprocess_final (int            rootfs_dfd,
    if (!ror_compose_postprocess_final (rootfs_dfd, error))
      return FALSE;
  
@@ -243,7 +254,7 @@ index d6c7328..72ae916 100644
    if (selinux)
      {
        g_print ("Recompiling policy\n");
-@@ -989,6 +990,7 @@ rpmostree_postprocess_final (int            rootfs_dfd,
+@@ -997,6 +998,7 @@ rpmostree_postprocess_final (int            rootfs_dfd,
                                cancellable, error))
          return FALSE;
      }
@@ -251,7 +262,7 @@ index d6c7328..72ae916 100644
  
    gboolean container = FALSE;
    if (!_rpmostree_jsonutil_object_get_optional_boolean_member (treefile,
-@@ -1019,11 +1021,13 @@ rpmostree_postprocess_final (int            rootfs_dfd,
+@@ -1027,11 +1029,13 @@ rpmostree_postprocess_final (int            rootfs_dfd,
    if (!replace_nsswitch (rootfs_dfd, cancellable, error))
      return glnx_prefix_error (error, "nsswitch replacement");
  
@@ -265,7 +276,20 @@ index d6c7328..72ae916 100644
  
    if (!convert_var_to_tmpfiles_d (rootfs_dfd, cancellable, error))
      return FALSE;
-@@ -2042,12 +2046,14 @@ rpmostree_compose_commit (int            rootfs_fd,
+@@ -1976,10 +1980,10 @@ count_filesizes (int dfd,
+                  GError **error)
+ {
+   g_auto(GLnxDirFdIterator) dfd_iter = { 0, };
+-  
++
+   if (!glnx_dirfd_iterator_init_at (dfd, path, TRUE, &dfd_iter, error))
+     return FALSE;
+-  
++
+   while (TRUE)
+     {
+       struct dirent *dent = NULL;
+@@ -2056,13 +2060,14 @@ rpmostree_compose_commit (int            rootfs_fd,
                            GError       **error)
  {
    g_autoptr(OstreeSePolicy) sepolicy = NULL;
@@ -276,11 +300,12 @@ index d6c7328..72ae916 100644
        if (!sepolicy)
          return FALSE;
      }
+-
 +#endif
- 
    g_autoptr(OstreeMutableTree) mtree = ostree_mutable_tree_new ();
    /* We may make this configurable if someone complains about including some
-@@ -2067,10 +2073,12 @@ rpmostree_compose_commit (int            rootfs_fd,
+    * unlabeled content, but I think the fix for that is to ensure that policy is
+@@ -2081,10 +2086,12 @@ rpmostree_compose_commit (int            rootfs_fd,
                                                    filter_xattrs_cb, NULL,
                                                    &tdata);
  
@@ -293,3 +318,6 @@ index d6c7328..72ae916 100644
  
    if (devino_cache)
      ostree_repo_commit_modifier_set_devino_cache (commit_modifier, devino_cache);
+-- 
+2.25.1
+

--- a/SPECS/rpm-ostree/rpm-ostree-libdnf-build.patch
+++ b/SPECS/rpm-ostree/rpm-ostree-libdnf-build.patch
@@ -1,9 +1,12 @@
---- libdnf/CMakeLists.txt
-+++ libdnf/CMakeLists.txt
-@@ -45,7 +45,8 @@ endif()
-
+diff --git a/libdnf/CMakeLists.txt b/libdnf/CMakeLists.txt
+index 2dd55c5..701cd4a 100644
+--- a/libdnf/CMakeLists.txt
++++ b/libdnf/CMakeLists.txt
+@@ -50,6 +50,7 @@ endif()
+ 
  # build dependencies
  find_package(Gpgme REQUIRED)
 +set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH};/usr/share/cmake/Modules/)
  find_package(LibSolv 0.6.30 REQUIRED COMPONENTS ext)
  find_package(OpenSSL REQUIRED)
+ 

--- a/SPECS/rpm-ostree/rpm-ostree.signatures.json
+++ b/SPECS/rpm-ostree/rpm-ostree.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "rpm-ostree-2021.11.tar.xz": "07a2b9731270a795a79d935d692729dcea28e879c1133b1c747cf0737abe552a"
+  "rpm-ostree-2020.4.tar.xz": "ac152243d4cb1a1184522495c655e1de6aa5adfddb990296cd745b285d953005"
  }
 }

--- a/SPECS/rpm-ostree/rpm-ostree.spec
+++ b/SPECS/rpm-ostree/rpm-ostree.spec
@@ -1,6 +1,6 @@
 Summary:        Commit RPMs to an OSTree repository
 Name:           rpm-ostree
-Version:        2021.11
+Version:        2020.4
 Release:        1%{?dist}
 License:        LGPLv2+
 Vendor:         Microsoft Corporation
@@ -9,7 +9,6 @@ URL:            https://github.com/coreos/rpm-ostree
 Source0:        %{url}/releases/download/v%{version}/%{name}-%{version}.tar.xz
 Patch0:         rpm-ostree-libdnf-build.patch
 Patch1:         rpm-ostree-disable-selinux.patch
-
 BuildRequires:  attr-devel
 BuildRequires:  autoconf
 BuildRequires:  autogen
@@ -19,7 +18,7 @@ BuildRequires:  check
 BuildRequires:  cmake
 BuildRequires:  cppunit-devel
 BuildRequires:  createrepo_c
-BuildRequires:  dbus
+BuildRequires:  dbus-devel
 BuildRequires:  docbook-style-xsl
 BuildRequires:  git
 BuildRequires:  gobject-introspection-devel
@@ -100,7 +99,7 @@ Requires:       %{name} = %{version}-%{release}
 Includes the scripts for rpm-ostree repo creation to act as server
 
 %prep
-%autosetup
+%autosetup -p1
 
 %build
 env NOCONFIGURE=1 ./autogen.sh
@@ -131,7 +130,7 @@ make check
 %{_libdir}/%{name}/
 %{_libdir}/*.so.1*
 %{_libdir}/girepository-1.0/*.typelib
-%{_sysconfdir}/dbus-1/system.d/*
+%{_datadir}/dbus-1/system.d/*
 %{_unitdir}/*.service
 %{_libexecdir}/*
 %{_datadir}/dbus-1/system-services/*
@@ -152,8 +151,9 @@ make check
 %{_datadir}/gir-1.0/*-1.0.gir
 
 %changelog
-* Mon Sep 27 2021 Thomas Crain <thcrain@microsoft.com> - 2021.11-1
-- Upgrade to latest upstream release (license verified)
+* Mon Sep 27 2021 Thomas Crain <thcrain@microsoft.com> - 2020.4-1
+- Upgrade to latest upstream release supported by 
+- License verified
 
 * Tue Apr 27 2021 Thomas Crain <thcrain@microsoft.com> - 2019.3-9
 - Merge the following releases from dev to 1.0 spec

--- a/SPECS/rpm-ostree/rpm-ostree.spec
+++ b/SPECS/rpm-ostree/rpm-ostree.spec
@@ -152,7 +152,8 @@ make check
 
 %changelog
 * Mon Sep 27 2021 Thomas Crain <thcrain@microsoft.com> - 2020.4-1
-- Upgrade to latest upstream release supported by 
+- Upgrade version and rebase patches
+- Move all dbus files to reside under %%{_datadir}
 - License verified
 
 * Tue Apr 27 2021 Thomas Crain <thcrain@microsoft.com> - 2019.3-9

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -5222,8 +5222,8 @@
         "type": "other",
         "other": {
           "name": "ostree",
-          "version": "2019.2",
-          "downloadUrl": "https://github.com/ostreedev/ostree/releases/download/v2019.2/libostree-2019.2.tar.xz"
+          "version": "2021.4",
+          "downloadUrl": "https://github.com/ostreedev/ostree/releases/download/v2021.4/libostree-2021.4.tar.xz"
         }
       }
     },
@@ -7572,8 +7572,8 @@
         "type": "other",
         "other": {
           "name": "rpm-ostree",
-          "version": "2021.11",
-          "downloadUrl": "https://github.com/coreos/rpm-ostree/releases/download/v2021.11/rpm-ostree-2021.11.tar.xz"
+          "version": "2020.4",
+          "downloadUrl": "https://github.com/coreos/rpm-ostree/releases/download/v2020.4/rpm-ostree-2020.4.tar.xz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Recent upgrade to libmodulemd broke rpm-ostree build. The attempted fix for that (upgrade rpm-ostree to 2021.11) ended up revealing some incompatibilities between our current versions of rust/systemd/rpm and newer versions of rpm-ostree. This new fix upgrades ostree and downgrades rpm-ostree to the newest version that will build with our package ecosystem. We can upgrade more once we get the above mentioned packages upgraded as part of our 2.0 push.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Upgrade ostree to 2021.4 and rebase patches
- Downgrade rpm-ostree to 2020.4 from 2021.11 and rebase patches
- Note: rpm-ostree 2021.11 was never built and released in our pipelines

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES/NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local package build
