### PR TITLE
Update bcc to 0.24.0 and fix two issues found with bpftrace and bcc

### DIFF
--- a/SPECS/bcc/bcc.signatures.json
+++ b/SPECS/bcc/bcc.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "bcc-0.22.0-src-with-submodule.tar.gz": "9d195db7fe617cdde03e2af7cfd1ac07751aaf0e7e966aaa19237db8fe91fd40"
+  "bcc-0.24.0.tar.gz": "4ff35d71f1dc3b6fc5626bbb7644afc9eb0953be23e873c61034c8f50c589268"
  }
 }

--- a/SPECS/bcc/bcc.spec
+++ b/SPECS/bcc/bcc.spec
@@ -1,7 +1,7 @@
 %global debug_package %{nil}
 Summary:        BPF Compiler Collection (BCC)
 Name:           bcc
-Version:        0.22.0
+Version:        0.24.0
 Release:        1%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
@@ -9,7 +9,7 @@ Distribution:   Mariner
 Group:          Development/Languages
 URL:            https://github.com/iovisor/bcc
 # Upstream now provides a release with the git submodule embedded in it
-Source0:        https://github.com/iovisor/bcc/releases/download/v%{version}/%{name}-%{version}-src-with-submodule.tar.gz
+Source0:        https://github.com/iovisor/bcc/releases/download/v%{version}/%{name}-src-with-submodule.tar.gz#/%{name}-%{version}.tar.gz
 
 BuildRequires:  bison
 BuildRequires:  clang-devel
