### PR TITLE
[dev] Unifying source attributions and `Release` tags

### DIFF
--- a/SPECS/Cython/Cython.spec
+++ b/SPECS/Cython/Cython.spec
@@ -63,7 +63,7 @@ rm -rf %{buildroot}%{python3_sitelib}/setuptools/tests
 
 %changelog
 * Fri Aug 21 2020 Thomas Crain <thcrain@microsoft.com> - 0.29.13-6
-- Initial CBL-Mariner import from Fedora 31 (License: MIT)
+- Initial CBL-Mariner import from Fedora 31 (license: MIT).
 
 * Thu Oct 03 2019 Miro Hrončok <mhroncok@redhat.com> - 0.29.13-5
 - Rebuilt for Python 3.8.0rc1 (#1748018)

--- a/SPECS/ant-contrib/ant-contrib.spec
+++ b/SPECS/ant-contrib/ant-contrib.spec
@@ -101,7 +101,7 @@ echo "call add_maven_depmap JPP.ant-%{name}.pom ant/%{name}.jar"
 
 %changelog
 * Fri Nov 20 2020 Joe Schmitt <joschmit@microsoft.com> - 1.0b3-19
-- Initial CBL-Mariner import from OpenSUSE Tumbleweed (license: same as "License" tag).
+- Initial CBL-Mariner import from openSUSE Tumbleweed (license: same as "License" tag).
 - Simplify buildrequires and runtime requires.
 - Remove junit integration.
 - Remove fdupes dependency.

--- a/SPECS/ant/ant.spec
+++ b/SPECS/ant/ant.spec
@@ -261,7 +261,7 @@ popd
 - Replace incorrect %%{_lib} usage with %%{_libdir}
 
 * Thu Nov 19 2020 Joe Schmitt <joschmit@microsoft.com> - 1.10.9-4
-- Initial CBL-Mariner import from OpenSUSE Tumbleweed (license: same as "License" tag).
+- Initial CBL-Mariner import from openSUSE Tumbleweed (license: same as "License" tag).
 - Remove non-applicable patches.
 - Remove suse_version checks.
 - Rename apache-ant-1.8.ant.conf to ant.conf.

--- a/SPECS/auoms/auoms.spec
+++ b/SPECS/auoms/auoms.spec
@@ -202,4 +202,4 @@ done
 - Fix setup macro
 
 * Thu Oct 22 2020 Andrew Phelps <anphel@microsoft.com> 2.2.5-1
-- Initial CBL-Mariner version.
+- Original version for CBL-Mariner.

--- a/SPECS/babeltrace2/babeltrace2.spec
+++ b/SPECS/babeltrace2/babeltrace2.spec
@@ -89,7 +89,7 @@ rm -fv %{buildroot}%{_docdir}/babeltrace2/*
 - License verified
 
 * Tue Feb 11 2020 Nick Bopp <nichbop@microsoft.com> - 2.0.1-2
-- Initial import from Fedora 32 (license: MIT and GPLv2)
+- Initial CBL-Mariner import from Fedora 32 (license: MIT).
 - Added runtime dependency on glib2
 - Remove python requirements
 - Removed ldconfig_scriptlets

--- a/SPECS/bazel-workspaces/bazel-workspaces.spec
+++ b/SPECS/bazel-workspaces/bazel-workspaces.spec
@@ -58,7 +58,7 @@ cp LICENSE README.md ..
 - Switching to using a single digit for the 'Release' tag.
 
 * Mon Jun 21 2021 Henry Li <lihl@microsoft.com> - 20200113-1.7
-- Initial CBL-Mariner import from OpenSUSE Tumbleweed (license: same as "License" tag).
+- Initial CBL-Mariner import from openSUSE Tumbleweed (license: same as "License" tag).
 - License Verified
 - Fix Source URL
 

--- a/SPECS/boringssl/boringssl.spec
+++ b/SPECS/boringssl/boringssl.spec
@@ -141,7 +141,7 @@ find src/include/openssl -type f -execdir install -D -m0644 "{}" "%{buildroot}%{
 - Switching to using a single digit for the 'Release' tag.
 
 * Thu Jun 10 2021 Henry Li <lihl@microsoft.com> - 20200921-1.2
-- Initial CBL-Mariner import from OpenSUSE Tumbleweed (license: same as "License" tag).
+- Initial CBL-Mariner import from openSUSE Tumbleweed (license: same as "License" tag).
 - License Verified
 - Fix Source URL
 - Change build requirement from ninja to ninja-build

--- a/SPECS/cni/cni.spec
+++ b/SPECS/cni/cni.spec
@@ -97,7 +97,7 @@ install -m 755 -d "%{buildroot}%{cni_doc_dir}"
 
 %changelog
 * Tue Aug 17 2021 Henry Li <lihl@microsoft.com> - 0.8.1-2
-- Initial CBL-Mariner import from OpenSUSE Tumbleweed (license: same as "License" tag).
+- Initial CBL-Mariner import from openSUSE Tumbleweed (license: same as "License" tag).
 - License Verified
 - Remove shadow from BR
 - Use systemd and fillup from runtime requirements

--- a/SPECS/conda/conda.spec
+++ b/SPECS/conda/conda.spec
@@ -236,7 +236,7 @@ PYTHONPATH=%{buildroot}%{python3_sitelib} \
 
 %changelog
 * Wed Jun 23 2021 Rachel Menge <rachelmenge@microsoft.com> - 4.10.1-2
-- Initial CBL-Mariner version imported from Fedora 34 (license: MIT)
+- Initial CBL-Mariner import from Fedora 34 (license: MIT)
 - License verified
 
 * Thu Apr 15 2021 Orion Poplawski <orion@nwra.com> - 4.10.1-1

--- a/SPECS/cri-o/cri-o.spec
+++ b/SPECS/cri-o/cri-o.spec
@@ -210,7 +210,7 @@ ln -sf service %{buildroot}%{_sbindir}/rccrio
 - Added missing BR on "systemd-rpm-macros".
 
 * Thu Aug 19 2021 Henry Li <lihl@microsoft.com> - 1.21.2-2
-- Initial CBL-Mariner import from OpenSUSE Tumbleweed (license: same as "License" tag)
+- Initial CBL-Mariner import from openSUSE Tumbleweed (license: same as "License" tag)
 - License Verified
 - Use prebuilt go vendor source
 - Use mariner packages as build/runtime requirements

--- a/SPECS/dialog/dialog.spec
+++ b/SPECS/dialog/dialog.spec
@@ -1,14 +1,15 @@
+%global dialogsubversion 20180621
+
 Summary:       A utility for creating TTY dialog boxes
 Name:          dialog
 Version:       1.3
-%global dialogsubversion 20180621
-Release:       3.%{dialogsubversion}%{?dist}
+Release:       4%{?dist}
 License:       LGPLv2+
 URL:           https://invisible-island.net/dialog/dialog.html
 Group:         Applications/System
 Vendor:        Microsoft Corporation
 Distribution:  Mariner
-Source0:       ftp://ftp.invisible-island.net/dialog/%{name}-%{version}-20180621.tgz
+Source0:       ftp://ftp.invisible-island.net/dialog/%{name}-%{version}-%{dialogsubversion}.tgz
 BuildRequires: ncurses-devel
 BuildRequires: gettext
 BuildRequires: findutils
@@ -85,18 +86,26 @@ chmod +x %{buildroot}%{_libdir}/*
 %{_mandir}/man3/dialog.*
 
 %changelog
+* Tue Oct 19 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.3-4
+- Converting the 'Release' tag to the '[number].[distribution]' format.
+
 * Sat May 09 2020 Nick Samson <nisamson@microsoft.com> - 1.3-3.20180621
 - Added %%license line automatically
 
-*   Thu Apr 16 2020 Nick Samson <nisamson@microsoft.com> 1.3-2
--   Updated Source0, URL, removed sha1. License verified.
-*   Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 1.3-1
--   Initial CBL-Mariner import from Photon (license: Apache2).
-*	Mon Jan 28 2019 Bo Gan <ganb@vmware.com> 1.3-4.20180621
--	Fix library permission.
-*	Wed Sep 19 2018 Bo Gan <ganb@vmware.com> 1.3-3.20180621
--	Update to 20180621
-*	Wed Apr 19 2017 Bo Gan <ganb@vmware.com> 1.3-2.20170131
--	update to 20170131
-*	Fri May 30 2016 Nick Shi <nshi@vmware.com> 1.3-1.20160209
--	Initial version
+* Thu Apr 16 2020 Nick Samson <nisamson@microsoft.com> - 1.3-2.20180621
+- Updated Source0, URL, removed sha1. License verified.
+
+* Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> - 1.3-1.20180621
+- Initial CBL-Mariner import from Photon (license: Apache2).
+
+* Mon Jan 28 2019 Bo Gan <ganb@vmware.com> - 1.3-4.20180621
+- Fix library permission.
+
+* Wed Sep 19 2018 Bo Gan <ganb@vmware.com> - 1.3-3.20180621
+- Update to 20180621
+
+* Wed Apr 19 2017 Bo Gan <ganb@vmware.com> - 1.3-2.20170131
+- update to 20170131
+
+* Fri May 30 2016 Nick Shi <nshi@vmware.com> - 1.3-1.20160209
+- Initial version

--- a/SPECS/dwarves/dwarves.spec
+++ b/SPECS/dwarves/dwarves.spec
@@ -138,7 +138,7 @@ rm -Rf %{buildroot}
 
 %changelog
 * Fri Aug 20 2021 Chris Co <chrco@microsoft.com> - 1.21-4
-- Initial CBL-Mariner import from Fedora 35 (License: MIT)
+- Initial CBL-Mariner import from Fedora 35 (license: MIT).
 
 * Wed Jul 21 2021 Fedora Release Engineering <releng@fedoraproject.org> - 1.21-3
 - Rebuilt for https://fedoraproject.org/wiki/Fedora_35_Mass_Rebuild

--- a/SPECS/envoy/envoy.spec
+++ b/SPECS/envoy/envoy.spec
@@ -271,7 +271,7 @@ fdupes %{buildroot}%{src_install_dir}
 - Update vendor source and file name
 
 * Tue Jun 15 2021 Henry Li <lihl@microsoft.com> - 1.14.4-3.4
-- Initial CBL-Mariner import from OpenSUSE Tumbleweed (license: same as "License" tag)
+- Initial CBL-Mariner import from openSUSE Tumbleweed (license: same as "License" tag)
 - License Verified
 - Use gcc-c++ for BR
 - Use ninja-build for BR

--- a/SPECS/fillup/fillup.spec
+++ b/SPECS/fillup/fillup.spec
@@ -73,7 +73,7 @@ make %{?_smp_mflags} test    OPTISPLUS="%{optflags}"
 
 %changelog
 * Tue Aug 17 2021 Henry Li <lihl@microsoft.com> - 1.42-277
-- Initial CBL-Mariner import from OpenSUSE Tumbleweed (license: same as "License" tag).
+- Initial CBL-Mariner import from openSUSE Tumbleweed (license: same as "License" tag).
 - License Verified
 - Update Source0 URL path
 - Manually create BIN and OBJ folder to build the project

--- a/SPECS/golang-packaging/golang-packaging.spec
+++ b/SPECS/golang-packaging/golang-packaging.spec
@@ -63,7 +63,7 @@ install -m0644 macros.go %{buildroot}%{_sysconfdir}/rpm/
 - Switching to using a single digit for the 'Release' tag.
 
 * Thu Jun 10 2021 Henry Li <lihl@microsoft.com>  15.0.15-1.4
-- Initial CBL-Mariner import from OpenSUSE Tumbleweed (license: same as "License" tag).
+- Initial CBL-Mariner import from openSUSE Tumbleweed (license: same as "License" tag).
 - License Verified
 - Remove distro condition checks that do not apply for CBL-Mariner
 - Fix Source0 URL

--- a/SPECS/installkernel/installkernel.spec
+++ b/SPECS/installkernel/installkernel.spec
@@ -31,4 +31,5 @@ cp %{SOURCE1} COPYING
 
 %changelog
 * Mon Mar 29 2021 Chris Co <chrco@microsoft.com> - 1.0.0-1
+- Original version for CBL-Mariner.
 - Initial version of the installkernel package

--- a/SPECS/jna/jna.spec
+++ b/SPECS/jna/jna.spec
@@ -136,7 +136,7 @@ ant
 
 %changelog
 * Fri Nov 20 2020 Joe Schmitt <joschmit@microsoft.com> - 5.5.0-1
-- Initial CBL-Mariner import from OpenSUSE Tumbleweed (license: same as "License" tag).
+- Initial CBL-Mariner import from openSUSE Tumbleweed (license: same as "License" tag).
 - Disable JAWT to avoid X11 header dependencies.
 - Remove unneeded patches.
 

--- a/SPECS/kured/kured.spec
+++ b/SPECS/kured/kured.spec
@@ -128,7 +128,7 @@ sed -i -e 's|image: .*|image: registry.opensuse.org/kubic/kured:%{version}|g' %{
 - Switching to using a single digit for the 'Release' tag.
 
 * Fri Jun 18 2021 Henry Li <lihl@microsoft.com> 1.6.1-1.6
-- Initial CBL-Mariner import from OpenSUSE Tumbleweed (license: same as "License" tag).
+- Initial CBL-Mariner import from openSUSE Tumbleweed (license: same as "License" tag).
 - License Verified
 - Use golang as build dependency
 - Remove {?ext_man}, which is not supported in CBL-Mariner

--- a/SPECS/leveldb/leveldb.spec
+++ b/SPECS/leveldb/leveldb.spec
@@ -90,7 +90,7 @@ ctest -V %{?_smp_mflags}
 
 %changelog
 * Fri Aug 21 2020 Thomas Crain <thcrain@microsoft.com> 1.22-3
-- Initial CBL-Mariner version imported from Fedora 33 (license: MIT)
+- Initial CBL-Mariner import from Fedora 33 (license: MIT)
 - License verified
 
 * Tue Jul 28 2020 Fedora Release Engineering <releng@fedoraproject.org> - 1.22-2

--- a/SPECS/libcontainers-common/libcontainers-common.spec
+++ b/SPECS/libcontainers-common/libcontainers-common.spec
@@ -161,7 +161,7 @@ fi
 
 %changelog
 * Thu Aug 19 2021 Henry Li <lihl@microsoft.com> - 20200727-2
-- Initial CBL-Mariner import from OpenSUSE Tumbleweed (license: same as "License" tag)
+- Initial CBL-Mariner import from openSUSE Tumbleweed (license: same as "License" tag)
 - License Verified
 - Remove {?ext_man}, which is not supported in CBL-Mariner
 

--- a/SPECS/libstoragemgmt/libstoragemgmt.spec
+++ b/SPECS/libstoragemgmt/libstoragemgmt.spec
@@ -534,7 +534,7 @@ fi
 - Remove manual placement of bash-completion file, now that this package has bash-completion.pc available to it
 
 * Fri Aug 21 2020 Thomas Crain <thcrain@microsoft.com> 1.8.4-6
-- Initial CBL-Mariner version imported from Fedora 33 (license: MIT)
+- Initial CBL-Mariner import from Fedora 33 (license: MIT)
 - License verified
 
 * Sat Aug 01 2020 Fedora Release Engineering <releng@fedoraproject.org> - 1.8.4-5

--- a/SPECS/lsb-release/lsb-release.spec
+++ b/SPECS/lsb-release/lsb-release.spec
@@ -34,5 +34,5 @@ install -D -m 755 lsb_release %{buildroot}%{_bindir}/lsb_release
 
 %changelog
 *   Wed Aug 26 2020 Thomas Crain <thcrain@microsoft.com> - 1.4-1
--   Original version for Mariner.
+-   Original version for CBL-Mariner.
 -   License verified.

--- a/SPECS/mailcap/mailcap.spec
+++ b/SPECS/mailcap/mailcap.spec
@@ -69,7 +69,7 @@ make check
 - Changing BR to be more accurate: "nginx" -> "nginx-filesystem".
 
 * Fri Aug 21 2020 Thomas Crain <thcrain@microsoft.com> - 2.1.49-3
-- Initial CBL-Mariner version imported from Fedora 33 (license: MIT)
+- Initial CBL-Mariner import from Fedora 33 (license: MIT)
 - License verified
 
 * Tue Jul 28 2020 Fedora Release Engineering <releng@fedoraproject.org> - 2.1.49-2

--- a/SPECS/openssh/openssh.spec
+++ b/SPECS/openssh/openssh.spec
@@ -1,15 +1,13 @@
 %global openssh_ver 8.8p1
-%global openssh_rel 1%{?dist}
 
 %global pam_ssh_agent_ver 0.10.3
-%global pam_ssh_agent_rel 10%{?dist}
 
 %define systemd_units_rel 20191026
 
 Summary:        Free version of the SSH connectivity tools
 Name:           openssh
 Version:        %{openssh_ver}
-Release:        %{openssh_rel}
+Release:        2%{?dist}
 License:        BSD
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -53,8 +51,8 @@ BuildRequires:  shadow-utils
 BuildRequires:  sudo
 %endif
 BuildRequires:  libselinux-devel
-Requires:       openssh-clients = %{openssh_ver}-%{openssh_rel}
-Requires:       openssh-server = %{openssh_ver}-%{openssh_rel}
+Requires:       openssh-clients = %{openssh_ver}-%{release}
+Requires:       openssh-server = %{openssh_ver}-%{release}
 
 %description
 The OpenSSH package contains ssh clients and the sshd daemon. This is
@@ -69,10 +67,23 @@ Requires:       openssl
 %description clients
 This provides the ssh client utilities.
 
+%package server
+Summary:        openssh server applications
+Requires:       ncurses-term
+Requires:       openssh-clients = %{openssh_ver}-%{release}
+Requires:       pam
+Requires:       shadow-utils
+Requires(post): /bin/chown
+Requires(pre):  %{_sbindir}/groupadd
+Requires(pre):  %{_sbindir}/useradd
+
+%description server
+This provides the ssh server daemons, utilities, configuration and service files.
+
 %package -n pam_ssh_agent_auth
 Summary: PAM module for authentication with ssh-agent
 Version: %{pam_ssh_agent_ver}
-Release: %{pam_ssh_agent_rel}.%{openssh_rel}
+Release: 11%{?dist}
 License: BSD
 
 %description -n pam_ssh_agent_auth
@@ -82,19 +93,6 @@ forwarding of ssh-agent connection it also allows to authenticate with
 remote ssh-agent instance.
 
 The module is most useful for su and sudo service stacks.
-
-%package server
-Summary:        openssh server applications
-Requires:       ncurses-term
-Requires:       openssh-clients = %{openssh_ver}-%{openssh_rel}
-Requires:       pam
-Requires:       shadow-utils
-Requires(post): /bin/chown
-Requires(pre):  %{_sbindir}/groupadd
-Requires(pre):  %{_sbindir}/useradd
-
-%description server
-This provides the ssh server daemons, utilities, configuration and service files.
 
 %prep
 %setup -q -a 4
@@ -261,6 +259,9 @@ rm -rf %{buildroot}/*
 %{_mandir}/man8/ssh-sk-helper.8.gz
 
 %changelog
+* Tue Oct 19 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 8.8p1-2
+- Converting the 'Release' tag to the '[number].[distribution]' format.
+
 * Wed Oct 6 2021 Rachel Menge <rachelmenge@microsoft.com> 8.8p1-1
 - Update to 8.8p1 to patch CVE-2021-41617
 

--- a/SPECS/p11-kit/p11-kit.spec
+++ b/SPECS/p11-kit/p11-kit.spec
@@ -146,7 +146,7 @@ fi
 - Update source URL
 
 * Wed May 27 2020 Paul Monson <paulmon@microsoft.com> - 0.23.16.1-2
-- Initial CBL-Mariner import from Fedora 29 (license:MIT).
+- Initial CBL-Mariner import from Fedora 29 (license: MIT).
 - License verified.
 
 * Thu May 23 2019 Daiki Ueno <dueno@redhat.com> - 0.23.16.1-1

--- a/SPECS/parted/parted.spec
+++ b/SPECS/parted/parted.spec
@@ -63,7 +63,7 @@ rm -rf %{buildroot}%{_infodir}/dir
 -  Added %%license line automatically
 
 *  Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 3.2-8
--  Initial CBL-Mariner import from Photon (license: dual Apache2/GPL2).
+-  Initial CBL-Mariner import from Photon (license: dual Apache2).
 
 *  Tue Oct 2 2018 Michelle Wang <michellew@vmware.com> 3.2-7
 -  Add conflict toybox.

--- a/SPECS/picosat/picosat.spec
+++ b/SPECS/picosat/picosat.spec
@@ -149,7 +149,7 @@ cp -p %{SOURCE1} %{SOURCE2} %{SOURCE3}  %{buildroot}%{_mandir}/man1
 
 %changelog
 * Mon Jun 21 2021 Rachel Menge <rachelmenge@microsoft.com> - 965-13
-- Initial CBL-Mariner version imported from Fedora 34 (license: MIT)
+- Initial CBL-Mariner import from Fedora 34 (license: MIT)
 - License verified
 
 * Wed Jan 27 2021 Fedora Release Engineering <releng@fedoraproject.org> - 965-12

--- a/SPECS/pugixml/pugixml.spec
+++ b/SPECS/pugixml/pugixml.spec
@@ -66,7 +66,7 @@ make check -C build
 - Update Source0
 
 * Wed Feb 12 2020 Nick Bopp <nichbop@microsoft.com> - 1.10-1
-- Initial import from Fedora 32 (license: MIT)
+- Initial CBL-Mariner import from Fedora 32 (license: MIT)
 - Update to 1.10
 
 * Fri Jul 26 2019 Fedora Release Engineering <releng@fedoraproject.org> - 1.9-4

--- a/SPECS/python-async-generator/python-async-generator.spec
+++ b/SPECS/python-async-generator/python-async-generator.spec
@@ -62,7 +62,7 @@ python%{python3_version} -m pytest -v
 
 %changelog
 * Wed Jun 23 2021 Rachel Menge <rachelmenge@microsoft.com> - 1.10-10
-- Initial CBL-Mariner version imported from Fedora 34 (license: MIT)
+- Initial CBL-Mariner import from Fedora 34 (license: MIT)
 - License verified
 
 * Wed Jan 27 2021 Fedora Release Engineering <releng@fedoraproject.org> - 1.10-9

--- a/SPECS/python-conda-package-handling/python-conda-package-handling.spec
+++ b/SPECS/python-conda-package-handling/python-conda-package-handling.spec
@@ -67,7 +67,7 @@ PYTHONPATH=%{buildroot}%{python3_sitelib} \
 
 %changelog
 * Wed Jun 23 2021 Rachel Menge <rachelmenge@microsoft.com> - 1.7.2-3
-- Initial CBL-Mariner version imported from Fedora 34 (license: MIT)
+- Initial CBL-Mariner import from Fedora 34 (license: MIT)
 - License verified
 
 * Wed Jan 27 2021 Fedora Release Engineering <releng@fedoraproject.org> - 1.7.2-2

--- a/SPECS/python-cytoolz/python-cytoolz.spec
+++ b/SPECS/python-cytoolz/python-cytoolz.spec
@@ -103,7 +103,7 @@ PYTHONPATH=%{buildroot}%{python3_sitelib} \
 
 %changelog
 * Wed Jun 23 2021 Rachel Menge <rachelmenge@microsoft.com> - 0.11.0-3
-- Initial CBL-Mariner version imported from Fedora 34 (license: MIT)
+- Initial CBL-Mariner import from Fedora 34 (license: MIT)
 - Remove python2
 - License verified
 

--- a/SPECS/python-frozendict/python-frozendict.spec
+++ b/SPECS/python-frozendict/python-frozendict.spec
@@ -45,7 +45,7 @@ BuildRequires:  python3-setuptools
 
 %changelog
 * Wed Jun 23 2021 Rachel Menge <rachelmenge@microsoft.com> - 1.2-19
-- Initial CBL-Mariner version imported from Fedora 34 (license: MIT)
+- Initial CBL-Mariner import from Fedora 34 (license: MIT)
 - License verified
 
 * Wed Jan 27 2021 Fedora Release Engineering <releng@fedoraproject.org> - 1.2-18

--- a/SPECS/python-mock/python-mock.spec
+++ b/SPECS/python-mock/python-mock.spec
@@ -67,7 +67,7 @@ PYTHONPATH=%{buildroot}%{python3_sitelib} \
 
 %changelog
 * Wed Jun 23 2021 Rachel Menge <rachelmenge@microsoft.com> - 3.0.5-9
-- Initial CBL-Mariner version imported from Fedora 32 (license: MIT)
+- Initial CBL-Mariner import from Fedora 32 (license: MIT)
 - License verified
 
 * Thu Jan 30 2020 Fedora Release Engineering <releng@fedoraproject.org> - 3.0.5-8

--- a/SPECS/python-nocasedict/python-nocasedict.spec
+++ b/SPECS/python-nocasedict/python-nocasedict.spec
@@ -63,5 +63,5 @@ python3 setup.py test
 - Add explicit dist provides.
 
 * Fri Aug 21 2020 Thomas Crain <thcrain@microsoft.com> - 0.5.0-1
-- Original CBL-Mariner version.
+- Original version for CBL-Mariner.
 - License verified.

--- a/SPECS/python-nose/python-nose.spec
+++ b/SPECS/python-nose/python-nose.spec
@@ -82,7 +82,7 @@ python3 selftest.py
 
 %changelog
 * Wed Jun 23 2021 Rachel Menge <rachelmenge@microsoft.com> - 1.3.7-31
-- Initial CBL-Mariner version imported from Fedora 32 (license: MIT)
+- Initial CBL-Mariner import from Fedora 32 (license: MIT)
 - License verified
 
 * Fri Jan 31 2020 Miro Hrončok <mhroncok@redhat.com> - 1.3.7-30

--- a/SPECS/python-pycosat/python-pycosat.spec
+++ b/SPECS/python-pycosat/python-pycosat.spec
@@ -64,7 +64,7 @@ PYTHONPATH=%{buildroot}%{python3_sitelib} \
 
 %changelog
 * Wed Jun 23 2021 Rachel Menge <rachelmenge@microsoft.com> - 0.6.3-15
-- Initial CBL-Mariner version imported from Fedora 34 (license: MIT)
+- Initial CBL-Mariner import from Fedora 34 (license: MIT)
 - License verified
 
 * Wed Jan 27 2021 Fedora Release Engineering <releng@fedoraproject.org> - 0.6.3-14

--- a/SPECS/python-pytest-mock/python-pytest-mock.spec
+++ b/SPECS/python-pytest-mock/python-pytest-mock.spec
@@ -65,7 +65,7 @@ PYTHONPATH=%{buildroot}%{python3_sitelib} \
 
 %changelog
 * Wed Jun 23 2021 Rachel Menge <rachelmenge@microsoft.com> - 3.5.1-3
-- Initial CBL-Mariner version imported from Fedora 34 (license: MIT)
+- Initial CBL-Mariner import from Fedora 34 (license: MIT)
 - License verified
 
 * Wed Jan 27 2021 Fedora Release Engineering <releng@fedoraproject.org> - 3.5.1-2

--- a/SPECS/python-responses/python-responses.spec
+++ b/SPECS/python-responses/python-responses.spec
@@ -62,7 +62,7 @@ PYTHONPATH=%{buildroot}%{python3_sitelib} \
 
 %changelog
 * Mon Jun 21 2021 Rachel Menge <rachelmenge@microsoft.com> - 0.10.15-4
-- Initial CBL-Mariner version imported from Fedora 34 (license: MIT)
+- Initial CBL-Mariner import from Fedora 34 (license: MIT)
 - License verified
 
 * Wed Jan 27 2021 Fedora Release Engineering <releng@fedoraproject.org> - 0.10.15-3

--- a/SPECS/python-ruamel-yaml-clib/python-ruamel-yaml-clib.spec
+++ b/SPECS/python-ruamel-yaml-clib/python-ruamel-yaml-clib.spec
@@ -47,7 +47,7 @@ python3 setup.py install --single-version-externally-managed --skip-build --root
 
 %changelog
 * Mon Jun 21 2021 Rachel Menge <rachelmenge@microsoft.com> - 0.1.2-7
-- Initial CBL-Mariner version imported from Fedora 34 (license: MIT)
+- Initial CBL-Mariner import from Fedora 34 (license: MIT)
 - License verified
 
 * Wed Jan 27 2021 Fedora Release Engineering <releng@fedoraproject.org> - 0.1.2-6

--- a/SPECS/python-ruamel-yaml/python-ruamel-yaml.spec
+++ b/SPECS/python-ruamel-yaml/python-ruamel-yaml.spec
@@ -57,7 +57,7 @@ python3 setup.py install --single-version-externally-managed --skip-build --root
 
 %changelog
 * Mon Jun 21 2021 Rachel Menge <rachelmenge@microsoft.com> - 0.16.6-6
-- Initial CBL-Mariner version imported from Fedora 34 (license: MIT)
+- Initial CBL-Mariner import from Fedora 34 (license: MIT)
 - License verified
 
 * Wed Jan 27 2021 Fedora Release Engineering <releng@fedoraproject.org> - 0.16.6-5

--- a/SPECS/python-toolz/python-toolz.spec
+++ b/SPECS/python-toolz/python-toolz.spec
@@ -68,7 +68,7 @@ nosetests-%{python3_version}
 
 %changelog
 * Wed Jun 23 2021 Rachel Menge <rachelmenge@microsoft.com> - 0.11.1-3
-- Initial CBL-Mariner version imported from Fedora 34 (license: MIT)
+- Initial CBL-Mariner import from Fedora 34 (license: MIT)
 - License verified
 
 * Wed Jan 27 2021 Fedora Release Engineering <releng@fedoraproject.org> - 0.11.1-2

--- a/SPECS/python-tqdm/python-tqdm.spec
+++ b/SPECS/python-tqdm/python-tqdm.spec
@@ -49,7 +49,7 @@ mv -v %{buildroot}%{python3_sitelib}/%{srcname}/%{srcname}.1 %{buildroot}%{_mand
 
 %changelog
 * Mon Jun 21 2021 Rachel Menge <rachelmenge@microsoft.com> - 4.50.2-2
-- Initial CBL-Mariner version imported from Fedora 33 (license: MIT)
+- Initial CBL-Mariner import from Fedora 33 (license: MIT)
 - License verified
 
 * Fri Oct 09 2020 Stephen Gallagher <sgallagh@redhat.com> - 4.50.2-1

--- a/SPECS/python3-pytest-asyncio/python3-pytest-asyncio.spec
+++ b/SPECS/python3-pytest-asyncio/python3-pytest-asyncio.spec
@@ -70,7 +70,7 @@ PYTHONPATH=%{buildroot}%{python3_sitelib} \
 
 %changelog
 * Mon Jun 21 2021 Rachel Menge <rachelmenge@microsoft.com> - 0.14.0-3
-- Initial CBL-Mariner version imported from Fedora 34 (license: MIT)
+- Initial CBL-Mariner import from Fedora 34 (license: MIT)
 - License verified
 
 * Wed Jan 27 2021 Fedora Release Engineering <releng@fedoraproject.org> - 0.14.0-2

--- a/SPECS/squashfs-tools/squashfs-tools.spec
+++ b/SPECS/squashfs-tools/squashfs-tools.spec
@@ -82,7 +82,7 @@ install -m 644 %{SOURCE2} %{buildroot}%{_mandir}/man1/unsquashfs.1
 
 %changelog
 * Fri Aug 07 2020 Mateusz Malisz <mamalisz@microsoft.com> 4.3-26
-- Initial CBL-Mariner import from Fedora32(license:MIT)
+- Initial CBL-Mariner import from Fedora 32 (license: MIT).
 
 * Sat Feb 08 2020 Bruno Wolff III <bruno@wolff.to> - 4.3-25
 - Fix duplicate definition flagged by gcc10

--- a/SPECS/verity-read-only-root/verity-read-only-root.spec
+++ b/SPECS/verity-read-only-root/verity-read-only-root.spec
@@ -74,4 +74,4 @@ install -p -m 0755  %{SOURCE5} %{buildroot}/mnt/create_linear_mount.sh
 
 %changelog
 * Fri Dec 11 2020 Daniel McIlvaney <damcilva@microsoft.com> - 1.0-1
-- Initial Mariner version.
+- Original version for CBL-Mariner.

--- a/SPECS/yasm/yasm.spec
+++ b/SPECS/yasm/yasm.spec
@@ -75,7 +75,7 @@ make install DESTDIR=%{buildroot}
 
 %changelog
 * Fri Aug 21 2020 Thomas Crain <thcrain@microsoft.com> 1.3.0-13
-- Initial CBL-Mariner version imported from Fedora 33 (license: MIT)
+- Initial CBL-Mariner import from Fedora 33 (license: MIT)
 - License verified
 
 * Wed Jul 29 2020 Fedora Release Engineering <releng@fedoraproject.org> - 1.3.0-12


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

Unifying all spec source attributions in the changelogs to follow the same pattern as well as making sure all `Release` tags have the same `[number].%{?dist}` or `%{release_number}.%{?dist}` format. This will allow us to set-up automated GitHub checks making sure all specs follow the same rules.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Unified spec source attributions in multiple specs.
- Modified the `Release` tags in `openssh.spec` and `dialog.spec` to follow the `[number].%{?dist}` format.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local package build of `openssh` and `dialog`.
- None for other modified specs - trivial text changes in the `%changelog` section.
