### PR TITLE
[dev] Fixing toolchain and `openssh` builds.

### DIFF
--- a/SPECS/openssh/openssh.spec
+++ b/SPECS/openssh/openssh.spec
@@ -1,3 +1,4 @@
+%global openssh_ver 8.5p1
 %global openssh_rel 4
 
 %global pam_ssh_agent_ver 0.10.3
@@ -7,14 +8,14 @@
 
 Summary:        Free version of the SSH connectivity tools
 Name:           openssh
-Version:        8.5p1
+Version:        %{openssh_ver}
 Release:        %{openssh_rel}%{?dist}
 License:        BSD
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Group:          System Environment/Security
 URL:            https://www.openssh.com/
-Source0:        https://ftp.usa.openbsd.org/pub/OpenBSD/OpenSSH/portable/%{name}-%{version}.tar.gz
+Source0:        https://ftp.usa.openbsd.org/pub/OpenBSD/OpenSSH/portable/%{name}-%{openssh_ver}.tar.gz
 Source1:        http://www.linuxfromscratch.org/blfs/downloads/stable-systemd/blfs-systemd-units-%{systemd_units_rel}.tar.xz
 Source2:        sshd.service
 Source3:        sshd-keygen.service
@@ -52,8 +53,8 @@ BuildRequires:  shadow-utils
 BuildRequires:  sudo
 %endif
 BuildRequires:  libselinux-devel
-Requires:       openssh-clients = %{version}-%{release}
-Requires:       openssh-server = %{version}-%{release}
+Requires:       openssh-clients = %{openssh_ver}-%{openssh_rel}
+Requires:       openssh-server = %{openssh_ver}-%{openssh_rel}
 
 %description
 The OpenSSH package contains ssh clients and the sshd daemon. This is
@@ -85,7 +86,7 @@ The module is most useful for su and sudo service stacks.
 %package server
 Summary:        openssh server applications
 Requires:       ncurses-term
-Requires:       openssh-clients = %{version}-%{release}
+Requires:       openssh-clients = %{openssh_ver}-%{openssh_rel}
 Requires:       pam
 Requires:       shadow-utils
 Requires(post): /bin/chown

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -77,9 +77,6 @@ filesystem-1.1-8.cm2.aarch64.rpm
 findutils-4.6.0-7.cm2.aarch64.rpm
 findutils-debuginfo-4.6.0-7.cm2.aarch64.rpm
 findutils-lang-4.6.0-7.cm2.aarch64.rpm
-finger-0.17-4.cm2.aarch64.rpm
-finger-debuginfo-0.17-4.cm2.aarch64.rpm
-finger-server-0.17-4.cm2.aarch64.rpm
 flex-2.6.4-7.cm2.aarch64.rpm
 flex-debuginfo-2.6.4-7.cm2.aarch64.rpm
 flex-devel-2.6.4-7.cm2.aarch64.rpm
@@ -571,9 +568,6 @@ systemd-bootstrap-debuginfo-239-36.cm2.aarch64.rpm
 systemd-bootstrap-devel-239-36.cm2.aarch64.rpm
 tar-1.32-2.cm2.aarch64.rpm
 tar-debuginfo-1.32-2.cm2.aarch64.rpm
-tcp_wrappers-7.6-9.cm2.aarch64.rpm
-tcp_wrappers-debuginfo-7.6-9.cm2.aarch64.rpm
-tcp_wrappers-devel-7.6-9.cm2.aarch64.rpm
 tdnf-2.1.0-7.cm2.aarch64.rpm
 tdnf-cli-libs-2.1.0-7.cm2.aarch64.rpm
 tdnf-debuginfo-2.1.0-7.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -77,9 +77,6 @@ filesystem-1.1-8.cm2.x86_64.rpm
 findutils-4.6.0-7.cm2.x86_64.rpm
 findutils-debuginfo-4.6.0-7.cm2.x86_64.rpm
 findutils-lang-4.6.0-7.cm2.x86_64.rpm
