### PR TITLE
[main] [core] Remove python2 from subversion, OpenIPMI packages

### DIFF
--- a/SPECS/OpenIPMI/OpenIPMI-py39.patch
+++ b/SPECS/OpenIPMI/OpenIPMI-py39.patch
@@ -1,0 +1,149 @@
+diff -urNp a/configure b/configure
+--- a/configure	2018-04-17 08:47:58.528284066 +0200
++++ b/configure	2018-04-17 10:00:24.091372864 +0200
+@@ -13406,7 +13406,7 @@ if test "x$pythoncflags" = "x" -o "x$pyt
+    pythonprog=
+    if test "x$trypython" != "xno"; then
+       # Extract the first word of "python", so it can be a program name with args.
+-set dummy python; ac_word=$2
++set dummy python3; ac_word=$2
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+ $as_echo_n "checking for $ac_word... " >&6; }
+ if ${ac_cv_path_pythonprog+:} false; then :
+@@ -13500,12 +13500,12 @@ if test "x$pythonprog" != "x"; then
+    if test "x$pythonusepthreads" = "x"; then
+       cat - <<_ACEOF >conftest.py
+ try:
+-  import thread
++  import threading
+   print('yes')
+ except:
+   print('no')
+ _ACEOF
+-      pythonusepthreads=`python conftest.py`
++      pythonusepthreads=`python3 conftest.py`
+       rm -f conftest.py
+    fi
+    echo "checking for python threads... $pythonusepthreads"
+@@ -13537,7 +13537,7 @@ try:
+ except:
+   print('no')
+ _ACEOF
+-      tkinter=`python conftest.py`
++      tkinter=`python3 conftest.py`
+       rm -f conftest.py
+    fi
+ fi
+diff -urNp a/configure.ac b/configure.ac
+--- a/configure.ac	2018-04-17 08:47:58.529284062 +0200
++++ b/configure.ac	2018-04-17 10:01:02.115576922 +0200
+@@ -526,7 +526,7 @@ AC_SUBST(PERL_POSIX_SO)
+ if test "x$pythoncflags" = "x" -o "x$pythoninstalldir" = "x"; then
+    pythonprog=
+    if test "x$trypython" != "xno"; then
+-      AC_PATH_PROG(pythonprog, python)
++      AC_PATH_PROG(pythonprog, python3)
+    fi
+    if test "x$pythonprog" != "x"; then
+       # Now find a proper installation location.
+@@ -578,12 +578,12 @@ if test "x$pythonprog" != "x"; then
+    if test "x$pythonusepthreads" = "x"; then
+       cat - <<_ACEOF >conftest.py
+ try:
+-  import thread
++  import threading
+   print('yes')
+ except:
+   print('no')
+ _ACEOF
+-      pythonusepthreads=`python conftest.py`
++      pythonusepthreads=`python3 conftest.py`
+       rm -f conftest.py
+    fi
+    echo "checking for python threads... $pythonusepthreads"
+@@ -615,7 +615,7 @@ try:
+ except:
+   print('no')
+ _ACEOF
+-      tkinter=`python conftest.py`
++      tkinter=`python3 conftest.py`
+       rm -f conftest.py
+    fi
+ fi
+diff -urNp a/swig/python/Makefile.am b/swig/python/Makefile.am
+--- a/swig/python/Makefile.am	2018-04-17 08:47:58.547283986 +0200
++++ b/swig/python/Makefile.am	2018-04-17 14:43:01.703963727 +0200
+@@ -22,19 +22,14 @@ EXTRA_DIST = OpenIPMI_lang.i OpenIPMI.h
+ OpenIPMI.pyc: OpenIPMI.py _OpenIPMI.la
+ 	-PYTHONPATH=$(PYPATH) $(pythonprog) -c 'import OpenIPMI.py'
+ 
+-OpenIPMI.pyo: OpenIPMI.py _OpenIPMI.la
+-	-PYTHONPATH=$(PYPATH) $(pythonprog) -O -c 'import OpenIPMI.py'
+-
+ OpenIPMI_wrap.c OpenIPMI.py: $(top_srcdir)/swig/OpenIPMI.i OpenIPMI_lang.i
+	$(SWIG) $(DEFS) -python -o OpenIPMI_wrap.c -I$(top_srcdir)/swig/python $<
+ 
+-CLEANFILES = OpenIPMI_wrap.c OpenIPMI.py OpenIPMI.pyo OpenIPMI.pyc
++CLEANFILES = OpenIPMI_wrap.c OpenIPMI.py
+ 
+-install-exec-local: _OpenIPMI.la OpenIPMI.py OpenIPMI.pyc OpenIPMI.pyo
++install-exec-local: _OpenIPMI.la OpenIPMI.py
+ 	$(INSTALL) -d $(DESTDIR)$(PYTHON_INSTALL_DIR)
+ 	$(INSTALL_DATA) OpenIPMI.py "$(DESTDIR)$(PYTHON_INSTALL_DIR)"
+-	$(INSTALL_DATA) OpenIPMI.pyc "$(DESTDIR)$(PYTHON_INSTALL_DIR)"
+-	$(INSTALL_DATA) OpenIPMI.pyo "$(DESTDIR)$(PYTHON_INSTALL_DIR)"
+ 	if test "x$(PYTHON_GUI_DIR)" = "xopenipmigui"; then \
+ 	    $(INSTALL) -d $(DESTDIR)$(bindir); \
+ 	    $(INSTALL_SCRIPT) $(srcdir)/openipmigui.py "$(DESTDIR)$(bindir)/openipmigui";\
+@@ -43,8 +38,6 @@ install-exec-local: _OpenIPMI.la OpenIPM
+ uninstall-local:
+ 	$(LIBTOOL) --mode=uninstall rm -f "$(DESTDIR)$(PYTHON_INSTALL_LIB_DIR)/_OpenIPMI.so"
+ 	rm -f "$(DESTDIR)$(PYTHON_INSTALL_DIR)/OpenIPMI.py"
+-	rm -f "$(DESTDIR)$(PYTHON_INSTALL_DIR)/OpenIPMI.pyc"
+-	rm -f "$(DESTDIR)$(PYTHON_INSTALL_DIR)/OpenIPMI.pyo"
+ 	rm -f "$(DESTDIR)$(bindir)/openipmigui"
+ 
+ rungui:
+diff -urNp a/swig/python/Makefile.in b/swig/python/Makefile.in
+--- a/swig/python/Makefile.in	2018-04-17 08:47:58.547283986 +0200
++++ b/swig/python/Makefile.in	2018-04-17 14:43:28.969899859 +0200
+@@ -443,7 +443,7 @@ nodist__OpenIPMI_la_SOURCES = OpenIPMI_w
+ _OpenIPMI_la_LDFLAGS = -module -avoid-version
+ _OpenIPMI_la_LIBADD = $(OPENIPMI_SWIG_LIBS) $(PYTHON_POSIX_LIB)
+ EXTRA_DIST = OpenIPMI_lang.i OpenIPMI.h openipmigui.py sample.py sample2.py
+-CLEANFILES = OpenIPMI_wrap.c OpenIPMI.py OpenIPMI.pyo OpenIPMI.pyc
++CLEANFILES = OpenIPMI_wrap.c OpenIPMI.py
+ all: all-recursive
+ 
+ .SUFFIXES:
+@@ -837,20 +837,12 @@ uninstall-am: uninstall-local uninstall-
+ .PRECIOUS: Makefile
+ 
+ 
+-OpenIPMI.pyc: OpenIPMI.py _OpenIPMI.la
+-	-PYTHONPATH=$(PYPATH) $(pythonprog) -c 'import OpenIPMI.py'
+-
+-OpenIPMI.pyo: OpenIPMI.py _OpenIPMI.la
+-	-PYTHONPATH=$(PYPATH) $(pythonprog) -O -c 'import OpenIPMI.py'
+-
+ OpenIPMI_wrap.c OpenIPMI.py: $(top_srcdir)/swig/OpenIPMI.i OpenIPMI_lang.i
+	$(SWIG) $(DEFS) -python -o OpenIPMI_wrap.c -I$(top_srcdir)/swig/python $<
+ 
+-install-exec-local: _OpenIPMI.la OpenIPMI.py OpenIPMI.pyc OpenIPMI.pyo
++install-exec-local: _OpenIPMI.la OpenIPMI.py
+ 	$(INSTALL) -d $(DESTDIR)$(PYTHON_INSTALL_DIR)
+ 	$(INSTALL_DATA) OpenIPMI.py "$(DESTDIR)$(PYTHON_INSTALL_DIR)"
+-	$(INSTALL_DATA) OpenIPMI.pyc "$(DESTDIR)$(PYTHON_INSTALL_DIR)"
+-	$(INSTALL_DATA) OpenIPMI.pyo "$(DESTDIR)$(PYTHON_INSTALL_DIR)"
+ 	if test "x$(PYTHON_GUI_DIR)" = "xopenipmigui"; then \
+ 	    $(INSTALL) -d $(DESTDIR)$(bindir); \
+ 	    $(INSTALL_SCRIPT) $(srcdir)/openipmigui.py "$(DESTDIR)$(bindir)/openipmigui";\
+@@ -859,8 +851,6 @@ install-exec-local: _OpenIPMI.la OpenIPM
+ uninstall-local:
+ 	$(LIBTOOL) --mode=uninstall rm -f "$(DESTDIR)$(PYTHON_INSTALL_LIB_DIR)/_OpenIPMI.so"
+ 	rm -f "$(DESTDIR)$(PYTHON_INSTALL_DIR)/OpenIPMI.py"
+-	rm -f "$(DESTDIR)$(PYTHON_INSTALL_DIR)/OpenIPMI.pyc"
+-	rm -f "$(DESTDIR)$(PYTHON_INSTALL_DIR)/OpenIPMI.pyo"
+ 	rm -f "$(DESTDIR)$(bindir)/openipmigui"
+ 
+ rungui:

