### PR TITLE
Add patch for libgcrypt CVE-2021-33560

### DIFF
--- a/SPECS/libgcrypt/CVE-2021-33560.patch
+++ b/SPECS/libgcrypt/CVE-2021-33560.patch
@@ -1,0 +1,72 @@
+From e8b7f10be275bcedb5fc05ed4837a89bfd605c61 Mon Sep 17 00:00:00 2001
+From: NIIBE Yutaka <gniibe@fsij.org>
+Date: Tue, 13 Apr 2021 10:00:00 +0900
+Subject: [PATCH] cipher: Hardening ElGamal by introducing exponent blinding
+ too.
+
+* cipher/elgamal.c (do_encrypt): Also do exponent blinding.
+
+--
+
+Base blinding had been introduced with USE_BLINDING.  This patch add
+exponent blinding as well to mitigate side-channel attack on mpi_powm.
+
+GnuPG-bug-id: 5328
+Signed-off-by: NIIBE Yutaka <gniibe@fsij.org>
+---
+ cipher/elgamal.c | 20 +++++++++++++++++---
+ 1 file changed, 17 insertions(+), 3 deletions(-)
+
+diff --git a/cipher/elgamal.c b/cipher/elgamal.c
+index 4eb52d62..9835122f 100644
+--- a/cipher/elgamal.c
++++ b/cipher/elgamal.c
+@@ -522,8 +522,9 @@ do_encrypt(gcry_mpi_t a, gcry_mpi_t b, gcry_mpi_t input, ELG_public_key *pkey )
+ static void
+ decrypt (gcry_mpi_t output, gcry_mpi_t a, gcry_mpi_t b, ELG_secret_key *skey )
+ {
+-  gcry_mpi_t t1, t2, r;
++  gcry_mpi_t t1, t2, r, r1, h;
+   unsigned int nbits = mpi_get_nbits (skey->p);
++  gcry_mpi_t x_blind;
+ 
+   mpi_normalize (a);
+   mpi_normalize (b);
+@@ -534,20 +535,33 @@ decrypt (gcry_mpi_t output, gcry_mpi_t a, gcry_mpi_t b, ELG_secret_key *skey )
+ 
+   t2 = mpi_snew (nbits);
+   r  = mpi_new (nbits);
++  r1 = mpi_new (nbits);
++  h  = mpi_new (nbits);
++  x_blind = mpi_snew (nbits);
+ 
+   /* We need a random number of about the prime size.  The random
+      number merely needs to be unpredictable; thus we use level 0.  */
+   _gcry_mpi_randomize (r, nbits, GCRY_WEAK_RANDOM);
+ 
++  /* Also, exponent blinding: x_blind = x + (p-1)*r1 */
++  _gcry_mpi_randomize (r1, nbits, GCRY_WEAK_RANDOM);
++  mpi_set_highbit (r1, nbits - 1);
++  mpi_sub_ui (h, skey->p, 1);
++  mpi_mul (x_blind, h, r1);
++  mpi_add (x_blind, skey->x, x_blind);
++
+   /* t1 = r^x mod p */
+-  mpi_powm (t1, r, skey->x, skey->p);
++  mpi_powm (t1, r, x_blind, skey->p);
+   /* t2 = (a * r)^-x mod p */
+   mpi_mulm (t2, a, r, skey->p);
+-  mpi_powm (t2, t2, skey->x, skey->p);
++  mpi_powm (t2, t2, x_blind, skey->p);
+   mpi_invm (t2, t2, skey->p);
+   /* t1 = (t1 * t2) mod p*/
+   mpi_mulm (t1, t1, t2, skey->p);
+ 
++  mpi_free (x_blind);
++  mpi_free (h);
++  mpi_free (r1);
+   mpi_free (r);
+   mpi_free (t2);
+ 
+-- 
+2.11.0

--- a/SPECS/libgcrypt/CVE-2021-40528.patch
+++ b/SPECS/libgcrypt/CVE-2021-40528.patch
@@ -1,15 +1,16 @@
+From 707c3c5c511ee70ad0e39ec613471f665305fbea Mon Sep 17 00:00:00 2001
 From: NIIBE Yutaka <gniibe@fsij.org>
-Date: Fri, 21 May 2021 02:15:07 +0000 (+0900)
-Subject: cipher: Fix ElGamal encryption for other implementations.
-X-Git-Url: http://git.gnupg.org/cgi-bin/gitweb.cgi?p=libgcrypt.git;a=commitdiff_plain;h=632d80ef30e13de6926d503aa697f92b5dbfbc5e
-
-cipher: Fix ElGamal encryption for other implementations.
+Date: Fri, 21 May 2021 11:15:07 +0900
+Subject: [PATCH] cipher: Fix ElGamal encryption for other implementations.
 
 * cipher/elgamal.c (gen_k): Remove support of smaller K.
 (do_encrypt): Never use smaller K.
 (sign): Folllow the change of gen_k.
 
 --
+
+Cherry-pick master commit of:
+	632d80ef30e13de6926d503aa697f92b5dbfbc5e
 
 This change basically reverts encryption changes in two commits:
 
@@ -31,9 +32,11 @@ GnuPG-bug-id: 5328
 Suggested-by: Luca De Feo, Bertram Poettering, Alessandro Sorniotti
 Signed-off-by: NIIBE Yutaka <gniibe@fsij.org>
 ---
+ cipher/elgamal.c | 24 ++++++------------------
+ 1 file changed, 6 insertions(+), 18 deletions(-)
 
 diff --git a/cipher/elgamal.c b/cipher/elgamal.c
-index 9835122f..eead4502 100644
+index 4eb52d620..ae7a631ee 100644
 --- a/cipher/elgamal.c
 +++ b/cipher/elgamal.c
 @@ -66,7 +66,7 @@ static const char *elg_names[] =
@@ -88,7 +91,7 @@ index 9835122f..eead4502 100644
    mpi_powm (a, pkey->g, k, pkey->p);
  
    /* b = (y^k * input) mod p
-@@ -608,7 +596,7 @@ sign(gcry_mpi_t a, gcry_mpi_t b, gcry_mpi_t input, ELG_secret_key *skey )
+@@ -594,7 +582,7 @@ sign(gcry_mpi_t a, gcry_mpi_t b, gcry_mpi_t input, ELG_secret_key *skey )
      *
      */
      mpi_sub_ui(p_1, p_1, 1);

--- a/SPECS/libgcrypt/libgcrypt.spec
+++ b/SPECS/libgcrypt/libgcrypt.spec
@@ -1,15 +1,15 @@
 Summary:        GNU Crypto Libraries
 Name:           libgcrypt
 Version:        1.8.7
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        GPLv2+ AND LGPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Group:          System Environment/Libraries
 URL:            https://gnupg.org/related_software/libgcrypt/
 Source0:        https://gnupg.org/ftp/gcrypt/%{name}/%{name}-%{version}.tar.bz2
-#libgcrypt CVE-2021-33560 fix
-Patch0:         libgcrypt-CVE-2021-33560-fix.patch
+Patch0:         CVE-2021-33560.patch
+Patch1:         CVE-2021-40528.patch
 BuildRequires:  libgpg-error-devel
 Requires:       libgpg-error
 
@@ -31,14 +31,14 @@ developing applications that use libgcrypt.
 
 %build
 %configure
-make %{?_smp_mflags}
+%make_build
 
 %install
-make DESTDIR=%{buildroot} install
+%make_install
 rm -rf %{buildroot}%{_infodir}
 
 %check
-make %{?_smp_mflags} check
+%make_build check
 
 %post -p /sbin/ldconfig
 %postun	-p /sbin/ldconfig
@@ -59,6 +59,11 @@ make %{?_smp_mflags} check
 %{_libdir}/pkgconfig/%{name}.pc
 
 %changelog
+* Mon Nov 01 2021 Thomas Crain <thcrain@microsoft.com> - 1.8.7-3
+- Add patch for CVE-2021-33560
+- Rename old CVE-2021-33560 patch to reflect that it actually fixed CVE-2021-40528
+  (CVE seems to have been renumbered at some point)
+
 * Tue Jun 22 2021 Suresh Babu Chalamalasetty <schalam@microsoft.com> - 1.8.7-2
 - libgcrypt CVE-2021-33560 fix
 

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -151,7 +151,7 @@ mariner-rpm-macros-1.0-5.cm1.noarch.rpm
 mariner-check-macros-1.0-5.cm1.noarch.rpm
 libassuan-2.5.1-3.cm1.aarch64.rpm
 libgpg-error-1.32-4.cm1.aarch64.rpm
-libgcrypt-1.8.7-2.cm1.aarch64.rpm
+libgcrypt-1.8.7-3.cm1.aarch64.rpm
 libksba-1.3.5-3.cm1.aarch64.rpm
 npth-1.6-3.cm1.aarch64.rpm
 pinentry-1.1.0-3.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -151,7 +151,7 @@ mariner-rpm-macros-1.0-5.cm1.noarch.rpm
 mariner-check-macros-1.0-5.cm1.noarch.rpm
 libassuan-2.5.1-3.cm1.x86_64.rpm
 libgpg-error-1.32-4.cm1.x86_64.rpm
-libgcrypt-1.8.7-2.cm1.x86_64.rpm
+libgcrypt-1.8.7-3.cm1.x86_64.rpm
 libksba-1.3.5-3.cm1.x86_64.rpm
 npth-1.6-3.cm1.x86_64.rpm
 pinentry-1.1.0-3.cm1.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -189,9 +189,9 @@ libffi-devel-3.2.1-12.cm1.aarch64.rpm
 libgcc-9.1.0-7.cm1.aarch64.rpm
 libgcc-atomic-9.1.0-7.cm1.aarch64.rpm
 libgcc-devel-9.1.0-7.cm1.aarch64.rpm
-libgcrypt-1.8.7-2.cm1.aarch64.rpm
-libgcrypt-debuginfo-1.8.7-2.cm1.aarch64.rpm
-libgcrypt-devel-1.8.7-2.cm1.aarch64.rpm
+libgcrypt-1.8.7-3.cm1.aarch64.rpm
+libgcrypt-debuginfo-1.8.7-3.cm1.aarch64.rpm
+libgcrypt-devel-1.8.7-3.cm1.aarch64.rpm
 libgomp-9.1.0-7.cm1.aarch64.rpm
 libgomp-devel-9.1.0-7.cm1.aarch64.rpm
 libgpg-error-1.32-4.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -189,9 +189,9 @@ libffi-devel-3.2.1-12.cm1.x86_64.rpm
 libgcc-9.1.0-7.cm1.x86_64.rpm
 libgcc-atomic-9.1.0-7.cm1.x86_64.rpm
 libgcc-devel-9.1.0-7.cm1.x86_64.rpm
-libgcrypt-1.8.7-2.cm1.x86_64.rpm
-libgcrypt-debuginfo-1.8.7-2.cm1.x86_64.rpm
-libgcrypt-devel-1.8.7-2.cm1.x86_64.rpm
+libgcrypt-1.8.7-3.cm1.x86_64.rpm
+libgcrypt-debuginfo-1.8.7-3.cm1.x86_64.rpm
+libgcrypt-devel-1.8.7-3.cm1.x86_64.rpm
 libgomp-9.1.0-7.cm1.x86_64.rpm
 libgomp-devel-9.1.0-7.cm1.x86_64.rpm
 libgpg-error-1.32-4.cm1.x86_64.rpm


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Add upstream patch for libgcrypt CVE-2021-33560.

Note: CVE-2021-33560 seems to have been renamed to CVE-2021-40528 at some point, and CVE-2021-33560 was given to a different bug. [This was also observed by the Ubuntu folks.](https://ubuntu.com/security/CVE-2021-33560)

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Rename CVE-2021-33560 patch to reflect that it actually applies to CVE-2021-40528.
- Add patch for CVE-2021-33560

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2021-33560

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build
