### PR TITLE
Fixing no `ExclusiveArch` tag case

### DIFF
--- a/toolkit/tools/internal/rpm/rpm_test.go
+++ b/toolkit/tools/internal/rpm/rpm_test.go
@@ -27,7 +27,15 @@ func TestMain(m *testing.M) {
 func TestShouldSucceedForSupportedArchitectures(t *testing.T) {
 	specFilePath := filepath.Join(specsDir, "supported_unsupported_architectures.spec")
 
-	matches, err := SpecArchitectureMatchesCurrent(specFilePath, specsDir, defines)
+	matches, err := SpecExclusiveArchIsCompatible(specFilePath, specsDir, defines)
+	assert.NoError(t, err)
+	assert.True(t, matches)
+}
+
+func TestShouldSucceedForNoExclusiveArch(t *testing.T) {
+	specFilePath := filepath.Join(specsDir, "no_exclusive_architecture.spec")
+
+	matches, err := SpecExclusiveArchIsCompatible(specFilePath, specsDir, defines)
 	assert.NoError(t, err)
 	assert.True(t, matches)
 }
@@ -35,7 +43,7 @@ func TestShouldSucceedForSupportedArchitectures(t *testing.T) {
 func TestShouldFailForUnsupportedArchitectures(t *testing.T) {
 	specFilePath := filepath.Join(specsDir, "unsupported_architectures.spec")
 
-	matches, err := SpecArchitectureMatchesCurrent(specFilePath, specsDir, defines)
+	matches, err := SpecExclusiveArchIsCompatible(specFilePath, specsDir, defines)
 	assert.NoError(t, err)
 	assert.False(t, matches)
 }

--- a/toolkit/tools/internal/rpm/testdata/no_exclusive_architecture.spec
+++ b/toolkit/tools/internal/rpm/testdata/no_exclusive_architecture.spec
@@ -1,0 +1,26 @@
+Summary:        Test spec file with with no "ExclusiveArch" tag
+Name:           no_exclusive_architecture
+Version:        1.0.0
+Release:        1%{?dist}
+License:        MIT
+URL:            https://test.com
+Group:          Test
+Vendor:         Microsoft
+Distribution:   Mariner
+
+%description
+Test spec. Make sure "ExclusiveArch" tag is not present!
+
+%prep
+
+%build
+
+%install
+
+%files
+%defattr(-,root,root)
+
+%changelog
+* Mon Oct 11 2021 Pawel Winogrodzki <pawelwi@microsoft.com> 1.0.0-1
+- Creation of the test spec.
+

--- a/toolkit/tools/specreader/specreader.go
+++ b/toolkit/tools/specreader/specreader.go
@@ -154,7 +154,7 @@ func readspec(specfile, distTag, srpmDir string, wg *sync.WaitGroup, ch chan []*
 	}()
 
 	// Sanity check that rpmspec can read the spec file so we don't flood the log with warning if it cant.
-	matches, err := rpm.SpecArchitectureMatchesCurrent(specfile, sourcedir, defines)
+	matches, err := rpm.SpecExclusiveArchIsCompatible(specfile, sourcedir, defines)
 	if err != nil {
 		logger.Log.Warnf("Failed to query exclusive architectures in spec (%s) with error: %s", specfile, err)
 		return

--- a/toolkit/tools/srpmpacker/srpmpacker.go
+++ b/toolkit/tools/srpmpacker/srpmpacker.go
@@ -297,7 +297,7 @@ func specsToPackWorker(allSpecFiles chan string, specResults chan *specState, di
 		}
 
 		// Sanity check that SRPMS is meant to be built for the machine architecture
-		matches, err := rpm.SpecArchitectureMatchesCurrent(specFile, sourceDir, defines)
+		matches, err := rpm.SpecExclusiveArchIsCompatible(specFile, sourceDir, defines)
 		if err != nil {
 			logger.Log.Panicf("Failed to query SPEC (%s), skipping", specFile)
 			specResults <- result


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

In #1511 I've missed the case where `ExclusiveArch` is not present. Fixing this here and unifying code with `dev` at the same time.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Fix `SpecExclusiveArchIsCompatible` for the case where there's no `ExclusiveArch` tag.
- Unify code with the version from `dev`.
- Extend unit tests to cover the missed case.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #1511
- #1514

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local test run.
