### PR TITLE
Upgrade nodejs to v14.18.1 to fix several CVEs and cryptography bugs

### DIFF
--- a/SPECS/nodejs/clean-source-tarball.sh
+++ b/SPECS/nodejs/clean-source-tarball.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# The nodejs source tarball contains a copy of the OpenSSL source tree.
+# OpenSSL contains patented algorithms that should not be distributed
+# as part of the SRPM. Since we use the shared OpenSSL libraries, we 
+# can just remove the entire OpenSSL source tree from the tarball.
+
+print_usage() {
+    echo "Usage:"
+    echo "make-hobbled-nodejs-source.sh {version}"
+    echo "Example: make-hobbled-nodejs-source.sh 14.18.1"
+    echo
+    exit
+}
+
+VERSION=$1
+
+if [ -z "$1" ]; then
+    print_usage
+fi
+
+
+# Quit on failure
+set -e
+
+namever="node-v${VERSION}"
+upstream_tarball_name="${namever}.tar.xz"
+clean_tarball_name="${namever}-clean.tar.xz"
+download_url="https://nodejs.org/download/release/v${VERSION}/${upstream_tarball_name}"
+
+tmpdir=$(mktemp -d)
+echo "Using temporary directory: $tmpdir"
+pushd $tmpdir > /dev/null
+
+echo "Downloading upstream source tarball..."
+curl -s -O $download_url
+
+echo "Unpacking upstream source tarball..."
+tar -xf $upstream_tarball_name
+
+echo "Removing bad vendored dependencies from source tree..."
+rm -rf ./$namever/deps/openssl
+
+# Create a reproducible tarball
+# Credit to https://reproducible-builds.org/docs/archives/ for instructions
+echo "Repacking source tarball..."
+tar --sort=name --mtime="2021-11-10 00:00Z" \
+    --owner=0 --group=0 --numeric-owner \
+    --pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime \
+    -cJf $clean_tarball_name ./$namever
+
+popd > /dev/null
+cp "${tmpdir}/${clean_tarball_name}" .
+echo "Clean nodejs source tarball available at $PWD/$clean_tarball_name"
+rm -rf $tmpdir

--- a/SPECS/nodejs/clean-source-tarball.sh
+++ b/SPECS/nodejs/clean-source-tarball.sh
@@ -9,8 +9,8 @@
 
 print_usage() {
     echo "Usage:"
-    echo "make-hobbled-nodejs-source.sh {version}"
-    echo "Example: make-hobbled-nodejs-source.sh 14.18.1"
+    echo "clean-source-tarball.sh {version}"
+    echo "Example: clean-source-tarball.sh 14.18.1"
     echo
     exit
 }

--- a/SPECS/nodejs/clean-source-tarball.sh
+++ b/SPECS/nodejs/clean-source-tarball.sh
@@ -45,6 +45,8 @@ rm -rf ./$namever/deps/openssl
 
 # Create a reproducible tarball
 # Credit to https://reproducible-builds.org/docs/archives/ for instructions
+# Do not update mtime value for new versions- keep the same value for ease of
+# reproducing old tarball versions in the future if necessary
 echo "Repacking source tarball..."
 tar --sort=name --mtime="2021-11-10 00:00Z" \
     --owner=0 --group=0 --numeric-owner \

--- a/SPECS/nodejs/nodejs.signatures.json
+++ b/SPECS/nodejs/nodejs.signatures.json
@@ -1,6 +1,6 @@
 {
  "Signatures": {
   "node-v14.18.1-clean.tar.xz": "0b9b5b024c1558f2e8ada493d76d39e077c9210c71e4624d7cc7a2213e2ccc63",
-  "clean-source-tarball.sh": "9ab8e92d7643da413b1f0d81d1d976edee0bcd86a9acb6ccb9c96fc8cb41b83d"
+  "clean-source-tarball.sh": "ab579872ec2f4e85a00fc1651b40a26876012256c722c3701ef3cdcb378c93d5"
  }
 }

