### PR TITLE
`pcsc-lite`: clean-up of invalid `Provides` and `BuildRequires`

### DIFF
--- a/SPECS/pcsc-lite-ccid/pcsc-lite-ccid.spec
+++ b/SPECS/pcsc-lite-ccid/pcsc-lite-ccid.spec
@@ -60,6 +60,7 @@ cp -p src/openct/LICENSE LICENSE.openct
 %changelog
 * Wed Oct 27 2021 Pawel Winogrodzki <pawel.winogrodzki@microsoft.com> - 1.4.33-3
 - Removing invalid "BuildRequires".
+- Fixing the "Release" tag.
 
 * Mon Aug 30 2021 Bala <balakumaran.kannan@microsoft.com> - 1.4.33-2
 - Initial CBL-Mariner import from Fedora 32 (license: MIT)

--- a/SPECS/pcsc-lite/pcsc-lite.spec
+++ b/SPECS/pcsc-lite/pcsc-lite.spec
@@ -154,7 +154,6 @@ fi
 %changelog
 * Wed Oct 27 2021 Pawel Winogrodzki <pawel.winogrodzki@microsoft.com> - 1.9.0-3
 - Removing invalid "Provides" and unused macros.
-- Fixing the "Release" tag.
 
 * Mon Aug 30 2021 Bala <balakumaran.kannan@microsoft.com> - 1.9.0-2
 - Initial CBL-Mariner import from Fedora 32 (license: MIT)


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

We've been recently having random build failures for `pcsc-lite-ccid` where it tried to build before its BR `pcsc-lite` was available. I'm still not clear, why that would happen, so for now I'm cleaning up some unusual (and invalid) `Provides` and `BuildRequires` from specs for both packages in hope, that this will remedy the situation. The issues is not observed when building with the tools from the `dev` branch, so it is possible, that we might not need to investigate this too deeply, since we're going to move to `dev` anyway.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Removed invalid `Provides` and `BuildRequires` from `pcsc-lite` and `pcsc-lite-ccid`.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local package builds.
