### PR TITLE
Fix package signatures

### DIFF
--- a/SPECS/bash-completion/bash-completion.signatures.json
+++ b/SPECS/bash-completion/bash-completion.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "bash-completion-2.11.tar.xz": "16adefabf43ec8ffb473704f5724d775c2f47e9f750d7d608f0251ec21fe8813"
+  "bash-completion-2.11.tar.gz": "16adefabf43ec8ffb473704f5724d775c2f47e9f750d7d608f0251ec21fe8813"
  }
 }

--- a/SPECS/catch/catch.signatures.json
+++ b/SPECS/catch/catch.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "Catch2-2.13.7.tar.gz": "b9b592bd743c09f13ee4bf35fc30eeee2748963184f6bea836b146e6cc2a585a"
+  "Catch2-2.13.8.tar.gz": "b9b592bd743c09f13ee4bf35fc30eeee2748963184f6bea836b146e6cc2a585a"
  }
 }

--- a/SPECS/chkconfig/chkconfig.signatures.json
+++ b/SPECS/chkconfig/chkconfig.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "chkconfig-1.11.tar.gz": "ae652c799290b9f158f410a1ef567fa11e6f729a1bd2a65b7410a6d49eb50d15"
+  "chkconfig-1.20.tar.gz": "ae652c799290b9f158f410a1ef567fa11e6f729a1bd2a65b7410a6d49eb50d15"
  }
 }


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Fix input-srpms build break by changing incorrect hashes.
Fixes errors:

WARN[0023] no signature for file (bash-completion-2.11.tar.gz) found. full path is (/build/bash-completion-2.11-1.cm2.src.rpm/SOURCES/bash-completion-2.11.tar.gz) 

WARN[0028] no signature for file (Catch2-2.13.8.tar.gz) found. full path is (/build/catch-2.13.8-1.cm2.src.rpm/SOURCES/Catch2-2.13.8.tar.gz) 

WARN[0016] no signature for file (chkconfig-1.20.tar.gz) found. full path is (/build/chkconfig-1.20-1.cm2.src.rpm/SOURCES/chkconfig-1.20.tar.gz) 

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change bash-completion
- Change catch
- Change chkconfig

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-YYYY-XXXX

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- sudo make input-srpms
