### PR TITLE
[main] Adding a workaround for the source name conflict in `ocaml-fileutils`.

### DIFF
--- a/SPECS/ocaml-fileutils/ocaml-fileutils.signatures.json
+++ b/SPECS/ocaml-fileutils/ocaml-fileutils.signatures.json
@@ -1,6 +1,6 @@
 {
  "Signatures": {
-  "ocaml-fileutils-0.5.2.tar.gz": "c96442d7c032d6ba45e63143476f0c5fe2ea6f9b4bb452b0b9406decc5268352",
+  "ocaml-fileutils_2-0.5.2.tar.gz": "c96442d7c032d6ba45e63143476f0c5fe2ea6f9b4bb452b0b9406decc5268352",
   "ocaml-fileutils-old-sources-build-files.tar.gz": "69c8ddcadefbb0d800c23e0e96f707fe181c03de39f59b309ee5542636d628ff"
  }
 }

--- a/SPECS/ocaml-fileutils/ocaml-fileutils.spec
+++ b/SPECS/ocaml-fileutils/ocaml-fileutils.spec
@@ -6,7 +6,9 @@ License:        LGPLv2 WITH exceptions
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 URL:            https://github.com/gildor478/ocaml-fileutils
-Source0:        https://github.com/gildor478/ocaml-fileutils/archive/refs/tags/%{version}.tar.gz#/%{name}-%{version}.tar.gz
+# NOTE: the "_2" suffix was added to avoid conflicts with an older source tarball for the same version of the sources.
+#       Please remove it during a version update.
+Source0:        https://github.com/gildor478/ocaml-fileutils/archive/refs/tags/%{version}.tar.gz#/%{name}_2-%{version}.tar.gz
 # Set of files from previous sources location allowing us to drop dependency on "ocaml-oasis-devel", which is no longer available.
 # Previous sources used to be available under http://forge.ocamlcore.org/frs/download.php/1695/ocaml-fileutils-0.5.2.tar.gz.
 # Currently still available in Fedora's SRPMs.


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

During migration of `ocaml-fileutils` I had to update the source URL, since the previous one was no longer available. The new GitHub source is missing a few build config files and has a different signature but the same version, so we ended up with a file name conflict in our blob storage. Initially, I was hoping to replace the old source with the new one once the old one was no longer used, but it seems to have caused more issues, so for now I'm re-naming the new source by adding a suffix, which can be removed during the next version update. The re-named source is already uploaded.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Re-named new source tarball for `ocaml-fileutils`.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local package build.
