### PR TITLE
[main][SPECS-EXTENDED] Fixing `cassandra` dependencies.

### DIFF
--- a/SPECS-EXTENDED/jlex/jlex.spec
+++ b/SPECS-EXTENDED/jlex/jlex.spec
@@ -21,7 +21,7 @@ Distribution:   Mariner
 %define section		free
 Name:           jlex
 Version:        1.2.6
-Release:        284%{?dist}
+Release:        285%{?dist}
 Summary:        A Lexical Analyzer Generator for Java
 License:        MIT
 Group:          Development/Libraries/Java
@@ -31,6 +31,7 @@ Source1:        %{name}-%{version}.build.xml
 Patch0:         %{name}-%{version}.static.patch
 BuildRequires:  ant
 BuildRequires:  java-devel
+BuildRequires:  javapackages-tools
 BuildRequires:  xml-commons-apis-bootstrap
 #!BuildIgnore:  xerces-j2
 #!BuildIgnore:  xml-commons
@@ -64,6 +65,9 @@ install -m 644 dist/lib/%{name}.jar %{buildroot}%{_javadir}/%{name}-%{version}.j
 %{_javadir}/*
 
 %changelog
+* Tue Apr 12 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.2.6-285
+- Adding missing BR on 'javapackages-tools'.
+
 * Fri Dec 10 2021 Thomas Crain <thcrain@microsoft.com> - 1.2.6-284
 - License verified
 

--- a/SPECS-EXTENDED/servletapi5/servletapi5.spec
+++ b/SPECS-EXTENDED/servletapi5/servletapi5.spec
@@ -22,9 +22,9 @@ Distribution:   Mariner
 %define full_name	jakarta-%{base_name}
 Name:           servletapi5
 Version:        5.0.18
-Release:        287%{?dist}
+Release:        288%{?dist}
 Summary:        Java servlet and JSP implementation classes
-License:        Apache-2.0
+License:        ASL 1.1
 Group:          Development/Libraries/Java
 Url:            http://jakarta.apache.org/tomcat/
 Source:         %{full_name}-5-src.tar.gz
@@ -32,6 +32,7 @@ Source:         %{full_name}-5-src.tar.gz
 #!BuildIgnore:  xml-commons-jaxp-1.3-apis
 BuildRequires:  ant
 BuildRequires:  java-devel
+BuildRequires:  javapackages-tools
 BuildRequires:  xml-commons-apis-bootstrap
 Requires(post): update-alternatives
 Provides:       servlet = %{version}
@@ -88,6 +89,10 @@ fi
 %ghost %{_sysconfdir}/alternatives/servlet.jar
 
 %changelog
+* Mon Apr 11 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 5.0.18-288
+- Adding BR on "javapackages-tools" to provide missing "%%{_javadir}" macro.
+- License verified.
+
 * Thu Oct 14 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 5.0.18-287
 - Initial CBL-Mariner import from openSUSE Tumbleweed (license: same as "License" tag).
 - Converting the 'Release' tag to the '[number].[distribution]' format.


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

It looks like `servletapi5` started failing to build due to a missing RPM macro after recent core package updates. I've added a `BuildRequires`, which should resolve this issue.

**NOTE:** not fixing missing URL in `cgmanifest.json` - we're going to cover that wholesale through a separate set of changes.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Added `BuildRequires: javapackages-tools` to fix missing RPM macros.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local package build.
