### PR TITLE
golang: bump version to 1.16.15 to address CVE-2022-24921

### DIFF
--- a/SPECS/audit/audit.spec
+++ b/SPECS/audit/audit.spec
@@ -4,7 +4,7 @@
 Summary:        Kernel Audit Tool
 Name:           audit
 Version:        3.0
-Release:        13%{?dist}
+Release:        14%{?dist}
 Source0:        https://people.redhat.com/sgrubb/audit/%{name}-%{version}-alpha8.tar.gz
 Patch0:         refuse-manual-stop.patch
 License:        GPLv2+
@@ -166,6 +166,8 @@ make %{?_smp_mflags} check
 %{python3_sitelib}/*
 
 %changelog
+*   Tue Mar 15 2022 Muhammad Falak <mwani@microsoft.com> - 3.0-14
+-   Bump release to force rebuild with golang 1.16.15
 *   Fri Feb 18 2022 Thomas Crain <thcrain@microsoft.com> - 3.0-13
 -   Bump release to force rebuild with golang 1.16.14
 *   Tue Feb 01 2022 Max Brodeur-Urbas <maxbr@microsoft.com> - 3.0-12

--- a/SPECS/blobfuse/blobfuse.spec
+++ b/SPECS/blobfuse/blobfuse.spec
@@ -1,7 +1,7 @@
 Summary:        FUSE adapter - Azure Storage Blobs
 Name:           blobfuse
 Version:        1.3.6
-Release:        7%{?dist}
+Release:        8%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -47,6 +47,9 @@ rm -rf %{buildroot}
 %{_bindir}/blobfuse
 
 %changelog
+* Tue Mar 15 2022 Muhammad Falak <mwani@microsoft.com> - 1.3.6-8
+- Bump release to force rebuild with golang 1.16.15
+
 * Fri Feb 18 2022 Thomas Crain <thcrain@microsoft.com> - 1.3.6-7
 - Bump release to force rebuild with golang 1.16.14
 

--- a/SPECS/cni/cni.spec
+++ b/SPECS/cni/cni.spec
@@ -3,7 +3,7 @@
 Summary:        Container Network Interface (CNI) plugins
 Name:           cni
 Version:        0.9.1
-Release:        4%{?dist}
+Release:        5%{?dist}
 License:        ASL 2.0
 URL:            https://github.com/containernetworking/plugins
 #Source0:       https://github.com/containernetworking/plugins/archive/refs/tags/v0.9.1.tar.gz
@@ -42,6 +42,9 @@ install -vpm 0755 -t %{buildroot}%{_default_cni_plugins_dir} bin/*
 %{_default_cni_plugins_dir}/*
 
 %changelog
+* Tue Mar 15 2022 Muhammad Falak <mwani@microsoft.com> - 0.9.1-5
+- Bump release to force rebuild with golang 1.16.15
+
 * Fri Feb 18 2022 Thomas Crain <thcrain@microsoft.com> - 0.9.1-4
 - Bump release to force rebuild with golang 1.16.14
 

--- a/SPECS/coredns/coredns-1.7.0.spec
+++ b/SPECS/coredns/coredns-1.7.0.spec
@@ -3,7 +3,7 @@
 Summary:        Fast and flexible DNS server
 Name:           coredns
 Version:        1.7.0
-Release:        7%{?dist}
+Release:        8%{?dist}
 License:        Apache License 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -61,6 +61,9 @@ rm -rf %{buildroot}/*
 %{_bindir}/%{name}
 
 %changelog
+* Tue Mar 15 2022 Muhammad Falak <mwani@microsoft.com> - 1.7.0-8
+- Bump release to force rebuild with golang 1.16.15
+
 * Fri Feb 18 2022 Thomas Crain <thcrain@microsoft.com> - 1.7.0-7
 - Bump release to force rebuild with golang 1.16.14
 

--- a/SPECS/coredns/coredns-1.8.0.spec
+++ b/SPECS/coredns/coredns-1.8.0.spec
@@ -3,7 +3,7 @@
 Summary:        Fast and flexible DNS server
 Name:           coredns
 Version:        1.8.0
-Release:        4%{?dist}
+Release:        5%{?dist}
 License:        Apache License 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -61,6 +61,9 @@ rm -rf %{buildroot}/*
 %{_bindir}/%{name}
 
 %changelog
+* Tue Mar 15 2022 Muhammad Falak <mwani@microsoft.com> - 1.8.0-5
+- Bump release to force rebuild with golang 1.16.15
+
 * Fri Feb 18 2022 Thomas Crain <thcrain@microsoft.com> - 1.8.0-4
 - Bump release to force rebuild with golang 1.16.14
 

--- a/SPECS/coredns/coredns-1.8.4.spec
+++ b/SPECS/coredns/coredns-1.8.4.spec
@@ -3,7 +3,7 @@
 Summary:        Fast and flexible DNS server
 Name:           coredns
 Version:        1.8.4
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        Apache License 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -61,6 +61,9 @@ rm -rf %{buildroot}/*
 %{_bindir}/%{name}
 
 %changelog
+* Tue Mar 15 2022 Muhammad Falak <mwani@microsoft.com> - 1.8.4-4
+- Bump release to force rebuild with golang 1.16.15
+
 * Fri Feb 18 2022 Thomas Crain <thcrain@microsoft.com> - 1.8.4-3
 - Bump release to force rebuild with golang 1.16.14
 

--- a/SPECS/cri-tools/cri-tools.spec
+++ b/SPECS/cri-tools/cri-tools.spec
@@ -3,7 +3,7 @@
 Summary:        CRI tools
 Name:           cri-tools
 Version:        1.22.0
-Release:        4%{?dist}
+Release:        5%{?dist}
 License:        ASL 2.0
 URL:            https://github.com/kubernetes-sigs/cri-tools
 #Source0:       https://github.com/kubernetes-sigs/cri-tools/archive/v%{version}.tar.gz
@@ -55,6 +55,9 @@ install -p -m 644 -t %{buildroot}%{_docdir}/%{name} ./docs/crictl.md
 rm -rf %{buildroot}/*
 
 %changelog
+* Tue Mar 15 2022 Muhammad Falak <mwani@microsoft.com> - 1.22.0-5
+- Bump release to force rebuild with golang 1.16.15
+
 * Fri Feb 18 2022 Thomas Crain <thcrain@microsoft.com> - 1.22.0-4
 - Bump release to force rebuild with golang 1.16.14
 

--- a/SPECS/etcd/etcd-3.4.13.spec
+++ b/SPECS/etcd/etcd-3.4.13.spec
@@ -1,7 +1,7 @@
 Summary:        A highly-available key value store for shared configuration
 Name:           etcd
 Version:        3.4.13
-Release:        8%{?dist}
+Release:        9%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -93,6 +93,9 @@ rm -rf %{buildroot}/*
 %{_bindir}/etcd-dump-*
 
 %changelog
+* Tue Mar 15 2022 Muhammad Falak <mwani@microsoft.com> - 3.4.13-9
+- Bump release to force rebuild with golang 1.16.15
+
 * Fri Feb 18 2022 Thomas Crain <thcrain@microsoft.com> - 3.4.13-8
 - Bump release to force rebuild with golang 1.16.14
 

--- a/SPECS/etcd/etcd-3.5.0.spec
+++ b/SPECS/etcd/etcd-3.5.0.spec
@@ -1,7 +1,7 @@
 Summary:        A highly-available key value store for shared configuration
 Name:           etcd
 Version:        3.5.0
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -141,6 +141,9 @@ rm -rf %{buildroot}/*
 /%{_docdir}/%{name}-%{version}-tools/*
 
 %changelog
+* Tue Mar 15 2022 Muhammad Falak <mwani@microsoft.com> - 3.5.0-4
+- Bump release to force rebuild with golang 1.16.15
+
 *   Fri Feb 18 2022 Thomas Crain <thcrain@microsoft.com> - 3.5.0-3
 -   Bump release to force rebuild with golang 1.16.14
 

--- a/SPECS/flannel/flannel.spec
+++ b/SPECS/flannel/flannel.spec
@@ -4,7 +4,7 @@
 Summary:        Simple and easy way to configure a layer 3 network fabric designed for Kubernetes
 Name:           flannel
 Version:        0.14.0
-Release:        4%{?dist}
+Release:        5%{?dist}
 License:        Apache License 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -50,6 +50,9 @@ rm -rf %{buildroot}/*
 %{_bindir}/flanneld
 
 %changelog
+* Tue Mar 15 2022 Muhammad Falak <mwani@microsoft.com> - 0.14.0-5
+- Bump release to force rebuild with golang 1.16.15
+
 * Fri Feb 18 2022 Thomas Crain <thcrain@microsoft.com> - 0.14.0-4
 - Bump release to force rebuild with golang 1.16.14
 

--- a/SPECS/glide/glide.spec
+++ b/SPECS/glide/glide.spec
@@ -1,7 +1,7 @@
 Summary:        Vendor Package Management for Golang
 Name:           glide
 Version:        0.13.3
-Release:        9%{?dist}
+Release:        10%{?dist}
 License:        MIT
 URL:            https://github.com/Masterminds/glide
 # Source0:      https://github.com/Masterminds/%{name}/archive/v%{version}.tar.gz
@@ -53,6 +53,9 @@ popd
 %{_bindir}/glide
 
 %changelog
+* Tue Mar 15 2022 Muhammad Falak <mwani@microsoft.com> - 0.13.3-10
+- Bump release to force rebuild with golang 1.16.15
+
 * Fri Feb 18 2022 Thomas Crain <thcrain@microsoft.com> - 0.13.3-9
 - Bump release to force rebuild with golang 1.16.14
 

--- a/SPECS/go-md2man/go-md2man.spec
+++ b/SPECS/go-md2man/go-md2man.spec
@@ -1,7 +1,7 @@
 Summary:    Converts markdown into roff (man pages)
 Name:       go-md2man
 Version:    2.0.0
-Release:    10%{?dist}
+Release:    11%{?dist}
 License:    MIT
 Group:      Tools/Container
 
@@ -49,6 +49,9 @@ cp go-md2man-2.0.0/LICENSE.md %{buildroot}/usr/share/doc/%{name}-%{version}/LICE
 %{_bindir}/go-md2man
 
 %changelog
+* Tue Mar 15 2022 Muhammad Falak <mwani@microsoft.com> - 2.0.0-11
+- Bump release to force rebuild with golang 1.16.15
+
 * Fri Feb 18 2022 Thomas Crain <thcrain@microsoft.com> - 2.0.0-10
 - Bump release to force rebuild with golang 1.16.14
 

--- a/SPECS/gobject-introspection/gobject-introspection.spec
+++ b/SPECS/gobject-introspection/gobject-introspection.spec
@@ -5,7 +5,7 @@ Name:           gobject-introspection
 Summary:        Introspection system for GObject-based libraries
 %define BaseVersion 1.58
 Version:        %{BaseVersion}.0
-Release:        14%{?dist}
+Release:        15%{?dist}
 Group:          Development/Libraries
 License:        GPLv2+ and LGPLv2+ and MIT
 URL:            https://github.com/GNOME/gobject-introspection
@@ -139,6 +139,9 @@ make  %{?_smp_mflags} check
 %doc %{_mandir}/man1/*.gz
 
 %changelog
+* Tue Mar 15 2022 Muhammad Falak <mwani@microsoft.com> - 1.58.0-15
+- Bump release to force rebuild with golang 1.16.15
+
 * Fri Feb 18 2022 Thomas Crain <thcrain@microsoft.com> - 1.58.0-14
 - Bump release to force rebuild with golang 1.16.14
 

--- a/SPECS/golang/golang-1.16.signatures.json
+++ b/SPECS/golang/golang-1.16.signatures.json
@@ -1,6 +1,6 @@
 {
  "Signatures": {
-  "go1.16.14.src.tar.gz": "467898cd3a216de54dcb9014f541efe77e9b79a7154dbc1fd2dd778b0c63fb56",
+  "go1.16.15.src.tar.gz": "90a08c689279e35f3865ba510998c33a63255c36089b3ec206c912fc0568c3d3",
   "go1.4-bootstrap-20171003.tar.gz": "f4ff5b5eb3a3cae1c993723f3eab519c5bae18866b5e5f96fe1102f0cb5c3e52"
  }
 }

--- a/SPECS/golang/golang-1.16.spec
+++ b/SPECS/golang/golang-1.16.spec
@@ -12,7 +12,7 @@
 %define __find_requires %{nil}
 Summary:        Go
 Name:           golang
-Version:        1.16.14
+Version:        1.16.15
 Release:        1%{?dist}
 License:        BSD
 Vendor:         Microsoft Corporation
@@ -119,6 +119,9 @@ fi
 %{_bindir}/*
 
 %changelog
+* Thu Mar 17 2022 Muhammad Falak <mwani@microsoft.com> - 1.16.15-1
+- Bump version to 1.16.15 to address CVE-2022-24921
+
 * Fri Feb 18 2022 Thomas Crain <thcrain@microsoft.com> - 1.16.14-1
 - Upgrade to version 1.16.14 to resolve CVE-2022-23806, CVE-2022-23772, CVE-2022-23773
 

--- a/SPECS/helm/helm.spec
+++ b/SPECS/helm/helm.spec
@@ -2,7 +2,7 @@
 Summary:        The Kubernetes Package Manager
 Name:           helm
 Version:        3.4.1
-Release:        7%{?dist}
+Release:        8%{?dist}
 License:        Apache 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -52,6 +52,9 @@ install -m 755 ./helm %{buildroot}%{_bindir}
 %{_bindir}/helm
 
 %changelog
+* Tue Mar 15 2022 Muhammad Falak <mwani@microsoft.com> - 3.4.1-8
+- Bump release to force rebuild with golang 1.16.15
+
 * Fri Feb 18 2022 Thomas Crain <thcrain@microsoft.com> - 3.4.1-7
 - Bump release to force rebuild with golang 1.16.14
 

--- a/SPECS/moby-buildx/moby-buildx.spec
+++ b/SPECS/moby-buildx/moby-buildx.spec
@@ -1,7 +1,7 @@
 Summary: A Docker CLI plugin for extended build capabilities with BuildKit
 Name: moby-buildx
 Version: 0.4.1+azure
-Release: 7%{?dist}
+Release: 8%{?dist}
 License: ASL 2.0
 Group: Tools/Container
 
@@ -79,6 +79,9 @@ cp %{SOURCE2} %{buildroot}/usr/share/doc/%{name}-%{version}/NOTICE
 %{_libexecdir}/docker/cli-plugins/docker-buildx
 
 %changelog
+* Tue Mar 15 2022 Muhammad Falak <mwani@microsoft.com> - 0.4.1+azure-8
+- Bump release to force rebuild with golang 1.16.15
+
 * Fri Feb 18 2022 Thomas Crain <thcrain@microsoft.com> - 0.4.1+azure-7
 - Bump release to force rebuild with golang 1.16.14
 

--- a/SPECS/moby-cli/moby-cli.spec
+++ b/SPECS/moby-cli/moby-cli.spec
@@ -1,7 +1,7 @@
 Summary: The open-source application container engine client.
 Name: moby-cli
 Version: 19.03.15+azure
-Release: 6%{?dist}
+Release: 7%{?dist}
 License: ASL 2.0
 Group: Tools/Container
 
@@ -94,6 +94,9 @@ cp %{SOURCE2} %{buildroot}/usr/share/doc/%{name}-%{version}/LICENSE
 /usr/share/fish/vendor_completions.d/docker.fish
 
 %changelog
+* Tue Mar 15 2022 Muhammad Falak <mwani@microsoft.com> - 19.03.15+azure-7
+- Bump release to force rebuild with golang 1.16.15
+
 * Fri Feb 18 2022 Thomas Crain <thcrain@microsoft.com> - 19.03.15+azure-6
 - Bump release to force rebuild with golang 1.16.14
 

--- a/SPECS/moby-containerd/moby-containerd.spec
+++ b/SPECS/moby-containerd/moby-containerd.spec
@@ -3,7 +3,7 @@
 Summary: Industry-standard container runtime
 Name: moby-containerd
 Version: 1.5.9+azure
-Release: 4%{?dist}
+Release: 5%{?dist}
 License: ASL 2.0
 Group: Tools/Container
 
@@ -134,6 +134,9 @@ fi
 %{_mandir}/*/*
 
 %changelog
