### PR TITLE
[dev] Prune unnecessary toolchain packages

### DIFF
--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -172,7 +172,6 @@ openssl-static-1.1.1k-5.cm2.aarch64.rpm
 openssl-debuginfo-1.1.1k-5.cm2.aarch64.rpm
 libcap-2.26-2.cm2.aarch64.rpm
 libcap-devel-2.26-2.cm2.aarch64.rpm
-libcap-ng-0.7.9-4.cm2.aarch64.rpm
 libdb-5.3.28-5.cm2.aarch64.rpm
 libdb-devel-5.3.28-5.cm2.aarch64.rpm
 libdb-docs-5.3.28-5.cm2.aarch64.rpm
@@ -234,7 +233,6 @@ dwz-0.13-4.cm2.aarch64.rpm
 unzip-6.0-19.cm2.aarch64.rpm
 python3-3.7.10-3.cm2.aarch64.rpm
 python3-devel-3.7.10-3.cm2.aarch64.rpm
-python3-libcap-ng-0.7.9-4.cm2.aarch64.rpm
 python3-libs-3.7.10-3.cm2.aarch64.rpm
 python3-setuptools-3.7.10-3.cm2.noarch.rpm
 python3-xml-3.7.10-3.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -188,6 +188,7 @@ libsolv-0.7.19-1.cm2.aarch64.rpm
 libsolv-devel-0.7.19-1.cm2.aarch64.rpm
 libssh2-1.9.0-1.cm2.aarch64.rpm
 libssh2-devel-1.9.0-1.cm2.aarch64.rpm
+krb5-1.18-1.cm2.aarch64.rpm
 curl-7.76.0-5.cm2.aarch64.rpm
 curl-devel-7.76.0-5.cm2.aarch64.rpm
 curl-libs-7.76.0-5.cm2.aarch64.rpm
@@ -204,7 +205,6 @@ libltdl-2.4.6-7.cm2.aarch64.rpm
 libltdl-devel-2.4.6-7.cm2.aarch64.rpm
 pcre-8.44-3.cm2.aarch64.rpm
 pcre-libs-8.44-3.cm2.aarch64.rpm
-krb5-1.18-1.cm2.aarch64.rpm
 lua-5.3.5-11.cm2.aarch64.rpm
 lua-libs-5.3.5-11.cm2.aarch64.rpm
 mariner-rpm-macros-2.0-7.cm2.noarch.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -172,7 +172,6 @@ openssl-static-1.1.1k-5.cm2.x86_64.rpm
 openssl-debuginfo-1.1.1k-5.cm2.x86_64.rpm
 libcap-2.26-2.cm2.x86_64.rpm
 libcap-devel-2.26-2.cm2.x86_64.rpm
-libcap-ng-0.7.9-4.cm2.x86_64.rpm
 libdb-5.3.28-5.cm2.x86_64.rpm
 libdb-devel-5.3.28-5.cm2.x86_64.rpm
 libdb-docs-5.3.28-5.cm2.x86_64.rpm
@@ -234,7 +233,6 @@ dwz-0.13-4.cm2.x86_64.rpm
 unzip-6.0-19.cm2.x86_64.rpm
 python3-3.7.10-3.cm2.x86_64.rpm
 python3-devel-3.7.10-3.cm2.x86_64.rpm
-python3-libcap-ng-0.7.9-4.cm2.x86_64.rpm
 python3-libs-3.7.10-3.cm2.x86_64.rpm
 python3-setuptools-3.7.10-3.cm2.noarch.rpm
 python3-xml-3.7.10-3.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -188,6 +188,7 @@ libsolv-0.7.19-1.cm2.x86_64.rpm
 libsolv-devel-0.7.19-1.cm2.x86_64.rpm
 libssh2-1.9.0-1.cm2.x86_64.rpm
 libssh2-devel-1.9.0-1.cm2.x86_64.rpm
+krb5-1.18-1.cm2.x86_64.rpm
 curl-7.76.0-5.cm2.x86_64.rpm
 curl-devel-7.76.0-5.cm2.x86_64.rpm
 curl-libs-7.76.0-5.cm2.x86_64.rpm
@@ -204,7 +205,6 @@ libltdl-2.4.6-7.cm2.x86_64.rpm
 libltdl-devel-2.4.6-7.cm2.x86_64.rpm
 pcre-8.44-3.cm2.x86_64.rpm
 pcre-libs-8.44-3.cm2.x86_64.rpm
-krb5-1.18-1.cm2.x86_64.rpm
 lua-5.3.5-11.cm2.x86_64.rpm
 lua-libs-5.3.5-11.cm2.x86_64.rpm
 mariner-rpm-macros-2.0-7.cm2.noarch.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -125,8 +125,6 @@ gpgme-devel-1.16.0-1.cm2.aarch64.rpm
 grep-3.7-1.cm2.aarch64.rpm
 grep-debuginfo-3.7-1.cm2.aarch64.rpm
 grep-lang-3.7-1.cm2.aarch64.rpm
-groff-1.22.3-7.cm2.aarch64.rpm
-groff-debuginfo-1.22.3-7.cm2.aarch64.rpm
 gtest-1.8.1-5.cm2.aarch64.rpm
 gtest-debuginfo-1.8.1-5.cm2.aarch64.rpm
 gtest-devel-1.8.1-5.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -359,7 +359,6 @@ perl-File-Fetch-0.56-463.cm2.noarch.rpm
 perl-File-Find-1.37-463.cm2.noarch.rpm
 perl-File-Path-2.16-463.cm2.noarch.rpm
 perl-File-Temp-0.230.900-463.cm2.noarch.rpm
