### PR TITLE
Skip "Microsoft" repo for non-amd64 architectures

### DIFF
--- a/toolkit/scripts/analysis.mk
+++ b/toolkit/scripts/analysis.mk
@@ -16,7 +16,14 @@ BUILD_SUMMARY_FILE=$(SODIFF_OUTPUT_FOLDER)/build-summary.csv
 # A list of packages built during the current run
 BUILT_PACKAGES_FILE=$(SODIFF_OUTPUT_FOLDER)/built-packages.txt
 # Repositories that SODIFF runs the checks against
+ifneq ($(build_arch),x86_64)
+# Microsoft repository only exists for x86_64 - skip that .repo file;
+# otherwise package manager will signal an error due to being unable to make contact
+SODIFF_REPO_SOURCES="mariner-official-base.repo mariner-official-update.repo"
+else
 SODIFF_REPO_SOURCES="mariner-official-base.repo mariner-official-update.repo mariner-microsoft.repo"
+endif
+
 SODIFF_REPO_FILE=$(SCRIPTS_DIR)/sodiff/sodiff.repo
 # An artifact containing a list of packages that need to be dash-rolled due to their dependency having a new .so version
 SODIFF_SUMMARY_FILE=$(SODIFF_OUTPUT_FOLDER)/sodiff-summary.txt

--- a/toolkit/scripts/analysis.mk
+++ b/toolkit/scripts/analysis.mk
@@ -74,7 +74,7 @@ $(SODIFF_REPO_FILE):
 sodiff-check: $(BUILT_PACKAGES_FILE) | $(SODIFF_REPO_FILE)
 	<$(BUILT_PACKAGES_FILE) $(SODIFF_SCRIPT) $(RPMS_DIR)/ $(SODIFF_REPO_FILE) $(RELEASE_MAJOR_ID) $(SODIFF_OUTPUT_FOLDER)
 	[ ! -f "$(SODIFF_SUMMARY_FILE)" ] \
-	|| [ `$(wc -w $(SODIFF_SUMMARY_FILE) | cut -f1 -d' ')`  -eq 0 ] \
+	|| [ "`$(wc -w $(SODIFF_SUMMARY_FILE) | cut -f1 -d' ')`"  -eq 0 ] \
 	|| ( echo "SRPM files that need to be updated due to sodiff:"; cat $(SODIFF_OUTPUT_FOLDER)/sodiff-summary.txt ; $(call print_error,$@ failed - see $(SODIFF_SUMMARY_FILE) for a list of failed files.) )
 	echo "SODIFF finished - no changes detected."
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
"Microsoft" repository is available only for AMD64 architecture. Updated the tooling to skip that repo on non-AMD64 archs.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Update sodiff .repo files list for non-amd64 architectures.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build
