### PR TITLE
Update polkit to disable man-pages

### DIFF
--- a/SPECS/polkit/polkit.spec
+++ b/SPECS/polkit/polkit.spec
@@ -1,7 +1,7 @@
 Summary:           A toolkit for defining and handling authorizations.
 Name:              polkit
 Version:           0.119
-Release:           2%{?dist}
+Release:           3%{?dist}
 Group:             Applications/System
 Vendor:            Microsoft Corporation
 License:           GPLv2+
@@ -45,7 +45,8 @@ header files and libraries for polkit
 %configure \
     --datadir=%{_datarootdir} \
     --enable-libsystemd-login=yes \
-    --with-systemdsystemunitdir=%{_libdir}/systemd/system
+    --with-systemdsystemunitdir=%{_libdir}/systemd/system \
+    --enable-man-pages=no
 make %{?_smp_mflags}
 
 %install
@@ -110,6 +111,9 @@ fi
 %{_libdir}/pkgconfig/*.pc
 
 %changelog
+*   Thu Mar 17 2022 Andrew Phelps <anphel@microsoft.com> - 0.119-3
+-   Disable documentation
+
 *   Mon Feb 07 2022 Neha Agarwal <nehaagarwal@microsoft.com> - 0.119-2
 -   Patch for CVE-2021-4034.
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Update polkit to build with gtk-doc
Recent autoconf upgrade added gtk-doc dependency, which triggered polkit to build manpages (even though they haven't been included before).

Fix for error:

time="2022-03-17T22:46:42Z" level=debug msg="    Installed (but unpackaged) file(s) found:"
time="2022-03-17T22:46:42Z" level=debug msg="   /usr/share/man/man1/pkaction.1.gz"
time="2022-03-17T22:46:42Z" level=debug msg="   /usr/share/man/man1/pkcheck.1.gz"
time="2022-03-17T22:46:42Z" level=debug msg="   /usr/share/man/man1/pkexec.1.gz"
time="2022-03-17T22:46:42Z" level=debug msg="   /usr/share/man/man1/pkttyagent.1.gz"
time="2022-03-17T22:46:42Z" level=debug msg="   /usr/share/man/man8/polkit.8.gz"
time="2022-03-17T22:46:42Z" level=debug msg="   /usr/share/man/man8/polkitd.8.gz"


###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change polkit.spec

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build