### PR TITLE
[main] Fixing `cmake` tests and restoring generation of its debug symbols.

### DIFF
--- a/SPECS/cmake/cmake.spec
+++ b/SPECS/cmake/cmake.spec
@@ -2,7 +2,7 @@
 Summary:        Cmake
 Name:           cmake
 Version:        3.21.4
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        BSD AND LGPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -44,18 +44,13 @@ operating system and in a compiler-independent manner.
 %autosetup -p1
 
 %build
-# Disable symbol generation
-export CFLAGS="`echo " %{build_cflags} " | sed 's/ -g//'`"
-export CXXFLAGS="`echo " %{build_cxxflags} " | sed 's/ -g//'`"
-
-ncores="$(%{_bindir}/getconf _NPROCESSORS_ONLN)"
 ./bootstrap \
     --prefix=%{_prefix} \
     --system-expat \
     --system-zlib \
     --system-libarchive \
     --system-bzip2 \
-    --parallel=$ncores
+    --parallel=$(nproc)
 %make_build
 
 %install
@@ -65,6 +60,10 @@ install -Dpm0644 %{SOURCE1} %{buildroot}%{_libdir}/rpm/macros.d/macros.cmake
 sed -i -e "s|@@CMAKE_VERSION@@|%{version}|" -e "s|@@CMAKE_MAJOR_VERSION@@|%{major_version}|" %{buildroot}%{_libdir}/rpm/macros.d/macros.cmake
 
 %check
+# Removing static libraries to fix issues with the "ParseImplicitLinkInfo" test runs for the "craype-C-Cray-8.7.input" and "craype-CXX-Cray-8.7.input" inputs.
+# Should be removed once the issue is fixed upstream and we apply the fix: https://gitlab.kitware.com/cmake/cmake/-/issues/22470.
+rm /usr/lib64/{libstdc++,libgfortran}.a
+
 %make_build test
 
 %files
