### PR TITLE
[dev] Add python3-perf subpackage to kernel

### DIFF
--- a/SPECS-SIGNED/kernel-signed/kernel-signed.spec
+++ b/SPECS-SIGNED/kernel-signed/kernel-signed.spec
@@ -10,7 +10,7 @@
 Summary:        Signed Linux Kernel for %{buildarch} systems
 Name:           kernel-signed-%{buildarch}
 Version:        5.10.74.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -146,6 +146,9 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %endif
 
 %changelog
+* Mon Nov 15 2021 Thomas Crian <thcrain@microsoft.com> - 5.10.74.1-4
+- Bump release number to match kernel release
+
 * Thu Nov 04 2021 Andrew Phelps <anphel@microsoft.com> - 5.10.74.1-3
 - Bump release number to match kernel release
 

--- a/SPECS/kernel-headers/kernel-headers.spec
+++ b/SPECS/kernel-headers/kernel-headers.spec
@@ -1,7 +1,7 @@
 Summary:        Linux API header files
 Name:           kernel-headers
 Version:        5.10.74.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -9,9 +9,9 @@ Group:          System Environment/Kernel
 URL:            https://github.com/microsoft/CBL-Mariner-Linux-Kernel
 #Source0:       https://github.com/microsoft/CBL-Mariner-Linux-Kernel/archive/rolling-lts/mariner/%%{version}.tar.gz
 Source0:        kernel-%{version}.tar.gz
-# Historical name shipped by other distros
-Provides:       glibc-kernheaders
 Patch0:         0001-clocksource-drivers-hyper-v-Re-enable-VDSO_CLOCKMODE.patch
+# Historical name shipped by other distros
+Provides:       glibc-kernheaders = %{version}-%{release}
 BuildArch:      noarch
 
 %description
@@ -39,6 +39,10 @@ cp -rv usr/include/* /%{buildroot}%{_includedir}
 %{_includedir}/*
 
 %changelog
+* Mon Nov 15 2021 Thomas Crian <thcrain@microsoft.com> - 5.10.74.1-4
+- Bump release number to match kernel release
+- Lint spec and version the glibc-kernheaders provides
+
 * Thu Nov 04 2021 Andrew Phelps <anphel@microsoft.com> - 5.10.74.1-3
 - Bump release number to match kernel release
 

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -1,5 +1,5 @@
 filesystem-1.1-8.cm2.aarch64.rpm
-kernel-headers-5.10.74.1-3.cm2.noarch.rpm
+kernel-headers-5.10.74.1-4.cm2.noarch.rpm
 glibc-2.34-2.cm2.aarch64.rpm
 glibc-devel-2.34-2.cm2.aarch64.rpm
 glibc-i18n-2.34-2.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -1,5 +1,5 @@
 filesystem-1.1-8.cm2.x86_64.rpm
-kernel-headers-5.10.74.1-3.cm2.noarch.rpm
+kernel-headers-5.10.74.1-4.cm2.noarch.rpm
 glibc-2.34-2.cm2.x86_64.rpm
 glibc-devel-2.34-2.cm2.x86_64.rpm
 glibc-i18n-2.34-2.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -142,7 +142,7 @@ json-c-debuginfo-0.14-3.cm2.aarch64.rpm
 json-c-devel-0.14-3.cm2.aarch64.rpm
 kbd-2.2.0-1.cm2.aarch64.rpm
 kbd-debuginfo-2.2.0-1.cm2.aarch64.rpm
-kernel-headers-5.10.74.1-3.cm2.noarch.rpm
+kernel-headers-5.10.74.1-4.cm2.noarch.rpm
 kmod-25-6.cm2.aarch64.rpm
 kmod-debuginfo-25-6.cm2.aarch64.rpm
 kmod-devel-25-6.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -142,7 +142,7 @@ json-c-debuginfo-0.14-3.cm2.x86_64.rpm
 json-c-devel-0.14-3.cm2.x86_64.rpm
 kbd-2.2.0-1.cm2.x86_64.rpm
 kbd-debuginfo-2.2.0-1.cm2.x86_64.rpm
-kernel-headers-5.10.74.1-3.cm2.noarch.rpm
+kernel-headers-5.10.74.1-4.cm2.noarch.rpm
 kmod-25-6.cm2.x86_64.rpm
 kmod-debuginfo-25-6.cm2.x86_64.rpm
 kmod-devel-25-6.cm2.x86_64.rpm


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
The kernel's perf tools expose a python extension library. This PR adds this as a `python3-perf` subpackage in the kernel spec.

Additionally, a fix is included to stop accessibility driver modules from being packaged in both the `kernel` package and the `kernel-drivers-accessibility` subpackage. These drivers will only be available in the `kernel-drivers-accessibility` subpackage going forward. 

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Build and package the kernel's `python3-perf` extension.
- Exclude accessibility driver modules from being packaged in the main kernel package.
- Bump `kernel-signed` and `kernel-headers` releases, lint kernel-headers

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Builds locally. Confirmed functionality of python extension in a custom image.