### PR TITLE
Add parameters to distroless manifest

### DIFF
--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -494,13 +494,11 @@ func generateContainerManifests(installChroot *safechroot.Chroot) {
 	rpmManifestDir := filepath.Join(installRoot, rpmManifestDirectory)
 	manifest1Path := filepath.Join(rpmManifestDir, "container-manifest-1")
 	manifest2Path := filepath.Join(rpmManifestDir, "container-manifest-2")
-	manifest3Path := filepath.Join(rpmManifestDir, "container-manifest-3")
 
 	os.MkdirAll(rpmManifestDir, os.ModePerm)
 
 	shell.ExecuteAndLogToFile(manifest1Path, "rpm", "--dbpath", rpmDir, "-qa")
 	shell.ExecuteAndLogToFile(manifest2Path, "rpm", "--dbpath", rpmDir, "-qa", "--qf", "%{NAME}\t%{VERSION}-%{RELEASE}\t%{INSTALLTIME}\t%{BUILDTIME}\t%{VENDOR}\t(none)\t%{SIZE}\t%{ARCH}\t%{EPOCHNUM}\t%{SOURCERPM}\n")
-	shell.ExecuteAndLogToFile(manifest3Path, "rpm", "--dbpath", rpmDir, "-qa", "--qf", "%{NAME}\t%{VERSION}-%{RELEASE}\t%{INSTALLTIME}\t%{BUILDTIME}\t%{VENDOR}\t%{INSTPREFIXES}\t%{SIZE}\t%{ARCH}\t%{EPOCHNUM}\t%{SOURCERPM}\n")
 
 	return
 }

--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -494,11 +494,13 @@ func generateContainerManifests(installChroot *safechroot.Chroot) {
 	rpmManifestDir := filepath.Join(installRoot, rpmManifestDirectory)
 	manifest1Path := filepath.Join(rpmManifestDir, "container-manifest-1")
 	manifest2Path := filepath.Join(rpmManifestDir, "container-manifest-2")
+	manifest3Path := filepath.Join(rpmManifestDir, "container-manifest-3")
 
 	os.MkdirAll(rpmManifestDir, os.ModePerm)
 
 	shell.ExecuteAndLogToFile(manifest1Path, "rpm", "--dbpath", rpmDir, "-qa")
-	shell.ExecuteAndLogToFile(manifest2Path, "rpm", "--dbpath", rpmDir, "-qa", "--qf", "%{NAME}\t%{VERSION}-%{RELEASE}\t%{INSTALLTIME}\t%{BUILDTIME}\n")
+	shell.ExecuteAndLogToFile(manifest2Path, "rpm", "--dbpath", rpmDir, "-qa", "--qf", "%{NAME}\t%{VERSION}-%{RELEASE}\t%{INSTALLTIME}\t%{BUILDTIME}\t%{VENDOR}\t(none)\t%{SIZE}\t%{ARCH}\t%{EPOCHNUM}\t%{SOURCERPM}\n")
+	shell.ExecuteAndLogToFile(manifest3Path, "rpm", "--dbpath", rpmDir, "-qa", "--qf", "%{NAME}\t%{VERSION}-%{RELEASE}\t%{INSTALLTIME}\t%{BUILDTIME}\t%{VENDOR}\t%{INSTPREFIXES}\t%{SIZE}\t%{ARCH}\t%{EPOCHNUM}\t%{SOURCERPM}\n")
 
 	return
 }


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Add parameters to distroless manifest to extend those added in #2391 

The file "/var/lib/rpmmanifest/container-manifest-2" now contains the output of:
"rpm", "--dbpath", rpmDir, "-qa", "--qf", "%{NAME}\t%{VERSION}-%{RELEASE}\t%{INSTALLTIME}\t%{BUILDTIME}\t%{VENDOR}\t(none)\t%{SIZE}\t%{ARCH}\t%{EPOCHNUM}\t%{SOURCERPM}\n"
Field 6 contains a hard-coded value of "(none)" instead of "%{INSTPREFIXES}"

Sample output:

$ docker run -it --rm marinerdistroless:latest busybox cat /var/lib/rpmmanifest/container-manifest-2
mariner-release 2.0-11.cm2      1651010830      1650940870      Microsoft Corporation   (none)  580     noarch  0       mariner-release-2.0-11.cm2.src.rpm
filesystem      1.1-8.cm2       1651010830      1650940870      Microsoft Corporation   (none)  7506    x86_64  0       filesystem-1.1-8.cm2.src.rpm
glibc   2.35-1.cm2      1651010830      1650940910      Microsoft Corporation   (none)  10855313        x86_64  0       glibc-2.35-1.cm2.src.rpm
...

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change installutils.go to generate additional information in manifest

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: 187927
$ docker import distroless-debug-2.0.20220426.tar.gz marinerdistroless:latest
$ docker run -it --rm marinerdistroless:latest busybox cat /var/lib/rpmmanifest/container-manifest-2