### PR TITLE
[dev] Adding proper spec source attribution for CentOS specs

### DIFF
--- a/.github/workflows/check-spec.yml
+++ b/.github/workflows/check-spec.yml
@@ -2,12 +2,8 @@ name: Spec files check
 
 on:
   push:
-    paths:
-      - '**.spec'
     branches: [main, dev, 1.0*]
   pull_request:
-    paths:
-      - '**.spec'
     branches: [main, dev, 1.0*]
 
 jobs:
@@ -57,4 +53,5 @@ jobs:
           path: 'main-checkout'
       
       - name: Verify .spec files
+        if: ${{ env.updated-specs != '' }}
         run: python3 .github/workflows/check_spec_guidelines.py ${{ env.updated-specs }}

--- a/.github/workflows/check_spec_guidelines.py
+++ b/.github/workflows/check_spec_guidelines.py
@@ -13,6 +13,7 @@ valid_release_tag_regex = re.compile(
 valid_source_attributions = [
     r'Original version for CBL-Mariner',
     r'Initial CBL-Mariner import from Azure',
+    r'Initial CBL-Mariner import from CentOS \d+ \(license: MIT\)',
     r'Initial CBL-Mariner import from Ceph source \(license: LGPLv2.1\)',
     r'Initial CBL-Mariner import from Fedora \d+ \(license: MIT\)',
     r'Initial CBL-Mariner import from Magnus Edenhill Open Source \(license: BSD\)',


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

Adding expected spec source attributions for CentOS specs. We're expecting to be importing these every now and then.

I'm also updating specs check to always run, since the check is mandatory and would block PRs, which don't modify any .spec files.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Added spec source attribution check for CentOS spec files.
- Updated specs check to always run.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local script run.
