### PR TITLE
[main] [core] pciutils: Require libs subpackage from main package

### DIFF
--- a/SPECS/pciutils/pciutils.spec
+++ b/SPECS/pciutils/pciutils.spec
@@ -47,7 +47,6 @@ chmod -v 766 %{buildroot}%{_libdir}/libpci.so
 %files
 %defattr(-,root,root)
 %{_sbindir}/*
-%{_libdir}/*.so.*
 %{_datadir}/misc/*
 %{_mandir}/*
 
@@ -64,6 +63,7 @@ chmod -v 766 %{buildroot}%{_libdir}/libpci.so
 %changelog
 * Mon Feb 07 2022 Thomas Crain <thcrain@microsoft.com> - 3.7.0-2
 - Require libs subpackage from main package
+- Remove libraries from main package
 
 * Wed Dec 29 2021 Max Brodeur-Urbas <maxbr@microsoft.com> - 3.7.0-1
 - Upgrading to 3.7.0

--- a/SPECS/pciutils/pciutils.spec
+++ b/SPECS/pciutils/pciutils.spec
@@ -52,7 +52,7 @@ chmod -v 766 %{buildroot}%{_libdir}/libpci.so
 
 %files libs
 %license COPYING
-%{_libdir}/libpci.so.*
+%{_libdir}/libpci.so.3*
 
 %files devel
 %defattr(-,root,root)

--- a/SPECS/pciutils/pciutils.spec
+++ b/SPECS/pciutils/pciutils.spec
@@ -1,7 +1,7 @@
 Summary:        System utilities to list pci devices
 Name:           pciutils
 Version:        3.7.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner

--- a/SPECS/pciutils/pciutils.spec
+++ b/SPECS/pciutils/pciutils.spec
@@ -8,6 +8,7 @@ Distribution:   Mariner
 Group:          System Environment/System Utilities
 URL:            https://www.kernel.org/pub/software/utils/pciutils/
 Source0:        https://www.kernel.org/pub/software/utils/%{name}/%{name}-%{version}.tar.gz
+Requires:       %{name}-libs = %{version}-%{release}
 
 %description
 The pciutils package contains a set of programs for listing PCI devices, inspecting their status and setting their configuration registers.
@@ -15,7 +16,7 @@ The pciutils package contains a set of programs for listing PCI devices, inspect
 %package devel
 Summary:        Linux PCI development library
 Group:          Development/Libraries
-Requires:       pciutils = %{version}-%{release}
+Requires:       %{name} = %{version}-%{release}
 
 %description devel
 Library files for doing development with pciutils.
@@ -36,7 +37,6 @@ make %{?_smp_mflags} PREFIX=%{_prefix} \
     SHARED=yes
 
 %install
-[ %{buildroot} != "/" ] && rm -rf %{buildroot}/*
 make DESTDIR=%{buildroot} \
     PREFIX=%{_prefix} \
     SHAREDIR=%{_datadir}/misc \
@@ -62,6 +62,9 @@ chmod -v 766 %{buildroot}%{_libdir}/libpci.so
 %{_includedir}/*
 
 %changelog
+* Mon Feb 07 2022 Thomas Crain <thcrain@microsoft.com> - 3.7.0-2
+- Require libs subpackage from main package
+
 * Wed Dec 29 2021 Max Brodeur-Urbas <maxbr@microsoft.com> - 3.7.0-1
 - Upgrading to 3.7.0
 - Adding libs subpackage.


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
A recent update (#1899) added a `libs` subpackage to `pciutils`, but did not add the appropriate requirement on the `libs` subpackage to the main subpackage. This caused the `lspci` utility to fail when the `libs` subpackage was not explicitly installed. This PR adds the appropriate requirement to the main package.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Require libs subpackage from main package
- Remove libs from main package

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local mock build, Installation in 2.0 container, and successful `lspci` invocation