### PR TITLE
Create util-linux-libs RPM package with libraries

### DIFF
--- a/SPECS/glibc/glibc.spec
+++ b/SPECS/glibc/glibc.spec
@@ -7,7 +7,7 @@
 Summary:        Main C library
 Name:           glibc
 Version:        2.35
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        BSD AND GPLv2+ AND Inner-Net AND ISC AND LGPLv2+ AND MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -174,24 +174,24 @@ rm -rf %{buildroot}%{_infodir}
 cat > %{buildroot}%{_sysconfdir}/nsswitch.conf <<- "EOF"
 #       Begin /etc/nsswitch.conf
 
-    passwd: files
-    group: files
-    shadow: files
+	passwd: files
+	group: files
+	shadow: files
 
-    hosts: files dns
-    networks: files
+	hosts: files dns
+	networks: files
 
-    protocols: files
-    services: files
-    ethers: files
-    rpc: files
+	protocols: files
+	services: files
+	ethers: files
+	rpc: files
 #       End /etc/nsswitch.conf
 EOF
 cat > %{buildroot}%{_sysconfdir}/ld.so.conf <<- "EOF"
 #       Begin /etc/ld.so.conf
-    %{_prefix}/local/lib
-    /opt/lib
-    include %{_sysconfdir}/ld.so.conf.d/*.conf
+	%{_prefix}/local/lib
+	/opt/lib
+	include %{_sysconfdir}/ld.so.conf.d/*.conf
 EOF
 popd
 %find_lang %{name} --all-name
@@ -299,6 +299,9 @@ grep "^FAIL: nptl/tst-eintr1" tests.sum >/dev/null && n=$((n+1)) ||:
 %defattr(-,root,root)
 
 %changelog
+* Mon May 02 2022 Sriram Nambakam <snambakam@microsoft.com> - 2.35-2
+- To remove leading spaces in /etc/nsswitch.conf, use tabs instead of spaces
+
 * Tue Apr 12 2022 Andrew Phelps <anphel@microsoft.com> - 2.35-1
 - Upgrade to version 2.35
 - Cleanup old patch files

--- a/SPECS/systemd/systemd.spec
+++ b/SPECS/systemd/systemd.spec
@@ -1,7 +1,7 @@
 Summary:        Systemd-250
 Name:           systemd
 Version:        250.3
-Release:        4%{?dist}
+Release:        5%{?dist}
 License:        LGPLv2+ AND GPLv2+ AND MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -42,7 +42,7 @@ Requires:       pam
 Requires:       xz
 Requires(post): audit-libs
 Requires(post): pam
-Requires(post): util-linux-devel
+Requires(post): util-linux-libs
 Obsoletes:      systemd-bootstrap
 Provides:       systemd-units = %{version}-%{release}
 Provides:       systemd-sysv = %{version}-%{release}
@@ -258,6 +258,9 @@ systemctl preset-all
 %files lang -f %{name}.lang
 
 %changelog
+* Mon May 02 2022 Sriram Nambakam <snambakam@microsoft.com> - 250.3-5
+- Change Requires(post) to depend on util-linux-libs
+
 * Wed Apr 13 2022 Cameron Baird <cameronbaird@microsoft.com> - 250.3-4
 - Bring in an upstream change as patch fix-journald-audit-logging.patch
 - to prevent many-fielded audit messages from crashing systemd-journal

--- a/SPECS/util-linux/util-linux.spec
+++ b/SPECS/util-linux/util-linux.spec
@@ -1,7 +1,7 @@
 Summary:        Utilities for file systems, consoles, partitions, and messages
 Name:           util-linux
 Version:        2.37.2
-Release:        4%{?dist}
+Release:        5%{?dist}
 License:        GPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -14,7 +14,7 @@ BuildRequires:  audit-devel
 BuildRequires:  libselinux-devel
 BuildRequires:  ncurses-devel
 BuildRequires:  pam-devel
-Requires:       %{name}-devel = %{version}-%{release}
+Requires:       %{name}-libs = %{version}-%{release}
 Requires:       audit-libs
 Conflicts:      toybox
 Provides:       %{name}-ng = %{version}-%{release}
@@ -40,6 +40,7 @@ These are the additional language files of util-linux.
 Summary:        Header and library files for util-linux
 Group:          Development/Libraries
 Requires:       %{name} = %{version}-%{release}
+Requires:       %{name}-libs = %{version}-%{release}
 Provides:       libmount-devel = %{version}-%{release}
 Provides:       libblkid = %{version}-%{release}
 Provides:       libblkid-devel = %{version}-%{release}
@@ -116,21 +117,27 @@ rm -rf %{buildroot}/lib/systemd/system
 %files lang -f %{name}.lang
 %defattr(-,root,root)
 
-%files devel
+%files libs
 %defattr(-,root,root)
-%license Documentation/licenses/COPYING.LGPL-2.1-or-later libsmartcols/COPYING
-%license libblkid/COPYING
-%{_libdir}/pkgconfig/*.pc
 %{_libdir}/*.so
 /lib/libblkid.so.*
 /lib/libmount.so.*
 /lib/libuuid.so.*
 /lib/libsmartcols.so.*
 /lib/libfdisk.so.*
+
+%files devel
+%defattr(-,root,root)
+%license Documentation/licenses/COPYING.LGPL-2.1-or-later libsmartcols/COPYING
+%license libblkid/COPYING
+%{_libdir}/pkgconfig/*.pc
 %{_includedir}/*
 %{_mandir}/man3/*
 
 %changelog
+* Mon May 05 2022 Sriram Nambakam <snambakam@microsoft.com> - 2.36.2-5
+- Split libraries into the util-linux-libs package
+
 * Mon Mar 14 2022 Daniel McIlvaney <damcilva@microsoft.com> - 2.36.2-4
 - Add Debian's PAM configs for runuser tool
 - Add build require on pam-devel so we have the pam headers


### PR DESCRIPTION
Change systemd.spec to depend on util-linux-libs

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?

This change segregates the libraries from util-linux-devel into util-linux-libs.
It also introduces a dependency for util-linux-devel and util-linux on util-linux-libs



