### PR TITLE
[main] Replace generated dependencies on java-headless with java

### DIFF
--- a/SPECS-EXTENDED/bsh/bsh.spec
+++ b/SPECS-EXTENDED/bsh/bsh.spec
@@ -33,7 +33,7 @@
 
 Name:           bsh
 Version:        2.0
-Release:        19%{?dist}
+Release:        20%{?dist}
 Summary:        Lightweight Scripting for Java
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -60,7 +60,7 @@ BuildRequires:  ImageMagick
 BuildRequires:  desktop-file-utils
 %endif
 
-Requires:       java-headless
+Requires:       java
 Requires:       bsf
 Requires:       jline
 # Explicit javapackages-tools requires since scripts use
@@ -171,6 +171,9 @@ cat scripts/bshdoc.bsh >> %{buildroot}%{_bindir}/bshdoc
 %license LICENSE NOTICE
 
 %changelog
+* Wed Jan 05 2022 Thomas Crain <thcrain@microsoft.com> - 2.0-20
+- Rename java-headless dependency to java
+
 * Mon Nov 01 2021 Muhammad Falak <mwani@microsft.com> - 2.0-19
 - Remove epoch
 

--- a/SPECS-EXTENDED/bsh/bsh.spec
+++ b/SPECS-EXTENDED/bsh/bsh.spec
@@ -173,6 +173,7 @@ cat scripts/bshdoc.bsh >> %{buildroot}%{_bindir}/bshdoc
 %changelog
 * Wed Jan 05 2022 Thomas Crain <thcrain@microsoft.com> - 2.0-20
 - Rename java-headless dependency to java
+- License verified
 
 * Mon Nov 01 2021 Muhammad Falak <mwani@microsft.com> - 2.0-19
 - Remove epoch

--- a/SPECS-EXTENDED/flute/flute.spec
+++ b/SPECS-EXTENDED/flute/flute.spec
@@ -40,16 +40,17 @@ mkdir -p $RPM_BUILD_ROOT%{_javadocdir}/%{name}
 cp -rp build/api $RPM_BUILD_ROOT%{_javadocdir}/%{name}
 
 %files
