### PR TITLE
Update Mariner Core base image keeping dnf wget vim as optional packages

### DIFF
--- a/.github/workflows/validate-cg-manifest.sh
+++ b/.github/workflows/validate-cg-manifest.sh
@@ -16,6 +16,7 @@ ignore_list=" \
   appstream-data \
   byacc \
   ca-certificates \
+  core-packages \
   Cython \
   dbus-x11 \
   grub2-efi-binary-signed-aarch64 \

--- a/SPECS/core-packages/core-packages.spec
+++ b/SPECS/core-packages/core-packages.spec
@@ -1,7 +1,7 @@
 Summary:        Metapackage with core sets of packages
 Name:           core-packages
 Version:        2.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -21,7 +21,6 @@ Requires:       cpio
 Requires:       cracklib-dicts
 Requires:       cryptsetup
 Requires:       dbus
-Requires:       dnf
 Requires:       file
 Requires:       gdbm
 Requires:       iana-etc
@@ -79,8 +78,6 @@ Requires:       tar
 Requires:       tdnf
 Requires:       tdnf-plugin-repogpgcheck
 Requires:       util-linux
-Requires:       vim
-Requires:       wget
 Requires:       xz
 Requires:       zlib
 
@@ -96,6 +93,9 @@ Requires:       zlib
 %files container
 
 %changelog
+* Wed Feb 23 2022 Suresh Babu Chalamalasetty <schalam@microsoft.com> - 2.0-2
+- Update Mariner Core base and container images to remove dnf vim wget by default.
+
 * Mon Dec 13 2021 Jon Slobodzian <joslobo@microsoft.com> - 2.0-1
 - Update core-package to include new repositories for default Mariner 2.0 Preview Images
 

--- a/SPECS/core-packages/core-packages.spec
+++ b/SPECS/core-packages/core-packages.spec
@@ -95,6 +95,7 @@ Requires:       zlib
 %changelog
 * Wed Feb 23 2022 Suresh Babu Chalamalasetty <schalam@microsoft.com> - 2.0-2
 - Update Mariner Core base and container images to remove dnf vim wget by default.
+- License verified
 
 * Mon Dec 13 2021 Jon Slobodzian <joslobo@microsoft.com> - 2.0-1
 - Update core-package to include new repositories for default Mariner 2.0 Preview Images

--- a/toolkit/imageconfigs/core-efi-aarch64.json
+++ b/toolkit/imageconfigs/core-efi-aarch64.json
@@ -47,14 +47,10 @@
             "PackageLists": [
                 "packagelists/hyperv-packages.json",
                 "packagelists/core-packages-image-aarch64.json",
-                "packagelists/cloud-init-packages.json",
-                "packagelists/selinux.json"
+                "packagelists/cloud-init-packages.json"
             ],
             "KernelOptions": {
                 "default": "kernel"
-            },
-            "KernelCommandLine": {
-                "SELinux": "permissive"
             },
             "Hostname": "cbl-mariner"
         }

--- a/toolkit/imageconfigs/core-efi-rt.json
+++ b/toolkit/imageconfigs/core-efi-rt.json
@@ -48,6 +48,7 @@
                 "packagelists/hyperv-packages.json",
                 "packagelists/core-packages-image.json",
                 "packagelists/cloud-init-packages.json",
+                "packagelists/core-tools-packages.json",
                 "packagelists/rt-packages.json"
             ],
             "KernelOptions": {

--- a/toolkit/imageconfigs/core-efi.json
+++ b/toolkit/imageconfigs/core-efi.json
@@ -47,14 +47,10 @@
             "PackageLists": [
                 "packagelists/hyperv-packages.json",
                 "packagelists/core-packages-image.json",
-                "packagelists/cloud-init-packages.json",
-                "packagelists/selinux.json"
+                "packagelists/cloud-init-packages.json"
             ],
             "KernelOptions": {
                 "default": "kernel"
-            },
-            "KernelCommandLine": {
-                "SELinux": "permissive"
             },
             "Hostname": "cbl-mariner"
         }

--- a/toolkit/imageconfigs/core-fips.json
+++ b/toolkit/imageconfigs/core-fips.json
@@ -46,6 +46,7 @@
                 "packagelists/hyperv-packages.json",
                 "packagelists/fips-packages.json",
                 "packagelists/core-packages-image.json",
+                "packagelists/core-tools-packages.json",
                 "packagelists/cloud-init-packages.json",
                 "packagelists/selinux.json"
             ],

--- a/toolkit/imageconfigs/core-legacy.json
+++ b/toolkit/imageconfigs/core-legacy.json
@@ -45,14 +45,10 @@
             "PackageLists": [
                 "packagelists/hyperv-packages.json",
                 "packagelists/core-packages-image.json",
-                "packagelists/cloud-init-packages.json",
-                "packagelists/selinux.json"
+                "packagelists/cloud-init-packages.json"
             ],
             "KernelOptions": {
                 "default": "kernel"
-            },
-            "KernelCommandLine": {
-                "SELinux": "permissive"
             },
             "Hostname": "cbl-mariner"
         }

--- a/toolkit/imageconfigs/core-ova.json
+++ b/toolkit/imageconfigs/core-ova.json
@@ -46,6 +46,7 @@
                 "packagelists/hyperv-packages.json",
                 "packagelists/core-packages-image.json",
                 "packagelists/cloud-init-packages.json",
