### PR TITLE
[main] Adding support for the `ExcludeArch` spec tag.

### DIFF
--- a/.github/workflows/check-clean-stage.yml
+++ b/.github/workflows/check-clean-stage.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Check the modified spec files
         run: |
-          changed_specs=$(git diff-tree --diff-filter=d --no-commit-id --name-only -r ${{ env.base_sha }} ${{ github.sha }} | { grep "\.spec$" || test $? = 1; })
+          changed_specs=$(git diff-tree --diff-filter=d --no-commit-id --name-only -r ${{ env.base_sha }} ${{ github.sha }} | { grep "SPECS.*/.*\.spec$" || test $? = 1; })
 
           for spec in $changed_specs
           do

--- a/.github/workflows/check-package-cgmanifest.yml
+++ b/.github/workflows/check-package-cgmanifest.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Get the changed files
       run: |
         echo "Files changed: '$(git diff-tree --no-commit-id --name-only -r ${{ env.base_sha }} ${{ github.sha }})'"
-        changed_specs=$(git diff-tree --diff-filter=d  --no-commit-id --name-only -r ${{ env.base_sha }} ${{ github.sha }} | { grep "\.spec$" || test $? = 1; })
+        changed_specs=$(git diff-tree --diff-filter=d  --no-commit-id --name-only -r ${{ env.base_sha }} ${{ github.sha }} | { grep "SPECS.*/.*\.spec$" || test $? = 1; })
         echo "Files to validate: '${changed_specs}'"
         echo "updated-specs=$(echo ${changed_specs})" >> $GITHUB_ENV
 

--- a/.github/workflows/check-spec.yml
+++ b/.github/workflows/check-spec.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Get the changed files
         run: |
           echo "Files changed: '$(git diff-tree --no-commit-id --name-only -r ${{ env.base_sha }} ${{ github.sha }})'"
-          changed_specs=$(git diff-tree --diff-filter=d --no-commit-id --name-only -r ${{ env.base_sha }} ${{ github.sha }} | { grep "\.spec$" || test $? = 1; })
+          changed_specs=$(git diff-tree --diff-filter=d --no-commit-id --name-only -r ${{ env.base_sha }} ${{ github.sha }} | { grep "SPECS.*/.*\.spec$" || test $? = 1; })
           echo "Files to validate: '${changed_specs}'"
           echo "updated-specs=$(echo ${changed_specs})" >> $GITHUB_ENV
 

--- a/.github/workflows/lint-specs.yml
+++ b/.github/workflows/lint-specs.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Get the changed files
         run: |
           echo "Files changed: '$(git diff-tree --no-commit-id --name-only -r ${{ env.base_sha }} ${{ github.sha }})'"
-          changed_specs=$(git diff-tree --no-commit-id --name-only -r ${{ env.base_sha }} ${{ github.sha }} | { grep "\.spec$" || test $? = 1; })
+          changed_specs=$(git diff-tree --no-commit-id --name-only -r ${{ env.base_sha }} ${{ github.sha }} | { grep "SPECS.*/.*\.spec$" || test $? = 1; })
           echo "Files to validate: '${changed_specs}'"
           echo "updated-specs=$(echo ${changed_specs})" >> $GITHUB_ENV
 

