### PR TITLE
[main] Add netplan support to cloud-init

### DIFF
--- a/SPECS/cloud-init/cloud-init.spec
+++ b/SPECS/cloud-init/cloud-init.spec
@@ -2,7 +2,7 @@
 Summary:        Cloud instance init scripts
 Name:           cloud-init
 Version:        22.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv3
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -10,7 +10,8 @@ Group:          System Environment/Base
 URL:            https://launchpad.net/cloud-init
 Source0:        https://launchpad.net/cloud-init/trunk/%{version}/+download/%{name}-%{version}.tar.gz
 Source1:        10-azure-kvp.cfg
-Patch0:         mariner.patch
+# Add Mariner distro support to cloud-init 22.1
+Patch0:         mariner-22.1.patch
 BuildRequires:  automake
 BuildRequires:  dbus
 BuildRequires:  iproute
@@ -141,6 +142,9 @@ make check %{?_smp_mflags}
 %config(noreplace) %{_sysconfdir}/cloud/cloud.cfg.d/10-azure-kvp.cfg
 
 %changelog
+* Mon Mar 28 2022 Henry Beberman <henry.beberman@microsoft.com> - 22.1-2
+- Add netplan defaults to Mariner distro config patch
+
 * Wed Feb 23 2022 Henry Beberman <henry.beberman@microsoft.com> - 22.1-1
 - Update to version 22.1
 - Port Mariner patch forward.

--- a/SPECS/cloud-init/mariner-22.1.patch
+++ b/SPECS/cloud-init/mariner-22.1.patch
@@ -1,6 +1,8 @@
+Patch cloud-init 22.1 to add distro support for CBL-Mariner
+
 diff -Naur a/cloudinit/config/cc_ntp.py b/cloudinit/config/cc_ntp.py
---- a/cloudinit/config/cc_ntp.py	2022-02-23 15:48:29.372268221 -0800
-+++ b/cloudinit/config/cc_ntp.py	2022-02-23 17:28:50.437796028 -0800
+--- a/cloudinit/config/cc_ntp.py	2022-02-15 10:02:23.000000000 -0800
++++ b/cloudinit/config/cc_ntp.py	2022-03-28 20:35:46.924019452 -0700
 @@ -32,6 +32,7 @@
      "debian",
      "eurolinux",
