### PR TITLE
lvm2: Fix double-packaging of dbusd files

### DIFF
--- a/SPECS/lvm2/lvm2.spec
+++ b/SPECS/lvm2/lvm2.spec
@@ -3,7 +3,7 @@
 Summary:        Userland logical volume management tools
 Name:           lvm2
 Version:        2.03.15
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2 AND BSD 2-Clause AND LGPLv2.1
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -312,6 +312,7 @@ echo "disable lvm2-monitor.service" >> %{buildroot}%{_libdir}/systemd/system-pre
 %{_sbindir}/blkdeactivate
 %{_sbindir}/fsadm
 %{_sbindir}/lv*
+%exclude %{_sbindir}/lvmdbusd
 %{_sbindir}/pv*
 %{_sbindir}/vg*
 %{_mandir}/man5/lvm.conf.5.gz
@@ -319,10 +320,12 @@ echo "disable lvm2-monitor.service" >> %{buildroot}%{_libdir}/systemd/system-pre
 %{_mandir}/man8/blkdeactivate.8.gz
 %{_mandir}/man8/fsadm.8.gz
 %{_mandir}/man8/lv*
+%exclude %{_mandir}/man8/lvmdbusd.8.gz
 %{_mandir}/man8/pv*
 %{_mandir}/man8/vg*
 %{_unitdir}/blk-availability.service
 %{_unitdir}/lvm2-*
+%exclude %{_unitdir}/lvm2-lvmdbusd.service
 %{_libdir}/systemd/system-preset/50-lvm2.preset
 %{_libdir}/tmpfiles.d/lvm2.conf
 %dir %{_sysconfdir}/lvm
@@ -333,6 +336,9 @@ echo "disable lvm2-monitor.service" >> %{buildroot}%{_libdir}/systemd/system-pre
 %ghost %{_sysconfdir}/lvm/cache/.cache
 
 %changelog
+* Thu Apr 21 2022 Olivia Crain <oliviacrain@microsoft.com> - 2.03.15-2
+- Fix double-packaging of dbusd files in main package
+
 * Wed Feb 23 2022 Max Brodeur-Urbas <maxbr@microsoft.com> - 2.03.15-1
 - Upgrading to newest version 2.03.15
 

--- a/SPECS/lvm2/lvm2.spec
+++ b/SPECS/lvm2/lvm2.spec
@@ -93,7 +93,6 @@ License:        LGPLv2
 Group:          Development/Libraries
 Requires:       device-mapper = %{version}-%{release}
 Requires:       libselinux-devel
-Provides:       pkgconfig(devmapper)
 
 %description -n device-mapper-devel
 This package contains files needed to develop applications that use
@@ -338,6 +337,7 @@ echo "disable lvm2-monitor.service" >> %{buildroot}%{_libdir}/systemd/system-pre
 %changelog
 * Thu Apr 21 2022 Olivia Crain <oliviacrain@microsoft.com> - 2.03.15-2
 - Fix double-packaging of dbusd files in main package
+- Remove manual pkgconfig provide
 
 * Wed Feb 23 2022 Max Brodeur-Urbas <maxbr@microsoft.com> - 2.03.15-1
 - Upgrading to newest version 2.03.15


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Co-installation of `lvm2` and `lvm2-dbusd` packages currently fails due to duplicate files between the two packages. We only need the duplicate files to be installed in the `dbusd` subpackage, so let's exclude them from the base package.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- `lvm2`: Exclude `dbusd` subpackage files from base package
- `lvm2`: Remove manual pkgconfig provides

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build, manual check of lvm package contents