-perl-File-Which-1.22-6.cm2.noarch.rpm
 perl-File-stat-1.09-463.cm2.noarch.rpm
 perl-FileCache-1.10-463.cm2.noarch.rpm
 perl-FileHandle-2.03-463.cm2.noarch.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -134,9 +134,6 @@ gzip-1.11-1.cm2.aarch64.rpm
 gzip-debuginfo-1.11-1.cm2.aarch64.rpm
 intltool-0.51.0-7.cm2.noarch.rpm
 itstool-2.0.6-4.cm2.noarch.rpm
-json-c-0.14-3.cm2.aarch64.rpm
-json-c-debuginfo-0.14-3.cm2.aarch64.rpm
-json-c-devel-0.14-3.cm2.aarch64.rpm
 kbd-2.2.0-1.cm2.aarch64.rpm
 kbd-debuginfo-2.2.0-1.cm2.aarch64.rpm
 kernel-headers-5.10.74.1-4.cm2.noarch.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -161,9 +161,6 @@ libassuan-devel-2.5.5-1.cm2.aarch64.rpm
 libcap-2.26-2.cm2.aarch64.rpm
 libcap-debuginfo-2.26-2.cm2.aarch64.rpm
 libcap-devel-2.26-2.cm2.aarch64.rpm
-libcap-ng-0.7.9-4.cm2.aarch64.rpm
-libcap-ng-debuginfo-0.7.9-4.cm2.aarch64.rpm
-libcap-ng-devel-0.7.9-4.cm2.aarch64.rpm
 libdb-5.3.28-5.cm2.aarch64.rpm
 libdb-debuginfo-5.3.28-5.cm2.aarch64.rpm
 libdb-devel-5.3.28-5.cm2.aarch64.rpm
@@ -529,7 +526,6 @@ python3-curses-3.7.10-3.cm2.aarch64.rpm
 python3-debuginfo-3.7.10-3.cm2.aarch64.rpm
 python3-devel-3.7.10-3.cm2.aarch64.rpm
 python3-gpg-1.16.0-1.cm2.aarch64.rpm
-python3-libcap-ng-0.7.9-4.cm2.aarch64.rpm
 python3-libs-3.7.10-3.cm2.aarch64.rpm
 python3-libxml2-2.9.12-2.cm2.aarch64.rpm
 python3-magic-5.40-1.cm2.noarch.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -186,9 +186,6 @@ libltdl-2.4.6-7.cm2.aarch64.rpm
 libltdl-devel-2.4.6-7.cm2.aarch64.rpm
 libmpc-1.2.1-1.cm2.aarch64.rpm
 libmpc-debuginfo-1.2.1-1.cm2.aarch64.rpm
-libnsl2-1.2.0-5.cm2.aarch64.rpm
-libnsl2-debuginfo-1.2.0-5.cm2.aarch64.rpm
-libnsl2-devel-1.2.0-5.cm2.aarch64.rpm
 libpipeline-1.5.0-5.cm2.aarch64.rpm
 libpipeline-debuginfo-1.5.0-5.cm2.aarch64.rpm
 libpipeline-devel-1.5.0-5.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -357,7 +357,6 @@ perl-File-Copy-2.34-463.cm2.noarch.rpm
 perl-File-DosGlob-1.12-463.cm2.aarch64.rpm
 perl-File-Fetch-0.56-463.cm2.noarch.rpm
 perl-File-Find-1.37-463.cm2.noarch.rpm
-perl-File-HomeDir-1.004-6.cm2.noarch.rpm
 perl-File-Path-2.16-463.cm2.noarch.rpm
 perl-File-Temp-0.230.900-463.cm2.noarch.rpm
 perl-File-Which-1.22-6.cm2.noarch.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -144,9 +144,6 @@ krb5-1.18-1.cm2.aarch64.rpm
 krb5-debuginfo-1.18-1.cm2.aarch64.rpm
 krb5-devel-1.18-1.cm2.aarch64.rpm
 krb5-lang-1.18-1.cm2.aarch64.rpm
-libaio-0.3.112-3.cm2.aarch64.rpm
-libaio-debuginfo-0.3.112-3.cm2.aarch64.rpm
-libaio-devel-0.3.112-3.cm2.aarch64.rpm
 libarchive-3.4.2-3.cm2.aarch64.rpm
 libarchive-debuginfo-3.4.2-3.cm2.aarch64.rpm
 libarchive-devel-3.4.2-3.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -302,11 +302,6 @@ perl-Compress-Raw-Bzip2-2.093-463.cm2.aarch64.rpm
 perl-Compress-Raw-Zlib-2.093-463.cm2.aarch64.rpm
 perl-Config-Extensions-0.03-463.cm2.noarch.rpm
 perl-Config-Perl-V-0.32-463.cm2.noarch.rpm
-perl-DBD-SQLite-1.62-4.cm2.aarch64.rpm
-perl-DBD-SQLite-debuginfo-1.62-4.cm2.aarch64.rpm
-perl-DBI-1.641-4.cm2.aarch64.rpm
-perl-DBI-debuginfo-1.641-4.cm2.aarch64.rpm
-perl-DBIx-Simple-1.37-3.cm2.noarch.rpm
 perl-DBM_Filter-0.06-463.cm2.noarch.rpm
 perl-DB_File-1.853-463.cm2.aarch64.rpm
 perl-Data-Dumper-2.174-463.cm2.aarch64.rpm
@@ -386,7 +381,6 @@ perl-NEXT-0.67-463.cm2.noarch.rpm
 perl-Net-1.02-463.cm2.noarch.rpm
 perl-Net-Ping-2.72-463.cm2.noarch.rpm
 perl-ODBM_File-1.16-463.cm2.aarch64.rpm
