### PR TITLE
Use lz4 compression in systemd instead of zstd

### DIFF
--- a/SPECS/systemd/systemd-bootstrap.spec
+++ b/SPECS/systemd/systemd-bootstrap.spec
@@ -1,7 +1,7 @@
 Summary:        Bootstrap version of systemd. Workaround for systemd circular dependency.
 Name:           systemd-bootstrap
 Version:        250.3
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        LGPLv2+ AND GPLv2+ AND MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -93,6 +93,7 @@ meson  --prefix %{_prefix}                                            \
        -Dlibcurl=false                                                \
        -Dpolkit=true                                                  \
        -Dlz4=true                                                     \
+       -Dzstd=false                                                   \
        -Ddbuspolicydir=%{_sysconfdir}/dbus-1/system.d                 \
        -Ddbussessionservicedir=%{_datadir}/dbus-1/services            \
        -Ddbussystemservicedir=%{_datadir}/dbus-1/system-services      \
@@ -226,6 +227,9 @@ systemctl preset-all
 %{_datadir}/pkgconfig/udev.pc
 
 %changelog
+* Thu Mar 17 2022 Andrew Phelps <anphel@microsoft.com> - 250.3-2
+- Disable zstd configuration to ensure lz4 compression is used for journal files and coredumps
+
 * Mon Jan 24 2022 Henry Beberman <henry.beberman@microsoft.com> - 250.3-1
 - Update to systemd-stable version 250.3
 - Explicitly disable systemd-homed

--- a/SPECS/systemd/systemd.spec
+++ b/SPECS/systemd/systemd.spec
@@ -1,7 +1,7 @@
 Summary:        Systemd-250
 Name:           systemd
 Version:        250.3
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        LGPLv2+ AND GPLv2+ AND MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -117,6 +117,7 @@ meson  --prefix %{_prefix}                                            \
        -Dlibcryptsetup=true                                           \
        -Dgcrypt=true                                                  \
        -Dlz4=true                                                     \
+       -Dzstd=false                                                   \
        -Ddbuspolicydir=%{_sysconfdir}/dbus-1/system.d                 \
        -Ddbussessionservicedir=%{_datadir}/dbus-1/services            \
        -Ddbussystemservicedir=%{_datadir}/dbus-1/system-services      \
@@ -257,6 +258,9 @@ systemctl preset-all
 %files lang -f %{name}.lang
 
 %changelog
+* Thu Mar 17 2022 Andrew Phelps <anphel@microsoft.com> - 250.3-2
+- Disable zstd configuration to ensure lz4 compression is used for journal files and coredumps
+
 * Mon Jan 24 2022 Henry Beberman <henry.beberman@microsoft.com> - 250.3-1
 - Update to systemd-stable version 250.3
 - Explicitly disable systemd-homed

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -533,10 +533,10 @@ sqlite-devel-3.36.0-2.cm2.aarch64.rpm
 sqlite-libs-3.36.0-2.cm2.aarch64.rpm
 swig-4.0.2-3.cm2.aarch64.rpm
 swig-debuginfo-4.0.2-3.cm2.aarch64.rpm
-systemd-bootstrap-250.3-1.cm2.aarch64.rpm
-systemd-bootstrap-debuginfo-250.3-1.cm2.aarch64.rpm
-systemd-bootstrap-devel-250.3-1.cm2.aarch64.rpm
-systemd-bootstrap-rpm-macros-250.3-1.cm2.noarch.rpm
+systemd-bootstrap-250.3-2.cm2.aarch64.rpm
+systemd-bootstrap-debuginfo-250.3-2.cm2.aarch64.rpm
+systemd-bootstrap-devel-250.3-2.cm2.aarch64.rpm
+systemd-bootstrap-rpm-macros-250.3-2.cm2.noarch.rpm
 tar-1.34-1.cm2.aarch64.rpm
 tar-debuginfo-1.34-1.cm2.aarch64.rpm
 tdnf-2.1.0-8.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -533,10 +533,10 @@ sqlite-devel-3.36.0-2.cm2.x86_64.rpm
 sqlite-libs-3.36.0-2.cm2.x86_64.rpm
 swig-4.0.2-3.cm2.x86_64.rpm
 swig-debuginfo-4.0.2-3.cm2.x86_64.rpm
-systemd-bootstrap-250.3-1.cm2.x86_64.rpm
-systemd-bootstrap-debuginfo-250.3-1.cm2.x86_64.rpm
-systemd-bootstrap-devel-250.3-1.cm2.x86_64.rpm
-systemd-bootstrap-rpm-macros-250.3-1.cm2.noarch.rpm
+systemd-bootstrap-250.3-2.cm2.x86_64.rpm
+systemd-bootstrap-debuginfo-250.3-2.cm2.x86_64.rpm
+systemd-bootstrap-devel-250.3-2.cm2.x86_64.rpm
+systemd-bootstrap-rpm-macros-250.3-2.cm2.noarch.rpm
 tar-1.34-1.cm2.x86_64.rpm
 tar-debuginfo-1.34-1.cm2.x86_64.rpm
 tdnf-2.1.0-8.cm2.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Change compression algorithm in systemd from zstd to lz4 for coredumps and journal logs. We already specified lz4 (-Dlz4=true), but since zstd is present in the build chroot environment, this is picked by default by systemd. Explicitly turn off zstd (with -Dzstd=false) to ensure that lz4 is used.
Note that in CBL-Mariner 1.0, systemd used lz4.
This will be a breaking change for CBL-Mariner 2.0 preview images that have previously used zstd compression (systemd coredumps and logs compressed with zstd will not be readable with the lz4-enabled systemd). journalctl calls will show something like: "Journal file /run/log/journal/3c8daabef00e4ea09f6be20c83c30f3b/system.journal uses an unsupported feature, ignoring file."

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change systemd compression to lz4

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build of systemd and VHD. Boot VHD, check logs with journalctl, trigger crashdump, check with coredumpctl