### PR TITLE
Update cppunit to v1.15.1

### DIFF
--- a/SPECS/cppunit/cppunit.signatures.json
+++ b/SPECS/cppunit/cppunit.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "cppunit-1.12.1.tar.gz": "ac28a04c8e6c9217d910b0ae7122832d28d9917fa668bcc9e0b8b09acb4ea44a"
+  "cppunit-1.15.1.tar.gz": "89c5c6665337f56fd2db36bc3805a5619709d51fb136e51937072f63fcc717a7"
  }
 }

--- a/SPECS/cppunit/cppunit.spec
+++ b/SPECS/cppunit/cppunit.spec
@@ -1,14 +1,14 @@
 %define sha1 cppunit=f1ab8986af7a1ffa6760f4bacf5622924639bf4a
 Summary:        C++ port of Junit test framework
 Name:           cppunit
-Version:        1.12.1
-Release:        6%{?dist}
+Version:        1.15.1
+Release:        1%{?dist}
 License:        LGPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Group:          Development/Tools
 URL:            https://sourceforge.net/projects/cppunit/
-Source0:        https://sourceforge.net/projects/cppunit/files/%{name}/%{version}/%{name}-%{version}.tar.gz
+Source0:        https://dev-www.libreoffice.org/src/%{name}-%{version}.tar.gz
 BuildRequires:  autoconf
 BuildRequires:  automake
 BuildRequires:  gcc
@@ -57,6 +57,10 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %{_datadir}/*
 
 %changelog
+* Wed Mar 16 2022 Neha Agarwal <nehaagarwal@microsoft.com> - 1.15.1-1
+- Update to v1.15.1.
+- License verified.
+
 * Mon Feb 08 2021 Henry Li <lihl@microsoft.com> - 1.12.1-6
 - Add cppunit as Requires for cppunit-devel
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -2247,8 +2247,8 @@
         "type": "other",
         "other": {
           "name": "cppunit",
-          "version": "1.12.1",
-          "downloadUrl": "https://sourceforge.net/projects/cppunit/files/cppunit/1.12.1/cppunit-1.12.1.tar.gz"
+          "version": "1.15.1",
+          "downloadUrl": "https://dev-www.libreoffice.org/src/cppunit-1.15.1.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
Update cppunit to v1.15.1

###### Change Log  <!-- REQUIRED -->
- Update cppunit to v1.15.1
- check section in softhsm was failing because of old version of cppunit

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Test Methodology
- Local build. Confirmed softhsm check section passed with the new version of cppunit.