+                "packagelists/core-tools-packages.json",
                 "packagelists/selinux.json"
             ],
             "Hostname": "mariner",

--- a/toolkit/imageconfigs/full-aarch64.json
+++ b/toolkit/imageconfigs/full-aarch64.json
@@ -7,6 +7,7 @@
                 "packagelists/developer-packages.json",
                 "packagelists/virtualization-host-packages.json",
                 "packagelists/core-packages-image-aarch64.json",
+                "packagelists/core-tools-packages.json",
                 "packagelists/selinux-full.json"
             ],
             "KernelCommandLine": {
@@ -20,12 +21,8 @@
             "Name": "CBL-Mariner Core",
             "PackageLists": [
                 "packagelists/hyperv-packages.json",
-                "packagelists/core-packages-image-aarch64.json",
-                "packagelists/selinux.json"
+                "packagelists/core-packages-image-aarch64.json"
             ],
-            "KernelCommandLine": {
-                "SELinux": "permissive"
-            },
             "KernelOptions": {
                 "default": "kernel"
             }

--- a/toolkit/imageconfigs/full-rt.json
+++ b/toolkit/imageconfigs/full-rt.json
@@ -8,6 +8,7 @@
                 "packagelists/core-packages-image.json",
                 "packagelists/hyperv-packages.json",
                 "packagelists/ssh-server.json",
+                "packagelists/core-tools-packages.json",
                 "packagelists/rt-packages.json"
             ],
             "KernelOptions": {
@@ -19,6 +20,7 @@
             "PackageLists": [
                 "packagelists/hyperv-packages.json",
                 "packagelists/core-packages-image.json",
+                "packagelists/core-tools-packages.json",
                 "packagelists/rt-packages.json"
             ],
             "KernelOptions": {

--- a/toolkit/imageconfigs/full.json
+++ b/toolkit/imageconfigs/full.json
@@ -6,6 +6,7 @@
                 "packagelists/developer-packages.json",
                 "packagelists/virtualization-host-packages.json",
                 "packagelists/core-packages-image.json",
+                "packagelists/core-tools-packages.json",
                 "packagelists/hyperv-packages.json",
                 "packagelists/ssh-server.json",
                 "packagelists/selinux-full.json"
@@ -21,12 +22,8 @@
             "Name": "CBL-Mariner Core",
             "PackageLists": [
                 "packagelists/hyperv-packages.json",
-                "packagelists/core-packages-image.json",
-                "packagelists/selinux.json"
+                "packagelists/core-packages-image.json"
             ],
-            "KernelCommandLine": {
-                "SELinux": "permissive"
-            },
             "KernelOptions": {
                 "default": "kernel"
             }

--- a/toolkit/imageconfigs/marketplace-gen1.json
+++ b/toolkit/imageconfigs/marketplace-gen1.json
@@ -54,6 +54,7 @@
             ],
             "PackageLists": [
                 "packagelists/core-packages-image.json",
+                "packagelists/core-tools-packages.json",
                 "packagelists/azurevm-packages.json"
             ],
             "AdditionalFiles": {

--- a/toolkit/imageconfigs/marketplace-gen2.json
+++ b/toolkit/imageconfigs/marketplace-gen2.json
@@ -56,6 +56,7 @@
             ],
             "PackageLists": [
                 "packagelists/core-packages-image.json",
+                "packagelists/core-tools-packages.json",
                 "packagelists/azurevm-packages.json"
             ],
             "AdditionalFiles": {

--- a/toolkit/imageconfigs/packagelists/core-tools-packages.json
+++ b/toolkit/imageconfigs/packagelists/core-tools-packages.json
@@ -1,0 +1,7 @@
+{
+    "packages": [
+        "dnf",
+        "vim",
+        "wget"
+    ]
+}

--- a/toolkit/imageconfigs/read-only-root-efi.json
+++ b/toolkit/imageconfigs/read-only-root-efi.json
@@ -75,6 +75,7 @@
                 "packagelists/hyperv-packages.json",
                 "packagelists/core-packages-image.json",
                 "packagelists/read-only-root-packages.json",
+                "packagelists/core-tools-packages.json",
                 "packagelists/selinux.json"
             ],
             "KernelOptions": {

--- a/toolkit/imageconfigs/swuvm.json
+++ b/toolkit/imageconfigs/swuvm.json
@@ -47,6 +47,7 @@
             ],
             "PackageLists": [
                 "packagelists/core-packages-image.json",
+                "packagelists/core-tools-packages.json",
                 "packagelists/hyperv-packages.json"
             ],
             "KernelOptions": {


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

1. Updating Mariner Core base and container images by keeping dnf, wget and vim as optional packages.
2. SELinux-Policy and its dependencies are consuming approximately ~18 MB of disk footprint in Core images. For now keeping it as an optional package in Mariner Core images only and adding it to Mariner Core-Fips, Mariner Full and other images by default. We will work with SELinux feature team to get this feature footprint reduced to required minimal footprint and will include in Mariner Core images. 
3. Created core-tools-packages.json with dnf, vim and wget packages. Added core-tools-packages.json in Mariner Market place images, Core-fips, Core-rt, Full images etc.
4. Current Mariner 2.0/main branch disk footprint is ~ 444 MB. Our goal is to keep Mariner Core images disk footprint to <380 MB. 

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change
   Update Mariner Core base and container images to remove dnf vim wget by default

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-YYYY-XXXX

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
-  Local build.
