### PR TITLE
scheduler: Include version constraint info when printing unresolved dependencies

### DIFF
--- a/toolkit/tools/scheduler/schedulerutils/printresults.go
+++ b/toolkit/tools/scheduler/schedulerutils/printresults.go
@@ -69,7 +69,7 @@ func PrintBuildSummary(pkgGraph *pkggraph.PkgGraph, graphMutex *sync.RWMutex, bu
 
 	for _, node := range pkgGraph.AllRunNodes() {
 		if node.State == pkggraph.StateUnresolved {
-			unresolvedDependencies[node.VersionedPkg.Name] = true
+			unresolvedDependencies[node.VersionedPkg.String()] = true
 		}
 	}
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
The `scheduler` tools prints a build summary at the end of each build. As part of that summary, we print unresolved dependencies. Sometimes, an unresolved dependency may be a package name that is present during the build (either cached or built), but with version constraints that the available package does not fulfill.

We should make it more obvious to our toolkit consumers that version constraints are causing a dependency to be unresolved. To reduce confusion in such cases, let's print out the version constraints for unresolved dependencies.

Logging sample pre-change:
```
INFO[27562] Unresolved dependencies:                    
INFO[27562] --> pkgconfig(atk-bridge-2.0)
INFO[27562] --> pkgconfig(gdk-pixbuf-2.0)
INFO[27562] --> pkgconfig(gtk+-3.0)
```

Logging sample post-change:
```
INFO[27562] Unresolved dependencies:
INFO[27562] --> pkgconfig(atk-bridge-2.0):C:''V:'',C2:''V2:''
INFO[27562] --> pkgconfig(gdk-pixbuf-2.0):C:'>='V:'2.30.0',C2:''V2:'' 
INFO[27562] --> pkgconfig(gtk+-3.0):C:'>='V:'3.24.22',C2:''V2:'' 
```

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- `scheduler`: Print version constraints for unresolved dependencies in the build summary

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Patch used in pipeline build 187324
