### PR TITLE
[main] python-nocasedict: Upgrade to 1.0.2

### DIFF
--- a/SPECS/python-nocasedict/python-nocasedict.signatures.json
+++ b/SPECS/python-nocasedict/python-nocasedict.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "nocasedict-0.5.0.tar.gz": "ddb5781d6ce7f5a0f2b1a89aa76f6c6ff6af733c2fda7b4ed837371884c885ca"
+  "nocasedict-1.0.2.tar.gz": "6a1fffcc7987dad15c3c3fd5f650f4329f3d2d08b90146bbb9e68cf5a13cfa00"
  }
 }

--- a/SPECS/python-nocasedict/python-nocasedict.spec
+++ b/SPECS/python-nocasedict/python-nocasedict.spec
@@ -1,33 +1,30 @@
-%{!?python3_sitelib: %define python3_sitelib %(python3 -c "from distutils.sysconfig import get_python_lib;print(get_python_lib())")}
-
 %define pkgname nocasedict
-
+%define six_version 1.14.0
 Summary:        Case-insensitive ordered dictionary library for Python
 Name:           python-%{pkgname}
-Version:        0.5.0
+Version:        1.0.2
 Release:        1%{?dist}
 License:        LGPLv2+
-URL:            https://github.com/pywbem/nocasedict
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
-#Source0:       https://github.com/pywbem/%{pkgname}/archive/%{version}.tar.gz
-Source0:        %{pkgname}-%{version}.tar.gz
-BuildArch:      noarch
-
-%description 
-The NocaseDict class supports the functionality of the built-in dict class of Python 3.8.
-
-
-%package -n python3-%{pkgname}
-Summary:        %{summary}
+URL:            https://github.com/pywbem/nocasedict
+Source0:        https://github.com/pywbem/nocasedict/archive/refs/tags/1.0.2.tar.gz#/%{pkgname}-%{version}.tar.gz
 BuildRequires:  python3-devel
 BuildRequires:  python3-setuptools
-BuildRequires:  python3-xml
-BuildRequires:  python3-six
-BuildRequires:  python3-pytest >= 3.0.7
-Requires:       python3
-Requires:       python3-six
+BuildRequires:  python3-six >= %{six_version}
+BuildRequires:  python3-wheel
+%if %{with_check}
+BuildRequires:  python3-pip
+%endif
+BuildArch:      noarch
 
+%description
+The NocaseDict class supports the functionality of the built-in dict class of Python 3.8.
+
+%package -n     python3-%{pkgname}
+Summary:        %{summary}
+Requires:       python3
+Requires:       python3-six >= %{six_version}
 
 %description -n python3-%{pkgname}
 The NocaseDict class supports the functionality of the built-in dict class of Python 3.8.
@@ -36,20 +33,15 @@ The NocaseDict class supports the functionality of the built-in dict class of Py
 %autosetup -n %{pkgname}-%{version} -p 1
 rm -rf *.egg-info
 
-
 %build
-python3 setup.py build
-
+%py3_build
 
 %install
-python3 setup.py install --skip-build --root=%{buildroot}
+%py3_install
 
-
-%if %{with tests}
 %check
-python3 setup.py test
-%endif
-
+pip3 install tox
+PYTHONPATH=%{buildroot}%{python3_sitelib} tox -e py%{python3_version_nodots}
 
 %files -n python3-%{pkgname}
 %license LICENSE
@@ -58,6 +50,11 @@ python3 setup.py test
 %{python3_sitelib}/*.egg-info
 
 %changelog
+* Tue Mar 15 2022 Thomas Crain <thcrain@microsoft.com> - 1.0.2-1
+- Upgrade to latest upstream release
+- Use tox as a test runner
+- Lint spec
+
 * Tue Jan 05 2021 Ruying Chen <v-ruyche@microsoft.com> - 0.5.0-2
 - Disable auto dependency generator.
 - Add explicit dist provides.

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -23304,8 +23304,8 @@
         "type": "other",
         "other": {
           "name": "python-nocasedict",
-          "version": "0.5.0",
-          "downloadUrl": "https://github.com/pywbem/nocasedict/archive/0.5.0.tar.gz"
+          "version": "1.0.2",
+          "downloadUrl": "https://github.com/pywbem/nocasedict/archive/refs/tags/1.0.2.tar.gz"
         }
       }
     },


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Upgrade `python-nocasedict` to the latest upstream version to keep our 2.0 repo updated.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Upgrade to latest upstream release
- Use tox as a test runner
- Lint spec

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Normal and check builds both pass locally
