### PR TITLE
Avoid starting the `check-restart` service on reboot

### DIFF
--- a/SPECS/check-restart/check-restart.service
+++ b/SPECS/check-restart/check-restart.service
@@ -5,6 +5,3 @@ Wants=check-restart.timer
 [Service]
 Type=oneshot
 ExecStart=/bin/bash /usr/bin/check-restart.sh
-
-[Install]
-WantedBy=multi-user.target

--- a/SPECS/check-restart/check-restart.signatures.json
+++ b/SPECS/check-restart/check-restart.signatures.json
@@ -1,7 +1,7 @@
 {
  "Signatures": {
-  "check-restart.service": "730950864f92277e377a8fc85677859cc8df628aad8061d2e7ce22c9d9bd5658",
+  "check-restart.service": "5beb9ec5cd944bf4effb31d699775fa074b2a0bc3920687b75ca50895efc6b42",
   "check-restart.sh": "b0a6bb06f7856ad6c591a084ebd9967ac41697f162ed38b9522997beb3287fd6",
-  "check-restart.timer": "74accbf8d3bfa514dd2109107cf37c9c266d6a6fa2bb61a7c9972618a6047fd5"
+  "check-restart.timer": "2ba9ddcd621aec19e3c87a30cdd078e9934b5613f0228c56940d2009d55fee7e"
  }
 }

--- a/SPECS/check-restart/check-restart.spec
+++ b/SPECS/check-restart/check-restart.spec
@@ -2,7 +2,7 @@
 Summary:        Create new systemd timer to check for system restart
 Name:           check-restart
 Version:        1.0.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -39,5 +39,8 @@ install -m644 %{SOURCE1} %{buildroot}%{_bindir}/%{name}.sh
 %{_bindir}/%{name}.sh
 
 %changelog
+* Tue Jan 04 2022 Neha Agarwal <nehaagarwal@microsoft.com> - 1.0.0-2
+- Update timer and service to avoid starting service on system reboot.
+
 * Mon Aug 02 2021 Neha Agarwal <nehaagarwal@microsoft.com> - 1.0.0-1
 - Original version for CBL-Mariner.

--- a/SPECS/check-restart/check-restart.timer
+++ b/SPECS/check-restart/check-restart.timer
@@ -1,6 +1,5 @@
 [Unit]
 Description=Checks if system needs to be restarted due to recent version updates
-Requires=check-restart.service
 
 [Timer]
 Unit=check-restart.service


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Avoid starting the service on reboot

###### Change Log  <!-- REQUIRED -->
- Fixes the service and timer so that the service is not started on every system reboot
- The timer starts on every system reboot. If it has a 'Require' on the service, it will start the service as well on reboot. Hence, removed that line
- A systemd service having an 'install' section marks its state as 'enabled'. This starts the service on every reboot. Removing this section marks the service unit's state as 'static'.

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Associated issues  <!-- optional -->
- https://microsoft.visualstudio.com/OS/_workitems/edit/37411367

###### Links to CVEs  <!-- optional -->
- None

###### Test Methodology
- Local build, tested new package in VM on hyper-v and observed correct behavior
