### PR TITLE
[main] Fixing tooling issues during package candidates resolution.

### DIFF
--- a/toolkit/Makefile
+++ b/toolkit/Makefile
@@ -88,9 +88,9 @@ IMAGES_DIR      ?= $(OUT_DIR)/images
 
 # If toolchain RPMs are being rebuilt locally, they belong with the other RPMs
 ifeq ($(REBUILD_TOOLCHAIN),y)
-toolchain_rpms_dir := $(RPMS_DIR)
+   toolchain_rpms_dir := $(RPMS_DIR)
 else
-toolchain_rpms_dir := $(CACHED_RPMS_DIR)/cache
+   toolchain_rpms_dir := $(CACHED_RPMS_DIR)/cache
 endif
 
 # External source server
@@ -102,10 +102,10 @@ REPO_LIST          ?=
 SRPM_URL_LIST      ?= https://packages.microsoft.com/cbl-mariner/$(RELEASE_MAJOR_ID)/prod/base/srpms
 
 ifeq ($(USE_PREVIEW_REPO),y)
-PACKAGE_URL_LIST   += https://packages.microsoft.com/cbl-mariner/$(RELEASE_MAJOR_ID)/preview/base/$(build_arch)
-PACKAGE_URL_LIST   += https://packages.microsoft.com/cbl-mariner/$(RELEASE_MAJOR_ID)/preview/base/debuginfo/$(build_arch)
-override REPO_LIST += $(REPOS_DIR)/mariner-official-preview.repo
-SRPM_URL_LIST      += https://packages.microsoft.com/cbl-mariner/$(RELEASE_MAJOR_ID)/preview/base/srpms
+   PACKAGE_URL_LIST   += https://packages.microsoft.com/cbl-mariner/$(RELEASE_MAJOR_ID)/preview/base/$(build_arch)
+   PACKAGE_URL_LIST   += https://packages.microsoft.com/cbl-mariner/$(RELEASE_MAJOR_ID)/preview/base/debuginfo/$(build_arch)
+   override REPO_LIST += $(REPOS_DIR)/mariner-official-preview.repo
+   SRPM_URL_LIST      += https://packages.microsoft.com/cbl-mariner/$(RELEASE_MAJOR_ID)/preview/base/srpms
 endif
 
 CA_CERT     ?=
@@ -117,7 +117,7 @@ DIST_TAG           ?= .cm2
 BUILD_NUMBER       ?= $(shell git rev-parse --short HEAD)
 # an empty BUILD_NUMBER breaks the build later on
 ifeq ($(BUILD_NUMBER),)
-        BUILD_NUMBER = non-git
+   BUILD_NUMBER = non-git
 endif
 RELEASE_MAJOR_ID   ?= 2.0
 # use minor ID defined in file (if exist) otherwise define it
@@ -189,10 +189,10 @@ include $(SCRIPTS_DIR)/toolkit.mk
 # They are guaranteed to run first and will verify there are no existing mount points
 # left after a chroot.
 clean:
-   rm -rf $(OUT_DIR)
-   rm -rf $(BUILD_DIR)
-   rm -rf $(toolkit_root)/out
+	rm -rf $(OUT_DIR)
+	rm -rf $(BUILD_DIR)
+	rm -rf $(toolkit_root)/out
 
 # output version number
 get-version:
-   @echo $(RELEASE_VERSION)
+	@echo $(RELEASE_VERSION)

--- a/toolkit/Makefile
+++ b/toolkit/Makefile
@@ -98,17 +98,14 @@ SOURCE_URL         ?=
 
 PACKAGE_URL_LIST   ?= https://packages.microsoft.com/cbl-mariner/$(RELEASE_MAJOR_ID)/prod/base/$(build_arch)
 PACKAGE_URL_LIST   += https://packages.microsoft.com/cbl-mariner/$(RELEASE_MAJOR_ID)/prod/base/debuginfo/$(build_arch)
