### PR TITLE
Bumpr release for Mariner 1.0 Dec 2021 Update

### DIFF
--- a/SPECS/mariner-release/mariner-release.spec
+++ b/SPECS/mariner-release/mariner-release.spec
@@ -1,7 +1,7 @@
 Summary:       CBL-Mariner release files
 Name:          mariner-release
 Version:       1.0
-Release:       28%{?dist}
+Release:       29%{?dist}
 License:       MIT
 Group:         System Environment/Base
 URL:           https://aka.ms/cbl-mariner
@@ -67,6 +67,8 @@ rm -rf $RPM_BUILD_ROOT
 %config(noreplace) /etc/issue.net
 
 %changelog
+*   Wed Dec 22 2021 Jon Slobodzian <joslobo@microsoft.com> - 1.0-29
+-   Updating version for December update.
 *   Thu Nov 25 2021 Jon Slobodzian <joslobo@microsoft.com> - 1.0-28
 -   Updating version for November update.
 *   Thu Nov 25 2021 Jon Slobodzian <joslobo@microsoft.com> - 1.0-27

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -58,7 +58,7 @@ findutils-lang-4.6.0-7.cm1.aarch64.rpm
 gettext-0.19.8.1-5.cm1.aarch64.rpm
 gzip-1.9-5.cm1.aarch64.rpm
 make-4.2.1-5.cm1.aarch64.rpm
-mariner-release-1.0-28.cm1.noarch.rpm
+mariner-release-1.0-29.cm1.noarch.rpm
 patch-2.7.6-7.cm1.aarch64.rpm
 util-linux-2.32.1-5.cm1.aarch64.rpm
 util-linux-devel-2.32.1-5.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -58,7 +58,7 @@ findutils-lang-4.6.0-7.cm1.x86_64.rpm
 gettext-0.19.8.1-5.cm1.x86_64.rpm
 gzip-1.9-5.cm1.x86_64.rpm
 make-4.2.1-5.cm1.x86_64.rpm
-mariner-release-1.0-28.cm1.noarch.rpm
+mariner-release-1.0-29.cm1.noarch.rpm
 patch-2.7.6-7.cm1.x86_64.rpm
 util-linux-2.32.1-5.cm1.x86_64.rpm
 util-linux-devel-2.32.1-5.cm1.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -263,7 +263,7 @@ m4-debuginfo-1.4.18-4.cm1.aarch64.rpm
 make-4.2.1-5.cm1.aarch64.rpm
 make-debuginfo-4.2.1-5.cm1.aarch64.rpm
 mariner-check-macros-1.0-6.cm1.noarch.rpm
-mariner-release-1.0-28.cm1.noarch.rpm
+mariner-release-1.0-29.cm1.noarch.rpm
 mariner-repos-1.0-14.cm1.noarch.rpm
 mariner-repos-extras-1.0-14.cm1.noarch.rpm
 mariner-repos-extras-preview-1.0-14.cm1.noarch.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -263,7 +263,7 @@ m4-debuginfo-1.4.18-4.cm1.x86_64.rpm
 make-4.2.1-5.cm1.x86_64.rpm
 make-debuginfo-4.2.1-5.cm1.x86_64.rpm
 mariner-check-macros-1.0-6.cm1.noarch.rpm
-mariner-release-1.0-28.cm1.noarch.rpm
+mariner-release-1.0-29.cm1.noarch.rpm
 mariner-repos-1.0-14.cm1.noarch.rpm
 mariner-repos-extras-1.0-14.cm1.noarch.rpm
 mariner-repos-extras-preview-1.0-14.cm1.noarch.rpm


### PR DESCRIPTION
This change bumps the mariner-release number in support of the Mariner 1.0 December 2021 update