@@ -123,6 +123,9 @@ find %{buildroot}%{_lib64dir} -name '*.a' -delete
 %{_datadir}/%{name}/man/*
 
 %changelog
+* Wed Feb 09 2022 Chris Co <chrco@microsoft.com> - 0.24.0-1
+- Update to 0.24.0
+
 * Fri Sep 17 2021 Chris Co <chrco@microsoft.com> - 0.22.0-1
 - Update to 0.22.0
 - Using shared `elfutils-libelf` libraries instead of static ones.

--- a/SPECS/bcc/bcc.spec
+++ b/SPECS/bcc/bcc.spec
@@ -10,7 +10,6 @@ Group:          Development/Languages
 URL:            https://github.com/iovisor/bcc
 # Upstream now provides a release with the git submodule embedded in it
 Source0:        https://github.com/iovisor/bcc/releases/download/v%{version}/%{name}-src-with-submodule.tar.gz#/%{name}-%{version}.tar.gz
-
 BuildRequires:  bison
 BuildRequires:  clang-devel
 BuildRequires:  cmake >= 2.8.7
@@ -23,8 +22,7 @@ BuildRequires:  make
 BuildRequires:  ncurses-devel
 BuildRequires:  pkg-config
 BuildRequires:  python3-devel
-
-Requires:  elfutils-libelf
+Requires:       elfutils-libelf
 
 %description
 BCC is a toolkit for creating efficient kernel tracing and manipulation programs,
@@ -42,8 +40,8 @@ Requires:       %{name} = %{version}-%{release}
 developing application.
 
 %package -n python3-%{name}
-%{?python_provide:%python_provide python3-bcc}
 Summary:        Python3 bindings for BPF Compiler Collection (BCC)
+%{?python_provide:%python_provide python3-bcc}
 Requires:       %{name} = %{version}-%{release}
 
 %description -n python3-%{name}

--- a/SPECS/bpftrace/bpftrace.spec
+++ b/SPECS/bpftrace/bpftrace.spec
@@ -1,7 +1,7 @@
 Summary:        Berkeley Packet Filter Tracing Language
 Name:           bpftrace
 Version:        0.13.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -51,6 +51,7 @@ cd build
 
 %cmake \
     -DCMAKE_BUILD_TYPE=Release \
+    -DBUILD_SHARED_LIBS:BOOL=OFF \
 %if !%{with_check}
     -DBUILD_TESTING=0 \
 %endif
@@ -76,6 +77,9 @@ install -p -m 644 tools/*.txt %{buildroot}%{_datadir}/bpftrace/tools/doc
 %{_datadir}/bpftrace/tools
 
 %changelog
+* Wed Feb 09 2022 Chris Co <chrco@microsoft.com> - 0.13.0-2
+- Disable building of shared libraries
+
 * Fri Sep 17 2021 Chris Co <chrco@microsoft.com> - 0.13.0-1
 - Update to 0.13.0.
 - Fixed source URL.

--- a/SPECS/bpftrace/bpftrace.spec
+++ b/SPECS/bpftrace/bpftrace.spec
@@ -8,7 +8,6 @@ Distribution:   Mariner
 Group:          Applications/System
 URL:            https://github.com/iovisor/bpftrace
 Source0:        %{url}/archive/refs/tags/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
-
 BuildRequires:  bcc-devel
 BuildRequires:  binutils-devel
 BuildRequires:  bison
@@ -22,14 +21,6 @@ BuildRequires:  llvm-devel >= 12.0.1-1
 BuildRequires:  make
 BuildRequires:  systemtap-sdt-devel
 BuildRequires:  zlib-devel
-
-%if %{with_check}
-BuildRequires:  gmock
-BuildRequires:  gmock-devel
-BuildRequires:  gtest
-BuildRequires:  gtest-devel
-%endif
-
 Requires:       bcc
 Requires:       binutils
 Requires:       clang
@@ -37,6 +28,12 @@ Requires:       glibc
 Requires:       libgcc
 Requires:       libstdc++
 Requires:       llvm >= 12.0.1-1
+%if %{with_check}
+BuildRequires:  gmock
+BuildRequires:  gmock-devel
+BuildRequires:  gtest
+BuildRequires:  gtest-devel
+%endif
 
 %description
 bpftrace is a high-level tracing language for Linux enhanced Berkeley Packet Filter (eBPF)

--- a/SPECS/clang/clang.spec
+++ b/SPECS/clang/clang.spec
@@ -38,7 +38,7 @@
 Summary:        C, C++, Objective C and Objective C++ front-end for the LLVM compiler.
 Name:           clang
 Version:        %{maj_ver}.%{min_ver}.%{patch_ver}
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        NCSA
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -136,6 +136,7 @@ cmake -DCMAKE_INSTALL_PREFIX=%{_prefix}   \
       -DCMAKE_BUILD_TYPE=Release    \
       -DLLVM_ENABLE_EH=ON \
       -DLLVM_ENABLE_RTTI=ON \
+      -DCLANG_LINK_CLANG_DYLIB=ON \
       -Wno-dev ..
 
 %make_build
@@ -214,6 +215,9 @@ make clang-check
 %{_datadir}/clang/clang-rename.py*
 
 %changelog
+* Wed Feb 09 2022 Chris Co <chrco@microsoft.com> - 12.0.1-3
+- Enable clang tools to link against libclang_shared.so
+
 * Wed Sep 29 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 12.0.1-2
 - Introduced following subpackages using Fedora 32 (license: MIT) spec as guidance:
   - clang-analyzer,

--- a/SPECS/llvm/llvm.spec
+++ b/SPECS/llvm/llvm.spec
@@ -1,7 +1,7 @@
 Summary:        A collection of modular and reusable compiler and toolchain technologies.
 Name:           llvm
 Version:        12.0.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        NCSA
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -43,6 +43,7 @@ cmake -G Ninja                              \
       -DCMAKE_BUILD_TYPE=Release            \
       -DLLVM_PARALLEL_LINK_JOBS=1           \
       -DLLVM_BUILD_LLVM_DYLIB=ON            \
+      -DLLVM_LINK_LLVM_DYLIB=ON             \
       -DLLVM_INCLUDE_TESTS=ON               \
       -DLLVM_BUILD_TESTS=ON                 \
       -DLLVM_TARGETS_TO_BUILD="host;AMDGPU;BPF" \
@@ -85,6 +86,9 @@ ninja check-all
 %{_includedir}/*
 
 %changelog
+* Wed Feb 09 2022 Chris Co <chrco@microsoft.com> - 12.0.1-4
+- Allow tools to link to libLLVM shared library
+
 * Mon Jan 31 2022 Thomas Crain <thcrain@microsoft.com> - 12.0.1-3
 - Use python3 during build
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -1115,8 +1115,8 @@
         "type": "other",
         "other": {
           "name": "bcc",
-          "version": "0.22.0",
-          "downloadUrl": "https://github.com/iovisor/bcc/releases/download/v0.22.0/bcc-src-with-submodule.tar.gz"
+          "version": "0.24.0",
+          "downloadUrl": "https://github.com/iovisor/bcc/releases/download/v0.24.0/bcc-src-with-submodule.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- bcc: Update to 0.24.0

Includes 5.15+ kernel support

- bpftrace: Disable building bpftrace shared libs

Issues reported installing the bpftrace package.

```
   # dnf install -y bpftrace
   Last metadata expiration check: 0:29:49 ago on Wed Feb  9 21:21:25 2022.
   Error:
   Problem: conflicting requests
     - nothing provides libast.so()(64bit) needed by bpftrace-0.13.0-1.cm2.x86_64
     - nothing provides libbpftrace.so()(64bit) needed by bpftrace-0.13.0-1.cm2.x86_64
   (try to add '--skip-broken' to skip uninstallable packages)
```

We are not packaging the shared libraries produced by bpftrace's cmake
build. During the packaging, rpmbuild is finding these shared libraries and
And in general, we prefer to just package bpftrace and tools and
not distribute its shared libraries.

So update the cmake build options to disable shared library builds.

- clang/llvm: Add support for shared library builds

Issue reported where tools built like bcc or bpftrace that are built
with clang and llvm run into the following error:

```
   # ./argdist
   : CommandLine Error: Option 'use-dbg-addr' registered more than once!
   LLVM ERROR: inconsistency in registered CommandLine options
   Aborted (core dumped)
```

Root cause of issue is due to how our clang and llvm are currently being
built. The libLLVM.so and libclang-cpp.so libraries are built in a way
that both are adding the same options to the system. This causes any
tools linking against these shared libraries to fail because the option
is indeed registered more than once.

To fix this, we need to enable both LLVM_LINK_LLVM_DYLIB in our llvm
build and CLANG_LINK_CLANG_DYLIB in our clang build.

Signed-off-by: Chris Co <chrco@microsoft.com>

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->

###### Links to CVEs  <!-- optional -->

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
Local build