-perl-Object-Accessor-0.48-7.cm2.noarch.rpm
 perl-Opcode-1.47-463.cm2.aarch64.rpm
 perl-POSIX-1.94-463.cm2.aarch64.rpm
 perl-Params-Check-0.38-463.cm2.noarch.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -117,7 +117,6 @@ gmp-debuginfo-6.2.1-2.cm2.aarch64.rpm
 gmp-devel-6.2.1-2.cm2.aarch64.rpm
 gnupg2-2.3.3-1.cm2.aarch64.rpm
 gnupg2-debuginfo-2.3.3-1.cm2.aarch64.rpm
-golang-1.17.1-1.cm2.aarch64.rpm
 gperf-3.1-3.cm2.aarch64.rpm
 gperf-debuginfo-3.1-3.cm2.aarch64.rpm
 gpgme-1.16.0-1.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -529,9 +529,6 @@ python3-xml-3.7.10-3.cm2.aarch64.rpm
 readline-7.0-5.cm2.aarch64.rpm
 readline-debuginfo-7.0-5.cm2.aarch64.rpm
 readline-devel-7.0-5.cm2.aarch64.rpm
-rpcsvc-proto-1.4-4.cm2.aarch64.rpm
-rpcsvc-proto-debuginfo-1.4-4.cm2.aarch64.rpm
-rpcsvc-proto-devel-1.4-4.cm2.aarch64.rpm
 rpm-4.14.2.1-4.cm2.aarch64.rpm
 rpm-build-4.14.2.1-4.cm2.aarch64.rpm
 rpm-build-libs-4.14.2.1-4.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -214,9 +214,6 @@ libstdc++-devel-11.2.0-1.cm2.aarch64.rpm
 libtasn1-4.14-3.cm2.aarch64.rpm
 libtasn1-debuginfo-4.14-3.cm2.aarch64.rpm
 libtasn1-devel-4.14-3.cm2.aarch64.rpm
-libtirpc-1.3.2-1.cm2.aarch64.rpm
-libtirpc-debuginfo-1.3.2-1.cm2.aarch64.rpm
-libtirpc-devel-1.3.2-1.cm2.aarch64.rpm
 libtool-2.4.6-7.cm2.aarch64.rpm
 libtool-debuginfo-2.4.6-7.cm2.aarch64.rpm
 libxml2-2.9.12-2.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -191,9 +191,6 @@ libpipeline-debuginfo-1.5.0-5.cm2.aarch64.rpm
 libpipeline-devel-1.5.0-5.cm2.aarch64.rpm
 libpkgconf-1.7.0-3.cm2.aarch64.rpm
 libpkgconf-devel-1.7.0-3.cm2.aarch64.rpm
-libpwquality-1.4.2-6.cm2.aarch64.rpm
-libpwquality-debuginfo-1.4.2-6.cm2.aarch64.rpm
-libpwquality-devel-1.4.2-6.cm2.aarch64.rpm
 libselinux-3.2-1.cm2.aarch64.rpm
 libselinux-debuginfo-3.2-1.cm2.aarch64.rpm
 libselinux-devel-3.2-1.cm2.aarch64.rpm
@@ -520,7 +517,6 @@ python3-libs-3.7.10-3.cm2.aarch64.rpm
 python3-libxml2-2.9.12-2.cm2.aarch64.rpm
 python3-magic-5.40-1.cm2.noarch.rpm
 python3-pip-3.7.10-3.cm2.noarch.rpm
-python3-pwquality-1.4.2-6.cm2.aarch64.rpm
 python3-rpm-4.14.2.1-4.cm2.aarch64.rpm
 python3-setuptools-3.7.10-3.cm2.noarch.rpm
 python3-test-3.7.10-3.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -359,7 +359,6 @@ perl-File-Fetch-0.56-463.cm2.noarch.rpm
 perl-File-Find-1.37-463.cm2.noarch.rpm
 perl-File-Path-2.16-463.cm2.noarch.rpm
 perl-File-Temp-0.230.900-463.cm2.noarch.rpm
-perl-File-Which-1.22-6.cm2.noarch.rpm
 perl-File-stat-1.09-463.cm2.noarch.rpm
 perl-FileCache-1.10-463.cm2.noarch.rpm
 perl-FileHandle-2.03-463.cm2.noarch.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -529,9 +529,6 @@ python3-xml-3.7.10-3.cm2.x86_64.rpm
 readline-7.0-5.cm2.x86_64.rpm
 readline-debuginfo-7.0-5.cm2.x86_64.rpm
 readline-devel-7.0-5.cm2.x86_64.rpm
-rpcsvc-proto-1.4-4.cm2.x86_64.rpm
-rpcsvc-proto-debuginfo-1.4-4.cm2.x86_64.rpm
-rpcsvc-proto-devel-1.4-4.cm2.x86_64.rpm
 rpm-4.14.2.1-4.cm2.x86_64.rpm
 rpm-build-4.14.2.1-4.cm2.x86_64.rpm
 rpm-build-libs-4.14.2.1-4.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -302,11 +302,6 @@ perl-Compress-Raw-Bzip2-2.093-463.cm2.x86_64.rpm
 perl-Compress-Raw-Zlib-2.093-463.cm2.x86_64.rpm
 perl-Config-Extensions-0.03-463.cm2.noarch.rpm
 perl-Config-Perl-V-0.32-463.cm2.noarch.rpm