@@ -30,8 +32,8 @@ diff -Naur a/cloudinit/config/cc_ntp.py b/cloudinit/config/cc_ntp.py
          "chrony": {
              "service_name": "chronyd",
 diff -Naur a/cloudinit/config/cc_resolv_conf.py b/cloudinit/config/cc_resolv_conf.py
---- a/cloudinit/config/cc_resolv_conf.py	2022-02-23 15:15:37.197609792 -0800
-+++ b/cloudinit/config/cc_resolv_conf.py	2022-02-23 15:15:41.397597119 -0800
+--- a/cloudinit/config/cc_resolv_conf.py	2022-02-15 10:02:23.000000000 -0800
++++ b/cloudinit/config/cc_resolv_conf.py	2022-03-28 20:35:46.924019452 -0700
 @@ -30,7 +30,7 @@
  
  **Module frequency:** per instance
@@ -52,7 +54,7 @@ diff -Naur a/cloudinit/config/cc_resolv_conf.py b/cloudinit/config/cc_resolv_con
      "/etc/resolv.conf": "resolv.conf",
 diff -Naur a/cloudinit/config/cc_yum_add_repo.py b/cloudinit/config/cc_yum_add_repo.py
 --- a/cloudinit/config/cc_yum_add_repo.py	2022-02-15 10:02:23.000000000 -0800
-+++ b/cloudinit/config/cc_yum_add_repo.py	2022-02-23 15:16:23.853470925 -0800
++++ b/cloudinit/config/cc_yum_add_repo.py	2022-03-28 20:35:46.924019452 -0700
 @@ -18,7 +18,7 @@
  
  **Module frequency:** always
@@ -72,7 +74,7 @@ diff -Naur a/cloudinit/config/cc_yum_add_repo.py b/cloudinit/config/cc_yum_add_r
      "rhel",
 diff -Naur a/cloudinit/distros/__init__.py b/cloudinit/distros/__init__.py
 --- a/cloudinit/distros/__init__.py	2022-02-15 10:02:23.000000000 -0800
-+++ b/cloudinit/distros/__init__.py	2022-02-23 15:16:44.073411995 -0800
++++ b/cloudinit/distros/__init__.py	2022-03-28 20:35:46.924019452 -0700
 @@ -45,6 +45,7 @@
          "cloudlinux",
          "eurolinux",
@@ -83,8 +85,8 @@ diff -Naur a/cloudinit/distros/__init__.py b/cloudinit/distros/__init__.py
          "photon",
 diff -Naur a/cloudinit/distros/mariner.py b/cloudinit/distros/mariner.py
 --- a/cloudinit/distros/mariner.py	1969-12-31 16:00:00.000000000 -0800
-+++ b/cloudinit/distros/mariner.py	2022-02-23 15:18:06.141179855 -0800
-@@ -0,0 +1,142 @@
++++ b/cloudinit/distros/mariner.py	2022-03-28 20:41:15.351781928 -0700
+@@ -0,0 +1,157 @@
 +#!/usr/bin/env python3
 +# vi: ts=4 expandtab
 +#
@@ -103,6 +105,13 @@ diff -Naur a/cloudinit/distros/mariner.py b/cloudinit/distros/mariner.py
 +
 +LOG = logging.getLogger(__name__)
 +
++NETWORK_FILE_HEADER = """\
++# This file is generated from information provided by the datasource. Changes
++# to it will not persist across an instance reboot. To disable cloud-init's
++# network configuration capabilities, write a file
++# /etc/cloud/cloud.cfg.d/99-disable-network-config.cfg with the following:
++# network: {config: disabled}
++"""
 +
 +class Distro(distros.Distro):
 +    systemd_hostname_conf_fn = '/etc/hostname'
@@ -110,10 +119,18 @@ diff -Naur a/cloudinit/distros/mariner.py b/cloudinit/distros/mariner.py
 +    systemd_locale_conf_fn = '/etc/locale.conf'
 +    resolve_conf_fn = '/etc/systemd/resolved.conf'
 +
++    network_conf_fn = {
++        "netplan": "/etc/netplan/50-cloud-init.yaml"
++    }
 +    renderer_configs = {
 +        'networkd': {
 +            'resolv_conf_fn': resolve_conf_fn,
 +            'network_conf_dir': network_conf_dir,
++        },
++        "netplan": {
++            "netplan_path": network_conf_fn["netplan"],
++            "netplan_header": NETWORK_FILE_HEADER,
++            "postcmds": True
 +        }
 +    }
 +
@@ -230,7 +247,7 @@ diff -Naur a/cloudinit/distros/mariner.py b/cloudinit/distros/mariner.py
 \ No newline at end of file
 diff -Naur a/cloudinit/util.py b/cloudinit/util.py
 --- a/cloudinit/util.py	2022-02-15 10:02:23.000000000 -0800
-+++ b/cloudinit/util.py	2022-02-23 15:31:23.827275090 -0800
++++ b/cloudinit/util.py	2022-03-28 20:35:46.924019452 -0700
 @@ -583,6 +583,7 @@
              "debian",
              "eurolinux",
@@ -241,7 +258,7 @@ diff -Naur a/cloudinit/util.py b/cloudinit/util.py
              "photon",
 diff -Naur a/config/cloud.cfg.tmpl b/config/cloud.cfg.tmpl
 --- a/config/cloud.cfg.tmpl	2022-02-15 10:02:23.000000000 -0800
-+++ b/config/cloud.cfg.tmpl	2022-02-23 15:29:02.899583212 -0800
++++ b/config/cloud.cfg.tmpl	2022-03-28 20:35:46.924019452 -0700
 @@ -11,7 +11,7 @@
  # when a 'default' entry is found it will reference the 'default_user'
  # from the distro configuration specified below
@@ -312,7 +329,7 @@ diff -Naur a/config/cloud.cfg.tmpl b/config/cloud.cfg.tmpl
        cloud_dir: /var/lib/cloud/
 diff -Naur a/systemd/cloud-init.service.tmpl b/systemd/cloud-init.service.tmpl
 --- a/systemd/cloud-init.service.tmpl	2022-02-15 10:02:23.000000000 -0800
-+++ b/systemd/cloud-init.service.tmpl	2022-02-23 15:29:54.351469880 -0800
++++ b/systemd/cloud-init.service.tmpl	2022-03-28 20:35:46.924019452 -0700
 @@ -1,7 +1,7 @@
  ## template:jinja
  [Unit]
@@ -324,7 +341,7 @@ diff -Naur a/systemd/cloud-init.service.tmpl b/systemd/cloud-init.service.tmpl
  Wants=cloud-init-local.service
 diff -Naur a/templates/hosts.mariner.tmpl b/templates/hosts.mariner.tmpl
 --- a/templates/hosts.mariner.tmpl	1969-12-31 16:00:00.000000000 -0800
-+++ b/templates/hosts.mariner.tmpl	2022-02-23 15:30:23.967405105 -0800
++++ b/templates/hosts.mariner.tmpl	2022-03-28 20:35:46.924019452 -0700
 @@ -0,0 +1,22 @@
 +## template:jinja
 +{#
@@ -351,7 +368,7 @@ diff -Naur a/templates/hosts.mariner.tmpl b/templates/hosts.mariner.tmpl
 \ No newline at end of file
 diff -Naur a/tests/unittests/config/test_cc_set_hostname.py b/tests/unittests/config/test_cc_set_hostname.py
 --- a/tests/unittests/config/test_cc_set_hostname.py	2022-02-15 10:02:23.000000000 -0800
-+++ b/tests/unittests/config/test_cc_set_hostname.py	2022-02-23 15:38:34.855919676 -0800
++++ b/tests/unittests/config/test_cc_set_hostname.py	2022-03-28 20:35:46.924019452 -0700
 @@ -153,6 +153,46 @@
                      )
                  ] not in m_subp.call_args_list
