### PR TITLE
[dev] Thcrain/fix numactl page conflict

### DIFF
--- a/SPECS/numactl/numactl.spec
+++ b/SPECS/numactl/numactl.spec
@@ -1,7 +1,7 @@
 Summary:        NUMA support for Linux
 Name:           numactl
 Version:        2.0.13
-Release:        5%{?dist}
+Release:        6%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -24,7 +24,7 @@ libnuma shared library ("NUMA API") to set NUMA policy in applications.
 %package -n libnuma-devel
 Summary:        Development libraries and header files for libnuma
 License:        GPLv2
-Requires:       %{name} = %{version}-%{release}
+Requires:       libnuma = %{version}-%{release}
 Provides:       %{name}-devel = %{version}-%{release}
 
 %description -n libnuma-devel
@@ -32,22 +32,24 @@ The package contains libraries and header files for
 developing applications that use libnuma.
 
 %prep
-%setup -q
+%autosetup
 
 %build
 autoreconf -fiv
 %configure --disable-static
-make %{?_smp_mflags}
+%make_build
 
 %install
-make DESTDIR=%{buildroot} install
+%make_install
 find %{buildroot} -type f -name "*.la" -delete -print
 
-%check
-make %{?_smp_mflags} check
+# Rename conflicting docs (also packaged in man-pages)
+mv %{buildroot}%{_mandir}/man2/move_pages.2 %{buildroot}%{_mandir}/man2/numa-move_pages.2
 
-%post -n libnuma  -p /sbin/ldconfig
-%postun -n libnuma -p /sbin/ldconfig
+%check
+%make_build check
+
+%ldconfig_scriptlets
 
 %files
 %defattr(-,root,root)
@@ -57,10 +59,12 @@ make %{?_smp_mflags} check
 
 %files -n libnuma
 %defattr(-,root,root)
+%license LICENSE.LGPL2.1
 %{_libdir}/*.so.*
 
 %files -n libnuma-devel
 %defattr(-,root,root)
+%license LICENSE.GPL2
 %{_includedir}/*
 %{_libdir}/*.so
 %{_libdir}/pkgconfig/numa.pc
@@ -68,6 +72,13 @@ make %{?_smp_mflags} check
 %{_mandir}/man3/*
 
 %changelog
+* Thu Sep 30 2021 Thomas Crain <thcrain@microsoft.com> - 2.0.13-6
+- Rename conflicting move_pages.2 man pages
+- Require libnuma from libnuma-devel
+- Fix license packaging
+- Lint specific
+- License verified
+
 * Fri Sep 10 2021 Thomas Crain <thcrain@microsoft.com> - 2.0.13-5
 - Remove libtool archive files from final packaging
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
`move_pages.2` man page conflicts between `numactl` and `man-pages` packages. We choose to rename the conflicting version from `numactl`.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Rename conflicting move_pages.2 man page
- Require libnuma from libnuma-devel
- Fix license packaging

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local package build, local simultaneous install of `numactl`/`man-pages` packages