-perl-DBD-SQLite-1.62-4.cm2.x86_64.rpm
-perl-DBD-SQLite-debuginfo-1.62-4.cm2.x86_64.rpm
-perl-DBI-1.641-4.cm2.x86_64.rpm
-perl-DBI-debuginfo-1.641-4.cm2.x86_64.rpm
-perl-DBIx-Simple-1.37-3.cm2.noarch.rpm
 perl-DBM_Filter-0.06-463.cm2.noarch.rpm
 perl-DB_File-1.853-463.cm2.x86_64.rpm
 perl-Data-Dumper-2.174-463.cm2.x86_64.rpm
@@ -386,7 +381,6 @@ perl-NEXT-0.67-463.cm2.noarch.rpm
 perl-Net-1.02-463.cm2.noarch.rpm
 perl-Net-Ping-2.72-463.cm2.noarch.rpm
 perl-ODBM_File-1.16-463.cm2.x86_64.rpm
-perl-Object-Accessor-0.48-7.cm2.noarch.rpm
 perl-Opcode-1.47-463.cm2.x86_64.rpm
 perl-POSIX-1.94-463.cm2.x86_64.rpm
 perl-Params-Check-0.38-463.cm2.noarch.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -357,7 +357,6 @@ perl-File-Copy-2.34-463.cm2.noarch.rpm
 perl-File-DosGlob-1.12-463.cm2.x86_64.rpm
 perl-File-Fetch-0.56-463.cm2.noarch.rpm
 perl-File-Find-1.37-463.cm2.noarch.rpm
-perl-File-HomeDir-1.004-6.cm2.noarch.rpm
 perl-File-Path-2.16-463.cm2.noarch.rpm
 perl-File-Temp-0.230.900-463.cm2.noarch.rpm
 perl-File-Which-1.22-6.cm2.noarch.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -191,9 +191,6 @@ libpipeline-debuginfo-1.5.0-5.cm2.x86_64.rpm
 libpipeline-devel-1.5.0-5.cm2.x86_64.rpm
 libpkgconf-1.7.0-3.cm2.x86_64.rpm
 libpkgconf-devel-1.7.0-3.cm2.x86_64.rpm
-libpwquality-1.4.2-6.cm2.x86_64.rpm
-libpwquality-debuginfo-1.4.2-6.cm2.x86_64.rpm
-libpwquality-devel-1.4.2-6.cm2.x86_64.rpm
 libselinux-3.2-1.cm2.x86_64.rpm
 libselinux-debuginfo-3.2-1.cm2.x86_64.rpm
 libselinux-devel-3.2-1.cm2.x86_64.rpm
@@ -520,7 +517,6 @@ python3-libs-3.7.10-3.cm2.x86_64.rpm
 python3-libxml2-2.9.12-2.cm2.x86_64.rpm
 python3-magic-5.40-1.cm2.noarch.rpm
 python3-pip-3.7.10-3.cm2.noarch.rpm
-python3-pwquality-1.4.2-6.cm2.x86_64.rpm
 python3-rpm-4.14.2.1-4.cm2.x86_64.rpm
 python3-setuptools-3.7.10-3.cm2.noarch.rpm
 python3-test-3.7.10-3.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -186,9 +186,6 @@ libltdl-2.4.6-7.cm2.x86_64.rpm
 libltdl-devel-2.4.6-7.cm2.x86_64.rpm
 libmpc-1.2.1-1.cm2.x86_64.rpm
 libmpc-debuginfo-1.2.1-1.cm2.x86_64.rpm
-libnsl2-1.2.0-5.cm2.x86_64.rpm
-libnsl2-debuginfo-1.2.0-5.cm2.x86_64.rpm
-libnsl2-devel-1.2.0-5.cm2.x86_64.rpm
 libpipeline-1.5.0-5.cm2.x86_64.rpm
 libpipeline-debuginfo-1.5.0-5.cm2.x86_64.rpm
 libpipeline-devel-1.5.0-5.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -144,9 +144,6 @@ krb5-1.18-1.cm2.x86_64.rpm
 krb5-debuginfo-1.18-1.cm2.x86_64.rpm
 krb5-devel-1.18-1.cm2.x86_64.rpm
 krb5-lang-1.18-1.cm2.x86_64.rpm
-libaio-0.3.112-3.cm2.x86_64.rpm
-libaio-debuginfo-0.3.112-3.cm2.x86_64.rpm
-libaio-devel-0.3.112-3.cm2.x86_64.rpm
 libarchive-3.4.2-3.cm2.x86_64.rpm
 libarchive-debuginfo-3.4.2-3.cm2.x86_64.rpm
 libarchive-devel-3.4.2-3.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -134,9 +134,6 @@ gzip-1.11-1.cm2.x86_64.rpm
 gzip-debuginfo-1.11-1.cm2.x86_64.rpm
 intltool-0.51.0-7.cm2.noarch.rpm
 itstool-2.0.6-4.cm2.noarch.rpm
-json-c-0.14-3.cm2.x86_64.rpm
-json-c-debuginfo-0.14-3.cm2.x86_64.rpm
-json-c-devel-0.14-3.cm2.x86_64.rpm
 kbd-2.2.0-1.cm2.x86_64.rpm
 kbd-debuginfo-2.2.0-1.cm2.x86_64.rpm
 kernel-headers-5.10.74.1-4.cm2.noarch.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -214,9 +214,6 @@ libstdc++-devel-11.2.0-1.cm2.x86_64.rpm
 libtasn1-4.14-3.cm2.x86_64.rpm
 libtasn1-debuginfo-4.14-3.cm2.x86_64.rpm
 libtasn1-devel-4.14-3.cm2.x86_64.rpm
