### PR TITLE
[workaround] `pcsc-lite-ccid`: disabling `Provides: bundled(simclist)`.

### DIFF
--- a/SPECS/pcsc-lite-ccid/pcsc-lite-ccid.spec
+++ b/SPECS/pcsc-lite-ccid/pcsc-lite-ccid.spec
@@ -1,9 +1,11 @@
+%define bundled_conflicts 1
 %global dropdir %(pkg-config libpcsclite --variable usbdropdir 2>/dev/null)
 %global pcsc_lite_ver 1.8.9
+
 Summary:        Generic USB CCID smart card reader driver
 Name:           pcsc-lite-ccid
 Version:        1.4.33
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        LGPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -22,8 +24,14 @@ Provides:       pcsc-ifd-handler
 # Provide upgrade path from 'ccid' package
 Obsoletes:      ccid < 1.4.0-3
 Provides:       ccid = %{version}-%{release}
+
+# Workaround for package build issues in CBL-Mariner where this build ordering issues with "pcsc-lite".
+# We want to keep the 'Provides' around for the sake of easier security vulnerability detection.
+# See Fedora's bundling guidelines for more insight: https://docs.fedoraproject.org/en-US/packaging-guidelines/#bundling
+%if ! 0%{?bundled_conflicts}
 # This is bundled from pcsc-lite upstream
 Provides:       bundled(simclist) = 1.6
+%endif
 
 %description
 Generic USB CCID (Chip/Smart Card Interface Devices) driver for use with the
@@ -58,6 +66,9 @@ cp -p src/openct/LICENSE LICENSE.openct
 %config(noreplace) %{_sysconfdir}/reader.conf.d/libccidtwin
 
 %changelog
+* Tue Nov 23 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.4.33-4
+- Disabling 'Provides = bundled(simclist) = 1.6' as a workaround for package build issues.
+
 * Wed Oct 27 2021 Pawel Winogrodzki <pawel.winogrodzki@microsoft.com> - 1.4.33-3
 - Removing invalid "BuildRequires".
 - Fixing the "Release" tag.

--- a/SPECS/pcsc-lite-ccid/pcsc-lite-ccid.spec
+++ b/SPECS/pcsc-lite-ccid/pcsc-lite-ccid.spec
@@ -25,7 +25,7 @@ Provides:       pcsc-ifd-handler
 Obsoletes:      ccid < 1.4.0-3
 Provides:       ccid = %{version}-%{release}
 
-# Workaround for package build issues in CBL-Mariner where this build ordering issues with "pcsc-lite".
+# Workaround for package build issues in CBL-Mariner where this creates ordering issues with "pcsc-lite".
 # We want to keep the 'Provides' around for the sake of easier security vulnerability detection.
 # See Fedora's bundling guidelines for more insight: https://docs.fedoraproject.org/en-US/packaging-guidelines/#bundling
 %if ! 0%{?bundled_conflicts}


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

Currently our build tooling is having issues with multiple packages providing the same version of `bundled(simclist)` and while we're waiting for the fix, we need to add this workaround.

Nothing is expected to ever require `bundled(simclist)` - that would probably be an invalid configuration, since `simclist` is compiled into the project, but is not exposed externally by the project's APIs/libraries. The `Provides` is there to make it easier to find packages, which would require an update in case a CVE is ever created against `simclist`.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Disabled `Provides: bundled(simclist)` by hiding it behind an always-off macro.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- None, simple .spec change, no build-time effect.
