### PR TITLE
Bootstrap toolchain build with mariner container

### DIFF
--- a/toolkit/scripts/toolchain/cgmanifest.json
+++ b/toolkit/scripts/toolchain/cgmanifest.json
@@ -4,9 +4,9 @@
             "Component": {
                 "Type": "DockerImage",
                 "DockerImage": {
-                    "Name": "Ubuntu",
-                    "Digest": "sha256:bec5a2727be7fff3d308193cfde3491f8fba1a2ba392b7546b43a051853a341d",
-                    "Tag": "18.04"
+                    "Name": "cblmariner.azurecr.io/base/core",
+                    "Digest": "sha256:665cd7cf847ac0bd7321398a13397d35a23a784569c14ca52cef64379e2328bf",
+                    "Tag": "1.0.20220226"
                 }
             }
         }

--- a/toolkit/scripts/toolchain/cgmanifest.json
+++ b/toolkit/scripts/toolchain/cgmanifest.json
@@ -4,8 +4,8 @@
             "Component": {
                 "Type": "DockerImage",
                 "DockerImage": {
-                    "Name": "cblmariner.azurecr.io/base/core",
-                    "Digest": "sha256:665cd7cf847ac0bd7321398a13397d35a23a784569c14ca52cef64379e2328bf",
+                    "Name": "mcr.microsoft.com/cbl-mariner/base/core",
+                    "Digest": "sha256:0a92146c52c59d25475e93d2acb0d7011af9411a57e237750eee7dd7c4fbbe59",
                     "Tag": "1.0.20220226"
                 }
             }

--- a/toolkit/scripts/toolchain/container/Dockerfile
+++ b/toolkit/scripts/toolchain/container/Dockerfile
@@ -3,7 +3,7 @@
 #
 # Dockerfile to Mariner toolchain from scratch
 #
-FROM cblmariner.azurecr.io/base/core:1.0.20220226
+FROM mcr.microsoft.com/cbl-mariner/base/core:1.0.20220226
 
 # Define LFS root directory and setup environment variables
 ENV LFS=/temptoolchain/lfs

--- a/toolkit/scripts/toolchain/container/Dockerfile
+++ b/toolkit/scripts/toolchain/container/Dockerfile
@@ -3,7 +3,7 @@
 #
 # Dockerfile to Mariner toolchain from scratch
 #
-FROM cblmariner.azurecr.io/base/core:1.0
+FROM cblmariner.azurecr.io/base/core:1.0.20220226
 
 # Define LFS root directory and setup environment variables
 ENV LFS=/temptoolchain/lfs
