### PR TITLE
Makefile fixes to reduce undesirable rebuild of files, clean up a chroot

### DIFF
--- a/toolkit/scripts/toolchain.mk
+++ b/toolkit/scripts/toolchain.mk
@@ -186,6 +186,7 @@ $(STATUS_FLAGS_DIR)/toolchain_verify.flag: $(TOOLCHAIN_MANIFEST) $(final_toolcha
 		echo "$${diff}"; \
 		$(call print_warning, $@ failed) ; \
 	fi
+	touch $@
 
 # The basic set of RPMs can always be produced by bootstrapping the toolchain.
 # Try to skip extracting individual RPMS if the toolchain step has already placed
@@ -196,7 +197,8 @@ $(toolchain_rpms): $(TOOLCHAIN_MANIFEST) | $(final_toolchain)
 		mkdir -p $(dir $@) && \
 		tar -I $(ARCHIVE_TOOL) -xvf $(final_toolchain) -C $(dir $@) --strip-components 1 built_rpms_all/$(notdir $@) && \
 		touch $@ ; \
-	fi || $(call print_error, $@ failed) ;
+	fi || $(call print_error, $@ failed) ; \
+	touch $@
 else
 ifneq (,$(TOOLCHAIN_ARCHIVE))
 # Extract a set of RPMS from an archive instead of building them from scratch.
@@ -217,7 +219,7 @@ $(toolchain_rpms): $(TOOLCHAIN_MANIFEST) $(toolchain_local_temp)
 		mkdir -p $(dir $@) && \
 		mv $$tempFile $(dir $@) && \
 		touch $@ ; \
-	fi || $(call print_error, $@ failed) && \
+	fi || $(call print_error, $@ failed) ; \
 	touch $@
 else
 # Download from online package server


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
We were not updating some timestamps when working with the toolchain RPMs. This would result in re-scanning the toolchain RPMs, and regenerating the worker chroot unnecessarily.

We were also not calling the safe unmount script for the SRPM packer chroot.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Call `safeunmount.sh` on `$(BUILD_DIR)/SRPM_packaging` before removing it.
- `touch` `$(STATUS_FLAGS_DIR)/toolchain_verify.flag` when we are done validating the toolchain so we don't revalidate it every time we build
- `touch` the toolchain RPMs when they are "rebuilt" but not extracted fresh from the archive (ie existing file is newer than the contents of the archive). This will ensure that the extracted RPMs are always newer than the archive they came from.

- ###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**