### PR TITLE
toolchain: Remove mariner-release package

### DIFF
--- a/SPECS/supermin/supermin.spec
+++ b/SPECS/supermin/supermin.spec
@@ -21,7 +21,7 @@
 Summary:        Tool for creating supermin appliances
 Name:           supermin
 Version:        5.2.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        GPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -71,6 +71,7 @@ Requires:       dnf-plugins-core
 # RHBZ#771310
 Requires:       e2fsprogs-libs >= 1.42
 Requires:       findutils
+Requires:       mariner-release
 Requires:       rpm
 Requires:       tar
 Requires:       util-linux-ng
@@ -128,6 +129,9 @@ make check || {
 %{_rpmconfigdir}/supermin-find-requires
 
 %changelog
+* Tue Apr 26 2022 Olivia Crain <oliviacrain@microsoft.com> - 5.2.1-3
+- Explicitly require mariner-release at run-time
+
 * Wed Mar 30 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 5.2.1-2
 - Updating dependencies.
 

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -63,7 +63,6 @@ findutils-lang-4.8.0-3.cm2.aarch64.rpm
 gettext-0.21-2.cm2.aarch64.rpm
 gzip-1.11-1.cm2.aarch64.rpm
 make-4.3-2.cm2.aarch64.rpm
-mariner-release-2.0-11.cm2.noarch.rpm
 patch-2.7.6-7.cm2.aarch64.rpm
 util-linux-2.37.2-5.cm2.aarch64.rpm
 util-linux-devel-2.37.2-5.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -63,7 +63,6 @@ findutils-lang-4.8.0-3.cm2.x86_64.rpm
 gettext-0.21-2.cm2.x86_64.rpm
 gzip-1.11-1.cm2.x86_64.rpm
 make-4.3-2.cm2.x86_64.rpm
-mariner-release-2.0-11.cm2.noarch.rpm
 patch-2.7.6-7.cm2.x86_64.rpm
 util-linux-2.37.2-5.cm2.x86_64.rpm
 util-linux-devel-2.37.2-5.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -221,7 +221,6 @@ m4-debuginfo-1.4.19-1.cm2.aarch64.rpm
 make-4.3-2.cm2.aarch64.rpm
 make-debuginfo-4.3-2.cm2.aarch64.rpm
 mariner-check-macros-2.0-14.cm2.noarch.rpm
-mariner-release-2.0-11.cm2.noarch.rpm
 mariner-repos-2.0-7.cm2.noarch.rpm
 mariner-repos-debug-2.0-7.cm2.noarch.rpm
 mariner-repos-debug-preview-2.0-7.cm2.noarch.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -221,7 +221,6 @@ m4-debuginfo-1.4.19-1.cm2.x86_64.rpm
 make-4.3-2.cm2.x86_64.rpm
 make-debuginfo-4.3-2.cm2.x86_64.rpm
 mariner-check-macros-2.0-14.cm2.noarch.rpm
-mariner-release-2.0-11.cm2.noarch.rpm
 mariner-repos-2.0-7.cm2.noarch.rpm
 mariner-repos-debug-2.0-7.cm2.noarch.rpm
 mariner-repos-debug-preview-2.0-7.cm2.noarch.rpm

--- a/toolkit/resources/manifests/package/update_manifests.sh
+++ b/toolkit/resources/manifests/package/update_manifests.sh
@@ -236,7 +236,6 @@ generate_pkggen_core () {
         grep "^gettext-" $TmpPkgGen
         grep "^gzip-" $TmpPkgGen
         grep "^make-" $TmpPkgGen
-        grep "^mariner-release-" $TmpPkgGen
         grep "^patch-" $TmpPkgGen
         grep "^util-linux-" $TmpPkgGen
         grep "^tar-" $TmpPkgGen

--- a/toolkit/scripts/imggen.mk
+++ b/toolkit/scripts/imggen.mk
@@ -121,7 +121,7 @@ $(STATUS_FLAGS_DIR)/imager_disk_output.flag: $(go-imager) $(image_package_cache_
 		--log-level=$(LOG_LEVEL) \
 		--log-file=$(LOGS_DIR)/imggen/imager.log \
 		--local-repo $(local_and_external_rpm_cache) \
-		--tdnf-worker $(BUILD_DIR)/worker/worker_chroot.tar.gz \
+		--tdnf-worker $(chroot_worker) \
 		--repo-file=$(imggen_local_repo) \
 		--assets $(assets_dir) \
 		--output-dir $(imager_disk_output_dir) && \

--- a/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
+++ b/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
@@ -215,8 +215,6 @@ build_rpm_in_chroot_no_install mariner-rpm-macros
 copy_rpm_subpackage mariner-check-macros
 chroot_and_install_rpms mariner-rpm-macros
 chroot_and_install_rpms mariner-check-macros
-build_rpm_in_chroot_no_install mariner-release
-chroot_and_install_rpms mariner-release
 build_rpm_in_chroot_no_install filesystem
 build_rpm_in_chroot_no_install kernel-headers
 build_rpm_in_chroot_no_install glibc

--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -376,6 +376,7 @@ func PackageNamesFromConfig(config configuration.Config) (packageList []*pkgjson
 func PopulateInstallRoot(installChroot *safechroot.Chroot, packagesToInstall []string, config configuration.SystemConfig, installMap, mountPointToFsTypeMap, mountPointToMountArgsMap map[string]string, isRootFS bool, encryptedRoot diskutils.EncryptedRootDevice, diffDiskBuild, hidepidEnabled bool) (err error) {
 	const (
 		filesystemPkg = "filesystem"
+		marinerReleasePkg = ""
 	)
 
 	defer stopGPGAgent(installChroot)
@@ -565,7 +566,8 @@ func TdnfInstallWithProgress(packageName, installRoot string, currentPackagesIns
 
 	// TDNF 3.x uses repositories from installchroot instead of host. Passing setopt for repo files directory to use local repo for installroot installation
 	err = shell.ExecuteLiveWithCallback(onStdout, logger.Log.Warn, true, "tdnf", "-v", "install", packageName,
-		"--installroot", installRoot, "--nogpgcheck", "--assumeyes", "--setopt", "reposdir=/etc/yum.repos.d/")
+		"--installroot", installRoot, "--nogpgcheck", "--assumeyes", "--setopt", "reposdir=/etc/yum.repos.d/",
+		"--releasever=2.0")
 	if err != nil {
 		logger.Log.Warnf("Failed to tdnf install: %v. Package name: %v", err, packageName)
 	}
@@ -584,7 +586,7 @@ func initializeTdnfConfiguration(installRoot string) (err error) {
 
 	logger.Log.Debugf("Downloading '%s' package to a clean RPM root under '%s'.", releasePackage, installRoot)
 
-	err = shell.ExecuteLive(squashErrors, "tdnf", "download", "--alldeps", "--destdir", installRoot, releasePackage)
+	err = shell.ExecuteLive(squashErrors, "tdnf", "download", "--releasever=2.0", "--alldeps", "--destdir", installRoot, releasePackage)
 	if err != nil {
 		logger.Log.Errorf("Failed to prepare the RPM database on downloading the 'mariner-release' package: %v", err)
 		return
@@ -655,7 +657,7 @@ func calculateTotalPackages(packages []string, installRoot string) (totalPackage
 		)
 
 		// Issue an install request but stop right before actually performing the install (assumeno)
-		stdout, stderr, err = shell.Execute("tdnf", "install", "--assumeno", "--nogpgcheck", pkg, "--installroot", installRoot)
+		stdout, stderr, err = shell.Execute("tdnf", "install", "--releasever=2.0","--assumeno", "--nogpgcheck", pkg, "--installroot", installRoot)
 		if err != nil {
 			// tdnf aborts the process when it detects an install with --assumeno.
 			if stderr == tdnfAssumeNoStdErr {

--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -376,8 +376,7 @@ func PackageNamesFromConfig(config configuration.Config) (packageList []*pkgjson
 // - hidepidEnabled is a flag that denotes whether /proc will be mounted with the hidepid option
 func PopulateInstallRoot(installChroot *safechroot.Chroot, packagesToInstall []string, config configuration.SystemConfig, installMap, mountPointToFsTypeMap, mountPointToMountArgsMap map[string]string, isRootFS bool, encryptedRoot diskutils.EncryptedRootDevice, diffDiskBuild, hidepidEnabled bool) (err error) {
 	const (
-		filesystemPkg     = "filesystem"
-		marinerReleasePkg = ""
+		filesystemPkg = "filesystem"
 	)
 
 	defer stopGPGAgent(installChroot)

--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -25,6 +25,7 @@ import (
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/retry"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/safechroot"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/shell"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/tdnf"
 )
 
 const (
@@ -375,7 +376,7 @@ func PackageNamesFromConfig(config configuration.Config) (packageList []*pkgjson
 // - hidepidEnabled is a flag that denotes whether /proc will be mounted with the hidepid option
 func PopulateInstallRoot(installChroot *safechroot.Chroot, packagesToInstall []string, config configuration.SystemConfig, installMap, mountPointToFsTypeMap, mountPointToMountArgsMap map[string]string, isRootFS bool, encryptedRoot diskutils.EncryptedRootDevice, diffDiskBuild, hidepidEnabled bool) (err error) {
 	const (
-		filesystemPkg = "filesystem"
+		filesystemPkg     = "filesystem"
 		marinerReleasePkg = ""
 	)
 
@@ -531,6 +532,10 @@ func TdnfInstall(packageName, installRoot string) (packagesInstalled int, err er
 
 // TdnfInstallWithProgress installs a package in the current environment while optionally reporting progress
 func TdnfInstallWithProgress(packageName, installRoot string, currentPackagesInstalled, totalPackages int, reportProgress bool) (packagesInstalled int, err error) {
+	var (
+		releaseverCliArg string
+	)
+
 	packagesInstalled = currentPackagesInstalled
 
 	onStdout := func(args ...interface{}) {
@@ -564,10 +569,15 @@ func TdnfInstallWithProgress(packageName, installRoot string, currentPackagesIns
 		}
 	}
 
+	releaseverCliArg, err = tdnf.GetReleaseverCliArg()
+	if err != nil {
+		return
+	}
+
 	// TDNF 3.x uses repositories from installchroot instead of host. Passing setopt for repo files directory to use local repo for installroot installation
 	err = shell.ExecuteLiveWithCallback(onStdout, logger.Log.Warn, true, "tdnf", "-v", "install", packageName,
 		"--installroot", installRoot, "--nogpgcheck", "--assumeyes", "--setopt", "reposdir=/etc/yum.repos.d/",
-		"--releasever=2.0")
+		releaseverCliArg)
 	if err != nil {
 		logger.Log.Warnf("Failed to tdnf install: %v. Package name: %v", err, packageName)
 	}
@@ -584,9 +594,18 @@ func initializeTdnfConfiguration(installRoot string) (err error) {
 		releasePackage = "mariner-release"
 	)
 
+	var (
+		releaseverCliArg string
+	)
+
 	logger.Log.Debugf("Downloading '%s' package to a clean RPM root under '%s'.", releasePackage, installRoot)
 
-	err = shell.ExecuteLive(squashErrors, "tdnf", "download", "--releasever=2.0", "--alldeps", "--destdir", installRoot, releasePackage)
+	releaseverCliArg, err = tdnf.GetReleaseverCliArg()
+	if err != nil {
+		return
+	}
+
+	err = shell.ExecuteLive(squashErrors, "tdnf", "download", releaseverCliArg, "--alldeps", "--destdir", installRoot, releasePackage)
 	if err != nil {
 		logger.Log.Errorf("Failed to prepare the RPM database on downloading the 'mariner-release' package: %v", err)
 		return
@@ -646,8 +665,16 @@ func configureSystemFiles(installChroot *safechroot.Chroot, hostname string, con
 }
 
 func calculateTotalPackages(packages []string, installRoot string) (totalPackages int, err error) {
+	var (
+		releaseverCliArg string
+	)
 	allPackageNames := make(map[string]bool)
 	const tdnfAssumeNoStdErr = "Error(1032) : Operation aborted.\n"
+
+	releaseverCliArg, err = tdnf.GetReleaseverCliArg()
+	if err != nil {
+		return
+	}
 
 	// For every package calculate what dependencies would also be installed from it.
 	for _, pkg := range packages {
@@ -657,7 +684,7 @@ func calculateTotalPackages(packages []string, installRoot string) (totalPackage
 		)
 
 		// Issue an install request but stop right before actually performing the install (assumeno)
-		stdout, stderr, err = shell.Execute("tdnf", "install", "--releasever=2.0","--assumeno", "--nogpgcheck", pkg, "--installroot", installRoot)
+		stdout, stderr, err = shell.Execute("tdnf", "install", releaseverCliArg, "--assumeno", "--nogpgcheck", pkg, "--installroot", installRoot)
 		if err != nil {
 			// tdnf aborts the process when it detects an install with --assumeno.
 			if stderr == tdnfAssumeNoStdErr {

--- a/toolkit/tools/internal/packagerepo/repocloner/rpmrepocloner/rpmrepocloner.go
+++ b/toolkit/tools/internal/packagerepo/repocloner/rpmrepocloner/rpmrepocloner.go
@@ -310,6 +310,7 @@ func (r *RpmRepoCloner) WhatProvides(pkgVer *pkgjson.PackageVer) (packageNames [
 		"provides",
 		provideQuery,
 		fmt.Sprintf("--disablerepo=%s", allRepoIDs),
+		fmt.Sprintf("--releasever=%s", "2.0"),
 	}
 
 	foundPackages := make(map[string]bool)
@@ -433,6 +434,7 @@ func (r *RpmRepoCloner) ClonedRepoContents() (repoContents *repocloner.RepoConte
 			"ALL",
 			fmt.Sprintf("--disablerepo=%s", allRepoIDs),
 			fmt.Sprintf("--enablerepo=%s", checkedRepoID),
+			fmt.Sprintf("--releasever=%s", "2.0"),
 		}
 		return shell.ExecuteLiveWithCallback(onStdout, logger.Log.Warn, true, "tdnf", tdnfArgs...)
 	})
@@ -467,6 +469,7 @@ func (r *RpmRepoCloner) clonePackage(baseArgs []string, enabledRepoOrder ...stri
 	// TDNF processes enable/disable repo requests in the order that they are passed.
 	// So if `--disablerepo=foo` and then `--enablerepo=foo` are passed, `foo` will be enabled.
 	baseArgs = append(baseArgs, "--disablerepo=*")
+	baseArgs = append(baseArgs, "--releasever=2.0")
 
 	var enabledRepoArgs []string
 	for _, repoID := range enabledRepoOrder {

--- a/toolkit/tools/internal/packagerepo/repocloner/rpmrepocloner/rpmrepocloner.go
+++ b/toolkit/tools/internal/packagerepo/repocloner/rpmrepocloner/rpmrepocloner.go
@@ -18,6 +18,7 @@ import (
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/pkgjson"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/safechroot"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/shell"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/tdnf"
 )
 
 const (
@@ -304,13 +305,22 @@ func (r *RpmRepoCloner) Clone(cloneDeps bool, packagesToClone ...*pkgjson.Packag
 
 // WhatProvides attempts to find packages which provide the requested PackageVer.
 func (r *RpmRepoCloner) WhatProvides(pkgVer *pkgjson.PackageVer) (packageNames []string, err error) {
+	var (
+		releaseverCliArg string
+	)
+
+	releaseverCliArg, err = tdnf.GetReleaseverCliArg()
+	if err != nil {
+		return
+	}
+
 	provideQuery := convertPackageVersionToTdnfArg(pkgVer)
 
 	baseArgs := []string{
 		"provides",
 		provideQuery,
 		fmt.Sprintf("--disablerepo=%s", allRepoIDs),
-		fmt.Sprintf("--releasever=%s", "2.0"),
+		releaseverCliArg,
 	}
 
 	foundPackages := make(map[string]bool)
@@ -399,6 +409,15 @@ func (r *RpmRepoCloner) ConvertDownloadedPackagesIntoRepo() (err error) {
 
 // ClonedRepoContents returns the packages contained in the cloned repository.
 func (r *RpmRepoCloner) ClonedRepoContents() (repoContents *repocloner.RepoContents, err error) {
+	var (
+		releaseverCliArg string
+	)
+
+	releaseverCliArg, err = tdnf.GetReleaseverCliArg()
+	if err != nil {
+		return
+	}
+
 	repoContents = &repocloner.RepoContents{}
 	onStdout := func(args ...interface{}) {
 		if len(args) == 0 {
@@ -434,7 +453,7 @@ func (r *RpmRepoCloner) ClonedRepoContents() (repoContents *repocloner.RepoConte
 			"ALL",
 			fmt.Sprintf("--disablerepo=%s", allRepoIDs),
 			fmt.Sprintf("--enablerepo=%s", checkedRepoID),
-			fmt.Sprintf("--releasever=%s", "2.0"),
+			releaseverCliArg,
 		}
 		return shell.ExecuteLiveWithCallback(onStdout, logger.Log.Warn, true, "tdnf", tdnfArgs...)
 	})
@@ -461,6 +480,10 @@ func (r *RpmRepoCloner) clonePackage(baseArgs []string, enabledRepoOrder ...stri
 		unresolvedOutputPostfix = "available"
 	)
 
+	var (
+		releaseverCliArg string
+	)
+
 	if len(enabledRepoOrder) == 0 {
 		return false, fmt.Errorf("enabledRepoOrder cannot be empty")
 	}
@@ -469,7 +492,12 @@ func (r *RpmRepoCloner) clonePackage(baseArgs []string, enabledRepoOrder ...stri
 	// TDNF processes enable/disable repo requests in the order that they are passed.
 	// So if `--disablerepo=foo` and then `--enablerepo=foo` are passed, `foo` will be enabled.
 	baseArgs = append(baseArgs, "--disablerepo=*")
-	baseArgs = append(baseArgs, "--releasever=2.0")
+
+	releaseverCliArg, err = tdnf.GetReleaseverCliArg()
+	if err != nil {
+		return
+	}
+	baseArgs = append(baseArgs, releaseverCliArg)
 
 	var enabledRepoArgs []string
 	for _, repoID := range enabledRepoOrder {

--- a/toolkit/tools/internal/tdnf/tdnf.go
+++ b/toolkit/tools/internal/tdnf/tdnf.go
@@ -41,7 +41,7 @@ func GetReleaseverCliArg() (arg string, err error) {
 		if err != nil {
 			return
 		}
-		arg = fmt.Sprintf("%s=\"%s\"", releaseverArgument, majorVersion)
+		arg = fmt.Sprintf("%s=%s", releaseverArgument, majorVersion)
 		releaseverArgumentPopulatedCache = arg
 	} else {
 		arg = releaseverArgumentPopulatedCache

--- a/toolkit/tools/internal/tdnf/tdnf.go
+++ b/toolkit/tools/internal/tdnf/tdnf.go
@@ -1,0 +1,85 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Package tdnf provides utility functions for interfacing with the TDNF package manager.
+package tdnf
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/exe"
+)
+
+const (
+	// ReleaseverArgument specifies the release version argument to be used with tdnf
+	releaseverArgument = "--releasever"
+)
+
+var (
+	// We consider the major version to be the first two numbers in the version string
+	// separated by a dot.
+	//
+	// Limiting this to digits only is a normative limitation based on past versioning
+	// of Mariner and its repositories.
+	//
+	// Examples: "1.0", "2.0", "3.0"
+	majorVersionRegex = regexp.MustCompile(`^(\d+\.\d+)(\..+)?$`)
+
+	// Cache the populated releasever argument
+	// so we don't have to run the same regex/string formatting thousands of times
+	releaseverArgumentPopulatedCache = ""
+)
+
+// GetReleaseverCliArg returns a TDNF CLI argument suitable for resolving the `$releasever` variable in
+// Mariner's RPM repo files to the major version of the toolkit. This argument allows TDNF to resolve
+// without the presence of the `mariner-release` package.
+func GetReleaseverCliArg() (arg string, err error) {
+	if releaseverArgumentPopulatedCache == "" {
+		var majorVersion string
+		majorVersion, err = getMajorVersionFromToolkitVersion()
+		if err != nil {
+			return
+		}
+		arg = fmt.Sprintf("%s=\"%s\"", releaseverArgument, majorVersion)
+		releaseverArgumentPopulatedCache = arg
+	} else {
+		arg = releaseverArgumentPopulatedCache
+	}
+	return
+
+}
+
+// getMajorVersionFromToolkitVersion returns the major version taken from the `exe` package's
+// `ToolkitVersion` string.
+func getMajorVersionFromToolkitVersion() (arg string, err error) {
+	if exe.ToolkitVersion == "" {
+		err = fmt.Errorf("failed to get Mariner major version- toolkit version not set in exe package at link-time")
+		return
+	}
+	arg, err = getMajorVersionFromString(exe.ToolkitVersion)
+	return
+}
+
+// getMajorVersionFromString returns the major version of a given string.
+// Specifically, we look for the first submatch in the input string using `majorVersionRegex`.
+func getMajorVersionFromString(version string) (majorVersion string, err error) {
+	const (
+		errorFormatString = "failed to extract major Mariner version from the following string: %s"
+	)
+
+	matches := majorVersionRegex.FindStringSubmatch(version)
+
+	if len(matches) < 2 {
+		err = fmt.Errorf(errorFormatString, version)
+		return
+	}
+
+	majorVersion = matches[1]
+
+	if majorVersion == "" {
+		err = fmt.Errorf(errorFormatString, version)
+		return
+	}
+	return
+}

--- a/toolkit/tools/internal/tdnf/tdnf_test.go
+++ b/toolkit/tools/internal/tdnf/tdnf_test.go
@@ -1,0 +1,74 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package tdnf
+
+import (
+	"os"
+	"testing"
+
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/logger"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMain(m *testing.M) {
+	logger.InitStderrLog()
+	os.Exit(m.Run())
+}
+
+func TestGetMajorVersionFromString_AcceptEmptyMinorVersion(t *testing.T) {
+	fullVersion := "2.0"
+	expectedMajorVersion := "2.0"
+	majorVersion, err := getMajorVersionFromString(fullVersion)
+
+	assert.NoError(t, err)
+	assert.Equal(t, expectedMajorVersion, majorVersion)
+}
+
+func TestGetMajorVersionFromString_AcceptPopulatedMinorVersionTimestamp(t *testing.T) {
+	fullVersion := "2.0.20220519.1844"
+	expectedMajorVersion := "2.0"
+	majorVersion, err := getMajorVersionFromString(fullVersion)
+
+	assert.NoError(t, err)
+	assert.Equal(t, expectedMajorVersion, majorVersion)
+}
+
+func TestGetMajorVersionFromString_AcceptAlphabeticalMinorVersion(t *testing.T) {
+	fullVersion := "2.0.reallycoolteststring"
+	expectedMajorVersion := "2.0"
+	majorVersion, err := getMajorVersionFromString(fullVersion)
+
+	assert.NoError(t, err)
+	assert.Equal(t, expectedMajorVersion, majorVersion)
+}
+
+func TestGetMajorVersionFromString_RejectAlphabeticalInMajor(t *testing.T) {
+	fullVersion := "2.A"
+	_, err := getMajorVersionFromString(fullVersion)
+	assert.Error(t, err)
+}
+
+func TestGetMajorVersionFromString_RejectEmpty(t *testing.T) {
+	fullVersion := ""
+	_, err := getMajorVersionFromString(fullVersion)
+	assert.Error(t, err)
+}
+
+func TestGetMajorVersionFromString_RejectWithNoDot(t *testing.T) {
+	fullVersion := "2"
+	_, err := getMajorVersionFromString(fullVersion)
+	assert.Error(t, err)
+}
+
+func TestGetMajorVersionFromString_RejectNoSecondComponentWithDot(t *testing.T) {
+	fullVersion := "2."
+	_, err := getMajorVersionFromString(fullVersion)
+	assert.Error(t, err)
+}
+
+func TestGetMajorVersionFromString_RejectTrailingDot(t *testing.T) {
+	fullVersion := "2.0."
+	_, err := getMajorVersionFromString(fullVersion)
+	assert.Error(t, err)
+}

--- a/toolkit/tools/pkgworker/pkgworker.go
+++ b/toolkit/tools/pkgworker/pkgworker.go
@@ -21,6 +21,7 @@ import (
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/safechroot"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/shell"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/sliceutils"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/tdnf"
 
 	"gopkg.in/alecthomas/kingpin.v2"
 )
@@ -245,6 +246,10 @@ func tdnfInstall(packages []string) (err error) {
 		packageMatchGroup       = 1
 	)
 
+	var (
+		releaseverCliArg string
+	)
+
 	if len(packages) == 0 {
 		return
 	}
@@ -257,7 +262,12 @@ func tdnfInstall(packages []string) (err error) {
 		packages[i] = filepath.Base(strings.TrimSuffix(packages[i], ".rpm"))
 	}
 
-	installArgs := []string{"install", "-y", "--releasever", "2.0"}
+	releaseverCliArg, err = tdnf.GetReleaseverCliArg()
+	if err != nil {
+		return
+	}
+
+	installArgs := []string{"install", "-y", releaseverCliArg}
 	installArgs = append(installArgs, packages...)
 	stdout, stderr, err := shell.Execute("tdnf", installArgs...)
 	foundNoMatchingPackages := false

--- a/toolkit/tools/pkgworker/pkgworker.go
+++ b/toolkit/tools/pkgworker/pkgworker.go
@@ -257,7 +257,7 @@ func tdnfInstall(packages []string) (err error) {
 		packages[i] = filepath.Base(strings.TrimSuffix(packages[i], ".rpm"))
 	}
 
-	installArgs := []string{"install", "-y"}
+	installArgs := []string{"install", "-y", "--releasever", "2.0"}
 	installArgs = append(installArgs, packages...)
 	stdout, stderr, err := shell.Execute("tdnf", installArgs...)
 	foundNoMatchingPackages := false


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Remove the `mariner-release` package from the toolchain.

Bumping the `mariner-release` package release is mostly a symbolic move to denote that a new monthly release has occurred. However, since this package is in the toolchain, this version bump causes a full toolchain rebuild, which in turn forces us to do a full package rebuild. Removing `mariner-release` from the toolchain allows us the possibility of doing a delta build release some months instead of a full rebuild release.

The biggest issue is that `tdnf` uses the version of `mariner-release` to determine the value of the `$releasever` variable in our repo files. We can correct for this by overriding the release version detection with a command line flag whenever we call `tdnf` from the toolkit in the context of the worker chroot.

We also need to make sure any implicit dependencies on `mariner-release` are declared.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- toolchain: Remove `mariner-release` from worker chroot manifest, toolchain manifest, toolchain build scripts, manifest update script
- tools/internal: Add `tdnf` package with helper functions for getting the proper `--releasever` argument. Change calls to `tdnf` to use the output from this package's helper functions.
- `supermin`: Add explicit run-time dependency on `mariner-release`

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Full pipeline test cycle
- Successfully built demo repository using packaged toolkit from this branch
