### PR TITLE
Add toolchain debug features to the depsearch tool

### DIFF
--- a/toolkit/tools/depsearch/depsearch.go
+++ b/toolkit/tools/depsearch/depsearch.go
@@ -6,26 +6,41 @@ package main
 import (
 	"fmt"
 	"os"
+	"path/filepath"
+	"sort"
 
 	"gonum.org/v1/gonum/graph"
 	"gopkg.in/alecthomas/kingpin.v2"
 
 	"microsoft.com/pkggen/internal/exe"
+	"microsoft.com/pkggen/internal/file"
 	"microsoft.com/pkggen/internal/logger"
 	"microsoft.com/pkggen/internal/pkggraph"
+	"microsoft.com/pkggen/scheduler/schedulerutils"
+)
+
+const (
+	defaultFilterPath = "./resources/manifests/package/toolchain_x86_64.txt"
 )
 
 var (
 	app = kingpin.New("depsearch", "Returns a list of everything that depends on a given package or spec")
 
 	inputGraphFile  = exe.InputFlag(app, "Path to the DOT graph file to search.")
-	outputGraphFile = exe.OutputFlag(app, "Path to save the graph.")
+	outputGraphFile = app.Flag("output", "Path to save the graph.").String()
 
 	pkgsToSearch  = app.Flag("packages", "Space seperated list of packages to search from.").String()
 	specsToSearch = app.Flag("specs", "Space seperated list of specfiles to search from.").String()
 	goalsToSearch = app.Flag("goals", "Space seperated list of goal names to search (Try 'ALL' or 'PackagesToBuild').").String()
 
 	reverseSearch = app.Flag("reverse", "Reverse the search to give a traditional dependency list for the packages instead of dependants.").Bool()
+
+	printTree       = app.Flag("tree", "Print output as a simple tree instead of a list").Bool()
+	verbosity       = app.Flag("verbosity", "Print the full node details (3), RPM (2), or SPEC name (1) for each result").Default("1").Int()
+	maxDepth        = app.Flag("max-depth", "Maximum depth into the tree to scan, -1 for unlimited").Default("-1").Int()
+	printDuplicates = app.Flag("print-duplicates", "In tree mode, if there is a duplicate node in the tree don't replace it with '...'").Bool()
+	filterFile      = app.Flag("rpm-filter-file", "Filter the returned packages based on this list of *.rpm filenames (defaults to the x86_64 toolchain manifest './resources/manifests/package/toolchain_x86_64.txt' if it exists)").ExistingFile()
+	filter          = app.Flag("rpm-filter", "Only print any packages that are missing from the rpm-filter-file (useful for debugging toolchain package issues for example)").Bool()
 
 	logFile  = exe.LogFileFlag(app)
 	logLevel = exe.LogLevelFlag(app)
@@ -34,11 +49,34 @@ var (
 func main() {
 	var (
 		outputGraph *pkggraph.PkgGraph
+		root        *pkggraph.PkgNode
 	)
 
 	app.Version(exe.ToolkitVersion)
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	logger.InitBestEffort(*logFile, *logLevel)
+
+	// only understand verbosity from 1 - 3 (spec, rpm, full node)
+	if verbosity == nil || *verbosity > 3 || *verbosity < 1 {
+		verbosity = new(int)
+		*verbosity = 1
+	}
+
+	if !(*maxDepth == -1 || *maxDepth >= 1) {
+		logger.Log.Fatalf("Invalid max depth '%d', valid ranges are -1, >=1", *maxDepth)
+	}
+
+	// We can colour the entries when using --tree, or limit the output in all modes with --rpm-filter
+	configureFilterFiles(filterFile, filter)
+	if len(*filterFile) > 0 && (*filter || *printTree) {
+		logger.Log.Infof("Applying package filter from '%s'", *filterFile)
+	} else {
+		logger.Log.Infof("Filter file '%s' not applicable here", *filterFile)
+	}
+
+	pkgSearchList := exe.ParseListArgument(*pkgsToSearch)
+	specSearchList := exe.ParseListArgument(*specsToSearch)
+	goalSearchList := exe.ParseListArgument(*goalsToSearch)
 
 	graph := pkggraph.NewPkgGraph()
 	err := pkggraph.ReadDOTGraphFile(graph, *inputGraphFile)
@@ -46,10 +84,7 @@ func main() {
 		logger.Log.Panicf("Failed to read DOT graph with error: %s", err)
 	}
 
-	pkgSearchList := exe.ParseListArgument(*pkgsToSearch)
-	specSearchList := exe.ParseListArgument(*specsToSearch)
-	goalSearchList := exe.ParseListArgument(*goalsToSearch)
-
+	// Generate a list of nodes to search from
 	nodeListPkg := searchForPkg(graph, pkgSearchList)
 	nodeListSpec := searchForSpec(graph, specSearchList)
 	nodeListGoal := searchForGoal(graph, goalSearchList)
@@ -64,16 +99,44 @@ func main() {
 	}
 
 	if *reverseSearch {
-		logger.Log.Infof("Forward dependency search")
-		outputGraph, err = buildRequiresGraph(graph, nodeSet)
+		logger.Log.Infof("Reversed search will list all the dependencies of the provided packages...")
+		outputGraph, root, err = buildRequiresGraph(graph, nodeSet)
 	} else {
-		logger.Log.Infof("Backwards dependants search")
-		outputGraph, err = buildDependsOnGraph(graph, nodeSet)
+		logger.Log.Infof("Forward search will list all dependants which rely on any of the provided packages...")
+		outputGraph, root, err = buildDependsOnGraph(graph, nodeSet)
 	}
 
-	printSpecs(outputGraph)
+	if err != nil {
+		logger.Log.Panicf("Failed to generate graph to run depsearch on: %s", err)
+	}
 
-	pkggraph.WriteDOTGraphFile(outputGraph, *outputGraphFile)
+	printSpecs(outputGraph, *printTree, *filter, *filterFile, *printDuplicates, *verbosity, *maxDepth, root)
+
+	if len(*outputGraphFile) > 0 {
+		pkggraph.WriteDOTGraphFile(outputGraph, *outputGraphFile)
+	}
+}
+
+func configureFilterFiles(filterFile *string, filter *bool) {
+	setDefault := false
+	if len(*filterFile) == 0 {
+		*filterFile = defaultFilterPath
+		setDefault = true
+	}
+	isFile, err := file.PathExists(*filterFile)
+	if err != nil {
+		logger.Log.Panicf("Failed to query if filter file ('%s') exists: %s", *filterFile, err)
+	}
+
+	// If we are just trying to use the default, its fine if its missing.
+	if !isFile && setDefault {
+		logger.Log.Warnf("Default toolchain filter file ('%s') not found, setting to ''", *filterFile)
+		*filterFile = ""
+	}
+
+	if len(*filterFile) == 0 && *filter {
+		logger.Log.Panic("Must pass a --rpm-filter-file to use the filter function, consider './resources/manifests/package/toolchain_x86_64.txt'")
+	}
 }
 
 func searchForGoal(graph *pkggraph.PkgGraph, goals []string) (list []*pkggraph.PkgNode) {
@@ -122,17 +185,15 @@ func removeDuplicates(nodeList []*pkggraph.PkgNode) (uniqueNodeList []*pkggraph.
 	return
 }
 
-func buildRequiresGraph(graphIn *pkggraph.PkgGraph, nodeList []*pkggraph.PkgNode) (graphOut *pkggraph.PkgGraph, err error) {
-	newGraph := pkggraph.NewPkgGraph()
-
+func buildRequiresGraph(graphIn *pkggraph.PkgGraph, nodeList []*pkggraph.PkgNode) (graphOut *pkggraph.PkgGraph, root *pkggraph.PkgNode, err error) {
 	// Make a copy of the graph
-	newGraph, err = graphIn.DeepCopy()
+	newGraph, err := graphIn.DeepCopy()
 	if err != nil {
 		return
 	}
 
 	// Add a goal node to all the things we care about
-	root := newGraph.AddMetaNode(nil, nodeList)
+	root = newGraph.AddMetaNode(nil, nodeList)
 	graphOut, err = newGraph.CreateSubGraph(root)
 	if err != nil {
 		return
@@ -141,11 +202,9 @@ func buildRequiresGraph(graphIn *pkggraph.PkgGraph, nodeList []*pkggraph.PkgNode
 	return
 }
 
-func buildDependsOnGraph(graphIn *pkggraph.PkgGraph, nodeList []*pkggraph.PkgNode) (graphOut *pkggraph.PkgGraph, err error) {
-	reversedGraph := pkggraph.NewPkgGraph()
-
+func buildDependsOnGraph(graphIn *pkggraph.PkgGraph, nodeList []*pkggraph.PkgNode) (graphOut *pkggraph.PkgGraph, root *pkggraph.PkgNode, err error) {
 	// Make a copy of the graph
-	reversedGraph, err = graphIn.DeepCopy()
+	reversedGraph, err := graphIn.DeepCopy()
 	if err != nil {
 		return
 	}
@@ -157,7 +216,7 @@ func buildDependsOnGraph(graphIn *pkggraph.PkgGraph, nodeList []*pkggraph.PkgNod
 	}
 
 	// Add a goal node to all the things we care about
-	root := reversedGraph.AddMetaNode(nil, nodeList)
+	root = reversedGraph.AddMetaNode(nil, nodeList)
 	graphOut, err = reversedGraph.CreateSubGraph(root)
 	if err != nil {
 		return
@@ -166,16 +225,235 @@ func buildDependsOnGraph(graphIn *pkggraph.PkgGraph, nodeList []*pkggraph.PkgNod
 	return
 }
 
-func printSpecs(graph *pkggraph.PkgGraph) {
-	specs := make(map[string]bool)
-	for _, n := range graph.AllNodes() {
+const (
+	colourReset = "\033[0m"
+	colourRed   = "\033[31m"
+)
+
+var (
+	reservedFiles map[string]bool
+)
+
+func formatNode(n *pkggraph.PkgNode, verbosity int) string {
+	switch verbosity {
+	case 1:
+		return n.SpecName()
+	case 2:
+		return filepath.Base(n.RpmPath)
+	case 3:
+		return fmt.Sprintf("'%s' from node '%s'", filepath.Base(n.RpmPath), n.FriendlyName())
+	default:
+		logger.Log.Fatalf("Invalid verbosity level %v", verbosity)
+	}
+	return ""
+}
+
+func isFilteredFile(path, filterFile string) bool {
+	if len(filterFile) > 0 {
+		if len(reservedFiles) == 0 {
+			reservedFileList, err := schedulerutils.ReadReservedFilesList(filterFile)
+			if err != nil {
+				logger.Log.Fatalf("Failed to load filter file '%s': %s", filterFile, err)
+			}
+			reservedFiles = make(map[string]bool)
+			for _, f := range reservedFileList {
+				reservedFiles[f] = true
+			}
+		}
+		base := filepath.Base(path)
+
+		return len(path) > 0 && reservedFiles[base]
+	} else {
+		return false
+	}
+}
+
+type treeNode struct {
+	lines []string
+}
+
+type treeSearch struct {
+	graph *pkggraph.PkgGraph
+
+	// Don't print a node twice, just add '...' instead to save space
+	alreadyAdded map[*pkggraph.PkgNode]bool
+	// These nodes were caught by the filter and should be marked
+	filteredNodes map[*pkggraph.PkgNode]bool
+	// These nodes are not in the filter list
+	normalNodes map[*pkggraph.PkgNode]bool
+
+	nodesVisited, nodesTotal int
+}
+
+func createSearch(g *pkggraph.PkgGraph, root *pkggraph.PkgNode) (t *treeSearch, err error) {
+	newSearch := &treeSearch{
+		graph:         g,
+		alreadyAdded:  make(map[*pkggraph.PkgNode]bool),
+		filteredNodes: make(map[*pkggraph.PkgNode]bool),
+		normalNodes:   make(map[*pkggraph.PkgNode]bool),
+		nodesVisited:  0,
+	}
+
+	//Calculate the number of nodes we might visit:
+	subGraph, err := g.CreateSubGraph(root)
+	if err != nil {
+		logger.Log.Fatalf("Failed to calculate number of nodes: %s", err)
+	}
+
+	//This is the worst case possible number of searche to make
+	possibleEdges := subGraph.Edges().Len() * subGraph.Nodes().Len()
+	newSearch.nodesTotal = possibleEdges
+
+	return newSearch, nil
+}
+
+func (t *treeSearch) FilteredNodes() (nodes []*pkggraph.PkgNode) {
+	nodes = []*pkggraph.PkgNode{}
+	for n := range t.filteredNodes {
+		nodes = append(nodes, n)
+	}
+	return nodes
+}
+
+func (t *treeSearch) NonFilteredNodes() (nodes []*pkggraph.PkgNode) {
+	nodes = []*pkggraph.PkgNode{}
+	for n := range t.normalNodes {
+		nodes = append(nodes, n)
+	}
+	return nodes
+}
+
+// Call this ever time a node is processed, will print an update ever 100 nodes
+func (t *treeSearch) printProgress() {
+	if t.nodesVisited%10000 == 0 {
+		logger.Log.Infof("Scanned %d nodes", t.nodesVisited)
+	}
+	t.nodesVisited++
+}
+
+// Run a DFS and generate a string representation of the tree. Optionally ignore all branches that only container nodes in
+//  the filter list (ie given the toolchain manifest, only print those branches which container non-toolchain packages)
+func (t *treeSearch) treeNodeToString(n *pkggraph.PkgNode, depth, maxDepth int, filter bool, filterFile string, verbosity int, generateStrings, printDuplicates bool) (lines []string, hasNonToolchain bool) {
+	t.printProgress()
+	// We only care about run nodes for the purposes of detecting toolchain files
+	hasNonToolchain = n.Type == pkggraph.TypeBuild && !isFilteredFile(n.RpmPath, filterFile)
+
+	if !printDuplicates && t.alreadyAdded[n] {
+		return []string{}, false
+	} else {
+		t.alreadyAdded[n] = true
+	}
+
+	thisNode := formatNode(n, verbosity)
+	if isFilteredFile(n.RpmPath, filterFile) {
+		// Highlight nodes that are in the filter file list in red, and add them to the list
+		if generateStrings {
+			lines = append(lines, "__"+colourRed+thisNode+colourReset)
+		}
 		if n.Type == pkggraph.TypeRun {
-			nodeSpec := n.SpecName()
-			specs[nodeSpec] = true
+			// We only want to record run nodes for the purposes of listing packages in non-tree mode
+			t.filteredNodes[n] = true
+		}
+	} else {
+		// Non filtered files print normally
+		if generateStrings {
+			lines = append(lines, "__"+thisNode)
+		}
+		if n.Type == pkggraph.TypeRun {
+			// We only want to record run nodes for the purposes of listing packages in non-tree mode
+			t.normalNodes[n] = true
 		}
 	}
 
-	for key, _ := range specs {
-		fmt.Printf("\t%s\n", key)
+	var childrenTreeNodes []treeNode
+	nodes := t.graph.From(n.ID())
+	// Bail out early if we exceed max depth, maxDepth of -1 means no limit.
+	if depth < maxDepth || maxDepth == -1 {
+		var (
+			childLines                  []string
+			childHasMissingToolchainPkg = false
+			haveDuplicatedEntry         = false
+		)
+		for nodes.Next() {
+			child := nodes.Node().(*pkggraph.PkgNode)
+			childLines, childHasMissingToolchainPkg = t.treeNodeToString(child, depth+1, maxDepth, filter, filterFile, verbosity, generateStrings, printDuplicates)
+			hasNonToolchain = hasNonToolchain || childHasMissingToolchainPkg
+
+			// A child will return an empty string list if it, and all its children, are either duplicates or have been filtered out
+			if len(childLines) > 0 {
+				tn := treeNode{lines: childLines}
+				childrenTreeNodes = append(childrenTreeNodes, tn)
+			} else {
+				haveDuplicatedEntry = true
+			}
+		}
+
+		// If we have duplicated entires (ie empty strings), and we aren't removing all non-filtered entries, represent them with a '...'
+		//  as the last entry instead of the node name.
+		if haveDuplicatedEntry && !filter {
+			childrenTreeNodes = append(childrenTreeNodes, treeNode{lines: []string{"..."}})
+		}
+
+		if len(childrenTreeNodes) > 0 && generateStrings {
+			firstN := childrenTreeNodes[:len(childrenTreeNodes)-1]
+			last := childrenTreeNodes[len(childrenTreeNodes)-1]
+			for _, tn := range firstN {
+				for _, l := range tn.lines {
+					lines = append(lines, "   |"+l)
+				}
+			}
+			lines = append(lines, "   |"+last.lines[0])
+			for _, l := range last.lines[1:] {
+				lines = append(lines, "   "+l)
+			}
+		}
+	} else {
+		lines = append(lines, "   |-->")
+		// We are bailing out early, we don't know if this should be filtered, assume the worst
+		hasNonToolchain = true
+	}
+
+	if !hasNonToolchain && filter && depth > 0 {
+		return []string{}, false
+	}
+
+	return lines, hasNonToolchain
+}
+
+func printSpecs(graph *pkggraph.PkgGraph, tree, filter bool, filterFile string, printDuplicates bool, verbosity, maxDepth int, root *pkggraph.PkgNode) {
+	t, err := createSearch(graph, root)
+	if err != nil {
+		logger.Log.Fatalf("Failed to start search: %s", err)
+	}
+	// May as well use the tree searh to parse all the filtered packages etc, even if we are
+	//    just printing a list
+	lines, _ := t.treeNodeToString(root, 0, maxDepth, filter, filterFile, verbosity, tree, printDuplicates)
+	if tree {
+		for _, l := range lines {
+			fmt.Println(l)
+		}
+	} else {
+		results := make(map[string]bool)
+		if !filter {
+			// Only include toolchain packages if we aren't trying to find packages that have
+			// infiltrated the toolchain
+			for _, n := range t.FilteredNodes() {
+				results[formatNode(n, verbosity)] = true
+			}
+		}
+		// Always include normal nodes
+		for _, n := range t.NonFilteredNodes() {
+			results[formatNode(n, verbosity)] = true
+		}
+
+		// Contert to list and sort
+		printLines := []string{}
+		for s := range results {
+			printLines = append(printLines, s)
+		}
+		sort.Strings(printLines)
+		for _, l := range printLines {
+			fmt.Println(l)
+		}
 	}
 }

--- a/toolkit/tools/depsearch/depsearch.go
+++ b/toolkit/tools/depsearch/depsearch.go
@@ -66,7 +66,7 @@ func main() {
 		logger.Log.Fatalf("Invalid max depth '%d', valid ranges are -1, >=1", *maxDepth)
 	}
 
-	// We can colour the entries when using --tree, or limit the output in all modes with --rpm-filter
+	// We can color the entries when using --tree, or limit the output in all modes with --rpm-filter
 	configureFilterFiles(filterFile, filter)
 	if len(*filterFile) > 0 && (*filter || *printTree) {
 		logger.Log.Infof("Applying package filter from '%s'", *filterFile)
@@ -226,8 +226,8 @@ func buildDependsOnGraph(graphIn *pkggraph.PkgGraph, nodeList []*pkggraph.PkgNod
 }
 
 const (
-	colourReset = "\033[0m"
-	colourRed   = "\033[31m"
+	colorReset = "\033[0m"
+	colorRed   = "\033[31m"
 )
 
 var (
@@ -348,7 +348,7 @@ func (t *treeSearch) treeNodeToString(n *pkggraph.PkgNode, depth, maxDepth int, 
 	if isFilteredFile(n.RpmPath, filterFile) {
 		// Highlight nodes that are in the filter file list in red, and add them to the list
 		if generateStrings {
-			lines = append(lines, "__"+colourRed+thisNode+colourReset)
+			lines = append(lines, "__"+colorRed+thisNode+colorReset)
 		}
 		if n.Type == pkggraph.TypeRun {
 			// We only want to record run nodes for the purposes of listing packages in non-tree mode

--- a/toolkit/tools/scheduler/schedulerutils/buildlist.go
+++ b/toolkit/tools/scheduler/schedulerutils/buildlist.go
@@ -4,6 +4,9 @@
 package schedulerutils
 
 import (
+	"bufio"
+	"os"
+
 	"microsoft.com/pkggen/imagegen/configuration"
 	"microsoft.com/pkggen/imagegen/installutils"
 	"microsoft.com/pkggen/internal/logger"
@@ -96,4 +99,27 @@ func filterLocalPackagesOnly(packageVersionsInConfig []*pkgjson.PackageVer, inpu
 	}
 
 	return
+}
+
+// ReadReservedFilesList updates the list of reserved files from the manifest file passed in.
+func ReadReservedFilesList(path string) (reservedFiles []string, err error) {
+	file, err := os.Open(path)
+	if err != nil {
+		logger.Log.Errorf("Failed to open file manifest %s with error %s", path, err)
+		return nil, err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		reservedFiles = append(reservedFiles, scanner.Text())
+	}
+
+	err = scanner.Err()
+	if err != nil {
+		logger.Log.Errorf("Failed to scan file manifest %s with error %s", path, err)
+		return nil, err
+	}
+
+	return reservedFiles, nil
 }


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Add tools to help debug toolchain build conflicts (ie the scheduler thinking it needs to rebuild toolchain packages, which it shouldn't)

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add a few features to the depsearch tool:
 - `--tree` now outputs a simple tree view of the subgraph.
 - `--rpm-filter`  will limit the results to just those that aren't inside the filter list
 - `--rpm-filter-file` sets the filter for the above flag. Defaults to the x86_64 toolchain manifest if it can find it.
 - `--print-duplicates` sets the tree mode to print all nodes. By default it won't print a node if its already printed it once (warning, this takes a LONG time to run and can use up all your memory for even medium sized graphs, use with --max-depth)

- Added a section to the scheduler summary that lists all packages that were rebuild that conflict with the toolchain. This may become a breaking error in the future.
 
 ###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES** (In that it may change the behaviour of toolchain packages as we are familiar with them since they will ALWAYS be the ones from the normal toolchain build)
