### PR TITLE
Fix moby-containerd CVE-2021-41103

### DIFF
--- a/SPECS/moby-containerd/CVE-2021-41103.patch
+++ b/SPECS/moby-containerd/CVE-2021-41103.patch
@@ -1,0 +1,632 @@
+From 7d56b24f1a9af82dfaa10ff55a4e3c36a7efd943 Mon Sep 17 00:00:00 2001
+From: Samuel Karp <skarp@amazon.com>
+Date: Mon, 20 Sep 2021 16:20:26 -0700
+Subject: [PATCH 1/3] v2 runtime: reduce permissions for bundle dir
+
+Bundle directory permissions should be 0700 by default.  On Linux with
+user namespaces enabled, the remapped root also needs access to the
+bundle directory.  In this case, the bundle directory is modified to
+0710 and group ownership is changed to the remapped root group.
+
+Signed-off-by: Samuel Karp <skarp@amazon.com>
+---
+ runtime/v2/bundle.go            |   5 +-
+ runtime/v2/bundle_default.go    |  24 ++++++
+ runtime/v2/bundle_linux.go      |  74 ++++++++++++++++
+ runtime/v2/bundle_linux_test.go | 145 ++++++++++++++++++++++++++++++++
+ runtime/v2/bundle_test.go       |  23 +++++
+ 5 files changed, 270 insertions(+), 1 deletion(-)
+ create mode 100644 runtime/v2/bundle_default.go
+ create mode 100644 runtime/v2/bundle_linux.go
+ create mode 100644 runtime/v2/bundle_linux_test.go
+ create mode 100644 runtime/v2/bundle_test.go
+
+diff --git a/runtime/v2/bundle.go b/runtime/v2/bundle.go
+index 1a58e627b5..954163b0f3 100644
+--- a/runtime/v2/bundle.go
++++ b/runtime/v2/bundle.go
+@@ -72,7 +72,10 @@ func NewBundle(ctx context.Context, root, state, id string, spec []byte) (b *Bun
+ 	if err := os.MkdirAll(filepath.Dir(b.Path), 0711); err != nil {
+ 		return nil, err
+ 	}
+-	if err := os.Mkdir(b.Path, 0711); err != nil {
++	if err := os.Mkdir(b.Path, 0700); err != nil {
++		return nil, err
++	}
++	if err := prepareBundleDirectoryPermissions(b.Path, spec); err != nil {
+ 		return nil, err
+ 	}
+ 	paths = append(paths, b.Path)
+diff --git a/runtime/v2/bundle_default.go b/runtime/v2/bundle_default.go
+new file mode 100644
+index 0000000000..2be40c8254
+--- /dev/null
++++ b/runtime/v2/bundle_default.go
+@@ -0,0 +1,24 @@
++//go:build !linux
++// +build !linux
++
++/*
++   Copyright The containerd Authors.
++
++   Licensed under the Apache License, Version 2.0 (the "License");
++   you may not use this file except in compliance with the License.
++   You may obtain a copy of the License at
++
++       http://www.apache.org/licenses/LICENSE-2.0
++
++   Unless required by applicable law or agreed to in writing, software
++   distributed under the License is distributed on an "AS IS" BASIS,
++   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++   See the License for the specific language governing permissions and
++   limitations under the License.
++*/
++
++package v2
++
++// prepareBundleDirectoryPermissions prepares the permissions of the bundle
++// directory according to the needs of the current platform.
++func prepareBundleDirectoryPermissions(path string, spec []byte) error { return nil }
+diff --git a/runtime/v2/bundle_linux.go b/runtime/v2/bundle_linux.go
+new file mode 100644
+index 0000000000..5f1915d776
+--- /dev/null
++++ b/runtime/v2/bundle_linux.go
+@@ -0,0 +1,74 @@
++/*
++   Copyright The containerd Authors.
++
++   Licensed under the Apache License, Version 2.0 (the "License");
++   you may not use this file except in compliance with the License.
++   You may obtain a copy of the License at
++
++       http://www.apache.org/licenses/LICENSE-2.0
++
++   Unless required by applicable law or agreed to in writing, software
++   distributed under the License is distributed on an "AS IS" BASIS,
++   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++   See the License for the specific language governing permissions and
++   limitations under the License.
++*/
++
++package v2
++
++import (
++	"encoding/json"
++	"os"
++
++	"github.com/opencontainers/runtime-spec/specs-go"
++)
++
++// prepareBundleDirectoryPermissions prepares the permissions of the bundle
++// directory according to the needs of the current platform.
++// On Linux when user namespaces are enabled, the permissions are modified to
++// allow the remapped root GID to access the bundle.
++func prepareBundleDirectoryPermissions(path string, spec []byte) error {
++	gid, err := remappedGID(spec)
++	if err != nil {
++		return err
++	}
++	if gid == 0 {
++		return nil
++	}
++	if err := os.Chown(path, -1, int(gid)); err != nil {
++		return err
++	}
++	return os.Chmod(path, 0710)
++}
++
++// ociSpecUserNS is a subset of specs.Spec used to reduce garbage during
++// unmarshal.
++type ociSpecUserNS struct {
++	Linux *linuxSpecUserNS
++}
++
++// linuxSpecUserNS is a subset of specs.Linux used to reduce garbage during
++// unmarshal.
++type linuxSpecUserNS struct {
++	GIDMappings []specs.LinuxIDMapping
++}
++
++// remappedGID reads the remapped GID 0 from the OCI spec, if it exists. If
++// there is no remapping, remappedGID returns 0. If the spec cannot be parsed,
++// remappedGID returns an error.
++func remappedGID(spec []byte) (uint32, error) {
++	var ociSpec ociSpecUserNS
++	err := json.Unmarshal(spec, &ociSpec)
++	if err != nil {
++		return 0, err
++	}
++	if ociSpec.Linux == nil || len(ociSpec.Linux.GIDMappings) == 0 {
++		return 0, nil
++	}
++	for _, mapping := range ociSpec.Linux.GIDMappings {
++		if mapping.ContainerID == 0 {
++			return mapping.HostID, nil
++		}
++	}
++	return 0, nil
++}
+diff --git a/runtime/v2/bundle_linux_test.go b/runtime/v2/bundle_linux_test.go
+new file mode 100644
+index 0000000000..1828fb8cf1
+--- /dev/null
++++ b/runtime/v2/bundle_linux_test.go
+@@ -0,0 +1,145 @@
++/*
++   Copyright The containerd Authors.
++
++   Licensed under the Apache License, Version 2.0 (the "License");
++   you may not use this file except in compliance with the License.
++   You may obtain a copy of the License at
++
++       http://www.apache.org/licenses/LICENSE-2.0
++
++   Unless required by applicable law or agreed to in writing, software
++   distributed under the License is distributed on an "AS IS" BASIS,
++   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++   See the License for the specific language governing permissions and
++   limitations under the License.
++*/
++
++package v2
++
++import (
++	"context"
++	"encoding/json"
++	"fmt"
++	"io/ioutil"
++	"os"
++	"path/filepath"
++	"strconv"
++	"syscall"
++	"testing"
++
++	"github.com/containerd/containerd/namespaces"
++	"github.com/containerd/containerd/oci"
++	"github.com/containerd/containerd/pkg/testutil"
++	"github.com/opencontainers/runtime-spec/specs-go"
++	"github.com/stretchr/testify/assert"
++	"github.com/stretchr/testify/require"
++)
++
++func TestNewBundle(t *testing.T) {
++	testutil.RequiresRoot(t)
++	tests := []struct {
++		userns bool
++	}{{
++		userns: false,
++	}, {
++		userns: true,
++	}}
++	const usernsGID = 4200
++
++	for i, tc := range tests {
++		t.Run(strconv.Itoa(i), func(t *testing.T) {
++			dir, err := ioutil.TempDir("", "test-new-bundle")
++			require.NoError(t, err, "failed to create test directory")
++			defer os.RemoveAll(dir)
++			work := filepath.Join(dir, "work")
++			state := filepath.Join(dir, "state")
++			id := fmt.Sprintf("new-bundle-%d", i)
++			spec := oci.Spec{}
++			if tc.userns {
++				spec.Linux = &specs.Linux{
++					GIDMappings: []specs.LinuxIDMapping{{ContainerID: 0, HostID: usernsGID}},
++				}
++			}
++			specBytes, err := json.Marshal(&spec)
++			require.NoError(t, err, "failed to marshal spec")
++
++			ctx := namespaces.WithNamespace(context.TODO(), namespaces.Default)
++			b, err := NewBundle(ctx, work, state, id, specBytes)
++			require.NoError(t, err, "NewBundle should succeed")
++			require.NotNil(t, b, "bundle should not be nil")
++
++			fi, err := os.Stat(b.Path)
++			assert.NoError(t, err, "should be able to stat bundle path")
++			if tc.userns {
++				assert.Equal(t, os.ModeDir|0710, fi.Mode(), "bundle path should be a directory with perm 0710")
++			} else {
++				assert.Equal(t, os.ModeDir|0700, fi.Mode(), "bundle path should be a directory with perm 0700")
++			}
++			stat, ok := fi.Sys().(*syscall.Stat_t)
++			require.True(t, ok, "should assert to *syscall.Stat_t")
++			expectedGID := uint32(0)
++			if tc.userns {
++				expectedGID = usernsGID
++			}
++			assert.Equal(t, expectedGID, stat.Gid, "gid should match")
++
++		})
++	}
++}
++
++func TestRemappedGID(t *testing.T) {
++	tests := []struct {
++		spec oci.Spec
++		gid  uint32
++	}{{
++		// empty spec
++		spec: oci.Spec{},
++		gid:  0,
++	}, {
++		// empty Linux section
++		spec: oci.Spec{
++			Linux: &specs.Linux{},
++		},
++		gid: 0,
++	}, {
++		// empty ID mappings
++		spec: oci.Spec{
++			Linux: &specs.Linux{
++				GIDMappings: make([]specs.LinuxIDMapping, 0),
++			},
++		},
++		gid: 0,
++	}, {
++		// valid ID mapping
++		spec: oci.Spec{
++			Linux: &specs.Linux{
++				GIDMappings: []specs.LinuxIDMapping{{
++					ContainerID: 0,
++					HostID:      1000,
++				}},
++			},
++		},
++		gid: 1000,
++	}, {
++		// missing ID mapping
++		spec: oci.Spec{
++			Linux: &specs.Linux{
++				GIDMappings: []specs.LinuxIDMapping{{
++					ContainerID: 100,
++					HostID:      1000,
++				}},
++			},
++		},
++		gid: 0,
++	}}
++
++	for i, tc := range tests {
++		t.Run(strconv.Itoa(i), func(t *testing.T) {
++			s, err := json.Marshal(tc.spec)
++			require.NoError(t, err, "failed to marshal spec")
++			gid, err := remappedGID(s)
++			assert.NoError(t, err, "should unmarshal successfully")
++			assert.Equal(t, tc.gid, gid, "expected GID to match")
++		})
++	}
++}
+diff --git a/runtime/v2/bundle_test.go b/runtime/v2/bundle_test.go
+new file mode 100644
+index 0000000000..54e5f24cc2
+--- /dev/null
++++ b/runtime/v2/bundle_test.go
+@@ -0,0 +1,23 @@
++/*
++   Copyright The containerd Authors.
++
++   Licensed under the Apache License, Version 2.0 (the "License");
++   you may not use this file except in compliance with the License.
++   You may obtain a copy of the License at
++
++       http://www.apache.org/licenses/LICENSE-2.0
++
++   Unless required by applicable law or agreed to in writing, software
++   distributed under the License is distributed on an "AS IS" BASIS,
++   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++   See the License for the specific language governing permissions and
++   limitations under the License.
++*/
++
++package v2
++
++import (
++	// When testutil is imported for one platform (bundle_linux_test.go) it
++	// should be imported for all platforms.
++	_ "github.com/containerd/containerd/pkg/testutil"
++)
+
+From 6886c6a2ec0c70dde1aa64e77b64a5ad47b983c3 Mon Sep 17 00:00:00 2001
+From: Samuel Karp <skarp@amazon.com>
+Date: Tue, 21 Sep 2021 13:46:40 -0700
+Subject: [PATCH 2/3] v1 runtime: reduce permissions for bundle dir
+
+Bundle directory permissions should be 0700 by default.  On Linux with
+user namespaces enabled, the remapped root also needs access to the
+bundle directory.  In this case, the bundle directory is modified to
+0710 and group ownership is changed to the remapped root group.
+
+Port of the same change for the v2 runtime
+
+Signed-off-by: Samuel Karp <skarp@amazon.com>
+---
+ runtime/v1/linux/bundle.go      |  56 +++++++++++-
+ runtime/v1/linux/bundle_test.go | 145 ++++++++++++++++++++++++++++++++
+ 2 files changed, 200 insertions(+), 1 deletion(-)
+ create mode 100644 runtime/v1/linux/bundle_test.go
+
+diff --git a/runtime/v1/linux/bundle.go b/runtime/v1/linux/bundle.go
+index deb94d285c..316ee672d6 100644
+--- a/runtime/v1/linux/bundle.go
++++ b/runtime/v1/linux/bundle.go
+@@ -22,6 +22,7 @@ package linux
+ import (
+ 	"context"
+ 	"crypto/sha256"
++	"encoding/json"
+ 	"fmt"
+ 	"io/ioutil"
+ 	"os"
+@@ -31,6 +32,7 @@ import (
+ 	"github.com/containerd/containerd/runtime/linux/runctypes"
+ 	"github.com/containerd/containerd/runtime/v1/shim"
+ 	"github.com/containerd/containerd/runtime/v1/shim/client"
++	"github.com/opencontainers/runtime-spec/specs-go"
+ 	"github.com/pkg/errors"
+ )
+ 
+@@ -49,7 +51,7 @@ func newBundle(id, path, workDir string, spec []byte) (b *bundle, err error) {
+ 		return nil, err
+ 	}
+ 	path = filepath.Join(path, id)
+-	if err := os.Mkdir(path, 0711); err != nil {
++	if err := os.Mkdir(path, 0700); err != nil {
+ 		return nil, err
+ 	}
+ 	defer func() {
+@@ -57,6 +59,9 @@ func newBundle(id, path, workDir string, spec []byte) (b *bundle, err error) {
+ 			os.RemoveAll(path)
+ 		}
+ 	}()
++	if err := prepareBundleDirectoryPermissions(path, spec); err != nil {
++		return nil, err
++	}
+ 	workDir = filepath.Join(workDir, id)
+ 	if err := os.MkdirAll(workDir, 0711); err != nil {
+ 		return nil, err
+@@ -78,6 +83,55 @@ func newBundle(id, path, workDir string, spec []byte) (b *bundle, err error) {
+ 	}, err
+ }
+ 
++// prepareBundleDirectoryPermissions prepares the permissions of the bundle
++// directory. When user namespaces are enabled, the permissions are modified
++// to allow the remapped root GID to access the bundle.
++func prepareBundleDirectoryPermissions(path string, spec []byte) error {
++	gid, err := remappedGID(spec)
++	if err != nil {
++		return err
++	}
++	if gid == 0 {
++		return nil
++	}
++	if err := os.Chown(path, -1, int(gid)); err != nil {
++		return err
++	}
++	return os.Chmod(path, 0710)
++}
++
++// ociSpecUserNS is a subset of specs.Spec used to reduce garbage during
++// unmarshal.
++type ociSpecUserNS struct {
++	Linux *linuxSpecUserNS
++}
++
++// linuxSpecUserNS is a subset of specs.Linux used to reduce garbage during
++// unmarshal.
++type linuxSpecUserNS struct {
++	GIDMappings []specs.LinuxIDMapping
++}
++
++// remappedGID reads the remapped GID 0 from the OCI spec, if it exists. If
++// there is no remapping, remappedGID returns 0. If the spec cannot be parsed,
++// remappedGID returns an error.
++func remappedGID(spec []byte) (uint32, error) {
++	var ociSpec ociSpecUserNS
++	err := json.Unmarshal(spec, &ociSpec)
++	if err != nil {
++		return 0, err
++	}
++	if ociSpec.Linux == nil || len(ociSpec.Linux.GIDMappings) == 0 {
++		return 0, nil
++	}
++	for _, mapping := range ociSpec.Linux.GIDMappings {
++		if mapping.ContainerID == 0 {
++			return mapping.HostID, nil
++		}
++	}
++	return 0, nil
++}
++
+ type bundle struct {
+ 	id      string
+ 	path    string
+diff --git a/runtime/v1/linux/bundle_test.go b/runtime/v1/linux/bundle_test.go
+new file mode 100644
+index 0000000000..e021dda5f9
+--- /dev/null
++++ b/runtime/v1/linux/bundle_test.go
+@@ -0,0 +1,145 @@
++//go:build linux
++// +build linux
++
++/*
++   Copyright The containerd Authors.
++
++   Licensed under the Apache License, Version 2.0 (the "License");
++   you may not use this file except in compliance with the License.
++   You may obtain a copy of the License at
++
++       http://www.apache.org/licenses/LICENSE-2.0
++
++   Unless required by applicable law or agreed to in writing, software
++   distributed under the License is distributed on an "AS IS" BASIS,
++   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++   See the License for the specific language governing permissions and
++   limitations under the License.
++*/
++
++package linux
++
++import (
++	"encoding/json"
++	"fmt"
++	"io/ioutil"
++	"os"
++	"path/filepath"
++	"strconv"
++	"syscall"
++	"testing"
++
++	"github.com/containerd/containerd/oci"
++	"github.com/containerd/continuity/testutil"
++	"github.com/opencontainers/runtime-spec/specs-go"
++	"github.com/stretchr/testify/assert"
++	"github.com/stretchr/testify/require"
++)
++
++func TestNewBundle(t *testing.T) {
++	testutil.RequiresRoot(t)
++	tests := []struct {
++		userns bool
++	}{{
++		userns: false,
++	}, {
++		userns: true,
++	}}
++	const usernsGID = 4200
++
++	for i, tc := range tests {
++		t.Run(strconv.Itoa(i), func(t *testing.T) {
++			dir, err := ioutil.TempDir("", "test-new-bundle")
++			require.NoError(t, err, "failed to create test directory")
++			defer os.RemoveAll(dir)
++			work := filepath.Join(dir, "work")
++			state := filepath.Join(dir, "state")
++			id := fmt.Sprintf("new-bundle-%d", i)
++			spec := oci.Spec{}
++			if tc.userns {
++				spec.Linux = &specs.Linux{
++					GIDMappings: []specs.LinuxIDMapping{{ContainerID: 0, HostID: usernsGID}},
++				}
++			}
++			specBytes, err := json.Marshal(&spec)
++			require.NoError(t, err, "failed to marshal spec")
++
++			b, err := newBundle(id, work, state, specBytes)
++			require.NoError(t, err, "newBundle should succeed")
++			require.NotNil(t, b, "bundle should not be nil")
++
++			fi, err := os.Stat(b.path)
++			assert.NoError(t, err, "should be able to stat bundle path")
++			if tc.userns {
++				assert.Equal(t, os.ModeDir|0710, fi.Mode(), "bundle path should be a directory with perm 0710")
++			} else {
++				assert.Equal(t, os.ModeDir|0700, fi.Mode(), "bundle path should be a directory with perm 0700")
++			}
++			stat, ok := fi.Sys().(*syscall.Stat_t)
++			require.True(t, ok, "should assert to *syscall.Stat_t")
++			expectedGID := uint32(0)
++			if tc.userns {
++				expectedGID = usernsGID
++			}
++			assert.Equal(t, expectedGID, stat.Gid, "gid should match")
++
++		})
++	}
++}
++
++func TestRemappedGID(t *testing.T) {
++	tests := []struct {
++		spec oci.Spec
++		gid  uint32
++	}{{
++		// empty spec
++		spec: oci.Spec{},
++		gid:  0,
++	}, {
++		// empty Linux section
++		spec: oci.Spec{
++			Linux: &specs.Linux{},
++		},
++		gid: 0,
++	}, {
++		// empty ID mappings
++		spec: oci.Spec{
++			Linux: &specs.Linux{
++				GIDMappings: make([]specs.LinuxIDMapping, 0),
++			},
++		},
++		gid: 0,
++	}, {
++		// valid ID mapping
++		spec: oci.Spec{
++			Linux: &specs.Linux{
++				GIDMappings: []specs.LinuxIDMapping{{
++					ContainerID: 0,
++					HostID:      1000,
++				}},
++			},
++		},
++		gid: 1000,
++	}, {
++		// missing ID mapping
++		spec: oci.Spec{
++			Linux: &specs.Linux{
++				GIDMappings: []specs.LinuxIDMapping{{
++					ContainerID: 100,
++					HostID:      1000,
++				}},
++			},
++		},
++		gid: 0,
++	}}
++
++	for i, tc := range tests {
++		t.Run(strconv.Itoa(i), func(t *testing.T) {
++			s, err := json.Marshal(tc.spec)
++			require.NoError(t, err, "failed to marshal spec")
++			gid, err := remappedGID(s)
++			assert.NoError(t, err, "should unmarshal successfully")
++			assert.Equal(t, tc.gid, gid, "expected GID to match")
++		})
++	}
++}
+
+From 7c621e1fcc08bcf5a1a48b837342cc22eada1685 Mon Sep 17 00:00:00 2001
+From: Derek McGowan <derek@mcg.dev>
+Date: Wed, 15 Sep 2021 17:57:13 -0700
+Subject: [PATCH 3/3] btrfs: reduce permissions on plugin directories
+
+Disallow traversal into directories that may contain
+unpacked or mounted image filesystems.
+
+Signed-off-by: Derek McGowan <derek@mcg.dev>
+Signed-off-by: Samuel Karp <skarp@amazon.com>
+---
+ snapshots/btrfs/btrfs.go | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/snapshots/btrfs/btrfs.go b/snapshots/btrfs/btrfs.go
+index 534b1c1e81..c289b32d46 100644
+--- a/snapshots/btrfs/btrfs.go
++++ b/snapshots/btrfs/btrfs.go
+@@ -51,11 +51,15 @@ type snapshotter struct {
+ // root needs to be a mount point of btrfs.
+ func NewSnapshotter(root string) (snapshots.Snapshotter, error) {
+ 	// If directory does not exist, create it
+-	if _, err := os.Stat(root); err != nil {
++	if st, err := os.Stat(root); err != nil {
+ 		if !os.IsNotExist(err) {
+ 			return nil, err
+ 		}
+-		if err := os.Mkdir(root, 0755); err != nil {
++		if err := os.Mkdir(root, 0700); err != nil {
++			return nil, err
++		}
++	} else if st.Mode()&os.ModePerm != 0700 {
++		if err := os.Chmod(root, 0700); err != nil {
+ 			return nil, err
+ 		}
+ 	}

--- a/SPECS/moby-containerd/moby-containerd.spec
+++ b/SPECS/moby-containerd/moby-containerd.spec
@@ -3,7 +3,7 @@
 Summary: Industry-standard container runtime
 Name: moby-containerd
 Version: 1.4.4+azure
-Release: 3%{?dist}
+Release: 4%{?dist}
 License: ASL 2.0
 Group: Tools/Container
 
@@ -18,6 +18,7 @@ Source2: containerd.toml
 Source3: NOTICE
 Source4: LICENSE
 Patch0:  CVE-2021-32760.patch
+Patch1:  CVE-2021-41103.patch
 URL: https://www.containerd.io
 Vendor: Microsoft Corporation
 Distribution: Mariner
@@ -71,6 +72,7 @@ used directly by developers or end-users.
 %prep
 %setup -q -n %{name}-%{version} -c
 %patch0 -p1
+%patch1 -p1
 mkdir -p %{OUR_GOPATH}/src/github.com/containerd
 ln -sfT %{_topdir}/BUILD/%{name}-%{version} %{OUR_GOPATH}/src/github.com/containerd/containerd
 
@@ -90,18 +92,15 @@ make binaries
 mkdir -p %{buildroot}/%{_bindir}
 for i in bin/*; do
     cp -aT $i %{buildroot}/%{_bindir}/$(basename $i)
-    echo %{_bindir}/$(basename $i) >> files
 done
 
 mkdir -p %{buildroot}/%{_unitdir}
 install -D -p -m 0644 %{SOURCE1} %{buildroot}%{_unitdir}/containerd.service
 install -D -p -m 0644 %{SOURCE2} %{buildroot}%{_sysconfdir}/containerd/config.toml
-echo %config %{_unitdir}/containerd.service >> ./files
-echo %config %{_sysconfdir}/containerd/config.toml >> ./files
 
-mkdir -p %{buildroot}/usr/share/doc/%{name}-%{version}
-cp %{SOURCE3} %{buildroot}/usr/share/doc/%{name}-%{version}/NOTICE
-cp %{SOURCE4} %{buildroot}/usr/share/doc/%{name}-%{version}/LICENSE
+mkdir -p %{buildroot}/%{_docdir}/%{name}-%{version}
+install -D -p -m 0644 %{SOURCE3} %{buildroot}/%{_docdir}/%{name}-%{version}/NOTICE
+install -D -p -m 0644 %{SOURCE4} %{buildroot}/%{_docdir}/%{name}-%{version}/LICENSE
 
 mkdir -p %{buildroot}/%{_mandir}
 for i in man/*; do
@@ -125,16 +124,20 @@ fi
 %postun
 %systemd_postun_with_restart containerd.service
 
-# list files owned by the package here
-%files -f ./files
-%license LICENSE
-
 %files
-/usr/share/doc/%{name}-%{version}/NOTICE
-/usr/share/doc/%{name}-%{version}/LICENSE
+%license LICENSE
+%{_bindir}/*
+%config(noreplace) %{_unitdir}/containerd.service
+%config(noreplace) %{_sysconfdir}/containerd/config.toml
+%{_docdir}/%{name}-%{version}/NOTICE
+%{_docdir}/%{name}-%{version}/LICENSE
 %{_mandir}/*/*
 
 %changelog
+* Mon Oct 04 2021 Henry Beberman <henry.beberman@microsoft.com> 1.4.4+azure-4
+- Patch CVE-2021-41103
+- Change config to noreplace
+- Refactor how files is specified
 * Fri Aug 06 2021 Nicolas Guibourge <nicolasg@microsoft.com> 1.4.4+azure-3
 - Increment release to force republishing using golang 1.16.7.
 * Mon Jul 19 2021 Neha Agarwal <nehaagarwal@microsoft.com> 1.4.4+azure-2


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Patch CVE-2021-41103 in moby-containerd

###### Change Log  <!-- REQUIRED -->
- Patch CVE-2021-41103 in moby-containerd
- Refactor moby-containerd spec file to be more idiomatic

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://github.com/containerd/containerd/security/advisories/GHSA-c2h3-6mxw-7mvq
- https://nvd.nist.gov/vuln/detail/CVE-2021-41103

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build
- Tested package update on a running kubernetes cluster
