### PR TITLE
[main] [core] Fix double packaging of python3-py

### DIFF
--- a/SPECS/python-py/python-py.spec
+++ b/SPECS/python-py/python-py.spec
@@ -1,7 +1,7 @@
 Summary:        Python development support library
 Name:           python-py
 Version:        1.10.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -43,17 +43,15 @@ py.code: dynamic code generation and introspection
 #python-py and python-pytest have circular dependency. Hence not adding tests
 %make_build -k check |& tee %{_specdir}/%{name}-check-log || %{nocheck}
 
-%files
-%defattr(-,root,root,-)
-
-%{python2_sitelib}/*
-
 %files -n python3-py
 %defattr(-,root,root,-)
 %license LICENSE
 %{python3_sitelib}/*
 
 %changelog
+* Wed Feb 16 2022 Thomas Crain <thcrian@microsoft.com> - 1.10.0-3
+- Fix accidental double-packaging of python3 subpackage in main package
+
 * Wed Oct 20 2021 Thomas Crain <thcrain@microsoft.com> - 1.10.0-2
 - Add license to python3 package
 - Remove python2 package


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Remove `%file` section for the main package in `python-py`. I missed this when mass-deleting python2 packages last year. 

Since python2 isn't a requirement of `python-py`, `%python2_sitelib` evaluates to an empty string within the spec. This causes the main package to capture everything under the buildroot, resulting in the python3 subpackage being double packaged within the main package.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Remove `%file` section for the main package in `python-py`.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local mock build
