### PR TITLE
Upgrade snappy to v1.1.9, telegraf to 1.21.2

### DIFF
--- a/SPECS/snappy/snappy-inline.patch
+++ b/SPECS/snappy/snappy-inline.patch
@@ -1,0 +1,12 @@
+diff -ruN a/snappy.cc b/snappy.cc
+--- a/snappy.cc	2022-01-21 13:54:18.000000000 -0800
++++ b/snappy.cc	2022-02-08 12:22:57.560576542 -0800
+@@ -1014,7 +1014,7 @@
+ }
+ 
+ SNAPPY_ATTRIBUTE_ALWAYS_INLINE
+-size_t AdvanceToNextTag(const uint8_t** ip_p, size_t* tag) {
++inline size_t AdvanceToNextTag(const uint8_t** ip_p, size_t* tag) {
+   const uint8_t*& ip = *ip_p;
+   // This section is crucial for the throughput of the decompression loop.
+   // The latency of an iteration is fundamentally constrained by the

--- a/SPECS/snappy/snappy.signatures.json
+++ b/SPECS/snappy/snappy.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "snappy-1.1.7.tar.gz": "3dfa02e873ff51a11ee02b9ca391807f0c8ea0529a4924afa645fbf97163f9d4"
+  "snappy-1.1.9.tar.gz": "3476c6b453fb808c567e7a0bad3212d96815e7a46088e168180ee3172afc57f8"
  }
 }

--- a/SPECS/snappy/snappy.spec
+++ b/SPECS/snappy/snappy.spec
@@ -1,15 +1,26 @@
 Summary:        Fast compression and decompression library
 Name:           snappy
-Version:        1.1.7
-Release:        6%{?dist}
+Version:        1.1.9
+Release:        1%{?dist}
 License:        BSD
-URL:            https://google.github.io/snappy/
-#Source0:       https://github.com/google/%{name}/archive/%{version}.tar.gz
-Source0:        %{name}-%{version}.tar.gz
-Group:          System/Libraries
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
-BuildRequires:  cmake
+Group:          System/Libraries
+URL:            https://github.com/google/snappy
+#Source0:       https://github.com/google/%{name}/archive/%{version}.tar.gz
+Source0:        %{name}-%{version}.tar.gz
+Patch0:         snappy-inline.patch
+BuildRequires:  cmake>=3.3
+
+# A buildable snappy environment needs functioning submodules that do not work from the archive download
+# To recreate the tar.gz run the following
+#  sudo git clone https://github.com/google/snappy
+#  git checkout <commitid-for-version>
+#  pushd snappy
+#  sudo git submodule update --init --recursive
+#  popd
+#  sudo mv %{name} %{name}-%{version}
+#  sudo tar -cvf %{name}-%{version}.tar.gz %{name}-%{version}/
 
 %description
 Snappy is a compression/decompression library. It does not aim for maximum
@@ -26,19 +37,15 @@ Requires:	%{name} = %{version}
 It contains the libraries and header files to create applications
 
 %prep
-%setup -q
+%autosetup -p1
 
 %build
-mkdir -p build/
-cd build
-cmake -DCMAKE_INSTALL_PREFIX=%{_prefix} -DBUILD_SHARED_LIBS=ON ..
-make %{?_smp_mflags}
+mkdir build && cd build
+%cmake ..
+%make_build
 
 %install
-cd build
-make DESTDIR=%{buildroot} install
-rm -rf %{buildroot}%{_datadir}/doc/snappy/
-find %{buildroot} -name '*.la' -delete
+%make_install -C build
 
 %check
 cd testdata
@@ -53,16 +60,22 @@ make test
 %defattr(-,root,root)
 %license COPYING
 %doc AUTHORS
