### PR TITLE
firewalld: Drop package obsoletes/conflicts that don't apply to Mariner

### DIFF
--- a/SPECS/firewalld/firewalld.spec
+++ b/SPECS/firewalld/firewalld.spec
@@ -3,7 +3,7 @@
 Summary:        A firewall daemon with D-Bus interface providing a dynamic firewall
 Name:           firewalld
 Version:        1.0.3
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -41,16 +41,6 @@ Requires(preun): systemd
 
 Suggests:       iptables-nft
 
-Conflicts:      cockpit-ws < 173-2
-Conflicts:      selinux-policy < 3.14.1-28
-
-# Remove old config subpackages
-Obsoletes:      firewalld-config-standard <= 0.3.15
-Obsoletes:      firewalld-config-cloud <= 0.3.15
-Obsoletes:      firewalld-config-server <= 0.3.15
-Obsoletes:      firewalld-config-workstation <= 0.3.15
-Obsoletes:      firewalld-selinux < 0.4.4.2-2
-
 Provides:       variant_config(Server)
 Provides:       variant_config(Workstation)
 
@@ -67,9 +57,6 @@ Summary:        Python3 bindings for firewalld
 Requires:       python3-dbus
 Requires:       python3-gobject-base
 Requires:       python3-nftables
-
-Obsoletes:      python-firewall < 0.5.2-2
-Obsoletes:      python2-firewall < 0.5.2-2
 
 %description -n python3-firewall
 Python3 bindings for firewalld.
@@ -316,6 +303,9 @@ fi
 %{_mandir}/man1/firewall-config*.1*
 
 %changelog
+* Wed Apr 20 2022 Olivia Crain <oliviacrain@microsoft.com> - 1.0.3-2
+- Drop Obsoletes/Conflicts that don't apply to Mariner
+
 * Fri Jan 21 2022 Rachel Menge <rachelmenge@microsoft.com> - 1.0.3-1
 - Update to 1.0.3
 - Add firewalld-test subpackage


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
`firewalld` currently fails to install on a system with `selinux-policy` installed, due to a `Conflicts: selinux-policy` line inherited from the Fedora spec. This conflict doesn't make any sense for Mariner, so let's remove it. Let's also remove a spattering of `Obsoletes` lines in the spec, for packages that haven't been shipped by Mariner.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- `firewalld`: Drop package obsoletes/conflicts that don't apply to Mariner

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build passes
- Was able to install `selinux-policy` and the full suite of `firewalld` packages at the same time in a Mariner 2.0 container after this change