### PR TITLE
[main] Reverting `javapackages-tools` update (6.0.0 -> 5.3.0)

### DIFF
--- a/SPECS/javapackages-tools/javapackages-tools.signatures.json
+++ b/SPECS/javapackages-tools/javapackages-tools.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "javapackages-tools-6.0.0.tar.gz": "5ee819c44c85c384b4bf4e24e768bca9068d5118d1d87767c72110d68645f651"
+  "javapackages-tools-5.3.0.tar.gz": "73803877c26b3e6c0440b2e1e4d78a5fadf63782a62374df400b8badb1de3046"
  }
 }

--- a/SPECS/javapackages-tools/javapackages-tools.spec
+++ b/SPECS/javapackages-tools/javapackages-tools.spec
@@ -8,13 +8,14 @@
 %global rpmmacrodir %{_rpmconfigdir}/macros.d
 Summary:        Macros and scripts for Java packaging support
 Name:           javapackages-tools
-Version:        6.0.0
-Release:        1%{?dist}
+Version:        5.3.0
+Release:        14%{?dist}
 License:        BSD
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 URL:            https://github.com/fedora-java/javapackages
-Source0:        https://github.com/fedora-java/javapackages/archive/%{version}.tar.gz#/%{name}-%{version}.tar.gz
+#Source0:       https://github.com/fedora-java/javapackages/archive/%{version}.tar.gz
+Source0:        %{name}-%{version}.tar.gz
 Patch0:         remove-epoch-from-java-requires.patch
 Patch1:         remove-headless-from-java-requires.patch
 BuildRequires:  asciidoc
@@ -83,15 +84,6 @@ Requires:       python3-javapackages = %{version}-%{release}
 This package provides non-essential macros and scripts to support Java packaging.
 It is a lightweight version with minimal runtime requirements.
 
-%package -n javapackages-generators
-Summary:        RPM dependency generators for Java packaging support
-Requires:       %{name} = %{version}-%{release}
-Requires:       python3-javapackages = %{version}-%{release}
-Requires:       %{python_interpreter}
- 
-%description -n javapackages-generators
-RPM dependency generators to support Java packaging.
-
 %prep
 %autosetup -p1 -n javapackages-%{version}
 
@@ -121,8 +113,6 @@ pip3 install -r test-requirements.txt
 
 %files -n javapackages-filesystem -f files-filesystem
 
-%files -n javapackages-generators -f files-generators
-
 %files -n javapackages-local-bootstrap -f files-local
 
 %files -n ivy-local-bootstrap -f files-ivy
@@ -131,11 +121,6 @@ pip3 install -r test-requirements.txt
 %license LICENSE
 
 %changelog
-* Thu Feb 24 2022 Cameron Baird <cameronbaird@microsoft.com> - 6.0.0-1
-- Update source to v6.0.0
-- Update remove-headless-from-java-requires.patch
-- Add javapackages-generators 
-
 * Wed Jan 05 2022 Thomas Crain <thcrain@microsoft.com> - 5.3.0-14
 - Add patch to replace generated dependency on "java-headless" with "java"
 - Amend epoch patch to fix expected test results

--- a/SPECS/javapackages-tools/remove-headless-from-java-requires.patch
+++ b/SPECS/javapackages-tools/remove-headless-from-java-requires.patch
@@ -1,5 +1,30 @@
+From 604a4ce5426099bc6459911c7773ffe39055febf Mon Sep 17 00:00:00 2001
+From: Thomas Crain <thcrain@microsoft.com>
+Date: Wed, 5 Jan 2022 11:01:54 -0800
+Subject: [PATCH 2/2] Replace java-headless generated requirement with java
+
+---
+ etc/javapackages-config-SCL.json              |  2 +-
+ etc/javapackages-config.json                  |  2 +-
+ .../config/filtered/javapackages-config.json  |  2 +-
+ test/maven_req_test.py                        | 62 +++++++++----------
+ 4 files changed, 34 insertions(+), 34 deletions(-)
+
+diff --git a/etc/javapackages-config-SCL.json b/etc/javapackages-config-SCL.json
+index 72dd5fb..789559d 100644
+--- a/etc/javapackages-config-SCL.json
++++ b/etc/javapackages-config-SCL.json
+@@ -4,7 +4,7 @@
+             "@{scl}-runtime"
+         ],
+         "java_requires": {
+-            "package_name": "java-headless",
++            "package_name": "java",
+             "always_generate": true,
+             "skip": false
+         },
 diff --git a/etc/javapackages-config.json b/etc/javapackages-config.json
-index 601fedcb..2e94ceb2 100644
+index 601fedc..2e94ceb 100644
 --- a/etc/javapackages-config.json
 +++ b/etc/javapackages-config.json
 @@ -4,7 +4,7 @@
@@ -12,7 +37,7 @@ index 601fedcb..2e94ceb2 100644
              "skip": false
          },
 diff --git a/test/data/config/filtered/javapackages-config.json b/test/data/config/filtered/javapackages-config.json
-index 7951d913..3feb345a 100644
+index 7951d91..3feb345 100644
 --- a/test/data/config/filtered/javapackages-config.json
 +++ b/test/data/config/filtered/javapackages-config.json
 @@ -4,7 +4,7 @@
@@ -25,7 +50,7 @@ index 7951d913..3feb345a 100644
              "skip": false
          },
 diff --git a/test/maven_req_test.py b/test/maven_req_test.py
-index b5ea4456..377b6143 100644
+index d7cb969..5650482 100644
 --- a/test/maven_req_test.py
 +++ b/test/maven_req_test.py
 @@ -21,7 +21,7 @@ class TestMavenReq(unittest.TestCase):
@@ -302,3 +327,6 @@ index b5ea4456..377b6143 100644
          self.assertEqual(set(want), set(sout))
  
  if __name__ == '__main__':
+-- 
+2.25.1
+

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -7891,8 +7891,8 @@
         "type": "other",
         "other": {
           "name": "javapackages-tools",
-          "version": "6.0.0",
-          "downloadUrl": "https://github.com/fedora-java/javapackages/archive/6.0.0.tar.gz"
+          "version": "5.3.0",
+          "downloadUrl": "https://github.com/fedora-java/javapackages/archive/5.3.0.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

The 6.0.0 version of `javapackages-tools` removes some RPM macro we rely on heavily in our builds. It might take a while before we get an update, which works with our other specs. Until then, I'm reverting #2318 to unblock our builds.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Reverted `javapackages-tools` back to version 5.3.0.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #2318

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local package build.