--- a/toolkit/tools/internal/rpm/rpm_test.go
+++ b/toolkit/tools/internal/rpm/rpm_test.go
@@ -24,7 +24,7 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func TestShouldSucceedForSupportedArchitectures(t *testing.T) {
+func TestExclusiveArchCheckShouldSucceedForSupportedArchitectures(t *testing.T) {
 	specFilePath := filepath.Join(specsDir, "supported_unsupported_architectures.spec")
 
 	matches, err := SpecExclusiveArchIsCompatible(specFilePath, specsDir, defines)
@@ -32,7 +32,7 @@ func TestShouldSucceedForSupportedArchitectures(t *testing.T) {
 	assert.True(t, matches)
 }
 
-func TestShouldSucceedForNoExclusiveArch(t *testing.T) {
+func TestExclusiveArchCheckShouldSucceedForNoExclusiveArch(t *testing.T) {
 	specFilePath := filepath.Join(specsDir, "no_exclusive_architecture.spec")
 
 	matches, err := SpecExclusiveArchIsCompatible(specFilePath, specsDir, defines)
@@ -40,10 +40,58 @@ func TestShouldSucceedForNoExclusiveArch(t *testing.T) {
 	assert.True(t, matches)
 }
 
-func TestShouldFailForUnsupportedArchitectures(t *testing.T) {
+func TestExclusiveArchCheckShouldFailForUnsupportedArchitectures(t *testing.T) {
 	specFilePath := filepath.Join(specsDir, "unsupported_architectures.spec")
 
 	matches, err := SpecExclusiveArchIsCompatible(specFilePath, specsDir, defines)
+	assert.NoError(t, err)
+	assert.False(t, matches)
+}
+
+func TestExcludedArchCheckShouldSucceedForSupportedArchitectures(t *testing.T) {
+	specFilePath := filepath.Join(specsDir, "supported_unsupported_architectures.spec")
+
+	matches, err := SpecExcludeArchIsCompatible(specFilePath, specsDir, defines)
+	assert.NoError(t, err)
+	assert.True(t, matches)
+}
+
+func TestExcludedArchShouldSucceedForNoExcludedArch(t *testing.T) {
+	specFilePath := filepath.Join(specsDir, "no_exclusive_architecture.spec")
+
+	matches, err := SpecExcludeArchIsCompatible(specFilePath, specsDir, defines)
+	assert.NoError(t, err)
+	assert.True(t, matches)
+}
+
+func TestExcludedArchShouldFailForExcludedArchitectures(t *testing.T) {
+	specFilePath := filepath.Join(specsDir, "unsupported_architectures.spec")
+
+	matches, err := SpecExcludeArchIsCompatible(specFilePath, specsDir, defines)
+	assert.NoError(t, err)
+	assert.False(t, matches)
+}
+
+func TestArchCheckShouldSucceedForSupportedArchitectures(t *testing.T) {
+	specFilePath := filepath.Join(specsDir, "supported_unsupported_architectures.spec")
+
+	matches, err := SpecArchIsCompatible(specFilePath, specsDir, defines)
+	assert.NoError(t, err)
+	assert.True(t, matches)
+}
+
+func TestArchShouldSucceedForNoExcludedArch(t *testing.T) {
+	specFilePath := filepath.Join(specsDir, "no_exclusive_architecture.spec")
+
+	matches, err := SpecArchIsCompatible(specFilePath, specsDir, defines)
+	assert.NoError(t, err)
+	assert.True(t, matches)
+}
+
+func TestArchShouldFailForExcludedArchitectures(t *testing.T) {
+	specFilePath := filepath.Join(specsDir, "unsupported_architectures.spec")
+
+	matches, err := SpecArchIsCompatible(specFilePath, specsDir, defines)
 	assert.NoError(t, err)
 	assert.False(t, matches)
 }

--- a/toolkit/tools/internal/rpm/testdata/supported_unsupported_architectures.spec
+++ b/toolkit/tools/internal/rpm/testdata/supported_unsupported_architectures.spec
@@ -8,8 +8,11 @@ Group:          Test
 Vendor:         Microsoft
 Distribution:   Mariner
 
+# Must contain only architectures not supported by CBL-Mariner!
+ExcludeArch:    i686
+
 # Must contain an architecture for each of the supported builds of CBL-Mariner!
-ExclusiveArch: x86_64 aarch64
+ExclusiveArch:  x86_64 aarch64
 
 %description
 Test spec. Make sure "ExclusiveArch" contains an entry for each architecture supported by CBL-Mariner!

--- a/toolkit/tools/internal/rpm/testdata/unsupported_architectures.spec
+++ b/toolkit/tools/internal/rpm/testdata/unsupported_architectures.spec
@@ -8,8 +8,11 @@ Group:          Test
 Vendor:         Microsoft
 Distribution:   Mariner
 
+# Must contain an architecture for each of the supported builds of CBL-Mariner!
+ExcludeArch:    x86_64 aarch64
+
 # Must contain only architectures not supported by CBL-Mariner!
-ExclusiveArch: i686
+ExclusiveArch:  i686
 
 %description
 Test spec. Make sure "ExclusiveArch" contains an architecture not supported by CBL-Mariner!

--- a/toolkit/tools/specreader/specreader.go
+++ b/toolkit/tools/specreader/specreader.go
@@ -283,7 +283,7 @@ func readSpecWorker(requests <-chan string, results chan<- *parseResult, cancel 
 
 		srpmPath := filepath.Join(srpmsDir, srpmResults[0])
 
-		isCompatible, err := rpm.SpecExclusiveArchIsCompatible(specfile, sourcedir, defines)
+		isCompatible, err := rpm.SpecArchIsCompatible(specfile, sourcedir, defines)
 		if err != nil {
 			result.err = err
 			results <- result

--- a/toolkit/tools/srpmpacker/srpmpacker.go
+++ b/toolkit/tools/srpmpacker/srpmpacker.go
@@ -457,7 +457,6 @@ func calculateSPECsToRepack(specFiles []string, distTag, outDir string, nestedSo
 func specsToPackWorker(requests <-chan string, results chan<- *specState, cancel <-chan struct{}, wg *sync.WaitGroup, distTag, outDir string, nestedSourcesDir, repackAll, runCheck bool) {
 	const (
 		queryFormat         = `%{NAME}-%{VERSION}-%{RELEASE}.src.rpm`
-		queryExclusiveArch  = "%{ARCH}\n[%{EXCLUSIVEARCH}]\n"
 		nestedSourceDirName = "SOURCES"
 	)
 
@@ -523,7 +522,7 @@ func specsToPackWorker(requests <-chan string, results chan<- *specState, cancel
 		}
 
 		// Sanity check that SRPMS is meant to be built for the machine architecture
-		isCompatible, err := rpm.SpecExclusiveArchIsCompatible(specFile, sourceDir, defines)
+		isCompatible, err := rpm.SpecArchIsCompatible(specFile, sourceDir, defines)
 		if err != nil {
 			result.err = err
 			results <- result


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

One of our extended packages failed to be correctly recognized as not buildable for ARM64 because it was using the `ExcludeArch` tag. So far, we were only supporting the `ExclusiveArch` tag when determining if a package should be queued for building and so that one package made it through our initial check and then failed during the build phase. This PR extends this initial check to also take into account the `ExcludeArch` tag.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Added support for the `ExcludeArch` tag.
- Modified our specs GitHub check to only look at specs inside the `SPECS*` directories and not the test ones.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local Go tests run.
