### PR TITLE
[main] Removing shell dependency from `icu` and `krb5` packages.

### DIFF
--- a/SPECS/icu/icu.spec
+++ b/SPECS/icu/icu.spec
@@ -1,7 +1,9 @@
+%define __requires_exclude ^/(usr/)?bin/(ba)?sh$
+
 Summary:        International Components for Unicode.
 Name:           icu
 Version:        68.2.0.6
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        BSD and MIT and Public Domain and naist-2003
 URL:            https://github.com/microsoft/icu
 Group:          System Environment/Libraries
@@ -61,6 +63,8 @@ make -C icu/icu4c/source DESTDIR=%{buildroot} install
 %{_libdir}/pkgconfig/*.pc
 
 %changelog
+* Mon Feb 28 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 68.2.0.6-2
+- Removing dependcy on Bash.
 
 * Fri Apr 16 2021 CBL-Mariner Service Account <cblmargh@microsoft.com> - 68.2.0.6-1
 - Update to version  "68.2.0.6".

--- a/SPECS/krb5/krb5.spec
+++ b/SPECS/krb5/krb5.spec
@@ -1,7 +1,9 @@
+%define __requires_exclude ^/(usr/)?bin/(ba)?sh$
+
 Summary:        The Kerberos newtork authentication system
 Name:           krb5
 Version:        1.18
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -117,6 +119,9 @@ make check
 %{_datarootdir}/locale/*
 
 %changelog
+* Mon Feb 28 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.18-4
+- Removing dependcy on Bash.
+
 * Tue Feb 08 2022 Thomas Crain <thcrain@microsoft.com> - 1.18-3
 - Remove manual pkgconfig(*) provides in toolchain specs
 

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -186,7 +186,7 @@ libsolv-0.7.20-1.cm2.aarch64.rpm
 libsolv-devel-0.7.20-1.cm2.aarch64.rpm
 libssh2-1.9.0-2.cm2.aarch64.rpm
 libssh2-devel-1.9.0-2.cm2.aarch64.rpm
-krb5-1.18-3.cm2.aarch64.rpm
+krb5-1.18-4.cm2.aarch64.rpm
 curl-7.76.0-6.cm2.aarch64.rpm
 curl-devel-7.76.0-6.cm2.aarch64.rpm
 curl-libs-7.76.0-6.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -186,7 +186,7 @@ libsolv-0.7.20-1.cm2.x86_64.rpm
 libsolv-devel-0.7.20-1.cm2.x86_64.rpm
 libssh2-1.9.0-2.cm2.x86_64.rpm
 libssh2-devel-1.9.0-2.cm2.x86_64.rpm
-krb5-1.18-3.cm2.x86_64.rpm
+krb5-1.18-4.cm2.x86_64.rpm
 curl-7.76.0-6.cm2.x86_64.rpm
 curl-devel-7.76.0-6.cm2.x86_64.rpm
 curl-libs-7.76.0-6.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -135,10 +135,10 @@ kernel-headers-5.15.18.1-2.cm2.noarch.rpm
 kmod-29-1.cm2.aarch64.rpm
 kmod-debuginfo-29-1.cm2.aarch64.rpm
 kmod-devel-29-1.cm2.aarch64.rpm
-krb5-1.18-3.cm2.aarch64.rpm
-krb5-debuginfo-1.18-3.cm2.aarch64.rpm
-krb5-devel-1.18-3.cm2.aarch64.rpm
-krb5-lang-1.18-3.cm2.aarch64.rpm
+krb5-1.18-4.cm2.aarch64.rpm
+krb5-debuginfo-1.18-4.cm2.aarch64.rpm
+krb5-devel-1.18-4.cm2.aarch64.rpm
+krb5-lang-1.18-4.cm2.aarch64.rpm
 libarchive-3.4.2-5.cm2.aarch64.rpm
 libarchive-debuginfo-3.4.2-5.cm2.aarch64.rpm
 libarchive-devel-3.4.2-5.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -135,10 +135,10 @@ kernel-headers-5.15.18.1-2.cm2.noarch.rpm
 kmod-29-1.cm2.x86_64.rpm
 kmod-debuginfo-29-1.cm2.x86_64.rpm
 kmod-devel-29-1.cm2.x86_64.rpm
-krb5-1.18-3.cm2.x86_64.rpm
-krb5-debuginfo-1.18-3.cm2.x86_64.rpm
-krb5-devel-1.18-3.cm2.x86_64.rpm
-krb5-lang-1.18-3.cm2.x86_64.rpm
+krb5-1.18-4.cm2.x86_64.rpm
+krb5-debuginfo-1.18-4.cm2.x86_64.rpm
+krb5-devel-1.18-4.cm2.x86_64.rpm
+krb5-lang-1.18-4.cm2.x86_64.rpm
 libarchive-3.4.2-5.cm2.x86_64.rpm
 libarchive-debuginfo-3.4.2-5.cm2.x86_64.rpm
 libarchive-devel-3.4.2-5.cm2.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

We have a growing need to use Mariner's packages in distroless containers and one of the frequently hit issues is that packages have a an implicit dependency on the shell either by having a `%(post|pre)` section or by containing scripts, which depend on an interpreted through the `#!` line. This PR removes shell dependencies from the `icu` and `krb5` packages. The assumption is that distroless images do not include a shell, so there's no expectation to be able to run any shell scripts and **non**-distroless images always have a shell (Bash) installed, so it's present anyway.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Removed dependency on a shell from `icu` and `krb5`.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local package builds.
