### PR TITLE
Enable predictable network interface names

### DIFF
--- a/SPECS/systemd/systemd-bootstrap.signatures.json
+++ b/SPECS/systemd/systemd-bootstrap.signatures.json
@@ -3,6 +3,6 @@
   "50-security-hardening.conf": "c9fc6624a3178cc0980ec3495ac2d5f02a8a1f3a4cdadb8770628d7394b92e2c",
   "99-dhcp-en.network": "158c0003826cef9d780799c6edb2814800d4518f85f884710550f4c46d14be67",
   "systemd-250.3.tar.gz": "87b0eee7b6e5aaab2ab56d158f9536daa6bfd5de011f2a5fc6ccdd81ee1e7a24",
-  "systemd.cfg": "1fd673c1da90560d9395a18df31f2ce6ef23972a6bf8c910ba6f3fb07818afa9"
+  "systemd.cfg": "7386227f3df410335dd0b603a2cdd14182f3ced1f5a9c3e02c489b5e6592c496"
  }
 }

--- a/SPECS/systemd/systemd-bootstrap.spec
+++ b/SPECS/systemd/systemd-bootstrap.spec
@@ -1,7 +1,7 @@
 Summary:        Bootstrap version of systemd. Workaround for systemd circular dependency.
 Name:           systemd-bootstrap
 Version:        250.3
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        LGPLv2+ AND GPLv2+ AND MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -227,6 +227,9 @@ systemctl preset-all
 %{_datadir}/pkgconfig/udev.pc
 
 %changelog
+* Fri Apr 08 2022 Chris Co <chrco@microsoft.com> - 250.3-3
+- Remove net.ifnames=0 from systemd.cfg
+
 * Thu Mar 17 2022 Andrew Phelps <anphel@microsoft.com> - 250.3-2
 - Disable zstd configuration to ensure lz4 compression is used for journal files and coredumps
 

--- a/SPECS/systemd/systemd.cfg
+++ b/SPECS/systemd/systemd.cfg
@@ -1,2 +1,2 @@
 # GRUB Environment Block
-systemd_cmdline=net.ifnames=0 plymouth.enable=0 systemd.legacy_systemd_cgroup_controller=yes systemd.unified_cgroup_hierarchy=0
+systemd_cmdline= plymouth.enable=0 systemd.legacy_systemd_cgroup_controller=yes systemd.unified_cgroup_hierarchy=0

--- a/SPECS/systemd/systemd.signatures.json
+++ b/SPECS/systemd/systemd.signatures.json
@@ -3,6 +3,6 @@
   "50-security-hardening.conf": "c9fc6624a3178cc0980ec3495ac2d5f02a8a1f3a4cdadb8770628d7394b92e2c",
   "99-dhcp-en.network": "158c0003826cef9d780799c6edb2814800d4518f85f884710550f4c46d14be67",
   "systemd-250.3.tar.gz": "87b0eee7b6e5aaab2ab56d158f9536daa6bfd5de011f2a5fc6ccdd81ee1e7a24",
-  "systemd.cfg": "1fd673c1da90560d9395a18df31f2ce6ef23972a6bf8c910ba6f3fb07818afa9"
+  "systemd.cfg": "7386227f3df410335dd0b603a2cdd14182f3ced1f5a9c3e02c489b5e6592c496"
  }
 }

--- a/SPECS/systemd/systemd.spec
+++ b/SPECS/systemd/systemd.spec
@@ -1,7 +1,7 @@
 Summary:        Systemd-250
 Name:           systemd
 Version:        250.3
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        LGPLv2+ AND GPLv2+ AND MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -257,6 +257,9 @@ systemctl preset-all
 %files lang -f %{name}.lang
 
 %changelog
+* Fri Apr 08 2022 Chris Co <chrco@microsoft.com> - 250.3-4
+- Remove net.ifnames=0 from systemd.cfg
+
 * Thu Mar 24 2022 Andrew Phelps <anphel@microsoft.com> - 250.3-3
 - Add Requires(post) on audit-libs, pam and util-linux-devel
 

--- a/SPECS/tboot/README.md
+++ b/SPECS/tboot/README.md
@@ -25,7 +25,7 @@ menuentry 'GNU/Linux, with tboot 1.10.2' --class gnu-linux --class gnu --class o
 	if [ -f  $bootprefix/systemd.cfg ]; then
 		load_env -f $bootprefix/systemd.cfg
 	else
-		set systemd_cmdline=net.ifnames=0
+		set systemd_cmdline=
 	fi
 	search --no-floppy --fs-uuid --set=root $bootID
 	echo	'Loading tboot 1.10.2 ...'

