### PR TITLE
Fix circular dependency from audit

### DIFF
--- a/SPECS/audit/audit.spec
+++ b/SPECS/audit/audit.spec
@@ -1,7 +1,7 @@
 Summary:        Kernel Audit Tool
 Name:           audit
 Version:        3.0.6
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        GPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -12,13 +12,14 @@ Patch0:         refuse-manual-stop.patch
 BuildRequires:  e2fsprogs-devel
 BuildRequires:  krb5-devel
 BuildRequires:  swig
-BuildRequires:  systemd-bootstrap
 Requires:       %{name}-libs = %{version}-%{release}
 Requires:       gawk
 Requires:       krb5
 Requires:       libcap-ng
 Requires:       openldap
-Requires:       systemd
+# Break circular dependency with systemd by using weak dependency tag 'Recommends'
+# Systemd should always be installed in a running system
+Recommends:     systemd
 
 %description
 The audit package contains the user space utilities for
@@ -141,6 +142,9 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %{python3_sitelib}/*
 
 %changelog
+* Tue Mar 15 2022 Andrew Phelps <anphel@microsoft.com> - 3.0.6-4
+- Break circular dependency with systemd by using Recommends
+
 * Fri Mar 04 2022 Andrew Phelps <anphel@microsoft.com> - 3.0.6-3
 - Reduce build requirements to build in toolchain environment
 

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -242,5 +242,5 @@ newt-0.52.21-3.cm2.aarch64.rpm
 chkconfig-1.20-2.cm2.aarch64.rpm
 msopenjdk-11-11.0.13+8-LTS-4.aarch64.rpm
 pyproject-rpm-macros-1.0.0~rc1-2.cm2.noarch.rpm
-audit-3.0.6-3.cm2.aarch64.rpm
-audit-libs-3.0.6-3.cm2.aarch64.rpm
+audit-3.0.6-4.cm2.aarch64.rpm
+audit-libs-3.0.6-4.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -242,5 +242,5 @@ newt-0.52.21-3.cm2.x86_64.rpm
 chkconfig-1.20-2.cm2.x86_64.rpm
 msopenjdk-11-11.0.13+8-LTS-4.x86_64.rpm
 pyproject-rpm-macros-1.0.0~rc1-2.cm2.noarch.rpm
-audit-3.0.6-3.cm2.x86_64.rpm
-audit-libs-3.0.6-3.cm2.x86_64.rpm
+audit-3.0.6-4.cm2.x86_64.rpm
+audit-libs-3.0.6-4.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -2,10 +2,10 @@ alsa-lib-1.2.6.1-1.cm2.aarch64.rpm
 alsa-lib-debuginfo-1.2.6.1-1.cm2.aarch64.rpm
 alsa-lib-devel-1.2.6.1-1.cm2.aarch64.rpm
 asciidoc-9.1.0-1.cm2.noarch.rpm
-audit-3.0.6-3.cm2.aarch64.rpm
-audit-debuginfo-3.0.6-3.cm2.aarch64.rpm
-audit-devel-3.0.6-3.cm2.aarch64.rpm
-audit-libs-3.0.6-3.cm2.aarch64.rpm
+audit-3.0.6-4.cm2.aarch64.rpm
+audit-debuginfo-3.0.6-4.cm2.aarch64.rpm
+audit-devel-3.0.6-4.cm2.aarch64.rpm
+audit-libs-3.0.6-4.cm2.aarch64.rpm
 autoconf-2.71-1.cm2.noarch.rpm
 automake-1.16.5-1.cm2.noarch.rpm
 bash-5.1.8-1.cm2.aarch64.rpm
@@ -494,7 +494,7 @@ procps-ng-lang-3.3.17-1.cm2.aarch64.rpm
 pyproject-rpm-macros-1.0.0~rc1-2.cm2.noarch.rpm
 python-markupsafe-debuginfo-2.1.0-1.cm2.aarch64.rpm
 python3-3.9.10-1.cm2.aarch64.rpm
-python3-audit-3.0.6-3.cm2.aarch64.rpm
+python3-audit-3.0.6-4.cm2.aarch64.rpm
 python3-cracklib-2.9.7-4.cm2.aarch64.rpm
 python3-curses-3.9.10-1.cm2.aarch64.rpm
 python3-debuginfo-3.9.10-1.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -2,10 +2,10 @@ alsa-lib-1.2.6.1-1.cm2.x86_64.rpm
 alsa-lib-debuginfo-1.2.6.1-1.cm2.x86_64.rpm
 alsa-lib-devel-1.2.6.1-1.cm2.x86_64.rpm
 asciidoc-9.1.0-1.cm2.noarch.rpm
-audit-3.0.6-3.cm2.x86_64.rpm
-audit-debuginfo-3.0.6-3.cm2.x86_64.rpm
-audit-devel-3.0.6-3.cm2.x86_64.rpm
-audit-libs-3.0.6-3.cm2.x86_64.rpm
+audit-3.0.6-4.cm2.x86_64.rpm
+audit-debuginfo-3.0.6-4.cm2.x86_64.rpm
+audit-devel-3.0.6-4.cm2.x86_64.rpm
+audit-libs-3.0.6-4.cm2.x86_64.rpm
 autoconf-2.71-1.cm2.noarch.rpm
 automake-1.16.5-1.cm2.noarch.rpm
 bash-5.1.8-1.cm2.x86_64.rpm
@@ -494,7 +494,7 @@ procps-ng-lang-3.3.17-1.cm2.x86_64.rpm
 pyproject-rpm-macros-1.0.0~rc1-2.cm2.noarch.rpm
 python-markupsafe-debuginfo-2.1.0-1.cm2.x86_64.rpm
 python3-3.9.10-1.cm2.x86_64.rpm
-python3-audit-3.0.6-3.cm2.x86_64.rpm
+python3-audit-3.0.6-4.cm2.x86_64.rpm
 python3-cracklib-2.9.7-4.cm2.x86_64.rpm
 python3-curses-3.9.10-1.cm2.x86_64.rpm
 python3-debuginfo-3.9.10-1.cm2.x86_64.rpm

--- a/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
+++ b/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
@@ -468,7 +468,7 @@ build_rpm_in_chroot_no_install createrepo_c
 
 build_rpm_in_chroot_no_install libsepol
 
-audit needs: systemd-bootstrap?, python3, krb5, swig, e2fsprogs
+audit needs: python3, krb5, swig, e2fsprogs
 build_rpm_in_chroot_no_install audit
 
 # rebuild pam with selinux and audit support


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Fix circular dependency by modifying audit.spec to Recommend systemd instead of Require it.

Fixes:
INFO[0001] Running cycle resolution to fix any cycles in the dependency graph 
ERRO[0004] Unfixable circular dependency found: {pam-1.5.1-4.cm2-RUN<Meta>} --> {libpwquality-1.4.4-1.cm2-RUN<Meta>} --> {cryptsetup-2.4.3-1.cm2-RUN<Meta>} --> {cryptsetup-devel-2.4.3-1.cm2-RUN<Meta>} --> {systemd-rpm-macros-250.3-1.cm2-BUILD<Build>} --> {systemd-rpm-macros-250.3-1.cm2-RUN<Meta>} --> {systemd-250.3-1.cm2-RUN<Meta>} --> {audit-3.0.6-3.cm2-RUN<Meta>} --> {Meta(15018)} --> {pam-1.5.1-4.cm2-RUN<Meta>} error: cycle contains no pre-build SRPMs, unresolvable 
PANI[0004] cycles detected in dependency graph


###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change audit.spec to Recommend systemd instead of Require systemd

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build