-libtirpc-1.3.2-1.cm2.x86_64.rpm
-libtirpc-debuginfo-1.3.2-1.cm2.x86_64.rpm
-libtirpc-devel-1.3.2-1.cm2.x86_64.rpm
 libtool-2.4.6-7.cm2.x86_64.rpm
 libtool-debuginfo-2.4.6-7.cm2.x86_64.rpm
 libxml2-2.9.12-2.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -117,7 +117,6 @@ gmp-debuginfo-6.2.1-2.cm2.x86_64.rpm
 gmp-devel-6.2.1-2.cm2.x86_64.rpm
 gnupg2-2.3.3-1.cm2.x86_64.rpm
 gnupg2-debuginfo-2.3.3-1.cm2.x86_64.rpm
-golang-1.17.1-1.cm2.x86_64.rpm
 gperf-3.1-3.cm2.x86_64.rpm
 gperf-debuginfo-3.1-3.cm2.x86_64.rpm
 gpgme-1.16.0-1.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -125,8 +125,6 @@ gpgme-devel-1.16.0-1.cm2.x86_64.rpm
 grep-3.7-1.cm2.x86_64.rpm
 grep-debuginfo-3.7-1.cm2.x86_64.rpm
 grep-lang-3.7-1.cm2.x86_64.rpm
-groff-1.22.3-7.cm2.x86_64.rpm
-groff-debuginfo-1.22.3-7.cm2.x86_64.rpm
 gtest-1.8.1-5.cm2.x86_64.rpm
 gtest-debuginfo-1.8.1-5.cm2.x86_64.rpm
 gtest-devel-1.8.1-5.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -161,9 +161,6 @@ libassuan-devel-2.5.5-1.cm2.x86_64.rpm
 libcap-2.26-2.cm2.x86_64.rpm
 libcap-debuginfo-2.26-2.cm2.x86_64.rpm
 libcap-devel-2.26-2.cm2.x86_64.rpm
-libcap-ng-0.7.9-4.cm2.x86_64.rpm
-libcap-ng-debuginfo-0.7.9-4.cm2.x86_64.rpm
-libcap-ng-devel-0.7.9-4.cm2.x86_64.rpm
 libdb-5.3.28-5.cm2.x86_64.rpm
 libdb-debuginfo-5.3.28-5.cm2.x86_64.rpm
 libdb-devel-5.3.28-5.cm2.x86_64.rpm
@@ -529,7 +526,6 @@ python3-curses-3.7.10-3.cm2.x86_64.rpm
 python3-debuginfo-3.7.10-3.cm2.x86_64.rpm
 python3-devel-3.7.10-3.cm2.x86_64.rpm
 python3-gpg-1.16.0-1.cm2.x86_64.rpm
-python3-libcap-ng-0.7.9-4.cm2.x86_64.rpm
 python3-libs-3.7.10-3.cm2.x86_64.rpm
 python3-libxml2-2.9.12-2.cm2.x86_64.rpm
 python3-magic-5.40-1.cm2.noarch.rpm

