### PR TITLE
libtiff: backport patches from upstream to fix CVE-2022-0561 & CVE-2022-0562

### DIFF
--- a/SPECS/libtiff/CVE-2022-0561.patch
+++ b/SPECS/libtiff/CVE-2022-0561.patch
@@ -1,0 +1,31 @@
+From eecb0712f4c3a5b449f70c57988260a667ddbdef Mon Sep 17 00:00:00 2001
+From: Even Rouault <even.rouault@spatialys.com>
+Date: Sun, 6 Feb 2022 13:08:38 +0100
+Subject: [PATCH] TIFFFetchStripThing(): avoid calling memcpy() with a null
+ source pointer and size of zero (fixes #362)
+
+Backported from upstream by mfrw
+
+Signed-off by: Muhammad Falak R Wani <falakreyaz@gmail.com>
+---
+ libtiff/tif_dirread.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/libtiff/tif_dirread.c b/libtiff/tif_dirread.c
+--- a/libtiff/tif_dirread.c
++++ b/libtiff/tif_dirread.c
+@@ -5682,8 +5683,9 @@ TIFFFetchStripThing(TIFF* tif, TIFFDirEntry* dir, uint32 nstrips, uint64** lpp)
+ 			_TIFFfree(data);
+ 			return(0);
+ 		}
+-                _TIFFmemcpy(resizeddata,data,(uint32)dir->tdir_count*sizeof(uint64));
+-                _TIFFmemset(resizeddata+(uint32)dir->tdir_count,0,(nstrips-(uint32)dir->tdir_count)*sizeof(uint64));
++		if (dir->tdir_count)
++		    _TIFFmemcpy(resizeddata,data,(uint32)dir->tdir_count*sizeof(uint64));
++		_TIFFmemset(resizeddata+(uint32)dir->tdir_count,0,(nstrips-(uint32)dir->tdir_count)*sizeof(uint64));
+ 		_TIFFfree(data);
+ 		data=resizeddata;
+ 	}
+-- 
+GitLab
+

--- a/SPECS/libtiff/CVE-2022-0562.patch
+++ b/SPECS/libtiff/CVE-2022-0562.patch
@@ -1,0 +1,29 @@
+From 561599c99f987dc32ae110370cfdd7df7975586b Mon Sep 17 00:00:00 2001
+From: Even Rouault <even.rouault@spatialys.com>
+Date: Sat, 5 Feb 2022 20:36:41 +0100
+Subject: [PATCH] TIFFReadDirectory(): avoid calling memcpy() with a null
+ source pointer and size of zero (fixes #362)
+
+Backported from upstream by mfrw
+
+Signed-off by: Muhammad Falak R Wani <falakreyaz@gmail.com>
+---
+ libtiff/tif_dirread.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/libtiff/tif_dirread.c b/libtiff/tif_dirread.c
+--- a/libtiff/tif_dirread.c
++++ b/libtiff/tif_dirread.c
+@@ -4126,7 +4126,8 @@ TIFFReadDirectory(TIFF* tif)
+                     goto bad;
+                 }
+ 
+-                memcpy(new_sampleinfo, tif->tif_dir.td_sampleinfo, old_extrasamples * sizeof(uint16));
++                if (old_extrasamples > 0)
++                    memcpy(new_sampleinfo, tif->tif_dir.td_sampleinfo, old_extrasamples * sizeof(uint16));
+                 _TIFFsetShortArray(&tif->tif_dir.td_sampleinfo, new_sampleinfo, tif->tif_dir.td_extrasamples);
+                 _TIFFfree(new_sampleinfo);
+         }
+-- 
+GitLab
+

