### PR TITLE
[dev] Fixing `libsepol` tests.

### DIFF
--- a/SPECS/libsepol/libsepol.signatures.json
+++ b/SPECS/libsepol/libsepol.signatures.json
@@ -1,5 +1,5 @@
 {
- "Signatures": {
-  "libsepol-3.2.tar.gz": "dfc7f662af8000116e56a01de6a0394ed79be1b34b999e551346233c5dd19508"
+ "signatures": {
+  "selinux-3.2.tar.gz": "cda0b315ea88f93b1e7b6aa9f48d3b568a5506af1f8f401f5d05fa2ce8c7008f"
  }
 }

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -3670,7 +3670,7 @@
         "other": {
           "name": "libsepol",
           "version": "3.2",
-          "downloadUrl": "https://github.com/SELinuxProject/selinux/releases/download/3.2/libsepol-3.2.tar.gz"
+          "downloadUrl": "https://codeload.github.com/SELinuxProject/selinux/tar.gz/refs/tags/3.2"
         }
       }
     },

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -199,7 +199,7 @@ tdnf-plugin-repogpgcheck-2.1.0-7.cm2.aarch64.rpm
 createrepo_c-0.17.5-1.cm2.aarch64.rpm
 libxml2-2.9.12-2.cm2.aarch64.rpm
 libxml2-devel-2.9.12-2.cm2.aarch64.rpm
-libsepol-3.2-1.cm2.aarch64.rpm
+libsepol-3.2-2.cm2.aarch64.rpm
 glib-2.60.1-5.cm2.aarch64.rpm
 libltdl-2.4.6-7.cm2.aarch64.rpm
 libltdl-devel-2.4.6-7.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -199,7 +199,7 @@ tdnf-plugin-repogpgcheck-2.1.0-7.cm2.x86_64.rpm
 createrepo_c-0.17.5-1.cm2.x86_64.rpm
 libxml2-2.9.12-2.cm2.x86_64.rpm
 libxml2-devel-2.9.12-2.cm2.x86_64.rpm
-libsepol-3.2-1.cm2.x86_64.rpm
+libsepol-3.2-2.cm2.x86_64.rpm
 glib-2.60.1-5.cm2.x86_64.rpm
 libltdl-2.4.6-7.cm2.x86_64.rpm
 libltdl-devel-2.4.6-7.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -206,9 +206,9 @@ libselinux-debuginfo-3.2-1.cm2.aarch64.rpm
 libselinux-devel-3.2-1.cm2.aarch64.rpm
 libselinux-python3-3.2-1.cm2.aarch64.rpm
 libselinux-utils-3.2-1.cm2.aarch64.rpm
-libsepol-3.2-1.cm2.aarch64.rpm
-libsepol-debuginfo-3.2-1.cm2.aarch64.rpm
-libsepol-devel-3.2-1.cm2.aarch64.rpm
+libsepol-3.2-2.cm2.aarch64.rpm
+libsepol-debuginfo-3.2-2.cm2.aarch64.rpm
+libsepol-devel-3.2-2.cm2.aarch64.rpm
 libsolv-0.7.19-1.cm2.aarch64.rpm
 libsolv-debuginfo-0.7.19-1.cm2.aarch64.rpm
 libsolv-devel-0.7.19-1.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -206,9 +206,9 @@ libselinux-debuginfo-3.2-1.cm2.x86_64.rpm
 libselinux-devel-3.2-1.cm2.x86_64.rpm
 libselinux-python3-3.2-1.cm2.x86_64.rpm
 libselinux-utils-3.2-1.cm2.x86_64.rpm
-libsepol-3.2-1.cm2.x86_64.rpm
-libsepol-debuginfo-3.2-1.cm2.x86_64.rpm
-libsepol-devel-3.2-1.cm2.x86_64.rpm
+libsepol-3.2-2.cm2.x86_64.rpm
+libsepol-debuginfo-3.2-2.cm2.x86_64.rpm
+libsepol-devel-3.2-2.cm2.x86_64.rpm
 libsolv-0.7.19-1.cm2.x86_64.rpm
 libsolv-debuginfo-0.7.19-1.cm2.x86_64.rpm
 libsolv-devel-0.7.19-1.cm2.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

The `libsepol` build was failing completely during our test builds due to invalid `BuildRequires` entry. In addition to fixing the entry, I've fixed the tests as well.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Using correct `BuildRequires` for `CUnit-devel` inside `libsepol.spec`.
- Fixing `libsepol` tests.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
Yes.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local package build with `RUN_CHECK=y`.
