### PR TITLE
Fix version requirements on ca-certificates packages

### DIFF
--- a/SPECS/ca-certificates/ca-certificates.spec
+++ b/SPECS/ca-certificates/ca-certificates.spec
@@ -80,10 +80,10 @@ BuildRequires:  openssl
 BuildRequires:  perl
 BuildRequires:  python3
 
-Requires:       %{name}-shared = %{version}-%{release}
-Requires(post): %{name}-tools = %{version}-%{release}
+Requires:       %{name}-shared = %{epoch}:%{version}-%{release}
+Requires(post): %{name}-tools = %{epoch}:%{version}-%{release}
 Requires(post): coreutils
-Requires(postun): %{name}-tools = %{version}-%{release}
+Requires(postun): %{name}-tools = %{epoch}:%{version}-%{release}
 
 Provides:       ca-certificates-microsoft = %{version}-%{release}
 Provides:       ca-certificates-mozilla = %{version}-%{release}
@@ -110,10 +110,10 @@ Group:          System Environment/Security
 Summary:        Basic set of trusted CAs required to authenticate the packages repository.
 Group:          System Environment/Security
 
-Requires:       %{name}-shared = %{version}-%{release}
-Requires(post): %{name}-tools = %{version}-%{release}
+Requires:       %{name}-shared = %{epoch}:%{version}-%{release}
+Requires(post): %{name}-tools = %{epoch}:%{version}-%{release}
 Requires(post): coreutils
-Requires(postun): %{name}-tools = %{version}-%{release}
+Requires(postun): %{name}-tools = %{epoch}:%{version}-%{release}
 
 %description base
 %{summary}
@@ -132,7 +132,7 @@ Set of scripts to generate certificates out of a certdata.txt file.
 Summary:        Support for legacy certificates configuration.
 Group:          System Environment/Security
 
-Requires:       %{name}-shared = %{version}-%{release}
+Requires:       %{name}-shared = %{epoch}:%{version}-%{release}
 
 %description legacy
 Provides a legacy version of ca-bundle.crt in the format of "[hash].0 -> [hash].pem"

--- a/SPECS/prebuilt-ca-certificates-base/prebuilt-ca-certificates-base.spec
+++ b/SPECS/prebuilt-ca-certificates-base/prebuilt-ca-certificates-base.spec
@@ -11,7 +11,7 @@ Group:          System Environment/Security
 URL:            https://docs.microsoft.com/en-us/security/trusted-root/program-requirements
 BuildArch:      noarch
 
-BuildRequires:  ca-certificates-base = %{version}-%{release}
+BuildRequires:  ca-certificates-base = %{epoch}:%{version}-%{release}
 
 Conflicts:      prebuilt-ca-certificates
 

--- a/SPECS/prebuilt-ca-certificates/prebuilt-ca-certificates.spec
+++ b/SPECS/prebuilt-ca-certificates/prebuilt-ca-certificates.spec
@@ -11,7 +11,7 @@ Group:          System Environment/Security
 URL:            https://docs.microsoft.com/en-us/security/trusted-root/program-requirements
 BuildArch:      noarch
 
-BuildRequires:  ca-certificates = %{version}-%{release}
+BuildRequires:  ca-certificates = %{epoch}:%{version}-%{release}
 
 Conflicts:      prebuilt-ca-certificates-base
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
#1773 added an epoch to our certificate packages in order to allow for a version scheme reset. However, that PR did not update some of the requirements on certificate packages that were looking for specific versions, leading to unresolved dependencies. This PR remedies this by making the requirements epoch-aware.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Update `ca-certificates`, `prebuilt-ca-certificates`, `prebuilt-ca-certificates-base` with epoch-aware requirements
- Package releases numbers were not bumped, as these packages have not built yet.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Re-seed pipeline build
