### PR TITLE
Bump Mariner Release for 2nd Full Off-Cycle Build

### DIFF
--- a/SPECS/mariner-release/mariner-release.spec
+++ b/SPECS/mariner-release/mariner-release.spec
@@ -69,7 +69,7 @@ rm -rf $RPM_BUILD_ROOT
 %changelog
 *   Fri Nov 05 2021 Jon Slobodzian <joslobo@microsoft.com> - 1.0-26
 -   Updating version for off-cycle post-October update to fix vim CVE and update glibc to patch 
--   dotnet/glibc garbage collector issue (pthread_cond_signal failed to wake up pthread_cond_wait ())
+-   dotnet/glibc garbage collector issue (pthread_cond_signal failed to wake up pthread_cond_wait)
 *   Wed Nov 03 2021 Jon Slobodzian <joslobo@microsoft.com> - 1.0-25
 -   Updating version for off-cycle post-October update to service toolchain CVE's and miscellaneous bug fixes.
 *   Tue Oct 26 2021 Jon Slobodzian <joslobo@microsoft.com> - 1.0-24

--- a/SPECS/mariner-release/mariner-release.spec
+++ b/SPECS/mariner-release/mariner-release.spec
@@ -1,7 +1,7 @@
 Summary:       CBL-Mariner release files
 Name:          mariner-release
 Version:       1.0
-Release:       25%{?dist}
+Release:       26%{?dist}
 License:       MIT
 Group:         System Environment/Base
 URL:           https://aka.ms/cbl-mariner
@@ -67,6 +67,9 @@ rm -rf $RPM_BUILD_ROOT
 %config(noreplace) /etc/issue.net
 
 %changelog
+*   Fri Nov 05 2021 Jon Slobodzian <joslobo@microsoft.com> - 1.0-26
+-   Updating version for off-cycle post-October update to fix vim CVE and update glibc to patch 
+-   dotnet/glibc garbage collector issue (pthread_cond_signal failed to wake up pthread_cond_wait ())
 *   Wed Nov 03 2021 Jon Slobodzian <joslobo@microsoft.com> - 1.0-25
 -   Updating version for off-cycle post-October update to service toolchain CVE's and miscellaneous bug fixes.
 *   Tue Oct 26 2021 Jon Slobodzian <joslobo@microsoft.com> - 1.0-24

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -58,7 +58,7 @@ findutils-lang-4.6.0-7.cm1.aarch64.rpm
 gettext-0.19.8.1-5.cm1.aarch64.rpm
 gzip-1.9-5.cm1.aarch64.rpm
 make-4.2.1-5.cm1.aarch64.rpm
-mariner-release-1.0-25.cm1.noarch.rpm
+mariner-release-1.0-26.cm1.noarch.rpm
 patch-2.7.6-7.cm1.aarch64.rpm
 util-linux-2.32.1-5.cm1.aarch64.rpm
 util-linux-devel-2.32.1-5.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -58,7 +58,7 @@ findutils-lang-4.6.0-7.cm1.x86_64.rpm
 gettext-0.19.8.1-5.cm1.x86_64.rpm
 gzip-1.9-5.cm1.x86_64.rpm
 make-4.2.1-5.cm1.x86_64.rpm
-mariner-release-1.0-25.cm1.noarch.rpm
+mariner-release-1.0-26.cm1.noarch.rpm
 patch-2.7.6-7.cm1.x86_64.rpm
 util-linux-2.32.1-5.cm1.x86_64.rpm
 util-linux-devel-2.32.1-5.cm1.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -265,7 +265,7 @@ m4-debuginfo-1.4.18-4.cm1.aarch64.rpm
 make-4.2.1-5.cm1.aarch64.rpm
 make-debuginfo-4.2.1-5.cm1.aarch64.rpm
 mariner-check-macros-1.0-6.cm1.noarch.rpm
-mariner-release-1.0-25.cm1.noarch.rpm
+mariner-release-1.0-26.cm1.noarch.rpm
 mariner-repos-1.0-14.cm1.noarch.rpm
 mariner-repos-extras-1.0-14.cm1.noarch.rpm
 mariner-repos-extras-preview-1.0-14.cm1.noarch.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -265,7 +265,7 @@ m4-debuginfo-1.4.18-4.cm1.x86_64.rpm
 make-4.2.1-5.cm1.x86_64.rpm
 make-debuginfo-4.2.1-5.cm1.x86_64.rpm
 mariner-check-macros-1.0-6.cm1.noarch.rpm
-mariner-release-1.0-25.cm1.noarch.rpm
+mariner-release-1.0-26.cm1.noarch.rpm
 mariner-repos-1.0-14.cm1.noarch.rpm
 mariner-repos-extras-1.0-14.cm1.noarch.rpm
 mariner-repos-extras-preview-1.0-14.cm1.noarch.rpm


### PR DESCRIPTION
This change just bumps the Mariner-Release again in support of a second off-cycle build.
This build includes a fix to the toolchain package glibc and a fix for vi.