### PR TITLE
[main] [extended] Fix grubby build with newer versions of RPM

### DIFF
--- a/.github/workflows/validate-cg-manifest.sh
+++ b/.github/workflows/validate-cg-manifest.sh
@@ -20,6 +20,7 @@ ignore_list=" \
   dbus-x11 \
   grub2-efi-binary-signed-aarch64 \
   grub2-efi-binary-signed-x86_64 \
+  grubby \
   initramfs \
   installkernel \
   kde-filesystem \

--- a/SPECS-EXTENDED/grubby/0013-Fix-build-RPM-416.patch
+++ b/SPECS-EXTENDED/grubby/0013-Fix-build-RPM-416.patch
@@ -1,0 +1,27 @@
+From 1afddd618629a97479560bedbdcfa11b2c492a0e Mon Sep 17 00:00:00 2001
+From: Javier Martinez Canillas <javierm@redhat.com>
+Date: Fri, 26 Jun 2020 10:02:51 +0200
+Subject: [PATCH] Fix build with rpm-4.16
+
+rpmvercmp() was moved to librpmio, so link against this library instead.
+
+Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>
+---
+ Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index 1ab58aeb039..a54b053a30b 100644
+--- a/Makefile
++++ b/Makefile
+@@ -59,7 +59,7 @@ grubby:: $(OBJECTS)
+ 	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^ $(grubby_LIBS)
+ 
+ rpm-sort::rpm-sort.o
+-	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^ -lrpm
++	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^ -lrpmio
+ 
+ clean:
+ 	rm -f *.o grubby rpm-sort *~
+-- 
+2.26.2

--- a/SPECS-EXTENDED/grubby/grubby.spec
+++ b/SPECS-EXTENDED/grubby/grubby.spec
@@ -1,52 +1,50 @@
+Summary:        Command line tool for updating bootloader configs
+Name:           grubby
+Version:        8.40
+Release:        42%{?dist}
+License:        GPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
-Name: grubby
-Version: 8.40
-Release: 41%{?dist}
-Summary: Command line tool for updating bootloader configs
-License: GPLv2+
-URL: https://github.com/rhinstaller/grubby
+URL:            https://github.com/rhinstaller/grubby
 # we only pull git snaps at the moment
 # git clone git@github.com:rhinstaller/grubby.git
 # git archive --format=tar --prefix=grubby-%%{version}/ HEAD |bzip2 > grubby-%%{version}.tar.bz2
 # Source0: %%{name}-%%{version}.tar.bz2
-Source0: https://github.com/rhboot/grubby/archive/%{version}-1.tar.gz#/%{name}-%{version}.tar.gz
-Source1: grubby-bls
-Source2: grubby.in
-Source3: installkernel.in
-Source4: installkernel-bls
-Source5: 95-kernel-hooks.install
-Patch0001: 0001-remove-the-old-crufty-u-boot-support.patch
-Patch0002: 0002-Change-return-type-in-getRootSpecifier.patch
-Patch0003: 0003-Add-btrfs-subvolume-support-for-grub2.patch
-Patch0004: 0004-Add-tests-for-btrfs-support.patch
-Patch0005: 0005-Use-system-LDFLAGS.patch
-Patch0006: 0006-Honor-sbindir.patch
-Patch0007: 0007-Make-installkernel-to-use-kernel-install-scripts-on-.patch
-Patch0008: 0008-Add-usr-libexec-rpm-sort.patch
-Patch0009: 0009-Improve-man-page-for-info-option.patch
-Patch0010: 0010-Fix-GCC-warnings-about-possible-string-truncations-a.patch
-Patch0011: 0011-Fix-stringop-overflow-warning.patch
-Patch0012: 0012-Fix-maybe-uninitialized-warning.patch
-
-BuildRequires: gcc
-BuildRequires: pkgconfig glib2-devel popt-devel 
-BuildRequires: libblkid-devel git-core sed make
-# for make test / getopt:
-BuildRequires: util-linux-ng
-BuildRequires: rpm-devel
-%ifarch aarch64 i686 x86_64 %{power64}
-BuildRequires: grub2-tools-minimal
-Requires: grub2-tools-minimal
-Requires: grub2-tools
+Source0:        https://github.com/rhboot/grubby/archive/%{version}-1.tar.gz#/%{name}-%{version}.tar.gz
+Source1:        grubby-bls
+Source2:        grubby.in
+Source3:        installkernel.in
+Source4:        installkernel-bls
+Source5:        95-kernel-hooks.install
+Patch0001:      0001-remove-the-old-crufty-u-boot-support.patch
+Patch0002:      0002-Change-return-type-in-getRootSpecifier.patch
+Patch0003:      0003-Add-btrfs-subvolume-support-for-grub2.patch
+Patch0004:      0004-Add-tests-for-btrfs-support.patch
+Patch0005:      0005-Use-system-LDFLAGS.patch
+Patch0006:      0006-Honor-sbindir.patch
+Patch0007:      0007-Make-installkernel-to-use-kernel-install-scripts-on-.patch
+Patch0008:      0008-Add-usr-libexec-rpm-sort.patch
+Patch0009:      0009-Improve-man-page-for-info-option.patch
+Patch0010:      0010-Fix-GCC-warnings-about-possible-string-truncations-a.patch
+Patch0011:      0011-Fix-stringop-overflow-warning.patch
+Patch0012:      0012-Fix-maybe-uninitialized-warning.patch
+Patch0013:      0013-Fix-build-RPM-416.patch
+BuildRequires:  gcc
+BuildRequires:  glib2-devel
+BuildRequires:  grub2-tools-minimal
+BuildRequires:  libblkid-devel
+BuildRequires:  make
+BuildRequires:  pkg-config
+BuildRequires:  popt-devel
+BuildRequires:  rpm-devel
+BuildRequires:  sed
+%if %{with_check}
+BuildRequires:  util-linux-ng
 %endif
