### PR TITLE
[dev] pgbouncer: bump version to fix CVE-2021-3935

### DIFF
--- a/SPECS/pgbouncer/pgbouncer.signatures.json
+++ b/SPECS/pgbouncer/pgbouncer.signatures.json
@@ -1,6 +1,6 @@
 {
  "Signatures": {
-  "pgbouncer-1.11.0.tar.gz": "84802fa48a2806c53675764ce10a8b6e4733f196eb23e1aa4b954dcbe7287e70",
+  "pgbouncer-1.16.1.tar.gz": "087477e9e4766d032b04b7b006c0c8d64160a54141a7bfc2c6e5ae7ae11bf7fc",
   "pgbouncer.service": "9c158af014827b4b96577caacce1d5fbf1e186ebb481c96f4f071a0f05425fe1"
  }
 }

--- a/SPECS/pgbouncer/pgbouncer.spec
+++ b/SPECS/pgbouncer/pgbouncer.spec
@@ -1,7 +1,7 @@
 Summary:	Connection pooler for PostgreSQL.
 Name:		pgbouncer
-Version:	1.11.0
-Release:	2%{?dist}
+Version:	1.16.1
+Release:	1%{?dist}
 License:	ISC License
 URL:		https://www.pgbouncer.org/
 Source0:	https://%{name}.github.io/downloads/files/%{version}/%{name}-%{version}.tar.gz
@@ -80,26 +80,38 @@ fi
 /usr/share/doc/pgbouncer/*
 
 %changelog
+* Sun Nov 28 2021 Muhammad Falak <mwani@microsoft.com> - 1.16.1-1
+- Bump version to fix CVE-2021-3935
+
 * Sat May 09 2020 Nick Samson <nisamson@microsoft.com> - 1.11.0-2
 - Added %%license line automatically
 
-*   Fri Mar 13 2020 Paul Monson <paulmon@microsoft.com> 1.11.0-1
--   Update to version 1.11.0. License verified.
-*   Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 1.9.0-2
--   Initial CBL-Mariner import from Photon (license: Apache2).
-*   Fri Sep 21 2018 Dweep Advani <dadvani@vmware.com> 1.9.0-1
--   Updated to version 1.9.0
-*   Mon Sep 18 2017 Alexey Makhalov <amakhalov@vmware.com> 1.7.2-7
--   Remove shadow from requires and use explicit tools for post actions
-*   Mon Jul 24 2017 Dheeraj Shetty <dheerajs@vmware.com> 1.7.2-6
--   Seperate the service file from the spec file
-*   Wed May 31 2017 Rongrong Qiu <rqiu@vmware.com> 1.7.2-5
--   Add RuntimeDirectory and Type=forking
-*   Thu Apr 13 2017 Harish Udaiya Kumar <hudaiyakumar@vmware.com> 1.7.2-4
--   Fixed the requires.
-*   Tue May 24 2016 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 1.7.2-3
--   GA - Bump release of all rpms
-*   Wed May 04 2016 Anish Swaminathan <anishs@vmware.com> 1.7.2-2
--   Edit scriptlets.
-*   Thu Apr 28 2016 Kumar Kaushik <kaushikk@vmware.com> 1.7.2-1
--   Initial Version.
+* Fri Mar 13 2020 Paul Monson <paulmon@microsoft.com> 1.11.0-1
+- Update to version 1.11.0. License verified.
+
+* Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 1.9.0-2
+- Initial CBL-Mariner import from Photon (license: Apache2).
+
+* Fri Sep 21 2018 Dweep Advani <dadvani@vmware.com> 1.9.0-1
+- Updated to version 1.9.0
+
+* Mon Sep 18 2017 Alexey Makhalov <amakhalov@vmware.com> 1.7.2-7
+- Remove shadow from requires and use explicit tools for post actions
+
+* Mon Jul 24 2017 Dheeraj Shetty <dheerajs@vmware.com> 1.7.2-6
+- Seperate the service file from the spec file
+
+* Wed May 31 2017 Rongrong Qiu <rqiu@vmware.com> 1.7.2-5
+- Add RuntimeDirectory and Type=forking
+
+* Thu Apr 13 2017 Harish Udaiya Kumar <hudaiyakumar@vmware.com> 1.7.2-4
+- Fixed the requires.
+
+* Tue May 24 2016 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 1.7.2-3
+- GA - Bump release of all rpms
+
+* Wed May 04 2016 Anish Swaminathan <anishs@vmware.com> 1.7.2-2
+- Edit scriptlets.
+
+* Thu Apr 28 2016 Kumar Kaushik <kaushikk@vmware.com> 1.7.2-1
+- Initial Version.

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -5802,8 +5802,8 @@
         "type": "other",
         "other": {
           "name": "pgbouncer",
-          "version": "1.11.0",
-          "downloadUrl": "https://pgbouncer.github.io/downloads/files/1.11.0/pgbouncer-1.11.0.tar.gz"
+          "version": "1.16.1",
+          "downloadUrl": "https://pgbouncer.github.io/downloads/files/1.16.1/pgbouncer-1.16.1.tar.gz"
         }
       }
     },


### PR DESCRIPTION
- pgbouncer: bump version to fix CVE-2021-3935
- cgmanifest: pgbouncer: bump version 1.11.0 -> 1.16.1

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?

- Bump version 1.11.0 -> 1.16.1 to fix CVE-2021-3935
- It's a `cherry-pick` of #1686

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Bump version 1.11.0 -> 1.16.1

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- NA

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2021-3935

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local Build with `RUN_CHECK=y`
