### PR TITLE
Reduce toolchain build time by reverting toolchain.mk modification

### DIFF
--- a/toolkit/scripts/toolchain.mk
+++ b/toolkit/scripts/toolchain.mk
@@ -19,8 +19,8 @@ populated_toolchain_chroot = $(toolchain_build_dir)/populated_toolchain
 toolchain_sources_dir = $(populated_toolchain_chroot)/usr/src/mariner/SOURCES
 populated_toolchain_rpms = $(populated_toolchain_chroot)/usr/src/mariner/RPMS
 toolchain_spec_list = $(toolchain_build_dir)/toolchain_specs.txt
-toolchain_actual_conents = $(toolchain_build_dir)/actual_archive_contents.txt
-toolchain_expected_conents = $(toolchain_build_dir)/expected_archive_contents.txt
+toolchain_actual_contents = $(toolchain_build_dir)/actual_archive_contents.txt
+toolchain_expected_contents = $(toolchain_build_dir)/expected_archive_contents.txt
 raw_toolchain = $(toolchain_build_dir)/toolchain_from_container.tar.gz
 final_toolchain = $(toolchain_build_dir)/toolchain_built_rpms_all.tar.gz
 toolchain_files = \
@@ -177,9 +177,10 @@ ifeq ($(REBUILD_TOOLCHAIN),y)
 #   `print_warning`
 $(STATUS_FLAGS_DIR)/toolchain_verify.flag: $(TOOLCHAIN_MANIFEST) $(final_toolchain)
 	@echo Validating contents of toolchain against manifest... && \
-	tar -tzf $(final_toolchain) | grep -oP "[^/]+rpm$$" | sort > $(toolchain_actual_conents) && \
-	sort $(TOOLCHAIN_MANIFEST) > $(toolchain_expected_conents) && \
-	diff="$$( comm -3 $(toolchain_actual_conents) $(toolchain_expected_conents) --check-order )" && \
+	tar -tzf $(final_toolchain) | grep -oP "[^/]+rpm$$" | sort > $(toolchain_actual_contents) && \
+	sort $(TOOLCHAIN_MANIFEST) > $(toolchain_expected_contents) && \
+	diff="$$( comm -3 $(toolchain_actual_contents) $(toolchain_expected_contents) --check-order )" && \
+	echo Toolchain manifest validation complete. && \
 	if [ -n "$${diff}" ]; then \
 		echo "ERROR: Missmatched packages between '$(TOOLCHAIN_MANIFEST)' and '$(final_toolchain)':" && \
 		echo "$${diff}"; \
@@ -189,7 +190,7 @@ $(STATUS_FLAGS_DIR)/toolchain_verify.flag: $(TOOLCHAIN_MANIFEST) $(final_toolcha
 # The basic set of RPMs can always be produced by bootstrapping the toolchain.
 # Try to skip extracting individual RPMS if the toolchain step has already placed
 # them into the RPM folder.
-$(toolchain_rpms): $(TOOLCHAIN_MANIFEST) $(final_toolchain) $(STATUS_FLAGS_DIR)/toolchain_verify.flag
+$(toolchain_rpms): $(TOOLCHAIN_MANIFEST) | $(final_toolchain)
 	@echo Extracting RPM $@ from toolchain && \
 	if [ ! -f $@ -o $(final_toolchain) -nt $@ ]; then \
 		mkdir -p $(dir $@) && \


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Revert a change from #2628 which caused all toolchain RPMs to be extracted at the end of the build process. This added 1hour to X64 builds and 2.5 hours to ARM64 builds.
Also fix minor typo issues, and print a log message when the toolchain manifest verification step is complete.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Revert toolchain_rpms target change in toolchain.mk
- Fix typos in toolchain.mk
- Print log message when toolchain manifest verification completes

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: 184806