-%ifarch s390 s390x
-Requires: s390utils-base
-%endif
-Requires: findutils
-Requires: util-linux
-
-Obsoletes:	%{name}-bls < %{version}-%{release}
+Requires:       findutils
+Requires:       grub2-tools
+Requires:       grub2-tools-minimal
+Requires:       util-linux
 
 %description
 This package provides a grubby compatibility script that manages
@@ -54,28 +52,19 @@ BootLoaderSpec files and is meant to only be used for legacy compatibility
 users with existing grubby users.
 
 %prep
-%setup -q -n grubby-%{version}-1
-
-git init
-git config user.email "noone@example.com"
-git config user.name "no one"
-git add .
-git commit -a -q -m "%{version} baseline"
-git am %{patches} </dev/null
-git config --unset user.email
-git config --unset user.name
+%autosetup -p1 -n grubby-%{version}-1
 
 %build
-%set_build_flags
-make %{?_smp_mflags} LDFLAGS="${LDFLAGS}"
+%{set_build_flags}
+%make_build LDFLAGS="${LDFLAGS}"
 
 %ifnarch aarch64 %{arm}
 %check
-make test
+%make_build test
 %endif
 
 %install
-make install DESTDIR=$RPM_BUILD_ROOT mandir=%{_mandir} sbindir=%{_sbindir} libexecdir=%{_libexecdir}
+%make_install mandir=%{_mandir} sbindir=%{_sbindir} libexecdir=%{_libexecdir}
 
 mkdir -p %{buildroot}%{_libexecdir}/{grubby,installkernel}/ %{buildroot}%{_sbindir}/
 mv -v %{buildroot}%{_sbindir}/grubby %{buildroot}%{_libexecdir}/grubby/grubby
@@ -86,18 +75,11 @@ sed -e "s,@@LIBEXECDIR@@,%{_libexecdir}/grubby,g" %{SOURCE2} \
 	> %{buildroot}%{_sbindir}/grubby
 sed -e "s,@@LIBEXECDIR@@,%{_libexecdir}/installkernel,g" %{SOURCE3} \
 	> %{buildroot}%{_sbindir}/installkernel
-install -D -m 0755 -t %{buildroot}%{_prefix}/lib/kernel/install.d/ %{SOURCE5}
+install -D -m 0755 -t %{buildroot}%{_libdir}/kernel/install.d/ %{SOURCE5}
 
-%post
-if [ "$1" = 2 ]; then
-    arch=$(uname -m)
-    [[ $arch == "s390x" ]] && \
-    zipl-switch-to-blscfg --backup-suffix=.rpmsave &>/dev/null || :
-fi
-
-%package deprecated
-Summary:	Legacy command line tool for updating bootloader configs
-Conflicts:	%{name} <= 8.40-18
+%package        deprecated
+Summary:        Legacy command line tool for updating bootloader configs
+Conflicts:      %{name} <= 8.40-18
 
 %description deprecated
 This package provides deprecated, legacy grubby.  This is for temporary
@@ -110,7 +92,6 @@ scripts which install new kernels and need to find information about the
 current boot environment.
 
 %files
-%{!?_licensedir:%global license %%doc}
 %license COPYING
 %dir %{_libexecdir}/grubby
 %dir %{_libexecdir}/installkernel
@@ -119,11 +100,10 @@ current boot environment.
 %attr(0755,root,root) %{_sbindir}/grubby
 %attr(0755,root,root) %{_libexecdir}/installkernel/installkernel-bls
 %attr(0755,root,root) %{_sbindir}/installkernel
-%attr(0755,root,root) %{_prefix}/lib/kernel/install.d/95-kernel-hooks.install
+%attr(0755,root,root) %{_libdir}/kernel/install.d/95-kernel-hooks.install
 %{_mandir}/man8/[gi]*.8*
 
 %files deprecated
-%{!?_licensedir:%global license %%doc}
 %license COPYING
 %dir %{_libexecdir}/grubby
 %dir %{_libexecdir}/installkernel
@@ -132,9 +112,16 @@ current boot environment.
 %attr(0755,root,root) %{_sbindir}/grubby
 %attr(0755,root,root) %{_sbindir}/installkernel
 %attr(0755,root,root) %{_sbindir}/new-kernel-pkg
- %{_mandir}/man8/*.8*
+%{_mandir}/man8/*.8*
 
 %changelog
+* Fri Jan 28 2022 Thomas Crain <thcrain@microsoft.com> - 8.40-42
+- Add Fedora patch file (license: MIT) to fix linking with RPM >= 4.16.0
+- Remove git setup steps, apply patches using %%autosetup
+- Remove s390x-specific instructions
+- Lint spec
+- License verified
+
 * Fri Oct 15 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 8.40-41
 - Initial CBL-Mariner import from Fedora 32 (license: MIT).
 
@@ -672,4 +659,3 @@ current boot environment.
 
 * Tue Jun  2 2009 Jeremy Katz <katzj@redhat.com> - 6.0.86-1
 - initial build after splitting out from mkinitrd
-


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
The `grubby` package regressed with our upgrade to RPM 4.17. This PR adds a patch to fix linking with our version of RPM.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add Fedora patch file (license: MIT) to fix linking with RPM >= 4.16.0
- Remove git setup steps, apply patches using %%autosetup
- Remove s390x-specific instructions
- Lint spec
- License verified

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local mock build
