### PR TITLE
dnf-plugins-core: Fix bad python path in cmake call

### DIFF
--- a/SPECS/dnf-plugins-core/dnf-plugins-core.spec
+++ b/SPECS/dnf-plugins-core/dnf-plugins-core.spec
@@ -210,7 +210,7 @@ mkdir build-py3
 
 %build
 pushd build-py3
-  %cmake ../ -DPYTHON_DESIRED:FILEPATH=python3 -DWITHOUT_LOCAL:str=0
+  %cmake ../ -DPYTHON_DESIRED:FILEPATH=%python3 -DWITHOUT_LOCAL:str=0
   %make_build
   make doc-man
 popd


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
#2630 caused a build break due to a change to the cmake call in `dnf-plugins-core`. The change caused cmake to be given `python3` instead of the desired file path `/usr/bin/python3`. This caused the build of `dnf-plugins-core` to fail, since the cmake script expects either a major version number or a file path. 

This PR changes the cmake call to use the full `python3` binary file path.\

Cherry-pick of #2658.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- `dnf-plugins-core`: Pass cmake the file path of our `python3` binary to fix build
- `dnf-plugins-core`: no changelog entry/release bump, since this release has not been published

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- N/A
