### PR TITLE
Remove unnecessary files in toolchain_from_container.tar.gz

### DIFF
--- a/toolkit/scripts/toolchain/container/toolchain_build_in_chroot.sh
+++ b/toolkit/scripts/toolchain/container/toolchain_build_in_chroot.sh
@@ -958,7 +958,7 @@ make install
 #mv -v /usr/lib/libprocps.so.* /lib
 #ln -sfv ../../lib/$(readlink /usr/lib/libprocps.so) /usr/lib/libprocps.so
 popd
-rm -rf procps-ng-3.3.17
+rm -rf procps-3.3.17
 touch /logs/status_procpsng_complete
 
 echo util-linux-2.37.2

--- a/toolkit/scripts/toolchain/create_toolchain_in_container.sh
+++ b/toolkit/scripts/toolchain/create_toolchain_in_container.sh
@@ -62,6 +62,7 @@ rm -rvf ./populated_toolchain
 mv ./lfs ./populated_toolchain
 rm -rvf ./populated_toolchain/.dockerenv
 rm -rvf ./populated_toolchain/sources
+rm -rvf ./populated_toolchain/tools
 tar czf toolchain_from_container.tar.gz populated_toolchain
 ls -la ./
 ls -la ./populated_toolchain

--- a/toolkit/scripts/toolchain/create_toolchain_in_container.sh
+++ b/toolkit/scripts/toolchain/create_toolchain_in_container.sh
@@ -62,7 +62,7 @@ rm -rvf ./populated_toolchain
 mv ./lfs ./populated_toolchain
 rm -rvf ./populated_toolchain/.dockerenv
 rm -rvf ./populated_toolchain/sources
-rm -rvf ./populated_toolchain/tools
+rm -rvf ./populated_toolchain/tools/libexec/gcc
 tar czf toolchain_from_container.tar.gz populated_toolchain
 ls -la ./
 ls -la ./populated_toolchain


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Cleanup unnecessary files found in toolchain_from_container.tar.gz intermediate toolchain file.

1) Fix typo when removing "procps-3.3.17" source build directory

2) Remove "/tools/libexec/gcc". This contains the bootstrapped gcc compiler used in the early part of the raw toolchain build. It is not needed for building the rest of the toolchain, and takes a large amount of space. Reducing the size will improve download/upload speed of artifacts in the full build pipelines.
Reduces compressed size of toolchain_from_container.tar.gz by around 600MB (from ~1.9GB to ~1.3 GB)

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Remove proper "procps-3.3.17" source folder
- Remove "/tools/libexec/gcc" from toolchain_from_container.tar.gz

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: 190779
