### PR TITLE
[main] Fixing build graph cycles resolutions.

### DIFF
--- a/toolkit/tools/internal/pkggraph/pkggraph.go
+++ b/toolkit/tools/internal/pkggraph/pkggraph.go
@@ -995,14 +995,18 @@ func (g *PkgGraph) AddMetaNode(from []*PkgNode, to []*PkgNode) (metaNode *PkgNod
 	metaNode.This = metaNode
 	g.AddNode(metaNode)
 
-	for _, n := range to {
-		toEdge := g.NewEdge(metaNode, n)
-		g.SetEdge(toEdge)
+	logger.Log.Trace("Adding edges TO the meta node:")
+	for _, n := range from {
+		logger.Log.Tracef("\t'%s' -> '%s'", n.FriendlyName(), metaNode.FriendlyName())
+		edge := g.NewEdge(n, metaNode)
+		g.SetEdge(edge)
 	}
 
-	for _, n := range from {
-		toEdge := g.NewEdge(n, metaNode)
-		g.SetEdge(toEdge)
+	logger.Log.Trace("Adding edges FROM the meta node:")
+	for _, n := range to {
+		logger.Log.Tracef("\t'%s' -> '%s'", metaNode.FriendlyName(), n.FriendlyName())
+		edge := g.NewEdge(metaNode, n)
+		g.SetEdge(edge)
 	}
 
 	return
@@ -1241,30 +1245,55 @@ func (g *PkgGraph) fixCycle(cycle []*PkgNode) (err error) {
 	return g.fixPrebuiltSRPMsCycle(trimmedCycle)
 }
 
-// fixIntraSpecCycle attempts to fix a cycle if all nodes are from the same spec file.
+// fixIntraSpecCycle attempts to fix a cycle if none of the cycle nodes are build nodes.
 // If a cycle can be fixed an additional meta node will be added to represent the interdependencies of the cycle.
 func (g *PkgGraph) fixIntraSpecCycle(trimmedCycle []*PkgNode) (err error) {
-	logger.Log.Debug("Checking if cycle consists only of subpackages of one .spec file.")
+	logger.Log.Debug("Checking if cycle contains build nodes.")
 
-	// For each node, remove any edges which point to other nodes in the cycle, and move any remaining dependencies to a new
-	// meta node, then have everything in the cycle depend on the new meta node.
-	groupedDependencies := make(map[int64]bool)
 	for _, currentNode := range trimmedCycle {
-		logger.Log.Tracef("\tCycle node: %s", currentNode.FriendlyName())
 		if currentNode.Type == TypeBuild {
 			logger.Log.Debug("Cycle contains build dependencies, cannot be solved this way.")
 			return fmt.Errorf("cycle contains build dependencies, unresolvable")
 		}
-		// Remove all links to other members of the cycle
-		for _, nodeInCycle := range trimmedCycle {
-			g.RemoveEdge(currentNode.ID(), nodeInCycle.ID())
-		}
+	}
 
-		// Record any other dependencies the nodes have (ie, where can we get to from here), then remove them
-		fromNodes := graph.NodesOf(g.From(currentNode.ID()))
-		for _, from := range fromNodes {
-			groupedDependencies[from.ID()] = true
-			g.RemoveEdge(currentNode.ID(), from.ID())
+	logger.Log.Debugf("Breaking cycle edges.")
+	cycleLength := len(trimmedCycle)
+	for i, currentNode := range trimmedCycle {
+		currentNodeID := currentNode.ID()
+		for j := i + 1; j < cycleLength; j++ {
+			nextNode := trimmedCycle[j]
+			nextNodeID := nextNode.ID()
+
+			if g.Edge(currentNodeID, nextNodeID) != nil {
+				logger.Log.Tracef("\t'%s' -> '%s'", currentNode.FriendlyName(), nextNode.FriendlyName())
+				g.RemoveEdge(currentNodeID, nextNodeID)
+			}
+
+			if g.Edge(nextNodeID, currentNodeID) != nil {
+				logger.Log.Tracef("\t'%s' -> '%s'", nextNode.FriendlyName(), currentNode.FriendlyName())
+				g.RemoveEdge(nextNodeID, currentNodeID)
+			}
+		}
+	}
+
+	// For each cycle node move any dependencies from a non-cycle node to a new
+	// meta node, then have the meta node depend on all cycle nodes.
+	groupedDependencies := make(map[int64]bool)
+	for _, currentNode := range trimmedCycle {
+		logger.Log.Debugf("Breaking NON-cycle edges connected to cycle node '%s'.", currentNode.FriendlyName())
+
+		currentNodeID := currentNode.ID()
+
+		toNodes := g.To(currentNodeID)
+		for toNodes.Next() {
+			toNode := toNodes.Node().(*PkgNode)
+			toNodeID := toNode.ID()
+
+			logger.Log.Tracef("\t'%s' -> '%s'", toNode.FriendlyName(), currentNode.FriendlyName())
+
+			groupedDependencies[toNodeID] = true
+			g.RemoveEdge(toNodeID, currentNodeID)
 		}
 	}
 
@@ -1274,10 +1303,7 @@ func (g *PkgGraph) fixIntraSpecCycle(trimmedCycle []*PkgNode) (err error) {
 		dependencyNodes = append(dependencyNodes, g.Node(id).(*PkgNode).This)
 	}
 
-	metaNode := g.AddMetaNode(trimmedCycle, dependencyNodes)
-
-	// Enable cycle detection between meta nodes within the same srpm file
-	metaNode.SrpmPath = trimmedCycle[0].SrpmPath
+	g.AddMetaNode(dependencyNodes, trimmedCycle)
 
 	return
 }


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

The PR attempts to fix recent mysterious package build failures. The issue consisted of two bugs:

1. The function attempting to fix cycles without build nodes in them was removing edges before it was done checking, that the cycle doesn't indeed have any build nodes. This was causing us to sometimes see a package being mentioned both as pre-built and blocked - the function would remove a run -> build node edge, in rare cases leaving the build node without any parents pointing to it, so the scheduler never attempted to build it and it was thus still left marked as a "to-build" node at the end of the build.
2. After breaking the cycle of non-build nodes, any node, which was not part of this cycle but dependent on one of them, would run into a risk of not installing all dependencies required for its build. Example:
```
Initial dependencies:

A<RUN> -> B<RUN> -> A<RUN> <--- cycle of non-build nodes
C<BUILD> -> A<RUN>               <--- package "C" requires "A" to build and has no knowledge, that "A" also requires "B"
A<RUN> -> D<RUN>                 <--- package "A" depends on a non-cycle package "D"
B<RUN> -> D<RUN>                 <--- package "B" depends on a non-cycle package "D"

After breaking the cycle PRE FIX:
C<BUILD> -> A<RUN> <--- no changes here, "C" still needs "A".
A<RUN> -> X<META>  <--- new dependency from "A" to a new meta node "X"
B<RUN> -> X<META>  <--- new dependency from "B" to a new meta node "X"
X<META> -> D<RUN> <--- new dependency between "X" and "D"

After the change we would attempt to install ONLY "A" while building "C", so we
lost the dependency between "A" and "B" and thus now "A" might not work correctly when "C" is built.

After breaking the cycle POST FIX:
C<BUILD> -> X<META> <--- new dependency from "C" to a new meta node "X"
A<RUN> -> D<RUN>    <--- no changes here, "A" still needs "D"
B<RUN> -> D<RUN>    <--- no changes here, "B" still needs "D"
X<META> -> A<RUN>  <--- new dependency between "X" and "A"
X<META> -> A<RUN>  <--- new dependency between "X" and "A"

Now building "C" will require "X", which in turn will pull in both "A" and "B", so all
build dependencies for "C" are still present and the cycle is gone.
```

Note, that we could have skipped the meta node `X` and create additional edges from `C` to all the cycle nodes. I left the meta node there for now, so it's clear that the dependency is not inferred directly from the spec, but a result of a cycle resolution.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Made sure we first check if a cycle can get resolved and then start removing edges.
- Moved the meta node to bridge between non-cycle -> cycle nodes instead of the other way around.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Full pipeline build.
