### PR TITLE
Print conflicting toolchain files

### DIFF
--- a/toolkit/scripts/pkggen.mk
+++ b/toolkit/scripts/pkggen.mk
@@ -191,6 +191,7 @@ $(STATUS_FLAGS_DIR)/build-rpms.flag: $(preprocessed_file) $(chroot_worker) $(go-
 		--packages="$(PACKAGE_BUILD_LIST)" \
 		--rebuild-packages="$(PACKAGE_REBUILD_LIST)" \
 		--image-config-file="$(CONFIG_FILE)" \
+		--reserved-file-list-file="$(TOOLCHAIN_MANIFEST)" \
 		$(if $(CONFIG_FILE),--base-dir="$(CONFIG_BASE_DIR)") \
 		$(if $(filter y,$(RUN_CHECK)),--run-check) \
 		$(if $(filter y,$(STOP_ON_PKG_FAIL)),--stop-on-failure) \

--- a/toolkit/tools/scheduler/scheduler.go
+++ b/toolkit/tools/scheduler/scheduler.go
@@ -63,6 +63,7 @@ var (
 	noCleanup            = app.Flag("no-cleanup", "Whether or not to delete the chroot folder after the build is done").Bool()
 	noCache              = app.Flag("no-cache", "Disables using prebuilt cached packages.").Bool()
 	stopOnFailure        = app.Flag("stop-on-failure", "Stop on failed build").Bool()
+	reservedFileListFile = app.Flag("reserved-file-list-file", "Path to a list of files which should not be generated during a build").ExistingFile()
 
 	validBuildAgentFlags = []string{buildagents.TestAgentFlag, buildagents.ChrootAgentFlag}
 	buildAgent           = app.Flag("build-agent", "Type of build agent to build packages with.").PlaceHolder(exe.PlaceHolderize(validBuildAgentFlags)).Required().Enum(validBuildAgentFlags...)
@@ -94,6 +95,7 @@ func main() {
 	}
 
 	ignoredPackages := exe.ParseListArgument(*ignoredPackages)
+	reservedFileListFile := *reservedFileListFile
 
 	// Generate the list of packages that need to be built.
 	// If none are requested then all packages will be built.
@@ -108,6 +110,14 @@ func main() {
 	packageVersToBuild, err := schedulerutils.CalculatePackagesToBuild(packagesNamesToBuild, packagesNamesToRebuild, *inputGraphFile, *imageConfig, *baseDirPath)
 	if err != nil {
 		logger.Log.Fatalf("Unable to generate package build list, error: %s", err)
+	}
+
+	var reservedFiles []string
+	if len(reservedFileListFile) > 0 {
+		reservedFiles, err = schedulerutils.ReadReservedFilesList(reservedFileListFile)
+		if err != nil {
+			logger.Log.Fatalf("unable to read reserved file list %s: %s", reservedFileListFile, err)
+		}
 	}
 
 	// Setup a build agent to handle build requests from the scheduler.
@@ -150,7 +160,7 @@ func main() {
 	signal.Notify(signals, unix.SIGINT, unix.SIGTERM)
 	go cancelBuildsOnSignal(signals, agent)
 
-	err = buildGraph(*inputGraphFile, *outputGraphFile, agent, *workers, *buildAttempts, *stopOnFailure, !*noCache, packageVersToBuild, packagesNamesToRebuild, ignoredPackages)
+	err = buildGraph(*inputGraphFile, *outputGraphFile, agent, *workers, *buildAttempts, *stopOnFailure, !*noCache, packageVersToBuild, packagesNamesToRebuild, ignoredPackages, reservedFiles)
 	if err != nil {
 		logger.Log.Fatalf("Unable to build package graph.\nFor details see the build summary section above.\nError: %s", err)
 	}
@@ -178,7 +188,7 @@ func cancelBuildsOnSignal(signals chan os.Signal, agent buildagents.BuildAgent) 
 
 // buildGraph builds all packages in the dependency graph requested.
 // It will save the resulting graph to outputFile.
-func buildGraph(inputFile, outputFile string, agent buildagents.BuildAgent, workers, buildAttempts int, stopOnFailure, canUseCache bool, packagesToBuild []*pkgjson.PackageVer, packagesNamesToRebuild, ignoredPackages []string) (err error) {
+func buildGraph(inputFile, outputFile string, agent buildagents.BuildAgent, workers, buildAttempts int, stopOnFailure, canUseCache bool, packagesToBuild []*pkgjson.PackageVer, packagesNamesToRebuild, ignoredPackages, reservedFiles []string) (err error) {
 	// graphMutex guards pkgGraph from concurrent reads and writes during build.
 	var graphMutex sync.RWMutex
 
@@ -194,7 +204,7 @@ func buildGraph(inputFile, outputFile string, agent buildagents.BuildAgent, work
 	logger.Log.Infof("Building %d nodes with %d workers", numberOfNodes, workers)
 
 	// After this call pkgGraph will be given to multiple routines and accessing it requires acquiring the mutex.
-	builtGraph, err := buildAllNodes(stopOnFailure, isGraphOptimized, canUseCache, packagesNamesToRebuild, pkgGraph, &graphMutex, goalNode, channels)
+	builtGraph, err := buildAllNodes(stopOnFailure, isGraphOptimized, canUseCache, packagesNamesToRebuild, pkgGraph, &graphMutex, goalNode, channels, reservedFiles)
 
 	if builtGraph != nil {
 		graphMutex.RLock()
@@ -243,7 +253,7 @@ func startWorkerPool(agent buildagents.BuildAgent, workers, buildAttempts, chann
 // - Attempts to satisfy any unresolved dynamic dependencies with new implicit provides from the build result.
 // - Attempts to subgraph the graph to only contain the requested packages if possible.
 // - Repeat.
-func buildAllNodes(stopOnFailure, isGraphOptimized, canUseCache bool, packagesNamesToRebuild []string, pkgGraph *pkggraph.PkgGraph, graphMutex *sync.RWMutex, goalNode *pkggraph.PkgNode, channels *schedulerChannels) (builtGraph *pkggraph.PkgGraph, err error) {
+func buildAllNodes(stopOnFailure, isGraphOptimized, canUseCache bool, packagesNamesToRebuild []string, pkgGraph *pkggraph.PkgGraph, graphMutex *sync.RWMutex, goalNode *pkggraph.PkgNode, channels *schedulerChannels, reservedFiles []string) (builtGraph *pkggraph.PkgGraph, err error) {
 	var (
 		// stopBuilding tracks if the build has entered a failed state and this routine should stop as soon as possible.
 		stopBuilding bool
@@ -256,7 +266,7 @@ func buildAllNodes(stopOnFailure, isGraphOptimized, canUseCache bool, packagesNa
 
 	// Start the build at the leaf nodes.
 	// The build will bubble up through the graph as it processes nodes.
-	buildState := schedulerutils.NewGraphBuildState()
+	buildState := schedulerutils.NewGraphBuildState(reservedFiles)
 	nodesToBuild := schedulerutils.LeafNodes(pkgGraph, graphMutex, goalNode, buildState, useCachedImplicit)
 
 	for {

--- a/toolkit/tools/scheduler/schedulerutils/buildlist.go
+++ b/toolkit/tools/scheduler/schedulerutils/buildlist.go
@@ -4,6 +4,9 @@
 package schedulerutils
 
 import (
+	"bufio"
+	"os"
+
 	"microsoft.com/pkggen/imagegen/configuration"
 	"microsoft.com/pkggen/imagegen/installutils"
 	"microsoft.com/pkggen/internal/logger"
@@ -96,4 +99,27 @@ func filterLocalPackagesOnly(packageVersionsInConfig []*pkgjson.PackageVer, inpu
 	}
 
 	return
+}
+
+// ReadReservedFilesList updates the list of reserved files from the manifest file passed in.
+func ReadReservedFilesList(path string) (reservedFiles []string, err error) {
+	file, err := os.Open(path)
+	if err != nil {
+		logger.Log.Errorf("Failed to open file manifest %s with error %s", path, err)
+		return nil, err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		reservedFiles = append(reservedFiles, scanner.Text())
+	}
+
+	err = scanner.Err()
+	if err != nil {
+		logger.Log.Errorf("Failed to scan file manifest %s with error %s", path, err)
+		return nil, err
+	}
+
+	return reservedFiles, nil
 }

--- a/toolkit/tools/scheduler/schedulerutils/graphbuildstate.go
+++ b/toolkit/tools/scheduler/schedulerutils/graphbuildstate.go
@@ -4,6 +4,9 @@
 package schedulerutils
 
 import (
+	"path/filepath"
+	"sort"
+
 	"microsoft.com/pkggen/internal/logger"
 	"microsoft.com/pkggen/internal/pkggraph"
 )
@@ -16,16 +19,27 @@ type nodeState struct {
 
 // GraphBuildState represents the build state of a graph.
 type GraphBuildState struct {
-	activeBuilds map[int64]*BuildRequest
-	nodeToState  map[*pkggraph.PkgNode]*nodeState
-	failures     []*BuildResult
+	activeBuilds     map[int64]*BuildRequest
+	nodeToState      map[*pkggraph.PkgNode]*nodeState
+	failures         []*BuildResult
+	reservedFiles    map[string]bool
+	conflictingRPMs  map[string]bool
+	conflictingSRPMs map[string]bool
 }
 
 // NewGraphBuildState returns a new GraphBuildState.
-func NewGraphBuildState() *GraphBuildState {
+// - reservedFiles is a list of reserved files which should NOT be rebuilt. Any files that ARE rebuilt will be recorded.
+func NewGraphBuildState(reservedFiles []string) (g *GraphBuildState) {
+	filesMap := make(map[string]bool)
+	for _, file := range reservedFiles {
+		filesMap[file] = true
+	}
 	return &GraphBuildState{
-		activeBuilds: make(map[int64]*BuildRequest),
-		nodeToState:  make(map[*pkggraph.PkgNode]*nodeState),
+		activeBuilds:     make(map[int64]*BuildRequest),
+		nodeToState:      make(map[*pkggraph.PkgNode]*nodeState),
+		reservedFiles:    filesMap,
+		conflictingRPMs:  make(map[string]bool),
+		conflictingSRPMs: make(map[string]bool),
 	}
 }
 
@@ -73,6 +87,32 @@ func (g *GraphBuildState) BuildFailures() []*BuildResult {
 	return g.failures
 }
 
+// ConflictingRPMs will return a list of *.rpm files which should not have been rebuilt.
+// This list is based on the manifest of pre-built toolchain rpms.
+func (g *GraphBuildState) ConflictingRPMs() (rpms []string) {
+	rpms = make([]string, len(g.conflictingRPMs))
+	i := 0
+	for f := range g.conflictingRPMs {
+		rpms[i] = f
+		i++
+	}
+	sort.Strings(rpms)
+	return rpms
+}
+
+// ConflictingSRPMs will return a list of *.src.rpm files which created rpms that should not have been rebuilt.
+// This list is based on the manifest of pre-built toolchain rpms.
+func (g *GraphBuildState) ConflictingSRPMs() (srpms []string) {
+	srpms = make([]string, len(g.conflictingSRPMs))
+	i := 0
+	for f := range g.conflictingSRPMs {
+		srpms[i] = f
+		i++
+	}
+	sort.Strings(srpms)
+	return srpms
+}
+
 // RecordBuildRequest records a build request in the graph build state.
 func (g *GraphBuildState) RecordBuildRequest(req *BuildRequest) {
 	logger.Log.Debugf("Recording build request: %s", req.Node.FriendlyName())
@@ -83,6 +123,11 @@ func (g *GraphBuildState) RecordBuildRequest(req *BuildRequest) {
 func (g *GraphBuildState) RemoveBuildRequest(req *BuildRequest) {
 	logger.Log.Debugf("Removing build request: %s", req.Node.FriendlyName())
 	delete(g.activeBuilds, req.Node.ID())
+}
+
+func (g *GraphBuildState) isConflictWithToolchain(fileToCheck string) (hadConflict bool) {
+	base := filepath.Base(fileToCheck)
+	return g.reservedFiles[base]
 }
 
 // RecordBuildResult records a build result in the graph build state.
@@ -105,6 +150,17 @@ func (g *GraphBuildState) RecordBuildResult(res *BuildResult) {
 
 	for _, node := range res.AncillaryNodes {
 		g.nodeToState[node] = state
+	}
+
+	if !res.Skipped && !res.UsedCache {
+		for _, file := range res.BuiltFiles {
+			if g.isConflictWithToolchain(file) {
+				g.conflictingRPMs[filepath.Base(file)] = true
+				g.conflictingSRPMs[filepath.Base(res.Node.SrpmPath)] = true
+			}
+		}
+	} else {
+		logger.Log.Debugf("skipping checking conflicts since this is not a built node (%v)", res.Node)
 	}
 
 	return

--- a/toolkit/tools/scheduler/schedulerutils/printresults.go
+++ b/toolkit/tools/scheduler/schedulerutils/printresults.go
@@ -48,6 +48,8 @@ func PrintBuildSummary(pkgGraph *pkggraph.PkgGraph, graphMutex *sync.RWMutex, bu
 	builtSRPMs := make(map[string]bool)
 	unbuiltSRPMs := make(map[string]bool)
 	unresolvedDependencies := make(map[string]bool)
+	rpmConflicts := buildState.ConflictingRPMs()
+	srpmConflicts := buildState.ConflictingSRPMs()
 
 	buildNodes := pkgGraph.AllBuildNodes()
 	for _, node := range buildNodes {
@@ -80,6 +82,13 @@ func PrintBuildSummary(pkgGraph *pkggraph.PkgGraph, graphMutex *sync.RWMutex, bu
 	logger.Log.Infof("Number of failed SRPMs:            %d", len(failures))
 	logger.Log.Infof("Number of blocked SRPMs:           %d", len(unbuiltSRPMs))
 	logger.Log.Infof("Number of unresolved dependencies: %d", len(unresolvedDependencies))
+	if len(rpmConflicts) > 0 || len(srpmConflicts) > 0 {
+		logger.Log.Errorf("Number of toolchain RPM conflicts: %d", len(rpmConflicts))
+		logger.Log.Errorf("Number of toolchain SRPM conflicts: %d", len(srpmConflicts))
+	} else {
+		logger.Log.Infof("Number of toolchain RPM conflicts: %d", len(rpmConflicts))
+		logger.Log.Infof("Number of toolchain SRPM conflicts: %d", len(srpmConflicts))
+	}
 
 	if len(builtSRPMs) != 0 {
 		logger.Log.Info("Built SRPMs:")
@@ -113,6 +122,20 @@ func PrintBuildSummary(pkgGraph *pkggraph.PkgGraph, graphMutex *sync.RWMutex, bu
 		logger.Log.Info("Unresolved dependencies:")
 		for dependency := range unresolvedDependencies {
 			logger.Log.Infof("--> %s", dependency)
+		}
+	}
+
+	if len(rpmConflicts) != 0 {
+		logger.Log.Error("RPM Conflicts with toolchain:")
+		for _, conflict := range rpmConflicts {
+			logger.Log.Errorf("--> %s", conflict)
+		}
+	}
+
+	if len(srpmConflicts) != 0 {
+		logger.Log.Error("SRPM Conflicts with toolchain:")
+		for _, conflict := range srpmConflicts {
+			logger.Log.Errorf("--> %s", conflict)
 		}
 	}
 }


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
The package build scheduler will print a list of files that it re-built that conflict with the toolchain manifests. No RPMs listed in the toolchain manifests should rebuild. Building them is the sole responsibility of the toolchain scripts.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add `--reserved-file-list-file` which should be a list of *.rpm filenames. By default this is the toolchain manifest file for the current build.
 - The build report at the end of the build will now include  `RPM Conflicts with toolchain` and `SRPM Conflicts with toolchain` sections if any such conflicts exist.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**