### PR TITLE
Remove py3_dist usage in gcovr and ocaml-dune

### DIFF
--- a/SPECS/gcovr/gcovr.spec
+++ b/SPECS/gcovr/gcovr.spec
@@ -2,7 +2,7 @@
 Summary:        A code coverage report generator using GNU gcov
 Name:           gcovr
 Version:        5.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        BSD
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -11,17 +11,17 @@ Source0:        https://github.com/gcovr/%{name}/archive/%{version}/%{name}-%{ve
 BuildRequires:  make
 BuildRequires:  python3-devel
 BuildRequires:  python3-setuptools
-Requires:       %{py3_dist Jinja2}
+Requires:       python3dist(jinja2)
 # for gcov
 Requires:       gcc
 BuildArch:      noarch
 %{?python_enable_dependency_generator}
 %if %{with docs}
-BuildRequires:  %{py3_dist Jinja2}
-BuildRequires:  %{py3_dist Sphinx}
-BuildRequires:  %{py3_dist lxml}
-BuildRequires:  %{py3_dist sphinx_rtd_theme}
-BuildRequires:  %{py3_dist sphinxcontrib-autoprogram} >= 0.1.5
+BuildRequires:  python3dist(jinja2)
+BuildRequires:  python3dist(sphinx)
+BuildRequires:  python3dist(lxml)
+BuildRequires:  python3dist(sphinx_rtd_theme)
+BuildRequires:  python3dist(sphinxcontrib-autoprogram) >= 0.1.5
 %endif
 
 %description
@@ -95,6 +95,9 @@ popd
 
 
 %changelog
+* Tue May 10 2022 Andrew Phelps <anphel@microsoft.com> - 5.0-2
+- Use python3dist instead of py3_dist macro
+
 * Wed Feb 02 2022 Cameron Baird <cameronbaird@microsoft.com> - 5.0-1
 - Update to v5.0
 

--- a/SPECS/ocaml-dune/ocaml-dune.spec
+++ b/SPECS/ocaml-dune/ocaml-dune.spec
@@ -8,7 +8,7 @@
 Summary:        A composable build system for OCaml
 Name:           ocaml-%{libname}
 Version:        2.8.5
-Release:        3%{?dist}
+Release:        4%{?dist}
 # Dune itself is MIT.  Some bundled libraries have a different license:
 # ISC:
 # - vendor/cmdliner
@@ -23,8 +23,8 @@ Distribution:   Mariner
 URL:            https://dune.build
 Source0:        https://github.com/ocaml/%{libname}/archive/%{version}/%{libname}-%{version}.tar.gz
 
-BuildRequires:  %{py3_dist sphinx-rtd-theme}
-BuildRequires:  %{py3_dist sphinx}
+BuildRequires:  python3dist(sphinx-rtd-theme)
+BuildRequires:  python3dist(sphinx)
 BuildRequires:  make
 BuildRequires:  ocaml >= 4.08
 BuildRequires:  ocaml-csexp-devel >= 1.3.0
@@ -224,6 +224,9 @@ cp -ar README.md CHANGES.md MIGRATION.md doc/_build/* %{buildroot}%{_pkgdocdir}/
 %endif
 
 %changelog
+* Tue May 10 2022 Andrew Phelps <anphel@microsoft.com> - 2.8.5-4
+- Use python3dist instead of py3_dist macro
+
 * Thu Mar 31 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 2.8.5-3
 - Cleaning-up spec. License verified.
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Remove usage of %{py3_dist} macro for Requires + BuildRequires. This macro might not be available on the host machine environment when downloading SRPM files from PMC. This can lead to an error from the following line in srpm_pack.mk:

	srpm_file=$(rpmspec -q ${spec_file} --srpm --define='with_check 1' --define='dist .cm2' --queryformat %{NAME}-%{VERSION}-%{RELEASE}.src.rpm) && \

error: line 26: Dependency tokens must begin with alpha-numeric, '_' or '/': BuildRequires:  %{py3_dist sphinx-rtd-theme}
error: query of specfile /__w/1/s/SPECS/ocaml-dune/ocaml-dune.spec failed, can't parse

error: line 14: Dependency tokens must begin with alpha-numeric, '_' or '/': Requires:       %{py3_dist Jinja2}
error: query of specfile /__w/1/s/SPECS/gcovr/gcovr.spec failed, can't parse


###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: xxxx
