### PR TITLE
[main] Resetting the version of `ca-certificates` to something more meaningful.

### DIFF
--- a/.github/workflows/check-entangled-specs.yml
+++ b/.github/workflows/check-entangled-specs.yml
@@ -29,4 +29,4 @@ jobs:
         run: python3 -m pip install python-rpm-spec
 
       - name: Run entanglement checking script
-        run: python3 ./.github/workflows/check_entangled_specs.py .
+        run: ./.github/workflows/check_entangled_specs.py .

--- a/.github/workflows/check-entangled-specs.yml
+++ b/.github/workflows/check-entangled-specs.yml
@@ -29,4 +29,4 @@ jobs:
         run: python3 -m pip install python-rpm-spec
 
       - name: Run entanglement checking script
-        run: ./.github/workflows/check_entangled_specs.py .
+        run: python3 ./.github/workflows/check_entangled_specs.py .

--- a/.github/workflows/check_entangled_specs.py
+++ b/.github/workflows/check_entangled_specs.py
@@ -1,3 +1,7 @@
+#!/usr/bin/python3
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 from typing import FrozenSet, List, Set
 from pyrpm.spec import Spec
 
@@ -56,11 +60,11 @@ def check_spec_tags(base_path: str, tags: List[str], groups: List[FrozenSet]) ->
 
 
 def check_version_release_match_groups(base_path: str) -> Set[FrozenSet]:
-    return check_spec_tags(base_path, ['version', 'release'], version_release_matching_groups)
+    return check_spec_tags(base_path, ['epoch', 'version', 'release'], version_release_matching_groups)
 
 
 def check_version_match_groups(base_path: str) -> Set[FrozenSet]:
-    return check_spec_tags(base_path, ['version'], version_matching_groups)
+    return check_spec_tags(base_path, ['epoch', 'version'], version_matching_groups)
 
 
 def check_matches(base_path: str):
@@ -75,13 +79,13 @@ def check_matches(base_path: str):
 
         if len(version_match_errors):
             print(
-                '\nPlease update the following sets of specs to have the same Version tags:')
+                '\nPlease update the following sets of specs to have the same "Epoch" and "Version" tags:')
             for e in version_match_errors:
                 printer.pprint(e)
 
         if len(version_release_match_errors):
             print(
-                '\nPlease update the following sets of specs to have the same Version and Release tags:')
+                '\nPlease update the following sets of specs to have the same "Epoch", "Version", and "Release" tags:')
             for e in version_release_match_errors:
                 printer.pprint(e)
         sys.exit(1)

--- a/.github/workflows/validate-cg-manifest.sh
+++ b/.github/workflows/validate-cg-manifest.sh
@@ -14,6 +14,7 @@
 # Ignore some specs, mostly those with Source0 files that are not from an external source, or have very odd URLs
 ignore_list=" \
   byacc \
+  ca-certificates \
   Cython \
   grub2-efi-binary-signed-aarch64 \
   grub2-efi-binary-signed-x86_64 \
@@ -48,8 +49,8 @@ ignore_list=" \
   verity-read-only-root \
   xorg-x11-apps \
   xorg-x11-font-utils \
-  xorg-x11-xkb-utils \
-  xorg-x11-server-utils"
+  xorg-x11-server-utils \
+  xorg-x11-xkb-utils"
 
 rm -f bad_registrations.txt
 rm -rf ./cgmanifest_test_dir/

--- a/SPECS/ca-certificates/ca-certificates.spec
+++ b/SPECS/ca-certificates/ca-certificates.spec
@@ -44,7 +44,7 @@ Name:           ca-certificates
 
 # When updating, "Version" AND "Release" tags must be updated in the "prebuilt-ca-certificates" package as well.
 Version:        20200720
