### PR TITLE
Fix systemd dhcp and cgroups

### DIFF
--- a/SPECS/systemd/99-dhcp-en.network
+++ b/SPECS/systemd/99-dhcp-en.network
@@ -4,3 +4,6 @@ Name=e*
 [Network]
 DHCP=yes
 IPv6AcceptRA=no
+
+[DHCPv4]
+SendRelease=false

--- a/SPECS/systemd/systemd-bootstrap.signatures.json
+++ b/SPECS/systemd/systemd-bootstrap.signatures.json
@@ -1,8 +1,8 @@
 {
  "Signatures": {
   "50-security-hardening.conf": "c9fc6624a3178cc0980ec3495ac2d5f02a8a1f3a4cdadb8770628d7394b92e2c",
-  "99-dhcp-en.network": "583c94adfa9821a06b28c5c6d0a0cb4c9c5805cf9e66e4e5beff359202668497",
+  "99-dhcp-en.network": "158c0003826cef9d780799c6edb2814800d4518f85f884710550f4c46d14be67",
   "systemd-249.7.tar.gz": "5dbf457431bb16e5dfc957200731ad302fe3ae4919470bc34b8224428e1addbb",
-  "systemd.cfg": "058b3f9c3ac85610c1e3629f63d80f5570cf716b90c2dd0caaf14b1be67aff51"
+  "systemd.cfg": "1fd673c1da90560d9395a18df31f2ce6ef23972a6bf8c910ba6f3fb07818afa9"
  }
 }