-%{_lib64dir}/*.so.*
-%exclude %{_lib64dir}/cmake
+%{_libdir}/*.so.*
+%exclude %{_libdir}/cmake
 
 %files devel
 %defattr(-,root,root)
 %doc format_description.txt framing_format.txt
 %{_includedir}/*
-%{_lib64dir}/libsnappy.so
+%{_libdir}/lib*.so
+%{_libdir}/cmake/Snappy/
+%{_libdir}/pkgconfig/*.pc
 
 %changelog
+* Wed Feb 09 2022 Neha Agarwal <nehaagarwal@microsoft.com> - 1.1.9-1
+- Update to version 1.1.9.
+- Add patch for fixing compiler error due to missing 'inline'.
+
 * Thu Dec 16 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.1.7-6
 - Removing the explicit %%clean stage.
 - License verified.
@@ -70,13 +83,17 @@ make test
 * Sat May 09 2020 Nick Samson <nisamson@microsoft.com> - 1.1.7-5
 - Added %%license line automatically
 
-*   Fri Apr 10 2020 Nick Samson <nisamson@microsoft.com> 1.1.7-4
--   Updated Source0, URL, license info. Removed licenses not mentioned in source. Removed sha1.
-*   Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 1.1.7-3
--   Initial CBL-Mariner import from Photon (license: Apache2).
+* Fri Apr 10 2020 Nick Samson <nisamson@microsoft.com> 1.1.7-4
+- Updated Source0, URL, license info. Removed licenses not mentioned in source. Removed sha1.
+
+* Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 1.1.7-3
+- Initial CBL-Mariner import from Photon (license: Apache2).
+
 *  Wed Jan 09 2019 Michelle Wang <michellew@vmware.com> 1.1.7-2
 -  Fix make check for snappy.
+
 *  Wed Sep 19 2018 Srinidhi Rao <srinidhir@vmware.com> 1.1.7-1
 -  Updating the version to 1.1.7.
+
 *  Fri Dec 16 2016 Dheeraj Shetty <Dheerajs@vmware.com> 1.1.3-1
 -  Initial build. First version.

--- a/SPECS/snappy/snappy.spec
+++ b/SPECS/snappy/snappy.spec
@@ -10,7 +10,7 @@ URL:            https://github.com/google/snappy
 #Source0:       https://github.com/google/%{name}/archive/%{version}.tar.gz
 Source0:        %{name}-%{version}.tar.gz
 Patch0:         snappy-inline.patch
-BuildRequires:  cmake>=3.3
+BuildRequires:  cmake >= 3.3
 
 # A buildable snappy environment needs functioning submodules that do not work from the archive download
 # To recreate the tar.gz run the following
@@ -31,8 +31,9 @@ inputs, but the resulting compressed files are anywhere from 20% to 100%
 bigger.
 
 %package	devel
-Summary:	Header and development files
-Requires:	%{name} = %{version}
+Summary:	 Header and development files
+Requires:	 %{name} = %{version}
+
 %description	devel
 It contains the libraries and header files to create applications
 

--- a/SPECS/telegraf/add-extra-metrics.patch
+++ b/SPECS/telegraf/add-extra-metrics.patch
@@ -1,20 +1,18 @@
-diff --git a/plugins/inputs/procstat/process.go b/plugins/inputs/procstat/process.go
-index 042929f0..cf4f5185 100644
---- a/plugins/inputs/procstat/process.go
-+++ b/plugins/inputs/procstat/process.go
-@@ -26,6 +26,7 @@ type Process interface {
+diff -ruN telegraf-1.21.2-a/plugins/inputs/procstat/process.go telegraf-1.21.2-b/plugins/inputs/procstat/process.go
+--- telegraf-1.21.2-a/plugins/inputs/procstat/process.go	2022-01-31 16:47:42.447035252 -0800
++++ telegraf-1.21.2-b/plugins/inputs/procstat/process.go	2022-01-31 16:49:30.036424290 -0800
+@@ -26,6 +26,7 @@
  	RlimitUsage(bool) ([]process.RlimitStat, error)
  	Username() (string, error)
  	CreateTime() (int64, error)
 +	MemoryMaps(bool) (*[]process.MemoryMapsStat, error)
+ 	Ppid() (int32, error)
  }
  
- type PIDFinder interface {
-diff --git a/plugins/inputs/procstat/procstat.go b/plugins/inputs/procstat/procstat.go
-index 8e56e4bf..bf2d5503 100644
---- a/plugins/inputs/procstat/procstat.go
-+++ b/plugins/inputs/procstat/procstat.go
-@@ -250,6 +250,14 @@ func (p *Procstat) addMetric(proc Process, acc telegraf.Accumulator) {
+diff -ruN telegraf-1.21.2-a/plugins/inputs/procstat/procstat.go telegraf-1.21.2-b/plugins/inputs/procstat/procstat.go
+--- telegraf-1.21.2-a/plugins/inputs/procstat/procstat.go	2022-01-31 16:47:42.447035252 -0800
++++ telegraf-1.21.2-b/plugins/inputs/procstat/procstat.go	2022-01-31 16:54:10.684079205 -0800
+@@ -289,6 +289,14 @@
  		fields[prefix+"memory_locked"] = mem.Locked
  	}
  
@@ -26,6 +24,6 @@ index 8e56e4bf..bf2d5503 100644
 +		fields[prefix+"memory_maps_private_clean"] = (*memMaps)[0].PrivateClean
 +	}
 +
- 	mem_perc, err := proc.MemoryPercent()
+ 	memPerc, err := proc.MemoryPercent()
  	if err == nil {
- 		fields[prefix+"memory_usage"] = mem_perc
+ 		fields[prefix+"memory_usage"] = memPerc

--- a/SPECS/telegraf/telegraf.signatures.json
+++ b/SPECS/telegraf/telegraf.signatures.json
@@ -1,6 +1,6 @@
 {
     "Signatures": {
-        "telegraf-1.14.5.tar.gz" : "66a02a8d9afe5621bb65297f74b9f2d62fbe28415771ac1dea0a13950642684c",
-        "telegraf-vendor-1.14.5.tar.gz" : "b6da69abb1d73f4ed782082b744189fe364fb59a1310c7a58e9d2144442b9a6e"
+     "telegraf-1.21.2.tar.gz": "2a6c0722c6999c438d316d5971502aa79abd92134c265ee0e53596cc125d175b",
+     "telegraf-vendor-1.21.2.tar.gz": "6008f6724aa2d9489152e3106eab696a7d1bb4f6616937c49d540b61d04104af"
     }
-}
+   }

--- a/SPECS/telegraf/telegraf.spec
+++ b/SPECS/telegraf/telegraf.spec
@@ -35,10 +35,10 @@ Requires:       logrotate
 Requires:       procps-ng
 Requires:       shadow-utils
 Requires:       systemd
-Requires(pre):  /usr/sbin/useradd
-Requires(pre):  /usr/sbin/groupadd
-Requires(postun): /usr/sbin/userdel
-Requires(postun): /usr/sbin/groupdel
+Requires(pre):  %{_sbindir}/useradd
+Requires(pre):  %{_sbindir}/groupadd
+Requires(postun): %{_sbindir}/userdel
+Requires(postun): %{_sbindir}/groupdel
 
 %description
 Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/SPECS/telegraf/telegraf.spec
+++ b/SPECS/telegraf/telegraf.spec
@@ -1,30 +1,44 @@
 Summary:        agent for collecting, processing, aggregating, and writing metrics.
 Name:           telegraf
-Version:        1.14.5
-Release:        8%{?dist}
+Version:        1.21.2
+Release:        1%{?dist}
 License:        MIT
-Group:          Development/Tools
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
+Group:          Development/Tools
 URL:            https://github.com/influxdata/telegraf
-
 #Source0:       %{url}/archive/v%{version}.tar.gz
 Source0:        %{name}-%{version}.tar.gz
 Source1:        %{name}-vendor-%{version}.tar.gz
-
+# Below is a manually created tarball, no download link.
+# We're using pre-populated Go modules from this tarball, since network is disabled during build time.
+# How to re-build this file:
+#   1. wget %{url}/archive/v%{version}.tar.gz -O %%{name}-%%{version}.tar.gz
+#   2. tar -xf %%{name}-%%{version}.tar.gz
+#   3. cd %%{name}-%%{version}
+#   4. go mod vendor
+#   5. tar  --sort=name \
+#           --mtime="2021-04-26 00:00Z" \
+#           --owner=0 --group=0 --numeric-owner \
+#           --pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime \
+#           -cf %%{name}-%%{version}-vendor.tar.gz vendor
+#
+#   NOTES:
+#       - You require GNU tar version 1.28+.
+#       - The additional options enable generation of a tarball with the same hash every time regardless of the environment.
+#         See: https://reproducible-builds.org/docs/archives/
+#       - For the value of "--mtime" use the date "2021-04-26 00:00Z" to simplify future updates.
 Patch0:         add-extra-metrics.patch
-
 BuildRequires:  golang
 BuildRequires:  systemd-devel
-
-Requires:           systemd
-Requires:           logrotate
-Requires:           procps-ng
-Requires:           shadow-utils
-Requires(pre):      /usr/sbin/useradd
-Requires(pre):      /usr/sbin/groupadd
-Requires(postun):   /usr/sbin/userdel
-Requires(postun):   /usr/sbin/groupdel
+Requires:       logrotate
+Requires:       procps-ng
+Requires:       shadow-utils
+Requires:       systemd
+Requires(pre):  /usr/sbin/useradd
+Requires(pre):  /usr/sbin/groupadd
+Requires(postun): /usr/sbin/userdel
+Requires(postun): /usr/sbin/groupdel
 
 %description
 Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.
@@ -53,9 +67,8 @@ getent passwd telegraf >/dev/null || useradd -c "Telegraf" -d %{_localstatedir}/
         -s /sbin/nologin -M -r %{name}
 
 %post
-chown -R telegraf:telegraf /etc/telegraf
+chown -R telegraf:telegraf %{_sysconfdir}/telegraf
 %systemd_post %{name}.service
-systemctl daemon-reload
 
 %preun
 %systemd_preun %{name}.service
@@ -77,29 +90,42 @@ fi
 %dir %{_sysconfdir}/%{name}/telegraf.d
 
 %changelog
-*   Thu Dec 16 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.14.5-8
--   Removing the explicit %%clean stage.
+* Tue Jan 18 2022 Neha Agarwal <nehaagarwal@microsoft.com> - 1.21.2-1
+- Update to version 1.21.2.
+- Modified patch to apply to new version.
 
-*   Tue Jun 08 2021 Henry Beberman <henry.beberman@microsoft.com> 1.14.5-7
--   Increment release to force republishing using golang 1.15.13.
-*   Mon Apr 26 2021 Nicolas Guibourge <nicolasg@microsoft.com> 1.14.5-6
--   Increment release to force republishing using golang 1.15.11.
-*   Thu Dec 10 2020 Andrew Phelps <anphel@microsoft.com> 1.14.5-5
--   Increment release to force republishing using golang 1.15.
-*   Thu Oct 15 2020 Pawel Winogrodzki <pawelwi@microsoft.com> 1.14.5-4
--   License verified.
--   Added %%license macro.
--   Fixed source URL.
--   Switched to %%autosetup.
-*   Fri Aug 21 2020 Suresh Babu Chalamalasetty <schalam@microsoft.com> 1.14.5-3
--   Add runtime required procps-ng and shadow-utils
-*   Tue Jul 14 2020 Jonathan Chiu <jochi@microsoft.com> 1.14.5-1
--   Update to version 1.14.5
-*   Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 1.7.4-2
--   Initial CBL-Mariner import from Photon (license: Apache2).
-*   Fri Sep 07 2018 Michelle Wang <michellew@vmware.com> 1.7.4-1
--   Update version to 1.7.4 and its plugin version to 1.4.0.
-*   Mon Sep 18 2017 Alexey Makhalov <amakhalov@vmware.com> 1.3.4-2
--   Remove shadow from requires and use explicit tools for post actions
-*   Tue Jul 18 2017 Dheeraj Shetty <dheerajs@vmware.com> 1.3.4-1
--   first version
+* Thu Dec 16 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.14.5-8
+- Removing the explicit %%clean stage.
+
+* Tue Jun 08 2021 Henry Beberman <henry.beberman@microsoft.com> 1.14.5-7
+- Increment release to force republishing using golang 1.15.13.
+
+* Mon Apr 26 2021 Nicolas Guibourge <nicolasg@microsoft.com> 1.14.5-6
+- Increment release to force republishing using golang 1.15.11.
+
+* Thu Dec 10 2020 Andrew Phelps <anphel@microsoft.com> 1.14.5-5
+- Increment release to force republishing using golang 1.15.
+
+* Thu Oct 15 2020 Pawel Winogrodzki <pawelwi@microsoft.com> 1.14.5-4
+- License verified.
+- Added %%license macro.
+- Fixed source URL.
+- Switched to %%autosetup.
+
+* Fri Aug 21 2020 Suresh Babu Chalamalasetty <schalam@microsoft.com> 1.14.5-3
+- Add runtime required procps-ng and shadow-utils
+
+* Tue Jul 14 2020 Jonathan Chiu <jochi@microsoft.com> 1.14.5-1
+- Update to version 1.14.5
+
+* Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 1.7.4-2
+- Initial CBL-Mariner import from Photon (license: Apache2).
+
+* Fri Sep 07 2018 Michelle Wang <michellew@vmware.com> 1.7.4-1
+- Update version to 1.7.4 and its plugin version to 1.4.0.
+
+* Mon Sep 18 2017 Alexey Makhalov <amakhalov@vmware.com> 1.3.4-2
+- Remove shadow from requires and use explicit tools for post actions
+
+* Tue Jul 18 2017 Dheeraj Shetty <dheerajs@vmware.com> 1.3.4-1
+- first version

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -27157,8 +27157,8 @@
         "type": "other",
         "other": {
           "name": "snappy",
-          "version": "1.1.7",
-          "downloadUrl": "https://github.com/google/snappy/archive/1.1.7.tar.gz"
+          "version": "1.1.9",
+          "downloadUrl": "https://github.com/google/snappy/archive/1.1.9.tar.gz"
         }
       }
     },
@@ -27917,8 +27917,8 @@
         "type": "other",
         "other": {
           "name": "telegraf",
-          "version": "1.14.5",
-          "downloadUrl": "https://github.com/influxdata/telegraf/archive/v1.14.5.tar.gz"
+          "version": "1.21.2",
+          "downloadUrl": "https://github.com/influxdata/telegraf/archive/v1.21.2.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Upgrade snappy to v1.1.9, telegraf to 1.21.2

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Upgrade snappy to v1.1.9
- Add patch to fix compile error due to missing 'inline' 
- Upgrade telegraf to 1.21.2
- Modify patch to apply to new version
- Remove systemctl daemon reload to fix systemd issue with installing it in Mariner container

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Test Methodology
- Local build with RUN_CHECK=y
- Verified that the systemd issue is fixed for telegraf by installing the new rpm in Mariner container
