### PR TITLE
[main] Fixing `ocaml*.spec` macros.

### DIFF
--- a/SPECS/ocaml-cmdliner/ocaml-cmdliner.spec
+++ b/SPECS/ocaml-cmdliner/ocaml-cmdliner.spec
@@ -1,6 +1,4 @@
-# In order for this to work as a "global" macro it has to come after the
-# definition of Name:, evidently.
-%global libname %(echo %{name} | sed -e 's/^ocaml-//')
+%define libname %(echo %{name} | sed -e 's/^ocaml-//')
 
 Summary:        Declarative definition of command line interfaces for OCaml
 Name:           ocaml-cmdliner

--- a/SPECS/ocaml-result/ocaml-result.spec
+++ b/SPECS/ocaml-result/ocaml-result.spec
@@ -1,4 +1,4 @@
-%global libname %(echo %{name} | sed -e 's/^ocaml-//')
+%define libname %(echo %{name} | sed -e 's/^ocaml-//')
 
 %ifnarch %{ocaml_native_compiler}
 %global debug_package %{nil}


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

**NOTE**: the packages haven't built since the last update due to the macro issues, thus not updating the `Release` tag.

Fixing a post-linting issue with `%global` vs `%define`. It looks like `%global` macros referencing spec tags defined **after** the macro will not expand the way I expected. Switching to `%define` seems to have fixed the problem.

Example from `ocaml-cmdliner.spec`: the `libname` macro defined with `%global` expands to the value of `%name` (`ocaml-cmdliner`), while using `%define` returns `cmdliner`, which was the expected value.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Replaced `%global` with `%define` in 2 `ocaml*.spec` files.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local spec parsing.
