### PR TITLE
Upgrade libedit to 3.1.20210910

### DIFF
--- a/SPECS/libedit/libedit.signatures.json
+++ b/SPECS/libedit/libedit.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "libedit-20180525-3.1.tar.gz": "c41bea8fd140fb57ba67a98ec1d8ae0b8ffa82f4aba9c35a87e5a9499e653116"
+  "libedit-20210910-3.1.tar.gz": "6792a6a992050762edcca28ff3318cdb7de37dccf7bc30db59fcd7017eed13c5"
  }
 }

--- a/SPECS/libedit/libedit.spec
+++ b/SPECS/libedit/libedit.spec
@@ -1,10 +1,10 @@
 %define libedit_version 3.1
-%define libedit_release 20180525
+%define libedit_release 20210910
 
 Summary:        The NetBSD Editline library
 Name:           libedit
-Version:        3.1.20180525
-Release:        6%{?dist}
+Version:        3.1.20210910
+Release:        1%{?dist}
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Source0:        https://www.thrysoee.dk/editline/libedit-%{libedit_release}-%{libedit_version}.tar.gz
@@ -84,16 +84,23 @@ rm -rf %{buildroot}/%{_mandir}/man3/history.3*
     %{_includedir}/*
 
 %changelog
+*   Fri Mar 11 2022 Jon Slobodzian <joslobo@microsoft.com> - 3.1.20210910-1
+-   Upgrade to 3.1.20210910-1
+
 *   Thu Dec 16 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 3.1.20180525-6
 -   Removing the explicit %%clean stage.
 
 *   Wed Aug 05 2020 Andrew Phelps <anphel@microsoft.com> 3.1.20180525-5
 -   Remove conflicting file _mandir/man3/history.3*
+
 *   Sat May 09 2020 Nick Samson <nisamson@microsoft.com> 3.1.20180525-4
 -   Added %%license line automatically
+
 *   Mon Apr 13 2020 Jon Slobodzian <joslobo@microsoft.com> 3.1.20180525-3
 -   Verified license. Removed sha1. Fixed Source0 URL.
+
 *   Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 3.1.20180525-2
 -   Initial CBL-Mariner import from Photon (license: Apache2).
+
 *   Tue Aug 14 2018 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 3.1.20180525-1
 -   Initial

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -9321,8 +9321,8 @@
         "type": "other",
         "other": {
           "name": "libedit",
-          "version": "3.1.20180525",
-          "downloadUrl": "https://www.thrysoee.dk/editline/libedit-20180525-3.1.tar.gz"
+          "version": "3.1.20210910",
+          "downloadUrl": "https://www.thrysoee.dk/editline/libedit-20210910-3.1.tar.gz"
         }
       }
     },


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x]Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
This change upgrades libedit to the latest version for Mariner 2.0

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO
