### PR TITLE
Drop old lines from StreamOutput if full

### DIFF
--- a/toolkit/tools/internal/logger/log.go
+++ b/toolkit/tools/internal/logger/log.go
@@ -133,6 +133,7 @@ func WarningOnError(err interface{}, args ...interface{}) {
 }
 
 // StreamOutput calls the provided logFunction on every line from the provided pipe
+// outputChan will contain the N most recent lines of output, based on the length of the channel
 func StreamOutput(pipe io.Reader, logFunction func(...interface{}), wg *sync.WaitGroup, outputChan chan string) {
 	for scanner := bufio.NewScanner(pipe); scanner.Scan(); {
 		line := scanner.Text()
@@ -142,10 +143,18 @@ func StreamOutput(pipe io.Reader, logFunction func(...interface{}), wg *sync.Wai
 
 		// Optionally buffer the output to print in the event of an error
 		if outputChan != nil {
+			// We are most interested in the most recent messages, if the channel is full drop the oldest entries
+			if len(outputChan) == cap(outputChan) {
+				select {
+				case <-outputChan:
+					// The buffer is full, discard the oldest value
+				default:
+				}
+			}
 			select {
 			case outputChan <- line:
 			default:
-				// In the event the buffer is full, drop the line
+				// In the event the buffer is full, drop the line. The block above should avoid this occuring however
 			}
 		}
 	}


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
StreamOutput was intended to preserve the last N lines of error. Instead it was preserving the first N lines instead.
Drop the oldest line of saved output if the buffer becomes full instead of dropping the new line.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Check if the output buffer is full in StreamOutput and drop the oldest line if so

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Quick local test
