### PR TITLE
[1.0] Add ptp_hyperv udev rule to systemd

### DIFF
--- a/SPECS/systemd/Add-ptp_hyperv-udev-rule.patch
+++ b/SPECS/systemd/Add-ptp_hyperv-udev-rule.patch
@@ -1,0 +1,14 @@
+Backport upstream udev rule so that the ptp time source from Hyper-V enumerates as /dev/ptp_hyperv
+
+Signed-off-by: Henry Beberman <henry.beberman@microsoft.com>
+
+diff -Naur a/rules/50-udev-default.rules.in b/rules/50-udev-default.rules.in
+--- a/rules/50-udev-default.rules.in	2018-06-22 04:11:49.000000000 -0700
++++ b/rules/50-udev-default.rules.in	2022-04-11 13:37:22.954292197 -0700
+@@ -83,4 +83,6 @@
+ 
+ SUBSYSTEM=="ptp", ATTR{clock_name}=="KVM virtual PTP", SYMLINK += "ptp_kvm"
+ 
++SUBSYSTEM=="ptp", ATTR{clock_name}=="hyperv", SYMLINK += "ptp_hyperv"
++
+ LABEL="default_end"

--- a/SPECS/systemd/systemd.spec
+++ b/SPECS/systemd/systemd.spec
@@ -1,7 +1,7 @@
 Summary:        Systemd-239
 Name:           systemd
 Version:        239
-Release:        41%{?dist}
+Release:        42%{?dist}
 License:        LGPLv2+ AND GPLv2+ AND MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -43,6 +43,7 @@ Patch22:        CVE-2020-13776.patch
 Patch23:        CVE-2018-21029.nopatch
 Patch24:        CVE-2021-33910.patch
 Patch25:        Backport-fix-dhcp-routes.patch
+Patch26:        Add-ptp_hyperv-udev-rule.patch
 #Portablectl patches for --now --enable and --no-block flags support
 Patch100:       100-portabled-allow-to-detach-an-image-with-a-unit-in-li.patch
 Patch101:       101-Portabled-fix-inspect-on-image-attached-as-directory.patch
@@ -285,6 +286,9 @@ rm -rf %{buildroot}/*
 %files lang -f %{name}.lang
 
 %changelog
+* Mon Apr 11 2022 Henry Beberman <henry.beberman@microsoft.com> - 239-42
+- Backport udev rule to enumerate Hyper-V ptp with a symlink.
+
 * Thu Apr 07 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 239-41
 - Making sure to obsolete the bootstrap version of systemd.
 

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -389,13 +389,13 @@ sqlite-devel-3.34.1-1.cm1.aarch64.rpm
 sqlite-libs-3.34.1-1.cm1.aarch64.rpm
 swig-4.0.2-1.cm1.aarch64.rpm
 swig-debuginfo-4.0.2-1.cm1.aarch64.rpm
-systemd-239-41.cm1.aarch64.rpm
+systemd-239-42.cm1.aarch64.rpm
 systemd-bootstrap-239-40.cm1.aarch64.rpm
 systemd-bootstrap-debuginfo-239-40.cm1.aarch64.rpm
 systemd-bootstrap-devel-239-40.cm1.aarch64.rpm
-systemd-debuginfo-239-41.cm1.aarch64.rpm
-systemd-devel-239-41.cm1.aarch64.rpm
-systemd-lang-239-41.cm1.aarch64.rpm
+systemd-debuginfo-239-42.cm1.aarch64.rpm
+systemd-devel-239-42.cm1.aarch64.rpm
+systemd-lang-239-42.cm1.aarch64.rpm
 tar-1.32-2.cm1.aarch64.rpm
 tar-debuginfo-1.32-2.cm1.aarch64.rpm
 tdnf-2.1.0-6.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -389,13 +389,13 @@ sqlite-devel-3.34.1-1.cm1.x86_64.rpm
 sqlite-libs-3.34.1-1.cm1.x86_64.rpm
 swig-4.0.2-1.cm1.x86_64.rpm
 swig-debuginfo-4.0.2-1.cm1.x86_64.rpm
-systemd-239-41.cm1.x86_64.rpm
+systemd-239-42.cm1.x86_64.rpm
 systemd-bootstrap-239-40.cm1.x86_64.rpm
 systemd-bootstrap-debuginfo-239-40.cm1.x86_64.rpm
 systemd-bootstrap-devel-239-40.cm1.x86_64.rpm
-systemd-debuginfo-239-41.cm1.x86_64.rpm
-systemd-devel-239-41.cm1.x86_64.rpm
-systemd-lang-239-41.cm1.x86_64.rpm
+systemd-debuginfo-239-42.cm1.x86_64.rpm
+systemd-devel-239-42.cm1.x86_64.rpm
+systemd-lang-239-42.cm1.x86_64.rpm
 tar-1.32-2.cm1.x86_64.rpm
 tar-debuginfo-1.32-2.cm1.x86_64.rpm
 tdnf-2.1.0-6.cm1.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Best practice for setting system time as an Azure VM is to retrieve it from the Hyper-V ptp device.

However, there's a race condition where the accelerated networking NIC can enumerate a ptp0 before Hyper-V's ptp device, meaning chrony shouldn't directly depend on /dev/ptp0. In upstream systemd they've fixed this with a udev rule to symlink the correct device to /dev/ptp_hyperv every boot. Backporting this rule to Mariner 1.0 so we can take a dependency on that device.

https://docs.microsoft.com/en-us/azure/virtual-machines/linux/time-sync

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Backport ptp_hyperv udev rule to Mariner 1.0

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local toolchain and package build.
- Booted image in Azure and locally. Observed /dev/ptp_hyperv was present and pointed to the correct device.