### PR TITLE
[main] Fixing `prebuilt-ca-certificates-*` packages builds and contents.

### DIFF
--- a/SPECS/prebuilt-ca-certificates-base/prebuilt-ca-certificates-base.spec
+++ b/SPECS/prebuilt-ca-certificates-base/prebuilt-ca-certificates-base.spec
@@ -19,7 +19,7 @@ Prebuilt version of the ca-certificates-base package with no runtime dependencie
 
 %prep -q
 
-# Remove 'ca-certificate', if present. We don't want them
+# Remove 'ca-certificates', if present. We don't want them
 # to get mixed into the bundle provided by 'ca-certificates-base'.
 if rpm -q ca-certificates &>/dev/null; then rpm -e --nodeps ca-certificates; fi
 

--- a/SPECS/prebuilt-ca-certificates-base/prebuilt-ca-certificates-base.spec
+++ b/SPECS/prebuilt-ca-certificates-base/prebuilt-ca-certificates-base.spec
@@ -46,6 +46,7 @@ find %{buildroot} -name README -delete
 %changelog
 * Tue Oct 12 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 20200720-20
 - Removing conflicts with 'ca-certificates-shared'.
+- License verified.
 
 * Thu Sep 23 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 20200720-19
 - Making 'Release' match with 'ca-certificates'.

--- a/SPECS/prebuilt-ca-certificates-base/prebuilt-ca-certificates-base.spec
+++ b/SPECS/prebuilt-ca-certificates-base/prebuilt-ca-certificates-base.spec
@@ -23,14 +23,14 @@ Prebuilt version of the ca-certificates-base package with no runtime dependencie
 
 %install
 
-mkdir -p %{buildroot}%{_sysconfdir}/pki/
+mkdir -p %{buildroot}%{_sysconfdir}/pki/{tls/certs,ca-trust/extracted,java}
 
