### PR TITLE
Fixing `python-distro` tests.

### DIFF
--- a/SPECS/python-distro/python-distro.spec
+++ b/SPECS/python-distro/python-distro.spec
@@ -4,7 +4,7 @@
 Summary:        Distro - an OS platform information API
 Name:           python-distro
 Version:        1.6.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        ASL
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -17,9 +17,7 @@ BuildRequires:  python3-libs
 BuildRequires:  python3-setuptools
 BuildRequires:  python3-xml
 %if %{with_check}
-BuildRequires:  git
 BuildRequires:  python3-pip
-BuildRequires:  python3-xml
 %endif
 
 BuildArch:      noarch
@@ -50,6 +48,12 @@ python3 setup.py build
 python3 setup.py install --prefix=%{_prefix} --root=%{buildroot}
 
 %check
+# Disabled tests:
+# - 'py27' - depends on Python 2, CBL-Mariner doesn't support that anymore.
+# - 'lint' - new test added in version 1.6.0, depends on 'pre-commit', which is not provided by CBL-Mariner.
+sed -i -E "s/(lint|py27), //g" tox.ini
+sed -i -E "/.*testenv:lint/Q" tox.ini
+
 pip3 install tox
 tox
 
@@ -61,6 +65,9 @@ tox
 %license LICENSE
 
 %changelog
+* Mon Oct 25 2021 Pawel Winogrodzki <pawel.winogrodzki@microsoft.com> - 1.6.0-2
+- Disabling tests we cannot run from the '%%check' section.
+
 * Mon Oct 25 2021 Pawel Winogrodzki <pawel.winogrodzki@microsoft.com> - 1.6.0-1
 - Updated to version 1.6.0 to make tests work with Python 3.7.
 - Removing Python 2 version.


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

Updating `python-distro` from version 1.4.0 to 1.6.0 in #1580 introduced two more tests, we don't support:
- `py27` - depends on Python 2, we're dropping support for that.
- `lint` - new test introduced with this version of the package, which depends on `pre-commit`, which we don't provide.

The remaining `py37` test succeeds.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Disabled the `py27` and `lint` tests.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #1580

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local package build.