@@ -401,7 +418,7 @@ diff -Naur a/tests/unittests/config/test_cc_set_hostname.py b/tests/unittests/co
          distro = self._fetch_distro("debian")
 diff -Naur a/tests/unittests/distros/test_mariner b/tests/unittests/distros/test_mariner
 --- a/tests/unittests/distros/test_mariner	1969-12-31 16:00:00.000000000 -0800
-+++ b/tests/unittests/distros/test_mariner	2022-02-23 15:32:50.719088324 -0800
++++ b/tests/unittests/distros/test_mariner	2022-03-28 20:35:46.924019452 -0700
 @@ -0,0 +1,68 @@
 +# This file is part of cloud-init. See LICENSE file for license information.
 +
@@ -474,7 +491,7 @@ diff -Naur a/tests/unittests/distros/test_mariner b/tests/unittests/distros/test
 \ No newline at end of file
 diff -Naur a/tests/unittests/distros/test_netconfig.py b/tests/unittests/distros/test_netconfig.py
 --- a/tests/unittests/distros/test_netconfig.py	2022-02-15 10:02:23.000000000 -0800
-+++ b/tests/unittests/distros/test_netconfig.py	2022-02-23 15:34:31.867247030 -0800
++++ b/tests/unittests/distros/test_netconfig.py	2022-03-28 20:35:46.924019452 -0700
 @@ -1005,6 +1005,124 @@
              self.distro.apply_network_config, net_cfg, expected_cfgs.copy()
          )
