### PR TITLE
[dev] Add support for caching of remote sources

### DIFF
--- a/toolkit/Makefile
+++ b/toolkit/Makefile
@@ -33,6 +33,7 @@ TOOLCHAIN_CONTAINER_ARCHIVE     ?=
 TOOLCHAIN_ARCHIVE               ?=
 TOOLCHAIN_SOURCES_ARCHIVE       ?=
 CACHE_DIR                       ?=
+SOURCE_CACHE_DIR                ?= 
 PACKAGE_CACHE_SUMMARY           ?=
 IMAGE_CACHE_SUMMARY             ?=
 INITRD_CACHE_SUMMARY            ?=
@@ -162,7 +163,7 @@ include $(SCRIPTS_DIR)/toolchain.mk
 include $(SCRIPTS_DIR)/tools.mk
 
 # Create SRPMS from local SPECS with:
-#	input-srpms, clean-input-srpms
+#	input-srpms, clean-input-srpms, clean-source-cache
 include $(SCRIPTS_DIR)/srpm_pack.mk
 
 # Expand local SRPMS into sources and SPECS with:

--- a/toolkit/docs/building/building.md
+++ b/toolkit/docs/building/building.md
@@ -326,6 +326,7 @@ USE_UPDATE_REPO        ?= y
 DISABLE_UPSTREAM_REPOS ?= n
 TOOLCHAIN_ARCHIVE      ?=
 PACKAGE_ARCHIVE        ?=
