### PR TITLE
update libxcrypt required glibc version

### DIFF
--- a/SPECS/libxcrypt/libxcrypt.spec
+++ b/SPECS/libxcrypt/libxcrypt.spec
@@ -47,7 +47,7 @@
 # Required for proper ELF symbol versioning support.
 %global _ld_strict_symbol_defs 1
 # override_glibc and glibcversion are temporary to make libxcrypt install on top of glibc
-%define glibcversion 2.28
+%define glibcversion 2.34
 %bcond_without override_glibc
 # Build the static library?
 %bcond_with new_api
@@ -102,7 +102,7 @@
 Summary:        Extended crypt library for descrypt, md5crypt, bcrypt, and others
 Name:           libxcrypt
 Version:        4.4.17
-Release:        3%{?dist}
+Release:        4%{?dist}
 # For explicit license breakdown, see the
 # LICENSING file in the source tarball.
 License:        LGPLv2+ AND BSD AND Public Domain
@@ -452,6 +452,9 @@ ln -s %{_libdir}/libcrypt-%{glibcversion}.so %{_libdir}/libcrypt.so.1
 
 
 %changelog
+* Mon Nov 22 2021 Andrew Phelps <anphel@microsoft.com> - 4.4.17-4
+- Update required glibc version to 2.34
+
 * Sat Nov 21 2020 Thomas Crain <thcrain@microsoft.com> - 4.4.17-3
 - Replace %%ldconfig_scriptlets with actual post/postun sections
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Update libxcrypt.spec to require current version of glibc 2.34.
Fixes following error:
INFO[21250] Blocked SRPMs: 
INFO[21250] --> libxcrypt-4.4.17-3.cm2.src.rpm 
INFO[21250] Unresolved dependencies: 
INFO[21250] --> glibc 
INFO[21250] --> glibc-devel 


###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change libxcrypt to require glibc version 2.34

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build
