### PR TITLE
toolchain: Rebuild audit with systemd-bootstrap-rpm-macros installed

### DIFF
--- a/SPECS/audit/audit.spec
+++ b/SPECS/audit/audit.spec
@@ -1,7 +1,7 @@
 Summary:        Kernel Audit Tool
 Name:           audit
 Version:        3.0.6
-Release:        5%{?dist}
+Release:        6%{?dist}
 License:        GPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -11,6 +11,7 @@ Source0:        https://people.redhat.com/sgrubb/audit/%{name}-%{version}.tar.gz
 Patch0:         refuse-manual-stop.patch
 BuildRequires:  e2fsprogs-devel
 BuildRequires:  krb5-devel
+BuildRequires:  systemd-bootstrap-rpm-macros
 BuildRequires:  swig
 Requires:       %{name}-libs = %{version}-%{release}
 Requires:       gawk
@@ -137,6 +138,9 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %{python3_sitelib}/*
 
 %changelog
+* Mon Apr 25 2022 Olivia Crain <oliviacrain@microsoft.com> - 3.0.6-6
+- Add BR on systemd-bootstrap-rpm-macros for correctness
+
 * Wed Apr 20 2022 Daniel McIlvaney <damcilva@microsoft.com> - 3.0.6-5
 - Return audit logs to their normal location without the use of a symlink
 

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -247,5 +247,5 @@ chkconfig-1.20-3.cm2.aarch64.rpm
 chkconfig-lang-1.20-3.cm2.aarch64.rpm
 msopenjdk-11-11.0.14.1+1-LTS-31207.aarch64.rpm
 pyproject-rpm-macros-1.0.0~rc1-2.cm2.noarch.rpm
-audit-3.0.6-5.cm2.aarch64.rpm
-audit-libs-3.0.6-5.cm2.aarch64.rpm
+audit-3.0.6-6.cm2.aarch64.rpm
+audit-libs-3.0.6-6.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -247,5 +247,5 @@ chkconfig-1.20-3.cm2.x86_64.rpm
 chkconfig-lang-1.20-3.cm2.x86_64.rpm
 msopenjdk-11-11.0.14.1+1-LTS-31207.x86_64.rpm
 pyproject-rpm-macros-1.0.0~rc1-2.cm2.noarch.rpm
-audit-3.0.6-5.cm2.x86_64.rpm
-audit-libs-3.0.6-5.cm2.x86_64.rpm
+audit-3.0.6-6.cm2.x86_64.rpm
+audit-libs-3.0.6-6.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -1,8 +1,8 @@
 asciidoc-9.1.0-1.cm2.noarch.rpm
-audit-3.0.6-5.cm2.aarch64.rpm
-audit-debuginfo-3.0.6-5.cm2.aarch64.rpm
-audit-devel-3.0.6-5.cm2.aarch64.rpm
-audit-libs-3.0.6-5.cm2.aarch64.rpm
+audit-3.0.6-6.cm2.aarch64.rpm
+audit-debuginfo-3.0.6-6.cm2.aarch64.rpm
+audit-devel-3.0.6-6.cm2.aarch64.rpm
+audit-libs-3.0.6-6.cm2.aarch64.rpm
 autoconf-2.71-3.cm2.noarch.rpm
 automake-1.16.5-1.cm2.noarch.rpm
 bash-5.1.8-1.cm2.aarch64.rpm
@@ -506,7 +506,7 @@ procps-ng-lang-3.3.17-1.cm2.aarch64.rpm
 pyproject-rpm-macros-1.0.0~rc1-2.cm2.noarch.rpm
 python-markupsafe-debuginfo-2.1.0-1.cm2.aarch64.rpm
 python3-3.9.10-1.cm2.aarch64.rpm
-python3-audit-3.0.6-5.cm2.aarch64.rpm
+python3-audit-3.0.6-6.cm2.aarch64.rpm
 python3-cracklib-2.9.7-4.cm2.aarch64.rpm
 python3-curses-3.9.10-1.cm2.aarch64.rpm
 python3-Cython-0.29.26-1.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -1,8 +1,8 @@
 asciidoc-9.1.0-1.cm2.noarch.rpm
-audit-3.0.6-5.cm2.x86_64.rpm
-audit-debuginfo-3.0.6-5.cm2.x86_64.rpm
-audit-devel-3.0.6-5.cm2.x86_64.rpm
-audit-libs-3.0.6-5.cm2.x86_64.rpm
+audit-3.0.6-6.cm2.x86_64.rpm
+audit-debuginfo-3.0.6-6.cm2.x86_64.rpm
+audit-devel-3.0.6-6.cm2.x86_64.rpm
+audit-libs-3.0.6-6.cm2.x86_64.rpm
 autoconf-2.71-3.cm2.noarch.rpm
 automake-1.16.5-1.cm2.noarch.rpm
 bash-5.1.8-1.cm2.x86_64.rpm
@@ -506,7 +506,7 @@ procps-ng-lang-3.3.17-1.cm2.x86_64.rpm
 pyproject-rpm-macros-1.0.0~rc1-2.cm2.noarch.rpm
 python-markupsafe-debuginfo-2.1.0-1.cm2.x86_64.rpm
 python3-3.9.10-1.cm2.x86_64.rpm
-python3-audit-3.0.6-5.cm2.x86_64.rpm
+python3-audit-3.0.6-6.cm2.x86_64.rpm
 python3-cracklib-2.9.7-4.cm2.x86_64.rpm
 python3-curses-3.9.10-1.cm2.x86_64.rpm
 python3-Cython-0.29.26-1.cm2.x86_64.rpm

--- a/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
+++ b/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
@@ -551,6 +551,12 @@ build_rpm_in_chroot_no_install chkconfig
 build_rpm_in_chroot_no_install mariner-repos
 build_rpm_in_chroot_no_install pyproject-rpm-macros
 
+# Rebuild audit with systemd-bootstrap-rpm-macros installed.
+# Without it, audit's systemd macros won't expand and install/uninstall
+# will fail.
+build_rpm_in_chroot_no_install audit
+copy_rpm_subpackage python3-audit
+
 chroot_and_print_installed_rpms
 
 # Ensure all RPMS are copied out of the chroot


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
The `audit` package was recently added to the toolchain in #2416.  The `audit` package uses `systemd` macros to handle service management. This was fine when `audit` was outside the toolchain, since `systemd-bootstrap-rpm-macros` is in the worker chroot and the `systemd` macros expand just fine at build-time. 

However, the raw toolchain does not have any `systemd` macros defined until `systemd-bootstrap` is built and installed into the raw toolchain chroot. So, specs in the toolchain built before `systemd-bootstrap` can't use `systemd` macros since they can't expand into a proper scriptlet at build-time. This causes scriptlet failures when upgrading the `audit` package.

So, let's just build `audit` again after we install `systemd-bootstrap`!  There's precedent for this- see how we do the same with `pam` to avoid circular dependencies. 

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add rebuild of `audit` at the end of the toolchai build

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #2858 

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build passes
- Final produced `audit` RPM has properly expanded systemd macros (` rpm -qp --scripts audit-3.0.6-5.cm2.x86_64.rpm`)