@@ -602,7 +619,7 @@ diff -Naur a/tests/unittests/distros/test_netconfig.py b/tests/unittests/distros
      return os.stat(subp.target_path(target, path)).st_mode & 0o777
 diff -Naur a/tests/unittests/test_cli.py b/tests/unittests/test_cli.py
 --- a/tests/unittests/test_cli.py	2022-02-15 10:02:23.000000000 -0800
-+++ b/tests/unittests/test_cli.py	2022-02-23 15:32:02.455191793 -0800
++++ b/tests/unittests/test_cli.py	2022-03-28 20:35:46.924019452 -0700
 @@ -256,7 +256,7 @@
              expected_doc_sections = [
                  "**Supported distros:** all",
@@ -613,8 +630,8 @@ diff -Naur a/tests/unittests/test_cli.py b/tests/unittests/test_cli.py
                  "virtuozzo",
                  "**Config schema**:\n    **resize_rootfs:** "
 diff -Naur a/tests/unittests/test_render_cloudcfg.py b/tests/unittests/test_render_cloudcfg.py
---- a/tests/unittests/test_render_cloudcfg.py	2022-02-23 17:38:10.720695569 -0800
-+++ b/tests/unittests/test_render_cloudcfg.py	2022-02-23 17:59:21.691034733 -0800
+--- a/tests/unittests/test_render_cloudcfg.py	2022-02-15 10:02:23.000000000 -0800
++++ b/tests/unittests/test_render_cloudcfg.py	2022-03-28 20:35:46.924019452 -0700
 @@ -17,6 +17,7 @@
      "fedora",
      "freebsd",
@@ -634,7 +651,7 @@ diff -Naur a/tests/unittests/test_render_cloudcfg.py b/tests/unittests/test_rend
          with open(outfile) as stream:
 diff -Naur a/tests/unittests/test_util.py b/tests/unittests/test_util.py
 --- a/tests/unittests/test_util.py	2022-02-15 10:02:23.000000000 -0800
-+++ b/tests/unittests/test_util.py	2022-02-23 15:22:36.936477500 -0800
++++ b/tests/unittests/test_util.py	2022-03-28 20:35:46.924019452 -0700
 @@ -316,6 +316,19 @@
          BUG_REPORT_URL="https://github.com/vmware/photon/issues"
  """
@@ -672,8 +689,8 @@ diff -Naur a/tests/unittests/test_util.py b/tests/unittests/test_util.py
      @mock.patch("platform.dist", create=True)
      def test_get_linux_distro_no_data(
 diff -Naur a/tools/render-cloudcfg b/tools/render-cloudcfg
---- a/tools/render-cloudcfg	2022-02-23 15:43:28.148249381 -0800
-+++ b/tools/render-cloudcfg	2022-02-23 15:47:18.108284158 -0800
+--- a/tools/render-cloudcfg	2022-02-15 10:02:23.000000000 -0800
++++ b/tools/render-cloudcfg	2022-03-28 20:35:46.924019452 -0700
 @@ -21,6 +21,7 @@
          "fedora",
          "freebsd",

--- a/toolkit/imageconfigs/packagelists/azurevm-packages.json
+++ b/toolkit/imageconfigs/packagelists/azurevm-packages.json
@@ -5,6 +5,7 @@
         "cloud-utils-growpart",
         "dhcp-client",
         "hyperv-daemons",
+        "netplan",
         "openssh-server",
         "python-xml",
         "rsyslog",


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
The default network config renderer in cloud-init for Mariner is currently systemd-networkd. This renderer is experimental in cloud-init and has some known shortcomings. This commit adds in some configs to the Mariner distro patch for cloud-init to support the use of netplan, and adds netplan into the marketplace image so that cloud-init will select it for network config rendering.

This is currently the behavior in 1.0, this commit brings the behavior over to 2.0.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add netplan defaults to cloud-init Mariner distro patch
- Add netplan package to the marketplace image so cloud-init uses it for network config rendering.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local toolchain/package/image build
- Booted gen1 Marketplace image on two Azure VMs, one with 1 address, and another with multiple static addresses.