--- a/SPECS/tboot/tboot.signatures.json
+++ b/SPECS/tboot/tboot.signatures.json
@@ -1,6 +1,6 @@
 {
  "Signatures": {
-  "README.md": "1743821e6df5542808d5aea2e42879611cc1588ce60de379ad8a8cbf36af264b",
+  "README.md": "7496cfeb45c19be1fdc789fa644da0600b58ac7fcd85c804ea7efa0893eea5a0",
   "create-drtm-policy.sh": "99144a61a17869ba2fcb75a82b477065dd689219363a21bd03fd402255bf468a",
   "tboot-1.10.2.tar.gz": "2e179ca3b50b83cee56c2f2a5e4096c06dd1f2388f7508339c390f04fcbab111"
  }

--- a/SPECS/tboot/tboot.spec
+++ b/SPECS/tboot/tboot.spec
@@ -1,7 +1,7 @@
 Summary:        Trusted pre-kernel module and tools.
 Name:           tboot
 Version:        1.10.2
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        BSD
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -58,6 +58,9 @@ install -m 755 %{SOURCE2} %{buildroot}%{_docdir}/README.md
 
 
 %changelog
+* Fri Apr 08 2022 Chris Co <chrco@microsoft.com> - 1.10.2-2
+- Remove net.ifnames=0 from readme
+
 * Fri Feb 25 2022 Henry Li <lihl@microsoft.com> 1.10.2-1
 - Upgrade to version 1.10.2
 - Add mandatory grub configuration files/tooling that are missing

--- a/toolkit/resources/assets/grub2/grub.cfg
+++ b/toolkit/resources/assets/grub2/grub.cfg
@@ -6,7 +6,7 @@ load_env -f $bootprefix/mariner.cfg
 if [ -f  $bootprefix/systemd.cfg ]; then
 	load_env -f $bootprefix/systemd.cfg
 else
-	set systemd_cmdline=net.ifnames=0
+	set systemd_cmdline=
 fi
 
 set rootdevice={{.RootPartition}}

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -543,10 +543,10 @@ sqlite-devel-3.36.0-2.cm2.aarch64.rpm
 sqlite-libs-3.36.0-2.cm2.aarch64.rpm
 swig-4.0.2-3.cm2.aarch64.rpm
 swig-debuginfo-4.0.2-3.cm2.aarch64.rpm
-systemd-bootstrap-250.3-2.cm2.aarch64.rpm
-systemd-bootstrap-debuginfo-250.3-2.cm2.aarch64.rpm
-systemd-bootstrap-devel-250.3-2.cm2.aarch64.rpm
-systemd-bootstrap-rpm-macros-250.3-2.cm2.noarch.rpm
+systemd-bootstrap-250.3-3.cm2.aarch64.rpm
+systemd-bootstrap-debuginfo-250.3-3.cm2.aarch64.rpm
+systemd-bootstrap-devel-250.3-3.cm2.aarch64.rpm
+systemd-bootstrap-rpm-macros-250.3-3.cm2.noarch.rpm
 tar-1.34-1.cm2.aarch64.rpm
 tar-debuginfo-1.34-1.cm2.aarch64.rpm
 tdnf-3.2.2-2.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -543,10 +543,10 @@ sqlite-devel-3.36.0-2.cm2.x86_64.rpm
 sqlite-libs-3.36.0-2.cm2.x86_64.rpm
 swig-4.0.2-3.cm2.x86_64.rpm
 swig-debuginfo-4.0.2-3.cm2.x86_64.rpm
-systemd-bootstrap-250.3-2.cm2.x86_64.rpm
-systemd-bootstrap-debuginfo-250.3-2.cm2.x86_64.rpm
-systemd-bootstrap-devel-250.3-2.cm2.x86_64.rpm
-systemd-bootstrap-rpm-macros-250.3-2.cm2.noarch.rpm
+systemd-bootstrap-250.3-3.cm2.x86_64.rpm
+systemd-bootstrap-debuginfo-250.3-3.cm2.x86_64.rpm
+systemd-bootstrap-devel-250.3-3.cm2.x86_64.rpm
+systemd-bootstrap-rpm-macros-250.3-3.cm2.noarch.rpm
 tar-1.34-1.cm2.x86_64.rpm
 tar-debuginfo-1.34-1.cm2.x86_64.rpm
 tdnf-3.2.2-2.cm2.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Today the assignment of networking interface names "eth0", "eth1", etc is assigned based on driver probe order, which is not predictable. systemd introduced predictable network interface naming in v197. However we were disabling this feature via the `net.ifnames=0` configuration. Instead let's enable predictable network interface names so users can reliably know which interface name belongs to which network device.

For more details, see: https://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames/

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- systemd: remove net.ifnames=0 reference
- tboot: remove net.ifnames=0 reference
- grub.cfg: remove net.ifnames=0 reference

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://microsoft.visualstudio.com/OS/_workitems/edit/37414414

###### Links to CVEs  <!-- optional -->

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
Local build