--- a/SPECS/OpenIPMI/OpenIPMI.spec
+++ b/SPECS/OpenIPMI/OpenIPMI.spec
@@ -1,7 +1,7 @@
 Summary:        A shared library implementation of IPMI and the basic tools
 Name:           OpenIPMI
 Version:        2.0.25
-Release:        6%{?dist}
+Release:        7%{?dist}
 License:        LGPLv2+ AND GPLv2+ OR BSD
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -10,11 +10,13 @@ URL:            https://sourceforge.net/projects/openipmi/
 Source0:        https://sourceforge.net/projects/openipmi/files/latest/download/openipmi-%{version}.tar.gz
 Source1:        openipmi-helper
 Source2:        ipmi.service
+# Enable detection of python versions with deprecated distutils modules (Source: Fedora 28, MIT license)
+Patch0:         %{name}-py39.patch
 BuildRequires:  ncurses-devel
 BuildRequires:  openssl-devel
 BuildRequires:  perl
 BuildRequires:  popt-devel
-BuildRequires:  python2-devel
+BuildRequires:  python3-devel
 BuildRequires:  swig
 BuildRequires:  systemd
 Requires:       systemd
@@ -46,7 +48,7 @@ A Perl interface for OpenIPMI.
 Summary:        Python interface for OpenIPMI
 Group:          Utilities
 Requires:       OpenIPMI = %{version}-%{release}