--- a/SPECS/systemd/systemd-bootstrap.spec
+++ b/SPECS/systemd/systemd-bootstrap.spec
@@ -1,7 +1,7 @@
 Summary:        Bootstrap version of systemd. Workaround for systemd circular dependency.
 Name:           systemd-bootstrap
 Version:        249.7
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        LGPLv2+ AND GPLv2+ AND MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -229,6 +229,10 @@ rm -rf %{buildroot}/*
 %{_datadir}/pkgconfig/udev.pc
 
 %changelog
+* Wed Dec 08 2021 Henry Beberman <henry.beberman@microsoft.com> 249.7-2
+- Update systemd boot args to force cgroups V1 with systemd.unified_cgroup_hierarchy=0
+- Update 99-dhcp-en.network with SendRelease=false so DHCP leases arent released on reboot
+
 * Wed Dec 01 2021 Henry Beberman <henry.beberman@microsoft.com> 249.7-1
 - Update to systemd-stable version 249.7 by bootstrapifying the systemd 249.7 spec
 

--- a/SPECS/systemd/systemd.cfg
+++ b/SPECS/systemd/systemd.cfg
@@ -1,2 +1,2 @@
 # GRUB Environment Block
-systemd_cmdline=net.ifnames=0 plymouth.enable=0 systemd.legacy_systemd_cgroup_controller=yes
+systemd_cmdline=net.ifnames=0 plymouth.enable=0 systemd.legacy_systemd_cgroup_controller=yes systemd.unified_cgroup_hierarchy=0

--- a/SPECS/systemd/systemd.signatures.json
+++ b/SPECS/systemd/systemd.signatures.json
@@ -1,8 +1,8 @@
 {
  "Signatures": {
   "50-security-hardening.conf": "c9fc6624a3178cc0980ec3495ac2d5f02a8a1f3a4cdadb8770628d7394b92e2c",
-  "99-dhcp-en.network": "583c94adfa9821a06b28c5c6d0a0cb4c9c5805cf9e66e4e5beff359202668497",
+  "99-dhcp-en.network": "158c0003826cef9d780799c6edb2814800d4518f85f884710550f4c46d14be67",
   "systemd-249.7.tar.gz": "5dbf457431bb16e5dfc957200731ad302fe3ae4919470bc34b8224428e1addbb",
-  "systemd.cfg": "058b3f9c3ac85610c1e3629f63d80f5570cf716b90c2dd0caaf14b1be67aff51"
+  "systemd.cfg": "1fd673c1da90560d9395a18df31f2ce6ef23972a6bf8c910ba6f3fb07818afa9"
  }
 }

--- a/SPECS/systemd/systemd.spec
+++ b/SPECS/systemd/systemd.spec
@@ -1,7 +1,7 @@
 Summary:        Systemd-249
 Name:           systemd
 Version:        249.7
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        LGPLv2+ AND GPLv2+ AND MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -262,6 +262,10 @@ rm -rf %{buildroot}/*
 %files lang -f %{name}.lang
 
 %changelog
+* Wed Dec 08 2021 Henry Beberman <henry.beberman@microsoft.com> 249.7-2
+- Update systemd boot args to force cgroups V1 with systemd.unified_cgroup_hierarchy=0
+- Update 99-dhcp-en.network with SendRelease=false so DHCP leases arent released on reboot
+
 * Wed Dec 01 2021 Henry Beberman <henry.beberman@microsoft.com> 249.7-1
 - Update to systemd-stable version 249.7
 - Remove all patches, most have been merged upstream.

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -530,10 +530,10 @@ sqlite-devel-3.34.1-1.cm2.aarch64.rpm
 sqlite-libs-3.34.1-1.cm2.aarch64.rpm
 swig-4.0.2-2.cm2.aarch64.rpm
 swig-debuginfo-4.0.2-2.cm2.aarch64.rpm
-systemd-bootstrap-249.7-1.cm2.aarch64.rpm
-systemd-bootstrap-debuginfo-249.7-1.cm2.aarch64.rpm
-systemd-bootstrap-devel-249.7-1.cm2.aarch64.rpm
-systemd-bootstrap-rpm-macros-249.7-1.cm2.noarch.rpm
+systemd-bootstrap-249.7-2.cm2.aarch64.rpm
+systemd-bootstrap-debuginfo-249.7-2.cm2.aarch64.rpm
+systemd-bootstrap-devel-249.7-2.cm2.aarch64.rpm
+systemd-bootstrap-rpm-macros-249.7-2.cm2.noarch.rpm
 tar-1.34-1.cm2.aarch64.rpm
 tar-debuginfo-1.34-1.cm2.aarch64.rpm
 tdnf-2.1.0-7.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -530,10 +530,10 @@ sqlite-devel-3.34.1-1.cm2.x86_64.rpm
 sqlite-libs-3.34.1-1.cm2.x86_64.rpm
 swig-4.0.2-2.cm2.x86_64.rpm
 swig-debuginfo-4.0.2-2.cm2.x86_64.rpm
-systemd-bootstrap-249.7-1.cm2.x86_64.rpm
-systemd-bootstrap-debuginfo-249.7-1.cm2.x86_64.rpm
-systemd-bootstrap-devel-249.7-1.cm2.x86_64.rpm
-systemd-bootstrap-rpm-macros-249.7-1.cm2.noarch.rpm
+systemd-bootstrap-249.7-2.cm2.x86_64.rpm
+systemd-bootstrap-debuginfo-249.7-2.cm2.x86_64.rpm
+systemd-bootstrap-devel-249.7-2.cm2.x86_64.rpm
+systemd-bootstrap-rpm-macros-249.7-2.cm2.noarch.rpm
 tar-1.34-1.cm2.x86_64.rpm
 tar-debuginfo-1.34-1.cm2.x86_64.rpm
 tdnf-2.1.0-7.cm2.x86_64.rpm


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Updating to systemd 249.7 caused some divergence from default behaviors that Mariner expects. This release addresses those changes and sets the default behaviors back to a working configuration.
Updated systemd-networkd setting with SendRelease=false so DHCP client won't release the IP address on shutdown.
Updated systemd cmdline args with systemd.unified_cgroup_hierarchy=0 to force cgroups v1

###### Change Log  <!-- REQUIRED -->
- Add SendRelease=false to 99-dhcp-en.network so IP addresses are retained across reboot.
- Add systemd.unified_cgroup_hierarchy=0 to systemd.cfg so that cgroups v1 is selected.

###### Does this affect the toolchain?  <!-- REQUIRED -->
**YES**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Full Local build
- Gen1 Hyper-V boot maintains IP addr on reboot and uses cgroups v1
