### PR TITLE
net-tools: Remove mv command

### DIFF
--- a/SPECS/net-tools/net-tools.spec
+++ b/SPECS/net-tools/net-tools.spec
@@ -1,7 +1,7 @@
 Summary:        Networking Tools
 Name:           net-tools
 Version:        2.10
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -33,7 +33,6 @@ make
 
 %install
 make BASEDIR=%{buildroot} install
-mv %{buildroot}/bin/ifconfig %{buildroot}/sbin/ifconfig
 
 %post	-p /sbin/ldconfig
 %postun	-p /sbin/ldconfig
@@ -48,6 +47,9 @@ mv %{buildroot}/bin/ifconfig %{buildroot}/sbin/ifconfig
 %{_mandir}/man8/*
 
 %changelog
+* Mon Apr 04 2022 Rachel Menge <rachelmenge@microsoft.com> - 2.10-2
+- Remove ifconfig mv command
+
 * Thu Feb 17 2022 Rachel Menge <rachelmenge@microsoft.com> - 2.10-1
 - Update to 2.10
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
https://microsoft.visualstudio.com/OS/_workitems/edit/38217259/

During testing, it appeared that the ifconfig executable was not being recognized in its new location `/bin` during the net-tools update to 2.10 (#2262). Therefore, a mv command was added to move it back to its original location of `/sbin`. 

After further investigation, the reason for this behavior was due to the fact that bash sessions cache the paths to executables. Therefore, if a user had run the `ifconfig` command, performed a net-tools package update, and tried to run `ifconfig` command again all in one session, an error would occur that the binary could not be found.  However if they ran `hash -d ifconfig`, created a new session, or restarted their session by logging out and in, the issue would be resolved.

Since we do not expect the package to be updated across Mariner versions and Mariner 2.0 is not yet released, simply support the new file locations for route and ifconfig 

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Remove ifconfig mv command

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- local build
