### PR TITLE
[main] toolchain: Remove alsa-lib

### DIFF
--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -1,6 +1,3 @@
-alsa-lib-1.2.6.1-1.cm2.aarch64.rpm
-alsa-lib-debuginfo-1.2.6.1-1.cm2.aarch64.rpm
-alsa-lib-devel-1.2.6.1-1.cm2.aarch64.rpm
 asciidoc-9.1.0-1.cm2.noarch.rpm
 audit-3.0.6-4.cm2.aarch64.rpm
 audit-debuginfo-3.0.6-4.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -1,6 +1,3 @@
-alsa-lib-1.2.6.1-1.cm2.x86_64.rpm
-alsa-lib-debuginfo-1.2.6.1-1.cm2.x86_64.rpm
-alsa-lib-devel-1.2.6.1-1.cm2.x86_64.rpm
 asciidoc-9.1.0-1.cm2.noarch.rpm
 audit-3.0.6-4.cm2.x86_64.rpm
 audit-debuginfo-3.0.6-4.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/update_manifests.sh
+++ b/toolkit/resources/manifests/package/update_manifests.sh
@@ -41,7 +41,6 @@ generate_toolchain () {
 
 # Remove specific packages that are not needed in pkggen_core
 remove_packages_for_pkggen_core () {
-    sed -i '/alsa-lib-/d' $TmpPkgGen
     sed -i '/audit-devel/d' $TmpPkgGen
     sed -i '/ca-certificates-legacy/d' $TmpPkgGen
     sed -i '/libtasn1-d/d' $TmpPkgGen

--- a/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
+++ b/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
@@ -304,8 +304,6 @@ build_rpm_in_chroot_no_install zip
 chroot_and_install_rpms zip
 build_rpm_in_chroot_no_install unzip
 chroot_and_install_rpms unzip
-build_rpm_in_chroot_no_install alsa-lib
-chroot_and_install_rpms alsa-lib
 build_rpm_in_chroot_no_install gperf
 chroot_and_install_rpms gperf
 
@@ -468,7 +466,7 @@ build_rpm_in_chroot_no_install createrepo_c
 
 build_rpm_in_chroot_no_install libsepol
 
-audit needs: python3, krb5, swig, e2fsprogs
+# audit needs: python3, krb5, swig, e2fsprogs
 build_rpm_in_chroot_no_install audit
 
 # rebuild pam with selinux and audit support


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
The only purpose of having `alsa-lib` built as part of the toolchain was to enable `openjdk8` to build in the toolchain. Since we no longer build `openjdk8` at all, we can safely remove `alsa-lib` from the toolchain. This work contributes to our ongoing toolchain minimization efforts.

Also, this PR fixes one line of the toolchain build script that should be a comment.

##### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Remove `alsa-lib` from the toolchain build script, the toolchain manifests, and the manifest update script.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: 175675
