### PR TITLE
[1.0] cifs-utils: patch cve-2022-29869, 2022-27239

### DIFF
--- a/SPECS/cifs-utils/CVE-2022-27239.patch
+++ b/SPECS/cifs-utils/CVE-2022-27239.patch
@@ -1,0 +1,34 @@
+From 955fb147e97a6a74e1aaa65766de91e2c1479765 Mon Sep 17 00:00:00 2001
+From: Jeffrey Bencteux <jbe@improsec.com>
+Date: Thu, 17 Mar 2022 12:58:52 -0400
+Subject: [PATCH] CVE-2022-27239: mount.cifs: fix length check for ip option
+ parsing
+
+Previous check was true whatever the length of the input string was,
+leading to a buffer overflow in the subsequent strcpy call.
+
+Bug: https://bugzilla.samba.org/show_bug.cgi?id=15025
+
+Signed-off-by: Jeffrey Bencteux <jbe@improsec.com>
+Reviewed-by: David Disseldorp <ddiss@suse.de>
+---
+ mount.cifs.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/mount.cifs.c b/mount.cifs.c
+index 84274c9..3a6b449 100644
+--- a/mount.cifs.c
++++ b/mount.cifs.c
+@@ -926,9 +926,10 @@ parse_options(const char *data, struct parsed_mount_info *parsed_info)
+ 			if (!value || !*value) {
+ 				fprintf(stderr,
+ 					"target ip address argument missing\n");
+-			} else if (strnlen(value, MAX_ADDRESS_LEN) <=
++			} else if (strnlen(value, MAX_ADDRESS_LEN) <
+ 				MAX_ADDRESS_LEN) {
+-				strcpy(parsed_info->addrlist, value);
++				strlcpy(parsed_info->addrlist, value,
++					MAX_ADDRESS_LEN);
+ 				if (parsed_info->verboseflag)
+ 					fprintf(stderr,
+ 						"ip address %s override specified\n",

--- a/SPECS/cifs-utils/CVE-2022-29869.patch
+++ b/SPECS/cifs-utils/CVE-2022-29869.patch
@@ -1,0 +1,41 @@
+From 8acc963a2e7e9d63fe1f2e7f73f5a03f83d9c379 Mon Sep 17 00:00:00 2001
+From: Jeffrey Bencteux <jbe@improsec.com>
+Date: Sat, 19 Mar 2022 13:41:15 -0400
+Subject: [PATCH] mount.cifs: fix verbose messages on option parsing
+
+When verbose logging is enabled, invalid credentials file lines may be
+dumped to stderr. This may lead to information disclosure in particular
+conditions when the credentials file given is sensitive and contains '='
+signs.
+
+Bug: https://bugzilla.samba.org/show_bug.cgi?id=15026
+
+Signed-off-by: Jeffrey Bencteux <jbe@improsec.com>
+Reviewed-by: David Disseldorp <ddiss@suse.de>
+---
+ mount.cifs.c | 6 +-----
+ 1 file changed, 1 insertion(+), 5 deletions(-)
+
+diff --git a/mount.cifs.c b/mount.cifs.c
+index 3a6b449..2278995 100644
+--- a/mount.cifs.c
++++ b/mount.cifs.c
+@@ -628,17 +628,13 @@ static int open_cred_file(char *file_name,
+ 				goto return_i;
+ 			break;
+ 		case CRED_DOM:
+-			if (parsed_info->verboseflag)
+-				fprintf(stderr, "domain=%s\n",
+-					temp_val);
+ 			strlcpy(parsed_info->domain, temp_val,
+ 				sizeof(parsed_info->domain));
+ 			break;
+ 		case CRED_UNPARSEABLE:
+ 			if (parsed_info->verboseflag)
+ 				fprintf(stderr, "Credential formatted "
+-					"incorrectly: %s\n",
+-					temp_val ? temp_val : "(null)");
++					"incorrectly\n");
+ 			break;
+ 		}
+ 	}

--- a/SPECS/cifs-utils/cifs-utils.spec
+++ b/SPECS/cifs-utils/cifs-utils.spec
@@ -1,7 +1,7 @@
 Summary:        cifs client utils
 Name:           cifs-utils
 Version:        6.8
-Release:        5%{?dist}
+Release:        6%{?dist}
 License:        GPLv3
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -11,6 +11,8 @@ Source0:        https://ftp.samba.org/pub/linux-cifs/cifs-utils/cifs-utils-%{ver
 Patch0:         CVE-2020-14342.patch
 Patch1:         CVE-2020-14342-fix.patch
 Patch2:         CVE-2021-20208.patch
+Patch3:         CVE-2022-29869.patch
+Patch4:         CVE-2022-27239.patch
 BuildRequires:  libcap-ng-devel
 BuildRequires:  libtalloc-devel
 Requires:       libcap-ng
@@ -49,6 +51,9 @@ make %{?_smp_mflags} check
 %{_includedir}/cifsidmap.h
 
 %changelog
+* Mon May 16 2022 Neha Agarwal <nehaagarwal@microsoft.com> - 6.8-6
+- Adding patches for CVE-2022-29869 and CVE-2022-27239.
+
 * Mon May 03 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 6.8-5
 - Adding a patch fo CVE-2021-20208.
 - Updated "URL" tag to use HTTPS.


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
[1.0] cifs-utils: patch cve-2022-29869, 2022-27239

###### Change Log  <!-- REQUIRED -->
- cifs-utils: patch cve-2022-29869, cve-2022-27239

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2022-29869
- https://nvd.nist.gov/vuln/detail/CVE-2022-27239

###### Test Methodology
- Local build with RUN_CHECK=y