### PR TITLE
Bump Mariner 1.0 Release version for March 2022 Update

### DIFF
--- a/SPECS/mariner-release/mariner-release.spec
+++ b/SPECS/mariner-release/mariner-release.spec
@@ -1,7 +1,7 @@
 Summary:       CBL-Mariner release files
 Name:          mariner-release
 Version:       1.0
-Release:       35%{?dist}
+Release:       36%{?dist}
 License:       MIT
 Group:         System Environment/Base
 URL:           https://aka.ms/cbl-mariner
@@ -67,8 +67,10 @@ rm -rf $RPM_BUILD_ROOT
 %config(noreplace) /etc/issue.net
 
 %changelog
-*   Fri Feb 25 2022 Jon Slobodzian <joslobo@microsoft.com> - 1.0-35
+*   Sat Mar 05 2022 Jon Slobodzian <joslobo@microsoft.com> - 1.0-36
 -   Updating version for March update.
+*   Fri Feb 25 2022 Jon Slobodzian <joslobo@microsoft.com> - 1.0-35
+-   Updating version for February update 2.
 *   Thu Feb 24 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.0-34
 -   Surrounding 'VERSION_ID' inside 'os-release' with double quotes.
 *   Mon Feb 07 2022 Jon Slobodzian <joslobo@microsoft.com> - 1.0-33

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -58,7 +58,7 @@ findutils-lang-4.6.0-7.cm1.aarch64.rpm
 gettext-0.19.8.1-5.cm1.aarch64.rpm
 gzip-1.9-5.cm1.aarch64.rpm
 make-4.2.1-5.cm1.aarch64.rpm
-mariner-release-1.0-35.cm1.noarch.rpm
+mariner-release-1.0-36.cm1.noarch.rpm
 patch-2.7.6-7.cm1.aarch64.rpm
 util-linux-2.32.1-5.cm1.aarch64.rpm
 util-linux-devel-2.32.1-5.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -58,7 +58,7 @@ findutils-lang-4.6.0-7.cm1.x86_64.rpm
 gettext-0.19.8.1-5.cm1.x86_64.rpm
 gzip-1.9-5.cm1.x86_64.rpm
 make-4.2.1-5.cm1.x86_64.rpm
-mariner-release-1.0-35.cm1.noarch.rpm
+mariner-release-1.0-36.cm1.noarch.rpm
 patch-2.7.6-7.cm1.x86_64.rpm
 util-linux-2.32.1-5.cm1.x86_64.rpm
 util-linux-devel-2.32.1-5.cm1.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -260,7 +260,7 @@ m4-debuginfo-1.4.18-4.cm1.aarch64.rpm
 make-4.2.1-5.cm1.aarch64.rpm
 make-debuginfo-4.2.1-5.cm1.aarch64.rpm
 mariner-check-macros-1.0-8.cm1.noarch.rpm
-mariner-release-1.0-35.cm1.noarch.rpm
+mariner-release-1.0-36.cm1.noarch.rpm
 mariner-repos-1.0-14.cm1.noarch.rpm
 mariner-repos-extras-1.0-14.cm1.noarch.rpm
 mariner-repos-extras-preview-1.0-14.cm1.noarch.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -260,7 +260,7 @@ m4-debuginfo-1.4.18-4.cm1.x86_64.rpm
 make-4.2.1-5.cm1.x86_64.rpm
 make-debuginfo-4.2.1-5.cm1.x86_64.rpm
 mariner-check-macros-1.0-8.cm1.noarch.rpm
-mariner-release-1.0-35.cm1.noarch.rpm
+mariner-release-1.0-36.cm1.noarch.rpm
 mariner-repos-1.0-14.cm1.noarch.rpm
 mariner-repos-extras-1.0-14.cm1.noarch.rpm
 mariner-repos-extras-preview-1.0-14.cm1.noarch.rpm


### PR DESCRIPTION
Bump Mariner 1.0 Release version for March 2022 Update