### PR TITLE
Update Mariner SPEC files with latest SymCrypt and SCOSSL source

### DIFF
--- a/SPECS/SymCrypt-OpenSSL/SymCrypt-OpenSSL.signatures.json
+++ b/SPECS/SymCrypt-OpenSSL/SymCrypt-OpenSSL.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "SymCrypt-OpenSSL-1.0.0.tar.gz": "5beec7b050bd48511c0d81a643f47df56d488c7af2bc5a69451a7c79f40688d9"
+  "SymCrypt-OpenSSL-1.1.0.tar.gz": "5f25989d4a13dfd07798c7c704419f932231f0a7033b8cb28ae240a5bb8254d3"
  }
 }

--- a/SPECS/SymCrypt-OpenSSL/SymCrypt-OpenSSL.spec
+++ b/SPECS/SymCrypt-OpenSSL/SymCrypt-OpenSSL.spec
@@ -1,6 +1,6 @@
 Summary:        The SymCrypt engine for OpenSSL (SCOSSL) allows the use of OpenSSL with SymCrypt as the provider for core cryptographic operations
 Name:           SymCrypt-OpenSSL
-Version:        1.0.0
+Version:        1.1.0
 Release:        1%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
@@ -13,7 +13,6 @@ BuildRequires:  SymCrypt
 BuildRequires:  cmake
 BuildRequires:  gcc
 BuildRequires:  make
-ExclusiveArch:  x86_64
 
 %description
 The SymCrypt engine for OpenSSL (SCOSSL) allows the use of OpenSSL with SymCrypt as the provider for core cryptographic operations
@@ -52,6 +51,9 @@ cmake --build . --target install
 %{_includedir}/scossl.h
 
 %changelog
+* Tue Mar 29 2022 Samuel Lee <saml@microsoft.com> - 1.1.0-1
+- Update SymCrypt-OpenSSL to v1.1.0 to include FIPS self-tests, and fix aarch64 build
+
 * Mon Feb 14 2022 Samuel Lee <saml@microsoft.com> - 1.0.0-1
 - Original version for CBL-Mariner
 - Verified license

--- a/SPECS/SymCrypt/SymCrypt.signatures.json
+++ b/SPECS/SymCrypt/SymCrypt.signatures.json
@@ -1,6 +1,6 @@
 {
  "Signatures": {
-  "SymCrypt-101.0.0.tar.gz": "f082a7d008657e8c675796657be4db4fd49c0f77db3defbaf556d8517738d27d",
+  "SymCrypt-101.2.0.tar.gz": "f5f0cea1b934a4ebbef8ba3201a77bc82f2202e4e949eeda2eb3120d9607b1a2",
   "jitterentropy-library-3.3.1.tar.gz": "4a50cb02b4836cd5550016e2fc2263e6982abaa11467a9e1cea260c1c2f7d487"
  }
 }

--- a/SPECS/SymCrypt/SymCrypt.spec
+++ b/SPECS/SymCrypt/SymCrypt.spec
@@ -1,7 +1,7 @@
 %define debug_package %{nil}
 Summary:        A core cryptographic library written by Microsoft
 Name:           SymCrypt
-Version:        101.0.0
+Version:        101.2.0
 Release:        1%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
@@ -17,7 +17,6 @@ BuildRequires:  gcc
 BuildRequires:  make
 BuildRequires:  python3
 BuildRequires:  python3-pyelftools
-ExclusiveArch:  x86_64
 
 %description
 A core cryptographic library written by Microsoft
@@ -62,6 +61,9 @@ chmod 755 %{buildroot}%{_libdir}/libsymcrypt.so.%{version}
 %{_includedir}/*
 
 %changelog
+* Tue Mar 29 2022 Samuel Lee <saml@microsoft.com> - 101.2.0-1
+- Update SymCrypt to v101.2.0 to include FIPS self-tests, certifiable AES-GCM, and fix aarch64 build
+
 * Mon Feb 14 2022 Samuel Lee <saml@microsoft.com> - 101.0.0-1
 - Original version for CBL-Mariner
 - Verified license

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -27677,18 +27677,18 @@
         "type": "other",
         "other": {
           "name": "SymCrypt",
-          "version": "101.0.0",
-          "downloadUrl": "https://github.com/microsoft/SymCrypt/archive/v101.0.0.tar.gz"
+          "version": "101.2.0",
+          "downloadUrl": "https://github.com/microsoft/SymCrypt/archive/v101.2.0.tar.gz"
         }
       }
     },
     {
       "component": {
-        "type": "SymCrypt-OpenSSL",
+        "type": "other",
         "other": {
           "name": "SymCrypt-OpenSSL",
-          "version": "1.0.0",
-          "downloadUrl": "https://github.com/microsoft/SymCrypt-OpenSSL/archive/v1.0.0.tar.gz"
+          "version": "1.1.0",
+          "downloadUrl": "https://github.com/microsoft/SymCrypt-OpenSSL/archive/v1.1.0.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Brings in the latest changes to SymCrypt and SCOSSL which include changes required for FIPS certification, and a fix for the build on aarch64.

###### Change Log  <!-- REQUIRED -->
- Update SymCrypt SPEC to consume v101.2.0, which includes changes required for FIPS certification, and a fix for building on Mariner aarch64. Remove ExclusiveArch: x86_64
- Update SymCrypt-OpenSSL SPEC to consume v1.1.0 which include changes required for FIPS certification (invokes SymCrypt with flags to run required self-tests). Remove ExclusiveArch: x86_64, as SymCrypt dependency should now build for aarch64.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->

###### Links to CVEs  <!-- optional -->

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build
