### PR TITLE
[main] Removing invalid `Conflicts` tag form `perl-DateTime-Locale`.

### DIFF
--- a/SPECS-EXTENDED/perl-DateTime-Locale/perl-DateTime-Locale.spec
+++ b/SPECS-EXTENDED/perl-DateTime-Locale/perl-DateTime-Locale.spec
@@ -1,6 +1,6 @@
 Name:           perl-DateTime-Locale
 Version:        1.25
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Localization support for DateTime.pm
 # Although the CLDR license is listed as "MIT" on the Fedora Wiki, it's more
 # similar to recently added "Unicode" license.
@@ -52,12 +52,6 @@ BuildRequires:  perl(CPAN::Meta::Requirements)
 BuildRequires:  perl(Storable)
 Requires:       perl(:MODULE_COMPAT_%(eval "$(perl -V:version)"; echo $version))
 Requires:       perl(Dist::CheckConflicts) >= 0.02
-# perl-DateTime-Locale used to be bundled with perl-DateTime
-# ideally, this would be resolved with
-# Requires:     perl-DateTime >= 0.70-1
-# but DateTime::Locale doesn't strictly require DateTime
-# and this would introduce circular build dependencies
-Conflicts:      perl-DateTime <= 1:0.7000-3.fc16
 
 %global __requires_exclude %{?__requires_exclude:%__requires_exclude|}^perl\\(Dist::CheckConflicts\\)$
 
@@ -87,6 +81,9 @@ make test
 %{_mandir}/man3/*
 
 %changelog
+* Fri Feb 04 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.25-4
+- Removing "Conflicts: perl-DateTime <= 1:0.7000-3.fc16". Version never present in CBL-Mariner.
+
 * Fri Oct 15 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.25-3
 - Initial CBL-Mariner import from Fedora 32 (license: MIT).
 - License verified.


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

After removing epochs from most of our specs we were left with a few lingering misconfigurations in the specs. For instance `perl-DateTime-Locale` claimed contained a `Conflicts: perl-DateTime <= 1:0.7000-3.fc16` line, which caused build failures, since our current version of `perl-DateTime` has the default epoch 0 but is not actually the conflicting package, which used to cause issues with `perl-DateTime-Locale` in the past.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Removed invalid `Conflicts` information from `perl-DateTime-Locale`.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- None, simple change.
