### PR TITLE
Add util-linux-devel into pkgggen_core

### DIFF
--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -66,6 +66,7 @@ make-4.3-2.cm2.aarch64.rpm
 mariner-release-2.0-11.cm2.noarch.rpm
 patch-2.7.6-7.cm2.aarch64.rpm
 util-linux-2.37.2-5.cm2.aarch64.rpm
+util-linux-devel-2.37.2-5.cm2.aarch64.rpm
 util-linux-libs-2.37.2-5.cm2.aarch64.rpm
 tar-1.34-1.cm2.aarch64.rpm
 xz-5.2.5-1.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -66,6 +66,7 @@ make-4.3-2.cm2.x86_64.rpm
 mariner-release-2.0-11.cm2.noarch.rpm
 patch-2.7.6-7.cm2.x86_64.rpm
 util-linux-2.37.2-5.cm2.x86_64.rpm
+util-linux-devel-2.37.2-5.cm2.x86_64.rpm
 util-linux-libs-2.37.2-5.cm2.x86_64.rpm
 tar-1.34-1.cm2.x86_64.rpm
 xz-5.2.5-1.cm2.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
In #2953 util-linux-libs was created and installed in the default worker chroot (in pkggen_core) instead of util-linux-devel. The uuid.h and uuid.pc files, contained in util-linux-devel, are no longer present by default. Add this package back into pkggen_core.

Should fix the following package issues:

INFO[37332] Failed SRPMs: 

INFO[37332] --> parted-3.4-1.cm2.src.rpm , error: exit status 2, for details see: /tmp/mariner/build/logs/pkggen/rpmbuilding/parted-3.4-1.cm2.src.rpm.log 
"checking uuid/uuid.h presence... no"

INFO[37332] --> xfsprogs-5.0.0-3.cm2.src.rpm , error: exit status 2, for details see: /tmp/mariner/build/logs/pkggen/rpmbuilding/xfsprogs-5.0.0-3.cm2.src.rpm.log 
"checking for uuid/uuid.h... no"

INFO[37332] --> nvme-cli-1.16-2.cm2.src.rpm , error: exit status 2, for details see: /tmp/mariner/build/logs/pkggen/rpmbuilding/nvme-cli-1.16-2.cm2.src.rpm.log 
"linux/nvme.h:21:10: fatal error: uuid/uuid.h: No such file or directory"

INFO[37332] --> libSM-1.2.3-8.cm2.src.rpm , error: exit status 2, for details see: /tmp/mariner/build/logs/pkggen/rpmbuilding/libSM-1.2.3-8.cm2.src.rpm.log 
"checking for LIBUUID... no"

INFO[37332] --> lttng-consume-0.2.1-2.cm2.src.rpm , error: exit status 2, for details see: /tmp/mariner/build/logs/pkggen/rpmbuilding/lttng-consume-0.2.1-2.cm2.src.rpm.log 
"--   Package 'uuid', required by 'virtual:world', not found"

INFO[37332] --> tpm2-tools-4.3.2-1.cm2.src.rpm , error: exit status 2, for details see: /tmp/mariner/build/logs/pkggen/rpmbuilding/tpm2-tools-4.3.2-1.cm2.src.rpm.log 
"checking for UUID... no"

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change pkggen_core to include util-linux-devel

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**


###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build
