### PR TITLE
Update postgresql and vsftpd for CVE-2021-23214, CVE-2021-23222, CVE-2021-3618

### DIFF
--- a/SPECS/postgresql/postgresql.signatures.json
+++ b/SPECS/postgresql/postgresql.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "postgresql-12.10.tar.bz2": "83dd192e6034951192b9a86dc19cf3717a8b82120e2f11a0a36723c820d2b257"
+  "postgresql-14.2.tar.bz2": "2cf78b2e468912f8101d695db5340cf313c2e9f68a612fb71427524e8c9a977a"
  }
 }

--- a/SPECS/postgresql/postgresql.signatures.json
+++ b/SPECS/postgresql/postgresql.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "postgresql-12.7.tar.bz2": "8490741f47c88edc8b6624af009ce19fda4dc9b31c4469ce2551d84075d5d995"
+  "postgresql-12.10.tar.bz2": "83dd192e6034951192b9a86dc19cf3717a8b82120e2f11a0a36723c820d2b257"
  }
 }

--- a/SPECS/postgresql/postgresql.spec
+++ b/SPECS/postgresql/postgresql.spec
@@ -1,6 +1,6 @@
 Summary:        PostgreSQL database engine
 Name:           postgresql
-Version:        12.10
+Version:        14.2
 Release:        1%{?dist}
 License:        PostgreSQL
 Vendor:         Microsoft Corporation
@@ -99,6 +99,7 @@ sudo -u nobody -s /bin/bash -c "PATH=$PATH make -k check"
 %license COPYRIGHT
 %{_bindir}/initdb
 %{_bindir}/oid2name
+%{_bindir}/pg_amcheck
 %{_bindir}/pg_archivecleanup
 %{_bindir}/pg_basebackup
 %{_bindir}/pg_checksums
@@ -110,10 +111,10 @@ sudo -u nobody -s /bin/bash -c "PATH=$PATH make -k check"
 %{_bindir}/pg_resetwal
 %{_bindir}/pg_resetxlog
 %{_bindir}/pg_rewind
-%{_bindir}/pg_standby
 %{_bindir}/pg_test_fsync
 %{_bindir}/pg_test_timing
 %{_bindir}/pg_upgrade
+%{_bindir}/pg_verifybackup
 %{_bindir}/pg_waldump
 %{_bindir}/pg_xlogdump
 %{_bindir}/pgbench
@@ -165,8 +166,9 @@ sudo -u nobody -s /bin/bash -c "PATH=$PATH make -k check"
 %{_libdir}/libpgtypes.a
 
 %changelog
-* Wed Apr 13 2022 Henry Beberman <henry.beberman@microsoft.com> - 12.10-1
+* Wed Apr 13 2022 Henry Beberman <henry.beberman@microsoft.com> - 14.2-1
 - Update package version to resolve CVE-2021-23214 and CVE-2021-23222
+- Add pg_verifybackup and pg_amcheck, remove pg_standby
 
 * Thu Dec 16 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 12.7-2
 - Removing the explicit %%clean stage.

--- a/SPECS/postgresql/postgresql.spec
+++ b/SPECS/postgresql/postgresql.spec
@@ -1,7 +1,7 @@
 Summary:        PostgreSQL database engine
 Name:           postgresql
-Version:        12.7
-Release:        2%{?dist}
+Version:        12.10
+Release:        1%{?dist}
 License:        PostgreSQL
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -165,6 +165,9 @@ sudo -u nobody -s /bin/bash -c "PATH=$PATH make -k check"
 %{_libdir}/libpgtypes.a
 
 %changelog
+* Wed Apr 13 2022 Henry Beberman <henry.beberman@microsoft.com> - 12.10-1
+- Update package version to resolve CVE-2021-23214 and CVE-2021-23222
+
 * Thu Dec 16 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 12.7-2
 - Removing the explicit %%clean stage.
 

--- a/SPECS/vsftpd/vsftpd.signatures.json
+++ b/SPECS/vsftpd/vsftpd.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "vsftpd-3.0.3.tar.gz": "9d4d2bf6e6e2884852ba4e69e157a2cecd68c5a7635d66a3a8cf8d898c955ef7"
+  "vsftpd-3.0.5.tar.gz": "26b602ae454b0ba6d99ef44a09b6b9e0dfa7f67228106736df1f278c70bc91d3"
  }
 }

--- a/SPECS/vsftpd/vsftpd.spec
+++ b/SPECS/vsftpd/vsftpd.spec
@@ -1,7 +1,7 @@
 Summary:        Very secure and very small FTP daemon.
 Name:           vsftpd
-Version:        3.0.3
-Release:        10%{?dist}
+Version:        3.0.5
+Release:        1%{?dist}
 License:        GPLv2 with exceptions
 URL:            https://security.appspot.com/vsftpd.html
 Group:          System Environment/Daemons
@@ -85,9 +85,10 @@ fi
 %{_datadir}/*
 
 %changelog
-* Sat May 09 2020 Nick Samson <nisamson@microsoft.com> - 3.0.3-10
-- Added %%license line automatically
-
+*   Wed Apr 13 2022 Henry Beberman <henry.beberman@microsoft.com> - 3.0.5-1
+-   Upgrade to version 3.0.5 to fix CVE-2021-3618
+*   Sat May 09 2020 Nick Samson <nisamson@microsoft.com> - 3.0.3-10
+-   Added %%license line automatically
 *   Tue Apr 28 2020 Emre Girgin <mrgirgin@microsoft.com> 3.0.3-9
 -   Renaming Linux-PAM to pam
 *   Fri Apr 17 2020 Nicolas Ontiveros <niontive@microsoft.com> 3.0.3-8

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -21404,8 +21404,8 @@
         "type": "other",
         "other": {
           "name": "postgresql",
-          "version": "12.10",
-          "downloadUrl": "https://ftp.postgresql.org/pub/source/v12.10/postgresql-12.10.tar.bz2"
+          "version": "14.2",
+          "downloadUrl": "https://ftp.postgresql.org/pub/source/v14.2/postgresql-14.2.tar.bz2"
         }
       }
     },

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -21404,8 +21404,8 @@
         "type": "other",
         "other": {
           "name": "postgresql",
-          "version": "12.7",
-          "downloadUrl": "https://ftp.postgresql.org/pub/source/v12.7/postgresql-12.7.tar.bz2"
+          "version": "12.10",
+          "downloadUrl": "https://ftp.postgresql.org/pub/source/v12.10/postgresql-12.10.tar.bz2"
         }
       }
     },

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -29377,8 +29377,8 @@
         "type": "other",
         "other": {
           "name": "vsftpd",
-          "version": "3.0.3",
-          "downloadUrl": "https://security.appspot.com/downloads/vsftpd-3.0.3.tar.gz"
+          "version": "3.0.5",
+          "downloadUrl": "https://security.appspot.com/downloads/vsftpd-3.0.5.tar.gz"
         }
       }
     },


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Current version of postgresql has CVE-2021-23214 and CVE-2021-23222. Upgrading to 14.2 addresses both.

Current version of vsftpd has CVE-2021-3618. Upgrading to version 3.0.5 fixes it.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Update postgresql to version 14.2
- Update vsftpd to version 3.0.5

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**



###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2021-23214
- https://nvd.nist.gov/vuln/detail/CVE-2021-23222
- https://nvd.nist.gov/vuln/detail/CVE-2021-3618

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Individual containerized package builds for postgresql and vsftpd.
- Full local package build
