### PR TITLE
[main] Fix blank mountidentifiers in ISO installers

### DIFF
--- a/toolkit/tools/imagegen/attendedinstaller/views/diskview/autopartitionwidget/autopartitionwidget.go
+++ b/toolkit/tools/imagegen/attendedinstaller/views/diskview/autopartitionwidget/autopartitionwidget.go
@@ -173,13 +173,15 @@ func (ap *AutoPartitionWidget) mustUpdateConfiguration(sysConfig *configuration.
 
 	partitionSettings := []configuration.PartitionSetting{
 		configuration.PartitionSetting{
-			ID:           bootPartitionName,
-			MountPoint:   bootMountPoint,
-			MountOptions: bootMountOptions,
+			ID:              bootPartitionName,
+			MountPoint:      bootMountPoint,
+			MountOptions:    bootMountOptions,
+			MountIdentifier: configuration.MountIdentifierDefault,
 		},
 		configuration.PartitionSetting{
-			ID:         rootPartitionName,
-			MountPoint: rootMountPoint,
+			ID:              rootPartitionName,
+			MountPoint:      rootMountPoint,
+			MountIdentifier: configuration.MountIdentifierDefault,
 		},
 	}
 
@@ -221,8 +223,9 @@ func (ap *AutoPartitionWidget) mustUpdateConfiguration(sysConfig *configuration.
 			FsType: bootDirPartitionFsType,
 		}
 		bootDirPartitionSetting := configuration.PartitionSetting{
-			ID:         bootDirPartitionName,
-			MountPoint: bootDirMountPoint,
+			ID:              bootDirPartitionName,
+			MountPoint:      bootDirMountPoint,
+			MountIdentifier: configuration.MountIdentifierDefault,
 		}
 
 		// Update the default root partition to move it farther down

--- a/toolkit/tools/imagegen/attendedinstaller/views/diskview/manualpartitionwidget/manualpartitionwidget.go
+++ b/toolkit/tools/imagegen/attendedinstaller/views/diskview/manualpartitionwidget/manualpartitionwidget.go
@@ -574,6 +574,8 @@ func (mp *ManualPartitionWidget) unmarshalPartitionTable() (err error) {
 		partitions[i].Start = diskCursor / basePartitionUnit
 		partitions[i].End = nextCursor / basePartitionUnit
 
+		partitionSettings[i].MountIdentifier = configuration.MountIdentifierDefault
+
 		if partitionSettings[i].MountPoint == rootMountPoint {
 			foundRootPartition = true
 		}


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
When running the ISO installer we manually instantiate the `PartitionSettings` which skips the default value generation found in the json unmarshal code. We need to explicitly set the `MountIdentifer` added in #1444 when running the ISO installer to the default value (`partuuid`).

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Auto set the `MountIdentifier` to `partuuid` when using the ISO installer

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Waiting on pipeline build of ISO installer to validate
