### PR TITLE
Add priority queue to scheduler

### DIFF
--- a/toolkit/tools/graphPreprocessor/graphPreprocessor.go
+++ b/toolkit/tools/graphPreprocessor/graphPreprocessor.go
@@ -29,9 +29,10 @@ func replaceRunNodesWithPrebuiltNodes(pkgGraph *pkggraph.PkgGraph) (err error) {
 			continue
 		}
 
-		isPrebuilt, _ := pkggraph.IsSRPMPrebuilt(node.SrpmPath, pkgGraph, nil)
+		isPrebuilt, _, missing := pkggraph.IsSRPMPrebuilt(node.SrpmPath, pkgGraph, nil)
 
 		if isPrebuilt == false {
+			logger.Log.Tracef("Can't mark %s as prebuilt, missing: %v", node.SrpmPath, missing)
 			continue
 		}
 

--- a/toolkit/tools/scheduler/scheduler.go
+++ b/toolkit/tools/scheduler/scheduler.go
@@ -289,7 +289,9 @@ func buildAllNodes(stopOnFailure, isGraphOptimized, canUseCache bool, packagesNa
 			// the hypothetical high priority node hidden further into the tree)
 			switch req.Node.Type {
 			case pkggraph.TypePreBuilt:
-				fallthrough
+				channels.PriorityRequests <- req
+
+				// For now all build nodes are of equal priority
 			case pkggraph.TypeGoal:
 				fallthrough
 			case pkggraph.TypePureMeta:
@@ -297,9 +299,7 @@ func buildAllNodes(stopOnFailure, isGraphOptimized, canUseCache bool, packagesNa
 			case pkggraph.TypeRun:
 				fallthrough
 			case pkggraph.TypeRemote:
-				channels.PriorityRequests <- req
-
-			// For now all build nodes are of equal priority
+				fallthrough
 			case pkggraph.TypeBuild:
 				fallthrough
 			default:

--- a/toolkit/tools/scheduler/scheduler.go
+++ b/toolkit/tools/scheduler/scheduler.go
@@ -285,7 +285,7 @@ func buildAllNodes(stopOnFailure, isGraphOptimized, canUseCache bool, packagesNa
 			buildState.RecordBuildRequest(req)
 			// Decide which priority the build should be. Generally we want to get any remote or prebuilt nodes out of the
 			// way as quickly as possible since they may help us optimize the graph early.
-			// Meta nodes may also be blocking somethign we want to examine and give higher priority (priority inheritance from
+			// Meta nodes may also be blocking something we want to examine and give higher priority (priority inheritance from
 			// the hypothetical high priority node hidden further into the tree)
 			switch req.Node.Type {
 			case pkggraph.TypePreBuilt:
@@ -441,7 +441,10 @@ func stopBuild(channels *schedulerChannels, buildState *schedulerutils.GraphBuil
 	close(channels.Requests)
 	close(channels.PriorityRequests)
 
-	// Drain the request buffer to sync the build state with the new number of outstanding builds.
+	// Drain the request buffers to sync the build state with the new number of outstanding builds.
+	for req := range channels.PriorityRequests {
+		buildState.RemoveBuildRequest(req)
+	}
 	for req := range channels.Requests {
 		buildState.RemoveBuildRequest(req)
 	}

--- a/toolkit/tools/scheduler/schedulerutils/buildworker.go
+++ b/toolkit/tools/scheduler/schedulerutils/buildworker.go
@@ -59,15 +59,21 @@ func selectNextBuildRequest(channels *BuildChannels) (req *BuildRequest, finish 
 	default:
 		select {
 		case req = <-channels.PriorityRequests:
-			logger.Log.Tracef("PRIORITY REQUEST: %v", *req)
+			if req != nil {
+				logger.Log.Tracef("PRIORITY REQUEST: %v", *req)
+			}
 			return req, false
 		default:
 			select {
 			case req = <-channels.PriorityRequests:
-				logger.Log.Tracef("PRIORITY REQUEST: %v", *req)
+				if req != nil {
+					logger.Log.Tracef("PRIORITY REQUEST: %v", *req)
+				}
 				return req, false
 			case req = <-channels.Requests:
-				logger.Log.Tracef("normal REQUEST: %v", *req)
+				if req != nil {
+					logger.Log.Tracef("normal REQUEST: %v", *req)
+				}
 				return req, false
 			case <-channels.Cancel:
 				logger.Log.Warn("Cancellation signal received")


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Adds the ability to prioritize certain build nodes in the graph. This means pre-built nodes can be scanned immediately, possibly unblocking other sections of the graph. This will also set the stage for future work on optimizing the order we process the graph.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add a `PriorityRequest` queue to the package workers.
 - Workers will check for jobs in that queue before checking the other queues. Added a `Done` channel to signal a graceful exit should be made.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**