+SOURCE_CACHE_DIR       ?=
 ```
 
 See [Local Build Variables](#local-build-variables) for details on what each variable does.
@@ -371,6 +372,10 @@ If that is not desired all remote sources can be disabled by clearing the follow
 #### `SOURCE_URL=...`
 
 > URL to download unavailable source files from when creating `*.src.rpm` files prior to build. Only one URL can be set at a time; there is no support for a list of multiple source URLs.
+
+#### `SOURCE_CACHE_DIR=...`
+
+> Path to a local folder for cached remote sources. The `srpmpacker` tool will search this directory before attempting to download sources remotely. The `srpmpacker` tool will copy remotely downloaded sources into this folder.
 
 #### `PACKAGE_URL_LIST=...`
 
@@ -513,6 +518,7 @@ These are the useful build targets:
 | chroot-tools                     | Create the chroot working from the toolchain RPMs.
 | clean                            | Clean all built files.
 | clean-*                          | Most targets have a `clean-<target>` target which selectively cleans the target's output.
+| clean-source-cache               | Deletes the source cache folder. Not invoked by the regular `clean` target.
 | compress-rpms                    | Compresses all RPMs in `../out/RPMS` into `../out/rpms.tar.gz`. See `hydrate-rpms` target.
 | compress-srpms                   | Compresses all SRPMs in `../out/SRPMS` into `../out/srpms.tar.gz`.
 | copy-toolchain-rpms              | Copy all toolchain RPMS from `../build/rpm_cache/cache` to  `../out/RPMS`.
@@ -645,6 +651,7 @@ To reproduce an ISO build, run the same make invocation as before, but set:
 | STOP_ON_WARNING               | n                                                                                                      | Stop on non-fatal makefile failures (see `$(call print_warning, message)`)
 | STOP_ON_PKG_FAIL              | n                                                                                                      | Stop all package builds on any failure rather than try and continue.
 | SRPM_FILE_SIGNATURE_HANDLING  | enforce                                                                                                | Behavior when checking source file hashes from SPEC files. `update` will create a new entry in the signature file (`enforce, skip, update`)
+| SOURCE_CACHE_DIR              | (empty)                                                                                                | Path to a local directory where remote sources will be cached for future use.
 | ARCHIVE_TOOL                  | $(shell if command -v pigz 1>/dev/null 2>&1 ; then echo pigz ; else echo gzip ; fi )                   | Default tool to use in conjunction with `tar` to extract `*.tar.gz` files. Tries to use `pigz` if available, otherwise uses `gzip`
 | INCREMENTAL_TOOLCHAIN         | n                                                                                                      | Only build toolchain RPM packages if they are not already present
 | RUN_CHECK                     | n                                                                                                      | Run the %check sections when compiling packages

--- a/toolkit/scripts/srpm_pack.mk
+++ b/toolkit/scripts/srpm_pack.mk
@@ -22,17 +22,22 @@ toolchain_spec_list = $(toolchain_build_dir)/toolchain_specs.txt
 $(call create_folder,$(BUILD_DIR))
 $(call create_folder,$(BUILD_SRPMS_DIR))
 $(call create_folder,$(BUILD_DIR)/SRPM_packaging)
+$(call create_folder,$(SOURCE_CACHE_DIR))
 
 # General targets
 .PHONY: toolchain-input-srpms input-srpms clean-input-srpms
 input-srpms: $(BUILD_SRPMS_DIR)
 toolchain-input-srpms: $(STATUS_FLAGS_DIR)/build_toolchain_srpms.flag
 
+# Main `clean` target deliberately does not include `clean-source-cache` as a dependency
+# The cache should persist through a `make clean` invocation
 clean: clean-input-srpms
 clean-input-srpms:
 	rm -rf $(BUILD_SRPMS_DIR)
 	rm -rf $(STATUS_FLAGS_DIR)/build_srpms.flag
 	rm -rf $(BUILD_DIR)/SRPM_packaging
+clean-source-cache:
+	rm -rf $(SOURCE_CACHE_DIR)
 
 # The directory freshness is tracked with a status flag. The status flag is only updated when all SRPMs have been
 # updated.
@@ -76,6 +81,7 @@ $(STATUS_FLAGS_DIR)/build_srpms.flag: $(chroot_worker) $(local_specs) $(local_sp
 		--build-dir=$(BUILD_DIR)/SRPM_packaging \
 		--signature-handling=$(SRPM_FILE_SIGNATURE_HANDLING) \
 		--worker-tar=$(chroot_worker) \
+		--source-cache-dir=$(SOURCE_CACHE_DIR) \
 		$(if $(filter y,$(RUN_CHECK)),--run-check) \
 		--log-file=$(LOGS_DIR)/pkggen/srpms/srpmpacker.log \
 		--log-level=$(LOG_LEVEL) && \
@@ -93,6 +99,7 @@ $(STATUS_FLAGS_DIR)/build_toolchain_srpms.flag: $(toolchain_spec_list) $(go-srpm
 		--build-dir=$(BUILD_DIR)/SRPM_packaging \
 		--signature-handling=$(SRPM_FILE_SIGNATURE_HANDLING) \
 		--pack-list=$(toolchain_spec_list) \
+		--source-cache-dir=$(SOURCE_CACHE_DIR) \
 		$(if $(filter y,$(RUN_CHECK)),--run-check) \
 		--log-file=$(LOGS_DIR)/toolchain/srpms/toolchain_srpmpacker.log \
 		--log-level=$(LOG_LEVEL) && \

--- a/toolkit/tools/srpmpacker/srpmpacker.go
+++ b/toolkit/tools/srpmpacker/srpmpacker.go
@@ -152,15 +152,9 @@ func main() {
 	}
 
 	// Setup remote source caching
-	if *sourceCacheDir != "" {
-		fileInfo, err := os.Stat(*sourceCacheDir)
-		if err != nil {
-			logger.Log.Fatalf("Received error getting information for source cache directory. Error: %v", err)
-		}
-		if !fileInfo.IsDir() {
-			logger.Log.Fatalf("Source cache directory (%s) is not a directory", *sourceCacheDir)
-		}
-		templateSrcConfig.localSourceCacheDir = *sourceCacheDir
+	templateSrcConfig.localSourceCacheDir = *sourceCacheDir
+	if *sourceCacheDir != "" && !file.IsDir(*sourceCacheDir) {
+		logger.Log.Fatalf("Source cache directory (%s) is not a directory", *sourceCacheDir)
 	}
 
 	// Setup remote source configuration


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Adds a `SOURCE_CACHE_DIR` make variable that can be used by the `srpmpacker` tool as (a) a local source directory and (b) a location to store remote sources.

I frequently switch between different git worktrees that corresponds to my different work items. I don't always have the best internet, which makes SRPM hydration slow (especially when larger source file downloads timeout intermittently). Having a source cache that persists through `make clean` invocations and is shared across multiple worktrees will greatly speed up my workflow.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add `SOURCE_CACHE_DIR` make variable and corresponding `clean-source-cache` target
- Update `srpmpacker` tool to use the source cache directory when retrieving local sources
- Update `srpmpacker` tool to copy remote sources to the source cache directory
- Update documentation to reflect the new make variables/targets

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Tested both storage and retrieval functionality across both toolchain and regular SRPM creation scenarios
