### PR TITLE
[dev] Adding a switch to skip chroot rebuilds

### DIFF
--- a/toolkit/Makefile
+++ b/toolkit/Makefile
@@ -38,6 +38,7 @@ IMAGE_CACHE_SUMMARY             ?=
 INITRD_CACHE_SUMMARY            ?=
 PACKAGE_ARCHIVE                 ?=
 PACKAGE_BUILD_RETRIES           ?= 1
+REFRESH_WORKER_CHROOT           ?= y
 # Set to 0 to use the number of logical CPUs.
 CONCURRENT_PACKAGE_BUILDS       ?= 0
 # Set to 0 to print all available results.

--- a/toolkit/docs/building/building.md
+++ b/toolkit/docs/building/building.md
@@ -52,6 +52,9 @@
       - [`REBUILD_TOOLS=...`](#rebuild_tools)
         - [`REBUILD_TOOLS=`**`n`** *(default)*](#rebuild_toolsn-default)
         - [`REBUILD_TOOLS=`**`y`**](#rebuild_toolsy)
+      - [`REFRESH_WORKER_CHROOT=...`](#refresh_worker_chroot)
+        - [`REFRESH_WORKER_CHROOT=`**`n`**](#refresh_worker_chrootn)
+        - [`REFRESH_WORKER_CHROOT=`**`y`** *(default)*](#refresh_worker_chrooty-default)
   - [All Build Targets](#all-build-targets)
   - [Reproducing a Build](#reproducing-a-build)
     - [Build Summaries](#build-summaries)
@@ -486,6 +489,20 @@ sudo make hydrate-rpms PACKAGE_ARCHIVE=./rpms.tar.gz
 ##### `REBUILD_TOOLS=`**`y`**
 
 > Build the go tools from source as needed.
+
+#### `REFRESH_WORKER_CHROOT=...`
+
+##### `REFRESH_WORKER_CHROOT=`**`n`**
+
+> If exists, don't attempt to rebuild the worker chroot, even if the its build script, its manifest, or the packages it consists of have been modified in the local repository.
+
+##### `REFRESH_WORKER_CHROOT=`**`y`** *(default)*
+
+> Rebuild the worker chroot every time at least one of the following has changes:
+>
+> - worker chroot's manifest file,
+> - at least one of the RPM packages mentioned in the manifest file, or
+> - the script responsible for building the chroot.
 
 ## All Build Targets
 

--- a/toolkit/docs/building/building.md
+++ b/toolkit/docs/building/building.md
@@ -494,11 +494,11 @@ sudo make hydrate-rpms PACKAGE_ARCHIVE=./rpms.tar.gz
 
 ##### `REFRESH_WORKER_CHROOT=`**`n`**
 
-> If exists, don't attempt to rebuild the worker chroot, even if the its build script, its manifest, or the packages it consists of have been modified in the local repository.
+> If exists, don't attempt to rebuild the worker chroot, even if its build script, its manifest, or the packages it consists of have been modified in the local repository.
 
 ##### `REFRESH_WORKER_CHROOT=`**`y`** *(default)*
 
-> Rebuild the worker chroot every time at least one of the following has changes:
+> Rebuild the worker chroot every time at least one of the following has changed:
 >
 > - worker chroot's manifest file,
 > - at least one of the RPM packages mentioned in the manifest file, or

--- a/toolkit/scripts/tools.mk
+++ b/toolkit/scripts/tools.mk
@@ -135,16 +135,18 @@ worker_chroot_manifest = $(TOOLCHAIN_MANIFESTS_DIR)/$(worker_manifest_name)
 # the exact path of the required rpm
 # Outputs: $(RPMS_DIR)/<arch>/<name>.<arch>.rpm
 sed_regex_full_path = 's`(.*\.([^\.]+)\.rpm)`$(toolchain_rpms_dir)/\2/\1`p'
-sed_regex_arch_only = 's`(.*\.([^\.]+)\.rpm)`\2`p'
 worker_chroot_rpm_paths := $(shell sed -nr $(sed_regex_full_path) < $(worker_chroot_manifest))
 
 worker_chroot_deps := \
 	$(worker_chroot_manifest) \
 	$(worker_chroot_rpm_paths) \
-	$(toolchain_rpms) \
 	$(PKGGEN_DIR)/worker/create_worker_chroot.sh
 
+ifeq ($(REFRESH_WORKER_CHROOT),y)
 $(chroot_worker): $(worker_chroot_deps)
+else
+$(chroot_worker):
+endif
 	$(PKGGEN_DIR)/worker/create_worker_chroot.sh $(BUILD_DIR)/worker $(worker_chroot_manifest) $(toolchain_rpms_dir) $(LOGS_DIR)
 
 validate-chroot: $(go-validatechroot) $(chroot_worker)


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

Due to how packages are built, the worker chroot kept being constantly rebuilt, even if it was unnecessary. Fixing the underlying issue with proper detection of when the rebuild is required will require more complex changes to our build infrastructure, so for now I'm adding the `REFRESH_WORKER_CHROOT` argument, to skip rebuilds, if you know they are not necessary. The default behaviour remains unchanged.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Adding an new `REFRESH_WORKER_CHROOT` build tools argument.
- 
###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local package builds.
