### PR TITLE
Add missing runtime requires for ansible

### DIFF
--- a/SPECS/ansible/ansible.spec
+++ b/SPECS/ansible/ansible.spec
@@ -3,7 +3,7 @@
 Summary:        Configuration-management, application deployment, cloud provisioning system
 Name:           ansible
 Version:        2.9.23
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv3+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -20,6 +20,8 @@ BuildRequires:  python3-pip
 
 Requires:       python3
 Requires:       python3-libs
+Requires:       python3-yamlloader
+Requires:       python3-jinja2
 
 BuildArch:      noarch
 
@@ -46,6 +48,9 @@ cd build/lib/ansible_test/_data && tox
 %{python3_sitelib}/*
 
 %changelog
+* Thu Oct 21 2021 Jon Slobodzian <joslobo@microsoft.com> - 2.9.23-2
+- Add missing runtime dependencies.
+
 * Fri Oct 15 2021 Bala <balakumaran.kannan@microsoft.com> - 2.9.23-1
 - Upgrade to version 2.9.23, which resolves CVE-2021-3583, CVE-2020-14330 and CVE-2021-20228
 - Switching to building with Python 3 to fix tests.
@@ -56,32 +61,32 @@ cd build/lib/ansible_test/_data && tox
 * Wed Dec 30 2020 Nicolas Ontiveros <niontive@microsoft.com> - 2.9.12-1
 - Upgrade to version 2.9.12, which resolves CVE-2020-10744
 
-*   Tue Jun 02 2020 Nicolas Ontiveros <niontive@microsoft.com> 2.9.9-1
--   Upgrade to version 2.9.9, which resolves CVE-2020-1733 and CVE-2020-1738.
+* Tue Jun 02 2020 Nicolas Ontiveros <niontive@microsoft.com> 2.9.9-1
+- Upgrade to version 2.9.9, which resolves CVE-2020-1733 and CVE-2020-1738.
 
-*   Sat May 09 2020 Nick Samson <nisamson@microsoft.com> 2.9.5-2
--   Added %%license line automatically
+* Sat May 09 2020 Nick Samson <nisamson@microsoft.com> 2.9.5-2
+- Added %%license line automatically
 
-*   Wed Mar 18 2020 Emre Girgin <mrgirgin@microsoft.com> 2.9.5-1
--   Version update to 2.9.5. License verified.
+* Wed Mar 18 2020 Emre Girgin <mrgirgin@microsoft.com> 2.9.5-1
+- Version update to 2.9.5. License verified.
 
-*   Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 2.7.6-2
--   Initial CBL-Mariner import from Photon (license: Apache2).
+* Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 2.7.6-2
+- Initial CBL-Mariner import from Photon (license: Apache2).
 
-*   Tue Jan 22 2019 Anish Swaminathan <anishs@vmware.com> 2.7.6-1
--   Version update to 2.7.6, fix CVE-2018-16876
+* Tue Jan 22 2019 Anish Swaminathan <anishs@vmware.com> 2.7.6-1
+- Version update to 2.7.6, fix CVE-2018-16876
 
-*   Mon Sep 17 2018 Ankit Jain <ankitja@vmware.com> 2.6.4-1
--   Version update to 2.6.4
+* Mon Sep 17 2018 Ankit Jain <ankitja@vmware.com> 2.6.4-1
+- Version update to 2.6.4
 
-*   Thu Oct 12 2017 Anish Swaminathan <anishs@vmware.com> 2.4.0.0-1
--   Version update to 2.4.0.0
+* Thu Oct 12 2017 Anish Swaminathan <anishs@vmware.com> 2.4.0.0-1
+- Version update to 2.4.0.0
 
-*   Thu Jun 01 2017 Dheeraj Shetty <dheerajs@vmware.com> 2.2.2.0-2
--   Use python2 explicitly
+* Thu Jun 01 2017 Dheeraj Shetty <dheerajs@vmware.com> 2.2.2.0-2
+- Use python2 explicitly
 
-*   Thu Apr 6 2017 Alexey Makhalov <amakhalov@vmware.com> 2.2.2.0-1
--   Version update
+* Thu Apr 6 2017 Alexey Makhalov <amakhalov@vmware.com> 2.2.2.0-1
+- Version update
 
-*   Wed Sep 21 2016 Xiaolin Li <xiaolinl@vmware.com> 2.1.1.0-1
--   Initial build. First version
+* Wed Sep 21 2016 Xiaolin Li <xiaolinl@vmware.com> 2.1.1.0-1
+- Initial build. First version


### PR DESCRIPTION
###### Merge Checklist  
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x]  The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary
Ansible does not run after installation.  It is missing two runtime requires to launch.  While the dependencies can be added manually, this change provides the missing packages.

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

