### PR TITLE
Fix ARM64 Build Break due to missing requires on edk2-aarch64

### DIFF
--- a/SPECS/libguestfs/libguestfs.spec
+++ b/SPECS/libguestfs/libguestfs.spec
@@ -260,7 +260,7 @@ Requires:       systemd-libs
 Requires:       yajl
 
 %ifarch aarch64
-Requires:       edk2-aarch64
+#Requires:       edk2-aarch64
 %endif
 
 Recommends:     libvirt-daemon-config-network


### PR DESCRIPTION
Resolve ARM64 build break.  Libguestfs builds without edk2-aarch64.  So this quick change just allows the build to complete.