### PR TITLE
[main] Update mysql to v8.0.28 to resolve 16 CVEs

### DIFF
--- a/SPECS/mysql/mysql.signatures.json
+++ b/SPECS/mysql/mysql.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "mysql-boost-8.0.24.tar.gz": "4bc9c54b38e9e2a3f5cc77f21791dc52372f15c5473f7d427793f6ec44bf5900"
+  "mysql-boost-8.0.28.tar.gz": "6dd0303998e70066d36905bd8fef1c01228ea182dbfbabc6c22ebacdbf8b5941"
  }
 }

--- a/SPECS/mysql/mysql.spec
+++ b/SPECS/mysql/mysql.spec
@@ -1,6 +1,6 @@
 Summary:        MySQL.
 Name:           mysql
-Version:        8.0.24
+Version:        8.0.28
 Release:        1%{?dist}
 License:        GPLv2 with exceptions AND LGPLv2 AND BSD
 Vendor:         Microsoft Corporation
@@ -72,10 +72,17 @@ make test
 %files devel
 %{_libdir}/*.so
 %{_libdir}/*.a
+%{_libdir}/private/icudt69l/brkitr/*.res
+%{_libdir}/private/icudt69l/brkitr/*.brk
+%{_libdir}/private/icudt69l/brkitr/*.dict
+%{_libdir}/private/icudt69l/unames.icu
 %{_includedir}/*
 %{_libdir}/pkgconfig/mysqlclient.pc
 
 %changelog
+* Wed Jan 26 2022 Neha Agarwal <thcrain@microsoft.com> - 8.0.28-1
+- Upgrade to 8.0.28 to fix 16 CVEs
+
 * Sat Apr 24 2021 Thomas Crain <thcrain@microsoft.com> - 8.0.24-1
 - Upgrade to 8.0.24 to fix 30 CVEs
 - Update source URL

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -14113,8 +14113,8 @@
         "type": "other",
         "other": {
           "name": "mysql",
-          "version": "8.0.24",
-          "downloadUrl": "https://dev.mysql.com/get/Downloads/MySQL-8.0/mysql-boost-8.0.24.tar.gz"
+          "version": "8.0.28",
+          "downloadUrl": "https://dev.mysql.com/get/Downloads/MySQL-8.0/mysql-boost-8.0.28.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
Update mysql to v8.0.28 to resolve 16 CVEs

###### Change Log  <!-- REQUIRED -->
- Update mysql to v8.0.28 fix 16 CVE
- Fix CVE: 2022-21245, 2022-21253, 2022-21254, 2022-21256, 2022-21264, 2022-21270, 2022-21284, 2022-21285, 2022-21286, 2022-21287, 2022-21288, 2022-21289, 2022-21290, 2022-21301, 2022-21302 and 2022-21304
- New files were added to mysql in this commit: mysql/mysql-server@b3e00fe. Adding these files to the mysql-devel package.

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2022-21245
- https://nvd.nist.gov/vuln/detail/CVE-2022-21253
- https://nvd.nist.gov/vuln/detail/CVE-2022-21254
- https://nvd.nist.gov/vuln/detail/CVE-2022-21256
- https://nvd.nist.gov/vuln/detail/CVE-2022-21264
- https://nvd.nist.gov/vuln/detail/CVE-2022-21270
- https://nvd.nist.gov/vuln/detail/CVE-2022-21284
- https://nvd.nist.gov/vuln/detail/CVE-2022-21285
- https://nvd.nist.gov/vuln/detail/CVE-2022-21286
- https://nvd.nist.gov/vuln/detail/CVE-2022-21287
- https://nvd.nist.gov/vuln/detail/CVE-2022-21288
- https://nvd.nist.gov/vuln/detail/CVE-2022-21289
- https://nvd.nist.gov/vuln/detail/CVE-2022-21290
- https://nvd.nist.gov/vuln/detail/CVE-2022-21301
- https://nvd.nist.gov/vuln/detail/CVE-2022-21302
- https://nvd.nist.gov/vuln/detail/CVE-2022-21304

###### Test Methodology
- Local build with RUN_CHECK=y