@@ -80,6 +79,10 @@ sed -i -e "s|@@CMAKE_VERSION@@|%{version}|" -e "s|@@CMAKE_MAJOR_VERSION@@|%{majo
 %{_prefix}/doc/%{name}-*/*
 
 %changelog
+* Sun Dec 12 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 3.21.4-2
+- Adding a workaround for two failing "ParseImplicitLinkInfo" test cases until a fix is available.
+- Bringing back generation of debug symbols.
+
 * Mon Nov 15 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 3.21.4-1
 - Update to version 3.21.4.
 - License verified.

--- a/SPECS/cmake/cmake.spec
+++ b/SPECS/cmake/cmake.spec
@@ -64,7 +64,7 @@ sed -i -e "s|@@CMAKE_VERSION@@|%{version}|" -e "s|@@CMAKE_MAJOR_VERSION@@|%{majo
 # Should be removed once the issue is fixed upstream and we apply the fix: https://gitlab.kitware.com/cmake/cmake/-/issues/22470.
 rm %{_lib64dir}/lib{stdc++,gfortran}.a
 
-%make_build test
+bin/ctest --force-new-ctest-process --rerun-failed --output-on-failure
 
 %files
 %defattr(-,root,root)
@@ -81,6 +81,7 @@ rm %{_lib64dir}/lib{stdc++,gfortran}.a
 %changelog
 * Sun Dec 12 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 3.21.4-2
 - Adding a workaround for two failing "ParseImplicitLinkInfo" test cases until a fix is available.
+- Adjusted test command to re-run flaky tests.
 - Bringing back generation of debug symbols.
 
 * Mon Nov 15 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 3.21.4-1

--- a/SPECS/cmake/cmake.spec
+++ b/SPECS/cmake/cmake.spec
@@ -62,7 +62,7 @@ sed -i -e "s|@@CMAKE_VERSION@@|%{version}|" -e "s|@@CMAKE_MAJOR_VERSION@@|%{majo
 %check
 # Removing static libraries to fix issues with the "ParseImplicitLinkInfo" test runs for the "craype-C-Cray-8.7.input" and "craype-CXX-Cray-8.7.input" inputs.
 # Should be removed once the issue is fixed upstream and we apply the fix: https://gitlab.kitware.com/cmake/cmake/-/issues/22470.
-rm /usr/lib64/{libstdc++,libgfortran}.a
+rm %{_lib64dir}/{libstdc++,libgfortran}.a
 
 %make_build test
 

--- a/SPECS/cmake/cmake.spec
+++ b/SPECS/cmake/cmake.spec
@@ -62,7 +62,7 @@ sed -i -e "s|@@CMAKE_VERSION@@|%{version}|" -e "s|@@CMAKE_MAJOR_VERSION@@|%{majo
 %check
 # Removing static libraries to fix issues with the "ParseImplicitLinkInfo" test runs for the "craype-C-Cray-8.7.input" and "craype-CXX-Cray-8.7.input" inputs.
 # Should be removed once the issue is fixed upstream and we apply the fix: https://gitlab.kitware.com/cmake/cmake/-/issues/22470.
-rm %{_lib64dir}/lib{stdc++,gfortran}.a
+rm -f %{_lib64dir}/lib{stdc++,gfortran}.a
 
 bin/ctest --force-new-ctest-process --rerun-failed --output-on-failure
 

--- a/SPECS/cmake/cmake.spec
+++ b/SPECS/cmake/cmake.spec
@@ -62,7 +62,7 @@ sed -i -e "s|@@CMAKE_VERSION@@|%{version}|" -e "s|@@CMAKE_MAJOR_VERSION@@|%{majo
 %check
 # Removing static libraries to fix issues with the "ParseImplicitLinkInfo" test runs for the "craype-C-Cray-8.7.input" and "craype-CXX-Cray-8.7.input" inputs.
 # Should be removed once the issue is fixed upstream and we apply the fix: https://gitlab.kitware.com/cmake/cmake/-/issues/22470.
-rm %{_lib64dir}/{libstdc++,libgfortran}.a
+rm %{_lib64dir}/lib{stdc++,gfortran}.a
 
 %make_build test
 

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -24,8 +24,8 @@ ca-certificates-shared-20200720-20.cm2.noarch.rpm
 ca-certificates-tools-20200720-20.cm2.noarch.rpm
 check-0.15.2-1.cm2.aarch64.rpm
 check-debuginfo-0.15.2-1.cm2.aarch64.rpm
-cmake-3.21.4-1.cm2.aarch64.rpm
-cmake-debuginfo-3.21.4-1.cm2.aarch64.rpm
+cmake-3.21.4-2.cm2.aarch64.rpm
+cmake-debuginfo-3.21.4-2.cm2.aarch64.rpm
 coreutils-8.32-1.cm2.aarch64.rpm
 coreutils-debuginfo-8.32-1.cm2.aarch64.rpm
 coreutils-lang-8.32-1.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -24,8 +24,8 @@ ca-certificates-shared-20200720-20.cm2.noarch.rpm
 ca-certificates-tools-20200720-20.cm2.noarch.rpm
 check-0.15.2-1.cm2.x86_64.rpm
 check-debuginfo-0.15.2-1.cm2.x86_64.rpm
-cmake-3.21.4-1.cm2.x86_64.rpm
-cmake-debuginfo-3.21.4-1.cm2.x86_64.rpm
+cmake-3.21.4-2.cm2.x86_64.rpm
+cmake-debuginfo-3.21.4-2.cm2.x86_64.rpm
 coreutils-8.32-1.cm2.x86_64.rpm
 coreutils-debuginfo-8.32-1.cm2.x86_64.rpm
 coreutils-lang-8.32-1.cm2.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

The 3.21.X+ version of `cmake` has[ an issue with one of its tests](https://gitlab.kitware.com/cmake/cmake/-/issues/22470), which hasn't been resolved, yet. I'm adding a workaround until the issue is resolved and the fix applied.

I've also restored generation of debug symbols for `cmake`.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Adding a workaround for two failing `cmake` test cases.
- Restoring generation of `cmake` debug symbols.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
Yes.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local package build and tests.