--- a/SPECS/nodejs/nodejs.signatures.json
+++ b/SPECS/nodejs/nodejs.signatures.json
@@ -1,6 +1,6 @@
 {
  "Signatures": {
   "node-v14.18.1-clean.tar.xz": "0b9b5b024c1558f2e8ada493d76d39e077c9210c71e4624d7cc7a2213e2ccc63",
-  "clean-source-tarball.sh": "1555439226582353d0d487d7816e8613348797e0d65cdcd1d6fd5306a1091d1e"
+  "clean-source-tarball.sh": "9ab8e92d7643da413b1f0d81d1d976edee0bcd86a9acb6ccb9c96fc8cb41b83d"
  }
 }

--- a/SPECS/nodejs/nodejs.signatures.json
+++ b/SPECS/nodejs/nodejs.signatures.json
@@ -1,5 +1,6 @@
 {
  "Signatures": {
-  "node-v14.17.5.tar.xz": "42b1a7ff87580c6058063e943d7d53efa8c236145e6e9c8264ee425b40911fa8"
+  "node-v14.18.1-clean.tar.xz": "0b9b5b024c1558f2e8ada493d76d39e077c9210c71e4624d7cc7a2213e2ccc63",
+  "clean-source-tarball.sh": "1555439226582353d0d487d7816e8613348797e0d65cdcd1d6fd5306a1091d1e"
  }
 }

--- a/SPECS/nodejs/nodejs.spec
+++ b/SPECS/nodejs/nodejs.spec
@@ -18,6 +18,7 @@ URL:            https://github.com/nodejs/node
 Source0:        node-v%{version}-clean.tar.xz
 Source1:        clean-source-tarball.sh
 Patch0:         patch_tls_nodejs14.patch
+Patch1:         remove_unsupported_tlsv13_ciphers.patch
 BuildRequires:  coreutils >= 8.22
 BuildRequires:  openssl-devel >= 1.1.1
 BuildRequires:  python3
@@ -89,10 +90,11 @@ done
 * Tue Nov 09 2021 Thomas Crain <thcrain@microsoft.com> - 14.18.1-1
 - Update to version 14.18.1 to fix CVE-2021-22959, CVE-2021-22960, CVE-2021-37701,
   CVE-2021-37712, CVE-2021-37713, CVE-2021-39134, CVE-2021-39135
+- Add patch to remove problematic cipher from default list
 - Add config flag to use OpenSSL cert store instead of built-in Mozilla certs
 - Add script to remove vendored OpenSSL tree from source tarball
 - Add runtime requirement on ca-certificates for base package
-- Update require OpenSSL version to 1.1.1
+- Update required OpenSSL version to 1.1.1
 - Use python configure script directly
 - Enable a larger set of tests
 - Lint spec

--- a/SPECS/nodejs/nodejs.spec
+++ b/SPECS/nodejs/nodejs.spec
@@ -42,7 +42,7 @@ for developing applications that use nodejs.
 %autosetup -p1 -n node-v%{version}
 
 %build
-%{python3} configure.py \
+python3 configure.py \
   --prefix=%{_prefix} \
   --shared-openssl \
   --shared-zlib \
@@ -62,8 +62,7 @@ for FILE in .gitmodules .gitignore .npmignore .travis.yml \*.py[co]; do
 done
 
 %check
-# Run all tests, minus linter/doc tests
-%make_build test-only
+make cctest
 
 %post -p /sbin/ldconfig
 %postun -p /sbin/ldconfig
@@ -92,7 +91,6 @@ done
 - Add runtime requirement on ca-certificates for base package
 - Update required OpenSSL version to 1.1.1
 - Use python configure script directly
-- Enable a larger set of tests
 - Lint spec
 
 * Mon Aug 30 2021 Andrew Phelps <anphel@microsoft.com> - 14.17.5-1

--- a/SPECS/nodejs/nodejs.spec
+++ b/SPECS/nodejs/nodejs.spec
@@ -1,25 +1,37 @@
+
+# WARNING: MUST check and update the 'npm_version' macro for every version update of this package.
+#           The version of NPM can be found inside the sources under 'deps/npm/package.json'.
+%define npm_version 6.14.15
+
 Summary:        A JavaScript runtime built on Chrome's V8 JavaScript engine.
 Name:           nodejs