-%doc COPYRIGHT.html
+%license COPYRIGHT.html
 %{_javadir}/*.jar
 
 %files javadoc
-%doc COPYRIGHT.html
+%license COPYRIGHT.html
 %{_javadocdir}/%{name}
 
 %changelog
 * Wed Jan 05 2022 Thomas Crain <thcrain@microsoft.com> - 1.3.0-24
 - Rename java-headless dependency to java
+- License verified
 
 * Thu Oct 14 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.3.0-23
 - Initial CBL-Mariner import from Fedora 32 (license: MIT).

--- a/SPECS-EXTENDED/flute/flute.spec
+++ b/SPECS-EXTENDED/flute/flute.spec
@@ -2,14 +2,14 @@ Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Name: flute
 Version: 1.3.0
-Release: 23%{?dist}
+Release: 24%{?dist}
 Summary: Java CSS parser using SAC
 # The entire source code is W3C except ParseException.java which is LGPLv2+
 License: W3C and LGPLv2+
 Source0: http://downloads.sourceforge.net/jfreereport/%{name}-%{version}-OOo31.zip
 URL: http://www.w3.org/Style/CSS/SAC/
 BuildRequires: ant, java-devel, jpackage-utils, sac
-Requires: java-headless, jpackage-utils sac
+Requires: java, jpackage-utils sac
 BuildArch: noarch
 
 %description
@@ -48,6 +48,9 @@ cp -rp build/api $RPM_BUILD_ROOT%{_javadocdir}/%{name}
 %{_javadocdir}/%{name}
 
 %changelog
+* Wed Jan 05 2022 Thomas Crain <thcrain@microsoft.com> - 1.3.0-24
+- Rename java-headless dependency to java
+
 * Thu Oct 14 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.3.0-23
 - Initial CBL-Mariner import from Fedora 32 (license: MIT).
 - Converting the 'Release' tag to the '[number].[distribution]' format.

--- a/SPECS-EXTENDED/jakarta-commons-httpclient/jakarta-commons-httpclient.spec
+++ b/SPECS-EXTENDED/jakarta-commons-httpclient/jakarta-commons-httpclient.spec
@@ -4,7 +4,7 @@ Distribution:   Mariner
 
 Name:           jakarta-commons-httpclient
 Version:        3.1
-Release:        35%{?dist}
+Release:        36%{?dist}
 Summary: Jakarta Commons HTTPClient implements the client side of HTTP standards
 License:        ASL 2.0 and (ASL 2.0 or LGPLv2+)
 URL:            http://jakarta.apache.org/commons/httpclient/
@@ -30,7 +30,7 @@ BuildRequires:  apache-commons-codec
 BuildRequires:  apache-commons-logging >= 1.0.3
 BuildRequires:  junit
 
-Requires:       java-headless
+Requires:       java
 Requires:       apache-commons-logging >= 1.0.3
 Requires:       apache-commons-codec
 Provides:       deprecated()
@@ -145,6 +145,9 @@ ln -s %{_javadocdir}/%{name} dist/docs/apidocs
 
 
 %changelog
+* Wed Jan 05 2022 Thomas Crain <thcrain@microsoft.com> - 3.1-36
+- Rename java-headless dependency to java
+
 * Mon Nov 01 2021 Muhammad Falak <mwani@microsft.com> - 3.1-35
 - Remove epoch
 

--- a/SPECS-EXTENDED/jakarta-commons-httpclient/jakarta-commons-httpclient.spec
+++ b/SPECS-EXTENDED/jakarta-commons-httpclient/jakarta-commons-httpclient.spec
@@ -131,11 +131,11 @@ ln -s %{_javadocdir}/%{name} dist/docs/apidocs
 
 
 %files -f .mfiles
-%doc LICENSE NOTICE
+%license LICENSE NOTICE
 %doc README RELEASE_NOTES
 
 %files javadoc -f .mfiles-javadoc
-%doc LICENSE NOTICE
+%license LICENSE NOTICE
 
 %files demo
 %{_datadir}/%{name}
@@ -147,6 +147,7 @@ ln -s %{_javadocdir}/%{name} dist/docs/apidocs
 %changelog
 * Wed Jan 05 2022 Thomas Crain <thcrain@microsoft.com> - 3.1-36
 - Rename java-headless dependency to java
+- License verified
 
 * Mon Nov 01 2021 Muhammad Falak <mwani@microsft.com> - 3.1-35
 - Remove epoch

--- a/SPECS-EXTENDED/jss/jss.spec
+++ b/SPECS-EXTENDED/jss/jss.spec
@@ -168,6 +168,7 @@ ctest --output-on-failure
 %changelog
 * Wed Jan 05 2022 Thomas Crain <thcrain@microsoft.com> - 4.8.1-4
 - Rename java-headless dependency to java
+- License verified
 
 * Thu Oct 14 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 4.8.1-3
 - Converting the 'Release' tag to the '[number].[distribution]' format.

--- a/SPECS-EXTENDED/jss/jss.spec
+++ b/SPECS-EXTENDED/jss/jss.spec
@@ -9,7 +9,7 @@ URL:            http://www.dogtagpki.org/wiki/JSS
 License:        MPLv1.1 or GPLv2+ or LGPLv2+
 
 Version:        4.8.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 #global         _phase -a1
 
 # To generate the source tarball:
@@ -57,7 +57,7 @@ BuildRequires:  apache-commons-lang3
 BuildRequires:  junit
 
 Requires:       nss >= 3.44
-Requires:       java-headless
+Requires:       java
 Requires:       jpackage-utils
 Requires:       slf4j
 Requires:       glassfish-jaxb-api
@@ -166,6 +166,9 @@ ctest --output-on-failure
 
 ################################################################################
 %changelog
+* Wed Jan 05 2022 Thomas Crain <thcrain@microsoft.com> - 4.8.1-4
+- Rename java-headless dependency to java
+
 * Thu Oct 14 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 4.8.1-3
 - Converting the 'Release' tag to the '[number].[distribution]' format.
 

--- a/SPECS-EXTENDED/lasso/lasso.spec
+++ b/SPECS-EXTENDED/lasso/lasso.spec
@@ -53,7 +53,7 @@ Distribution:   Mariner
 Summary: Liberty Alliance Single Sign On
 Name: lasso
 Version: 2.6.0
-Release: 23%{?dist}
+Release: 24%{?dist}
 License: GPLv2+
 URL: http://lasso.entrouvert.org/
 Source: http://dev.entrouvert.org/lasso/lasso-%{version}.tar.gz
@@ -144,7 +144,7 @@ Perl language bindings for the lasso (Liberty Alliance Single Sign On) library.
 %if %{with_java}
 %package -n java-%{name}
 Summary: Liberty Alliance Single Sign On (lasso) Java bindings
-Requires: java-headless
+Requires: java
 Requires: jpackage-utils
 Requires: %{name}%{?_isa} = %{version}-%{release}
 %if %{obsolete_old_lang_subpackages}
@@ -317,6 +317,9 @@ rm -fr %{buildroot}%{_defaultdocdir}/%{name}
 %endif
 
 %changelog
+* Wed Jan 05 2022 Thomas Crain <thcrain@microsoft.com> - 2.6.0-24
+- Rename java-headless dependency to java
+
 * Wed Jul 14 2021 Muhammad Falak Wani <mwani@microsoft.com> - 2.6.0-23
 - Add explict provides 'lasso-python'
 

--- a/SPECS-EXTENDED/lasso/lasso.spec
+++ b/SPECS-EXTENDED/lasso/lasso.spec
@@ -319,6 +319,7 @@ rm -fr %{buildroot}%{_defaultdocdir}/%{name}
 %changelog
 * Wed Jan 05 2022 Thomas Crain <thcrain@microsoft.com> - 2.6.0-24
 - Rename java-headless dependency to java
+- License verified
 
 * Wed Jul 14 2021 Muhammad Falak Wani <mwani@microsoft.com> - 2.6.0-23
 - Add explict provides 'lasso-python'

--- a/SPECS-EXTENDED/libvirt-java/libvirt-java.spec
+++ b/SPECS-EXTENDED/libvirt-java/libvirt-java.spec
@@ -4,7 +4,7 @@ Summary:    Java bindings for the libvirt virtualization API
 Name:       libvirt-java
 Version:    0.4.9
 Prefix:     libvirt
-Release:    18%{?dist}
+Release:    17%{?dist}
 License:    MIT
 BuildArch:  noarch
 Source:     http://libvirt.org/sources/java/%{name}-%{version}.tar.gz
@@ -16,7 +16,7 @@ URL:        http://libvirt.org/
 Requires:   jna
 Requires:   libvirt-client >= 0.9.12
 
-Requires:   java >= 1.5.0
+Requires:   java-headless >= 1.5.0
 
 
 
@@ -75,8 +75,7 @@ cp -r target/javadoc/* %{buildroot}%{_javadocdir}/%{name}-%{version}
 ant test
 
 %files
-%license LICENCE
-%doc AUTHORS NEWS README INSTALL
+%doc AUTHORS LICENCE NEWS README INSTALL
 %{_javadir}/*.jar
 
 %files devel
@@ -88,10 +87,6 @@ ant test
 %{_javadocdir}/%{name}
 
 %changelog
-* Wed Jan 05 2022 Thomas Crain <thcrain@microsoft.com> - 0.4.9-18
-- Rename java-headless dependency to java
-- License verified
-
 * Fri Oct 15 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 0.4.9-17
 - Initial CBL-Mariner import from Fedora 32 (license: MIT).
 

--- a/SPECS-EXTENDED/libvirt-java/libvirt-java.spec
+++ b/SPECS-EXTENDED/libvirt-java/libvirt-java.spec
@@ -4,7 +4,7 @@ Summary:    Java bindings for the libvirt virtualization API
 Name:       libvirt-java
 Version:    0.4.9
 Prefix:     libvirt
-Release:    17%{?dist}
+Release:    18%{?dist}
 License:    MIT
 BuildArch:  noarch
 Source:     http://libvirt.org/sources/java/%{name}-%{version}.tar.gz
@@ -16,7 +16,7 @@ URL:        http://libvirt.org/
 Requires:   jna
 Requires:   libvirt-client >= 0.9.12
 
-Requires:   java-headless >= 1.5.0
+Requires:   java >= 1.5.0
 
 
 
@@ -87,6 +87,9 @@ ant test
 %{_javadocdir}/%{name}
 
 %changelog
+* Wed Jan 05 2022 Thomas Crain <thcrain@microsoft.com> - 0.4.9-18
+- Rename java-headless dependency to java
+
 * Fri Oct 15 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 0.4.9-17
 - Initial CBL-Mariner import from Fedora 32 (license: MIT).
 

--- a/SPECS-EXTENDED/libvirt-java/libvirt-java.spec
+++ b/SPECS-EXTENDED/libvirt-java/libvirt-java.spec
@@ -75,7 +75,8 @@ cp -r target/javadoc/* %{buildroot}%{_javadocdir}/%{name}-%{version}
 ant test
 
 %files
-%doc AUTHORS LICENCE NEWS README INSTALL
+%license LICENCE
+%doc AUTHORS NEWS README INSTALL
 %{_javadir}/*.jar
 
 %files devel
@@ -89,6 +90,7 @@ ant test
 %changelog
 * Wed Jan 05 2022 Thomas Crain <thcrain@microsoft.com> - 0.4.9-18
 - Rename java-headless dependency to java
+- License verified
 
 * Fri Oct 15 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 0.4.9-17
 - Initial CBL-Mariner import from Fedora 32 (license: MIT).

--- a/SPECS-EXTENDED/openmpi/openmpi.spec
+++ b/SPECS-EXTENDED/openmpi/openmpi.spec
@@ -35,7 +35,7 @@ Distribution:   Mariner
 
 Name:            openmpi%{?_cc_name_suffix}
 Version:         4.0.3x
-Release:         4%{?dist}
+Release:         5%{?dist}
 Summary:         Open Message Passing Interface
 License:         BSD and MIT and Romio
 URL:             http://www.open-mpi.org/
@@ -128,7 +128,7 @@ Contains development headers and libraries for openmpi.
 Summary:    Java library
 Requires:   %{name} = %{version}-%{release}
 
-Requires:   java-headless
+Requires:   java
 
 
 
@@ -360,6 +360,9 @@ make check
 
 
 %changelog
+* Wed Jan 05 2022 Thomas Crain <thcrain@microsoft.com> - 4.0.3x-5
+- Rename java-headless dependency to java
+
 * Mon May 17 2021 Thomas Crain <thcrain@microsoft.com> - 4.0.3x-4
 - Change JDK dir to match JDK version
 

--- a/SPECS-EXTENDED/openmpi/openmpi.spec
+++ b/SPECS-EXTENDED/openmpi/openmpi.spec
@@ -362,6 +362,7 @@ make check
 %changelog
 * Wed Jan 05 2022 Thomas Crain <thcrain@microsoft.com> - 4.0.3x-5
 - Rename java-headless dependency to java
+- License verified
 
 * Mon May 17 2021 Thomas Crain <thcrain@microsoft.com> - 4.0.3x-4
 - Change JDK dir to match JDK version

--- a/SPECS-EXTENDED/sblim-cim-client2/sblim-cim-client2.spec
+++ b/SPECS-EXTENDED/sblim-cim-client2/sblim-cim-client2.spec
@@ -96,7 +96,7 @@ cp -pr %{archive_folder}/doc/* $RPM_BUILD_ROOT%{_javadocdir}/%{name}
 %dir %{_pkgdocdir}
 %config(noreplace) %{_sysconfdir}/java/sblim-cim-client2.properties
 %config(noreplace) %{_sysconfdir}/java/sblim-slp-client2.properties
-%doc %{_pkgdocdir}/COPYING
+%license %{_pkgdocdir}/COPYING
 %doc %{_pkgdocdir}/README
 %doc %{_pkgdocdir}/ChangeLog
 %doc %{_pkgdocdir}/NEWS
@@ -106,13 +106,13 @@ cp -pr %{archive_folder}/doc/* $RPM_BUILD_ROOT%{_javadocdir}/%{name}
 %{_javadocdir}/%{name}
 
 %files manual
-%doc %{_pkgdocdir}/COPYING
+%license %{_pkgdocdir}/COPYING
 %doc %{_pkgdocdir}/org
-
 
 %changelog
 * Wed Jan 05 2022 Thomas Crain <thcrain@microsoft.com> - 2.2.5-15
 - Rename java-headless dependency to java
+- License verified
 
 * Wed Nov 03 2021 Muhammad Falak <mwani@microsft.com> - 2.2.5-14
 - Remove epoch

--- a/SPECS-EXTENDED/sblim-cim-client2/sblim-cim-client2.spec
+++ b/SPECS-EXTENDED/sblim-cim-client2/sblim-cim-client2.spec
@@ -6,7 +6,7 @@ Distribution:   Mariner
 
 Name:           sblim-cim-client2
 Version:        2.2.5
-Release:        14%{?dist}
+Release:        15%{?dist}
 Summary:        Java CIM Client library
 
 License:        EPL
@@ -19,7 +19,7 @@ BuildRequires:  java-devel >= 1.4
 BuildRequires:  jpackage-utils >= 1.5.32
 BuildRequires:  ant >= 1.6
 
-Requires:       java-headless >= 1.4
+Requires:       java >= 1.4
 Requires:       jpackage-utils >= 1.5.32
 
 %description
@@ -111,6 +111,9 @@ cp -pr %{archive_folder}/doc/* $RPM_BUILD_ROOT%{_javadocdir}/%{name}
 
 
 %changelog
+* Wed Jan 05 2022 Thomas Crain <thcrain@microsoft.com> - 2.2.5-15
+- Rename java-headless dependency to java
+
 * Wed Nov 03 2021 Muhammad Falak <mwani@microsft.com> - 2.2.5-14
 - Remove epoch
 

--- a/SPECS-EXTENDED/tomcat/tomcat.spec
+++ b/SPECS-EXTENDED/tomcat/tomcat.spec
@@ -631,6 +631,7 @@ fi
 %changelog
 * Wed Jan 05 2022 Thomas Crain <thcrain@microsoft.com> - 9.0.39-6
 - Rename java-headless dependency to java
+- License verified
 
 * Thu Oct 28 2021 Muhammad Falak <mwani@microsft.com> - 9.0.39-5
 - Remove epoch

--- a/SPECS-EXTENDED/tomcat/tomcat.spec
+++ b/SPECS-EXTENDED/tomcat/tomcat.spec
@@ -65,7 +65,7 @@ Summary:       Apache Servlet/JSP Engine, RI for Servlet %{servletspec}/JSP %{js
 
 License:       ASL 2.0
 URL:           http://tomcat.apache.org/
-Source0:       http://www.apache.org/dist/tomcat/tomcat-%{major_version}/v%{version}/src/%{packdname}.tar.gz
+Source0:       https://archive.apache.org/dist/%{name}/%{name}-%{major_version}/v%{version}/src/%{packdname}.tar.gz
 Source1:       %{name}-%{major_version}.%{minor_version}.conf
 Source3:       %{name}-%{major_version}.%{minor_version}.sysconfig
 Source4:       %{name}-%{major_version}.%{minor_version}.wrapper
@@ -631,6 +631,7 @@ fi
 %changelog
 * Wed Jan 05 2022 Thomas Crain <thcrain@microsoft.com> - 9.0.39-6
 - Rename java-headless dependency to java
+- Change Source URL to pull from Apache arhive
 - License verified
 
 * Thu Oct 28 2021 Muhammad Falak <mwani@microsft.com> - 9.0.39-5

--- a/SPECS-EXTENDED/tomcat/tomcat.spec
+++ b/SPECS-EXTENDED/tomcat/tomcat.spec
@@ -60,7 +60,7 @@ Distribution:   Mariner
 
 Name:          tomcat
 Version:       %{major_version}.%{minor_version}.%{micro_version}
-Release:       5%{?dist}
+Release:       6%{?dist}
 Summary:       Apache Servlet/JSP Engine, RI for Servlet %{servletspec}/JSP %{jspspec} API
 
 License:       ASL 2.0
@@ -109,7 +109,7 @@ BuildRequires: wsdl4j
 BuildRequires: systemd
 
 Requires:      apache-commons-daemon
-Requires:      java-headless >= 1.8.0
+Requires:      java >= 1.8.0
 Requires:      javapackages-tools
 Requires:      procps
 Requires:      %{name}-lib = %{version}-%{release}
@@ -628,6 +628,9 @@ fi
 %attr(0660,tomcat,tomcat) %verify(not size md5 mtime) %{logdir}/catalina.out
 
 %changelog
+* Wed Jan 05 2022 Thomas Crain <thcrain@microsoft.com> - 9.0.39-6
+- Rename java-headless dependency to java
+
 * Thu Oct 28 2021 Muhammad Falak <mwani@microsft.com> - 9.0.39-5
 - Remove epoch
 

--- a/SPECS-EXTENDED/tomcat/tomcat.spec
+++ b/SPECS-EXTENDED/tomcat/tomcat.spec
@@ -521,7 +521,8 @@ fi
 
 %files 
 %defattr(0664,root,tomcat,0755)
-%doc {LICENSE,NOTICE,RELEASE*}
+%license LICENSE
+%doc {NOTICE,RELEASE*}
 %attr(0755,root,root) %{_bindir}/%{name}-digest
 %attr(0755,root,root) %{_bindir}/%{name}-tool-wrapper
 %attr(0755,root,root) %{_sbindir}/%{name}
@@ -607,11 +608,11 @@ fi
 %exclude %{_javadir}/%{name}-jsp-%{jspspec}*.jar
 
 %files servlet-%{servletspec}-api -f output/dist/src/res/maven/.mfiles-tomcat-servlet-api
-%doc LICENSE
+%license LICENSE
 %{_javadir}/%{name}-servlet-%{servletspec}*.jar
 
 %files el-%{elspec}-api -f output/dist/src/res/maven/.mfiles-tomcat-el-api
-%doc LICENSE
+%license LICENSE
 %{_javadir}/%{name}-el-%{elspec}-api.jar
 %{libdir}/%{name}-el-%{elspec}-api.jar
 

--- a/SPECS-EXTENDED/tomcatjss/tomcatjss.spec
+++ b/SPECS-EXTENDED/tomcatjss/tomcatjss.spec
@@ -10,7 +10,7 @@ License:          LGPLv2+
 BuildArch:        noarch
 
 Version:          7.6.1
-Release:          3%{?dist}
+Release:          4%{?dist}
 #global           _phase -a1
 
 # To generate the source tarball:
@@ -68,7 +68,7 @@ BuildRequires:    tomcat >= 9.0.7
 # Java
 Requires:         apache-commons-lang3
 
-Requires:         java-headless
+Requires:         java
 
 
 
@@ -143,6 +143,9 @@ ant -f build.xml \
 
 ################################################################################
 %changelog
+* Wed Jan 05 2022 Thomas Crain <thcrain@microsoft.com> - 7.6.1-4
+- Rename java-headless dependency to java
+
 * Thu Oct 28 2021 Muhammad Falak <mwani@microsft.com> - 7.6.1-3
 - Drop epoch from tomcat.
 

--- a/SPECS-EXTENDED/tomcatjss/tomcatjss.spec
+++ b/SPECS-EXTENDED/tomcatjss/tomcatjss.spec
@@ -138,13 +138,13 @@ ant -f build.xml \
 
 %defattr(-,root,root)
 %doc README
-%doc LICENSE
 %{_javadir}/*
 
 ################################################################################
 %changelog
 * Wed Jan 05 2022 Thomas Crain <thcrain@microsoft.com> - 7.6.1-4
 - Rename java-headless dependency to java
+- License verified
 
 * Thu Oct 28 2021 Muhammad Falak <mwani@microsft.com> - 7.6.1-3
 - Drop epoch from tomcat.

--- a/SPECS/javapackages-tools/javapackages-tools.spec
+++ b/SPECS/javapackages-tools/javapackages-tools.spec
@@ -9,7 +9,7 @@
 Summary:        Macros and scripts for Java packaging support
 Name:           javapackages-tools
 Version:        5.3.0
-Release:        13%{?dist}
+Release:        14%{?dist}
 License:        BSD
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -17,6 +17,7 @@ URL:            https://github.com/fedora-java/javapackages
 #Source0:       https://github.com/fedora-java/javapackages/archive/%{version}.tar.gz
 Source0:        %{name}-%{version}.tar.gz
 Patch0:         remove-epoch-from-java-requires.patch
+Patch1:         remove-headless-from-java-requires.patch
 BuildRequires:  asciidoc
 BuildRequires:  coreutils
 BuildRequires:  msopenjdk-11
@@ -27,6 +28,9 @@ BuildRequires:  python3-setuptools
 BuildRequires:  python3-six
 BuildRequires:  which
 BuildRequires:  xmlto
+%if %{with_check}
+BuildRequires:  python3-pip
+%endif
 Requires:       coreutils
 Requires:       findutils
 # default JRE
@@ -45,7 +49,6 @@ This package provides macros and scripts to support Java packaging.
 
 %package -n javapackages-filesystem
 Summary:        Java packages filesystem layout
-Obsoletes:      eclipse-filesystem < 2
 Provides:       eclipse-filesystem = %{version}-%{release}
 
 %description -n javapackages-filesystem
@@ -65,7 +68,6 @@ artifact resolution using XMvn resolver.
 Summary:        Module for handling various files for Java packaging
 Requires:       python3-lxml
 Requires:       python3-six
-Obsoletes:      python-javapackages < %{version}-%{release}
 
 %description -n python3-javapackages
 Module for handling, querying and manipulating of various files for Java
@@ -83,8 +85,7 @@ This package provides non-essential macros and scripts to support Java packaging
 It is a lightweight version with minimal runtime requirements.
 
 %prep
-%setup -q -n javapackages-%{version}
-%patch0 -p1
+%autosetup -p1 -n javapackages-%{version}
 
 %build
 %define jdk_home $(find %{_libdir}/jvm -name "msopenjdk*")
@@ -105,6 +106,7 @@ rm -rf %{buildroot}%{_datadir}/gradle-local
 rm -rf %{buildroot}%{_mandir}/man7/gradle_build.7
 
 %check
+pip3 install -r test-requirements.txt
 ./check
 
 %files -f files-tools
@@ -119,6 +121,12 @@ rm -rf %{buildroot}%{_mandir}/man7/gradle_build.7
 %license LICENSE
 
 %changelog
+* Wed Jan 05 2022 Thomas Crain <thcrain@microsoft.com> - 5.3.0-14
+- Add patch to replace generated dependency on "java-headless" with "java"
+- Amend epoch patch to fix expected test results
+- Remove obsoletes statements that don't apply to Mariner
+- Install test requirements with pip during check section
+
 * Thu Dec 02 2021 Andrew Phelps <anphel@microsoft.com> - 5.3.0-13
 - Update to build with JDK 11
 - License verified

--- a/SPECS/javapackages-tools/remove-epoch-from-java-requires.patch
+++ b/SPECS/javapackages-tools/remove-epoch-from-java-requires.patch
@@ -1,4 +1,15 @@
+From e07e0151799de936535c48fbc65770160a64dfdd Mon Sep 17 00:00:00 2001
+From: Thomas Crain <thcrain@microsoft.com>
+Date: Wed, 5 Jan 2022 10:59:13 -0800
+Subject: [PATCH 1/2] Remove epoch from java requires generation
+
+---
+ depgenerators/maven.req |  4 ++--
+ test/maven_req_test.py  | 12 ++++++------
+ 2 files changed, 8 insertions(+), 8 deletions(-)
+
 diff --git a/depgenerators/maven.req b/depgenerators/maven.req
+index b3597f7..1179ffc 100755
 --- a/depgenerators/maven.req
 +++ b/depgenerators/maven.req
 @@ -295,9 +295,9 @@ class TagBuilder(object):
@@ -13,3 +24,64 @@ diff --git a/depgenerators/maven.req b/depgenerators/maven.req
  
      def _parse_java_requires(self, req):
          match = re.match(r'^(\d+)(?:\.(\d+))?$', req)
+diff --git a/test/maven_req_test.py b/test/maven_req_test.py
+index 9cc9711..d7cb969 100644
+--- a/test/maven_req_test.py
++++ b/test/maven_req_test.py
+@@ -30,7 +30,7 @@ class TestMavenReq(unittest.TestCase):
+         self.assertEqual(return_value, 0, stderr)
+         sout = [x for x in stdout.split('\n') if x]
+         want = ("javapackages-filesystem", "mvn(org.apache.maven:maven-project)",
+-                "java-headless >= 1:1.6")
++                "java-headless >= 1.6")
+         self.assertEqual(set(want), set(sout))
+ 
+     @mavenreq(["require-java2/buildroot/usr/share/maven-metadata/require.xml"])
+@@ -38,7 +38,7 @@ class TestMavenReq(unittest.TestCase):
+         self.assertEqual(return_value, 0, stderr)
+         sout = [x for x in stdout.split('\n') if x]
+         want = ("javapackages-filesystem", "mvn(org.apache.maven:maven-project)",
+-                "java-headless >= 1:1.8")
++                "java-headless >= 1.8")
+         self.assertEqual(set(want), set(sout))
+ 
+     @mavenreq(["require-java3/buildroot/usr/share/maven-metadata/require.xml"])
+@@ -46,7 +46,7 @@ class TestMavenReq(unittest.TestCase):
+         self.assertEqual(return_value, 0, stderr)
+         sout = [x for x in stdout.split('\n') if x]
+         want = ("javapackages-filesystem", "mvn(org.apache.maven:maven-project)",
+-                "java-headless >= 1:1.8")
++                "java-headless >= 1.8")
+         self.assertEqual(set(want), set(sout))
+ 
+     @mavenreq(["require-java9/buildroot/usr/share/maven-metadata/require.xml"])
+@@ -54,7 +54,7 @@ class TestMavenReq(unittest.TestCase):
+         self.assertEqual(return_value, 0, stderr)
+         sout = [x for x in stdout.split('\n') if x]
+         want = ("javapackages-filesystem", "mvn(org.apache.maven:maven-project)",
+-                "java-headless >= 1:9")
++                "java-headless >= 9")
+         self.assertEqual(set(want), set(sout))
+ 
+     @mavenreq(["require-java10/buildroot/usr/share/maven-metadata/require.xml"])
+@@ -62,7 +62,7 @@ class TestMavenReq(unittest.TestCase):
+         self.assertEqual(return_value, 0, stderr)
+         sout = [x for x in stdout.split('\n') if x]
+         want = ("javapackages-filesystem", "mvn(org.apache.maven:maven-project)",
+-                "java-headless >= 1:10")
++                "java-headless >= 10")
+         self.assertEqual(set(want), set(sout))
+ 
+     @mavenreq(["require-java9and10/buildroot/usr/share/maven-metadata/require.xml"])
+@@ -70,7 +70,7 @@ class TestMavenReq(unittest.TestCase):
+         self.assertEqual(return_value, 0, stderr)
+         sout = [x for x in stdout.split('\n') if x]
+         want = ("javapackages-filesystem", "mvn(org.apache.maven:maven-project)",
+-                "java-headless >= 1:10")
++                "java-headless >= 10")
+         self.assertEqual(set(want), set(sout))
+ 
+     @mavenreq(["require-java-fail/buildroot/usr/share/maven-metadata/require.xml"])
+-- 
+2.25.1
+

--- a/SPECS/javapackages-tools/remove-headless-from-java-requires.patch
+++ b/SPECS/javapackages-tools/remove-headless-from-java-requires.patch
@@ -1,0 +1,332 @@
+From 604a4ce5426099bc6459911c7773ffe39055febf Mon Sep 17 00:00:00 2001
+From: Thomas Crain <thcrain@microsoft.com>
+Date: Wed, 5 Jan 2022 11:01:54 -0800
+Subject: [PATCH 2/2] Replace java-headless generated requirement with java
+
+---
+ etc/javapackages-config-SCL.json              |  2 +-
+ etc/javapackages-config.json                  |  2 +-
+ .../config/filtered/javapackages-config.json  |  2 +-
+ test/maven_req_test.py                        | 62 +++++++++----------
+ 4 files changed, 34 insertions(+), 34 deletions(-)
+
+diff --git a/etc/javapackages-config-SCL.json b/etc/javapackages-config-SCL.json
+index 72dd5fb..789559d 100644
+--- a/etc/javapackages-config-SCL.json
++++ b/etc/javapackages-config-SCL.json
+@@ -4,7 +4,7 @@
+             "@{scl}-runtime"
+         ],
+         "java_requires": {
+-            "package_name": "java-headless",
++            "package_name": "java",
+             "always_generate": true,
+             "skip": false
+         },
+diff --git a/etc/javapackages-config.json b/etc/javapackages-config.json
+index 601fedc..2e94ceb 100644
+--- a/etc/javapackages-config.json
++++ b/etc/javapackages-config.json
+@@ -4,7 +4,7 @@
+             "javapackages-filesystem"
+         ],
+         "java_requires": {
+-            "package_name": "java-headless",
++            "package_name": "java",
+             "always_generate": true,
+             "skip": false
+         },
+diff --git a/test/data/config/filtered/javapackages-config.json b/test/data/config/filtered/javapackages-config.json
+index 7951d91..3feb345 100644
+--- a/test/data/config/filtered/javapackages-config.json
++++ b/test/data/config/filtered/javapackages-config.json
+@@ -4,7 +4,7 @@
+             "javapackages-tools"
+         ],
+         "java_requires": {
+-            "package_name": "java-headless",
++            "package_name": "java",
+             "always_generate": true,
+             "skip": false
+         },
+diff --git a/test/maven_req_test.py b/test/maven_req_test.py
+index d7cb969..5650482 100644
+--- a/test/maven_req_test.py
++++ b/test/maven_req_test.py
+@@ -21,7 +21,7 @@ class TestMavenReq(unittest.TestCase):
+     def test_require1(self, stdout, stderr, return_value):
+         self.assertEqual(return_value, 0, stderr)
+         sout = [x for x in stdout.split('\n') if x]
+-        want = ("javapackages-filesystem", "java-headless",
++        want = ("javapackages-filesystem", "java",
+                 "mvn(org.apache.maven:maven-project)")
+         self.assertEqual(set(want), set(sout))
+ 
+@@ -30,7 +30,7 @@ class TestMavenReq(unittest.TestCase):
+         self.assertEqual(return_value, 0, stderr)
+         sout = [x for x in stdout.split('\n') if x]
+         want = ("javapackages-filesystem", "mvn(org.apache.maven:maven-project)",
+-                "java-headless >= 1.6")
++                "java >= 1.6")
+         self.assertEqual(set(want), set(sout))
+ 
+     @mavenreq(["require-java2/buildroot/usr/share/maven-metadata/require.xml"])
+@@ -38,7 +38,7 @@ class TestMavenReq(unittest.TestCase):
+         self.assertEqual(return_value, 0, stderr)
+         sout = [x for x in stdout.split('\n') if x]
+         want = ("javapackages-filesystem", "mvn(org.apache.maven:maven-project)",
+-                "java-headless >= 1.8")
++                "java >= 1.8")
+         self.assertEqual(set(want), set(sout))
+ 
+     @mavenreq(["require-java3/buildroot/usr/share/maven-metadata/require.xml"])
+@@ -46,7 +46,7 @@ class TestMavenReq(unittest.TestCase):
+         self.assertEqual(return_value, 0, stderr)
+         sout = [x for x in stdout.split('\n') if x]
+         want = ("javapackages-filesystem", "mvn(org.apache.maven:maven-project)",
+-                "java-headless >= 1.8")
++                "java >= 1.8")
+         self.assertEqual(set(want), set(sout))
+ 
+     @mavenreq(["require-java9/buildroot/usr/share/maven-metadata/require.xml"])
+@@ -54,7 +54,7 @@ class TestMavenReq(unittest.TestCase):
+         self.assertEqual(return_value, 0, stderr)
+         sout = [x for x in stdout.split('\n') if x]
+         want = ("javapackages-filesystem", "mvn(org.apache.maven:maven-project)",
+-                "java-headless >= 9")
++                "java >= 9")
+         self.assertEqual(set(want), set(sout))
+ 
+     @mavenreq(["require-java10/buildroot/usr/share/maven-metadata/require.xml"])
+@@ -62,7 +62,7 @@ class TestMavenReq(unittest.TestCase):
+         self.assertEqual(return_value, 0, stderr)
+         sout = [x for x in stdout.split('\n') if x]
+         want = ("javapackages-filesystem", "mvn(org.apache.maven:maven-project)",
+-                "java-headless >= 10")
++                "java >= 10")
+         self.assertEqual(set(want), set(sout))
+ 
+     @mavenreq(["require-java9and10/buildroot/usr/share/maven-metadata/require.xml"])
+@@ -70,7 +70,7 @@ class TestMavenReq(unittest.TestCase):
+         self.assertEqual(return_value, 0, stderr)
+         sout = [x for x in stdout.split('\n') if x]
+         want = ("javapackages-filesystem", "mvn(org.apache.maven:maven-project)",
+-                "java-headless >= 10")
++                "java >= 10")
+         self.assertEqual(set(want), set(sout))
+ 
+     @mavenreq(["require-java-fail/buildroot/usr/share/maven-metadata/require.xml"])
+@@ -83,7 +83,7 @@ class TestMavenReq(unittest.TestCase):
+     def test_require_parent(self, stdout, stderr, return_value):
+         self.assertEqual(return_value, 0, stderr)
+         sout = [x for x in stdout.split('\n') if x]
+-        want = ("javapackages-filesystem", "java-headless",
++        want = ("javapackages-filesystem", "java",
+                 "ns-mvn(org.codehaus.plexus:plexus-ant-factory)")
+         self.assertEqual(set(want), set(sout))
+ 
+@@ -92,7 +92,7 @@ class TestMavenReq(unittest.TestCase):
+         self.assertEqual(return_value, 0, stderr)
+         sout = [x for x in stdout.split('\n') if x]
+         want = ("javapackages-filesystem", "ns-mvn(org.codehaus.plexus:plexus-ant-factory)",
+-                "ns-mvn(codehaus:plexus-utils) = 1.2", "java-headless",
++                "ns-mvn(codehaus:plexus-utils) = 1.2", "java",
+                 "mvn(org.apache.maven.wagon:wagon-provider-api::test-jar:)")
+         self.assertEqual(set(want), set(sout))
+ 
+@@ -100,7 +100,7 @@ class TestMavenReq(unittest.TestCase):
+     def test_require_multi_namespace(self, stdout, stderr, return_value):
+         self.assertEqual(return_value, 0, stderr)
+         sout = [x for x in stdout.split('\n') if x]
+-        want = ("javapackages-filesystem", "java-headless",
++        want = ("javapackages-filesystem", "java",
+                 "ns2-mvn(codehaus:plexus-cipher)", "ns-mvn(codehaus:plexus-utils)",
+                 "mvn(org.apache.maven.wagon:wagon-provider-api::test-jar:)")
+         self.assertEqual(set(want), set(sout))
+@@ -109,7 +109,7 @@ class TestMavenReq(unittest.TestCase):
+     def test_require_multi_versioned(self, stdout, stderr, return_value):
+         self.assertEqual(return_value, 0, stderr)
+         sout = [x for x in stdout.split('\n') if x]
+-        want = ("java-headless", "javapackages-filesystem",
++        want = ("java", "javapackages-filesystem",
+                 "ns-mvn(org.codehaus.plexus:plexus-ant-factory:1.0) = 1.0",
+                 "ns-mvn(codehaus:plexus-utils:1.2)",
+                 "ns-mvn(codehaus:plexus-cipher:1.0) = 1.1",
+@@ -121,7 +121,7 @@ class TestMavenReq(unittest.TestCase):
+     def test_mixed(self, stdout, stderr, return_value):
+         self.assertEqual(return_value, 0, stderr)
+         sout = [x for x in stdout.split('\n') if x]
+-        want = ("javapackages-filesystem", "java-headless",
++        want = ("javapackages-filesystem", "java",
+                 "ns-mvn(org.codehaus.plexus:plexus-ant-factory)",
+                 "ns-mvn(codehaus:plexus-utils) = 1.2",
+                 "mvn(org.apache.maven.wagon:wagon-provider-api::test-jar:)",
+@@ -132,7 +132,7 @@ class TestMavenReq(unittest.TestCase):
+     def test_simple_subpackage(self, stdout, stderr, return_value):
+         self.assertEqual(return_value, 0, stderr)
+         sout = [x for x in stdout.split('\n') if x]
+-        want = ("javapackages-filesystem", "java-headless",
++        want = ("javapackages-filesystem", "java",
+                 "mvn(org.apache.maven:maven-plugin-api) = 3.2.1")
+         self.assertEqual(set(want), set(sout))
+ 
+@@ -140,7 +140,7 @@ class TestMavenReq(unittest.TestCase):
+     def test_simple_subpackage2(self, stdout, stderr, return_value):
+         self.assertEqual(return_value, 0, stderr)
+         sout = [x for x in stdout.split('\n') if x]
+-        want = ("javapackages-filesystem", "java-headless",
++        want = ("javapackages-filesystem", "java",
+                 "mvn(org.apache.maven:maven-plugin-api) = 3.2.1",
+                 "mvn(org.codehaus.plexus:plexus-utils)")
+         self.assertEqual(set(want), set(sout))
+@@ -149,7 +149,7 @@ class TestMavenReq(unittest.TestCase):
+     def test_simple_subpackage3(self, stdout, stderr, return_value):
+         self.assertEqual(return_value, 0, stderr)
+         sout = [x for x in stdout.split('\n') if x]
+-        want = ("javapackages-filesystem", "java-headless",
++        want = ("javapackages-filesystem", "java",
+                  "mvn(org.apache.maven:maven-plugin-api:3.2.0) = 3.2.1")
+         self.assertEqual(set(want), set(sout))
+ 
+@@ -157,7 +157,7 @@ class TestMavenReq(unittest.TestCase):
+     def test_simple_subpackage4(self, stdout, stderr, return_value):
+         self.assertEqual(return_value, 0, stderr)
+         sout = [x for x in stdout.split('\n') if x]
+-        want = ("javapackages-filesystem", "java-headless",
++        want = ("javapackages-filesystem", "java",
+                 "mvn(org.apache.maven:maven-plugin-api)")
+         self.assertEqual(set(want), set(sout))
+ 
+@@ -165,7 +165,7 @@ class TestMavenReq(unittest.TestCase):
+     def test_simple_artifact_in_same_package(self, stdout, stderr, return_value):
+         self.assertEqual(return_value, 0, stderr)
+         sout = [x for x in stdout.split('\n') if x]
+-        want = ("javapackages-filesystem", "java-headless")
++        want = ("javapackages-filesystem", "java")
+         self.assertEqual(set(want), set(sout))
+ 
+     #test for rhbz#1012980
+@@ -183,7 +183,7 @@ class TestMavenReq(unittest.TestCase):
+     def test_rhbz1017701_c2(self, stdout, stderr, return_value):
+         self.assertEqual(return_value, 0, stderr)
+         sout = [x for x in stdout.split('\n') if x]
+-        want = ("javapackages-filesystem", "java-headless",
++        want = ("javapackages-filesystem", "java",
+                 "maven31-mvn(org.eclipse.aether:aether-api) = 0.9.0.M3")
+         self.assertEqual(set(want), set(sout))
+ 
+@@ -200,7 +200,7 @@ class TestMavenReq(unittest.TestCase):
+     def test_dep_filtering(self, stdout, stderr, return_value):
+         self.assertEqual(return_value, 0, stderr)
+         sout = [x for x in stdout.split('\n') if x]
+-        want = ("ns-mvn(org.codehaus.plexus:plexus-ant-factory)", "java-headless",
++        want = ("ns-mvn(org.codehaus.plexus:plexus-ant-factory)", "java",
+                 "mvn(org.apache.maven.wagon:wagon-provider-api::test-jar:)",
+                 "javapackages-tools")
+         self.assertEqual(set(want), set(sout))
+@@ -209,7 +209,7 @@ class TestMavenReq(unittest.TestCase):
+     def test_config_env1(self, stdout, stderr, return_value):
+         self.assertEqual(return_value, 0, stderr)
+         sout = [x for x in stdout.split('\n') if x]
+-        want = ("ns-mvn(org.codehaus.plexus:plexus-ant-factory)", "java-headless",
++        want = ("ns-mvn(org.codehaus.plexus:plexus-ant-factory)", "java",
+                 "mvn(org.apache.maven.wagon:wagon-provider-api::test-jar:)",
+                 "javapackages-tools")
+         self.assertEqual(set(want), set(sout))
+@@ -219,7 +219,7 @@ class TestMavenReq(unittest.TestCase):
+     def test_config_env2(self, stdout, stderr, return_value):
+         self.assertEqual(return_value, 0, stderr)
+         sout = [x for x in stdout.split('\n') if x]
+-        want = ("ns-mvn(org.codehaus.plexus:plexus-ant-factory)", "java-headless",
++        want = ("ns-mvn(org.codehaus.plexus:plexus-ant-factory)", "java",
+                 "mvn(org.apache.maven.wagon:wagon-provider-api::test-jar:)",
+                 "javapackages-tools")
+         self.assertEqual(set(want), set(sout))
+@@ -230,7 +230,7 @@ class TestMavenReq(unittest.TestCase):
+         self.assertEqual(return_value, 0, stderr)
+         sout = [x for x in stdout.split('\n') if x]
+         want = ("mvn(org.fedoraproject.xmvn:xmvn-core)",
+-                "java-headless", "javapackages-filesystem",
++                "java", "javapackages-filesystem",
+                 "mvn(org.fedoraproject.xmvn:xmvn-api)")
+         self.assertEqual(set(want), set(sout))
+ 
+@@ -240,7 +240,7 @@ class TestMavenReq(unittest.TestCase):
+         self.assertEqual(return_value, 0, stderr)
+         sout = [x for x in stdout.split('\n') if x]
+         want = ("mvn(plugin:external)", "javapackages-filesystem",
+-                "mvn(ppom:parent-pom:pom:)", "java-headless")
++                "mvn(ppom:parent-pom:pom:)", "java")
+         self.assertEqual(set(want), set(sout))
+ 
+     @mavenreq(["require4/buildroot/usr/share/maven-metadata/require.xml"],
+@@ -249,7 +249,7 @@ class TestMavenReq(unittest.TestCase):
+         self.assertEqual(return_value, 0, stderr)
+         sout = [x for x in stdout.split('\n') if x]
+         want = ("mvn(extension:from-subpackage) = 1.1", "javapackages-filesystem",
+-                "mvn(ppom:parent-pom:pom:)", "java-headless")
++                "mvn(ppom:parent-pom:pom:)", "java")
+         self.assertEqual(set(want), set(sout))
+ 
+     @mavenreq(["require5/buildroot/usr/share/maven-metadata/require.xml"])
+@@ -270,28 +270,28 @@ class TestMavenReq(unittest.TestCase):
+     def test_osgi_basic(self, stdout, stderr, return_value):
+         self.assertEqual(return_value, 0, stderr)
+         sout = [x for x in stdout.split('\n') if x]
+-        want = ("osgi(osgi.req1)", "javapackages-filesystem", "java-headless")
++        want = ("osgi(osgi.req1)", "javapackages-filesystem", "java")
+         self.assertEqual(set(want), set(sout))
+ 
+     @mavenreq(["osgi_self/buildroot/usr/share/maven-metadata/require.xml"])
+     def test_osgi_self(self, stdout, stderr, return_value):
+         self.assertEqual(return_value, 0, stderr)
+         sout = [x for x in stdout.split('\n') if x]
+-        want = ("javapackages-filesystem", "java-headless")
++        want = ("javapackages-filesystem", "java")
+         self.assertEqual(set(want), set(sout))
+ 
+     @mavenreq(["osgi_versioned/buildroot/usr/share/maven-metadata/require.xml"])
+     def test_osgi_versioned(self, stdout, stderr, return_value):
+         self.assertEqual(return_value, 0, stderr)
+         sout = [x for x in stdout.split('\n') if x]
+-        want = ("osgi(osgi.req1) = 1.0", "javapackages-filesystem", "java-headless")
++        want = ("osgi(osgi.req1) = 1.0", "javapackages-filesystem", "java")
+         self.assertEqual(set(want), set(sout))
+ 
+     @mavenreq(["osgi_versioned_ns/buildroot/usr/share/maven-metadata/require.xml"])
+     def test_osgi_versioned_ns(self, stdout, stderr, return_value):
+         self.assertEqual(return_value, 0, stderr)
+         sout = [x for x in stdout.split('\n') if x]
+-        want = ("devtoolset-3-osgi(osgi.req1) = 1.0", "javapackages-filesystem", "java-headless")
++        want = ("devtoolset-3-osgi(osgi.req1) = 1.0", "javapackages-filesystem", "java")
+         self.assertEqual(set(want), set(sout))
+ 
+     @mavenreq(["dashes/buildroot/usr/share/maven-metadata/require.xml"])
+@@ -300,21 +300,21 @@ class TestMavenReq(unittest.TestCase):
+         sout = [x for x in stdout.split('\n') if x]
+         want = ("mvn(org.apache.maven:maven-plugin-api) = 1.alpha.2",
+                 "osgi(osgi2) = 1.5.1.SNAPSHOT",
+-                "java-headless", "javapackages-filesystem")
++                "java", "javapackages-filesystem")
+         self.assertEqual(set(want), set(sout))
+ 
+     @mavenreq(["require_optional/buildroot/usr/share/maven-metadata/require.xml"])
+     def test_optional(self, stdout, stderr, return_value):
+         self.assertEqual(return_value, 0, stderr)
+         sout = [x for x in stdout.split('\n') if x]
+-        want = ("mvn(dg:da)", "java-headless", "javapackages-filesystem")
++        want = ("mvn(dg:da)", "java", "javapackages-filesystem")
+         self.assertEqual(set(want), set(sout))
+ 
+     @mavenreq(["require-no-artifacts/buildroot/usr/share/maven-metadata/require.xml"])
+     def test_no_artifacts(self, stdout, stderr, return_value):
+         self.assertEqual(return_value, 0, stderr)
+         sout = [x for x in stdout.split('\n') if x]
+-        want = ("java-headless", "javapackages-filesystem")
++        want = ("java", "javapackages-filesystem")
+         self.assertEqual(set(want), set(sout))
+ 
+ if __name__ == '__main__':
+-- 
+2.25.1
+

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -1446,6 +1446,16 @@
       "component": {
         "type": "other",
         "other": {
+          "name": "bsh",
+          "version": "2.0",
+          "downloadUrl": "https://github.com/beanshell/beanshell/archive/2.0b6.tar.gz"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "other",
+        "other": {
           "name": "bsh2",
           "version": "2.0.0.b6",
           "downloadUrl": "https://github.com/beanshell/beanshell/archive/2.0b6.tar.gz"
@@ -28088,7 +28098,7 @@
         "other": {
           "name": "tomcat",
           "version": "9.0.39",
-          "downloadUrl": "http://www.apache.org/dist/tomcat/tomcat-9/v9.0.39/src/apache-tomcat-9.0.39-src.tar.gz"
+          "downloadUrl": "https://archive.apache.org/dist/tomcat/tomcat-9/v9.0.39/src/apache-tomcat-9.0.39-src.tar.gz"
         }
       }
     },


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Our current RPM build of `msopenjdk-11` does not provide the `java-headless` name. This PR patches the `javapackages-tools` package to generate RPM dependencies on `java` rather than `java-headless` accordingly.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add patch to replace generated dependency on "java-headless" with "java"
- Amend epoch patch to fix expected test results
- Remove obsoletes statements that don't apply to Mariner
- Install test requirements with pip during check section

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Ongoing pipeline build
