### PR TITLE
Update bash to version 4.4.23

### DIFF
--- a/SPECS/bash/bash-4.4.patch
+++ b/SPECS/bash/bash-4.4.patch
@@ -1,6 +1,6 @@
-diff -dupr a/config-top.h b/config-top.h
---- a/config-top.h	2016-05-19 11:34:02.000000000 -0700
-+++ b/config-top.h	2017-01-13 19:48:28.940934708 -0800
+diff -dupr config-top.h config-top.h
+--- config-top.h	2016-05-19 11:34:02.000000000 -0700
++++ config-top.h	2017-01-13 19:48:28.940934708 -0800
 @@ -87,7 +87,7 @@
  #define DEFAULT_BASHRC "~/.bashrc"
  

--- a/SPECS/bash/bash.spec
+++ b/SPECS/bash/bash.spec
@@ -1,19 +1,24 @@
 Summary:        Bourne-Again SHell
 Name:           bash
-Version:        4.4.18
-Release:        6%{?dist}
+Version:        4.4.23
+Release:        1%{?dist}
 License:        GPLv3
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Group:          System Environment/Base
 URL:            https://www.gnu.org/software/bash/
-Source0:        https://ftp.gnu.org/gnu/%{name}/%{name}-%{version}.tar.gz
+Source0:        https://ftp.gnu.org/gnu/%{name}/%{name}-4.4.18.tar.gz
 Source1:        bash_completion
 Patch0:         bash-4.4.patch
 # CVE-2019-18276 has a negligible security impact, 
 # since we don't ship bash with suid.
 # Backporting the patch is non-trivial, as well.
 Patch1:         CVE-2019-18276.nopatch
+Patch2:         bash44-019.patch
+Patch3:         bash44-020.patch
+Patch4:         bash44-021.patch
+Patch5:         bash44-022.patch
+Patch6:         bash44-023.patch
 BuildRequires:  readline
 Requires:       readline
 Requires(post):   /bin/cp
@@ -44,7 +49,7 @@ Requires:       bash >= 4.4
 These are the additional language files of bash.
 
 %prep
-%autosetup -p 1
+%autosetup -p0 -n %{name}-4.4.18
 
 %build
 %configure \
@@ -332,6 +337,11 @@ fi
 %defattr(-,root,root)
 
 %changelog
+* Tue Jan 18 2022 Henry Beberman <henry.beberman@microsoft.com> - 4.4.23-1
+- Resolving a rare hang that was fixed in 4.4.20
+- Update bash to version 4.4.23
+- Update bash-4.4.patch for autosetup -p0
+
 * Thu Oct 22 2020 Thomas Crain <thcrain@microsoft.com> - 4.4.18-6
 - Nopatch CVE-2019-18276
 

