### PR TITLE
Make prometheus-node-exporter executable

### DIFF
--- a/SPECS/prometheus-node-exporter/prometheus-node-exporter.spec
+++ b/SPECS/prometheus-node-exporter/prometheus-node-exporter.spec
@@ -58,7 +58,11 @@ LDFLAGS="-X github.com/prometheus/common/version.Version=%{version}      \
          -X github.com/prometheus/common/version.Branch=tarball          \
          -X github.com/prometheus/common/version.BuildDate=%{build_date} \
          -X github.com/ncabatoff/process-exporter/version.GoVersion=%{go_version}"
-go build -ldflags "$LDFLAGS" -mod=vendor -v -a -tags "$BUILDTAGS" -o bin/node_exporter ./collector
+go build -ldflags "$LDFLAGS" -mod=vendor -v -a -tags "$BUILDTAGS" -o bin/node_exporter
+
+%check
+make test
+bin/node_exporter --help
 
 %install
 install -m 0755 -vd %{buildroot}%{_bindir}
@@ -72,9 +76,6 @@ install -Dpm0644 %{SOURCE4} %{buildroot}%{_sysconfdir}/default/%{name}
 install -Dpm0644 example-rules.yml %{buildroot}%{_datadir}/prometheus/node-exporter/example-rules.yml
 install -Dpm0644 %{SOURCE5} %{buildroot}%{_sysconfdir}/logrotate.d/%{name}
 mkdir -vp %{buildroot}%{_sharedstatedir}/prometheus/node-exporter
-
-%check
-make test
 
 %pre
 # Steps extracted from Fedora's /usr/lib/rpm/sysusers.generate-pre.sh script.
@@ -107,6 +108,9 @@ getent passwd 'prometheus' >/dev/null || useradd -r -g 'prometheus' -d '%{_share
 %dir %attr(0755,prometheus,prometheus) %{_sharedstatedir}/prometheus/node-exporter
 
 %changelog
+* Tue Mar 29 2022 Matthew Torr <matthewtorr@microsoft.com> - 1.3.1-7
+- Build executable, not ar archive.
+
 * Mon Jan 31 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.3.1-6
 - Initial CBL-Mariner import from Fedora 36 (license: MIT).
 - License verified.

--- a/SPECS/prometheus-node-exporter/prometheus-node-exporter.spec
+++ b/SPECS/prometheus-node-exporter/prometheus-node-exporter.spec
@@ -61,8 +61,7 @@ LDFLAGS="-X github.com/prometheus/common/version.Version=%{version}      \
 go build -ldflags "$LDFLAGS" -mod=vendor -v -a -tags "$BUILDTAGS" -o bin/node_exporter
 
 %check
-make test
-bin/node_exporter --help
+bin/node_exporter --help && make test
 
 %install
 install -m 0755 -vd %{buildroot}%{_bindir}

--- a/SPECS/prometheus-node-exporter/prometheus-node-exporter.spec
+++ b/SPECS/prometheus-node-exporter/prometheus-node-exporter.spec
@@ -5,7 +5,7 @@
 Summary:        Exporter for machine metrics
 Name:           prometheus-node-exporter
 Version:        1.3.1
-Release:        6%{?dist}
+Release:        7%{?dist}
 # Upstream license specification: Apache-2.0
 License:        ASL 2.0 AND MIT
 Vendor:         Microsoft Corporation
@@ -60,9 +60,6 @@ LDFLAGS="-X github.com/prometheus/common/version.Version=%{version}      \
          -X github.com/ncabatoff/process-exporter/version.GoVersion=%{go_version}"
 go build -ldflags "$LDFLAGS" -mod=vendor -v -a -tags "$BUILDTAGS" -o bin/node_exporter
 
-%check
-bin/node_exporter --help && make test
-
 %install
 install -m 0755 -vd %{buildroot}%{_bindir}
 install -m 0755 -vp bin/* %{buildroot}%{_bindir}/
@@ -75,6 +72,9 @@ install -Dpm0644 %{SOURCE4} %{buildroot}%{_sysconfdir}/default/%{name}
 install -Dpm0644 example-rules.yml %{buildroot}%{_datadir}/prometheus/node-exporter/example-rules.yml
 install -Dpm0644 %{SOURCE5} %{buildroot}%{_sysconfdir}/logrotate.d/%{name}
 mkdir -vp %{buildroot}%{_sharedstatedir}/prometheus/node-exporter
+
+%check
+bin/node_exporter --help && make test
 
 %pre
 # Steps extracted from Fedora's /usr/lib/rpm/sysusers.generate-pre.sh script.
@@ -107,7 +107,7 @@ getent passwd 'prometheus' >/dev/null || useradd -r -g 'prometheus' -d '%{_share
 %dir %attr(0755,prometheus,prometheus) %{_sharedstatedir}/prometheus/node-exporter
 
 %changelog
-* Tue Mar 29 2022 Matthew Torr <matthewtorr@microsoft.com> - 1.3.1-7
+* Thu Mar 31 2022 Matthew Torr <matthewtorr@microsoft.com> - 1.3.1-7
 - Build executable, not ar archive.
 
 * Mon Jan 31 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.3.1-6


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
By specifying the name of a directory to build, the spec file was instructing go build to create an archive file, not an executable. Using a plain go build command makes it build an executable as intended.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- See above.
- Also added a sense test under %check that the output file can be run.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- OS Bug 38396447

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
I installed my locally-built RPM on a Mariner VM. prometheus-node-exporter is now an executable file, which is an improvement already:

```
centos@ci1382011-mt5-s-sde-2 [ ~ ]$ file $(which node_exporter)
/usr/bin/node_exporter: symbolic link to prometheus-node-exporter
centos@ci1382011-mt5-s-sde-2 [ ~ ]$ file $(which prometheus-node-exporter)
/usr/bin/prometheus-node-exporter: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=GjRwdH7oW4SHZmPKOYhv/Q8FwkpBJy2S4TQGzKns_/3vLm-CTNOqf6j_RroK_9/VmruVG3o_a88Nenl3dw9, not stripped
```

Additionally after starting the systemd service, it ran and did not crash, and curling http://127.0.0.1:9100/metrics returned some sensible-looking metrics.