### PR TITLE
Using quotes in `os-release`. (CP #2316)

### DIFF
--- a/SPECS/mariner-release/mariner-release.spec
+++ b/SPECS/mariner-release/mariner-release.spec
@@ -1,7 +1,7 @@
 Summary:       CBL-Mariner release files
 Name:          mariner-release
 Version:       1.0
-Release:       33%{?dist}
+Release:       34%{?dist}
 License:       MIT
 Group:         System Environment/Base
 URL:           https://aka.ms/cbl-mariner
@@ -36,7 +36,7 @@ cat > %{buildroot}/usr/lib/os-release << EOF
 NAME="Common Base Linux Mariner"
 VERSION="%{mariner_release_version}"
 ID=mariner
-VERSION_ID=$version_id
+VERSION_ID="$version_id"
 PRETTY_NAME="CBL-Mariner/Linux"
 ANSI_COLOR="1;34"
 HOME_URL="%{url}"
@@ -67,6 +67,8 @@ rm -rf $RPM_BUILD_ROOT
 %config(noreplace) /etc/issue.net
 
 %changelog
+*   Thu Feb 24 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.0-34
+-   Surrounding 'VERSION_ID' inside 'os-release' with double quotes.
 *   Mon Feb 07 2022 Jon Slobodzian <joslobo@microsoft.com> - 1.0-33
 -   Updating version for February update.
 *   Wed Jan 26 2022 Jon Slobodzian <joslobo@microsoft.com> - 1.0-32

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -58,7 +58,7 @@ findutils-lang-4.6.0-7.cm1.aarch64.rpm
 gettext-0.19.8.1-5.cm1.aarch64.rpm
 gzip-1.9-5.cm1.aarch64.rpm
 make-4.2.1-5.cm1.aarch64.rpm
-mariner-release-1.0-33.cm1.noarch.rpm
+mariner-release-1.0-34.cm1.noarch.rpm
 patch-2.7.6-7.cm1.aarch64.rpm
 util-linux-2.32.1-5.cm1.aarch64.rpm
 util-linux-devel-2.32.1-5.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -58,7 +58,7 @@ findutils-lang-4.6.0-7.cm1.x86_64.rpm
 gettext-0.19.8.1-5.cm1.x86_64.rpm
 gzip-1.9-5.cm1.x86_64.rpm
 make-4.2.1-5.cm1.x86_64.rpm
-mariner-release-1.0-33.cm1.noarch.rpm
+mariner-release-1.0-34.cm1.noarch.rpm
 patch-2.7.6-7.cm1.x86_64.rpm
 util-linux-2.32.1-5.cm1.x86_64.rpm
 util-linux-devel-2.32.1-5.cm1.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -260,7 +260,7 @@ m4-debuginfo-1.4.18-4.cm1.aarch64.rpm
 make-4.2.1-5.cm1.aarch64.rpm
 make-debuginfo-4.2.1-5.cm1.aarch64.rpm
 mariner-check-macros-1.0-8.cm1.noarch.rpm
-mariner-release-1.0-33.cm1.noarch.rpm
+mariner-release-1.0-34.cm1.noarch.rpm
 mariner-repos-1.0-14.cm1.noarch.rpm
 mariner-repos-extras-1.0-14.cm1.noarch.rpm
 mariner-repos-extras-preview-1.0-14.cm1.noarch.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -260,7 +260,7 @@ m4-debuginfo-1.4.18-4.cm1.x86_64.rpm
 make-4.2.1-5.cm1.x86_64.rpm
 make-debuginfo-4.2.1-5.cm1.x86_64.rpm
 mariner-check-macros-1.0-8.cm1.noarch.rpm
-mariner-release-1.0-33.cm1.noarch.rpm
+mariner-release-1.0-34.cm1.noarch.rpm
 mariner-repos-1.0-14.cm1.noarch.rpm
 mariner-repos-extras-1.0-14.cm1.noarch.rpm
 mariner-repos-extras-preview-1.0-14.cm1.noarch.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

@slaymaker1907 raised an issue (#2297) that the format of the `VERSION_ID` value inside `os-release` is invalid - it should be surrounded with double quotes if it contains non-alphanumeric characters (see: [here](https://www.freedesktop.org/software/systemd/man/os-release.html)). This PR is addressing that issue.

This is a 1.0 port of #2316.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Surrounded `VERSION_ID` inside `os-release` with double quotes.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
Yes.

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #2297
- #2316

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- None, minor change.
