### PR TITLE
Add scheduler support for prebuilt toolchain packages

### DIFF
--- a/toolkit/scripts/pkggen.mk
+++ b/toolkit/scripts/pkggen.mk
@@ -110,7 +110,7 @@ ifeq ($(STOP_ON_FETCH_FAIL),y)
 graphpkgfetcher_extra_flags += --stop-on-failure
 endif
 
-$(cached_file): $(graph_file) $(go-graphpkgfetcher) $(chroot_worker) $(pkggen_local_repo) $(depend_REPO_LIST) $(REPO_LIST) $(shell find $(CACHED_RPMS_DIR)/) $(pkggen_rpms)
+$(cached_file): $(graph_file) $(go-graphpkgfetcher) $(chroot_worker) $(pkggen_local_repo) $(depend_REPO_LIST) $(REPO_LIST) $(shell find $(CACHED_RPMS_DIR)/) $(pkggen_rpms) $(TOOLCHAIN_MANIFEST)
 	mkdir -p $(CACHED_RPMS_DIR)/cache && \
 	$(go-graphpkgfetcher) \
 		--input=$(graph_file) \
@@ -118,6 +118,7 @@ $(cached_file): $(graph_file) $(go-graphpkgfetcher) $(chroot_worker) $(pkggen_lo
 		--rpm-dir=$(RPMS_DIR) \
 		--tmp-dir=$(cache_working_dir) \
 		--tdnf-worker=$(chroot_worker) \
+		--toolchain-manifest=$(TOOLCHAIN_MANIFEST) \
 		--tls-cert=$(TLS_CERT) \
 		--tls-key=$(TLS_KEY) \
 		$(foreach repo, $(pkggen_local_repo) $(graphpkgfetcher_cloned_repo) $(REPO_LIST),--repo-file=$(repo) ) \
@@ -135,6 +136,7 @@ $(preprocessed_file): $(cached_file) $(go-graphPreprocessor)
 		$(logging_command) \
 		--output=$@ && \
 	touch $@
+
 ######## PACKAGE BUILD ########
 
 pkggen_archive	= $(OUT_DIR)/rpms.tar.gz
@@ -191,6 +193,7 @@ $(STATUS_FLAGS_DIR)/build-rpms.flag: $(preprocessed_file) $(chroot_worker) $(go-
 		--packages="$(PACKAGE_BUILD_LIST)" \
 		--rebuild-packages="$(PACKAGE_REBUILD_LIST)" \
 		--image-config-file="$(CONFIG_FILE)" \
+		--reserved-file-list-file="$(TOOLCHAIN_MANIFEST)" \
 		$(if $(CONFIG_FILE),--base-dir="$(CONFIG_BASE_DIR)") \
 		$(if $(filter y,$(RUN_CHECK)),--run-check) \
 		$(if $(filter y,$(STOP_ON_PKG_FAIL)),--stop-on-failure) \

--- a/toolkit/tools/imagepkgfetcher/imagepkgfetcher.go
+++ b/toolkit/tools/imagepkgfetcher/imagepkgfetcher.go
@@ -121,7 +121,8 @@ func cloneSystemConfigs(cloner repocloner.RepoCloner, configFile, baseDirPath st
 	packageVersionsInConfig = append(packageVersionsInConfig, installutils.GetRequiredPackagesForInstall()...)
 
 	logger.Log.Infof("Cloning: %v", packageVersionsInConfig)
-	err = cloner.Clone(cloneDeps, packageVersionsInConfig...)
+	// The image tools don't care if a package was created locally or not, just that it exists. Disregard if it is prebuilt or not.
+	_, err = cloner.Clone(cloneDeps, packageVersionsInConfig...)
 	return
 }
 

--- a/toolkit/tools/internal/packagerepo/repocloner/repocloner.go
+++ b/toolkit/tools/internal/packagerepo/repocloner/repocloner.go
@@ -26,7 +26,7 @@ type RepoPackage struct {
 type RepoCloner interface {
 	Initialize(destinationDir, tmpDir, workerTar, existingRpmsDir string, usePreviewRepo bool, repoDefinitions []string) error
 	AddNetworkFiles(tlsClientCert, tlsClientKey string) error
-	Clone(cloneDeps bool, packagesToClone ...*pkgjson.PackageVer) error
+	Clone(cloneDeps bool, packagesToClone ...*pkgjson.PackageVer) (prebuiltPackage bool, err error)
 	WhatProvides(pkgVer *pkgjson.PackageVer) (packageNames []string, err error)
 	ConvertDownloadedPackagesIntoRepo() error
 	ClonedRepoContents() (repoContents *RepoContents, err error)

--- a/toolkit/tools/internal/packagerepo/repoutils/repoutils.go
+++ b/toolkit/tools/internal/packagerepo/repoutils/repoutils.go
@@ -52,7 +52,7 @@ func RestoreClonedRepoContents(cloner repocloner.RepoCloner, srcFile string) (er
 			logger.Log.Debugf("%s already exists, skipping clone", rpmName)
 			continue
 		}
-		err = cloner.Clone(cloneDeps, pkgVer)
+		_, err = cloner.Clone(cloneDeps, pkgVer)
 		if err != nil {
 			return err
 		}

--- a/toolkit/tools/internal/pkggraph/pkggraph.go
+++ b/toolkit/tools/internal/pkggraph/pkggraph.go
@@ -1123,6 +1123,7 @@ func (g *PkgGraph) CreateSubGraph(rootNode *PkgNode) (subGraph *PkgGraph, err er
 // The function will lock 'graphMutex' before performing the check if the mutex is not nil.
 func IsSRPMPrebuilt(srpmPath string, pkgGraph *PkgGraph, graphMutex *sync.RWMutex) (isPrebuilt bool, rpmFiles []string) {
 	rpmFiles = rpmsProvidedBySRPM(srpmPath, pkgGraph, graphMutex)
+	logger.Log.Tracef("Expected RPMs from %s: %v", srpmPath, rpmFiles)
 	isPrebuilt = findAllRPMS(rpmFiles)
 	return
 }

--- a/toolkit/tools/scheduler/schedulerutils/preparerequest.go
+++ b/toolkit/tools/scheduler/schedulerutils/preparerequest.go
@@ -81,6 +81,7 @@ func canUseCacheForNode(pkgGraph *pkggraph.PkgGraph, node *pkggraph.PkgNode, pac
 		dependency := dependencies.Node().(*pkggraph.PkgNode)
 
 		if !buildState.IsNodeCached(dependency) {
+			logger.Log.Debugf("Can't use cached version of %v because %v is rebuilding", node.FriendlyName(), dependency.FriendlyName())
 			canUseCache = false
 			break
 		}


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
The scheduler will now accept capabilities from pre-built nodes (specifically toochain packges) as being available from the beginning. Previously they would be handled as if they were remote cached nodes, and would be left until all possible local nodes had been rebuilt before being used.

Now when the package fetcher translates a capability into a package that is part of the toolchain it will add a "prebult" node for it rather than a "cached" node.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- `go-graphpkgfetcher` now takes the toolchain manifest as an input
 - Any capability/dynamic package that is translated to a package in the manifest will result in a `prebuilt` node rather than a cached node.
- Prebuilt nodes can be scanned immediately and provide their dynamic capabilities to both unblock further builds, and allow a subgraph to be generated sooner speeding the build up.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**