### PR TITLE
[main] [bug] Address Constant Journald crash on Mariner 2.0 

### DIFF
--- a/SPECS/systemd/fix-journald-audit-logging.patch
+++ b/SPECS/systemd/fix-journald-audit-logging.patch
@@ -1,0 +1,13 @@
+diff --git a/src/journal/journald-audit.c b/src/journal/journald-audit.c
+index a8e3b175ac49..ea535a27af7f 100644
+--- a/src/journal/journald-audit.c
++++ b/src/journal/journald-audit.c
+@@ -399,7 +399,7 @@ void process_audit_string(Server *s, int type, const char *data, size_t size) {
+ 
+         z = n;
+ 
+-        map_all_fields(p, map_fields_kernel, "_AUDIT_FIELD_", true, iovec, &n, ELEMENTSOF(iovec));
++        map_all_fields(p, map_fields_kernel, "_AUDIT_FIELD_", true, iovec, &n, n + N_IOVEC_AUDIT_FIELDS);
+ 
+         server_dispatch_message(s, iovec, n, ELEMENTSOF(iovec), NULL, NULL, LOG_NOTICE, 0);
+ 

--- a/SPECS/systemd/fix-journald-audit-logging.patch
+++ b/SPECS/systemd/fix-journald-audit-logging.patch
@@ -1,3 +1,22 @@
+From df4ec48f45f518b6926e02ef4d77c8ed1a8b4e2c Mon Sep 17 00:00:00 2001
+From: YmrDtnJu <YmrDtnJu@users.noreply.github.com>
+Date: Fri, 21 Jan 2022 18:21:27 +0100
+Subject: [PATCH] Fix journald audit logging with fields >
+ N_IOVEC_AUDIT_FIELDS.
+
+ELEMENTSOF(iovec) is not the correct value for the newly introduced parameter m
+to function map_all_fields because it is the maximum number of elements in the
+iovec array, including those reserved for N_IOVEC_META_FIELDS. The correct
+value is the current number of already used elements in the array plus the
+maximum number to use for fields decoded from the kernel audit message.
+
+Upstream fix for journald-audit issue,
+No longer needed when upgrading to v251+ 
+Signed-off-by: Cameron Baird <cameronbaird@microsoft.com>
+---
+ src/journal/journald-audit.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
 diff --git a/src/journal/journald-audit.c b/src/journal/journald-audit.c
 index a8e3b175ac49..ea535a27af7f 100644
 --- a/src/journal/journald-audit.c
@@ -10,4 +29,3 @@ index a8e3b175ac49..ea535a27af7f 100644
 +        map_all_fields(p, map_fields_kernel, "_AUDIT_FIELD_", true, iovec, &n, n + N_IOVEC_AUDIT_FIELDS);
  
          server_dispatch_message(s, iovec, n, ELEMENTSOF(iovec), NULL, NULL, LOG_NOTICE, 0);
- 

--- a/SPECS/systemd/fix-journald-audit-logging.patch
+++ b/SPECS/systemd/fix-journald-audit-logging.patch
@@ -29,3 +29,4 @@ index a8e3b175ac49..ea535a27af7f 100644
 +        map_all_fields(p, map_fields_kernel, "_AUDIT_FIELD_", true, iovec, &n, n + N_IOVEC_AUDIT_FIELDS);
  
          server_dispatch_message(s, iovec, n, ELEMENTSOF(iovec), NULL, NULL, LOG_NOTICE, 0);
+         

--- a/SPECS/systemd/systemd-bootstrap.spec
+++ b/SPECS/systemd/systemd-bootstrap.spec
@@ -11,9 +11,6 @@ Source0:        https://github.com/systemd/systemd-stable/archive/v%{version}.ta
 Source1:        50-security-hardening.conf
 Source2:        systemd.cfg
 Source3:        99-dhcp-en.network
-# Upstream fix for journald-audit issue 
-# https://github.com/systemd/systemd/commit/df4ec48f45f518b6926e02ef4d77c8ed1a8b4e2c 
-# No longer needed when upgrading to v251+ 
 Patch0:         fix-journald-audit-logging.patch
 BuildRequires:  docbook-dtd-xml
 BuildRequires:  docbook-style-xsl

--- a/SPECS/systemd/systemd-bootstrap.spec
+++ b/SPECS/systemd/systemd-bootstrap.spec
@@ -1,7 +1,7 @@
 Summary:        Bootstrap version of systemd. Workaround for systemd circular dependency.
 Name:           systemd-bootstrap
 Version:        250.3
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        LGPLv2+ AND GPLv2+ AND MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -11,6 +11,10 @@ Source0:        https://github.com/systemd/systemd-stable/archive/v%{version}.ta
 Source1:        50-security-hardening.conf
 Source2:        systemd.cfg
 Source3:        99-dhcp-en.network
+# Upstream fix for journald-audit issue 
+# https://github.com/systemd/systemd/commit/df4ec48f45f518b6926e02ef4d77c8ed1a8b4e2c 
+# No longer needed when upgrading to v251+ 
+Patch0:         fix-journald-audit-logging.patch
 BuildRequires:  docbook-dtd-xml
 BuildRequires:  docbook-style-xsl
 BuildRequires:  gettext
@@ -227,6 +231,10 @@ systemctl preset-all
 %{_datadir}/pkgconfig/udev.pc
 
 %changelog
+* Wed Apr 13 2022 Cameron Baird <cameronbaird@microsoft.com> - 250.3-3
+- Bring in an upstream change as patch fix-journald-audit-logging.patch
+- to prevent many-fielded audit messages from crashing systemd-journal
+
 * Thu Mar 17 2022 Andrew Phelps <anphel@microsoft.com> - 250.3-2
 - Disable zstd configuration to ensure lz4 compression is used for journal files and coredumps
 

--- a/SPECS/systemd/systemd.spec
+++ b/SPECS/systemd/systemd.spec
@@ -1,7 +1,7 @@
 Summary:        Systemd-250
 Name:           systemd
 Version:        250.3
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        LGPLv2+ AND GPLv2+ AND MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -11,6 +11,10 @@ Source0:        https://github.com/%{name}/%{name}-stable/archive/v%{version}.ta
 Source1:        50-security-hardening.conf
 Source2:        systemd.cfg
 Source3:        99-dhcp-en.network
+# Upstream fix for journald-audit issue 
+# https://github.com/systemd/systemd/commit/df4ec48f45f518b6926e02ef4d77c8ed1a8b4e2c 
+# No longer needed when upgrading to v251+ 
+Patch0:         fix-journald-audit-logging.patch
 BuildRequires:  cryptsetup-devel
 BuildRequires:  docbook-dtd-xml
 BuildRequires:  docbook-style-xsl
@@ -257,6 +261,10 @@ systemctl preset-all
 %files lang -f %{name}.lang
 
 %changelog
+* Wed Apr 13 2022 Cameron Baird <cameronbaird@microsoft.com> - 250.3-4
+- Bring in an upstream change as patch fix-journald-audit-logging.patch
+- to prevent many-fielded audit messages from crashing systemd-journal
+
 * Thu Mar 24 2022 Andrew Phelps <anphel@microsoft.com> - 250.3-3
 - Add Requires(post) on audit-libs, pam and util-linux-devel
 

--- a/SPECS/systemd/systemd.spec
+++ b/SPECS/systemd/systemd.spec
@@ -11,9 +11,6 @@ Source0:        https://github.com/%{name}/%{name}-stable/archive/v%{version}.ta
 Source1:        50-security-hardening.conf
 Source2:        systemd.cfg
 Source3:        99-dhcp-en.network
-# Upstream fix for journald-audit issue 
-# https://github.com/systemd/systemd/commit/df4ec48f45f518b6926e02ef4d77c8ed1a8b4e2c 
-# No longer needed when upgrading to v251+ 
 Patch0:         fix-journald-audit-logging.patch
 BuildRequires:  cryptsetup-devel
 BuildRequires:  docbook-dtd-xml

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -543,10 +543,10 @@ sqlite-devel-3.36.0-2.cm2.aarch64.rpm
 sqlite-libs-3.36.0-2.cm2.aarch64.rpm
 swig-4.0.2-3.cm2.aarch64.rpm
 swig-debuginfo-4.0.2-3.cm2.aarch64.rpm
-systemd-bootstrap-250.3-2.cm2.aarch64.rpm
-systemd-bootstrap-debuginfo-250.3-2.cm2.aarch64.rpm
-systemd-bootstrap-devel-250.3-2.cm2.aarch64.rpm
-systemd-bootstrap-rpm-macros-250.3-2.cm2.noarch.rpm
+systemd-bootstrap-250.3-3.cm2.aarch64.rpm
+systemd-bootstrap-debuginfo-250.3-3.cm2.aarch64.rpm
+systemd-bootstrap-devel-250.3-3.cm2.aarch64.rpm
+systemd-bootstrap-rpm-macros-250.3-3.cm2.noarch.rpm
 tar-1.34-1.cm2.aarch64.rpm
 tar-debuginfo-1.34-1.cm2.aarch64.rpm
 tdnf-3.2.2-2.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -543,10 +543,10 @@ sqlite-devel-3.36.0-2.cm2.x86_64.rpm
 sqlite-libs-3.36.0-2.cm2.x86_64.rpm
 swig-4.0.2-3.cm2.x86_64.rpm
 swig-debuginfo-4.0.2-3.cm2.x86_64.rpm
-systemd-bootstrap-250.3-2.cm2.x86_64.rpm
-systemd-bootstrap-debuginfo-250.3-2.cm2.x86_64.rpm
-systemd-bootstrap-devel-250.3-2.cm2.x86_64.rpm
-systemd-bootstrap-rpm-macros-250.3-2.cm2.noarch.rpm
+systemd-bootstrap-250.3-3.cm2.x86_64.rpm
+systemd-bootstrap-debuginfo-250.3-3.cm2.x86_64.rpm
+systemd-bootstrap-devel-250.3-3.cm2.x86_64.rpm
+systemd-bootstrap-rpm-macros-250.3-3.cm2.noarch.rpm
 tar-1.34-1.cm2.x86_64.rpm
 tar-debuginfo-1.34-1.cm2.x86_64.rpm
 tdnf-3.2.2-2.cm2.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Systemd-journal was failing an assertion when logging especially long audit messages to the journal, causing systemd-journal to repeatedly crash. This is due to a bug in process_audit_string(), which fails to account for the meta fields in audit messages. The issue is fixed upstream here https://github.com/systemd/systemd/commit/df4ec48f45f518b6926e02ef4d77c8ed1a8b4e2c

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Backport of commit https://github.com/systemd/systemd/commit/df4ec48f45f518b6926e02ef4d77c8ed1a8b4e2c as patch fix-journald-audit-logging.patch

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
YES

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://microsoft.visualstudio.com/OS/_workitems/edit/38575138

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build, upgraded VM with newly built systemd-* rpms, reboot, verify that the bug is no longer triggerable 
- AMD: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=184076&view=results
- ARM: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=184208&view=results (still running...)
