### PR TITLE
Revert "Upgrading Parted to v3.4"

### DIFF
--- a/SPECS/parted/parted.signatures.json
+++ b/SPECS/parted/parted.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "parted-3.4.tar.xz": "e1298022472da5589b7f2be1d5ee3c1b66ec3d96dfbad03dc642afd009da5342"
+  "parted-3.2.tar.xz": "3643dc59db49c6339f19ac2b0a2d3de31b7a6722ce363e5fe857ed34bcf7ad71"
  }
 }

--- a/SPECS/parted/parted.spec
+++ b/SPECS/parted/parted.spec
@@ -1,13 +1,13 @@
 Summary:        GNU Parted manipulates partition tables
 Name:           parted
-Version:        3.4
-Release:        1%{?dist}
+Version:        3.2
+Release:        12%{?dist}
 License:        GPLv3+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Group:          Applications/System
-URL:            https://www.gnu.org/software/parted/
-Source0:        http://ftp.gnu.org/gnu/%{name}/%{name}-%{version}.tar.xz
+URL:            https://ftp.gnu.org/gnu/parted/parted-3.2.tar.xz
+Source0:        http://ftp.gnu.org/gnu/parted/%{name}-%{version}.tar.xz
 Conflicts:      toybox
 Provides:       %{name}-devel = %{version}-%{release}
 
@@ -50,10 +50,6 @@ rm -rf %{buildroot}%{_infodir}/dir
 %{_datadir}/*
 
 %changelog
-* Tue Dec 21 2021 Max Brodeur-Urbas <maxbr@microsoft.com> - 3.4-1
-- Upgrading to 3.4
-- License verified.
-
 * Fri Sep 10 2021 Thomas Crain <thcrain@microsoft.com> - 3.2-12
 - Remove libtool archive files from final packaging
 

--- a/SPECS/parted/parted.spec
+++ b/SPECS/parted/parted.spec
@@ -1,7 +1,7 @@
 Summary:        GNU Parted manipulates partition tables
 Name:           parted
 Version:        3.2
-Release:        12%{?dist}
+Release:        13%{?dist}
 License:        GPLv3+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -50,6 +50,9 @@ rm -rf %{buildroot}%{_infodir}/dir
 %{_datadir}/*
 
 %changelog
+* Thu Jan 20 2022 Max Brodeur-Urbas <maxbr@microsoft.com> - 3.2-13
+- License verified.
+
 * Fri Sep 10 2021 Thomas Crain <thcrain@microsoft.com> - 3.2-12
 - Remove libtool archive files from final packaging
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -16134,8 +16134,8 @@
         "type": "other",
         "other": {
           "name": "parted",
-          "version": "3.4",
-          "downloadUrl": "http://ftp.gnu.org/gnu/parted/parted-3.4.tar.xz"
+          "version": "3.2",
+          "downloadUrl": "http://ftp.gnu.org/gnu/parted/parted-3.2.tar.xz"
         }
       }
     },


### PR DESCRIPTION
Reverts microsoft/CBL-Mariner#1898

Parted is breaking boot from full.iso. Reverting upgrade until patch is thoroughly tested