### PR TITLE
toolchain: Remove raw toolchain chroot's old buildroots prior to RPM build

### DIFF
--- a/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
+++ b/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
@@ -25,6 +25,7 @@ set -x
 
 export LFS=$MARINER_BUILD_DIR/toolchain/populated_toolchain
 TOPDIR=/usr/src/mariner
+CHROOT_BUILDROOT_DIR=$LFS$TOPDIR/BUILDROOT
 CHROOT_SOURCES_DIR=$LFS$TOPDIR/SOURCES
 CHROOT_SPECS_DIR=$LFS$TOPDIR/SPECS
 CHROOT_SRPMS_DIR=$LFS$TOPDIR/SRPMS
@@ -59,8 +60,10 @@ mkdir -pv $CHROOT_INSTALL_RPM_DIR
 mkdir -pv $TOOLCHAIN_LOGS
 mkdir -pv $CHROOT_RPMS_DIR
 
+# Remove artifacts from previous toolchain builds
 sudo rm -f $TOOLCHAIN_BUILD_LIST
 sudo rm -f $TOOLCHAIN_FAILURES
+sudo rm -rf $CHROOT_BUILDROOT_DIR
 touch $TOOLCHAIN_FAILURES
 
 chroot_mount () {


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
In the toolchain, after a failed build, the buildroot folders of failed RPMs are preserved in the LFS chroot. Preservation of the buildroot folders is great, since it allows us a bit more flexibility when debugging failures. However, the preserved buildroot folder is never actually removed. When the LFS chroot is re-used for another toolchain build (common when doing rebuilds during development), the contents of the preserved buildroot folder can cause build failures. These failures usually occur because the buildroot contains files that are not packaged by the new RPM build. To get around this, let's wipe the LFS chroot's buildroot folder before each build.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- toolchain: wipe the LFS chroot's buildroot folder before starting the official toolchain build

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Used in pipeline build 1872968