--- a/SPECS/bash/bash44-019.patch
+++ b/SPECS/bash/bash44-019.patch
@@ -1,0 +1,50 @@
+			     BASH PATCH REPORT
+			     =================
+
+Bash-Release:	4.4
+Patch-ID:	bash44-019
+
+Bug-Reported-by:	Kieran Grant <kieran.thehacker.grant@gmail.com>
+Bug-Reference-ID:	<ec9071ae-efb1-9e09-5d03-e905daf2835c@gmail.com>
+Bug-Reference-URL:	http://lists.gnu.org/archive/html/bug-bash/2018-02/msg00002.html
+
+Bug-Description:
+
+With certain values for PS1, especially those that wrap onto three or more
+lines, readline will miscalculate the number of invisible characters,
+leading to crashes and core dumps.
+
+Patch (apply with `patch -p0'):
+
+*** ../bash-4.4.18/lib/readline/display.c	2016-07-28 14:49:33.000000000 -0400
+--- lib/readline/display.c	2018-02-03 19:19:35.000000000 -0500
+***************
+*** 772,776 ****
+        wadjust = (newlines == 0)
+  		  ? prompt_invis_chars_first_line
+! 		  : ((newlines == prompt_lines_estimate) ? wrap_offset : prompt_invis_chars_first_line);
+  
+        /* fix from Darin Johnson <darin@acuson.com> for prompt string with
+--- 788,794 ----
+        wadjust = (newlines == 0)
+  		  ? prompt_invis_chars_first_line
+! 		  : ((newlines == prompt_lines_estimate)
+! 		  	? (wrap_offset - prompt_invis_chars_first_line)
+! 		  	: 0);
+  
+        /* fix from Darin Johnson <darin@acuson.com> for prompt string with
+*** ../bash-4.4/patchlevel.h	2016-06-22 14:51:03.000000000 -0400
+--- patchlevel.h	2016-10-01 11:01:28.000000000 -0400
+***************
+*** 26,30 ****
+     looks for to find the patch level (for the sccs version string). */
+  
+! #define PATCHLEVEL 18
+  
+  #endif /* _PATCHLEVEL_H_ */
+--- 26,30 ----
+     looks for to find the patch level (for the sccs version string). */
+  
+! #define PATCHLEVEL 19
+  
+  #endif /* _PATCHLEVEL_H_ */

--- a/SPECS/bash/bash44-020.patch
+++ b/SPECS/bash/bash44-020.patch
@@ -1,0 +1,177 @@
+			     BASH PATCH REPORT
+			     =================
+
+Bash-Release:	4.4
+Patch-ID:	bash44-020
+
+Bug-Reported-by:	Graham Northup <northug@clarkson.edu>
+Bug-Reference-ID:	<537530c3-61f0-349b-9de6-fa4e2487f428@clarkson.edu>
+Bug-Reference-URL:	http://lists.gnu.org/archive/html/bug-bash/2017-02/msg00025.html
+
+Bug-Description:
+
+In circumstances involving long-running scripts that create and reap many
+processes, it is possible for the hash table bash uses to store exit
+statuses from asynchronous processes to develop loops. This patch fixes
+the loop causes and adds code to detect any future loops.
+
+Patch (apply with `patch -p0'):
+
+*** ../bash-4.4-patched/jobs.c	2016-11-11 13:42:55.000000000 -0500
+--- jobs.c	2017-02-22 15:16:28.000000000 -0500
+***************
+*** 813,818 ****
+    struct pidstat *ps;
+  
+!   bucket = pshash_getbucket (pid);
+!   psi = bgp_getindex ();
+    ps = &bgpids.storage[psi];
+  
+--- 796,815 ----
+    struct pidstat *ps;
+  
+!   /* bucket == existing chain of pids hashing to same value
+!      psi = where were going to put this pid/status */
+! 
+!   bucket = pshash_getbucket (pid);	/* index into pidstat_table */
+!   psi = bgp_getindex ();		/* bgpids.head, index into storage */
+! 
+!   /* XXX - what if psi == *bucket? */
+!   if (psi == *bucket)
+!     {
+! #ifdef DEBUG
+!       internal_warning ("hashed pid %d (pid %d) collides with bgpids.head, skipping", psi, pid);
+! #endif
+!       bgpids.storage[psi].pid = NO_PID;		/* make sure */
+!       psi = bgp_getindex ();			/* skip to next one */
+!     }
+! 
+    ps = &bgpids.storage[psi];
+  
+***************
+*** 842,845 ****
+--- 839,843 ----
+  {
+    struct pidstat *ps;
++   ps_index_t *bucket;
+  
+    ps = &bgpids.storage[psi];
+***************
+*** 847,856 ****
+      return;
+  
+!   if (ps->bucket_next != NO_PID)
+      bgpids.storage[ps->bucket_next].bucket_prev = ps->bucket_prev;
+!   if (ps->bucket_prev != NO_PID)
+      bgpids.storage[ps->bucket_prev].bucket_next = ps->bucket_next;
+    else
+!     *(pshash_getbucket (ps->pid)) = ps->bucket_next;
+  }
+  
+--- 845,861 ----
+      return;
+  
+!   if (ps->bucket_next != NO_PIDSTAT)
+      bgpids.storage[ps->bucket_next].bucket_prev = ps->bucket_prev;
+!   if (ps->bucket_prev != NO_PIDSTAT)
+      bgpids.storage[ps->bucket_prev].bucket_next = ps->bucket_next;
+    else
+!     {
+!       bucket = pshash_getbucket (ps->pid);
+!       *bucket = ps->bucket_next;	/* deleting chain head in hash table */
+!     }
+! 
+!   /* clear out this cell, just in case */
+!   ps->pid = NO_PID;
+!   ps->bucket_next = ps->bucket_prev = NO_PIDSTAT;
+  }
+  
+***************
+*** 859,863 ****
+       pid_t pid;
+  {
+!   ps_index_t psi;
+  
+    if (bgpids.storage == 0 || bgpids.nalloc == 0 || bgpids.npid == 0)
+--- 864,868 ----
+       pid_t pid;
+  {
+!   ps_index_t psi, orig_psi;
+  
+    if (bgpids.storage == 0 || bgpids.nalloc == 0 || bgpids.npid == 0)
+***************
+*** 865,871 ****
+  
+    /* Search chain using hash to find bucket in pidstat_table */
+!   for (psi = *(pshash_getbucket (pid)); psi != NO_PIDSTAT; psi = bgpids.storage[psi].bucket_next)
+!     if (bgpids.storage[psi].pid == pid)
+!       break;
+  
+    if (psi == NO_PIDSTAT)
+--- 870,883 ----
+  
+    /* Search chain using hash to find bucket in pidstat_table */
+!   for (orig_psi = psi = *(pshash_getbucket (pid)); psi != NO_PIDSTAT; psi = bgpids.storage[psi].bucket_next)
+!     {
+!       if (bgpids.storage[psi].pid == pid)
+! 	break;
+!       if (orig_psi == bgpids.storage[psi].bucket_next)	/* catch reported bug */
+! 	{
+! 	  internal_warning ("bgp_delete: LOOP: psi (%d) == storage[psi].bucket_next", psi);
+! 	  return 0;
+! 	}
+!     }
+  
+    if (psi == NO_PIDSTAT)
+***************
+*** 905,909 ****
+       pid_t pid;
+  {
+!   ps_index_t psi;
+  
+    if (bgpids.storage == 0 || bgpids.nalloc == 0 || bgpids.npid == 0)
+--- 917,921 ----
+       pid_t pid;
+  {
+!   ps_index_t psi, orig_psi;
+  
+    if (bgpids.storage == 0 || bgpids.nalloc == 0 || bgpids.npid == 0)
+***************
+*** 911,917 ****
+  
+    /* Search chain using hash to find bucket in pidstat_table */
+!   for (psi = *(pshash_getbucket (pid)); psi != NO_PIDSTAT; psi = bgpids.storage[psi].bucket_next)
+!     if (bgpids.storage[psi].pid == pid)
+!       return (bgpids.storage[psi].status);
+  
+    return -1;
+--- 923,936 ----
+  
+    /* Search chain using hash to find bucket in pidstat_table */
+!   for (orig_psi = psi = *(pshash_getbucket (pid)); psi != NO_PIDSTAT; psi = bgpids.storage[psi].bucket_next)
+!     {
+!       if (bgpids.storage[psi].pid == pid)
+! 	return (bgpids.storage[psi].status);
+!       if (orig_psi == bgpids.storage[psi].bucket_next)	/* catch reported bug */
+! 	{
+! 	  internal_warning ("bgp_search: LOOP: psi (%d) == storage[psi].bucket_next", psi);
+! 	  return -1;
+! 	}
+!     }
+  
+    return -1;
+*** ../bash-4.4/patchlevel.h	2016-06-22 14:51:03.000000000 -0400
+--- patchlevel.h	2016-10-01 11:01:28.000000000 -0400
+***************
+*** 26,30 ****
+     looks for to find the patch level (for the sccs version string). */
+  
+! #define PATCHLEVEL 19
+  
+  #endif /* _PATCHLEVEL_H_ */
+--- 26,30 ----
+     looks for to find the patch level (for the sccs version string). */
+  
+! #define PATCHLEVEL 20
+  
+  #endif /* _PATCHLEVEL_H_ */

--- a/SPECS/bash/bash44-021.patch
+++ b/SPECS/bash/bash44-021.patch
@@ -1,0 +1,57 @@
+			     BASH PATCH REPORT
+			     =================
+
+Bash-Release:	4.4
+Patch-ID:	bash44-021
+
+Bug-Reported-by:	werner@suse.de
+Bug-Reference-ID:	<201803281402.w2SE2VOa000476@noether.suse.de>
+Bug-Reference-URL:	http://lists.gnu.org/archive/html/bug-bash/2018-03/msg00196.html
+
+Bug-Description:
+
+A SIGINT received inside a SIGINT trap handler can possibly cause the
+shell to loop.
+
+Patch (apply with `patch -p0'):
+
+*** ../bash-20180329/jobs.c	2018-02-11 18:07:22.000000000 -0500
+--- jobs.c	2018-04-02 14:24:21.000000000 -0400
+***************
+*** 2690,2694 ****
+    if (job_control == 0 || (subshell_environment&SUBSHELL_COMSUB))
+      {
+!       old_sigint_handler = set_signal_handler (SIGINT, wait_sigint_handler);
+        waiting_for_child = 0;
+        if (old_sigint_handler == SIG_IGN)
+--- 2690,2704 ----
+    if (job_control == 0 || (subshell_environment&SUBSHELL_COMSUB))
+      {
+!       SigHandler *temp_sigint_handler;
+! 
+!       temp_sigint_handler = set_signal_handler (SIGINT, wait_sigint_handler);
+!       if (temp_sigint_handler == wait_sigint_handler)
+!         {
+! #if defined (DEBUG)
+! 	  internal_warning ("wait_for: recursively setting old_sigint_handler to wait_sigint_handler: running_trap = %d", running_trap);
+! #endif
+!         }
+!       else
+! 	old_sigint_handler = temp_sigint_handler;
+        waiting_for_child = 0;
+        if (old_sigint_handler == SIG_IGN)
+*** ../bash-4.4/patchlevel.h	2016-06-22 14:51:03.000000000 -0400
+--- patchlevel.h	2016-10-01 11:01:28.000000000 -0400
+***************
+*** 26,30 ****
+     looks for to find the patch level (for the sccs version string). */
+  
+! #define PATCHLEVEL 20
+  
+  #endif /* _PATCHLEVEL_H_ */
+--- 26,30 ----
+     looks for to find the patch level (for the sccs version string). */
+  
+! #define PATCHLEVEL 21
+  
+  #endif /* _PATCHLEVEL_H_ */

--- a/SPECS/bash/bash44-022.patch
+++ b/SPECS/bash/bash44-022.patch
@@ -1,0 +1,61 @@
+			     BASH PATCH REPORT
+			     =================
+
+Bash-Release:	4.4
+Patch-ID:	bash44-022
+
+Bug-Reported-by:	Nuzhna Pomoshch <nuzhna_pomoshch@yahoo.com>
+Bug-Reference-ID:	<1317167476.1492079.1495999776464@mail.yahoo.com>
+Bug-Reference-URL:	https://lists.gnu.org/archive/html/bug-readline/2017-05/msg00005.html
+
+Bug-Description:
+
+There are cases where a failing readline command (e.g., delete-char at the end
+of a line) can cause a multi-character key sequence to `back up' and attempt
+to re-read some of the characters in the sequence.
+
+Patch (apply with `patch -p0'):
+
+*** ../bash-4.4-patched/lib/readline/readline.c	2016-04-20 15:53:52.000000000 -0400
+--- lib/readline/readline.c	2018-05-26 17:19:00.000000000 -0400
+***************
+*** 1058,1062 ****
+  	r = _rl_dispatch (ANYOTHERKEY, m);
+      }
+!   else if (r && map[ANYOTHERKEY].function)
+      {
+        /* We didn't match (r is probably -1), so return something to
+--- 1056,1060 ----
+  	r = _rl_dispatch (ANYOTHERKEY, m);
+      }
+!   else if (r < 0 && map[ANYOTHERKEY].function)
+      {
+        /* We didn't match (r is probably -1), so return something to
+***************
+*** 1070,1074 ****
+        return -2;
+      }
+!   else if (r && got_subseq)
+      {
+        /* OK, back up the chain. */
+--- 1068,1072 ----
+        return -2;
+      }
+!   else if (r < 0 && got_subseq)		/* XXX */
+      {
+        /* OK, back up the chain. */
+*** ../bash-4.4/patchlevel.h	2016-06-22 14:51:03.000000000 -0400
+--- patchlevel.h	2016-10-01 11:01:28.000000000 -0400
+***************
+*** 26,30 ****
+     looks for to find the patch level (for the sccs version string). */
+  
+! #define PATCHLEVEL 21
+  
+  #endif /* _PATCHLEVEL_H_ */
+--- 26,30 ----
+     looks for to find the patch level (for the sccs version string). */
+  
+! #define PATCHLEVEL 22
+  
+  #endif /* _PATCHLEVEL_H_ */

--- a/SPECS/bash/bash44-023.patch
+++ b/SPECS/bash/bash44-023.patch
@@ -1,0 +1,52 @@
+			     BASH PATCH REPORT
+			     =================
+
+Bash-Release:	4.4
+Patch-ID:	bash44-023
+
+Bug-Reported-by:	Martijn Dekker <martijn@inlv.org>
+Bug-Reference-ID:	<5326d6b9-2625-1d32-3e6e-ad1d15462c09@inlv.org>
+Bug-Reference-URL:	http://lists.gnu.org/archive/html/bug-bash/2016-11/msg00041.html
+
+Bug-Description:
+
+When sourcing a file from an interactive shell, setting the SIGINT handler
+to the default and typing ^C will cause the shell to exit.
+
+Patch (apply with `patch -p0'):
+
+*** ../bash-4.4-patched/builtins/trap.def	2016-01-25 13:32:38.000000000 -0500
+--- builtins/trap.def	2016-11-06 12:04:35.000000000 -0500
+***************
+*** 99,102 ****
+--- 99,103 ----
+  
+  extern int posixly_correct, subshell_environment;
++ extern int sourcelevel, running_trap;
+  
+  int
+***************
+*** 213,216 ****
+--- 214,220 ----
+  			if (interactive)
+  			  set_signal_handler (SIGINT, sigint_sighandler);
++ 			/* special cases for interactive == 0 */
++ 			else if (interactive_shell && (sourcelevel||running_trap))
++ 			  set_signal_handler (SIGINT, sigint_sighandler);
+  			else
+  			  set_signal_handler (SIGINT, termsig_sighandler);
+*** ../bash-4.4/patchlevel.h	2016-06-22 14:51:03.000000000 -0400
+--- patchlevel.h	2016-10-01 11:01:28.000000000 -0400
+***************
+*** 26,30 ****
+     looks for to find the patch level (for the sccs version string). */
+  
+! #define PATCHLEVEL 22
+  
+  #endif /* _PATCHLEVEL_H_ */
+--- 26,30 ----
+     looks for to find the patch level (for the sccs version string). */
+  
+! #define PATCHLEVEL 23
+  
+  #endif /* _PATCHLEVEL_H_ */

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -295,7 +295,7 @@
         "type": "other",
         "other": {
           "name": "bash",
-          "version": "4.4.18",
+          "version": "4.4.23",
           "downloadUrl": "http://ftp.gnu.org/gnu/bash/bash-4.4.18.tar.gz"
         }
       }

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -37,9 +37,9 @@ readline-7.0-4.cm1.aarch64.rpm
 readline-devel-7.0-4.cm1.aarch64.rpm
 coreutils-8.30-10.cm1.aarch64.rpm
 coreutils-lang-8.30-10.cm1.aarch64.rpm
-bash-4.4.18-6.cm1.aarch64.rpm
-bash-devel-4.4.18-6.cm1.aarch64.rpm
-bash-lang-4.4.18-6.cm1.aarch64.rpm
+bash-4.4.23-1.cm1.aarch64.rpm
+bash-devel-4.4.23-1.cm1.aarch64.rpm
+bash-lang-4.4.23-1.cm1.aarch64.rpm
 bzip2-1.0.6-15.cm1.aarch64.rpm
 bzip2-devel-1.0.6-15.cm1.aarch64.rpm
 bzip2-libs-1.0.6-15.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -37,9 +37,9 @@ readline-7.0-4.cm1.x86_64.rpm
 readline-devel-7.0-4.cm1.x86_64.rpm
 coreutils-8.30-10.cm1.x86_64.rpm
 coreutils-lang-8.30-10.cm1.x86_64.rpm
-bash-4.4.18-6.cm1.x86_64.rpm
-bash-devel-4.4.18-6.cm1.x86_64.rpm
-bash-lang-4.4.18-6.cm1.x86_64.rpm
+bash-4.4.23-1.cm1.x86_64.rpm
+bash-devel-4.4.23-1.cm1.x86_64.rpm
+bash-lang-4.4.23-1.cm1.x86_64.rpm
 bzip2-1.0.6-15.cm1.x86_64.rpm
 bzip2-devel-1.0.6-15.cm1.x86_64.rpm
 bzip2-libs-1.0.6-15.cm1.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -9,10 +9,10 @@ audit-libs-3.0-9.cm1.aarch64.rpm
 audit-python-3.0-9.cm1.aarch64.rpm
 autoconf-2.69-10.cm1.noarch.rpm
 automake-1.16.1-3.cm1.noarch.rpm
-bash-4.4.18-6.cm1.aarch64.rpm
-bash-debuginfo-4.4.18-6.cm1.aarch64.rpm
-bash-devel-4.4.18-6.cm1.aarch64.rpm
-bash-lang-4.4.18-6.cm1.aarch64.rpm
+bash-4.4.23-1.cm1.aarch64.rpm
+bash-debuginfo-4.4.23-1.cm1.aarch64.rpm
+bash-devel-4.4.23-1.cm1.aarch64.rpm
+bash-lang-4.4.23-1.cm1.aarch64.rpm
 binutils-2.36.1-2.cm1.aarch64.rpm
 binutils-debuginfo-2.36.1-2.cm1.aarch64.rpm
 binutils-devel-2.36.1-2.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -9,10 +9,10 @@ audit-libs-3.0-9.cm1.x86_64.rpm
 audit-python-3.0-9.cm1.x86_64.rpm
 autoconf-2.69-10.cm1.noarch.rpm
 automake-1.16.1-3.cm1.noarch.rpm
-bash-4.4.18-6.cm1.x86_64.rpm
-bash-debuginfo-4.4.18-6.cm1.x86_64.rpm
-bash-devel-4.4.18-6.cm1.x86_64.rpm
-bash-lang-4.4.18-6.cm1.x86_64.rpm
+bash-4.4.23-1.cm1.x86_64.rpm
+bash-debuginfo-4.4.23-1.cm1.x86_64.rpm
+bash-devel-4.4.23-1.cm1.x86_64.rpm
+bash-lang-4.4.23-1.cm1.x86_64.rpm
 binutils-2.36.1-2.cm1.x86_64.rpm
 binutils-debuginfo-2.36.1-2.cm1.x86_64.rpm
 binutils-devel-2.36.1-2.cm1.x86_64.rpm


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Certain users of our bash package have encountered a rare hang in bash due to exhaustion of the hash table which bash uses to store exit codes. Our current version of bash is 4.4.18, and this hang was fixed in bash 4.4.20.  This PR upgrades our version to bash 4.4.23, which is the latest patch version of bash 4.4.

Bash 4.4.18 is the last source tar.gz they released for 4.4, and subsequent versions beyond are provided as patch files.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Update bash to 4.4.23 to fix a rare hang.
- Update existing patch to work with `patch -p0`

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Full local build
- Installed updated bash in a VM
