### PR TITLE
Add cloud-init-azure-kvp subpackage and include in Azure defaults

### DIFF
--- a/SPECS/cloud-init/10-azure-kvp.cfg
+++ b/SPECS/cloud-init/10-azure-kvp.cfg
@@ -1,0 +1,5 @@
+reporting:
+  logging:
+    type: log
+  telemetry:
+    type: hyperv

--- a/SPECS/cloud-init/cloud-init.signatures.json
+++ b/SPECS/cloud-init/cloud-init.signatures.json
@@ -1,5 +1,6 @@
 {
  "Signatures": {
+  "10-azure-kvp.cfg": "79e0370c010be5cd4717960e4b414570c9ec6e6d29aede77ccecc43d2b03bb9a",
   "cloud-init-21.3.tar.gz": "bab5b99567eae216eb44b11e7a358055b563a2585de3b7ead94936118b9f374a",
   "dscheck_VMwareGuestInfo": "8ec3db577c749accff961cd3e723b312cf2bbc41473f2e164c76332fb972f73c"
  }

--- a/SPECS/cloud-init/cloud-init.spec
+++ b/SPECS/cloud-init/cloud-init.spec
@@ -3,7 +3,7 @@
 Summary:        Cloud instance init scripts
 Name:           cloud-init
 Version:        21.3
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        GPLv3
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -11,6 +11,7 @@ Group:          System Environment/Base
 URL:            https://launchpad.net/cloud-init
 Source0:        https://launchpad.net/cloud-init/trunk/%{version}/+download/%{name}-%{version}.tar.gz
 Source1:        dscheck_VMwareGuestInfo
+Source2:        10-azure-kvp.cfg
 Patch0:         cloud-init-azureds.patch
 Patch1:         ds-identify.patch
 Patch2:         ds-vmware-mariner.patch
@@ -68,6 +69,12 @@ Cloud-init is a set of init scripts for cloud instances.  Cloud instances
 need special scripts to run during initialization to retrieve and install
 ssh keys and to let the user run various scripts.
 
+%package azure-kvp
+Summary:        Cloud-init configuration for Hyper-v telemetry
+Requires:       %{name} = %{version}-%{release}
+%description    azure-kvp
+Cloud-init configuration for Hyper-v telemetry
+
 %prep
 %autosetup -p1 -n %{name}-%{version}
 
@@ -91,6 +98,7 @@ mkdir -p %{buildroot}%{_sharedstatedir}/cloud
 mkdir -p %{buildroot}/%{_sysconfdir}/cloud/cloud.cfg.d
 
 install -m 755 %{SOURCE1} %{buildroot}/%{_bindir}
+install -m 644 %{SOURCE2} %{buildroot}/%{_sysconfdir}/cloud/cloud.cfg.d/
 
 %check
 touch vd ud
@@ -146,7 +154,13 @@ rm -rf %{buildroot}
 %{_udevrulesdir}/10-cloud-init-hook-hotplug.rules
 %{_datadir}/bash-completion/completions/cloud-init
 
+%files azure-kvp
+%config(noreplace) %{_sysconfdir}/cloud/cloud.cfg.d/10-azure-kvp.cfg
+
 %changelog
+* Mon Oct 18 2021 Henry Beberman <henry.beberman@microsoft.com> - 21.3-3
+- Add azure-kvp subpackage.
+
 * Wed Sep 15 2021 Jiri Appl <jiria@microsoft.com> - 21.3-2
 - Port from Photon to Mariner
 - Fix dependencies

--- a/toolkit/imageconfigs/packagelists/azurevm-packages.json
+++ b/toolkit/imageconfigs/packagelists/azurevm-packages.json
@@ -1,6 +1,7 @@
 {
     "packages": [
         "cloud-init",
+        "cloud-init-azure-kvp",
         "cloud-utils-growpart",
         "dhcp-client",
         "hyperv-daemons",


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Add an additional subpackage cloud-init-azure-kvp. This subpackage is a config for cloud-init that lets cloud-init emit logs through Hyper-v kvp, which is critical for advanced analysis of VM provisioning and startup issues.

Include this new configuration by default in the azurevm-packages json.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add cloud-init-azure-kvp package which contains 10-azure-kvp.cfg
- Include cloud-init-azure-kvp by default in azurevm-packages.json

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Full local package build
- Built and booted Marketplace gen1 image. Observed new cloud-init log lines about kvp logging.
