### PR TITLE
[1.0] vim:upgrade to v8.2.4120 to fix CVE-2022-0261

### DIFF
--- a/SPECS/vim/vim.signatures.json
+++ b/SPECS/vim/vim.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "vim-8.2.4081.tar.gz": "96c39240f77395dbcc74181c5e997850338bd574faf08f9e2cde9d4685a7fb28"
+  "vim-8.2.4120.tar.gz": "735b37ec28cc625baacfd2c277c47ea8960f1c841c5b16b1dad55ab3c4b756ce"
  }
 }

--- a/SPECS/vim/vim.spec
+++ b/SPECS/vim/vim.spec
@@ -1,7 +1,7 @@
 %define debug_package %{nil}
 Summary:        Text editor
 Name:           vim
-Version:        8.2.4081
+Version:        8.2.4120
 Release:        1%{?dist}
 License:        Vim
 Vendor:         Microsoft Corporation
@@ -190,6 +190,9 @@ fi
 %{_bindir}/vimdiff
 
 %changelog
+* Wed Jan 26 2022 Neha Agarwal <nehaagarwal@microsoft.com> - 8.2.4120-1
+- Update version to 8.2.4120 to fix CVE-2022-0261.
+
 * Thu Jan 13 2022 Rachel Menge <rachelmenge@microsoft.com> - 8.2.4081-1
 - Update version to 8.2.4081 to fix CVE-2022-0128.
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -8625,8 +8625,8 @@
         "type": "other",
         "other": {
           "name": "vim",
-          "version": "8.2.4081",
-          "downloadUrl": "https://github.com/vim/vim/archive/v8.2.4081.tar.gz"
+          "version": "8.2.4120",
+          "downloadUrl": "https://github.com/vim/vim/archive/v8.2.4120.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
vim: upgrade to v8.2.4120 to fix CVE-2022-0261

###### Change Log  <!-- REQUIRED -->
- vim: upgrade to v8.2.4120 to fix CVE-2022-0261

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2022-0261

###### Test Methodology
- Local build with RUN_CHECK=y