### PR TITLE
Add lib files to rubygems from source

### DIFF
--- a/SPECS-EXTENDED/rubygem-semantic_puppet/rubygem-semantic_puppet.spec
+++ b/SPECS-EXTENDED/rubygem-semantic_puppet/rubygem-semantic_puppet.spec
@@ -5,7 +5,7 @@
 Summary:        Useful tools for working with Semantic Versions
 Name:           rubygem-%{gem_name}
 Version:        1.0.4
-Release:        2%{?dist}
+Release:        3%{?dist}
 Group:          Development/Languages
 License:        MIT
 Vendor:         Microsoft Corporation
@@ -29,13 +29,19 @@ gem build %{gem_name}
 gem install -V --local --force --install-dir %{buildroot}/%{gemdir} %{gem_name}-%{version}.gem
 #add LICENSE file to buildroot from Source0
 cp LICENSE %{buildroot}%{gem_instdir}/
+#add lib folder to buildroot from Source0
+cp -r lib/ %{buildroot}%{gem_instdir}/
 
 %files
 %defattr(-,root,root,-)
 %license %{gemdir}/gems/%{gem_name}-%{version}/LICENSE
+%{gem_instdir}/lib
 %{gemdir}
 
 %changelog
+* Tue May 03 2022 Neha Agarwal <nehaagarwal@microsoft.com> - 1.0.4-3
+- Add lib/ from source.
+
 * Tue Mar 22 2022 Neha Agarwal <nehaagarwal@microsoft.com> - 1.0.4-2
 - Build from .tar.gz source.
 

--- a/SPECS/rubygem-concurrent-ruby/rubygem-concurrent-ruby.spec
+++ b/SPECS/rubygem-concurrent-ruby/rubygem-concurrent-ruby.spec
@@ -4,7 +4,7 @@
 Summary:        Modern concurrency tools for Ruby
 Name:           rubygem-concurrent-ruby
 Version:        1.1.10
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -29,13 +29,19 @@ gem build %{gem_name}
 
 %install
 gem install -V --local --force --install-dir %{buildroot}/%{gemdir} %{gem_name}-%{version}.gem
+#add lib folder to buildroot from Source0
+cp -r lib/ %{buildroot}%{gem_instdir}/
 
 %files
 %defattr(-,root,root,-)
 %license %{gemdir}/gems/%{gem_name}-%{version}/LICENSE.txt
+%{gem_instdir}/lib
 %{gemdir}
 
 %changelog
+* Tue May 03 2022 Neha Agarwal <nehaagarwal@microsoft.com> - 1.1.10-3
+- Add lib/ from source
+
 * Wed Apr 20 2022 Neha Agarwal <nehaagarwal@microsoft.com> - 1.1.10-2
 - Add provides
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
These gems were missing lib files (.rb), that have now been copied from source.tar.gz

###### Change Log  <!-- REQUIRED -->
- Earlier, we were using .gem files to build rubygems, that would install lib files. Now, these files have to be copied from the source and added to files section. Without lib files, their functionality was impacted.

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Test Methodology
- Installed the new rpm on a Mariner VM, could 'require' these gems in test programs successfully.