+* Tue Mar 15 2022 Muhammad Falak <mwani@microsoft.com> - 1.5.9+azure-5
+- Bump release to force rebuild with golang 1.16.15
+
 * Thu Mar 03 2022 Anirudh Gopal <angop@microsoft.com> - 1.5.9+azure-4
 - Enable containerd service restart
 * Wed Mar 02 2022 Nicolas Guibourge <nicolasg@microsoft.com> - 1.5.9+azure-3

--- a/SPECS/moby-engine/moby-engine.spec
+++ b/SPECS/moby-engine/moby-engine.spec
@@ -1,7 +1,7 @@
 Summary: The open-source application container engine
 Name:    moby-engine
 Version: 19.03.15+azure
-Release: 7%{?dist}
+Release: 8%{?dist}
 License: ASL 2.0
 Group:   Tools/Container
 
@@ -151,6 +151,9 @@ fi
 /usr/share/doc/%{name}-%{version}/*
 
 %changelog
+* Tue Mar 15 2022 Muhammad Falak <mwani@microsoft.com> - 19.03.15+azure-8
+- Bump release to force rebuild with golang 1.16.15
+
 * Fri Feb 18 2022 Thomas Crain <thcrain@microsoft.com> - 19.03.15+azure-7
 - Bump release to force rebuild with golang 1.16.14
 

--- a/SPECS/moby-runc/moby-runc.spec
+++ b/SPECS/moby-runc/moby-runc.spec
@@ -1,7 +1,7 @@
 Summary:        CLI tool for spawning and running containers per OCI spec.
 Name:           moby-runc
 Version:        1.1.0+azure
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -108,6 +108,9 @@ cp %{SOURCE7} %{buildroot}%{_docdir}/%{name}-%{version}/LICENSE
 %{_mandir}/*/*
 
 %changelog