-finger-0.17-4.cm2.x86_64.rpm
-finger-debuginfo-0.17-4.cm2.x86_64.rpm
-finger-server-0.17-4.cm2.x86_64.rpm
 flex-2.6.4-7.cm2.x86_64.rpm
 flex-debuginfo-2.6.4-7.cm2.x86_64.rpm
 flex-devel-2.6.4-7.cm2.x86_64.rpm
@@ -571,9 +568,6 @@ systemd-bootstrap-debuginfo-239-36.cm2.x86_64.rpm
 systemd-bootstrap-devel-239-36.cm2.x86_64.rpm
 tar-1.32-2.cm2.x86_64.rpm
 tar-debuginfo-1.32-2.cm2.x86_64.rpm
-tcp_wrappers-7.6-9.cm2.x86_64.rpm
-tcp_wrappers-debuginfo-7.6-9.cm2.x86_64.rpm
-tcp_wrappers-devel-7.6-9.cm2.x86_64.rpm
 tdnf-2.1.0-7.cm2.x86_64.rpm
 tdnf-cli-libs-2.1.0-7.cm2.x86_64.rpm
 tdnf-debuginfo-2.1.0-7.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/update_manifests.sh
+++ b/toolkit/resources/manifests/package/update_manifests.sh
@@ -61,7 +61,6 @@ remove_packages_for_pkggen_core () {
     sed -i '/e2fsprogs-lang/d' $TmpPkgGen
     sed -i '/openj/d' $TmpPkgGen
     sed -i '/freetype2/d' $TmpPkgGen
-    sed -i '/finger-[[:alpha:]]/d' $TmpPkgGen
     sed -i '/gfortran/d' $TmpPkgGen
     sed -i '/glib-devel/d' $TmpPkgGen
     sed -i '/glib-schemas/d' $TmpPkgGen
@@ -201,7 +200,6 @@ remove_packages_for_pkggen_core () {
     sed -i '/python3-test/d' $TmpPkgGen
     sed -i '/python3-tools/d' $TmpPkgGen
     sed -i '/tdnf-python/d' $TmpPkgGen
-    sed -i '/tcp_wrappers-[[:alpha:]]/d' $TmpPkgGen
     sed -i '/util-linux-lang/d' $TmpPkgGen
     sed -i '/wget/d' $TmpPkgGen
     sed -i '/XML-Parser/d' $TmpPkgGen

--- a/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
+++ b/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
@@ -532,12 +532,8 @@ chroot_and_install_rpms libtirpc
 chroot_and_install_rpms rpcsvc-proto
 build_rpm_in_chroot_no_install libnsl2
 
-build_rpm_in_chroot_no_install finger
-
-# tcp_wrappers needs libnsl2, finger
+# Removed 'tcp_wrappers', might not need: libnsl2
 chroot_and_install_rpms libnsl2
-chroot_and_install_rpms finger
-build_rpm_in_chroot_no_install tcp_wrappers
 
 # groff needs perl-File-HomeDir installed to run
 # perl-File-HomeDir needs perl-File-Which installed to run
@@ -551,9 +547,8 @@ chroot_and_install_rpms groff
 
 build_rpm_in_chroot_no_install libcap-ng
 
-# Removed 'audit', might not need: golang, tcp_wrappers and libcap-ng
+# Removed 'audit', might not need: golang, libcap-ng
 chroot_and_install_rpms golang
-chroot_and_install_rpms tcp_wrappers
 chroot_and_install_rpms libcap-ng
 
 # p11-kit needs libtasn1, systemd-bootstrap


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

Fixing the toolchain build after recent changes. I've missed the dependency `finger` has on `systemd`. Turns out, we don't need  `tcp_wrapper` (the only package depending on it) in the toolchain any more, so both are being removed from that phase of the build.

Also, I misconfigured `openssh.spec` while adding a new subpackage. The new package's `Version` tag overwrote the first declaration of `Version` and made `openssh-server` defined underneath the new package require a non-existing version of `openssh-client`.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Remove `tcp_wrapper` and `finger` from toolchain builds.
- Fix version requirements inside `openssh.spec`.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
Yes.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local package builds.
