### PR TITLE
Adding missing `Obsoletes` to `systemd`.

### DIFF
--- a/SPECS/systemd/systemd.spec
+++ b/SPECS/systemd/systemd.spec
@@ -1,7 +1,7 @@
 Summary:        Systemd-239
 Name:           systemd
 Version:        239
-Release:        40%{?dist}
+Release:        41%{?dist}
 License:        LGPLv2+ AND GPLv2+ AND MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -51,6 +51,7 @@ Patch103:       103-core-allow-portablectl-to-load-new-services-without-.patch
 Patch104:       104-portablectl-block-when-stopping-a-unit-on-detach-now.patch
 Patch105:       105-portablectl-use-replace-unload-when-stopping-a-servi.patch
 Patch106:       106-portabled-implement-container-host-os-release-interf.patch
+
 BuildRequires:  cryptsetup-devel
 BuildRequires:  docbook-dtd-xml
 BuildRequires:  docbook-style-xsl
@@ -70,6 +71,7 @@ BuildRequires:  pam-devel
 BuildRequires:  perl-XML-Parser
 BuildRequires:  util-linux-devel >= 2.30
 BuildRequires:  xz-devel
+
 Requires:       filesystem >= 1.1
 Requires:       glib
 Requires:       kmod
@@ -78,6 +80,7 @@ Requires:       libgcrypt
 Requires:       lz4
 Requires:       pam
 Requires:       xz
+
 Obsoletes:      systemd-bootstrap
 
 %description
@@ -85,15 +88,21 @@ Systemd is an init replacement with better process control and security
 
 %package devel
 Summary:        Development headers for systemd
+
 Requires:       %{name} = %{version}-%{release}
 Requires:       glib-devel
+
+Obsoletes:      systemd-bootstrap-devel
 
 %description devel
 Development headers for developing applications linking to libsystemd
 
 %package lang
 Summary:        Language pack for systemd
+
 Requires:       %{name} = %{version}-%{release}
+
+Obsoletes:      systemd-bootstrap-lang
 
 %description lang
 Language pack for systemd
@@ -276,6 +285,9 @@ rm -rf %{buildroot}/*
 %files lang -f %{name}.lang
 
 %changelog
+* Thu Apr 07 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 239-41
+- Making sure to obsolete the bootstrap version of systemd.
+
 * Wed Mar 16 2022 Henry Beberman <henry.beberman@microsoft.com> - 239-40
 - Backport upstream change so dhcp-provided gateway uses dhcp-provided source ip for route.
 

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -389,13 +389,13 @@ sqlite-devel-3.34.1-1.cm1.aarch64.rpm
 sqlite-libs-3.34.1-1.cm1.aarch64.rpm
 swig-4.0.2-1.cm1.aarch64.rpm
 swig-debuginfo-4.0.2-1.cm1.aarch64.rpm
-systemd-239-40.cm1.aarch64.rpm
+systemd-239-41.cm1.aarch64.rpm
 systemd-bootstrap-239-40.cm1.aarch64.rpm
 systemd-bootstrap-debuginfo-239-40.cm1.aarch64.rpm
 systemd-bootstrap-devel-239-40.cm1.aarch64.rpm
-systemd-debuginfo-239-40.cm1.aarch64.rpm
-systemd-devel-239-40.cm1.aarch64.rpm
-systemd-lang-239-40.cm1.aarch64.rpm
+systemd-debuginfo-239-41.cm1.aarch64.rpm
+systemd-devel-239-41.cm1.aarch64.rpm
+systemd-lang-239-41.cm1.aarch64.rpm
 tar-1.32-2.cm1.aarch64.rpm
 tar-debuginfo-1.32-2.cm1.aarch64.rpm
 tdnf-2.1.0-6.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -389,13 +389,13 @@ sqlite-devel-3.34.1-1.cm1.x86_64.rpm
 sqlite-libs-3.34.1-1.cm1.x86_64.rpm
 swig-4.0.2-1.cm1.x86_64.rpm
 swig-debuginfo-4.0.2-1.cm1.x86_64.rpm
-systemd-239-40.cm1.x86_64.rpm
+systemd-239-41.cm1.x86_64.rpm
 systemd-bootstrap-239-40.cm1.x86_64.rpm
 systemd-bootstrap-debuginfo-239-40.cm1.x86_64.rpm
 systemd-bootstrap-devel-239-40.cm1.x86_64.rpm
-systemd-debuginfo-239-40.cm1.x86_64.rpm
-systemd-devel-239-40.cm1.x86_64.rpm
-systemd-lang-239-40.cm1.x86_64.rpm
+systemd-debuginfo-239-41.cm1.x86_64.rpm
+systemd-devel-239-41.cm1.x86_64.rpm
+systemd-lang-239-41.cm1.x86_64.rpm
 tar-1.32-2.cm1.x86_64.rpm
 tar-debuginfo-1.32-2.cm1.x86_64.rpm
 tdnf-2.1.0-6.cm1.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

We've recently encountered a few issues with TDNF choosing `systemd-bootstrap-devel` over `systemd-devel`. While ideally, we should drop bootstrap versions of packages from PMC, we're making sure `systemd` now obsoletes all possible `systemd-bootstrap` packages until a better fix can be implemented.

I don't know how to obsolete `systemd-bootstrap-debuginfo` since it's automatically generated. Help greatly appreciated. The risk of running into conflicts with this package is minimal, however.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Added `Obsoletes` inside `systemd.spec` for all possible `systemd-bootstrap` packages.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
Yes.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: 181782
