### PR TITLE
Update tools for hydrated test

### DIFF
--- a/toolkit/Makefile
+++ b/toolkit/Makefile
@@ -45,6 +45,7 @@ NUM_OF_ANALYTICS_RESULTS        ?= 10
 CLEANUP_PACKAGE_BUILDS          ?= y
 USE_PACKAGE_BUILD_CACHE         ?= y
 REBUILD_DEP_CHAINS              ?= y
+RPM_HYDRATED_TEST               ?= n
 
 # Folder defines
 toolkit_root     := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))

--- a/toolkit/scripts/pkggen.mk
+++ b/toolkit/scripts/pkggen.mk
@@ -120,6 +120,7 @@ $(cached_file): $(graph_file) $(go-graphpkgfetcher) $(chroot_worker) $(pkggen_lo
 		$(logging_command) \
 		--input-summary-file=$(PACKAGE_CACHE_SUMMARY) \
 		--output-summary-file=$(PKGBUILD_DIR)/graph_external_deps.json \
+		--remove-unresolved-dep=$(RPM_HYDRATED_TEST) \
 		--output=$(cached_file) && \
 	touch $@
 
@@ -179,6 +180,7 @@ $(STATUS_FLAGS_DIR)/build-rpms.flag: $(cached_file) $(chroot_worker) $(go-schedu
 		--packages="$(PACKAGE_BUILD_LIST)" \
 		--rebuild-packages="$(PACKAGE_REBUILD_LIST)" \
 		--image-config-file="$(CONFIG_FILE)" \
+		--rpm-hydrated-test="$(RPM_HYDRATED_TEST)" \
 		$(if $(CONFIG_FILE),--base-dir="$(CONFIG_BASE_DIR)") \
 		$(if $(filter y,$(RUN_CHECK)),--run-check) \
 		$(if $(filter y,$(STOP_ON_PKG_FAIL)),--stop-on-failure) \

--- a/toolkit/tools/graphpkgfetcher/graphpkgfetcher.go
+++ b/toolkit/tools/graphpkgfetcher/graphpkgfetcher.go
@@ -38,9 +38,9 @@ var (
 	tlsClientCert = app.Flag("tls-cert", "TLS client certificate to use when downloading files.").String()
 	tlsClientKey  = app.Flag("tls-key", "TLS client key to use when downloading files.").String()
 
-	inputSummaryFile  = app.Flag("input-summary-file", "Path to a file with the summary of packages cloned to be restored").String()
-	outputSummaryFile = app.Flag("output-summary-file", "Path to save the summary of packages cloned").String()
-    removeUnresolvedDep = app.Flag("remove-unresolved-dep", "Remove a depedency if its not resolvable").String()
+	inputSummaryFile    = app.Flag("input-summary-file", "Path to a file with the summary of packages cloned to be restored").String()
+	outputSummaryFile   = app.Flag("output-summary-file", "Path to save the summary of packages cloned").String()
+	removeUnresolvedDep = app.Flag("remove-unresolved-dep", "Remove a depedency if its not resolvable").String()
 
 	logFile  = exe.LogFileFlag(app)
 	logLevel = exe.LogLevelFlag(app)
@@ -112,12 +112,12 @@ func resolveGraphNodes(dependencyGraph *pkggraph.PkgGraph, inputSummaryFile, out
 				// Failing to clone a dependency should not halt a build.
 				// The build should continue and attempt best effort to build as many packages as possible.
 				if resolveErr != nil {
-                    if *removeUnresolvedDep == "y" {
-                        // Let the build proceed and fail. We'll get the detail from the build log
-                        logger.Log.Warnf("Removing unresolved node: %s", n.FriendlyName())
-                        dependencyGraph.RemovePkgNode(n)
-                        continue
-                    }
+					if *removeUnresolvedDep == "y" {
+						// Let the build proceed and fail. We'll get the detail from the build log
+						logger.Log.Warnf("Removing unresolved node: %s", n.FriendlyName())
+						dependencyGraph.RemovePkgNode(n)
+						continue
+					}
 					errorMessage := strings.Builder{}
 					errorMessage.WriteString(fmt.Sprintf("Failed to resolve all nodes in the graph while resolving '%s'\n", n))
 					errorMessage.WriteString("Nodes which have this as a dependency:\n")

--- a/toolkit/tools/graphpkgfetcher/graphpkgfetcher.go
+++ b/toolkit/tools/graphpkgfetcher/graphpkgfetcher.go
@@ -40,6 +40,7 @@ var (
 
 	inputSummaryFile  = app.Flag("input-summary-file", "Path to a file with the summary of packages cloned to be restored").String()
 	outputSummaryFile = app.Flag("output-summary-file", "Path to save the summary of packages cloned").String()
+    removeUnresolvedDep = app.Flag("remove-unresolved-dep", "Remove a depedency if its not resolvable").String()
 
 	logFile  = exe.LogFileFlag(app)
 	logLevel = exe.LogLevelFlag(app)
@@ -111,6 +112,12 @@ func resolveGraphNodes(dependencyGraph *pkggraph.PkgGraph, inputSummaryFile, out
 				// Failing to clone a dependency should not halt a build.
 				// The build should continue and attempt best effort to build as many packages as possible.
 				if resolveErr != nil {
+                    if *removeUnresolvedDep == "y" {
+                        // Let the build proceed and fail. We'll get the detail from the build log
+                        logger.Log.Warnf("Removing unresolved node: %s", n.FriendlyName())
+                        dependencyGraph.RemovePkgNode(n)
+                        continue
+                    }
 					errorMessage := strings.Builder{}
 					errorMessage.WriteString(fmt.Sprintf("Failed to resolve all nodes in the graph while resolving '%s'\n", n))
 					errorMessage.WriteString("Nodes which have this as a dependency:\n")

--- a/toolkit/tools/scheduler/schedulerutils/buildworker.go
+++ b/toolkit/tools/scheduler/schedulerutils/buildworker.go
@@ -100,7 +100,7 @@ func buildBuildNode(node *pkggraph.PkgNode, pkgGraph *pkggraph.PkgGraph, graphMu
 		return
 	}
 
-    oldUsedCache := usedCache
+	oldUsedCache := usedCache
 	usedCache = false
 
 	dependencies := getBuildDependencies(node, pkgGraph, graphMutex)
@@ -108,13 +108,13 @@ func buildBuildNode(node *pkggraph.PkgNode, pkgGraph *pkggraph.PkgGraph, graphMu
 	logger.Log.Infof("Building %s", baseSrpmName)
 	builtFiles, logFile, err = buildSRPMFile(agent, buildAttempts, node.SrpmPath, dependencies)
 
-    if ((rpmHydratedBuild == "y") && (err != nil)) {
-        if (oldUsedCache) {
-            err = nil
-            usedCache = oldUsedCache
-            logger.Log.Infof("Build failed. Using PreBuilt RPM: %s", baseSrpmName)
-        }
-    }
+	if (rpmHydratedBuild == "y") && (err != nil) {
+		if oldUsedCache {
+			err = nil
+			usedCache = oldUsedCache
+			logger.Log.Infof("Build failed. Using PreBuilt RPM: %s", baseSrpmName)
+		}
+	}
 	return
 }
 

--- a/toolkit/tools/scheduler/schedulerutils/preparerequest.go
+++ b/toolkit/tools/scheduler/schedulerutils/preparerequest.go
@@ -34,11 +34,11 @@ func ConvertNodesToRequests(pkgGraph *pkggraph.PkgGraph, graphMutex *sync.RWMute
 			AncillaryNodes: []*pkggraph.PkgNode{node},
 		}
 
-        if forceUseCache == true {
-            req.CanUseCache = true
-        } else {
-		    req.CanUseCache = isCacheAllowed && canUseCacheForNode(pkgGraph, req.Node, packagesToRebuild, buildState, noDepRebuild)
-        }
+		if forceUseCache == true {
+			req.CanUseCache = true
+		} else {
+			req.CanUseCache = isCacheAllowed && canUseCacheForNode(pkgGraph, req.Node, packagesToRebuild, buildState, noDepRebuild)
+		}
 
 		requests = append(requests, req)
 	}
@@ -52,11 +52,11 @@ func ConvertNodesToRequests(pkgGraph *pkggraph.PkgGraph, graphMutex *sync.RWMute
 			AncillaryNodes: nodes,
 		}
 
-        if forceUseCache == true {
-            req.CanUseCache = true
-        } else {
-		    req.CanUseCache = isCacheAllowed && canUseCacheForNode(pkgGraph, req.Node, packagesToRebuild, buildState, noDepRebuild)
-        }
+		if forceUseCache == true {
+			req.CanUseCache = true
+		} else {
+			req.CanUseCache = isCacheAllowed && canUseCacheForNode(pkgGraph, req.Node, packagesToRebuild, buildState, noDepRebuild)
+		}
 
 		requests = append(requests, req)
 	}
@@ -83,11 +83,11 @@ func canUseCacheForNode(pkgGraph *pkggraph.PkgGraph, node *pkggraph.PkgNode, pac
 		return
 	}
 
-    // Don't rebuild package even if its dependency is newly built. Makes sense while running TestRPM
-    if noDepRebuild == "y" {
-        canUseCache = true
-        return
-    }
+	// Don't rebuild package even if its dependency is newly built. Makes sense while running TestRPM
+	if noDepRebuild == "y" {
+		canUseCache = true
+		return
+	}
 
 	// If any of the node's dependencies were built instead of being cached then a build is required.
 	dependencies := pkgGraph.From(node.ID())


### PR DESCRIPTION
When focused on testing the RPMs, we don't need to follow normal build
procedure. So updating the toolchain for hydrated test in below ways,

 * Remove unresolved dependency nodes. Let the build proceed and package
 fail due to dependency failure. We'll get the info from the log
 * Don't rebuild a package if its dependency is built. As the build is
 only for testing it, there won't be changes which will cause the
 dependent package to fail
 * Don't stop the build after a package build failure. For that if a
 package fails to build, record its failure in logs and proceed by
 using its pre-built RPM

 For this purpose, adding a new macro - RPM_HYDRATED_TEST

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
When focused on testing the RPMs, we don't need to follow normal build
    procedure. So updating the toolchain for hydrated test in below ways,

     * Remove unresolved dependency nodes. Let the build proceed and package
     fail due to dependency failure. We'll get the info from the log
     * Don't rebuild a package if its dependency is built. As the build is
     only for testing it, there won't be changes which will cause the
     dependent package to fail
     * Don't stop the build after a package build failure. For that if a
     package fails to build, recored its failure in logs and proceed by
     using its pre-built RPM

     For this purpose, adding a new macro - RPM_HYDRATED_TEST

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->


###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->

###### Links to CVEs  <!-- optional -->

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build
