### PR TITLE
[main] Don't overwrite TERM in containers

### DIFF
--- a/toolkit/imageconfigs/core-container.json
+++ b/toolkit/imageconfigs/core-container.json
@@ -17,7 +17,7 @@
             ],
             "PostInstallScripts": [
                 {
-                    "Path": "postinstallscripts/core-container/cleanup-and-set-term.sh"
+                    "Path": "postinstallscripts/core-container/cleanup.sh"
                 }
             ]
         }

--- a/toolkit/imageconfigs/postinstallscripts/core-container/cleanup.sh
+++ b/toolkit/imageconfigs/postinstallscripts/core-container/cleanup.sh
@@ -4,5 +4,3 @@ rm -rf /boot/*
 rm -rf /usr/src/
 rm -rf /home/*
 rm -rf /var/log/*
-# set TERM to linux
-echo "export TERM=linux" >> /etc/bash.bashrc


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Ports https://github.com/microsoft/CBL-Mariner/pull/1550 to Mariner 2.0.

Don't overwrite $TERM env-var in container images, the terminal (provided by dockerd or whatever) will set it correctly. the current setting causes issues in e.g. vim where some operations (like ctrl+left/ctrl+right) completely butcher the file being edited.

###### Change Log  <!-- REQUIRED -->
Probably doesn't need a CHANGELOG entry

###### Does this affect the toolchain?  <!-- REQUIRED -->
No

###### Associated issues  <!-- optional -->
- None

###### Links to CVEs  <!-- optional -->
- None

###### Test Methodology
Tested manually
