### PR TITLE
[main] Preventing core build breaks when running with `USE_PREVIEW_REPO=y`.

### DIFF
--- a/toolkit/Makefile
+++ b/toolkit/Makefile
@@ -51,7 +51,7 @@ HYDRATED_BUILD                  ?= n
 toolkit_root     := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 TOOLS_DIR        ?= $(toolkit_root)/tools
 TOOL_BINS_DIR    ?= $(toolkit_root)/out/tools
-REPOS_DIR        ?= $(toolkit_root)/repos
+PREVIEW_REPO     ?= $(toolkit_root)/repos/mariner-official-preview.repo
 RESOURCES_DIR    ?= $(toolkit_root)/resources
 SCRIPTS_DIR      ?= $(toolkit_root)/scripts
 
@@ -104,8 +104,14 @@ SRPM_URL_LIST      ?= https://packages.microsoft.com/cbl-mariner/$(RELEASE_MAJOR
 ifeq ($(USE_PREVIEW_REPO),y)
    PACKAGE_URL_LIST   += https://packages.microsoft.com/cbl-mariner/$(RELEASE_MAJOR_ID)/preview/base/$(build_arch)
    PACKAGE_URL_LIST   += https://packages.microsoft.com/cbl-mariner/$(RELEASE_MAJOR_ID)/preview/base/debuginfo/$(build_arch)
-   override REPO_LIST += $(REPOS_DIR)/mariner-official-preview.repo
    SRPM_URL_LIST      += https://packages.microsoft.com/cbl-mariner/$(RELEASE_MAJOR_ID)/preview/base/srpms
+   ifneq ($(wildcard $(PREVIEW_REPO)),)
+      override REPO_LIST += $(PREVIEW_REPO)
+   else
+      $(warning ######################### WARNING #########################)
+      $(warning 'USE_PREVIEW_REPO=y' set but '$(PREVIEW_REPO)' is missing. Regenerate toolkit's 'repos' directory. Remove 'USE_PREVIEW_REPO' for core builds.)
+      $(warning ######################### WARNING #########################)
+   endif
 endif
 
 CA_CERT     ?=

--- a/toolkit/Makefile
+++ b/toolkit/Makefile
@@ -108,9 +108,11 @@ ifeq ($(USE_PREVIEW_REPO),y)
    ifneq ($(wildcard $(PREVIEW_REPO)),)
       override REPO_LIST += $(PREVIEW_REPO)
    else
+      $(warning )
       $(warning ######################### WARNING #########################)
       $(warning 'USE_PREVIEW_REPO=y' set but '$(PREVIEW_REPO)' is missing. Regenerate toolkit's 'repos' directory. Remove 'USE_PREVIEW_REPO' for core builds.)
       $(warning ######################### WARNING #########################)
+      $(warning )
    endif
 endif
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

Change #2091 made `USE_PREVIEW_REPO=y` add a .repo file to derivative builds, so they pull core RPMs from the correct repository. Unfortunately, if a core build was ran with this argument, the build would break (core's toolkit doesn't have the .repo files added to its `repos` subdirectory). While the argument is unnecessary for core builds, it shouldn't be breaking them, so I'm adding a check and printing a warning message.

Warning message:

```
Makefile:111: 
Makefile:112: ######################### WARNING #########################
Makefile:113: 'USE_PREVIEW_REPO=y' set but '/home/pawel/CBL-Mariner_package_tests_2.0/toolkit/repos/mariner-official-preview.repo' is missing. Regenerate toolkit's 'repos' directory. Remove 'USE_PREVIEW_REPO' for core builds.
Makefile:114: ######################### WARNING #########################
Makefile:115:
```

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Added a check for existence of the preview .repo file.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #2091

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local package builds with and without `USE_PREVIEW_REPO=y`.