-Release:        20%{?dist}
+Release:        21%{?dist}
 License:        MPLv2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -317,6 +317,9 @@ rm -f %{pkidir}/tls/certs/*.{0,pem}
 %{_bindir}/bundle2pem.sh
 
 %changelog
+* Wed Dec 15 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 20200720-21
+- Making 'Release' match with 'prebuilt-ca-certificates-base'.
+
 * Tue Oct 12 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 20200720-20
 - Making 'Release' match with 'prebuilt-ca-certificates*'.
 

--- a/SPECS/ca-certificates/ca-certificates.spec
+++ b/SPECS/ca-certificates/ca-certificates.spec
@@ -42,7 +42,8 @@ touch -r %{SOURCE23} %{buildroot}%{_datadir}/pki/ca-trust-source/%{2}
 Summary:        Certificate Authority certificates
 Name:           ca-certificates
 
-# When updating, "Version" AND "Release" tags must be updated in the "prebuilt-ca-certificates" package as well.
+# When updating, "Epoch, "Version", AND "Release" tags must be updated in the "prebuilt-ca-certificates*" packages as well.
+Epoch:          1
 Version:        2.0.0
 Release:        1%{?dist}
 License:        MPLv2.0
@@ -317,7 +318,7 @@ rm -f %{pkidir}/tls/certs/*.{0,pem}
 %{_bindir}/bundle2pem.sh
 
 %changelog
-* Wed Dec 15 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 2.0.0-1
+* Wed Dec 15 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 1:2.0.0-1
 - Making 'Release' match with 'prebuilt-ca-certificates-base'.
 - Updating 'URL' and 'Version' tags for CBL-Mariner 2.0.
 

--- a/SPECS/ca-certificates/ca-certificates.spec
+++ b/SPECS/ca-certificates/ca-certificates.spec
@@ -43,13 +43,13 @@ Summary:        Certificate Authority certificates
 Name:           ca-certificates
 
 # When updating, "Version" AND "Release" tags must be updated in the "prebuilt-ca-certificates" package as well.
-Version:        20200720
-Release:        21%{?dist}
+Version:        2.0.0
+Release:        1%{?dist}
 License:        MPLv2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Group:          System Environment/Security
-URL:            https://hg.mozilla.org
+URL:            https://docs.microsoft.com/en-us/security/trusted-root/program-requirements
 Source2:        update-ca-trust
 Source3:        trust-fixes
 Source4:        certdata2pem.py
@@ -317,8 +317,9 @@ rm -f %{pkidir}/tls/certs/*.{0,pem}
 %{_bindir}/bundle2pem.sh
 
 %changelog
-* Wed Dec 15 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 20200720-21
+* Wed Dec 15 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 2.0.0-1
 - Making 'Release' match with 'prebuilt-ca-certificates-base'.
+- Updating 'URL' and 'Version' tags for CBL-Mariner 2.0.
 
 * Tue Oct 12 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 20200720-20
 - Making 'Release' match with 'prebuilt-ca-certificates*'.

--- a/SPECS/prebuilt-ca-certificates-base/prebuilt-ca-certificates-base.spec
+++ b/SPECS/prebuilt-ca-certificates-base/prebuilt-ca-certificates-base.spec
@@ -1,6 +1,7 @@
-# When updating, "Version" AND "Release" tags must be updated in the "ca-certificates" package as well.
 Summary:        Prebuilt version of ca-certificates-base package.
 Name:           prebuilt-ca-certificates-base
+# When updating, "Epoch, "Version", AND "Release" tags must be updated in the "ca-certificates" package as well.
+Epoch:          1
 Version:        2.0.0
 Release:        1%{?dist}
 License:        MIT
@@ -44,7 +45,7 @@ find %{buildroot} -name README -delete
 %{_sysconfdir}/pki/java/cacerts
 
 %changelog
-* Wed Dec 15 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 2.0.0-1
+* Wed Dec 15 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 1:2.0.0-1
 - Updating 'URL' and 'Version' tags for CBL-Mariner 2.0.
 
 * Tue Oct 12 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 20200720-20

--- a/SPECS/prebuilt-ca-certificates-base/prebuilt-ca-certificates-base.spec
+++ b/SPECS/prebuilt-ca-certificates-base/prebuilt-ca-certificates-base.spec
@@ -2,7 +2,7 @@
 Summary:        Prebuilt version of ca-certificates-base package.
 Name:           prebuilt-ca-certificates-base
 Version:        20200720
-Release:        20%{?dist}
+Release:        21%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -18,6 +18,10 @@ Conflicts:      prebuilt-ca-certificates
 Prebuilt version of the ca-certificates-base package with no runtime dependencies.
 
 %prep -q
+
+# Remove 'ca-certificate', if present. We don't want them
+# to get mixed into the bundle provided by 'ca-certificates-base'.
+if rpm -q ca-certificates &>/dev/null; then rpm -e ca-certificates; fi
 
 %build
 
@@ -40,6 +44,9 @@ rm %{buildroot}%{_sysconfdir}/pki/rpm-gpg/*
 %{_sysconfdir}/pki/java/cacerts
 
 %changelog
+* Wed Dec 15 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 20200720-21
+- Removing 'ca-certificates' from the prebuilt base set.
+
 * Tue Oct 12 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 20200720-20
 - Removing conflicts with 'ca-certificates-shared'.
 

--- a/SPECS/prebuilt-ca-certificates-base/prebuilt-ca-certificates-base.spec
+++ b/SPECS/prebuilt-ca-certificates-base/prebuilt-ca-certificates-base.spec
@@ -1,13 +1,13 @@
 # When updating, "Version" AND "Release" tags must be updated in the "ca-certificates" package as well.
 Summary:        Prebuilt version of ca-certificates-base package.
 Name:           prebuilt-ca-certificates-base
-Version:        20200720
-Release:        21%{?dist}
+Version:        2.0.0
+Release:        1%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Group:          System Environment/Security
-URL:            https://hg.mozilla.org
+URL:            https://docs.microsoft.com/en-us/security/trusted-root/program-requirements
 BuildArch:      noarch
 
 BuildRequires:  ca-certificates-base = %{version}-%{release}
@@ -44,8 +44,9 @@ rm %{buildroot}%{_sysconfdir}/pki/rpm-gpg/*
 %{_sysconfdir}/pki/java/cacerts
 
 %changelog
-* Wed Dec 15 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 20200720-21
+* Wed Dec 15 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 2.0.0-1
 - Removing 'ca-certificates' from the prebuilt base set.
+- Updating 'URL' and 'Version' tags for CBL-Mariner 2.0.
 
 * Tue Oct 12 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 20200720-20
 - Removing conflicts with 'ca-certificates-shared'.

--- a/SPECS/prebuilt-ca-certificates-base/prebuilt-ca-certificates-base.spec
+++ b/SPECS/prebuilt-ca-certificates-base/prebuilt-ca-certificates-base.spec
@@ -47,6 +47,7 @@ rm %{buildroot}%{_sysconfdir}/pki/rpm-gpg/*
 * Wed Dec 15 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 2.0.0-1
 - Removing 'ca-certificates' from the prebuilt base set.
 - Updating 'URL' and 'Version' tags for CBL-Mariner 2.0.
+- License verified.
 
 * Tue Oct 12 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 20200720-20
 - Removing conflicts with 'ca-certificates-shared'.

--- a/SPECS/prebuilt-ca-certificates/prebuilt-ca-certificates.spec
+++ b/SPECS/prebuilt-ca-certificates/prebuilt-ca-certificates.spec
@@ -2,7 +2,7 @@
 Summary:        Prebuilt version of ca-certificates package.
 Name:           prebuilt-ca-certificates
 Version:        20200720
-Release:        20%{?dist}
+Release:        21%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -19,9 +19,9 @@ Prebuilt version of the ca-certificates package with no runtime dependencies.
 
 %prep -q
 
-# We don't want the pre-installed base set of certificates
-# to get mixed into the bundle provided by 'ca-certificates'.
-rpm -e ca-certificates-base
+# Remove 'ca-certificate-base', if present. We don't want them
+# to get mixed into the bundle provided by 'ca-certificates-base'.
+if rpm -q ca-certificates-base &>/dev/null ; then rpm -e ca-certificates-base; fi
 
 %build
 
@@ -44,6 +44,9 @@ rm %{buildroot}%{_sysconfdir}/pki/rpm-gpg/*
 %{_sysconfdir}/pki/java/cacerts
 
 %changelog
+* Wed Dec 15 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 20200720-21
+- Making removal of 'ca-certificates-base' account for the package not being installed.
+
 * Tue Oct 12 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 20200720-20
 - Removing conflicts with 'ca-certificates-shared'.
 

--- a/SPECS/prebuilt-ca-certificates/prebuilt-ca-certificates.spec
+++ b/SPECS/prebuilt-ca-certificates/prebuilt-ca-certificates.spec
@@ -20,7 +20,7 @@ Prebuilt version of the ca-certificates package with no runtime dependencies.
 %prep -q
 
 # Remove 'ca-certificate-base', if present. We don't want them
-# to get mixed into the bundle provided by 'ca-certificates-base'.
+# to get mixed into the bundle provided by 'ca-certificates'.
 if rpm -q ca-certificates-base &>/dev/null ; then rpm -e ca-certificates-base; fi
 
 %build

--- a/SPECS/prebuilt-ca-certificates/prebuilt-ca-certificates.spec
+++ b/SPECS/prebuilt-ca-certificates/prebuilt-ca-certificates.spec
@@ -47,6 +47,7 @@ rm %{buildroot}%{_sysconfdir}/pki/rpm-gpg/*
 * Wed Dec 15 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 2.0.0-1
 - Making removal of 'ca-certificates-base' account for the package not being installed.
 - Updating 'URL' and 'Version' tags for CBL-Mariner 2.0.
+- License verified.
 
 * Tue Oct 12 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 20200720-20
 - Removing conflicts with 'ca-certificates-shared'.

--- a/SPECS/prebuilt-ca-certificates/prebuilt-ca-certificates.spec
+++ b/SPECS/prebuilt-ca-certificates/prebuilt-ca-certificates.spec
@@ -1,13 +1,13 @@
 # When updating, "Version" AND "Release" tags must be updated in the "ca-certificates" package as well.
 Summary:        Prebuilt version of ca-certificates package.
 Name:           prebuilt-ca-certificates
-Version:        20200720
-Release:        21%{?dist}
+Version:        2.0.0
+Release:        1%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Group:          System Environment/Security
-URL:            https://hg.mozilla.org
+URL:            https://docs.microsoft.com/en-us/security/trusted-root/program-requirements
 BuildArch:      noarch
 
 BuildRequires:  ca-certificates = %{version}-%{release}
@@ -44,8 +44,9 @@ rm %{buildroot}%{_sysconfdir}/pki/rpm-gpg/*
 %{_sysconfdir}/pki/java/cacerts
 
 %changelog
-* Wed Dec 15 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 20200720-21
+* Wed Dec 15 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 2.0.0-1
 - Making removal of 'ca-certificates-base' account for the package not being installed.
+- Updating 'URL' and 'Version' tags for CBL-Mariner 2.0.
 
 * Tue Oct 12 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 20200720-20
 - Removing conflicts with 'ca-certificates-shared'.

--- a/SPECS/prebuilt-ca-certificates/prebuilt-ca-certificates.spec
+++ b/SPECS/prebuilt-ca-certificates/prebuilt-ca-certificates.spec
@@ -1,6 +1,7 @@
-# When updating, "Version" AND "Release" tags must be updated in the "ca-certificates" package as well.
 Summary:        Prebuilt version of ca-certificates package.
 Name:           prebuilt-ca-certificates
+# When updating, "Epoch, "Version", AND "Release" tags must be updated in the "ca-certificates" package as well.
+Epoch:          1
 Version:        2.0.0
 Release:        1%{?dist}
 License:        MIT
@@ -44,7 +45,7 @@ find %{buildroot} -name README -delete
 %{_sysconfdir}/pki/java/cacerts
 
 %changelog
-* Wed Dec 15 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 2.0.0-1
+* Wed Dec 15 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 1:2.0.0-1
 - Updating 'URL' and 'Version' tags for CBL-Mariner 2.0.
 
 * Tue Oct 12 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 20200720-20

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -646,16 +646,6 @@
       "component": {
         "type": "other",
         "other": {
-          "name": "ca-certificates",
-          "version": "20200720",
-          "downloadUrl": "https://hg.mozilla.org/releases/mozilla-release/raw-file/712412cb974c0392afe31fd9ce974b26ae3993c3/security/nss/lib/ckfw/builtins/certdata.txt"
-        }
-      }
-    },
-    {
-      "component": {
-        "type": "other",
-        "other": {
           "name": "cairo",
           "version": "1.17.4",
           "downloadUrl": "https://cairographics.org/snapshots/cairo-1.17.4.tar.xz"

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -223,10 +223,10 @@ libffi-devel-3.4.2-1.cm2.aarch64.rpm
 libtasn1-4.14-3.cm2.aarch64.rpm
 p11-kit-0.23.22-3.cm2.aarch64.rpm
 p11-kit-trust-0.23.22-3.cm2.aarch64.rpm
-ca-certificates-shared-20200720-20.cm2.noarch.rpm
-ca-certificates-tools-20200720-20.cm2.noarch.rpm
-ca-certificates-base-20200720-20.cm2.noarch.rpm
-ca-certificates-20200720-20.cm2.noarch.rpm
+ca-certificates-shared-20200720-21.cm2.noarch.rpm
+ca-certificates-tools-20200720-21.cm2.noarch.rpm
+ca-certificates-base-20200720-21.cm2.noarch.rpm
+ca-certificates-20200720-21.cm2.noarch.rpm
 dwz-0.13-4.cm2.aarch64.rpm
 unzip-6.0-19.cm2.aarch64.rpm
 python3-3.9.9-1.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -223,10 +223,10 @@ libffi-devel-3.4.2-1.cm2.aarch64.rpm
 libtasn1-4.14-3.cm2.aarch64.rpm
 p11-kit-0.23.22-3.cm2.aarch64.rpm
 p11-kit-trust-0.23.22-3.cm2.aarch64.rpm
-ca-certificates-shared-20200720-21.cm2.noarch.rpm
-ca-certificates-tools-20200720-21.cm2.noarch.rpm
-ca-certificates-base-20200720-21.cm2.noarch.rpm
-ca-certificates-20200720-21.cm2.noarch.rpm
+ca-certificates-shared-2.0.0-1.cm2.noarch.rpm
+ca-certificates-tools-2.0.0-1.cm2.noarch.rpm
+ca-certificates-base-2.0.0-1.cm2.noarch.rpm
+ca-certificates-2.0.0-1.cm2.noarch.rpm
 dwz-0.13-4.cm2.aarch64.rpm
 unzip-6.0-19.cm2.aarch64.rpm
 python3-3.9.9-1.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -223,10 +223,10 @@ libffi-devel-3.4.2-1.cm2.x86_64.rpm
 libtasn1-4.14-3.cm2.x86_64.rpm
 p11-kit-0.23.22-3.cm2.x86_64.rpm
 p11-kit-trust-0.23.22-3.cm2.x86_64.rpm
-ca-certificates-shared-20200720-20.cm2.noarch.rpm
-ca-certificates-tools-20200720-20.cm2.noarch.rpm
-ca-certificates-base-20200720-20.cm2.noarch.rpm
-ca-certificates-20200720-20.cm2.noarch.rpm
+ca-certificates-shared-20200720-21.cm2.noarch.rpm
+ca-certificates-tools-20200720-21.cm2.noarch.rpm
+ca-certificates-base-20200720-21.cm2.noarch.rpm
+ca-certificates-20200720-21.cm2.noarch.rpm
 dwz-0.13-4.cm2.x86_64.rpm
 unzip-6.0-19.cm2.x86_64.rpm
 python3-3.9.9-1.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -223,10 +223,10 @@ libffi-devel-3.4.2-1.cm2.x86_64.rpm
 libtasn1-4.14-3.cm2.x86_64.rpm
 p11-kit-0.23.22-3.cm2.x86_64.rpm
 p11-kit-trust-0.23.22-3.cm2.x86_64.rpm
-ca-certificates-shared-20200720-21.cm2.noarch.rpm
-ca-certificates-tools-20200720-21.cm2.noarch.rpm
-ca-certificates-base-20200720-21.cm2.noarch.rpm
-ca-certificates-20200720-21.cm2.noarch.rpm
+ca-certificates-shared-2.0.0-1.cm2.noarch.rpm
+ca-certificates-tools-2.0.0-1.cm2.noarch.rpm
+ca-certificates-base-2.0.0-1.cm2.noarch.rpm
+ca-certificates-2.0.0-1.cm2.noarch.rpm
 dwz-0.13-4.cm2.x86_64.rpm
 unzip-6.0-19.cm2.x86_64.rpm
 python3-3.9.9-1.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -17,11 +17,11 @@ bzip2-1.0.8-1.cm2.aarch64.rpm
 bzip2-debuginfo-1.0.8-1.cm2.aarch64.rpm
 bzip2-devel-1.0.8-1.cm2.aarch64.rpm
 bzip2-libs-1.0.8-1.cm2.aarch64.rpm
-ca-certificates-20200720-20.cm2.noarch.rpm
-ca-certificates-base-20200720-20.cm2.noarch.rpm
-ca-certificates-legacy-20200720-20.cm2.noarch.rpm
-ca-certificates-shared-20200720-20.cm2.noarch.rpm
-ca-certificates-tools-20200720-20.cm2.noarch.rpm
+ca-certificates-20200720-21.cm2.noarch.rpm
+ca-certificates-base-20200720-21.cm2.noarch.rpm
+ca-certificates-legacy-20200720-21.cm2.noarch.rpm
+ca-certificates-shared-20200720-21.cm2.noarch.rpm
+ca-certificates-tools-20200720-21.cm2.noarch.rpm
 check-0.15.2-1.cm2.aarch64.rpm
 check-debuginfo-0.15.2-1.cm2.aarch64.rpm
 cmake-3.21.4-2.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -17,11 +17,11 @@ bzip2-1.0.8-1.cm2.aarch64.rpm
 bzip2-debuginfo-1.0.8-1.cm2.aarch64.rpm
 bzip2-devel-1.0.8-1.cm2.aarch64.rpm
 bzip2-libs-1.0.8-1.cm2.aarch64.rpm
-ca-certificates-20200720-21.cm2.noarch.rpm
-ca-certificates-base-20200720-21.cm2.noarch.rpm
-ca-certificates-legacy-20200720-21.cm2.noarch.rpm
-ca-certificates-shared-20200720-21.cm2.noarch.rpm
-ca-certificates-tools-20200720-21.cm2.noarch.rpm
+ca-certificates-2.0.0-1.cm2.noarch.rpm
+ca-certificates-base-2.0.0-1.cm2.noarch.rpm
+ca-certificates-legacy-2.0.0-1.cm2.noarch.rpm
+ca-certificates-shared-2.0.0-1.cm2.noarch.rpm
+ca-certificates-tools-2.0.0-1.cm2.noarch.rpm
 check-0.15.2-1.cm2.aarch64.rpm
 check-debuginfo-0.15.2-1.cm2.aarch64.rpm
 cmake-3.21.4-2.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -17,11 +17,11 @@ bzip2-1.0.8-1.cm2.x86_64.rpm
 bzip2-debuginfo-1.0.8-1.cm2.x86_64.rpm
 bzip2-devel-1.0.8-1.cm2.x86_64.rpm
 bzip2-libs-1.0.8-1.cm2.x86_64.rpm
-ca-certificates-20200720-20.cm2.noarch.rpm
-ca-certificates-base-20200720-20.cm2.noarch.rpm
-ca-certificates-legacy-20200720-20.cm2.noarch.rpm
-ca-certificates-shared-20200720-20.cm2.noarch.rpm
-ca-certificates-tools-20200720-20.cm2.noarch.rpm
+ca-certificates-20200720-21.cm2.noarch.rpm
+ca-certificates-base-20200720-21.cm2.noarch.rpm
+ca-certificates-legacy-20200720-21.cm2.noarch.rpm
+ca-certificates-shared-20200720-21.cm2.noarch.rpm
+ca-certificates-tools-20200720-21.cm2.noarch.rpm
 check-0.15.2-1.cm2.x86_64.rpm
 check-debuginfo-0.15.2-1.cm2.x86_64.rpm
 cmake-3.21.4-2.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -17,11 +17,11 @@ bzip2-1.0.8-1.cm2.x86_64.rpm
 bzip2-debuginfo-1.0.8-1.cm2.x86_64.rpm
 bzip2-devel-1.0.8-1.cm2.x86_64.rpm
 bzip2-libs-1.0.8-1.cm2.x86_64.rpm
-ca-certificates-20200720-21.cm2.noarch.rpm
-ca-certificates-base-20200720-21.cm2.noarch.rpm
-ca-certificates-legacy-20200720-21.cm2.noarch.rpm
-ca-certificates-shared-20200720-21.cm2.noarch.rpm
-ca-certificates-tools-20200720-21.cm2.noarch.rpm
+ca-certificates-2.0.0-1.cm2.noarch.rpm
+ca-certificates-base-2.0.0-1.cm2.noarch.rpm
+ca-certificates-legacy-2.0.0-1.cm2.noarch.rpm
+ca-certificates-shared-2.0.0-1.cm2.noarch.rpm
+ca-certificates-tools-2.0.0-1.cm2.noarch.rpm
 check-0.15.2-1.cm2.x86_64.rpm
 check-debuginfo-0.15.2-1.cm2.x86_64.rpm
 cmake-3.21.4-2.cm2.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

As part of updating `rust` in #1678 I added `ca-certificates` to the worker chroot, which caused `prebuilt-ca-certificates-base` to accidentally build with the contents of `ca-certificates`, so way more certificates, than we need there. I'm fixing this bug here.

While I'm here, I've also updated the versions and URLs for our certificate packages.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Made sure we remove `ca-certificates` before building `prebuilt-ca-certificates`.
- Updated the versions of the cert packages to 2.0.0.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local package builds.
