### PR TITLE
ca-certificates: Obsolete old microsoft subpackage

### DIFF
--- a/SPECS/ca-certificates/ca-certificates.spec
+++ b/SPECS/ca-certificates/ca-certificates.spec
@@ -44,7 +44,7 @@ Name:           ca-certificates
 
 # When updating, "Version" AND "Release" tags must be updated in the "prebuilt-ca-certificates" package as well.
 Version:        20200720
-Release:        22%{?dist}
+Release:        23%{?dist}
 License:        MPLv2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -84,6 +84,10 @@ Requires(post): %{name}-tools = %{version}-%{release}
 Requires(post): coreutils
 Requires(postun): %{name}-tools = %{version}-%{release}
 
+# ca-certificates-microsoft was folded into the base package in 20200720-19
+# Obsolete all published versions of the separate ca-certificates-microsoft package
+# Otherwise, those with old versions of ca-certificates-microsoft can't upgrade
+Obsoletes:      ca-certificates-microsoft <= 20200720-18
 Provides:       ca-certificates-microsoft = %{version}-%{release}
 Provides:       ca-certificates-mozilla = %{version}-%{release}
 
@@ -317,6 +321,9 @@ rm -f %{pkidir}/tls/certs/*.{0,pem}
 %{_bindir}/bundle2pem.sh
 
 %changelog
+* Thu Apr 28 2022 Olivia Crain <oliviacrain@microsoft.com> - 20200720-23
+- Have base package obsolete published versions of separate ca-certificates-microsoft package 
+
 * Mon Apr 04 2022 CBL-Mariner Service Account <cblmargh@microsoft.com> - 20200720-22
 - Updating Microsoft trusted root CAs.
 

--- a/SPECS/prebuilt-ca-certificates-base/prebuilt-ca-certificates-base.spec
+++ b/SPECS/prebuilt-ca-certificates-base/prebuilt-ca-certificates-base.spec
@@ -2,7 +2,7 @@
 Summary:        Prebuilt version of ca-certificates-base package.
 Name:           prebuilt-ca-certificates-base
 Version:        20200720
-Release:        22%{?dist}
+Release:        23%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -40,6 +40,9 @@ rm %{buildroot}%{_sysconfdir}/pki/rpm-gpg/*
 %{_sysconfdir}/pki/java/cacerts
 
 %changelog
+* Thu Apr 28 2022 Olivia Crain <oliviacrain@microsoft.com> - 20200720-23
+- Bump release to match ca-certificates
+
 * Mon Apr 04 2022 CBL-Mariner Service Account <cblmargh@microsoft.com> - 20200720-22
 - Making 'Release' match with 'ca-certificates'.
 

--- a/SPECS/prebuilt-ca-certificates/prebuilt-ca-certificates.spec
+++ b/SPECS/prebuilt-ca-certificates/prebuilt-ca-certificates.spec
@@ -2,7 +2,7 @@
 Summary:        Prebuilt version of ca-certificates package.
 Name:           prebuilt-ca-certificates
 Version:        20200720
-Release:        22%{?dist}
+Release:        23%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -44,6 +44,9 @@ rm %{buildroot}%{_sysconfdir}/pki/rpm-gpg/*
 %{_sysconfdir}/pki/java/cacerts
 
 %changelog
+* Thu Apr 28 2022 Olivia Crain <oliviacrain@microsoft.com> - 20200720-23
+- Bump release to match ca-certificates
+
 * Mon Apr 04 2022 CBL-Mariner Service Account <cblmargh@microsoft.com> - 20200720-22
 - Making 'Release' match with 'ca-certificates'.
 

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -163,7 +163,7 @@ libffi-3.2.1-12.cm1.aarch64.rpm
 libtasn1-4.14-2.cm1.aarch64.rpm
 p11-kit-0.23.22-1.cm1.aarch64.rpm
 p11-kit-trust-0.23.22-1.cm1.aarch64.rpm
-ca-certificates-shared-20200720-22.cm1.noarch.rpm
-ca-certificates-tools-20200720-22.cm1.noarch.rpm
-ca-certificates-base-20200720-22.cm1.noarch.rpm
+ca-certificates-shared-20200720-23.cm1.noarch.rpm
+ca-certificates-tools-20200720-23.cm1.noarch.rpm
+ca-certificates-base-20200720-23.cm1.noarch.rpm
 libselinux-3.2-1.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -163,7 +163,7 @@ libffi-3.2.1-12.cm1.x86_64.rpm
 libtasn1-4.14-2.cm1.x86_64.rpm
 p11-kit-0.23.22-1.cm1.x86_64.rpm
 p11-kit-trust-0.23.22-1.cm1.x86_64.rpm
-ca-certificates-shared-20200720-22.cm1.noarch.rpm
-ca-certificates-tools-20200720-22.cm1.noarch.rpm
-ca-certificates-base-20200720-22.cm1.noarch.rpm
+ca-certificates-shared-20200720-23.cm1.noarch.rpm
+ca-certificates-tools-20200720-23.cm1.noarch.rpm
+ca-certificates-base-20200720-23.cm1.noarch.rpm
 libselinux-3.2-1.cm1.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -22,11 +22,11 @@ bzip2-1.0.6-15.cm1.aarch64.rpm
 bzip2-debuginfo-1.0.6-15.cm1.aarch64.rpm
 bzip2-devel-1.0.6-15.cm1.aarch64.rpm
 bzip2-libs-1.0.6-15.cm1.aarch64.rpm
-ca-certificates-20200720-22.cm1.noarch.rpm
-ca-certificates-base-20200720-22.cm1.noarch.rpm
-ca-certificates-legacy-20200720-22.cm1.noarch.rpm
-ca-certificates-shared-20200720-22.cm1.noarch.rpm
-ca-certificates-tools-20200720-22.cm1.noarch.rpm
+ca-certificates-20200720-23.cm1.noarch.rpm
+ca-certificates-base-20200720-23.cm1.noarch.rpm
+ca-certificates-legacy-20200720-23.cm1.noarch.rpm
+ca-certificates-shared-20200720-23.cm1.noarch.rpm
+ca-certificates-tools-20200720-23.cm1.noarch.rpm
 check-0.12.0-4.cm1.aarch64.rpm
 check-debuginfo-0.12.0-4.cm1.aarch64.rpm
 cmake-3.21.4-2.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -22,11 +22,11 @@ bzip2-1.0.6-15.cm1.x86_64.rpm
 bzip2-debuginfo-1.0.6-15.cm1.x86_64.rpm
 bzip2-devel-1.0.6-15.cm1.x86_64.rpm
 bzip2-libs-1.0.6-15.cm1.x86_64.rpm
-ca-certificates-20200720-22.cm1.noarch.rpm
-ca-certificates-base-20200720-22.cm1.noarch.rpm
-ca-certificates-legacy-20200720-22.cm1.noarch.rpm
-ca-certificates-shared-20200720-22.cm1.noarch.rpm
-ca-certificates-tools-20200720-22.cm1.noarch.rpm
+ca-certificates-20200720-23.cm1.noarch.rpm
+ca-certificates-base-20200720-23.cm1.noarch.rpm
+ca-certificates-legacy-20200720-23.cm1.noarch.rpm
+ca-certificates-shared-20200720-23.cm1.noarch.rpm
+ca-certificates-tools-20200720-23.cm1.noarch.rpm
 check-0.12.0-4.cm1.x86_64.rpm
 check-debuginfo-0.12.0-4.cm1.x86_64.rpm
 cmake-3.21.4-2.cm1.x86_64.rpm


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
In #1502, we removed the `ca-certificates-microsoft` package and folded it into the base package. We added a compatibility provides for the `microsoft` subpackage to the base package, but that isn't enough for the package manager to recognize that `ca-certificates-microsoft` can be removed in favor of newer base package. For that, we need to have the base package obsolete published versions of the separate `ca-certificates-microsoft` package.

This fixes issues where users with installed versions of `ca-certificates-microsoft <= 20200720-18` can't upgrade to newer versions of `ca-certificates` packages.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- `ca-certificates`: Have base package obsolete published versions of separate ca-certificates-microsoft package 

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build ongoing