### PR TITLE
ruby: Do not store certain compiler flags for extension building

### DIFF
--- a/SPECS/ruby/ruby.spec
+++ b/SPECS/ruby/ruby.spec
@@ -21,7 +21,7 @@
 Summary:        Ruby
 Name:           ruby
 Version:        2.7.4
-Release:        4%{?dist}
+Release:        5%{?dist}
 License:        (Ruby OR BSD) AND Public Domain AND MIT AND CC0 AND zlib AND UCD
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -244,6 +244,13 @@ writing tests, checking results and automated testing in Ruby.
 %autosetup -p1
 
 %build
+# Remove GCC specs and build environment linker scripts
+# from the flags used when compiling outside of an RPM environment
+export XCFLAGS="%{build_cflags}"
+export XLDFLAGS="%{build_ldflags}"
+export CFLAGS="%{extension_cflags}"
+export LDFLAGS="%{extension_ldflags}"
+
 autoconf
 
 %configure \
@@ -451,6 +458,9 @@ sudo -u test make test TESTS="-v"
 %doc %{gem_dir}/gems/test-unit-%{test_unit_version}/doc
 
 %changelog
+* Mon Apr 11 2022 Olivia Crain <oliviacrain@microsoft.com> - 2.7.4-5
+- Specify which flags should be stored for extension building
+
 * Tue Mar 29 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 2.7.4-4
 - Fixing "Provides".
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
A customer pointed out that our build-environment-specific linker flags are poisoning the flags that `ruby` stores to build C extensions with. This was causing gems with C extensions to fail to install, since they couldn't link with the stored flags.

This problem is pretty much the same as #1824. The solution is also similar- use our extension flag macros to tell `ruby` to only store linker flags that are usable outside of our RPM build environment. 

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- `ruby`: Tell ruby to only store linker flags that are valid outside of our RPM build environment.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build, installed new `ruby` version in a container, created a minimal Ruby C extension and verified the generated `Makefile` did not contain the unwanted flags.