+* Tue Mar 15 2022 Muhammad Falak <mwani@microsoft.com> - 1.1.0+azure-4
+- Bump release to force rebuild with golang 1.16.15
+
 * Fri Feb 18 2022 Thomas Crain <thcrain@microsoft.com> - 1.1.0+azure-3
 - Bump release to force rebuild with golang 1.16.14
 

--- a/SPECS/node-problem-detector/node-problem-detector.spec
+++ b/SPECS/node-problem-detector/node-problem-detector.spec
@@ -1,7 +1,7 @@
 Summary:        Kubernetes daemon to detect and report node issues
 Name:           node-problem-detector
 Version:        0.8.8
-Release:        5%{?dist}
+Release:        6%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -61,6 +61,9 @@ make test
 %config(noreplace) %{_sysconfdir}/node-problem-detector.d/*
 
 %changelog
+* Tue Mar 15 2022 Muhammad Falak <mwani@microsoft.com> - 0.8.8-6
+- Bump release to force rebuild with golang 1.16.15
+
 * Fri Feb 18 2022 Thomas Crain <thcrain@microsoft.com> - 0.8.8-5
 - Bump release to force rebuild with golang 1.16.14
 

--- a/SPECS/nvidia-container-runtime/nvidia-container-runtime.spec
+++ b/SPECS/nvidia-container-runtime/nvidia-container-runtime.spec
@@ -2,7 +2,7 @@
 Summary:        NVIDIA container runtime
 Name:           nvidia-container-runtime
 Version:        3.5.0
-Release:        4%{?dist}
+Release:        5%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -32,6 +32,9 @@ install -m 755 %{name} %{buildroot}%{_bindir}/%{name}
 %{_bindir}/%{name}
 
 %changelog
+* Tue Mar 15 2022 Muhammad Falak <mwani@microsoft.com> - 3.5.0-5
+- Bump release to force rebuild with golang 1.16.15
+
 * Fri Feb 18 2022 Thomas Crain <thcrain@microsoft.com> - 3.5.0-4
 - Bump release to force rebuild with golang 1.16.14
 

--- a/SPECS/nvidia-container-toolkit/nvidia-container-toolkit.spec
+++ b/SPECS/nvidia-container-toolkit/nvidia-container-toolkit.spec
@@ -2,7 +2,7 @@
 Summary:        NVIDIA container runtime hook
 Name:           nvidia-container-toolkit
 Version:        1.5.1
-Release:        4%{?dist}
+Release:        5%{?dist}
 License:        ALS2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -70,6 +70,9 @@ rm -f %{_bindir}/nvidia-container-runtime-hook
 %{_datadir}/containers/oci/hooks.d/oci-nvidia-hook.json
 
 %changelog
+* Tue Mar 15 2022 Muhammad Falak <mwani@microsoft.com> - 1.5.1-5
+- Bump release to force rebuild with golang 1.16.15
+
 * Fri Feb 18 2022 Thomas Crain <thcrain@microsoft.com> - 1.5.1-4
 - Bump release to force rebuild with golang 1.16.14
 

--- a/SPECS/telegraf/telegraf.spec
+++ b/SPECS/telegraf/telegraf.spec
@@ -1,7 +1,7 @@
 Summary:        agent for collecting, processing, aggregating, and writing metrics.
 Name:           telegraf
 Version:        1.14.5
-Release:        11%{?dist}
+Release:        12%{?dist}
 License:        MIT
 Group:          Development/Tools
 Vendor:         Microsoft Corporation
@@ -80,6 +80,9 @@ fi
 %dir %{_sysconfdir}/%{name}/telegraf.d
 
 %changelog
+* Tue Mar 15 2022 Muhammad Falak <mwani@microsoft.com> - 1.14.5-12
+- Bump release to force rebuild with golang 1.16.15
+
 * Fri Feb 18 2022 Thomas Crain <thcrain@microsoft.com> - 1.14.5-11
 - Bump release to force rebuild with golang 1.16.14
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -1865,8 +1865,8 @@
         "type": "other",
         "other": {
           "name": "golang",
-          "version": "1.16.14",
-          "downloadUrl": "https://golang.org/dl/go1.16.14.src.tar.gz"
+          "version": "1.16.15",
+          "downloadUrl": "https://golang.org/dl/go1.16.15.src.tar.gz"
         }
       }
     },

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -2,11 +2,11 @@ alsa-lib-1.2.2-1.cm1.aarch64.rpm
 alsa-lib-debuginfo-1.2.2-1.cm1.aarch64.rpm
 alsa-lib-devel-1.2.2-1.cm1.aarch64.rpm
 asciidoc-8.6.10-4.cm1.noarch.rpm
-audit-3.0-13.cm1.aarch64.rpm
-audit-debuginfo-3.0-13.cm1.aarch64.rpm
-audit-devel-3.0-13.cm1.aarch64.rpm
-audit-libs-3.0-13.cm1.aarch64.rpm
-audit-python-3.0-13.cm1.aarch64.rpm
+audit-3.0-14.cm1.aarch64.rpm
+audit-debuginfo-3.0-14.cm1.aarch64.rpm
+audit-devel-3.0-14.cm1.aarch64.rpm
+audit-libs-3.0-14.cm1.aarch64.rpm
+audit-python-3.0-14.cm1.aarch64.rpm
 autoconf-2.69-10.cm1.noarch.rpm
 automake-1.16.1-3.cm1.noarch.rpm
 bash-4.4.23-1.cm1.aarch64.rpm
@@ -127,7 +127,7 @@ gmp-debuginfo-6.1.2-6.cm1.aarch64.rpm
 gmp-devel-6.1.2-6.cm1.aarch64.rpm
 gnupg2-2.2.20-3.cm1.aarch64.rpm
 gnupg2-debuginfo-2.2.20-3.cm1.aarch64.rpm
-golang-1.16.14-1.cm1.aarch64.rpm
+golang-1.16.15-1.cm1.aarch64.rpm
 gperf-3.1-3.cm1.aarch64.rpm
 gperf-debuginfo-3.1-3.cm1.aarch64.rpm
 gpgme-1.13.1-6.cm1.aarch64.rpm
@@ -353,7 +353,7 @@ python2-libcap-ng-0.7.9-3.cm1.aarch64.rpm
 python2-libs-2.7.18-9.cm1.aarch64.rpm
 python2-test-2.7.18-9.cm1.aarch64.rpm
 python2-tools-2.7.18-9.cm1.aarch64.rpm
-python3-audit-3.0-13.cm1.aarch64.rpm
+python3-audit-3.0-14.cm1.aarch64.rpm
 python3-cracklib-2.9.7-2.cm1.aarch64.rpm
 python3-gpg-1.13.1-6.cm1.aarch64.rpm
 python3-libcap-ng-0.7.9-3.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -2,11 +2,11 @@ alsa-lib-1.2.2-1.cm1.x86_64.rpm
 alsa-lib-debuginfo-1.2.2-1.cm1.x86_64.rpm
 alsa-lib-devel-1.2.2-1.cm1.x86_64.rpm
 asciidoc-8.6.10-4.cm1.noarch.rpm
-audit-3.0-13.cm1.x86_64.rpm
-audit-debuginfo-3.0-13.cm1.x86_64.rpm
-audit-devel-3.0-13.cm1.x86_64.rpm
-audit-libs-3.0-13.cm1.x86_64.rpm
-audit-python-3.0-13.cm1.x86_64.rpm
+audit-3.0-14.cm1.x86_64.rpm
+audit-debuginfo-3.0-14.cm1.x86_64.rpm
+audit-devel-3.0-14.cm1.x86_64.rpm
+audit-libs-3.0-14.cm1.x86_64.rpm
+audit-python-3.0-14.cm1.x86_64.rpm
 autoconf-2.69-10.cm1.noarch.rpm
 automake-1.16.1-3.cm1.noarch.rpm
 bash-4.4.23-1.cm1.x86_64.rpm
@@ -127,7 +127,7 @@ gmp-debuginfo-6.1.2-6.cm1.x86_64.rpm
 gmp-devel-6.1.2-6.cm1.x86_64.rpm
 gnupg2-2.2.20-3.cm1.x86_64.rpm
 gnupg2-debuginfo-2.2.20-3.cm1.x86_64.rpm
-golang-1.16.14-1.cm1.x86_64.rpm
+golang-1.16.15-1.cm1.x86_64.rpm
 gperf-3.1-3.cm1.x86_64.rpm
 gperf-debuginfo-3.1-3.cm1.x86_64.rpm
 gpgme-1.13.1-6.cm1.x86_64.rpm
@@ -353,7 +353,7 @@ python2-libcap-ng-0.7.9-3.cm1.x86_64.rpm
 python2-libs-2.7.18-9.cm1.x86_64.rpm
 python2-test-2.7.18-9.cm1.x86_64.rpm
 python2-tools-2.7.18-9.cm1.x86_64.rpm
-python3-audit-3.0-13.cm1.x86_64.rpm
+python3-audit-3.0-14.cm1.x86_64.rpm
 python3-cracklib-2.9.7-2.cm1.x86_64.rpm
 python3-gpg-1.13.1-6.cm1.x86_64.rpm
 python3-libcap-ng-0.7.9-3.cm1.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

###### TODO:

- [x] Bump version for k8s to force rebuild.

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Bump version to 1.16.15 to address CVE-2022-24921

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Bump version to 1.16.15 to address CVE-2022-24921
- Bump version of dependent packages to force rebuild with go1.16.15

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #2471
-  #2507 
    [on hold as it needs to enable `CGO` which is disabled as of now]




###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2022-24921

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: ~~In progress~~ 176925
- Local Build with RUN_CHECK=y
