### PR TITLE
Permit users to type Ctrl^C during ISO installing progress

### DIFF
--- a/toolkit/tools/imagegen/attendedinstaller/views/progressview/progressview.go
+++ b/toolkit/tools/imagegen/attendedinstaller/views/progressview/progressview.go
@@ -90,9 +90,6 @@ func (pv *ProgressView) Initialize(backButtonText string, sysConfig *configurati
 // HandleInput handles custom input.
 func (pv *ProgressView) HandleInput(event *tcell.EventKey) *tcell.EventKey {
 	switch event.Key() {
-	// Prevent exiting the UI here as installation has already begun.
-	case tcell.KeyCtrlC:
-		return nil
 	case tcell.KeyCtrlA:
 		pv.switchDetailLevel(!pv.moreDetails)
 	}


### PR DESCRIPTION
Hi

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->

Before this PR, users cannot type Ctrl^C to exit the ISO installing progress when the progress bar is printed.
This behavior was thought to avoid users to exit this process by mistake.
I had a problem during which the installation froze so I removed the code handling Ctrl^C from `HandleInput()` and was once you typed Ctrl^C you are prompted to confirm you want to exit the installation process.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Remove Ctrl^C from `HandleInput` to enable users to exit ISO installation process.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- I built an ISO with this patch and typed Ctrl^C once the progress bar is printed.
![image](https://user-images.githubusercontent.com/12171754/152013538-e1da6d63-4222-490c-9eab-f352570487a8.png)


Best regards.