@@ -15,26 +15,26 @@ COPY [ "./version-check-container.sh", \
 
 # Install toolchain build dependencies
 RUN tdnf install -y \
-    build-essential \
     bison \
+    build-essential \
+    byacc \
+    ca-certificates \
+    ccache \
+    cpio \
+    file \
+    flex \
     gawk \
     gcc \
     make \
     patch \
+    perl \
     rpm \
-    texinfo \
     sudo \
+    texinfo \
+    unzip \
     vim \
     wget \
-    cpio \
-    file \
-    unzip \
-    zip \
-    ccache \
-    flex \
-    byacc \
-    ca-certificates \
-    perl && \
+    zip && \
     ln    -sf bash /bin/sh && \
     mkdir -pv $LFS/sources && \
     chmod -v a+wt $LFS/sources && \
@@ -62,7 +62,7 @@ USER root
 RUN sha256sum -c $LFS/tools/toolchain-sha256sums && \
     groupadd lfs && \
     useradd -s /bin/bash -g lfs -m -k /dev/null lfs && \
-    echo "lfs:lf2asfasf" | chpasswd && \
+    echo "lfs:lfscblmariner" | chpasswd && \
     usermod -a -G sudo lfs && \
     chown -v lfs $LFS/tools && \
     chown -v lfs $LFS/sources && \

--- a/toolkit/scripts/toolchain/container/Dockerfile
+++ b/toolkit/scripts/toolchain/container/Dockerfile
@@ -55,9 +55,9 @@ COPY [ "./toolchain-sha256sums", \
 # Note: Fetch the kernel sources differently to ensure we rename the source tarball appropriately. The rename is needed to comply with
 # the naming convention of the source cache (convention used to prevent naming collisions).
 WORKDIR $LFS/sources
-RUN wget -nv --no-clobber --timeout=30 --no-check-certificate --continue --input-file=$LFS/tools/toolchain-local-wget-list --directory-prefix=$LFS/sources; exit 0
-RUN wget -nv --no-clobber --timeout=30 --no-check-certificate --continue --input-file=$LFS/tools/toolchain-remote-wget-list --directory-prefix=$LFS/sources; exit 0
-RUN wget -nv --no-clobber --timeout=30 --no-check-certificate --continue https://github.com/microsoft/CBL-Mariner-Linux-Kernel/archive/rolling-lts/mariner/5.15.18.1.tar.gz -O kernel-5.15.18.1.tar.gz --directory-prefix=$LFS/sources; exit 0
+RUN wget -nv --no-clobber --timeout=30 --continue --input-file=$LFS/tools/toolchain-local-wget-list --directory-prefix=$LFS/sources; exit 0
+RUN wget -nv --no-clobber --timeout=30 --continue --input-file=$LFS/tools/toolchain-remote-wget-list --directory-prefix=$LFS/sources; exit 0
+RUN wget -nv --no-clobber --timeout=30 --continue https://github.com/microsoft/CBL-Mariner-Linux-Kernel/archive/rolling-lts/mariner/5.15.18.1.tar.gz -O kernel-5.15.18.1.tar.gz --directory-prefix=$LFS/sources; exit 0
 USER root
 RUN sha256sum -c $LFS/tools/toolchain-sha256sums && \
     groupadd lfs && \

--- a/toolkit/scripts/toolchain/container/Dockerfile
+++ b/toolkit/scripts/toolchain/container/Dockerfile
@@ -3,7 +3,7 @@
 #
 # Dockerfile to Mariner toolchain from scratch
 #
-FROM ubuntu:18.04
+FROM cblmariner.azurecr.io/base/core:1.0
 
 # Define LFS root directory and setup environment variables
 ENV LFS=/temptoolchain/lfs
@@ -14,15 +14,13 @@ COPY [ "./version-check-container.sh", \
        "$LFS/tools/" ]
 
 # Install toolchain build dependencies
-RUN apt-get update -y -qq && \
-    DEBIAN_FRONTEND=noninteractive apt-get -yq install \
+RUN tdnf install -y \
+    build-essential \
     bison \
     gawk \
     gcc \
-    g++ \
     make \
     patch \
-    python-aptdaemon \
     rpm \
     texinfo \
     sudo \
@@ -33,8 +31,10 @@ RUN apt-get update -y -qq && \
     unzip \
     zip \
     ccache \
-    flex && \
-    apt-get clean && \
+    flex \
+    byacc \
+    ca-certificates \
+    perl && \
     ln    -sf bash /bin/sh && \
     mkdir -pv $LFS/sources && \
     chmod -v a+wt $LFS/sources && \
@@ -56,14 +56,14 @@ COPY [ "./toolchain-sha256sums", \
 # the naming convention of the source cache (convention used to prevent naming collisions).
 WORKDIR $LFS/sources
 RUN wget -nv --no-clobber --timeout=30 --no-check-certificate --continue --input-file=$LFS/tools/toolchain-local-wget-list --directory-prefix=$LFS/sources; exit 0
-RUN wget -nv --no-clobber --timeout=30 --continue --input-file=$LFS/tools/toolchain-remote-wget-list --directory-prefix=$LFS/sources; exit 0
-RUN wget -nv --no-clobber --timeout=30 --continue https://github.com/microsoft/CBL-Mariner-Linux-Kernel/archive/rolling-lts/mariner/5.15.18.1.tar.gz -O kernel-5.15.18.1.tar.gz --directory-prefix=$LFS/sources; exit 0
+RUN wget -nv --no-clobber --timeout=30 --no-check-certificate --continue --input-file=$LFS/tools/toolchain-remote-wget-list --directory-prefix=$LFS/sources; exit 0
+RUN wget -nv --no-clobber --timeout=30 --no-check-certificate --continue https://github.com/microsoft/CBL-Mariner-Linux-Kernel/archive/rolling-lts/mariner/5.15.18.1.tar.gz -O kernel-5.15.18.1.tar.gz --directory-prefix=$LFS/sources; exit 0
 USER root
 RUN sha256sum -c $LFS/tools/toolchain-sha256sums && \
     groupadd lfs && \
     useradd -s /bin/bash -g lfs -m -k /dev/null lfs && \
-    echo "lfs:lfs" | chpasswd && \
-    adduser lfs sudo && \
+    echo "lfs:lf2asfasf" | chpasswd && \
+    usermod -a -G sudo lfs && \
     chown -v lfs $LFS/tools && \
     chown -v lfs $LFS/sources && \
     chown -Rv lfs $LFS/logs && \

--- a/toolkit/scripts/toolchain/container/version-check-container.sh
+++ b/toolkit/scripts/toolchain/container/version-check-container.sh
@@ -16,7 +16,7 @@ bison --version | head -n1
 if [ -h /usr/bin/yacc ]; then
   echo "/usr/bin/yacc -> `readlink -f /usr/bin/yacc`";
 elif [ -x /usr/bin/yacc ]; then
-  echo yacc is `/usr/bin/yacc --version | head -n1`
+  echo yacc is `/usr/bin/yacc -V | head -n1`
 else
   echo "yacc not found"
 fi


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?

The Mariner toolchain builds have previously been bootstrapped with an ubuntu 18.04 container, to compile the initial toolchain packages from scratch. This change switches to a recent Mariner 1.0 container image (1.0.20220226), which removes our dependency on another distribution for full toolchain builds. I've also seen slightly faster (~15-30min) toolchain builds on x64. This could be due to some newer utilities in the Mariner container (gcc 7.5.0 -> 9.1.0, binutils 2.30 -> 2.36.1, glibc 2.27 -> 2.28)


###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change toolchain Dockerfile to use mariner 1.0 container instead of ubuntu 18.04 container

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: 174151 (AMD64)
- Pipeline build id: 174152 (AMD64)