### PR TITLE
Fix cgmanifest validation script by allowing tilde substitution in version match

### DIFF
--- a/.github/workflows/validate-cg-manifest.sh
+++ b/.github/workflows/validate-cg-manifest.sh
@@ -64,6 +64,7 @@ do
   fi
 
   version=$(rpmspec --srpm  --define "with_check 0" --qf "%{VERSION}" -q $spec 2>/dev/null )
+  version_no_tilde=$(echo $version | sed "s/~/-/g")
 
   # Get the source0 for the package, it apears to always occur last in the list of sources
   source0=$(rpmspec --srpm  --define "with_check 0" --qf "[%{SOURCE}\n]" -q $spec  2>/dev/null | tail -1)
@@ -82,7 +83,7 @@ do
 
   # Pull the current registration from the cgmanifest file. Every registration should have a url, so if we don't find one
   # that implies the registration is missing.
-  manifesturl=$(jq --raw-output ".Registrations[].component.other | select(.name==\"$name\" and .version==\"$version\") | .downloadUrl" cgmanifest.json)
+  manifesturl=$(jq --raw-output ".Registrations[].component.other | select(.name==\"$name\" and (.version==\"$version\" or .version==\"$version_no_tilde\")) | .downloadUrl" cgmanifest.json)
   if [[ -z $manifesturl ]]
   then
     echo "Registration for \"$name\":\"$version\" is missing" >> bad_registrations.txt


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
As per #1094, we are not allowed to use tildes in the cgmanifest file. We should be replacing tildes with dashes to meet the requirements of those consuming this file. However, we have no allowances for this behavior in our mandatory cgmanifest check. This substitution causes a failure.

So, I wrote a quick hack to allow for tilde substitutions when version matching the cgmanifest entries.

This could probably be a more robust check, but for now I just want to unblock #1603. This fix should keep people from seeing an erroneous check failure and undoing the change in #1094.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Allow `jq` lookup in `validate-cg-manifest.sh` to account for tilde substitution.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Manual testing, as well as using this patch for #1603