-cp -r %{_sysconfdir}/pki/* %{buildroot}%{_sysconfdir}/pki/
+cp %{_sysconfdir}/pki/tls/cert.pem %{buildroot}%{_sysconfdir}/pki/tls/
+cp -r %{_sysconfdir}/pki/tls/certs/* %{buildroot}%{_sysconfdir}/pki/tls/certs/
+cp -r %{_sysconfdir}/pki/ca-trust/extracted/* %{buildroot}%{_sysconfdir}/pki/ca-trust/extracted/
+cp %{_sysconfdir}/pki/java/cacerts %{buildroot}%{_sysconfdir}/pki/java/
 
 find %{buildroot} -name README -delete
-
-rm %{buildroot}%{_sysconfdir}/pki/tls/*.cnf
-rm %{buildroot}%{_sysconfdir}/pki/rpm-gpg/*
 
 %files
 # Base certs bundle file with trust

--- a/SPECS/prebuilt-ca-certificates-base/prebuilt-ca-certificates-base.spec
+++ b/SPECS/prebuilt-ca-certificates-base/prebuilt-ca-certificates-base.spec
@@ -19,6 +19,10 @@ Prebuilt version of the ca-certificates-base package with no runtime dependencie
 
 %prep -q
 
+# Remove 'ca-certificate', if present. We don't want them
+# to get mixed into the bundle provided by 'ca-certificates-base'.
+if rpm -q ca-certificates &>/dev/null; then rpm -e ca-certificates; fi
+
 %build
 
 %install

--- a/SPECS/prebuilt-ca-certificates-base/prebuilt-ca-certificates-base.spec
+++ b/SPECS/prebuilt-ca-certificates-base/prebuilt-ca-certificates-base.spec
@@ -21,7 +21,7 @@ Prebuilt version of the ca-certificates-base package with no runtime dependencie
 
 # Remove 'ca-certificate', if present. We don't want them
 # to get mixed into the bundle provided by 'ca-certificates-base'.
-if rpm -q ca-certificates &>/dev/null; then rpm -e ca-certificates; fi
+if rpm -q ca-certificates &>/dev/null; then rpm -e --nodeps ca-certificates; fi
 
 %build
 

--- a/SPECS/prebuilt-ca-certificates/prebuilt-ca-certificates.spec
+++ b/SPECS/prebuilt-ca-certificates/prebuilt-ca-certificates.spec
@@ -27,14 +27,14 @@ rpm -e ca-certificates-base
 
 %install
 
-mkdir -p %{buildroot}%{_sysconfdir}/pki/
+mkdir -p %{buildroot}%{_sysconfdir}/pki/{tls/certs,ca-trust/extracted,java}
 
-cp -r %{_sysconfdir}/pki/* %{buildroot}%{_sysconfdir}/pki/
+cp %{_sysconfdir}/pki/tls/cert.pem %{buildroot}%{_sysconfdir}/pki/tls/
+cp -r %{_sysconfdir}/pki/tls/certs/* %{buildroot}%{_sysconfdir}/pki/tls/certs/
+cp -r %{_sysconfdir}/pki/ca-trust/extracted/* %{buildroot}%{_sysconfdir}/pki/ca-trust/extracted/
+cp %{_sysconfdir}/pki/java/cacerts %{buildroot}%{_sysconfdir}/pki/java/
 
 find %{buildroot} -name README -delete
-
-rm %{buildroot}%{_sysconfdir}/pki/tls/*.cnf
-rm %{buildroot}%{_sysconfdir}/pki/rpm-gpg/*
 
 %files
 # Certs bundle file with trust

--- a/SPECS/prebuilt-ca-certificates/prebuilt-ca-certificates.spec
+++ b/SPECS/prebuilt-ca-certificates/prebuilt-ca-certificates.spec
@@ -19,7 +19,7 @@ Prebuilt version of the ca-certificates package with no runtime dependencies.
 
 %prep -q
 
-# Remove 'ca-certificate-base', if present. We don't want them
+# Remove 'ca-certificates-base', if present. We don't want them
 # to get mixed into the bundle provided by 'ca-certificates'.
 if rpm -q ca-certificates-base &>/dev/null ; then rpm -e --nodeps ca-certificates-base; fi
 

--- a/SPECS/prebuilt-ca-certificates/prebuilt-ca-certificates.spec
+++ b/SPECS/prebuilt-ca-certificates/prebuilt-ca-certificates.spec
@@ -19,9 +19,9 @@ Prebuilt version of the ca-certificates package with no runtime dependencies.
 
 %prep -q
 
-# We don't want the pre-installed base set of certificates
+# Remove 'ca-certificate-base', if present. We don't want them
 # to get mixed into the bundle provided by 'ca-certificates'.
-rpm -e ca-certificates-base
+if rpm -q ca-certificates-base &>/dev/null ; then rpm -e ca-certificates-base; fi
 
 %build
 

--- a/SPECS/prebuilt-ca-certificates/prebuilt-ca-certificates.spec
+++ b/SPECS/prebuilt-ca-certificates/prebuilt-ca-certificates.spec
@@ -21,7 +21,7 @@ Prebuilt version of the ca-certificates package with no runtime dependencies.
 
 # Remove 'ca-certificate-base', if present. We don't want them
 # to get mixed into the bundle provided by 'ca-certificates'.
-if rpm -q ca-certificates-base &>/dev/null ; then rpm -e ca-certificates-base; fi
+if rpm -q ca-certificates-base &>/dev/null ; then rpm -e --nodeps ca-certificates-base; fi
 
 %build
 

--- a/SPECS/prebuilt-ca-certificates/prebuilt-ca-certificates.spec
+++ b/SPECS/prebuilt-ca-certificates/prebuilt-ca-certificates.spec
@@ -46,6 +46,7 @@ find %{buildroot} -name README -delete
 %changelog
 * Tue Oct 12 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 20200720-20
 - Removing conflicts with 'ca-certificates-shared'.
+- License verified.
 
 * Thu Sep 23 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 20200720-19
 - Original version for CBL-Mariner.


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

The `prebuilt-ca-certificates-*` were making too many assumptions on the contents of the worker chroot in their build steps, which caused build breaks when the environment changed recently. This PR makes the build assume only the existence of the components, which absolutely need to be there for the build to succeed.

The `prebuilt-ca-certificates-base` package was also accidentally providing the certs from `ca-certificates`, which shouldn't happen. Fixed this as well.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Fixed the build steps for `prebuilt-ca-certificates-*`.
- Removed certs from `ca-certificates` from `prebuilt-ca-certificates-base`.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local package build.
