### PR TITLE
change /etc/shadow permission to 000 

### DIFF
--- a/SPECS/shadow-utils/shadow-utils.spec
+++ b/SPECS/shadow-utils/shadow-utils.spec
@@ -1,7 +1,7 @@
 Summary:        Programs for handling passwords in a secure way
 Name:           shadow-utils
 Version:        4.9
-Release:        8%{?dist}
+Release:        9%{?dist}
 License:        BSD
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -150,6 +150,7 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %post
 %{_sbindir}/pwconv
 %{_sbindir}/grpconv
+chmod 000 etc/shadow
 
 %files -f shadow.lang
 %defattr(-,root,root)
@@ -173,6 +174,9 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %{_libdir}/libsubid.so
 
 %changelog
+* Mon Apr 18 2022 Minghe Reb <mingheren@microsoft.com> - 4.9-9
+- Change /etc/shadow file permission to 000
+
 * Fri Mar 25 2022 Rachel Menge <rachelmenge@microsoft.com> - 4.9-8
 - Add requires libpwquality
 

--- a/SPECS/shadow-utils/shadow-utils.spec
+++ b/SPECS/shadow-utils/shadow-utils.spec
@@ -150,7 +150,7 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %post
 %{_sbindir}/pwconv
 %{_sbindir}/grpconv
-chmod 000 etc/shadow
+chmod 000 %{_sysconfdir}/shadow
 
 %files -f shadow.lang
 %defattr(-,root,root)
@@ -164,6 +164,7 @@ chmod 000 etc/shadow
 %{_mandir}/*
 /bin/passwd
 %config(noreplace) %{_sysconfdir}/pam.d/*
+%attr(0000,root,root) %config(noreplace,missingok) %ghost %{_sysconfdir}/shadow
 
 %files subid
 %license COPYING
@@ -174,8 +175,8 @@ chmod 000 etc/shadow
 %{_libdir}/libsubid.so
 
 %changelog
-* Mon Apr 18 2022 Minghe Reb <mingheren@microsoft.com> - 4.9-9
-- Change /etc/shadow file permission to 000
+* Mon Apr 18 2022 Minghe Ren <mingheren@microsoft.com> - 4.9-9
+- Change /etc/shadow file permission to 000 and make it trackable by shadow-utils
 
 * Fri Mar 25 2022 Rachel Menge <rachelmenge@microsoft.com> - 4.9-8
 - Add requires libpwquality


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
change /etc/shadow permission to 000 

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- After the /etc/shadow folder is created by pwconv command. We immediately change its permission to 000 

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
 NO

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- [Bug 38190102](https://microsoft.visualstudio.com/OS/_workitems/edit/38190102)


###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local package and image build
- Install the build image, verify that the /etc/shadow folder has changed permission to 000
- Verify that shadow folder has dependency on shadow-utils rpm package by running: dnf provides /etc/shadow