### PR TITLE
golang inherit ENV proxy settings

### DIFF
--- a/toolkit/tools/internal/network/network.go
+++ b/toolkit/tools/internal/network/network.go
@@ -41,9 +41,8 @@ func DownloadFile(url, dst string, caCerts *x509.CertPool, tlsCerts []tls.Certif
 		RootCAs:      caCerts,
 		Certificates: tlsCerts,
 	}
-	transport := &http.Transport{
-		TLSClientConfig: tlsConfig,
-	}
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = tlsConfig
 	client := &http.Client{
 		Transport: transport,
 	}


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge (applicable to 1.x and 2.x branches?

---

###### Summary <!-- REQUIRED -->

This PR resolves a bug where the golang HTTP transport code wasn't inheriting the default values which include respecting any http_proxy ENV values.  Thus running `srpmpacker` behind a proxy'd network would timeout prior to this change.

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Test Methodology

- Checkout 1.0-stable branch and do a local build as follows.  
make clean
make toolchain -j$(nproc) CONFIG_FILE=./imageconfigs/core-legacy.json PACKAGE_IGNORE_LIST="openjdk8"
make image -j$(nproc) CONFIG_FILE=./imageconfigs/core-legacy.json REBUILD_TOOLS=y PACKAGE_IGNORE_LIST="openjdk8"

- The failure case is on a network which requires ENV values set for http_proxy, https_proxy and ftp_proxy.  Set those values and try to do a build.  With `LOG_LEVEL=trace ` we'll see the Download log hang.  Breaking out of that, manually doing a wget of the same url works.  Next make the change in this PR and repeat to show no hang and successful download.