### PR TITLE
[1.0] Upgrade expat to v.2.4.4 to fix CVE-2022-23852

### DIFF
--- a/SPECS/expat/expat.signatures.json
+++ b/SPECS/expat/expat.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "expat-2.4.3.tar.bz2": "6f262e216a494fbf42d8c22bc841b3e117c21f2467a19dc4c27c991b5622f986"
+  "expat-2.4.4.tar.bz2": "14c58c2a0b5b8b31836514dfab41bd191836db7aa7b84ae5c47bc0327a20d64a"
  }
 }

--- a/SPECS/expat/expat.spec
+++ b/SPECS/expat/expat.spec
@@ -1,7 +1,7 @@
 %global 		underscore_version $(echo %{version} | cut -d. -f1-3 --output-delimiter="_")
 Summary:        An XML parser library
 Name:           expat
-Version:        2.4.3
+Version:        2.4.4
 Release:        1%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
@@ -65,6 +65,9 @@ rm -rf %{buildroot}/%{_docdir}/%{name}
 %{_libdir}/libexpat.so.1*
 
 %changelog
+* Mon Jan 31 2022 Neha Agarwal <nehaagarwal@microsoft.com> - 2.4.4-1
+- Update version to 2.4.4 to address CVE-2022-23852
+
 * Sun Jan 16 2022 Rachel Menge <rachelmenge@microsoft.com> - 2.4.3-1
 - Update source to 2.4.3 to address CVE-2021-46143, CVE-2021-45960,
   CVE-2022-22822 to CVE-2022-22827

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -1435,8 +1435,8 @@
         "type": "other",
         "other": {
           "name": "expat",
-          "version": "2.4.3",
-          "downloadUrl": "https://github.com/libexpat/libexpat/releases/download/R_2_4_3/expat-2.4.3.tar.bz2"
+          "version": "2.4.4",
+          "downloadUrl": "https://github.com/libexpat/libexpat/releases/download/R_2_4_4/expat-2.4.4.tar.bz2"
         }
       }
     },

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -93,9 +93,9 @@ elfutils-libelf-0.176-4.cm1.aarch64.rpm
 elfutils-libelf-devel-0.176-4.cm1.aarch64.rpm
 elfutils-libelf-devel-static-0.176-4.cm1.aarch64.rpm
 elfutils-libelf-lang-0.176-4.cm1.aarch64.rpm
-expat-2.4.3-1.cm1.aarch64.rpm
-expat-devel-2.4.3-1.cm1.aarch64.rpm
-expat-libs-2.4.3-1.cm1.aarch64.rpm
+expat-2.4.4-1.cm1.aarch64.rpm
+expat-devel-2.4.4-1.cm1.aarch64.rpm
+expat-libs-2.4.4-1.cm1.aarch64.rpm
 libpipeline-1.5.0-4.cm1.aarch64.rpm
 libpipeline-devel-1.5.0-4.cm1.aarch64.rpm
 gdbm-1.18-3.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -93,9 +93,9 @@ elfutils-libelf-0.176-4.cm1.x86_64.rpm
 elfutils-libelf-devel-0.176-4.cm1.x86_64.rpm
 elfutils-libelf-devel-static-0.176-4.cm1.x86_64.rpm
 elfutils-libelf-lang-0.176-4.cm1.x86_64.rpm
-expat-2.4.3-1.cm1.x86_64.rpm
-expat-devel-2.4.3-1.cm1.x86_64.rpm
-expat-libs-2.4.3-1.cm1.x86_64.rpm
+expat-2.4.4-1.cm1.x86_64.rpm
+expat-devel-2.4.4-1.cm1.x86_64.rpm
+expat-libs-2.4.4-1.cm1.x86_64.rpm
 libpipeline-1.5.0-4.cm1.x86_64.rpm
 libpipeline-devel-1.5.0-4.cm1.x86_64.rpm
 gdbm-1.18-3.cm1.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -80,10 +80,10 @@ elfutils-libelf-0.176-4.cm1.aarch64.rpm
 elfutils-libelf-devel-0.176-4.cm1.aarch64.rpm
 elfutils-libelf-devel-static-0.176-4.cm1.aarch64.rpm
 elfutils-libelf-lang-0.176-4.cm1.aarch64.rpm
-expat-2.4.3-1.cm1.aarch64.rpm
-expat-debuginfo-2.4.3-1.cm1.aarch64.rpm
-expat-devel-2.4.3-1.cm1.aarch64.rpm
-expat-libs-2.4.3-1.cm1.aarch64.rpm
+expat-2.4.4-1.cm1.aarch64.rpm
+expat-debuginfo-2.4.4-1.cm1.aarch64.rpm
+expat-devel-2.4.4-1.cm1.aarch64.rpm
+expat-libs-2.4.4-1.cm1.aarch64.rpm
 file-5.38-1.cm1.aarch64.rpm
 file-debuginfo-5.38-1.cm1.aarch64.rpm
 file-devel-5.38-1.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -80,10 +80,10 @@ elfutils-libelf-0.176-4.cm1.x86_64.rpm
 elfutils-libelf-devel-0.176-4.cm1.x86_64.rpm
 elfutils-libelf-devel-static-0.176-4.cm1.x86_64.rpm
 elfutils-libelf-lang-0.176-4.cm1.x86_64.rpm
-expat-2.4.3-1.cm1.x86_64.rpm
-expat-debuginfo-2.4.3-1.cm1.x86_64.rpm
-expat-devel-2.4.3-1.cm1.x86_64.rpm
-expat-libs-2.4.3-1.cm1.x86_64.rpm
+expat-2.4.4-1.cm1.x86_64.rpm
+expat-debuginfo-2.4.4-1.cm1.x86_64.rpm
+expat-devel-2.4.4-1.cm1.x86_64.rpm
+expat-libs-2.4.4-1.cm1.x86_64.rpm
 file-5.38-1.cm1.x86_64.rpm
 file-debuginfo-5.38-1.cm1.x86_64.rpm
 file-devel-5.38-1.cm1.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
Upgrade expat to v.2.4.4 to fix CVE-2022-23852

###### Change Log  <!-- REQUIRED -->
- Upgrade expat to v.2.4.4 to fix CVE-2022-23852

###### Does this affect the toolchain?  <!-- REQUIRED -->
YES

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2022-23852

###### Test Methodology
- Local build with RUN_CHECK=y, rebuilt toolchain locally


Closes: #2034 [Autopatcher]