-Version:        14.17.5
+Version:        14.18.1
 Release:        1%{?dist}
 License:        BSD and MIT and Public Domain and naist-2003
 Group:          Applications/System
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 URL:            https://github.com/nodejs/node
-Source0:        https://nodejs.org/download/release/v%{version}/node-v%{version}.tar.xz
+# Source0 has a vendored OpenSSL source tree with patented algorithms.
+# Use Source1 to create a clean and reproducible source tarball.
+#Source0:       https://nodejs.org/download/release/v%{version}/node-v%{version}.tar.xz
+Source0:        node-v%{version}-clean.tar.xz
+Source1:        clean-source-tarball.sh
 Patch0:         patch_tls_nodejs14.patch
-
 BuildRequires:  coreutils >= 8.22
-BuildRequires:  openssl-devel >= 1.0.1
+BuildRequires:  openssl-devel >= 1.1.1
 BuildRequires:  python3
 BuildRequires:  which
+# ca-certificates is needed to communicate with default npm registry
+Requires:       ca-certificates
 Requires:       coreutils >= 8.22
-Requires:       openssl >= 1.0.1
+Requires:       openssl >= 1.1.1
 Requires:       python3
 
 %description
-Node.js is a JavaScript runtime built on Chrome's V8 JavaScript engine. Node.js uses an event-driven, non-blocking I/O model that makes it lightweight and efficient. The Node.js package ecosystem, npm, is the largest ecosystem of open source libraries in the world.
+Node.js is a JavaScript runtime built on Chrome's V8 JavaScript engine.
+Node.js uses an event-driven, non-blocking I/O model that makes it lightweight and efficient.
+The Node.js package ecosystem, npm, is the largest ecosystem of open source libraries in the world.
 
 %package        devel
 Summary:        Development files node
@@ -31,19 +43,18 @@ The nodejs-devel package contains libraries, header files and documentation
 for developing applications that use nodejs.
 
 %prep
-%setup -q -n node-v%{version}
-%patch0 -p1
+%autosetup -p1 -n node-v%{version}
 
 %build
-sh configure --prefix=%{_prefix} \
-           --shared-openssl \
-           --shared-zlib
-
-make %{?_smp_mflags}
+%{python3} configure.py \
+  --prefix=%{_prefix} \
+  --shared-openssl \
+  --shared-zlib \
+  --openssl-use-def-ca-store
+%make_build
 
 %install
-
-make %{?_smp_mflags} install DESTDIR=$RPM_BUILD_ROOT
+%make_install
 rm -fr %{buildroot}%{_libdir}/dtrace/  # No systemtap support.
 install -m 755 -d %{buildroot}%{_libdir}/node_modules/
 install -m 755 -d %{buildroot}%{_datadir}/%{name}
@@ -55,17 +66,18 @@ for FILE in .gitmodules .gitignore .npmignore .travis.yml \*.py[co]; do
 done
 
 %check
-make cctest
+# Run all tests, minus linter/doc tests
+%make_build test-only
 
-%post -p /sbin/ldconfig
+%ldconfig_scriptlets
 
 %files
 %defattr(-,root,root)
 %license LICENSE
+%doc CHANGELOG.md README.md
 %{_bindir}/*
 %{_libdir}/node_modules/*
 %{_mandir}/man*/*
-%doc CHANGELOG.md LICENSE README.md
 
 %files devel
 %defattr(-,root,root)
@@ -74,36 +86,63 @@ make cctest
 %{_datadir}/systemtap/tapset/node.stp
 
 %changelog
