### PR TITLE
Updating tool message.

### DIFF
--- a/toolkit/scripts/license_map.py
+++ b/toolkit/scripts/license_map.py
@@ -156,7 +156,18 @@ def process_licenses(json_filename, markdown_filename, file_paths, check, update
             if outdated_markdown:
                 print(f"License map '{markdown_filename}' is out of date.")
 
-            print(f"Specs' license information is out of date. Run '{__file__} licenses.json_file_path LICENSES-MAP.md_file_path --no_check --update --remove_missing [spec_directory ...]' to regenerate.")
+            print(f"""
+Specs' license information is out of date. Run the following command to regenerate:
+
+    {__file__} --no_check --update --remove_missing \\
+        {json_filename} \\
+        {markdown_filename} \\
+        SPECS SPECS-EXTENDED SPECS-SIGNED
+
+NOTE: the script requires installation of the 'python-rpm-spec' module:
+
+    python3 -m pip install python-rpm-spec
+""")
 
             sys.exit(1)
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

The error message displayed by `license_map.py` was confusing, making the tool hard to use to fix any PR check failures. I hope this change will help a little bit. Now the printed error will look like so:

```bash
Specs' license information is out of date. Run the following command to regenerate:

    toolkit/scripts/license_map.py --no_check --update --remove_missing \
        SPECS/LICENSES-AND-NOTICES/data/licenses.json \
        SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md \
        SPECS SPECS-EXTENDED SPECS-SIGNED

NOTE: the script requires installation of the 'python-rpm-spec' module:

    python3 -m pip install python-rpm-spec
```

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Updated message from `license_map.py`.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local script run.