--- a/SPECS/libtiff/CVE-2022-0891.patch
+++ b/SPECS/libtiff/CVE-2022-0891.patch
@@ -1,0 +1,213 @@
+From 232282fd8f9c21eefe8d2d2b96cdbbb172fe7b7c Mon Sep 17 00:00:00 2001
+From: Su Laus <sulau@freenet.de>
+Date: Tue, 8 Mar 2022 17:02:44 +0000
+Subject: [PATCH] tiffcrop: fix issue #380 and #382 heap buffer overflow in
+ extractImageSection
+
+Bakported from upstream by mfrw.
+
+Signed-off by: Muhammad Falak R Wani <falakreyaz@gmail.com>
+
+
+---
+ tools/tiffcrop.c | 92 +++++++++++++++++++-----------------------------
+ 1 file changed, 36 insertions(+), 56 deletions(-)
+
+diff --git a/tools/tiffcrop.c b/tools/tiffcrop.c
+index 7b3c9e7..ac8a643 100644
+--- a/tools/tiffcrop.c
++++ b/tools/tiffcrop.c
+@@ -105,8 +105,8 @@
+  *                of messages to monitor progess without enabling dump logs.
+  */
+ 
+-static   char tiffcrop_version_id[] = "2.4";
+-static   char tiffcrop_rev_date[] = "12-13-2010";
++static   char tiffcrop_version_id[] = "2.4.1";
++static   char tiffcrop_rev_date[] = "03-03-2010";
+ 
+ #include "tif_config.h"
+ #include "tiffiop.h"
+@@ -6669,10 +6669,10 @@ extractImageSection(struct image_data *image, struct pageseg *section,
+ #ifdef DEVELMODE
+   uint32    img_length;
+ #endif
+-  uint32    j, shift1, shift2, trailing_bits;
++  uint32    j, shift1, trailing_bits;
+   uint32    row, first_row, last_row, first_col, last_col;
+   uint32    src_offset, dst_offset, row_offset, col_offset;
+-  uint32    offset1, offset2, full_bytes;
++  uint32    offset1, full_bytes;
+   uint32    sect_width;
+ #ifdef DEVELMODE
+   uint32    sect_length;
+@@ -6682,7 +6682,6 @@ extractImageSection(struct image_data *image, struct pageseg *section,
+ #ifdef DEVELMODE
+   int      k;
+   unsigned char bitset;
+-  static char *bitarray = NULL;
+ #endif
+ 
+   img_width = image->width;
+@@ -6700,17 +6699,12 @@ extractImageSection(struct image_data *image, struct pageseg *section,
+   dst_offset = 0;
+ 
+ #ifdef DEVELMODE
+-  if (bitarray == NULL)
+-    {
+-    if ((bitarray = (char *)malloc(img_width)) == NULL)
+-      {
+-      TIFFError ("", "DEBUG: Unable to allocate debugging bitarray");
+-      return (-1);
+-      }
+-    }
++  char bitarray[39];
+ #endif
+ 
+-  /* rows, columns, width, length are expressed in pixels */
++  /* rows, columns, width, length are expressed in pixels
++   * first_row, last_row, .. are index into image array starting at 0 to width-1,
++   * last_col shall be also extracted.  */
+   first_row = section->y1;
+   last_row  = section->y2;
+   first_col = section->x1;
+@@ -6720,9 +6714,14 @@ extractImageSection(struct image_data *image, struct pageseg *section,
+ #ifdef DEVELMODE
+   sect_length = last_row - first_row + 1;
+ #endif
+-  img_rowsize = ((img_width * bps + 7) / 8) * spp;
+-  full_bytes = (sect_width * spp * bps) / 8;   /* number of COMPLETE bytes per row in section */
+-  trailing_bits = (sect_width * bps) % 8;
++    /* The read function loadImage() used copy separate plane data into a buffer as interleaved
++     * samples rather than separate planes so the same logic works to extract regions
++     * regardless of the way the data are organized in the input file.
++     * Furthermore, bytes and bits are arranged in buffer according to COMPRESSION=1 and FILLORDER=1 
++     */
++    img_rowsize = (((img_width * spp * bps) + 7) / 8);    /* row size in full bytes of source image */
++    full_bytes = (sect_width * spp * bps) / 8;            /* number of COMPLETE bytes per row in section */
++    trailing_bits = (sect_width * spp * bps) % 8;         /* trailing bits within the last byte of destination buffer */
+ 
+ #ifdef DEVELMODE
+     TIFFError ("", "First row: %d, last row: %d, First col: %d, last col: %d\n",
+@@ -6735,10 +6734,9 @@ extractImageSection(struct image_data *image, struct pageseg *section,
+ 
+   if ((bps % 8) == 0)
+     {
+-    col_offset = first_col * spp * bps / 8;
++    col_offset = (first_col * spp * bps) / 8;
+     for (row = first_row; row <= last_row; row++)
+       {
+-      /* row_offset = row * img_width * spp * bps / 8; */
+       row_offset = row * img_rowsize;
+       src_offset = row_offset + col_offset;
+ 
+@@ -6751,14 +6749,12 @@ extractImageSection(struct image_data *image, struct pageseg *section,
+     }
+   else
+     { /* bps != 8 */
+-    shift1  = spp * ((first_col * bps) % 8);
+-    shift2  = spp * ((last_col * bps) % 8);
++    shift1 = ((first_col * spp * bps) % 8);           /* shift1 = bits to skip in the first byte of source buffer*/
+     for (row = first_row; row <= last_row; row++)
+       {
+       /* pull out the first byte */
+       row_offset = row * img_rowsize;
+-      offset1 = row_offset + (first_col * bps / 8);
+-      offset2 = row_offset + (last_col * bps / 8);
++      offset1 = row_offset + ((first_col * spp * bps) / 8);   /* offset1 = offset into source of byte with first bits to be extracted */
+ 
+ #ifdef DEVELMODE
+       for (j = 0, k = 7; j < 8; j++, k--)
+@@ -6770,12 +6766,12 @@ extractImageSection(struct image_data *image, struct pageseg *section,
+       sprintf(&bitarray[9], " ");
+       for (j = 10, k = 7; j < 18; j++, k--)
+         {
+-        bitset = *(src_buff + offset2) & (((unsigned char)1 << k)) ? 1 : 0;
++        bitset = *(src_buff + offset1 + full_bytes) & (((unsigned char)1 << k)) ? 1 : 0;
+         sprintf(&bitarray[j], (bitset) ? "1" : "0");
+         }
+       bitarray[18] = '\0';
+-      TIFFError ("", "Row: %3d Offset1: %d,  Shift1: %d,    Offset2: %d,  Shift2:  %d\n", 
+-                 row, offset1, shift1, offset2, shift2); 
++      TIFFError ("", "Row: %3d Offset1: %d,  Shift1: %d,    Offset2: %d,  Trailing_bits:  %d\n",
++                 row, offset1, shift1, offset1+full_bytes, trailing_bits);
+ #endif
+ 
+       bytebuff1 = bytebuff2 = 0;
+@@ -6799,11 +6795,12 @@ extractImageSection(struct image_data *image, struct pageseg *section,
+ 
+         if (trailing_bits != 0)
+           {
+-	  bytebuff2 = src_buff[offset2] & ((unsigned char)255 << (7 - shift2));
++      /* Only copy higher bits of samples and mask lower bits of not wanted column samples to zero */
++	  bytebuff2 = src_buff[offset1 + full_bytes] & ((unsigned char)255 << (8 - trailing_bits));
+           sect_buff[dst_offset] = bytebuff2;
+ #ifdef DEVELMODE
+ 	  TIFFError ("", "        Trailing bits src offset:  %8d, Dst offset: %8d\n", 
+-                              offset2, dst_offset); 
++          offset1 + full_bytes, dst_offset);
+           for (j = 30, k = 7; j < 38; j++, k--)
+             {
+             bitset = *(sect_buff + dst_offset) & (((unsigned char)1 << k)) ? 1 : 0;
+@@ -6822,8 +6819,10 @@ extractImageSection(struct image_data *image, struct pageseg *section,
+ #endif
+         for (j = 0; j <= full_bytes; j++) 
+           {
+-	  bytebuff1 = src_buff[offset1 + j] & ((unsigned char)255 >> shift1);
+-	  bytebuff2 = src_buff[offset1 + j + 1] & ((unsigned char)255 << (7 - shift1));
++          /* Skip the first shift1 bits and shift the source up by shift1 bits before save to destination.*/
++          /* Attention: src_buff size needs to be some bytes larger than image size, because could read behind image here. */
++          bytebuff1 = src_buff[offset1 + j] & ((unsigned char)255 >> shift1);
++          bytebuff2 = src_buff[offset1 + j + 1] & ((unsigned char)255 << (8 - shift1));
+           sect_buff[dst_offset + j] = (bytebuff1 << shift1) | (bytebuff2 >> (8 - shift1));
+           }
+ #ifdef DEVELMODE
+@@ -6839,36 +6838,14 @@ extractImageSection(struct image_data *image, struct pageseg *section,
+ #endif
+         dst_offset += full_bytes;
+ 
++        /* Copy the trailing_bits for the last byte in the destination buffer. 
++           Could come from one ore two bytes of the source buffer. */
+         if (trailing_bits != 0)
+           {
+ #ifdef DEVELMODE
+-	    TIFFError ("", "        Trailing bits   src offset: %8d, Dst offset: %8d\n", offset1 + full_bytes, dst_offset); 
+-#endif
+-	  if (shift2 > shift1)
+-            {
+-	    bytebuff1 = src_buff[offset1 + full_bytes] & ((unsigned char)255 << (7 - shift2));
+-            bytebuff2 = bytebuff1 & ((unsigned char)255 << shift1);
+-            sect_buff[dst_offset] = bytebuff2;
+-#ifdef DEVELMODE
+-	    TIFFError ("", "        Shift2 > Shift1\n"); 
++          TIFFError("", "        Trailing bits %4"PRIu32"   src offset: %8"PRIu32", Dst offset: %8"PRIu32"\n", trailing_bits, offset1 + full_bytes, dst_offset);
+ #endif
+             }
+-          else
+-            {
+-	    if (shift2 < shift1)
+-              {
+-              bytebuff2 = ((unsigned char)255 << (shift1 - shift2 - 1));
+-	      sect_buff[dst_offset] &= bytebuff2;
+-#ifdef DEVELMODE
+-	      TIFFError ("", "        Shift2 < Shift1\n"); 
+-#endif
+-              }
+-#ifdef DEVELMODE
+-            else
+-	      TIFFError ("", "        Shift2 == Shift1\n"); 
+-#endif
+-            }
+-	  }
+ #ifdef DEVELMODE
+ 	  sprintf(&bitarray[28], " ");
+ 	  sprintf(&bitarray[29], " ");
+@@ -7021,7 +6998,7 @@ writeImageSections(TIFF *in, TIFF *out, struct image_data *image,
+     width  = sections[i].x2 - sections[i].x1 + 1;
+     length = sections[i].y2 - sections[i].y1 + 1;
+     sectsize = (uint32)
+-	    ceil((width * image->bps + 7) / (double)8) * image->spp * length;
++	    ceil((width * image->bps * image->spp + 7) / (double)8) * length;
+     /* allocate a buffer if we don't have one already */
+     if (createImageSection(sectsize, sect_buff_ptr))
+       {

--- a/SPECS/libtiff/libtiff.spec
+++ b/SPECS/libtiff/libtiff.spec
@@ -15,6 +15,7 @@ Patch2: CVE-2020-35523.patch
 Patch3: CVE-2020-35524.patch
 Patch4: CVE-2022-0561.patch
 Patch5: CVE-2022-0562.patch
+Patch6: CVE-2022-0891.patch
 BuildRequires:  libjpeg-turbo-devel
 Requires:       libjpeg-turbo
 
@@ -36,6 +37,7 @@ It contains the libraries and header files to create applications
 %patch3 -p1
 %patch4 -p1
 %patch5 -p1
+%patch6 -p1
 
 %build
 sh autogen.sh
@@ -73,7 +75,7 @@ make %{?_smp_mflags} -k check
 
 %changelog
 * Thu Mar 17 2022 Muhammad Falak <mwani@microsoft.com> - 4.1.0-3
-- Backport patches from upstream to fix CVE-2022-0561 & CVE-2022-0562
+- Backport patches from upstream to fix CVE-2022-0561, CVE-2022-0562 & CVE-2022-0891
 
 * Fri Mar 19 2021 Jon Slobodzian <joslobo@microsoft.com> - 4.1.0-2
 - Add patches for CVE-2020-35521, CVE-2020-35522, CVE-2020-35523, CVE-2020-35524

--- a/SPECS/libtiff/libtiff.spec
+++ b/SPECS/libtiff/libtiff.spec
@@ -1,7 +1,7 @@
 Summary:        TIFF libraries and associated utilities.
 Name:           libtiff
 Version:        4.1.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        libtiff
 URL:            https://gitlab.com/libtiff/libtiff
 Group:          System Environment/Libraries
@@ -13,6 +13,8 @@ Patch0: CVE-2020-35521.nopatch
 Patch1: CVE-2020-35522.patch
 Patch2: CVE-2020-35523.patch
 Patch3: CVE-2020-35524.patch
+Patch4: CVE-2022-0561.patch
+Patch5: CVE-2022-0562.patch
 BuildRequires:  libjpeg-turbo-devel
 Requires:       libjpeg-turbo
 
@@ -32,6 +34,8 @@ It contains the libraries and header files to create applications
 %patch1 -p1
 %patch2 -p1
 %patch3 -p1
+%patch4 -p1
+%patch5 -p1
 
 %build
 sh autogen.sh
@@ -68,61 +72,90 @@ make %{?_smp_mflags} -k check
 %{_datadir}/man/man3/*
 
 %changelog
-*   Fri Mar 19 2021 Jon Slobodzian <joslobo@microsoft.com> - 4.1.0-2
--   Add patches for CVE-2020-35521, CVE-2020-35522, CVE-2020-35523, CVE-2020-35524
-*   Tue May 26 2020 Ruying Chen <v-ruyche@microsoft.com> - 4.1.0-1
--   Update to 4.1.0
-*   Wed May 13 2020 Nick Samson <nisamson@microsoft.com> - 4.0.10-6
--   Added %%license line automatically
-*   Mon May 11 2020 Nicolas Ontiveros <niontive@microsoft.com> 4.0.10-5
--   Fix CVE-2019-17546.
--   Remove sha1 macro.
-*   Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 4.0.10-4
--   Initial CBL-Mariner import from Photon (license: Apache2).
-*   Tue Feb 05 2019 Keerthana K <keerthanak@vmware.com> 4.0.10-3
--   Fix for CVE-2019-6128.
-*   Mon Jan 28 2019 Keerthana K <keerthanak@vmware.com> 4.0.10-2
--   Fix for CVE-2018-12900
-*   Mon Dec 10 2018 Ashwin H <ashwinh@vmware.com> 4.0.10-1
--   Update to 4.0.10
-*   Sun Dec 02 2018 Ashwin H <ashwinh@vmware.com> 4.0.9-5
--   Fix CVE-2018-17100, CVE-2018-17101
-*   Mon May 14 2018 Xiaolin Li <xiaolinl@vmware.com> 4.0.9-4
--   Fix CVE-2018-7456, CVE-2018-8905, CVE-2018-5784, CVE-2017-11613
-*   Wed Feb 14 2018 Dheeraj Shetty <dheerajs@vmware.com> 4.0.9-3
--   Patch for CVE-2017-17095
-*   Wed Jan 31 2018 Dheeraj Shetty <dheerajs@vmware.com> 4.0.9-2
--   Repatched CVE-2017-9935
-*   Wed Jan 17 2018 Dheeraj Shetty <dheerajs@vmware.com> 4.0.9-1
--   Updated to version 4.0.9 to fix CVE-2017-11613, CVE-2017-9937,
--   CVE-2017-17973. Added a patch for CVE-2017-18013
-*   Mon Dec 11 2017 Xiaolin Li <xiaolinl@vmware.com> 4.0.8-7
--   Added patch for CVE-2017-9935
-*   Mon Nov 27 2017 Xiaolin Li <xiaolinl@vmware.com> 4.0.8-6
--   Added patches for CVE-2017-13726, CVE-2017-13727
-*   Mon Nov 13 2017 Dheeraj Shetty <dheerajs@vmware.com> 4.0.8-5
--   Patch : CVE-2017-12944
-*   Fri Oct 13 2017 Alexey Makhalov <amakhalov@vmware.com> 4.0.8-4
--   Use standard configure macros
-*   Wed Aug 09 2017 Harish Udaiya Kumar <hudaiyakumar@vmware.com> 4.0.8-3
--   Added patch for CVE-2017-9936, CVE-2017-11335
-*   Tue Jul 11 2017 Divya Thaluru <dthaluru@vmware.com> 4.0.8-2
--   Applied patch for CVE-2017-10688
-*   Wed Jun 07 2017 Xiaolin Li <xiaolinl@vmware.com> 4.0.8-1
--   Updated to version 4.0.8.
-*   Tue May 16 2017 Harish Udaiya Kumar <hudaiyakumar@vmware.com> 4.0.7-4
--   Added patch for CVE-2016-10266, CVE-2016-10268, CVE-2016-10269, CVE-2016-10267 and libtiff-heap-buffer-overflow patch
-*   Mon Apr 10 2017 Dheeraj Shetty <dheerajs@vmware.com> 4.0.7-3
--   Patch : CVE-2016-10092, CVE-2016-10093, CVE-2016-10094
-*   Thu Jan 19 2017 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 4.0.7-2
--   Patch : CVE-2017-5225
-*   Thu Nov 24 2016 Alexey Makhalov <amakhalov@vmware.com> 4.0.7-1
--   Update to 4.0.7. It fixes CVE-2016-953[3456789] and CVE-2016-9540
--   Remove obsolete patches
-*   Wed Oct 12 2016 Dheeraj Shetty <dheerajs@vmware.com> 4.0.6-3
--   Fixed security issues : CVE-2016-3945, CVE-2016-3990, CVE-2016-3991
-*   Thu Sep 22 2016 Harish Udaiya Kumar <hudaiyakumar@vmware.com> 4.0.6-2
--   Fixed security issues : CVE-2015-8668, CVE-2015-7554, CVE-2015-8683+CVE-2015-8665,CVE-2016-3186
--   CVE-2015-1547
-*   Wed Jul 27 2016 Divya Thaluru <dthaluru@vmware.com> 4.0.6-1
--   Initial version
+* Thu Mar 17 2022 Muhammad Falak <mwani@microsoft.com> - 4.1.0-3
+- Backport patches from upstream to fix CVE-2022-0561 & CVE-2022-0562
+
+* Fri Mar 19 2021 Jon Slobodzian <joslobo@microsoft.com> - 4.1.0-2
+- Add patches for CVE-2020-35521, CVE-2020-35522, CVE-2020-35523, CVE-2020-35524
+
+* Tue May 26 2020 Ruying Chen <v-ruyche@microsoft.com> - 4.1.0-1
+- Update to 4.1.0
+
+* Wed May 13 2020 Nick Samson <nisamson@microsoft.com> - 4.0.10-6
+- Added %%license line automatically
+
+* Mon May 11 2020 Nicolas Ontiveros <niontive@microsoft.com> 4.0.10-5
+- Fix CVE-2019-17546.
+- Remove sha1 macro.
+
+* Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 4.0.10-4
+- Initial CBL-Mariner import from Photon (license: Apache2).
+
+* Tue Feb 05 2019 Keerthana K <keerthanak@vmware.com> 4.0.10-3
+- Fix for CVE-2019-6128.
+
+* Mon Jan 28 2019 Keerthana K <keerthanak@vmware.com> 4.0.10-2
+- Fix for CVE-2018-12900
+
+* Mon Dec 10 2018 Ashwin H <ashwinh@vmware.com> 4.0.10-1
+- Update to 4.0.10
+
+* Sun Dec 02 2018 Ashwin H <ashwinh@vmware.com> 4.0.9-5
+- Fix CVE-2018-17100, CVE-2018-17101
+
+* Mon May 14 2018 Xiaolin Li <xiaolinl@vmware.com> 4.0.9-4
+- Fix CVE-2018-7456, CVE-2018-8905, CVE-2018-5784, CVE-2017-11613
+
+* Wed Feb 14 2018 Dheeraj Shetty <dheerajs@vmware.com> 4.0.9-3
+- Patch for CVE-2017-17095
+
+* Wed Jan 31 2018 Dheeraj Shetty <dheerajs@vmware.com> 4.0.9-2
+- Repatched CVE-2017-9935
+
+* Wed Jan 17 2018 Dheeraj Shetty <dheerajs@vmware.com> 4.0.9-1
+- Updated to version 4.0.9 to fix CVE-2017-11613, CVE-2017-9937,
+- CVE-2017-17973. Added a patch for CVE-2017-18013
+
+* Mon Dec 11 2017 Xiaolin Li <xiaolinl@vmware.com> 4.0.8-7
+- Added patch for CVE-2017-9935
+
+* Mon Nov 27 2017 Xiaolin Li <xiaolinl@vmware.com> 4.0.8-6
+- Added patches for CVE-2017-13726, CVE-2017-13727
+
+* Mon Nov 13 2017 Dheeraj Shetty <dheerajs@vmware.com> 4.0.8-5
+- Patch : CVE-2017-12944
+
+* Fri Oct 13 2017 Alexey Makhalov <amakhalov@vmware.com> 4.0.8-4
+- Use standard configure macros
+
+* Wed Aug 09 2017 Harish Udaiya Kumar <hudaiyakumar@vmware.com> 4.0.8-3
+- Added patch for CVE-2017-9936, CVE-2017-11335
+
+* Tue Jul 11 2017 Divya Thaluru <dthaluru@vmware.com> 4.0.8-2
+- Applied patch for CVE-2017-10688
+
+* Wed Jun 07 2017 Xiaolin Li <xiaolinl@vmware.com> 4.0.8-1
+- Updated to version 4.0.8.
+
+* Tue May 16 2017 Harish Udaiya Kumar <hudaiyakumar@vmware.com> 4.0.7-4
+- Added patch for CVE-2016-10266, CVE-2016-10268, CVE-2016-10269, CVE-2016-10267 and libtiff-heap-buffer-overflow patch
+
+* Mon Apr 10 2017 Dheeraj Shetty <dheerajs@vmware.com> 4.0.7-3
+- Patch : CVE-2016-10092, CVE-2016-10093, CVE-2016-10094
+
+* Thu Jan 19 2017 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 4.0.7-2
+- Patch : CVE-2017-5225
+
+* Thu Nov 24 2016 Alexey Makhalov <amakhalov@vmware.com> 4.0.7-1
+- Update to 4.0.7. It fixes CVE-2016-953[3456789] and CVE-2016-9540
+- Remove obsolete patches
+
+* Wed Oct 12 2016 Dheeraj Shetty <dheerajs@vmware.com> 4.0.6-3
+- Fixed security issues : CVE-2016-3945, CVE-2016-3990, CVE-2016-3991
+
+* Thu Sep 22 2016 Harish Udaiya Kumar <hudaiyakumar@vmware.com> 4.0.6-2
+- Fixed security issues : CVE-2015-8668, CVE-2015-7554, CVE-2015-8683+CVE-2015-8665,CVE-2016-3186
+- CVE-2015-1547
+
+* Wed Jul 27 2016 Divya Thaluru <dthaluru@vmware.com> 4.0.6-1
+- Initial version


### PR DESCRIPTION
Signed-off-by: Muhammad Falak R Wani <falakreyaz@gmail.com>

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Address CVE-2022-0561, CVE-2022-0562 & CVE-2022-0891

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Backport patches from upstream to fix CVE-2022-0561 & CVE-2022-0562

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- NA

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2022-0561
- https://nvd.nist.gov/vuln/detail/CVE-2022-0562
- https://nvd.nist.gov/vuln/detail/CVE-2022-0891

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: Local Build with RUN_CHECK=y