-*   Mon Aug 30 2021 Andrew Phelps <anphel@microsoft.com> - 14.17.5-1
--   Update to version 14.17.5 to fix CVE-2021-22931
-*   Mon Jul 19 2021 Neha Agarwal <nehaagarwal@microsoft.com> - 14.17.2-1
--   Update to version 14.17.2 to fix CVE-2021-22918
-*   Mon Jun 07 2021 Henry Beberman <henry.beberman@microsoft.com> - 14.17.0-1
--   Update to nodejs version 14.17.0
-*   Sat May 09 2020 Nick Samson <nisamson@microsoft.com> - 9.11.2-7
--   Added %%license line automatically
-*   Mon May 04 2020 Paul Monson <paulmon@microsoft.com> 9.11.2-6
--   Add patch that enables building openssl without TLS versions less 1.2
-*   Thu Apr 09 2020 Nicolas Ontiveros <niontive@microsoft.com> 9.11.2-5
--   Remove toybox and only use coreutils for requires.
-*   Wed Apr 08 2020 Pawel Winogrodzki <pawelwi@microsoft.com> 9.11.2-4
--   License verified.
--   Removed "%%define sha1".
-*   Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 9.11.2-3
--   Initial CBL-Mariner import from Photon (license: Apache2).
-*   Tue Jan 08 2019 Alexey Makhalov <amakhalov@vmware.com> 9.11.2-2
--   Added BuildRequires python2, which
-*   Thu Sep 20 2018 Him Kalyan Bordoloi <bordoloih@vmware.com> 9.11.2-1
--   Updated to version 9.11.2
-*   Mon Sep 10 2018 Him Kalyan Bordoloi <bordoloih@vmware.com> 9.9.0-1
--   Updated to version 9.9.0
-*   Wed Feb 14 2018 Xiaolin Li <xiaolinl@vmware.com> 8.3.0-1
--   Updated to version 8.3.0
-*   Fri Oct 13 2017 Alexey Makhalov <amakhalov@vmware.com> 7.7.4-4
--   Remove BuildArch
-*   Mon Sep 18 2017 Alexey Makhalov <amakhalov@vmware.com> 7.7.4-3
--   Requires coreutils or toybox
-*   Fri Jul 14 2017 Chang Lee <changlee@vmware.com> 7.7.4-2
--   Updated %check
-*   Mon Mar 20 2017 Xiaolin Li <xiaolinl@vmware.com> 7.7.4-1
--   Initial packaging for Photon
+* Tue Nov 09 2021 Thomas Crain <thcrain@microsoft.com> - 14.18.1-1
+- Update to version 14.18.1 to fix CVE-2021-22959, CVE-2021-22960, CVE-2021-37701,
+  CVE-2021-37712, CVE-2021-37713, CVE-2021-39134, CVE-2021-39135
+- Add config flag to use OpenSSL cert store instead of built-in Mozilla certs
+- Add script to remove vendored OpenSSL tree from source tarball
+- Add runtime requirement on ca-certificates for base package
+- Update require OpenSSL version to 1.1.1
+- Use python configure script directly
+- Enable a larger set of tests
+- Lint spec
+
+* Mon Aug 30 2021 Andrew Phelps <anphel@microsoft.com> - 14.17.5-1
+- Update to version 14.17.5 to fix CVE-2021-22931
+
+* Mon Jul 19 2021 Neha Agarwal <nehaagarwal@microsoft.com> - 14.17.2-1
+- Update to version 14.17.2 to fix CVE-2021-22918
+
+* Mon Jun 07 2021 Henry Beberman <henry.beberman@microsoft.com> - 14.17.0-1
+- Update to nodejs version 14.17.0
+
+* Sat May 09 2020 Nick Samson <nisamson@microsoft.com> - 9.11.2-7
+- Added %%license line automatically
+
+* Mon May 04 2020 Paul Monson <paulmon@microsoft.com> - 9.11.2-6
+- Add patch that enables building openssl without TLS versions less 1.2
+
+* Thu Apr 09 2020 Nicolas Ontiveros <niontive@microsoft.com> - 9.11.2-5
+- Remove toybox and only use coreutils for requires.
+
+* Wed Apr 08 2020 Pawel Winogrodzki <pawelwi@microsoft.com> - 9.11.2-4
+- License verified.
+- Removed "%%define sha1".
+
+* Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> - 9.11.2-3
+- Initial CBL-Mariner import from Photon (license: Apache2).
+
+* Tue Jan 08 2019 Alexey Makhalov <amakhalov@vmware.com> - 9.11.2-2
+- Added BuildRequires python2, which
+
+* Thu Sep 20 2018 Him Kalyan Bordoloi <bordoloih@vmware.com> - 9.11.2-1
+- Updated to version 9.11.2
+
+* Mon Sep 10 2018 Him Kalyan Bordoloi <bordoloih@vmware.com> - 9.9.0-1
+- Updated to version 9.9.0
+
+* Wed Feb 14 2018 Xiaolin Li <xiaolinl@vmware.com> - 8.3.0-1
+- Updated to version 8.3.0
+
+* Fri Oct 13 2017 Alexey Makhalov <amakhalov@vmware.com> - 7.7.4-4
+- Remove BuildArch
+
+* Mon Sep 18 2017 Alexey Makhalov <amakhalov@vmware.com> - 7.7.4-3
+- Requires coreutils or toybox
+
+* Fri Jul 14 2017 Chang Lee <changlee@vmware.com> - 7.7.4-2
+- Updated %check
+
+* Mon Mar 20 2017 Xiaolin Li <xiaolinl@vmware.com> - 7.7.4-1
+- Initial packaging for Photon
+

