### PR TITLE
Modify pam to require audit-libs

### DIFF
--- a/SPECS/pam/pam.spec
+++ b/SPECS/pam/pam.spec
@@ -1,7 +1,7 @@
 Summary:        Linux Pluggable Authentication Modules
 Name:           pam
 Version:        1.5.1
-Release:        4%{?dist}
+Release:        5%{?dist}
 License:        BSD and GPLv2+
 URL:            https://github.com/linux-pam/linux-pam
 Source0:        https://github.com/linux-pam/linux-pam/releases/download/v%{version}/Linux-PAM-%{version}.tar.xz
@@ -11,7 +11,7 @@ Distribution:   Mariner
 BuildRequires:  cracklib-devel
 BuildRequires:  libselinux-devel
 BuildRequires:  audit-devel
-Recommends:     audit-libs
+Requires:       audit-libs
 Recommends:     cracklib-dicts
 
 %description
@@ -98,6 +98,9 @@ EOF
 %{_docdir}/%{name}-%{version}/*
 
 %changelog
+* Tue Mar 22 2022 Andrew Phelps <anphel@microsoft.com> - 1.5.1-5
+- Require audit-libs
+
 * Mon Mar 14 2022 Andrew Phelps <anphel@microsoft.com> - 1.5.1-4
 - Add Recommends for audit-libs and cracklib-dicts to resolve circular dependency and boot issue
 

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -263,10 +263,10 @@ p11-kit-debuginfo-0.24.1-1.cm2.aarch64.rpm
 p11-kit-devel-0.24.1-1.cm2.aarch64.rpm
 p11-kit-server-0.24.1-1.cm2.aarch64.rpm
 p11-kit-trust-0.24.1-1.cm2.aarch64.rpm
-pam-1.5.1-4.cm2.aarch64.rpm
-pam-debuginfo-1.5.1-4.cm2.aarch64.rpm
-pam-devel-1.5.1-4.cm2.aarch64.rpm
-pam-lang-1.5.1-4.cm2.aarch64.rpm
+pam-1.5.1-5.cm2.aarch64.rpm
+pam-debuginfo-1.5.1-5.cm2.aarch64.rpm
+pam-devel-1.5.1-5.cm2.aarch64.rpm
+pam-lang-1.5.1-5.cm2.aarch64.rpm
 patch-2.7.6-7.cm2.aarch64.rpm
 patch-debuginfo-2.7.6-7.cm2.aarch64.rpm
 pcre-8.45-2.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -263,10 +263,10 @@ p11-kit-debuginfo-0.24.1-1.cm2.x86_64.rpm
 p11-kit-devel-0.24.1-1.cm2.x86_64.rpm
 p11-kit-server-0.24.1-1.cm2.x86_64.rpm
 p11-kit-trust-0.24.1-1.cm2.x86_64.rpm
-pam-1.5.1-4.cm2.x86_64.rpm
-pam-debuginfo-1.5.1-4.cm2.x86_64.rpm
-pam-devel-1.5.1-4.cm2.x86_64.rpm
-pam-lang-1.5.1-4.cm2.x86_64.rpm
+pam-1.5.1-5.cm2.x86_64.rpm
+pam-debuginfo-1.5.1-5.cm2.x86_64.rpm
+pam-devel-1.5.1-5.cm2.x86_64.rpm
+pam-lang-1.5.1-5.cm2.x86_64.rpm
 patch-2.7.6-7.cm2.x86_64.rpm
 patch-debuginfo-2.7.6-7.cm2.x86_64.rpm
 pcre-8.45-2.cm2.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Resolve boot issue seen with ISO installer. Systemd needs to have audit-libs installed at runtime. This change ensure that, since systemd requires pam, and pam now requires audit-libs.
Error seen during ISO build was: 
"WARN[0014] systemctl: error while loading shared libraries: libaudit.so.1: cannot open shared object file: No such file or directory"

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change pam to require audit-libs

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local package build, local ISO build, booted the ISO to installer screen
