### PR TITLE
[1.0] freetype: patch CVE-2022-27404

### DIFF
--- a/SPECS/freetype/CVE-2022-27404.patch
+++ b/SPECS/freetype/CVE-2022-27404.patch
@@ -1,0 +1,42 @@
+From 53dfdcd8198d2b3201a23c4bad9190519ba918db Mon Sep 17 00:00:00 2001
+From: Werner Lemberg <wl@gnu.org>
+Date: Thu, 17 Mar 2022 19:24:16 +0100
+Subject: [PATCH] [sfnt] Avoid invalid face index.
+
+Fixes #1138.
+
+* src/sfnt/sfobjs.c (sfnt_init_face), src/sfnt/sfwoff2.c (woff2_open_font):
+Check `face_index` before decrementing.
+---
+ src/sfnt/sfobjs.c  | 2 +-
+ src/sfnt/sfwoff2.c | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/sfnt/sfobjs.c b/src/sfnt/sfobjs.c
+index f9d4d3858..9771c35df 100644
+--- a/src/sfnt/sfobjs.c
++++ b/src/sfnt/sfobjs.c
+@@ -566,7 +566,7 @@
+     face_index = FT_ABS( face_instance_index ) & 0xFFFF;
+ 
+     /* value -(N+1) requests information on index N */
+-    if ( face_instance_index < 0 )
++    if ( face_instance_index < 0 && face_index > 0 )
+       face_index--;
+ 
+     if ( face_index >= face->ttc_header.count )
+diff --git a/src/sfnt/sfwoff2.c b/src/sfnt/sfwoff2.c
+index cb1e0664a..165b875e5 100644
+--- a/src/sfnt/sfwoff2.c
++++ b/src/sfnt/sfwoff2.c
+@@ -2085,7 +2085,7 @@
+     /* Validate requested face index. */
+     *num_faces = woff2.num_fonts;
+     /* value -(N+1) requests information on index N */
+-    if ( *face_instance_index < 0 )
++    if ( *face_instance_index < 0 && face_index > 0 )
+       face_index--;
+ 
+     if ( face_index >= woff2.num_fonts )
+-- 
+GitLab

--- a/SPECS/freetype/freetype.spec
+++ b/SPECS/freetype/freetype.spec
@@ -9,7 +9,6 @@ Group:          System Environment/Libraries
 URL:            https://www.freetype.org/
 Source0:        https://download.savannah.gnu.org/releases/%{name}/%{name}-%{version}.tar.gz
 Patch0:         CVE-2022-27404.patch
-
 BuildRequires:  libtool
 BuildRequires:  zlib-devel
 

--- a/SPECS/freetype/freetype.spec
+++ b/SPECS/freetype/freetype.spec
@@ -1,13 +1,14 @@
 Summary:        software font engine.
 Name:           freetype
 Version:        2.11.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        BSD WITH advertising OR GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Group:          System Environment/Libraries
 URL:            https://www.freetype.org/
 Source0:        https://download.savannah.gnu.org/releases/%{name}/%{name}-%{version}.tar.gz
+Patch0:         CVE-2022-27404.patch
 
 BuildRequires:  libtool
 BuildRequires:  zlib-devel
@@ -23,7 +24,7 @@ Requires:       freetype = %{version}-%{release}
 It contains the libraries and header files to create applications
 
 %prep
-%setup -q
+%autosetup -p1
 
 %build
 ./configure \
@@ -55,6 +56,9 @@ make -k check |& tee %{_specdir}/%{name}-check-log || %{nocheck}
 %{_libdir}/pkgconfig/*.pc
 
 %changelog
+* Mon May 16 2022 Neha Agarwal <nehaagarwal@microsoft.com> - 2.11.1-2
+- Add patch to address CVE-2022-27404.
+
 * Mon Mar 07 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 2.11.1-1
 - Updating to version 2.11.1 to address CVE-2020-15999.
 

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -95,9 +95,9 @@ findutils-lang-4.6.0-8.cm1.aarch64.rpm
 flex-2.6.4-6.cm1.aarch64.rpm
 flex-debuginfo-2.6.4-6.cm1.aarch64.rpm
 flex-devel-2.6.4-6.cm1.aarch64.rpm
-freetype-2.11.1-1.cm1.aarch64.rpm
-freetype-debuginfo-2.11.1-1.cm1.aarch64.rpm
-freetype-devel-2.11.1-1.cm1.aarch64.rpm
+freetype-2.11.1-2.cm1.aarch64.rpm
+freetype-debuginfo-2.11.1-2.cm1.aarch64.rpm
+freetype-devel-2.11.1-2.cm1.aarch64.rpm
 gawk-4.2.1-4.cm1.aarch64.rpm
 gawk-debuginfo-4.2.1-4.cm1.aarch64.rpm
 gcc-9.1.0-7.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -95,9 +95,9 @@ findutils-lang-4.6.0-8.cm1.x86_64.rpm
 flex-2.6.4-6.cm1.x86_64.rpm
 flex-debuginfo-2.6.4-6.cm1.x86_64.rpm
 flex-devel-2.6.4-6.cm1.x86_64.rpm
-freetype-2.11.1-1.cm1.x86_64.rpm
-freetype-debuginfo-2.11.1-1.cm1.x86_64.rpm
-freetype-devel-2.11.1-1.cm1.x86_64.rpm
+freetype-2.11.1-2.cm1.x86_64.rpm
+freetype-debuginfo-2.11.1-2.cm1.x86_64.rpm
+freetype-devel-2.11.1-2.cm1.x86_64.rpm
 gawk-4.2.1-4.cm1.x86_64.rpm
 gawk-debuginfo-4.2.1-4.cm1.x86_64.rpm
 gcc-9.1.0-7.cm1.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
[1.0] freetype: patch CVE-2022-27404

###### Change Log  <!-- REQUIRED -->
- freetype: patch CVE-2022-27404

###### Does this affect the toolchain?  <!-- REQUIRED -->
**YES**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2022-27404

###### Test Methodology
- Local build with RUN_CHECK=y