--- a/SPECS/nodejs/nodejs.spec
+++ b/SPECS/nodejs/nodejs.spec
@@ -3,9 +3,9 @@ Name:           nodejs
 Version:        14.18.1
 Release:        1%{?dist}
 License:        BSD and MIT and Public Domain and naist-2003
-Group:          Applications/System
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
+Group:          Applications/System
 URL:            https://github.com/nodejs/node
 # Source0 has a vendored OpenSSL source tree with patented algorithms.
 # Use Source1 to create a clean and reproducible source tarball.
@@ -143,4 +143,3 @@ done
 
 * Mon Mar 20 2017 Xiaolin Li <xiaolinl@vmware.com> - 7.7.4-1
 - Initial packaging for Photon
-

--- a/SPECS/nodejs/nodejs.spec
+++ b/SPECS/nodejs/nodejs.spec
@@ -1,8 +1,3 @@
-
-# WARNING: MUST check and update the 'npm_version' macro for every version update of this package.
-#           The version of NPM can be found inside the sources under 'deps/npm/package.json'.
-%define npm_version 6.14.15
-
 Summary:        A JavaScript runtime built on Chrome's V8 JavaScript engine.
 Name:           nodejs
 Version:        14.18.1
@@ -70,7 +65,8 @@ done
 # Run all tests, minus linter/doc tests
 %make_build test-only
 
-%ldconfig_scriptlets
+%post -p /sbin/ldconfig
+%postun -p /sbin/ldconfig
 
 %files
 %defattr(-,root,root)
@@ -87,7 +83,7 @@ done
 %{_datadir}/systemtap/tapset/node.stp
 
 %changelog
-* Tue Nov 09 2021 Thomas Crain <thcrain@microsoft.com> - 14.18.1-1
+* Thu Nov 18 2021 Thomas Crain <thcrain@microsoft.com> - 14.18.1-1
 - Update to version 14.18.1 to fix CVE-2021-22959, CVE-2021-22960, CVE-2021-37701,
   CVE-2021-37712, CVE-2021-37713, CVE-2021-39134, CVE-2021-39135
 - Add patch to remove problematic cipher from default list

--- a/SPECS/nodejs/nodejs.spec
+++ b/SPECS/nodejs/nodejs.spec
@@ -18,8 +18,6 @@ BuildRequires:  coreutils >= 8.22
 BuildRequires:  openssl-devel >= 1.1.1
 BuildRequires:  python3
 BuildRequires:  which
-# ca-certificates is needed to communicate with default npm registry
-Requires:       ca-certificates
 Requires:       coreutils >= 8.22
 Requires:       openssl >= 1.1.1
 Requires:       python3
@@ -88,7 +86,6 @@ make cctest
 - Add patch to remove problematic cipher from default list
 - Add config flag to use OpenSSL cert store instead of built-in Mozilla certs
 - Add script to remove vendored OpenSSL tree from source tarball
-- Add runtime requirement on ca-certificates for base package
 - Update required OpenSSL version to 1.1.1
 - Use python configure script directly
 - Lint spec

