### PR TITLE
[1.0] Add cloud-init patches to support preprovisioned VMs

### DIFF
--- a/SPECS/cloud-init/apply-netconfig-every-boot.patch
+++ b/SPECS/cloud-init/apply-netconfig-every-boot.patch
@@ -1,0 +1,42 @@
+From dc22786980a05129c5971e68ae37b1a9f76f882d Mon Sep 17 00:00:00 2001
+From: James Falcon <therealfalcon@gmail.com>
+Date: Fri, 17 Sep 2021 16:25:22 -0500
+Subject: [PATCH] Set Azure to apply networking config every BOOT (#1023)
+
+In #1006, we set Azure to apply networking config every
+BOOT_NEW_INSTANCE because the BOOT_LEGACY option was causing problems
+applying networking the second time per boot. However,
+BOOT_NEW_INSTANCE is also wrong as Azure needs to apply networking
+once per boot, during init-local phase.
+
+Signed-off-by: Henry Beberman <henry.beberman@microsoft.com>
+
+---
+ cloudinit/sources/DataSourceAzure.py                |  6 +++++-
+ tests/integration_tests/modules/test_user_events.py | 10 ++++++----
+ 2 files changed, 11 insertions(+), 5 deletions(-)
+
+diff --git a/cloudinit/sources/DataSourceAzure.py b/cloudinit/sources/DataSourceAzure.py
+index 3fb564c8dd..f8641dfd2f 100755
+--- a/cloudinit/sources/DataSourceAzure.py
++++ b/cloudinit/sources/DataSourceAzure.py
+@@ -22,7 +22,7 @@
+ from cloudinit import dmi
+ from cloudinit import log as logging
+ from cloudinit import net
+-from cloudinit.event import EventType
++from cloudinit.event import EventScope, EventType
+ from cloudinit.net import device_driver
+ from cloudinit.net.dhcp import EphemeralDHCPv4
+ from cloudinit import sources
+@@ -339,6 +339,10 @@ def temporary_hostname(temp_hostname, cfg, hostname_command='hostname'):
+ class DataSourceAzure(sources.DataSource):
+ 
+     dsname = 'Azure'
++    default_update_events = {EventScope.NETWORK: {
++        EventType.BOOT_NEW_INSTANCE,
++        EventType.BOOT,
++    }}
+     _negotiated = False
+     _metadata_imds = sources.UNSET
+     _ci_pkl_version = 1

--- a/SPECS/cloud-init/cloud-init.spec
+++ b/SPECS/cloud-init/cloud-init.spec
@@ -3,7 +3,7 @@
 Summary:        Cloud instance init scripts
 Name:           cloud-init
 Version:        21.3
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        GPLv3
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -18,6 +18,8 @@ Patch2:         ds-vmware-mariner.patch
 Patch3:         cloud-cfg.patch
 Patch4:         networkd.patch
 Patch5:         mariner.patch
+Patch6:         update-metadata-on-BOOT_NEW_INSTANCE.patch
+Patch7:         apply-netconfig-every-boot.patch
 BuildRequires:  automake
 BuildRequires:  dbus
 BuildRequires:  iproute
@@ -158,6 +160,9 @@ rm -rf %{buildroot}
 %config(noreplace) %{_sysconfdir}/cloud/cloud.cfg.d/10-azure-kvp.cfg
 
 %changelog
+* Tue Feb 22 2022 Henry Beberman <henry.beberman@microsoft.com> - 21.3-4
+- Add patches from upstream to resolve a hang when reinitializing preprovisioned VMs.
+
 * Mon Oct 18 2021 Henry Beberman <henry.beberman@microsoft.com> - 21.3-3
 - Add azure-kvp subpackage.
 

--- a/SPECS/cloud-init/update-metadata-on-BOOT_NEW_INSTANCE.patch
+++ b/SPECS/cloud-init/update-metadata-on-BOOT_NEW_INSTANCE.patch
@@ -1,0 +1,60 @@
+From e69a88745e37061e0ab0a1e67ad11015cca610c1 Mon Sep 17 00:00:00 2001
+From: James Falcon <therealfalcon@gmail.com>
+Date: Fri, 3 Sep 2021 12:57:20 -0500
+Subject: [PATCH] Set Azure to only update metadata on BOOT_NEW_INSTANCE
+ (#1006)
+
+In #834, we refactored the handling of events for fetching new metadata.
+Previously, in Azure's __init__, the BOOT event was added to the
+update_events, so it was assumed that Azure required the standard BOOT
+behavior, which is to apply metadata twice every boot: once during
+local-init, then again during standard init phase.
+https://github.com/canonical/cloud-init/blob/21.2/cloudinit/sources/DataSourceAzure.py#L356
+
+However, this line was effectively meaningless. After the metadata was
+fetched in local-init, it was then pickled out to disk. Because
+"update_events" was a class variable, the EventType.BOOT was not
+persisted into the pickle. When the pickle was then unpickled in the
+init phase, metadata did not get re-fetched because EventType.BOOT was
+not present, so Azure is effectely only BOOT_NEW_INSTANCE.
+
+Fetching metadata twice during boot causes some issue for
+pre-provisioning on Azure because updating metadata during
+re-provisioning will cause cloud-init to poll for reprovisiondata again
+in DataSourceAzure, which will infinitely return 404(reprovisiondata
+is deleted from IMDS after health signal was sent by cloud-init during
+init-local). This makes cloud-init stuck in 'init'
+
+Signed-off-by: Henry Beberman <henry.beberman@microsoft.com>
+
+---
+ cloudinit/sources/DataSourceAzure.py | 9 +--------
+ 1 file changed, 1 insertion(+), 8 deletions(-)
+
+diff --git a/cloudinit/sources/DataSourceAzure.py b/cloudinit/sources/DataSourceAzure.py
+index caffa944f3..3fb564c8dd 100755
+--- a/cloudinit/sources/DataSourceAzure.py
++++ b/cloudinit/sources/DataSourceAzure.py
+@@ -22,7 +22,7 @@
+ from cloudinit import dmi
+ from cloudinit import log as logging
+ from cloudinit import net
+-from cloudinit.event import EventScope, EventType
++from cloudinit.event import EventType
+ from cloudinit.net import device_driver
+ from cloudinit.net.dhcp import EphemeralDHCPv4
+ from cloudinit import sources
+@@ -339,13 +339,6 @@ def temporary_hostname(temp_hostname, cfg, hostname_command='hostname'):
+ class DataSourceAzure(sources.DataSource):
+ 
+     dsname = 'Azure'
+-    # Regenerate network config new_instance boot and every boot
+-    default_update_events = {EventScope.NETWORK: {
+-        EventType.BOOT_NEW_INSTANCE,
+-        EventType.BOOT,
+-        EventType.BOOT_LEGACY
+-    }}
+-
+     _negotiated = False
+     _metadata_imds = sources.UNSET
+     _ci_pkl_version = 1


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Cloud-init 21.3 has some compatibility issues with pre-provisioned VMs in Azure, leading to a long poll on IMDS that fails and a VM that doesn't have the correct networking configuration. The two patches included in this commit address the issue.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- cherry-pick e69a8874: Set Azure to only update metadata on BOOT_NEW_INSTANCE
- cherry-pick dc227869: Set Azure to apply networking config every BOOT

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local package build
- %check section passed without issue
- Marketplace image initialized successfully in Azure.