### PR TITLE
[dev] `systemd`: removing incorrect `Provides` and changing `libinput` BR.

### DIFF
--- a/SPECS/libinput/libinput.spec
+++ b/SPECS/libinput/libinput.spec
@@ -3,7 +3,7 @@
 Summary:        Input device library
 Name:           libinput
 Version:        1.16.4
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -17,9 +17,9 @@ BuildRequires:  meson
 BuildRequires:  pkg-config
 BuildRequires:  python3-devel
 BuildRequires:  pkgconfig(libevdev)
-BuildRequires:  pkgconfig(libudev)
 BuildRequires:  pkgconfig(libwacom)
 BuildRequires:  pkgconfig(mtdev)
+BuildRequires:  systemd-devel
 
 %description
 libinput is a library that handles input devices for display servers and other
@@ -99,6 +99,10 @@ find %{buildroot}/%{_mandir}/man1 -type f -regextype posix-egrep -regex "$UTILS_
 %{_mandir}/man1/libinput-test-suite.1*
 
 %changelog
+* Mon Oct 04 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.16.4-4
+- Replacing BR 'pkgconfig(libudev)' with 'systemd-devel' to avoid build confusion
+  between 'systemd-bootstrap-devel' and 'systemd-devel'.
+
 * Mon Aug 30 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.16.4-3
 - Removing BR on 'marinerui-rpm-macros'. Using macros from the build env.
 

--- a/SPECS/systemd/systemd.spec
+++ b/SPECS/systemd/systemd.spec
@@ -80,7 +80,6 @@ Requires:       pam
 Requires:       xz
 
 Obsoletes:      systemd-bootstrap
-Provides:       systemd-bootstrap = %{version}-%{release}
 
 Provides:       systemd-units = %{version}-%{release}
 Provides:       systemd-sysv = %{version}-%{release}
@@ -106,7 +105,6 @@ Requires:       %{name} = %{version}-%{release}
 Requires:       glib-devel
 
 Obsoletes:      systemd-bootstrap-devel
-Provides:       systemd-bootstrap-devel = %{version}-%{release}
 
 Provides:       systemd-libs = %{version}-%{release}
 Provides:       libudev-devel = %{version}-%{release}


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

The additional `Provides: systemd-boostrap` inside `systemd.spec` was creating circular dependencies from packages, which explicitly pick `systemd-bootstrap`. We're making `systemd` obsolete `systemd-bootstrap`, but the latter still has to be considered an option, when `systemd` is not yet available.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Removed `Provides: systemd-boostrap*` from `systemd.spec`.
- Made `libinput` BR explicitly `systemd-devel` instead of `pkgconfig(libudev)` to avoid confusion between `systemd-devel` and `systemd-bootstrap-devel`.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #1488

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local package build of all packages involved in the circular dependency and `libinput`, which previously suffered from misconfigured dependencies and tooling limitations.
