### PR TITLE
[main] Correct CentOS License 

### DIFF
--- a/SPECS-EXTENDED/crash-ptdump-command/crash-ptdump-command.spec
+++ b/SPECS-EXTENDED/crash-ptdump-command/crash-ptdump-command.spec
@@ -45,7 +45,7 @@ cp %{_builddir}/ptdump-%{version}/ptdump.so %{buildroot}%{_libdir}/crash/extensi
 - License verified.
 
 * Sun Jul 25 2021 Jon Slobodzian <joslobo@microsoft.com> - 1.0.7-2
-- Initial CBL-Mariner import from CentOS 8 (license: MIT).
+- Initial CBL-Mariner import from CentOS 8 (license: GPLv2).
 - Modified spec to provide architecture arguments to make
 
 * Wed Jul 8 2020 Bhupesh Sharma <bhsharma@redhat.com> - 1.0.7-1

--- a/SPECS-EXTENDED/delve/delve.spec
+++ b/SPECS-EXTENDED/delve/delve.spec
@@ -73,7 +73,7 @@ done
 
 %changelog
 * Thu Sep 23 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.5.0-3
-- Initial CBL-Mariner import from CentOS 8 (license: MIT).
+- Initial CBL-Mariner import from CentOS 8 (license: GPLv2).
 - Adding missing BR on 'go-rpm-macros'.
 - Running with empty 'LDFLAGS' to fix the build.
 

--- a/SPECS-EXTENDED/delve/delve.spec
+++ b/SPECS-EXTENDED/delve/delve.spec
@@ -76,6 +76,7 @@ done
 - Initial CBL-Mariner import from CentOS 8 (license: GPLv2).
 - Adding missing BR on 'go-rpm-macros'.
 - Running with empty 'LDFLAGS' to fix the build.
+- License verified
 
 * Tue Nov 24 2020 David Benoit <dbenoit@redhat.com> - 1.5.0-2
 - Add golang-1.15.4 related patch

--- a/SPECS-EXTENDED/nodejs-nodemon/nodejs-nodemon.spec
+++ b/SPECS-EXTENDED/nodejs-nodemon/nodejs-nodemon.spec
@@ -81,6 +81,7 @@ npm run test
 %changelog
 * Fri Oct 15 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 2.0.3-2
 - Initial CBL-Mariner import from CentOS 8 (license: GPLv2).
+- License verified
 
 * Fri May 01 2020 Honza Horak <hhorak@redhat.com> - 2.0.3-1
 - Update to 2.0.3

--- a/SPECS-EXTENDED/nodejs-nodemon/nodejs-nodemon.spec
+++ b/SPECS-EXTENDED/nodejs-nodemon/nodejs-nodemon.spec
@@ -80,7 +80,7 @@ npm run test
 
 %changelog
 * Fri Oct 15 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 2.0.3-2
-- Initial CBL-Mariner import from CentOS 8 (license: MIT).
+- Initial CBL-Mariner import from CentOS 8 (license: GPLv2).
 
 * Fri May 01 2020 Honza Horak <hhorak@redhat.com> - 2.0.3-1
 - Update to 2.0.3

--- a/SPECS-EXTENDED/rhnlib/rhnlib.spec
+++ b/SPECS-EXTENDED/rhnlib/rhnlib.spec
@@ -88,7 +88,7 @@ make -f Makefile.rhnlib
 - License verified.
 
 * Fri Mar 05 2021 Henry Li <lihl@microsoft.com> 2.8.6-9
-- Initial CBL-Mariner import from CentOS 8 (license: MIT).
+- Initial CBL-Mariner import from CentOS 8 (license: GPLv2).
 - Fix distro condition checking to enable python3 build
 
 * Fri Jun 21 2019 Michael Mraka <michael.mraka@redhat.com> 2.8.6-8

--- a/toolkit/scripts/spec_source_attributions.py
+++ b/toolkit/scripts/spec_source_attributions.py
@@ -8,7 +8,7 @@ import re
 
 VALID_SOURCE_ATTRIBUTIONS = {
     "Microsoft":                    r'\n-\s+(Original version for CBL-Mariner|Initial CBL-Mariner import from Azure)( \(license: MIT\))?(\.|\n|$)',
-    "CentOS":                       r'\n-\s+Initial CBL-Mariner import from CentOS \d+ \(license: MIT\)(\.|\n|$)',
+    "CentOS":                       r'\n-\s+Initial CBL-Mariner import from CentOS \d+ \(license: GPLv2\)(\.|\n|$)',
     "Ceph source":                  r'\n-\s+Initial CBL-Mariner import from Ceph source \(license: LGPLv2.1\)(\.|\n|$)',
     "Netplan source":               r'\n-\s+Initial CBL-Mariner import from Netplan source \(license: GPLv3\)(\.|\n|$)',
     "Fedora":                       r'\n-\s+Initial CBL-Mariner import from Fedora \d+ \(license: MIT\)(\.|\n|$)',


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
spec_source_attributions.py has a regex indicating what spec files from CentOS should have the MIT license. This is incorrect (https://centos.org/legal/licensing-policy/), it should actually be GPLv2.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Update CentOS regex in spec_source_attributions.py
- Modify changelog entries to reflect actual specfile licenses

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
NO

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- So long as the 'Spec files check' github action doesn't complain, we should be good. 