-Requires:       python2
+Requires:       python3
 Provides:       python3-openipmi = %{version}-%{release}
 
 %description    python
@@ -69,7 +71,8 @@ Requires:       OpenIPMI = %{version}-%{release}
 This package contains a network IPMI listener.
 
 %prep
-%setup -q
+%autosetup -p1
+autoreconf -fiv
 
 %build
 # USERFIX: Things you might have to add to configure:
@@ -81,7 +84,9 @@ This package contains a network IPMI listener.
     --with-tkinter=no                       \
     --docdir=%{_docdir}/%{name}-%{version}  \
     --with-perl=yes                         \
-    --with-perlinstall=%{perl_vendorarch}
+    --with-perlinstall=%{perl_vendorarch}   \
+    --with-python=%python3                  \
+    --with-pythoninstall=%{python3_sitearch}
 make
 
 %install
@@ -100,7 +105,7 @@ install -vdm755 %{buildroot}%{_libdir}/systemd/system-preset
 echo "disable ipmi.service" > %{buildroot}%{_libdir}/systemd/system-preset/50-ipmi.preset
 
 #The build VM does not support ipmi.
-#%check
+#%%check
 #make %{?_smp_mflags} check
 
 %preun
@@ -139,7 +144,8 @@ echo "disable ipmi.service" > %{buildroot}%{_libdir}/systemd/system-preset/50-ip
 
 %files python
 %defattr(-,root,root)
-%{_libdir}/python*/site-packages/*OpenIPMI.*
+%{python3_sitelib}/*OpenIPMI.*
+%{python3_sitelib}/__pycache__/*
 %doc swig/OpenIPMI.i
 
 %files devel
@@ -184,6 +190,11 @@ echo "disable ipmi.service" > %{buildroot}%{_libdir}/systemd/system-preset/50-ip
 %{_mandir}/man5/ipmi_sim_cmd.5.gz
 
 %changelog
+* Mon Jan 31 2022 Thomas Crain <thcrain@microsoft.com> - 2.0.25-7
+- Use python3 instead of python2 in python subpackage
+- Add Fedora patch to enable build with python >= 3.9
+- License verified
+
 * Tue Mar 02 2021 Henry Li <lihl@microsoft.com> - 2.0.25-6
 - Provides python3-openipmi from OpenIPMI-python
 

--- a/SPECS/subversion/subversion.spec
+++ b/SPECS/subversion/subversion.spec
@@ -1,7 +1,7 @@
 Summary:        The Apache Subversion control system
 Name:           subversion
 Version:        1.14.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -20,8 +20,7 @@ BuildRequires:  sqlite-devel
 BuildRequires:  swig
 BuildRequires:  utf8proc-devel
 %if %{with_check}
-BuildRequires:  python-xml
-BuildRequires:  python2
+BuildRequires:  python3
 BuildRequires:  shadow-utils
 BuildRequires:  sudo
 %endif
@@ -103,6 +102,9 @@ sudo -u test make check && userdel test -r -f
 %{_mandir}/man3/SVN*
 
 %changelog
+* Mon Jan 31 2022 Thomas Crain <thcrain@microsoft.com> - 1.14.1-2
+- Use python3 during %%check section instead of python2
+
 * Fri Jan 14 2022 Neha Agarwal <nehaagarwal@microsoft.com> - 1.14.1-1
 - Update to version 1.14.1.
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Remove `python2` from `subversion` and `OpenIPMI` as part of our `python2` eradication effort.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- `subversion`: Run tests using `python3` instead of `python2`
- `OpenIPMI`: Use `python3` instead of `python2` in the python subpackage. Add Fedora 28 patch to enable build with python >= 3.9

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local mock build
