### PR TITLE
[main] `kernel-signed`: skip copying `ld` scripts from `%prep` phase.

### DIFF
--- a/SPECS-SIGNED/kernel-signed/kernel-signed.spec
+++ b/SPECS-SIGNED/kernel-signed/kernel-signed.spec
@@ -91,15 +91,19 @@ The kernel package contains the signed Linux kernel.
 %build
 mkdir rpm_contents
 pushd rpm_contents
-     # This spec's whole purpose is to inject the signed kernel binary
-     rpm2cpio %{SOURCE0} | cpio -idmv
-     cp %{SOURCE1} ./boot/vmlinuz-%{uname_r}
+
+# This spec's whole purpose is to inject the signed kernel binary
+rpm2cpio %{SOURCE0} | cpio -idmv
+cp %{SOURCE1} ./boot/vmlinuz-%{uname_r}
+
 popd
 
 %install
 pushd rpm_contents
-     # Don't use * wildcard. It does not copy over hidden files in the root folder...
-     cp -rp ./. %{buildroot}/
+
+# Don't use * wildcard. It does not copy over hidden files in the root folder...
+cp -rp ./. %{buildroot}/
+
 popd
 
 # Recalculate sha512hmac for FIPS

--- a/SPECS-SIGNED/kernel-signed/kernel-signed.spec
+++ b/SPECS-SIGNED/kernel-signed/kernel-signed.spec
@@ -89,13 +89,18 @@ The kernel package contains the signed Linux kernel.
 %prep
 
 %build
-# This spec's whole purpose is to inject the signed kernel binary
-rpm2cpio %{SOURCE0} | cpio -idmv
-cp %{SOURCE1} ./boot/vmlinuz-%{uname_r}
+mkdir rpm_contents
+pushd rpm_contents
+     # This spec's whole purpose is to inject the signed kernel binary
+     rpm2cpio %{SOURCE0} | cpio -idmv
+     cp %{SOURCE1} ./boot/vmlinuz-%{uname_r}
+popd
 
 %install
-# Don't use * wildcard. It does not copy over hidden files in the root folder...
-cp -rp ./. %{buildroot}/
+pushd rpm_contents
+     # Don't use * wildcard. It does not copy over hidden files in the root folder...
+     cp -rp ./. %{buildroot}/
+popd
 
 # Recalculate sha512hmac for FIPS
 %{sha512hmac} %{buildroot}/boot/vmlinuz-%{uname_r} | sed -e "s,$RPM_BUILD_ROOT,," > %{buildroot}/boot/.vmlinuz-%{uname_r}.hmac


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

In 2.0 the `%prep` stage populates the build directory with an `ld` script, which most specs use while linking but the file itself never ends up in the `BUILDROOT` folder. The `kernel-signed.spec` doesn't do any building, just extracts an already built RPM containing the `kernel` package, copies over its contents and the signed kernel, and bundles this all up in another RPM. The copying was now accidentally picking up the `ld` scripts and placing them inside the `BUILDROOT` folder, so it needed to be fixed.

**NOTE**: I'm not updating the `Release` tag as this package and its SRPM were never published for 2.0.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Made sure we only copy over the files we need for `kernel-signed`.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local test build.
