### PR TITLE
[1.0-dev] python3: Add patch to fix XML tests with newer expat

### DIFF
--- a/SPECS/python3/fix-xml-tests-expat.patch
+++ b/SPECS/python3/fix-xml-tests-expat.patch
@@ -1,0 +1,101 @@
+From d4f5bb912e67299b59b814b89a5afd9a8821a14e Mon Sep 17 00:00:00 2001
+From: "Miss Islington (bot)"
+ <31488909+miss-islington@users.noreply.github.com>
+Date: Mon, 21 Feb 2022 11:03:08 -0800
+Subject: [PATCH] bpo-46811: Make test suite support Expat >=2.4.5 (GH-31453)
+ (GH-31471)
+
+Curly brackets were never allowed in namespace URIs
+according to RFC 3986, and so-called namespace-validating
+XML parsers have the right to reject them a invalid URIs.
+
+libexpat >=2.4.5 has become strcter in that regard due to
+related security issues; with ET.XML instantiating a
+namespace-aware parser under the hood, this test has no
+future in CPython.
+
+References:
+- https://datatracker.ietf.org/doc/html/rfc3968
+- https://www.w3.org/TR/xml-names/
+
+Also, test_minidom.py: Support Expat >=2.4.5
+(cherry picked from commit 2cae93832f46b245847bdc252456ddf7742ef45e)
+
+Co-authored-by: Sebastian Pipping <sebastian@pipping.org>
+---
+ Lib/test/test_minidom.py                        | 17 +++++++++++++++--
+ Lib/test/test_xml_etree.py                      |  6 ------
+ .../2022-02-20-21-03-31.bpo-46811.8BxgdQ.rst    |  1 +
+ 3 files changed, 16 insertions(+), 8 deletions(-)
+ create mode 100644 Misc/NEWS.d/next/Library/2022-02-20-21-03-31.bpo-46811.8BxgdQ.rst
+
+diff --git a/Lib/test/test_minidom.py b/Lib/test/test_minidom.py
+index 041a41511314a..0b76f6e87bc50 100644
+--- a/Lib/test/test_minidom.py
++++ b/Lib/test/test_minidom.py
+@@ -5,10 +5,12 @@
+ from test import support
+ import unittest
+ 
++import pyexpat
+ import xml.dom.minidom
+ 
+ from xml.dom.minidom import parse, Node, Document, parseString
+ from xml.dom.minidom import getDOMImplementation
++from xml.parsers.expat import ExpatError
+ 
+ 
+ tstfile = support.findfile("test.xml", subdir="xmltestdata")
+@@ -1146,7 +1148,13 @@ def testEncodings(self):
+ 
+         # Verify that character decoding errors raise exceptions instead
+         # of crashing
+-        self.assertRaises(UnicodeDecodeError, parseString,
++        if pyexpat.version_info >= (2, 4, 5):
++            self.assertRaises(ExpatError, parseString,
++                    b'<fran\xe7ais></fran\xe7ais>')
++            self.assertRaises(ExpatError, parseString,
++                    b'<franais>Comment \xe7a va ? Tr\xe8s bien ?</franais>')
++        else:
++            self.assertRaises(UnicodeDecodeError, parseString,
+                 b'<fran\xe7ais>Comment \xe7a va ? Tr\xe8s bien ?</fran\xe7ais>')
+ 
+         doc.unlink()
+@@ -1592,7 +1600,12 @@ def testEmptyXMLNSValue(self):
+         self.confirm(doc2.namespaceURI == xml.dom.EMPTY_NAMESPACE)
+ 
+     def testExceptionOnSpacesInXMLNSValue(self):
+-        with self.assertRaisesRegex(ValueError, 'Unsupported syntax'):
++        if pyexpat.version_info >= (2, 4, 5):
++            context = self.assertRaisesRegex(ExpatError, 'syntax error')
++        else:
++            context = self.assertRaisesRegex(ValueError, 'Unsupported syntax')
++
++        with context:
+             parseString('<element xmlns:abc="http:abc.com/de f g/hi/j k"><abc:foo /></element>')
+ 
+     def testDocRemoveChild(self):
+diff --git a/Lib/test/test_xml_etree.py b/Lib/test/test_xml_etree.py
+index 75c9c25a8b639..5ba0de82cdf9a 100644
+--- a/Lib/test/test_xml_etree.py
++++ b/Lib/test/test_xml_etree.py
+@@ -1683,12 +1683,6 @@ def test_issue6233(self):
+                 b"<?xml version='1.0' encoding='ascii'?>\n"
+                 b'<body>t&#227;g</body>')
+ 
+-    def test_issue3151(self):
+-        e = ET.XML('<prefix:localname xmlns:prefix="${stuff}"/>')
+-        self.assertEqual(e.tag, '{${stuff}}localname')
+-        t = ET.ElementTree(e)
+-        self.assertEqual(ET.tostring(e), b'<ns0:localname xmlns:ns0="${stuff}" />')
+-
+     def test_issue6565(self):
+         elem = ET.XML("<body><tag/></body>")
+         self.assertEqual(summarize_list(elem), ['tag'])
+diff --git a/Misc/NEWS.d/next/Library/2022-02-20-21-03-31.bpo-46811.8BxgdQ.rst b/Misc/NEWS.d/next/Library/2022-02-20-21-03-31.bpo-46811.8BxgdQ.rst
+new file mode 100644
+index 0000000000000..6969bd1898f65
+--- /dev/null
++++ b/Misc/NEWS.d/next/Library/2022-02-20-21-03-31.bpo-46811.8BxgdQ.rst
+@@ -0,0 +1 @@
++Make test suite support Expat >=2.4.5

--- a/SPECS/python3/python3.spec
+++ b/SPECS/python3/python3.spec
@@ -15,6 +15,8 @@ Patch1:         python3-support-mariner-platform.patch
 Patch2:         Replace-unsupported-TLS-methods.patch
 Patch3:         fix_broken_mariner_ssl_tests.patch
 Patch4:         CVE-2022-0391.patch
+# Upstream patch to fix XML tests with expat >= 2.4.5
+Patch5:         fix-xml-tests-expat.patch
 BuildRequires:  bzip2-devel
 BuildRequires:  expat-devel >= 2.1.0
 BuildRequires:  libffi-devel >= 3.0.13
@@ -275,6 +277,9 @@ make  %{?_smp_mflags} test
 %{_libdir}/python3.7/test/*
 
 %changelog
+* Tue Mar 01 2022 Thomas Crain <thcrain@microsoft.com> - 3.7.10-7
+- Add patch to fix tests with expat >= 2.4.5
+
 * Fri Feb 18 2022 Cameron Baird <cameronbaird@microsoft.com> - 3.7.10-6
 - Patch CVE-2022-0391
 

--- a/SPECS/python3/python3.spec
+++ b/SPECS/python3/python3.spec
@@ -3,7 +3,7 @@
 Summary:        A high-level scripting language
 Name:           python3
 Version:        3.7.10
-Release:        6%{?dist}
+Release:        7%{?dist}
 License:        PSF
 Vendor:         Microsoft Corporation
 Distribution:   Mariner


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
A recent `expat` security fix broke some of the package tests for `python3` by enforcing XML standards more thoroughly. So, let's take an upstream patch to fix these tests.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- `python3`: Add patch to fix tests with expat >= 2.4.5

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Full pipeline build, tests now pass