--- a/SPECS/nodejs/remove_unsupported_tlsv13_ciphers.patch
+++ b/SPECS/nodejs/remove_unsupported_tlsv13_ciphers.patch
@@ -1,0 +1,30 @@
+From bc1684951d93403cb8a4453ef0e4ce9b37c8c798 Mon Sep 17 00:00:00 2001
+From: Thomas Crain <thcrain@microsoft.com>
+Date: Thu, 18 Nov 2021 07:22:22 -0800
+Subject: [PATCH] Remove TLS_CHACHA20_POLY1305_SHA256 from default cipher list
+
+Mariner's OpenSSL configuration does not allow for this TLSv1.3
+cipher. OpenSSL does not like being asked to use TLSv1.3 ciphers
+it doesn't support (despite being fine processing similar cipher
+requests for TLS < 1.3). This cipher's presence in the default
+cipher list causes failures when initializing secure contexts
+in the context of Node's TLS library.
+---
+ src/node_constants.h | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/src/node_constants.h b/src/node_constants.h
+index d7de705f..750c00a1 100644
+--- a/src/node_constants.h
++++ b/src/node_constants.h
+@@ -48,7 +48,6 @@
+ //   https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_ciphersuites.html
+ #define DEFAULT_CIPHER_LIST_CORE \
+                                  "TLS_AES_256_GCM_SHA384:"          \
+-                                 "TLS_CHACHA20_POLY1305_SHA256:"    \
+                                  "TLS_AES_128_GCM_SHA256:"          \
+                                  "ECDHE-RSA-AES128-GCM-SHA256:"     \
+                                  "ECDHE-ECDSA-AES128-GCM-SHA256:"   \
+-- 
+2.25.1
+

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -4555,8 +4555,8 @@
         "type": "other",
         "other": {
           "name": "nodejs",
-          "version": "14.17.5",
-          "downloadUrl": "https://nodejs.org/download/release/v14.17.5/node-v14.17.5.tar.xz"
+          "version": "14.18.1",
+          "downloadUrl": "https://nodejs.org/download/release/v14.18.1/node-v14.18.1.tar.xz"
         }
       }
     },


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Upgrades nodejs to v14.18.1, the latest version of the v14 LTS branch. This fixes several CVEs, which are all linked further down.

An interaction between our OpenSSL configuration and Node's default cipher list was causing failures when creating secure contexts in the TLS library. The `TLS_CHACHA20_POLY1305_SHA256` ciphersuite is unsupported by our OpenSSL configuration, but is a default nodejs cipher. OpenSSL does not like being asked to use TLSv1.3 ciphersuites it does not support, so we remove this ciphersuite from the default cipher list. Note that this is not an issue with TLS <= v1.2 ciphers.

Node ships with a bundled OpenSSL source tree. This source tree contains patented code that we should not ship as part of the SRPM. We don't build with the bundled OpenSSL version, so we can safely remove it from the tarball shipped in the SRPM. This PR adds a script to clean the upstream tarball before being uploaded to our source blobstore.

Node was using bundled Mozilla CA certs instead of our OpenSSL CA cert store. This PR adds a configuration flag to use our distro's cert store instead.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Update to version 14.18.1 to fix CVE-2021-22959, CVE-2021-22960, CVE-2021-37701,
  CVE-2021-37712, CVE-2021-37713, CVE-2021-39134, CVE-2021-39135
- Add patch to remove problematic ciphersuite from default list
- Add config flag to use OpenSSL cert store instead of built-in Mozilla certs
- Add script to remove vendored OpenSSL tree from source tarball
- Update required OpenSSL version to 1.1.1
- Use python configure script directly
- Lint spec

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2021-22959
- https://nvd.nist.gov/vuln/detail/CVE-2021-22960
- https://nvd.nist.gov/vuln/detail/CVE-2021-37701
- https://nvd.nist.gov/vuln/detail/CVE-2021-37712
- https://nvd.nist.gov/vuln/detail/CVE-2021-37713
- https://nvd.nist.gov/vuln/detail/CVE-2021-39134
- https://nvd.nist.gov/vuln/detail/CVE-2021-39135

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build and test in custom image