--- a/toolkit/resources/manifests/package/update_manifests.sh
+++ b/toolkit/resources/manifests/package/update_manifests.sh
@@ -191,7 +191,6 @@ remove_packages_for_pkggen_core () {
     sed -i '/python3-libxml2/d' $TmpPkgGen
     sed -i '/python3-magic/d' $TmpPkgGen
     sed -i '/python3-pip/d' $TmpPkgGen
-    sed -i '/python3-pwquality/d' $TmpPkgGen
     sed -i '/python3-rpm/d' $TmpPkgGen
     sed -i '/python3-test/d' $TmpPkgGen
     sed -i '/python3-tools/d' $TmpPkgGen

--- a/toolkit/resources/manifests/package/update_manifests.sh
+++ b/toolkit/resources/manifests/package/update_manifests.sh
@@ -111,7 +111,6 @@ remove_packages_for_pkggen_core () {
     sed -i '/perl-File-Dos/d' $TmpPkgGen
     sed -i '/perl-File-Fetch/d' $TmpPkgGen
     sed -i '/perl-File-Find/d' $TmpPkgGen
-    sed -i '/perl-File-Which/d' $TmpPkgGen
     sed -i '/perl-FileCache/d' $TmpPkgGen
     sed -i '/perl-filetest/d' $TmpPkgGen
     sed -i '/perl-Filter/d' $TmpPkgGen

--- a/toolkit/resources/manifests/package/update_manifests.sh
+++ b/toolkit/resources/manifests/package/update_manifests.sh
@@ -266,6 +266,7 @@ generate_pkggen_core () {
         grep "^e2fsprogs-" $TmpPkgGen
         grep "^libsolv-" $TmpPkgGen
         grep "^libssh2-" $TmpPkgGen
+        grep "^krb5-" $TmpPkgGen
         grep "^curl-" $TmpPkgGen
         grep "^tdnf-" $TmpPkgGen
         grep "^createrepo_c-" $TmpPkgGen
@@ -274,7 +275,6 @@ generate_pkggen_core () {
         grep "^glib-" $TmpPkgGen
         grep "^libltdl-" $TmpPkgGen
         grep "^pcre-" $TmpPkgGen
-        grep "^krb5-" $TmpPkgGen
         grep "^lua-" $TmpPkgGen
         grep "^mariner-rpm-macros-" $TmpPkgGen
         grep "^mariner-check-" $TmpPkgGen

--- a/toolkit/resources/manifests/package/update_manifests.sh
+++ b/toolkit/resources/manifests/package/update_manifests.sh
@@ -72,7 +72,6 @@ remove_packages_for_pkggen_core () {
     sed -i '/kmod/d' $TmpPkgGen
     sed -i '/krb5-[[:alpha:]]/d' $TmpPkgGen
     sed -i '/libarchive/d' $TmpPkgGen
-    sed -i '/libcap-ng-[[:alpha:]]/d' $TmpPkgGen
     sed -i '/libdb-utils/d' $TmpPkgGen
     sed -i '/libgpg-error-[[:alpha:]]/d' $TmpPkgGen
     sed -i '/libgcrypt-[[:alpha:]]/d' $TmpPkgGen

--- a/toolkit/resources/manifests/package/update_manifests.sh
+++ b/toolkit/resources/manifests/package/update_manifests.sh
@@ -182,7 +182,6 @@ remove_packages_for_pkggen_core () {
     sed -i '/perl-version/d' $TmpPkgGen
     sed -i '/perl-vmsish/d' $TmpPkgGen
     sed -i '/perl-libintl/d' $TmpPkgGen
-    sed -i '/perl-Object-Accessor/d' $TmpPkgGen
     sed -i '/perl-Test-Warnings/d' $TmpPkgGen
     sed -i '/perl-Text-Template/d' $TmpPkgGen
     sed -i '/python3-audit/d' $TmpPkgGen

--- a/toolkit/resources/manifests/package/update_manifests.sh
+++ b/toolkit/resources/manifests/package/update_manifests.sh
@@ -111,7 +111,6 @@ remove_packages_for_pkggen_core () {
     sed -i '/perl-File-Dos/d' $TmpPkgGen
     sed -i '/perl-File-Fetch/d' $TmpPkgGen
     sed -i '/perl-File-Find/d' $TmpPkgGen
-    sed -i '/perl-File-HomeDir/d' $TmpPkgGen
     sed -i '/perl-File-Which/d' $TmpPkgGen
     sed -i '/perl-FileCache/d' $TmpPkgGen
     sed -i '/perl-filetest/d' $TmpPkgGen

--- a/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
+++ b/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
@@ -498,9 +498,7 @@ chroot_and_install_rpms meson
 chroot_and_install_rpms intltool
 build_rpm_in_chroot_no_install systemd-bootstrap
 
-# Removed 'lvm2', might not need: libselinux, libsepol, ncurses
-chroot_and_install_rpms libselinux
-chroot_and_install_rpms libsepol
+# Removed 'lvm2', might not need: ncurses
 chroot_and_install_rpms ncurses
 
 # Removed 'cryptsetup', might not need: popt

--- a/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
+++ b/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
@@ -520,7 +520,6 @@ chroot_and_install_rpms json-c
 chroot_and_install_rpms intltool
 chroot_and_install_rpms gperf
 
-build_rpm_in_chroot_no_install golang-1.17
 build_rpm_in_chroot_no_install groff
 
 # libtiprc needs krb5
@@ -548,8 +547,7 @@ chroot_and_install_rpms groff
 
 build_rpm_in_chroot_no_install libcap-ng
 
-# Removed 'audit', might not need: golang, libcap-ng
-chroot_and_install_rpms golang
+# Removed 'audit', might not need: libcap-ng
 chroot_and_install_rpms libcap-ng
 
 # p11-kit needs libtasn1, systemd-bootstrap

--- a/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
+++ b/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
@@ -496,6 +496,7 @@ build_rpm_in_chroot_no_install rpm
 build_rpm_in_chroot_no_install pam
 
 # systemd-bootstrap requires libcap, xz, kbd, kmod, util-linux, meson
+# gperf is also needed, but is installed earlier
 chroot_and_install_rpms libcap
 chroot_and_install_rpms lz4
 chroot_and_install_rpms xz
@@ -517,9 +518,8 @@ chroot_and_install_rpms popt
 chroot_and_install_rpms libpwquality
 chroot_and_install_rpms json-c
 
-# Removed 'systemd', might not need: intltool, gperf
+# Removed 'systemd', might not need: intltool
 chroot_and_install_rpms intltool
-chroot_and_install_rpms gperf
 
 # p11-kit needs libtasn1, systemd-bootstrap
 chroot_and_install_rpms libtasn1

--- a/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
+++ b/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
@@ -525,13 +525,9 @@ chroot_and_install_rpms krb5
 build_rpm_in_chroot_no_install libtirpc
 build_rpm_in_chroot_no_install rpcsvc-proto
 
-# libnsl2 needs libtirpc and rpcsvc-proto
+# Removed libnsl2, might not need: libtirpc, rpcsvc-proto
 chroot_and_install_rpms libtirpc
 chroot_and_install_rpms rpcsvc-proto
-build_rpm_in_chroot_no_install libnsl2
-
-# Removed 'tcp_wrappers', might not need: libnsl2
-chroot_and_install_rpms libnsl2
 
 # p11-kit needs libtasn1, systemd-bootstrap
 chroot_and_install_rpms libtasn1

--- a/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
+++ b/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
@@ -480,7 +480,6 @@ chroot_and_install_rpms file
 chroot_and_install_rpms glib
 build_rpm_in_chroot_no_install createrepo_c
 
-build_rpm_in_chroot_no_install libpwquality
 build_rpm_in_chroot_no_install json-c
 build_rpm_in_chroot_no_install libsepol
 
@@ -514,9 +513,8 @@ chroot_and_install_rpms libsepol
 chroot_and_install_rpms ncurses
 chroot_and_install_rpms libaio
 
-# Removed 'cryptsetup', might not need: popt, libpwquality, json-c
+# Removed 'cryptsetup', might not need: popt, json-c
 chroot_and_install_rpms popt
-chroot_and_install_rpms libpwquality
 chroot_and_install_rpms json-c
 
 # p11-kit needs libtasn1, systemd-bootstrap

--- a/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
+++ b/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
@@ -520,12 +520,8 @@ chroot_and_install_rpms json-c
 chroot_and_install_rpms intltool
 chroot_and_install_rpms gperf
 
-# libtiprc needs krb5
+# Removed 'libtiprc', might not need: krb5
 chroot_and_install_rpms krb5
-build_rpm_in_chroot_no_install rpcsvc-proto
-
-# Removed libnsl2, might not need: rpcsvc-proto
-chroot_and_install_rpms rpcsvc-proto
 
 # p11-kit needs libtasn1, systemd-bootstrap
 chroot_and_install_rpms libtasn1

--- a/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
+++ b/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
@@ -533,13 +533,9 @@ build_rpm_in_chroot_no_install libnsl2
 # Removed 'tcp_wrappers', might not need: libnsl2
 chroot_and_install_rpms libnsl2
 
-# Removed 'groff', might not need: perl-File-HomeDir, perl-File-Which
-# groff needs perl-File-HomeDir installed to run
-# perl-File-HomeDir needs perl-File-Which installed to run
+# Removed 'perl-File-HomeDir', might not need: perl-File-Which
 build_rpm_in_chroot_no_install perl-File-Which
 chroot_and_install_rpms perl-File-Which
-build_rpm_in_chroot_no_install perl-File-HomeDir
-chroot_and_install_rpms perl-File-HomeDir
 
 # p11-kit needs libtasn1, systemd-bootstrap
 chroot_and_install_rpms libtasn1

--- a/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
+++ b/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
@@ -267,16 +267,9 @@ build_rpm_in_chroot_no_install flex
 build_rpm_in_chroot_no_install libarchive
 build_rpm_in_chroot_no_install diffutils
 
-# Need to install perl-DBI in order for perl-DBD-SQLite to build
-build_rpm_in_chroot_no_install perl-DBI
-chroot_and_install_rpms perl-DBI
-
-build_rpm_in_chroot_no_install perl-Object-Accessor
 build_rpm_in_chroot_no_install bison
 build_rpm_in_chroot_no_install autoconf
 build_rpm_in_chroot_no_install texinfo
-build_rpm_in_chroot_no_install perl-DBD-SQLite
-build_rpm_in_chroot_no_install perl-DBIx-Simple
 build_rpm_in_chroot_no_install elfutils
 build_rpm_in_chroot_no_install automake
 

--- a/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
+++ b/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
@@ -522,11 +522,9 @@ chroot_and_install_rpms gperf
 
 # libtiprc needs krb5
 chroot_and_install_rpms krb5
-build_rpm_in_chroot_no_install libtirpc
 build_rpm_in_chroot_no_install rpcsvc-proto
 
-# Removed libnsl2, might not need: libtirpc, rpcsvc-proto
-chroot_and_install_rpms libtirpc
+# Removed libnsl2, might not need: rpcsvc-proto
 chroot_and_install_rpms rpcsvc-proto
 
 # p11-kit needs libtasn1, systemd-bootstrap

--- a/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
+++ b/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
@@ -495,7 +495,7 @@ build_rpm_in_chroot_no_install rpm
 # rebuild pam with selinux support
 build_rpm_in_chroot_no_install pam
 
-# systemd-bootstrap requires libcap, xz, kbd, kmod, util-linux, meson
+# systemd-bootstrap requires libcap, xz, kbd, kmod, util-linux, meson, intltool
 # gperf is also needed, but is installed earlier
 chroot_and_install_rpms libcap
 chroot_and_install_rpms lz4
@@ -504,6 +504,7 @@ chroot_and_install_rpms kbd
 chroot_and_install_rpms kmod
 chroot_and_install_rpms util-linux
 chroot_and_install_rpms meson
+chroot_and_install_rpms intltool
 build_rpm_in_chroot_no_install systemd-bootstrap
 build_rpm_in_chroot_no_install libaio
 
@@ -517,9 +518,6 @@ chroot_and_install_rpms libaio
 chroot_and_install_rpms popt
 chroot_and_install_rpms libpwquality
 chroot_and_install_rpms json-c
-
-# Removed 'systemd', might not need: intltool
-chroot_and_install_rpms intltool
 
 # p11-kit needs libtasn1, systemd-bootstrap
 chroot_and_install_rpms libtasn1

--- a/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
+++ b/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
@@ -374,8 +374,9 @@ build_rpm_in_chroot_no_install kbd
 chroot_and_install_rpms e2fsprogs
 build_rpm_in_chroot_no_install krb5
 
-# curl needs libssh2
+# curl needs libssh2, krb5
 chroot_and_install_rpms libssh2
+chroot_and_install_rpms krb5
 build_rpm_in_chroot_no_install curl
 
 # python3-setuptools needs python3-xml
@@ -519,9 +520,6 @@ chroot_and_install_rpms json-c
 # Removed 'systemd', might not need: intltool, gperf
 chroot_and_install_rpms intltool
 chroot_and_install_rpms gperf
-
-# Removed 'libtiprc', might not need: krb5
-chroot_and_install_rpms krb5
 
 # p11-kit needs libtasn1, systemd-bootstrap
 chroot_and_install_rpms libtasn1

--- a/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
+++ b/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
@@ -504,13 +504,11 @@ chroot_and_install_rpms util-linux
 chroot_and_install_rpms meson
 chroot_and_install_rpms intltool
 build_rpm_in_chroot_no_install systemd-bootstrap
-build_rpm_in_chroot_no_install libaio
 
-# Removed 'lvm2', might not need: libselinux, libsepol, ncurses, libaio,
+# Removed 'lvm2', might not need: libselinux, libsepol, ncurses
 chroot_and_install_rpms libselinux
 chroot_and_install_rpms libsepol
 chroot_and_install_rpms ncurses
-chroot_and_install_rpms libaio
 
 # Removed 'cryptsetup', might not need: popt
 chroot_and_install_rpms popt

--- a/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
+++ b/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
@@ -533,10 +533,6 @@ build_rpm_in_chroot_no_install libnsl2
 # Removed 'tcp_wrappers', might not need: libnsl2
 chroot_and_install_rpms libnsl2
 
-# Removed 'perl-File-HomeDir', might not need: perl-File-Which
-build_rpm_in_chroot_no_install perl-File-Which
-chroot_and_install_rpms perl-File-Which
-
 # p11-kit needs libtasn1, systemd-bootstrap
 chroot_and_install_rpms libtasn1
 chroot_and_install_rpms systemd-bootstrap

--- a/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
+++ b/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
@@ -480,7 +480,6 @@ chroot_and_install_rpms file
 chroot_and_install_rpms glib
 build_rpm_in_chroot_no_install createrepo_c
 
-build_rpm_in_chroot_no_install json-c
 build_rpm_in_chroot_no_install libsepol
 
 # libselinux requires libsepol
@@ -513,9 +512,8 @@ chroot_and_install_rpms libsepol
 chroot_and_install_rpms ncurses
 chroot_and_install_rpms libaio
 
-# Removed 'cryptsetup', might not need: popt, json-c
+# Removed 'cryptsetup', might not need: popt
 chroot_and_install_rpms popt
-chroot_and_install_rpms json-c
 
 # p11-kit needs libtasn1, systemd-bootstrap
 chroot_and_install_rpms libtasn1

--- a/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
+++ b/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
@@ -520,8 +520,6 @@ chroot_and_install_rpms json-c
 chroot_and_install_rpms intltool
 chroot_and_install_rpms gperf
 
-build_rpm_in_chroot_no_install groff
-
 # libtiprc needs krb5
 chroot_and_install_rpms krb5
 build_rpm_in_chroot_no_install libtirpc
@@ -535,15 +533,13 @@ build_rpm_in_chroot_no_install libnsl2
 # Removed 'tcp_wrappers', might not need: libnsl2
 chroot_and_install_rpms libnsl2
 
+# Removed 'groff', might not need: perl-File-HomeDir, perl-File-Which
 # groff needs perl-File-HomeDir installed to run
 # perl-File-HomeDir needs perl-File-Which installed to run
 build_rpm_in_chroot_no_install perl-File-Which
 chroot_and_install_rpms perl-File-Which
 build_rpm_in_chroot_no_install perl-File-HomeDir
 chroot_and_install_rpms perl-File-HomeDir
-
-# Removed 'openldap', might not need: groff
-chroot_and_install_rpms groff
 
 # p11-kit needs libtasn1, systemd-bootstrap
 chroot_and_install_rpms libtasn1

--- a/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
+++ b/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
@@ -545,11 +545,6 @@ chroot_and_install_rpms perl-File-HomeDir
 # Removed 'openldap', might not need: groff
 chroot_and_install_rpms groff
 
-build_rpm_in_chroot_no_install libcap-ng
-
-# Removed 'audit', might not need: libcap-ng
-chroot_and_install_rpms libcap-ng
-
 # p11-kit needs libtasn1, systemd-bootstrap
 chroot_and_install_rpms libtasn1
 chroot_and_install_rpms systemd-bootstrap

--- a/toolkit/scripts/toolchain/container/Dockerfile
+++ b/toolkit/scripts/toolchain/container/Dockerfile
@@ -105,7 +105,6 @@ COPY [ "./toolchain_initial_chroot_setup.sh", \
        "./Awt_build_headless_only.patch", \
        "./check-system-ca-certs.patch", \
        "./rpm-define-RPM-LD-FLAGS.patch", \
-       "./go14_bootstrap_aarch64.patch", \
        "./cpio_extern_nocommon.patch", \
        "$LFS/tools/" ]
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
We have a fair number of packages in the toolchain. Toolchain packages should be a base set of packages needed to bootstrap a package building environment along with the packages needed to build them. After the recent removal of certain packages (`audit`, `openldap`, `tcp_wrappers`, `cryptsetup`, `lvm2`) from the toolchain, we no longer need several of their dependencies to be in the toolchain.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Remove `golang` from the toolchain- not needed after previous removal of `audit`
- Remove `libcap-ng` from the toolchain- not needed after previous removal of `audit`
- Remove `groff` from the toolchain- not needed after previous removal of `openldap`
- Remove `perl-File-HomeDir` from the toolchain- not needed after removal of `groff`
- Remove `perl-File-Which` from the toolchain- not needed after removal of `perl-File-HomeDir`
- Remove `libnsl2` from the toolchain- not needed after previous removal of `tcp_wrappers`
- Remove `libtirpc` from the toolchain- not needed after removal of `libnsl2`
- Remove `rpcsvc-proto` from the toolchain- not needed after removal of `libnsl2`
- Remove `libpwquality` from the toolchain- not needed after previous removal of `cryptsetup`
- Remove `json-c` from the toolchain- not needed after previous removal of `cryptsetup`
- Remove `libaio` from the toolchain- not needed after previous removal of `lvm2`
- Remove several perl packages that are part of the `groff` dependency chain
- Move `krb5` install to before `curl` build
- Move `intltool` install to before `systemd-bootstrap` build
- Remove double installs of `gperf`, `libselinux`, `libsepol`

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Full local package build to ensure packages aren't relying implicitly on removed worker chroot packages
