### PR TITLE
[main] Fixing Ruby packages builds.

### DIFF
--- a/SPECS-EXTENDED/rubygem-rspec/rubygem-rspec.spec
+++ b/SPECS-EXTENDED/rubygem-rspec/rubygem-rspec.spec
@@ -5,7 +5,7 @@ Distribution:   Mariner
 Summary:  Behaviour driven development (BDD) framework for Ruby
 Name:     rubygem-%{gem_name}
 Version:  3.9.0
-Release:  4%{?dist}
+Release:  5%{?dist}
 License:  MIT
 URL:      https://rspec.info
 Source0:  https://github.com/rspec/rspec-metagem/archive/refs/tags/v%{version}.tar.gz#/%{gem_name}-metagem-%{version}.tar.gz
@@ -41,7 +41,6 @@ cp -a .%{gem_dir}/* %{buildroot}%{gem_dir}/
 
 %files
 %dir	%{gem_instdir}
-%{gem_instdir}/lib
 %license	%{gem_instdir}/LICENSE.md
 %doc	%{gem_instdir}/README.md
 %exclude %{gem_cache}
@@ -51,6 +50,9 @@ cp -a .%{gem_dir}/* %{buildroot}%{gem_dir}/
 %doc	%{gem_docdir}
 
 %changelog
+* Wed Apr 13 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 3.9.0-5
+- Fixing the %%files section.
+
 * Tue Mar 22 2022 Neha Agarwal <nehaagarwal@microsoft.com> - 3.9.0-4
 - License verified.
 - Build from .tar.gz source.

--- a/SPECS/ruby/macros.rubygems
+++ b/SPECS/ruby/macros.rubygems
@@ -2,6 +2,9 @@
 %gem_dir %(IFS=: R=($(gem env gempath)); echo ${R[${#R[@]}-1]})
 %gem_archdir %{_libdir}/gems
 
+# For compatibility with some older specs.
+%gemdir %{gem_dir}
+
 # Common gem locations and files.
 %gem_instdir %{gem_dir}/gems/%{gem_name}-%{version}%{?prerelease}
 %gem_extdir_mri %{gem_archdir}/%{name}/%{gem_name}-%{version}%{?prerelease}

--- a/SPECS/ruby/ruby.signatures.json
+++ b/SPECS/ruby/ruby.signatures.json
@@ -1,7 +1,7 @@
 {
  "Signatures": {
   "macros.ruby": "fc26a1eeb3f507c65619a2760a6cf9e1cfb6468731c2a75ab164c577bf632083",
-  "macros.rubygems": "2f034f933924e45cf16e024fbd28eb8e5a0ac824e4506b42b1f444585f69b4a0",
+  "macros.rubygems": "ab73aa910f59cb8041ca942d0031fe0b03c0385014e5c5e64c686c48ec5faa54",
   "operating_system.rb": "91bb8c3c6742392dc18838b6c762c9ba2a39b7558afc9160239e946540207a51",
   "ruby-2.7.4.tar.xz": "2a80824e0ad6100826b69b9890bf55cfc4cf2b61a1e1330fccbcb30c46cef8d7",
   "rubygems.attr": "a89a6c82d6e534539ab499e1d5464161429562133dfb5adad1c8d157a60994fa",

--- a/SPECS/ruby/ruby.spec
+++ b/SPECS/ruby/ruby.spec
@@ -21,7 +21,7 @@
 Summary:        Ruby
 Name:           ruby
 Version:        2.7.4
-Release:        5%{?dist}
+Release:        6%{?dist}
 License:        (Ruby OR BSD) AND Public Domain AND MIT AND CC0 AND zlib AND UCD
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -458,6 +458,9 @@ sudo -u test make test TESTS="-v"
 %doc %{gem_dir}/gems/test-unit-%{test_unit_version}/doc
 
 %changelog
+* Tue Apr 12 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 2.7.4-6
+- Adding "gemdir" macro for compatibility with older specs.
+
 * Mon Apr 11 2022 Olivia Crain <oliviacrain@microsoft.com> - 2.7.4-5
 - Specify which flags should be stored for extension building
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

Some `rubygem-*` specs rely on the `gemdir` macro, while we used the `gem_dir` version. Some of the specs defined their own version of `gemdir` (in value identical to our `gem_dir`) but the ones, that didn't ended up installing files under directories like `/%{gemdir}/specifications` (the macro didn't get expanded). Example:

```
root [ / ]# dnf -q repoquery -l rubygem-coderay
/%{gemdir}/specifications
/%{gemdir}/specifications/coderay-1.1.3.rc1.gemspec
(...)
```

This change adds the `gemdir` macro alongside `gem_dir` to fix the paths.

There's also a small fix for `rubygem-rspec`.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Added an alternative version of the `gem_dir` macro to enable compatibility with some Ruby specs.
- Removed no longer published files from `rubygem-rspec` to fix the package build.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local package builds.