+REPO_LIST          ?=
 SRPM_URL_LIST      ?= https://packages.microsoft.com/cbl-mariner/$(RELEASE_MAJOR_ID)/prod/base/srpms
 
 ifeq ($(USE_PREVIEW_REPO),y)
 PACKAGE_URL_LIST   += https://packages.microsoft.com/cbl-mariner/$(RELEASE_MAJOR_ID)/preview/base/$(build_arch)
 PACKAGE_URL_LIST   += https://packages.microsoft.com/cbl-mariner/$(RELEASE_MAJOR_ID)/preview/base/debuginfo/$(build_arch)
-SRPM_URL_LIST      += https://packages.microsoft.com/cbl-mariner/$(RELEASE_MAJOR_ID)/preview/base/srpms
-endif
-
-REPO_LIST   ?=
-ifeq ($(USE_PREVIEW_REPO),y)
 override REPO_LIST += $(REPOS_DIR)/mariner-official-preview.repo
+SRPM_URL_LIST      += https://packages.microsoft.com/cbl-mariner/$(RELEASE_MAJOR_ID)/preview/base/srpms
 endif
 
 CA_CERT     ?=

--- a/toolkit/Makefile
+++ b/toolkit/Makefile
@@ -2,9 +2,9 @@
 # Licensed under the MIT License.
 
 # Contains:
-#	- Definitions
-#	- High Level Targets
-#	- Submake Includes
+#   - Definitions
+#   - High Level Targets
+#   - Submake Includes
 
 ######## DEFINITIONS ########
 
@@ -51,6 +51,7 @@ HYDRATED_BUILD                  ?= n
 toolkit_root     := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 TOOLS_DIR        ?= $(toolkit_root)/tools
 TOOL_BINS_DIR    ?= $(toolkit_root)/out/tools
+REPOS_DIR        ?= $(toolkit_root)/repos
 RESOURCES_DIR    ?= $(toolkit_root)/resources
 SCRIPTS_DIR      ?= $(toolkit_root)/scripts
 
@@ -106,6 +107,10 @@ SRPM_URL_LIST      += https://packages.microsoft.com/cbl-mariner/$(RELEASE_MAJOR
 endif
 
 REPO_LIST   ?=
+ifeq ($(USE_PREVIEW_REPO),y)
+override REPO_LIST += $(REPOS_DIR)/mariner-official-preview.repo
+endif
+
 CA_CERT     ?=
 TLS_CERT    ?=
 TLS_KEY     ?=
@@ -121,9 +126,9 @@ RELEASE_MAJOR_ID   ?= 2.0
 # use minor ID defined in file (if exist) otherwise define it
 # note this file must be single line
 ifneq ($(wildcard $(OUT_DIR)/version-minor-id.config),)
-	RELEASE_MINOR_ID ?= .$(shell cat $(OUT_DIR)/version-minor-id.config)
+   RELEASE_MINOR_ID ?= .$(shell cat $(OUT_DIR)/version-minor-id.config)
 else
-	RELEASE_MINOR_ID ?= .$(shell date +'%Y%m%d.%H%M')
+   RELEASE_MINOR_ID ?= .$(shell date +'%Y%m%d.%H%M')
 endif
 RELEASE_VERSION    ?= $(RELEASE_MAJOR_ID)$(RELEASE_MINOR_ID)
 
@@ -134,6 +139,7 @@ IMAGE_TAG          ?= Preview-C
 LOG_LEVEL          ?= info
 STOP_ON_WARNING    ?= n
 STOP_ON_PKG_FAIL   ?= n
+STOP_ON_FETCH_FAIL ?= n
 
 ######## HIGH LEVEL TARGETS ########
 
@@ -147,29 +153,29 @@ all: toolchain go-tools chroot-tools
 include $(SCRIPTS_DIR)/utils.mk
 
 # Bootstrap the toolchain's compilers and other tools with:
-#	toolchain, raw-toolchain, clean-toolchain, check-manifests, check-x86_64-manifests, check-aarch64-manifests
+#   toolchain, raw-toolchain, clean-toolchain, check-manifests, check-x86_64-manifests, check-aarch64-manifests
 include $(SCRIPTS_DIR)/toolchain.mk
 
 # go utilities with:
-#	go-tools, clean-go-tools, go-tidy-all (tidy go utilities before committing) go-test-coverage
+#   go-tools, clean-go-tools, go-tidy-all (tidy go utilities before committing) go-test-coverage
 # chroot worker with:
-#	chroot-tools clean-chroot-tools
+#   chroot-tools clean-chroot-tools
 # macro definitions with:
-#	macro-tools clean-macro-tools
+#   macro-tools clean-macro-tools
 include $(SCRIPTS_DIR)/tools.mk
 
 # Create SRPMS from local SPECS with:
-#	input-srpms, clean-input-srpms
+#   input-srpms, clean-input-srpms
 include $(SCRIPTS_DIR)/srpm_pack.mk
 
 # Expand local SRPMS into sources and SPECS with:
-#	expand-specs clean-expand-specs
+#   expand-specs clean-expand-specs
 include $(SCRIPTS_DIR)/srpm_expand.mk
 
 # Create a package build workplan with:
-#	workplan, clean-workplan clean-cache
+#   workplan, clean-workplan clean-cache
 # Build a package with:
-#	build-packages clean-build-packages
+#   build-packages clean-build-packages
 # Either create or consume compressed folders of rpms with:
 #   hydrate-rpms, compress-rpms, clean-compress-rpms, compress-srpms, clean-compress-srpms
 include $(SCRIPTS_DIR)/pkggen.mk
@@ -186,10 +192,10 @@ include $(SCRIPTS_DIR)/toolkit.mk
 # They are guaranteed to run first and will verify there are no existing mount points
 # left after a chroot.
 clean:
-	rm -rf $(OUT_DIR)
-	rm -rf $(BUILD_DIR)
-	rm -rf $(toolkit_root)/out
+   rm -rf $(OUT_DIR)
+   rm -rf $(BUILD_DIR)
+   rm -rf $(toolkit_root)/out
 
 # output version number
 get-version:
-	@echo $(RELEASE_VERSION)
+   @echo $(RELEASE_VERSION)

--- a/toolkit/scripts/pkggen.mk
+++ b/toolkit/scripts/pkggen.mk
@@ -106,6 +106,10 @@ ifeq ($(USE_PREVIEW_REPO),y)
 graphpkgfetcher_extra_flags += --use-preview-repo
 endif
 
+ifeq ($(STOP_ON_FETCH_FAIL),y)
+graphpkgfetcher_extra_flags += --stop-on-failure
+endif
+
 $(cached_file): $(graph_file) $(go-graphpkgfetcher) $(chroot_worker) $(pkggen_local_repo) $(depend_REPO_LIST) $(REPO_LIST) $(shell find $(CACHED_RPMS_DIR)/) $(pkggen_rpms)
 	mkdir -p $(CACHED_RPMS_DIR)/cache && \
 	$(go-graphpkgfetcher) \

--- a/toolkit/scripts/pkggen.mk
+++ b/toolkit/scripts/pkggen.mk
@@ -31,7 +31,7 @@ validate-pkggen-config = $(STATUS_FLAGS_DIR)/validate-image-config-pkggen.flag
 specs_file        = $(PKGBUILD_DIR)/specs.json
 graph_file        = $(PKGBUILD_DIR)/graph.dot
 cached_file       = $(PKGBUILD_DIR)/cached_graph.dot
-preprocessed_file     = $(PKGBUILD_DIR)/preprocessed_graph.dot
+preprocessed_file = $(PKGBUILD_DIR)/preprocessed_graph.dot
 built_file        = $(PKGBUILD_DIR)/built_graph.dot
 
 logging_command = --log-file=$(LOGS_DIR)/pkggen/workplan/$(notdir $@).log --log-level=$(LOG_LEVEL)


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

We've been having issues building packages and images in non-core environments. It looks like the main cause was a bug in the code picking the best candidate package when more than one provided the same capability.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Update the tooling to not error out when choosing between multiple packages providing the same capability.
- Fixed support for using the preview repo for package and image builds.
- Added creation of empty local chroot repositories to avoid noisy TDNF errors inside the logs.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local package and image builds wit the new toolkit.
