### PR TITLE
[main] Tidying up `Release` tag restrictions.

### DIFF
--- a/SPECS/shim/shim.spec
+++ b/SPECS/shim/shim.spec
@@ -1,9 +1,9 @@
 %global debug_package %{nil}
-%global release_number 2
+%define release_number %(echo "%{release}" | cut -d. -f1)
 Summary:        First stage UEFI bootloader
 Name:           shim
 Version:        15.4
-Release:        %{release_number}%{?dist}
+Release:        2%{?dist}
 License:        BSD
 Vendor:         Microsoft Corporation
 Distribution:   Mariner

--- a/toolkit/scripts/check_spec_guidelines.py
+++ b/toolkit/scripts/check_spec_guidelines.py
@@ -15,7 +15,7 @@ license_regex = re.compile(
     r"\b(license verified|verified license)\b", re.IGNORECASE)
 
 valid_release_tag_regex = re.compile(
-    r'^([1-9]\d*|%\{release_number\})%\{\?dist\}$')
+    r'^[1-9]\d*%\{\?dist\}$')
 
 valid_source_attributions_one_per_line = "\n".join(f"- {key}: '{value}'" for key, value in VALID_SOURCE_ATTRIBUTIONS.items())
 
@@ -28,21 +28,11 @@ def check_release_tag(spec_path: str):
         print(f"""
 ERROR: invalid 'Release' tag.
 
-    Accepted formats are:
-    - '[number]%{{?dist}}' (example: 10%{{?dist}}),
-    - '%{{release_number}}%{{?dist}}', where the value of 'release_number' must be a single number.
+    Accepted format is:
+
+        '[number]%{{?dist}}' (example: 10%{{?dist}})
 """)
         return False
-
-    if "release_number" in spec.release:
-        if not spec.macros["release_number"].isdigit():
-            print(f"""
-ERROR: invalid 'Release' tag.
-
-    The 'release_number' macro must be a plain number (no nested macros).
-    Found '{spec.macros["release_number"]}' instead.
-""")
-            return False
 
     return True
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

A small clean-up making sure all of our specs follow a uniform `Release` tag format.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Removed exception for the `release_number` macro in defining the value for the `Release` tag.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local check script run.
