### PR TITLE
Port cloud-init ovf_is_accessible DataSourceAzure.py fix

### DIFF
--- a/SPECS/cloud-init/azureds-set-ovf_is_accesible.patch
+++ b/SPECS/cloud-init/azureds-set-ovf_is_accesible.patch
@@ -1,0 +1,59 @@
+From 0988fb89be06aeb08083ce609f755509d08fa459 Mon Sep 17 00:00:00 2001
+From: Chris Patterson <cpatterson@microsoft.com>
+Date: Tue, 18 Jan 2022 15:45:59 -0500
+Subject: [PATCH] sources/azure: set ovf_is_accessible when OVF is read
+ successfully (#1193)
+
+The if-statement set ovf_is_accessible to True if the OVF is read
+from /dev/sr0, but not from other data sources.  It defaults to
+True, but may get flipped to False while processing an invalid
+source, and never get set back to True when reading from the data
+directory.
+
+Instead, default ovf_is_accessible to False, and only set it to
+True once we've read an OVF successfully (and end the search).
+
+This fixes an error when OVF is read from data_dir and IMDS
+data is unavailable (failing with "No OVF or IMDS available").
+
+[Backport to 21.4]
+Signed-off-by: Anirudh Gopal <angop@microsoft.com>
+---
+ cloudinit/sources/DataSourceAzure.py | 5 ++---
+ 1 file changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/cloudinit/sources/DataSourceAzure.py b/cloudinit/sources/DataSourceAzure.py
+index 93493fa0..3ff043da 100755
+--- a/cloudinit/sources/DataSourceAzure.py
++++ b/cloudinit/sources/DataSourceAzure.py
+@@ -429,7 +429,7 @@ class DataSourceAzure(sources.DataSource):
+         # the candidate list determines the path to take in order to get the
+         # metadata we need.
+         reprovision = False
+-        ovf_is_accessible = True
++        ovf_is_accessible = False
+         reprovision_after_nic_attach = False
+         metadata_source = None
+         ret = None
+@@ -459,9 +459,9 @@ class DataSourceAzure(sources.DataSource):
+                             ret = util.mount_cb(src, load_azure_ds_dir)
+                         # save the device for ejection later
+                         self.iso_dev = src
+-                        ovf_is_accessible = True
+                     else:
+                         ret = load_azure_ds_dir(src)
++                    ovf_is_accessible = True
+                     metadata_source = src
+                     break
+                 except NonAzureDataSource:
+@@ -473,7 +473,6 @@ class DataSourceAzure(sources.DataSource):
+                     report_diagnostic_event(
+                         '%s was not mountable' % src,
+                         logger_func=LOG.debug)
+-                    ovf_is_accessible = False
+                     empty_md = {'local-hostname': ''}
+                     empty_cfg = dict(
+                         system_info=dict(
+-- 
+2.17.1
+

--- a/SPECS/cloud-init/cloud-init.spec
+++ b/SPECS/cloud-init/cloud-init.spec
@@ -1,3 +1,5 @@
+%define python3_sitelib %{_libdir}/python3.7/site-packages
+%define cl_services cloud-config.service cloud-config.target cloud-final.service cloud-init.service cloud-init.target cloud-init-local.service
 Summary:        Cloud instance init scripts
 Name:           cloud-init
 Version:        21.4
@@ -18,8 +20,7 @@ Patch3:         cloud-cfg.patch
 Patch4:         mariner-21.4.patch
 # backport patch https://github.com/canonical/cloud-init/commit/0988fb89be06aeb08083ce609f755509d08fa459.patch to 21.4
 Patch5:         azureds-set-ovf_is_accesible.patch
-%define python3_sitelib %{_libdir}/python3.7/site-packages
-%define cl_services cloud-config.service cloud-config.target cloud-final.service cloud-init.service cloud-init.target cloud-init-local.service
+
 BuildRequires:  automake
 BuildRequires:  dbus
 BuildRequires:  iproute
@@ -124,18 +125,18 @@ rm tests/unittests/test_net_freebsd.py
 
 make check %{?_smp_mflags}
 
-%{clean}
+%clean
 rm -rf %{buildroot}
 
 
 %post
-%{systemd_post} %{cl_services}
+%systemd_post %{cl_services}
 
 %preun
 %systemd_preun %{cl_services}
 
 %postun
-%{systemd_postun} %{cl_services}
+%systemd_postun %{cl_services}
 
 %files
 %{_bindir}/*

--- a/SPECS/cloud-init/cloud-init.spec
+++ b/SPECS/cloud-init/cloud-init.spec
@@ -132,7 +132,7 @@ rm -rf %{buildroot}
 %{systemd_post} %{cl_services}
 
 %preun
-%{systemd_preun} %{cl_services}
+%systemd_preun %{cl_services}
 
 %postun
 %{systemd_postun} %{cl_services}

--- a/SPECS/cloud-init/cloud-init.spec
+++ b/SPECS/cloud-init/cloud-init.spec
@@ -1,9 +1,7 @@
-%define python3_sitelib %{_libdir}/python3.7/site-packages
-%define cl_services cloud-config.service cloud-config.target cloud-final.service cloud-init.service cloud-init.target cloud-init-local.service
 Summary:        Cloud instance init scripts
 Name:           cloud-init
 Version:        21.4
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv3
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -18,6 +16,10 @@ Patch2:         ds-vmware-mariner.patch
 Patch3:         cloud-cfg.patch
 # Add Mariner distro support to cloud-init
 Patch4:         mariner-21.4.patch
+# backport patch https://github.com/canonical/cloud-init/commit/0988fb89be06aeb08083ce609f755509d08fa459.patch to 21.4
+Patch5:         azureds-set-ovf_is_accesible.patch
+%define python3_sitelib %{_libdir}/python3.7/site-packages
+%define cl_services cloud-config.service cloud-config.target cloud-final.service cloud-init.service cloud-init.target cloud-init-local.service
 BuildRequires:  automake
 BuildRequires:  dbus
 BuildRequires:  iproute
@@ -72,6 +74,7 @@ ssh keys and to let the user run various scripts.
 %package azure-kvp
 Summary:        Cloud-init configuration for Hyper-V telemetry
 Requires:       %{name} = %{version}-%{release}
+
 %description    azure-kvp
 Cloud-init configuration for Hyper-V telemetry
 
@@ -121,18 +124,18 @@ rm tests/unittests/test_net_freebsd.py
 
 make check %{?_smp_mflags}
 
-%clean
+%{clean}
 rm -rf %{buildroot}
 
 
 %post
-%systemd_post %{cl_services}
+%{systemd_post} %{cl_services}
 
 %preun
-%systemd_preun %{cl_services}
+%{systemd_preun} %{cl_services}
 
 %postun
-%systemd_postun %{cl_services}
+%{systemd_postun} %{cl_services}
 
 %files
 %{_bindir}/*
@@ -158,6 +161,9 @@ rm -rf %{buildroot}
 %config(noreplace) %{_sysconfdir}/cloud/cloud.cfg.d/10-azure-kvp.cfg
 
 %changelog
+* Tue Mar 22 2022 Anirudh Gopal <angop@microsoft.com> - 21.4-2
+- Backport cloud-init ovf_is_accessible DataSourceAzure.py fix to 21.4
+
 * Wed Mar 16 2022 Henry Beberman <henry.beberman@microsoft.com> - 21.4-1
 - Update to version 21.4
 - Remove several upstreamed patches already present in source


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?

Backporting fix ovf_is_accessible in DataSourceAzure.py.
Source Commit: https://github.com/canonical/cloud-init/commit/4496ad036505d0fbef80c8bf45a5e7ff8adea1e7 
Previously the code only considered ovf being accessible if iso could be
mounted, it missed the case where ovf was available in /var/lib/waagent.

For more context on the fix, contact Christopher Patterson/Anh Vo.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
Ported cloud-init ovf_is_accessible DataSourceAzure.py fix.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build
