### PR TITLE
shadow-utils: Add explicit run-time requirement on libpwquality

### DIFF
--- a/SPECS/shadow-utils/shadow-utils.spec
+++ b/SPECS/shadow-utils/shadow-utils.spec
@@ -1,7 +1,7 @@
 Summary:        Programs for handling passwords in a secure way
 Name:           shadow-utils
 Version:        4.9
-Release:        7%{?dist}
+Release:        8%{?dist}
 License:        BSD
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -38,6 +38,7 @@ BuildRequires:  docbook-style-xsl
 BuildRequires:  libxml2
 BuildRequires:  itstool
 Requires:       cracklib
+Requires:       libpwquality
 Requires:       libselinux
 Requires:       libsemanage
 Requires:       pam
@@ -193,6 +194,9 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %{_libdir}/libsubid.so
 
 %changelog
+* Fri Apr 22 2022 Olivia Crain <oliviacrain@microsoft.com> - 4.9-8
+- Add explicit requirement on libpwquality (used in system-password pam file)
+
 * Thu Feb 17 2022 Max Brodeur-Urbas <maxbr@microsoft.com> - 4.9-7
 - Adding missing docbook-dtd-xml, docbook-style-xsl and libxml2 BR to build man pages.
 - Adding man file handling in files section.

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -381,8 +381,8 @@ rpm-libs-4.14.2-14.cm1.aarch64.rpm
 sed-4.5-3.cm1.aarch64.rpm
 sed-debuginfo-4.5-3.cm1.aarch64.rpm
 sed-lang-4.5-3.cm1.aarch64.rpm
-shadow-utils-4.9-7.cm1.aarch64.rpm
-shadow-utils-debuginfo-4.9-7.cm1.aarch64.rpm
+shadow-utils-4.9-8.cm1.aarch64.rpm
+shadow-utils-debuginfo-4.9-8.cm1.aarch64.rpm
 sqlite-3.34.1-1.cm1.aarch64.rpm
 sqlite-debuginfo-3.34.1-1.cm1.aarch64.rpm
 sqlite-devel-3.34.1-1.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -381,8 +381,8 @@ rpm-libs-4.14.2-14.cm1.x86_64.rpm
 sed-4.5-3.cm1.x86_64.rpm
 sed-debuginfo-4.5-3.cm1.x86_64.rpm
 sed-lang-4.5-3.cm1.x86_64.rpm
-shadow-utils-4.9-7.cm1.x86_64.rpm
-shadow-utils-debuginfo-4.9-7.cm1.x86_64.rpm
+shadow-utils-4.9-8.cm1.x86_64.rpm
+shadow-utils-debuginfo-4.9-8.cm1.x86_64.rpm
 sqlite-3.34.1-1.cm1.x86_64.rpm
 sqlite-debuginfo-3.34.1-1.cm1.x86_64.rpm
 sqlite-devel-3.34.1-1.cm1.x86_64.rpm


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
We're getting reports of the following error when changing a user password in the base container image:

```console
root [ / ]# myUsername=mdahrea
root [ / ]# adduser -G wheel olivia
root [ / ]# passwd olivia
passwd: Module is unknown
passwd: password unchanged
```

In the container image, `shadow-utils` is present without `libpwquality`. This is problematic because `libpwquality` provides the `pam_pwquality.so` module referenced in `shadow-util`'s `system-password` pam config. The above error can be fixed by installing `libpwquality` manually before running `passwd`.

This PR adds `libpwquality` as a run-time requirement of `shadow-utils` to ensure users don't need to install the package manually.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- `shadow-utils`: Add explicit run-time requirement on libpwquality

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Full pipeline build succeeded
- Imported base container image and successfully changed user password without installing `libpwquality` manually
