### PR TITLE
cpio: address CVE-2021-38185

### DIFF
--- a/SPECS/cpio/CVE-2021-38185.patch
+++ b/SPECS/cpio/CVE-2021-38185.patch
@@ -1,0 +1,583 @@
+This patch is a combination of the following commits:
+
+https://git.savannah.gnu.org/cgit/cpio.git/commit/?id=dd96882877721703e19272fe25034560b794061b
+https://git.savannah.gnu.org/cgit/cpio.git/commit/?id=dfc801c44a93bed7b3951905b188823d6a0432c8
+https://git.savannah.gnu.org/cgit/cpio.git/commit/?id=236684f6deb3178043fe72a8e2faca538fa2aae1
+
+---------------
+
+https://git.savannah.gnu.org/cgit/cpio.git/commit/?id=dd96882877721703e19272fe25034560b794061b
+
+author	Sergey Poznyakoff <gray@gnu.org>	2021-08-07 12:52:21 +0300
+committer	Sergey Poznyakoff <gray@gnu.org>	2021-08-07 12:52:21 +0300
+commit	dd96882877721703e19272fe25034560b794061b (patch)
+tree	2d81f2521f55cf3d82e7305d1475be9c8c1e0812
+parent	269d2040a62e45a35d7f5eef3e868813d44213c0 (diff)
+download	cpio-dd96882877721703e19272fe25034560b794061b.tar.gz
+
+Rewrite dynamic string support.
+
+* src/dstring.c (ds_init): Take a single argument.
+(ds_free): New function.
+(ds_resize): Take a single argument.  Use x2nrealloc to expand
+the storage.
+(ds_reset,ds_append,ds_concat,ds_endswith): New function.
+(ds_fgetstr): Rewrite.  In particular, this fixes integer overflow.
+* src/dstring.h (dynamic_string): Keep both the allocated length
+(ds_size) and index of the next free byte in the string (ds_idx).
+(ds_init,ds_resize): Change signature.
+(ds_len): New macro.
+(ds_free,ds_reset,ds_append,ds_concat,ds_endswith): New protos.
+* src/copyin.c: Use new ds_ functions.
+* src/copyout.c: Likewise.
+* src/copypass.c: Likewise.
+* src/util.c: Likewise.
+
+
+diff --git a/src/copyin.c b/src/copyin.c
+index a096048..4fb14af 100644
+--- a/src/copyin.c
++++ b/src/copyin.c
+@@ -55,11 +55,12 @@ query_rename(struct cpio_file_stat* file_hdr, FILE *tty_in, FILE *tty_out,
+   char *str_res;		/* Result for string function.  */
+   static dynamic_string new_name;	/* New file name for rename option.  */
+   static int initialized_new_name = false;
++
+   if (!initialized_new_name)
+-  {
+-    ds_init (&new_name, 128);
+-    initialized_new_name = true;
+-  }
++    {
++      ds_init (&new_name);
++      initialized_new_name = true;
++    }
+ 
+   if (rename_flag)
+     {
+@@ -779,37 +780,36 @@ long_format (struct cpio_file_stat *file_hdr, char const *link_name)
+    already in `save_patterns' (from the command line) are preserved.  */
+ 
+ static void
+-read_pattern_file ()
++read_pattern_file (void)
+ {
+-  int max_new_patterns;
+-  char **new_save_patterns;
+-  int new_num_patterns;
++  char **new_save_patterns = NULL;
++  size_t max_new_patterns;
++  size_t new_num_patterns;
+   int i;
+-  dynamic_string pattern_name;
++  dynamic_string pattern_name = DYNAMIC_STRING_INITIALIZER;
+   FILE *pattern_fp;
+ 
+   if (num_patterns < 0)
+     num_patterns = 0;
+-  max_new_patterns = 1 + num_patterns;
+-  new_save_patterns = (char **) xmalloc (max_new_patterns * sizeof (char *));
+   new_num_patterns = num_patterns;
+-  ds_init (&pattern_name, 128);
++  max_new_patterns = num_patterns;
++  new_save_patterns = xcalloc (max_new_patterns, sizeof (new_save_patterns[0]));
+ 
+   pattern_fp = fopen (pattern_file_name, "r");
+   if (pattern_fp == NULL)
+     open_fatal (pattern_file_name);
+   while (ds_fgetstr (pattern_fp, &pattern_name, '\n') != NULL)
+     {
+-      if (new_num_patterns >= max_new_patterns)
+-	{
+-	  max_new_patterns += 1;
+-	  new_save_patterns = (char **)
+-	    xrealloc ((char *) new_save_patterns,
+-		      max_new_patterns * sizeof (char *));
+-	}
++      if (new_num_patterns == max_new_patterns)
++	new_save_patterns = x2nrealloc (new_save_patterns,
++					&max_new_patterns,
++					sizeof (new_save_patterns[0]));
+       new_save_patterns[new_num_patterns] = xstrdup (pattern_name.ds_string);
+       ++new_num_patterns;
+     }
++
++  ds_free (&pattern_name);
++  
+   if (ferror (pattern_fp) || fclose (pattern_fp) == EOF)
+     close_error (pattern_file_name);
+ 
+@@ -1196,7 +1196,7 @@ swab_array (char *ptr, int count)
+    in the file system.  */
+ 
+ void
+-process_copy_in ()
++process_copy_in (void)
+ {
+   char done = false;		/* True if trailer reached.  */
+   FILE *tty_in = NULL;		/* Interactive file for rename option.  */
+diff --git a/src/copyout.c b/src/copyout.c
+index 5ca587f..ca6798c 100644
+--- a/src/copyout.c
++++ b/src/copyout.c
+@@ -594,9 +594,10 @@ assign_string (char **pvar, char *value)
+    The format of the header depends on the compatibility (-c) flag.  */
+ 
+ void
+-process_copy_out ()
++process_copy_out (void)
+ {
+-  dynamic_string input_name;	/* Name of file read from stdin.  */
++  dynamic_string input_name = DYNAMIC_STRING_INITIALIZER;
++                                /* Name of file read from stdin.  */
+   struct stat file_stat;	/* Stat record for file.  */
+   struct cpio_file_stat file_hdr = CPIO_FILE_STAT_INITIALIZER;
+                                 /* Output header information.  */
+@@ -605,7 +606,6 @@ process_copy_out ()
+   char *orig_file_name = NULL;
+ 
+   /* Initialize the copy out.  */
+-  ds_init (&input_name, 128);
+   file_hdr.c_magic = 070707;
+ 
+   /* Check whether the output file might be a tape.  */
+@@ -657,14 +657,9 @@ process_copy_out ()
+ 	    {
+ 	      if (file_hdr.c_mode & CP_IFDIR)
+ 		{
+-		  int len = strlen (input_name.ds_string);
+ 		  /* Make sure the name ends with a slash */
+-		  if (input_name.ds_string[len-1] != '/')
+-		    {
+-		      ds_resize (&input_name, len + 2);
+-		      input_name.ds_string[len] = '/';
+-		      input_name.ds_string[len+1] = 0;
+-		    }
++		  if (!ds_endswith (&input_name, '/'))
++		    ds_append (&input_name, '/');
+ 		}
+ 	    }
+ 	  
+@@ -875,6 +870,7 @@ process_copy_out ()
+ 			 (unsigned long) blocks), (unsigned long) blocks);
+     }
+   cpio_file_stat_free (&file_hdr);
++  ds_free (&input_name);
+ }
+ 
+ 
+diff --git a/src/copypass.c b/src/copypass.c
+index 5d5e939..23ee687 100644
+--- a/src/copypass.c
++++ b/src/copypass.c
+@@ -48,10 +48,12 @@ set_copypass_perms (int fd, const char *name, struct stat *st)
+    If `link_flag', link instead of copying.  */
+ 
+ void
+-process_copy_pass ()
++process_copy_pass (void)
+ {
+-  dynamic_string input_name;	/* Name of file from stdin.  */
+-  dynamic_string output_name;	/* Name of new file.  */
++  dynamic_string input_name = DYNAMIC_STRING_INITIALIZER;
++                                /* Name of file from stdin.  */
++  dynamic_string output_name = DYNAMIC_STRING_INITIALIZER;
++                                /* Name of new file.  */
+   size_t dirname_len;		/* Length of `directory_name'.  */
+   int res;			/* Result of functions.  */
+   char *slash;			/* For moving past slashes in input name.  */
+@@ -65,25 +67,18 @@ process_copy_pass ()
+ 				   created files  */
+ 
+   /* Initialize the copy pass.  */
+-  ds_init (&input_name, 128);
+   
+   dirname_len = strlen (directory_name);
+   if (change_directory_option && !ISSLASH (directory_name[0]))
+     {
+       char *pwd = xgetcwd ();
+-
+-      dirname_len += strlen (pwd) + 1;
+-      ds_init (&output_name, dirname_len + 2);
+-      strcpy (output_name.ds_string, pwd);
+-      strcat (output_name.ds_string, "/");
+-      strcat (output_name.ds_string, directory_name);
++      
++      ds_concat (&output_name, pwd);
++      ds_append (&output_name, '/');
+     }
+-  else
+-    {
+-      ds_init (&output_name, dirname_len + 2);
+-      strcpy (output_name.ds_string, directory_name);
+-    }
+-  output_name.ds_string[dirname_len] = '/';
++  ds_concat (&output_name, directory_name);
++  ds_append (&output_name, '/');
++  dirname_len = ds_len (&output_name);
+   output_is_seekable = true;
+ 
+   change_dir ();
+@@ -116,8 +111,8 @@ process_copy_pass ()
+       /* Make the name of the new file.  */
+       for (slash = input_name.ds_string; *slash == '/'; ++slash)
+ 	;
+-      ds_resize (&output_name, dirname_len + strlen (slash) + 2);
+-      strcpy (output_name.ds_string + dirname_len + 1, slash);
++      ds_reset (&output_name, dirname_len);
++      ds_concat (&output_name, slash);
+ 
+       existing_dir = false;
+       if (lstat (output_name.ds_string, &out_file_stat) == 0)
+@@ -333,6 +328,9 @@ process_copy_pass ()
+ 			 (unsigned long) blocks),
+ 	       (unsigned long) blocks);
+     }
++
++  ds_free (&input_name);
++  ds_free (&output_name);
+ }
+ 
+ /* Try and create a hard link from FILE_NAME to another file 
+diff --git a/src/dstring.c b/src/dstring.c
+index b261d5a..692d3e7 100644
+--- a/src/dstring.c
++++ b/src/dstring.c
+@@ -20,8 +20,8 @@
+ #if defined(HAVE_CONFIG_H)
+ # include <config.h>
+ #endif
+-
+ #include <stdio.h>
++#include <stdlib.h>
+ #if defined(HAVE_STRING_H) || defined(STDC_HEADERS)
+ #include <string.h>
+ #else
+@@ -33,24 +33,41 @@
+ /* Initialiaze dynamic string STRING with space for SIZE characters.  */
+ 
+ void
+-ds_init (dynamic_string *string, int size)
++ds_init (dynamic_string *string)
++{
++  memset (string, 0, sizeof *string);
++}
++
++/* Free the dynamic string storage. */
++
++void
++ds_free (dynamic_string *string)
+ {
+-  string->ds_length = size;
+-  string->ds_string = (char *) xmalloc (size);
++  free (string->ds_string);
+ }
+ 
+-/* Expand dynamic string STRING, if necessary, to hold SIZE characters.  */
++/* Expand dynamic string STRING, if necessary.  */
+ 
+ void
+-ds_resize (dynamic_string *string, int size)
++ds_resize (dynamic_string *string)
+ {
+-  if (size > string->ds_length)
++  if (string->ds_idx == string->ds_size)
+     {
+-      string->ds_length = size;
+-      string->ds_string = (char *) xrealloc ((char *) string->ds_string, size);
++      string->ds_string = x2nrealloc (string->ds_string, &string->ds_size,
++				      1);
+     }
+ }
+ 
++/* Reset the index of the dynamic string S to LEN. */
++
++void
++ds_reset (dynamic_string *s, size_t len)
++{
++  while (len > s->ds_size)
++    ds_resize (s);
++  s->ds_idx = len;
++}
++
+ /* Dynamic string S gets a string terminated by the EOS character
+    (which is removed) from file F.  S will increase
+    in size during the function if the string from F is longer than
+@@ -61,34 +78,50 @@ ds_resize (dynamic_string *string, int size)
+ char *
+ ds_fgetstr (FILE *f, dynamic_string *s, char eos)
+ {
+-  int insize;			/* Amount needed for line.  */
+-  int strsize;			/* Amount allocated for S.  */
+   int next_ch;
+ 
+   /* Initialize.  */
+-  insize = 0;
+-  strsize = s->ds_length;
++  s->ds_idx = 0;
+ 
+   /* Read the input string.  */
+-  next_ch = getc (f);
+-  while (next_ch != eos && next_ch != EOF)
++  while ((next_ch = getc (f)) != eos && next_ch != EOF)
+     {
+-      if (insize >= strsize - 1)
+-	{
+-	  ds_resize (s, strsize * 2 + 2);
+-	  strsize = s->ds_length;
+-	}
+-      s->ds_string[insize++] = next_ch;
+-      next_ch = getc (f);
++      ds_resize (s);
++      s->ds_string[s->ds_idx++] = next_ch;
+     }
+-  s->ds_string[insize++] = '\0';
++  ds_resize (s);
++  s->ds_string[s->ds_idx] = '\0';
+ 
+-  if (insize == 1 && next_ch == EOF)
++  if (s->ds_idx == 0 && next_ch == EOF)
+     return NULL;
+   else
+     return s->ds_string;
+ }
+ 
++void
++ds_append (dynamic_string *s, int c)
++{
++  ds_resize (s);
++  s->ds_string[s->ds_idx] = c;
++  if (c)
++    {
++      s->ds_idx++;
++      ds_resize (s);
++      s->ds_string[s->ds_idx] = 0;
++    }      
++}
++
++void
++ds_concat (dynamic_string *s, char const *str)
++{
++  size_t len = strlen (str);
++  while (len + 1 > s->ds_size)
++    ds_resize (s);
++  memcpy (s->ds_string + s->ds_idx, str, len);
++  s->ds_idx += len;
++  s->ds_string[s->ds_idx] = 0;
++}
++
+ char *
+ ds_fgets (FILE *f, dynamic_string *s)
+ {
+@@ -100,3 +133,10 @@ ds_fgetname (FILE *f, dynamic_string *s)
+ {
+   return ds_fgetstr (f, s, '\0');
+ }
++
++/* Return true if the dynamic string S ends with character C. */
++int
++ds_endswith (dynamic_string *s, int c)
++{
++  return (s->ds_idx > 0 && s->ds_string[s->ds_idx - 1] == c);
++}
+diff --git a/src/dstring.h b/src/dstring.h
+index 5d24181..ca7a5f1 100644
+--- a/src/dstring.h
++++ b/src/dstring.h
+@@ -17,10 +17,6 @@
+    Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+    Boston, MA 02110-1301 USA.  */
+ 
+-#ifndef NULL
+-#define NULL 0
+-#endif
+-
+ /* A dynamic string consists of record that records the size of an
+    allocated string and the pointer to that string.  The actual string
+    is a normal zero byte terminated string that can be used with the
+@@ -30,22 +26,25 @@
+ 
+ typedef struct
+ {
+-  int ds_length;		/* Actual amount of storage allocated.  */
+-  char *ds_string;		/* String.  */
++  size_t ds_size;   /* Actual amount of storage allocated.  */
++  size_t ds_idx;    /* Index of the next free byte in the string. */
++  char *ds_string;  /* String storage. */
+ } dynamic_string;
+ 
++#define DYNAMIC_STRING_INITIALIZER { 0, 0, NULL }
+ 
+-/* Macros that look similar to the original string functions.
+-   WARNING:  These macros work only on pointers to dynamic string records.
+-   If used with a real record, an "&" must be used to get the pointer.  */
+-#define ds_strlen(s)		strlen ((s)->ds_string)
+-#define ds_strcmp(s1, s2)	strcmp ((s1)->ds_string, (s2)->ds_string)
+-#define ds_strncmp(s1, s2, n)	strncmp ((s1)->ds_string, (s2)->ds_string, n)
+-#define ds_index(s, c)		index ((s)->ds_string, c)
+-#define ds_rindex(s, c)		rindex ((s)->ds_string, c)
++void ds_init (dynamic_string *string);
++void ds_free (dynamic_string *string);
++void ds_reset (dynamic_string *s, size_t len);
+ 
+-void ds_init (dynamic_string *string, int size);
+-void ds_resize (dynamic_string *string, int size);
++/* All functions below guarantee that s->ds_string[s->ds_idx] == '\0' */
+ char *ds_fgetname (FILE *f, dynamic_string *s);
+ char *ds_fgets (FILE *f, dynamic_string *s);
+ char *ds_fgetstr (FILE *f, dynamic_string *s, char eos);
++void ds_append (dynamic_string *s, int c);
++void ds_concat (dynamic_string *s, char const *str);
++
++#define ds_len(s) ((s)->ds_idx)
++
++int ds_endswith (dynamic_string *s, int c);
++
+diff --git a/src/util.c b/src/util.c
+index 996d4fa..ff2746d 100644
+--- a/src/util.c
++++ b/src/util.c
+@@ -846,11 +846,9 @@ get_next_reel (int tape_des)
+   FILE *tty_out;		/* File for interacting with user.  */
+   int old_tape_des;
+   char *next_archive_name;
+-  dynamic_string new_name;
++  dynamic_string new_name = DYNAMIC_STRING_INITIALIZER;
+   char *str_res;
+ 
+-  ds_init (&new_name, 128);
+-
+   /* Open files for interactive communication.  */
+   tty_in = fopen (TTY_NAME, "r");
+   if (tty_in == NULL)
+@@ -925,7 +923,7 @@ get_next_reel (int tape_des)
+     error (PAXEXIT_FAILURE, 0, _("internal error: tape descriptor changed from %d to %d"),
+ 	   old_tape_des, tape_des);
+ 
+-  free (new_name.ds_string);
++  ds_free (&new_name);
+   fclose (tty_in);
+   fclose (tty_out);
+ }
+-- 
+cgit v1.2.1
+
+
+https://git.savannah.gnu.org/cgit/cpio.git/commit/?id=dfc801c44a93bed7b3951905b188823d6a0432c8
+
+author	Sergey Poznyakoff <gray@gnu.org>	2021-08-11 18:10:38 +0300
+committer	Sergey Poznyakoff <gray@gnu.org>	2021-08-11 18:10:38 +0300
+commit	dfc801c44a93bed7b3951905b188823d6a0432c8 (patch)
+tree	3819af8593dc8beb29cb419e98691850947e425d
+parent	dd96882877721703e19272fe25034560b794061b (diff)
+download	cpio-dfc801c44a93bed7b3951905b188823d6a0432c8.tar.gz
+
+Fix previous commit
+
+* src/dstring.c (ds_reset,ds_concat): Don't call ds_resize in a
+loop.
+
+diff --git a/src/dstring.c b/src/dstring.c
+index 692d3e7..b7e0bb5 100644
+--- a/src/dstring.c
++++ b/src/dstring.c
+@@ -64,7 +64,7 @@ void
+ ds_reset (dynamic_string *s, size_t len)
+ {
+   while (len > s->ds_size)
+-    ds_resize (s);
++    s->ds_string = x2nrealloc (s->ds_string, &s->ds_size, 1);
+   s->ds_idx = len;
+ }
+ 
+@@ -116,7 +116,7 @@ ds_concat (dynamic_string *s, char const *str)
+ {
+   size_t len = strlen (str);
+   while (len + 1 > s->ds_size)
+-    ds_resize (s);
++    s->ds_string = x2nrealloc (s->ds_string, &s->ds_size, 1);
+   memcpy (s->ds_string + s->ds_idx, str, len);
+   s->ds_idx += len;
+   s->ds_string[s->ds_idx] = 0;
+
+
+https://git.savannah.gnu.org/cgit/cpio.git/commit/?id=236684f6deb3178043fe72a8e2faca538fa2aae1
+
+author	Sergey Poznyakoff <gray@gnu.org>	2021-08-18 09:41:39 +0300
+committer	Sergey Poznyakoff <gray@gnu.org>	2021-08-18 09:41:39 +0300
+commit	236684f6deb3178043fe72a8e2faca538fa2aae1 (patch)
+tree	55a49d2a190db2c4d0239cb66fa5d679962da0c5
+parent	dfc801c44a93bed7b3951905b188823d6a0432c8 (diff)
+download	cpio-236684f6deb3178043fe72a8e2faca538fa2aae1.tar.gz
+
+Fix dynamic string reallocations
+
+* src/dstring.c (ds_resize): Take additional argument: number of
+bytes to leave available after ds_idx.  All uses changed.
+
+
+
+diff --git a/src/dstring.c b/src/dstring.c
+index b7e0bb5..fd4e030 100644
+--- a/src/dstring.c
++++ b/src/dstring.c
+@@ -49,9 +49,9 @@ ds_free (dynamic_string *string)
+ /* Expand dynamic string STRING, if necessary.  */
+ 
+ void
+-ds_resize (dynamic_string *string)
++ds_resize (dynamic_string *string, size_t len)
+ {
+-  if (string->ds_idx == string->ds_size)
++  while (len + string->ds_idx >= string->ds_size)
+     {
+       string->ds_string = x2nrealloc (string->ds_string, &string->ds_size,
+ 				      1);
+@@ -63,8 +63,7 @@ ds_resize (dynamic_string *string)
+ void
+ ds_reset (dynamic_string *s, size_t len)
+ {
+-  while (len > s->ds_size)
+-    s->ds_string = x2nrealloc (s->ds_string, &s->ds_size, 1);
++  ds_resize (s, len);
+   s->ds_idx = len;
+ }
+ 
+@@ -86,10 +85,10 @@ ds_fgetstr (FILE *f, dynamic_string *s, char eos)
+   /* Read the input string.  */
+   while ((next_ch = getc (f)) != eos && next_ch != EOF)
+     {
+-      ds_resize (s);
++      ds_resize (s, 0);
+       s->ds_string[s->ds_idx++] = next_ch;
+     }
+-  ds_resize (s);
++  ds_resize (s, 0);
+   s->ds_string[s->ds_idx] = '\0';
+ 
+   if (s->ds_idx == 0 && next_ch == EOF)
+@@ -101,12 +100,12 @@ ds_fgetstr (FILE *f, dynamic_string *s, char eos)
+ void
+ ds_append (dynamic_string *s, int c)
+ {
+-  ds_resize (s);
++  ds_resize (s, 0);
+   s->ds_string[s->ds_idx] = c;
+   if (c)
+     {
+       s->ds_idx++;
+-      ds_resize (s);
++      ds_resize (s, 0);
+       s->ds_string[s->ds_idx] = 0;
+     }      
+ }
+@@ -115,8 +114,7 @@ void
+ ds_concat (dynamic_string *s, char const *str)
+ {
+   size_t len = strlen (str);
+-  while (len + 1 > s->ds_size)
+-    s->ds_string = x2nrealloc (s->ds_string, &s->ds_size, 1);
++  ds_resize (s, len);
+   memcpy (s->ds_string + s->ds_idx, str, len);
+   s->ds_idx += len;
+   s->ds_string[s->ds_idx] = 0;

--- a/SPECS/cpio/cpio.spec
+++ b/SPECS/cpio/cpio.spec
@@ -3,23 +3,22 @@ Name:           cpio
 Version:        2.13
 Release:        4%{?dist}
 License:        GPLv3+
-URL:            https://www.gnu.org/software/cpio/
-Group:          System Environment/System utilities
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
+Group:          System Environment/System utilities
+URL:            https://www.gnu.org/software/cpio/
 Source0:        https://ftp.gnu.org/gnu/%{name}/%{name}-%{version}.tar.bz2
 Patch0:         cpio_extern_nocommon.patch
 Patch1:         CVE-2021-38185.patch
-
 Conflicts:      toybox
 
 %description
 The cpio package contains tools for archiving.
 
 %package lang
-Summary: Additional language files for cpio
-Group:   System Environment/System utilities
-Requires: %{name} = %{version}-%{release}
+Summary:        Additional language files for cpio
+Group:          System Environment/System utilities
+Requires:       %{name} = %{version}-%{release}
 
 %description lang
 These are the additional language files of cpio
@@ -33,7 +32,7 @@ sed -i -e '/gets is a/d' gnu/stdio.in.h
     --prefix=%{_prefix} \
     --bindir=%{_bindir} \
     --enable-mt   \
-    --with-rmt=/usr/libexec/rmt
+    --with-rmt=%{_libexecdir}/rmt
 make %{?_smp_mflags}
 makeinfo --html            -o doc/html      doc/cpio.texi
 makeinfo --html --no-split -o doc/cpio.html doc/cpio.texi
@@ -61,27 +60,38 @@ make %{?_smp_mflags} check
 %defattr(-,root,root)
 
 %changelog
-* Wed May 18 2022 Chris Co <chrco@microsoft.com> 2.13-4
+* Wed May 18 2022 Chris Co <chrco@microsoft.com> - 2.13-4
 - Address CVE-2021-38185
-* Fri Oct 22 2021 Andrew Phelps <anphel@microsoft.com> 2.13-3
+- Fix lint
+
+* Fri Oct 22 2021 Andrew Phelps <anphel@microsoft.com> - 2.13-3
 - Add patch for gcc 11 compatability
-* Sat May 09 2020 Nick Samson <nisamson@microsoft.com> 2.13-2
+
+* Sat May 09 2020 Nick Samson <nisamson@microsoft.com> - 2.13-2
 - Added %%license line automatically
-* Fri May 01 2020 Pawel Winogrodzki <pawelwi@microsoft.com> 2.13-1
+
+* Fri May 01 2020 Pawel Winogrodzki <pawelwi@microsoft.com> - 2.13-1
 - Bumping version up to 2.13 to fix CVE-2019-14866.
 - Fixed "Source0" and "URL" tags.
 - License verified.
-* Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 2.12-5
+
+* Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> - 2.12-5
 - Initial CBL-Mariner import from Photon (license: Apache2).
-* Mon Oct 02 2017 Alexey Makhalov <amakhalov@vmware.com> 2.12-4
+
+* Mon Oct 02 2017 Alexey Makhalov <amakhalov@vmware.com> - 2.12-4
 - Added conflicts toybox
-* Tue May 02 2017 Anish Swaminathan <anishs@vmware.com> 2.12-3
+
+* Tue May 02 2017 Anish Swaminathan <anishs@vmware.com> - 2.12-3
 - Add lang package
-* Tue May 24 2016 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 2.12-2
+
+* Tue May 24 2016 Priyesh Padmavilasom <ppadmavilasom@vmware.com> - 2.12-2
 - GA - Bump release of all rpms
-* Thu Jan 14 2016 Xiaolin Li <xiaolinl@vmware.com> 2.12-1
+
+* Thu Jan 14 2016 Xiaolin Li <xiaolinl@vmware.com> - 2.12-1
 - Updated to version 2.12
-* Fri Aug 14 2015 Divya Thaluru <dthaluru@vmware.com> 2.11-2
+
+* Fri Aug 14 2015 Divya Thaluru <dthaluru@vmware.com> - 2.11-2
 - Adding security patch for CVE-2014-9112
-* Tue Nov 04 2014 Divya Thaluru <dthaluru@vmware.com> 2.11-1
+
+* Tue Nov 04 2014 Divya Thaluru <dthaluru@vmware.com> - 2.11-1
 - Initial build. First version

--- a/SPECS/cpio/cpio.spec
+++ b/SPECS/cpio/cpio.spec
@@ -1,7 +1,7 @@
 Summary:        cpio-2.13
 Name:           cpio
 Version:        2.13
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        GPLv3+
 URL:            https://www.gnu.org/software/cpio/
 Group:          System Environment/System utilities
@@ -9,6 +9,7 @@ Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Source0:        https://ftp.gnu.org/gnu/%{name}/%{name}-%{version}.tar.bz2
 Patch0:         cpio_extern_nocommon.patch
+Patch1:         CVE-2021-38185.patch
 
 Conflicts:      toybox
 
@@ -60,6 +61,8 @@ make %{?_smp_mflags} check
 %defattr(-,root,root)
 
 %changelog
+* Wed May 18 2022 Chris Co <chrco@microsoft.com> 2.13-4
+- Address CVE-2021-38185
 * Fri Oct 22 2021 Andrew Phelps <anphel@microsoft.com> 2.13-3
 - Add patch for gcc 11 compatability
 * Sat May 09 2020 Nick Samson <nisamson@microsoft.com> 2.13-2

--- a/toolkit/.gitignore
+++ b/toolkit/.gitignore
@@ -4,6 +4,7 @@ out/
 scripts/toolchain/container/.bashrc
 scripts/toolchain/container/coreutils-fix-get-sys_getdents-aarch64.patch
 scripts/toolchain/container/cpio_extern_nocommon.patch
+scripts/toolchain/container/CVE-2021-38185.patch
 scripts/toolchain/container/linker-script-readonly-keyword-support.patch
 scripts/toolchain/container/rpm-define-RPM-LD-FLAGS.patch
 scripts/toolchain/container/texinfo-perl-fix.patch

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -182,8 +182,8 @@ rpm-build-libs-4.17.0-7.cm2.aarch64.rpm
 rpm-devel-4.17.0-7.cm2.aarch64.rpm
 rpm-lang-4.17.0-7.cm2.aarch64.rpm
 rpm-libs-4.17.0-7.cm2.aarch64.rpm
-cpio-2.13-3.cm2.aarch64.rpm
-cpio-lang-2.13-3.cm2.aarch64.rpm
+cpio-2.13-4.cm2.aarch64.rpm
+cpio-lang-2.13-4.cm2.aarch64.rpm
 e2fsprogs-libs-1.46.5-1.cm2.aarch64.rpm
 libsolv-0.7.20-1.cm2.aarch64.rpm
 libsolv-devel-0.7.20-1.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -182,8 +182,8 @@ rpm-build-libs-4.17.0-7.cm2.x86_64.rpm
 rpm-devel-4.17.0-7.cm2.x86_64.rpm
 rpm-lang-4.17.0-7.cm2.x86_64.rpm
 rpm-libs-4.17.0-7.cm2.x86_64.rpm
-cpio-2.13-3.cm2.x86_64.rpm
-cpio-lang-2.13-3.cm2.x86_64.rpm
+cpio-2.13-4.cm2.x86_64.rpm
+cpio-lang-2.13-4.cm2.x86_64.rpm
 e2fsprogs-libs-1.46.5-1.cm2.x86_64.rpm
 libsolv-0.7.20-1.cm2.x86_64.rpm
 libsolv-devel-0.7.20-1.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -33,9 +33,9 @@ cmake-debuginfo-3.21.4-2.cm2.aarch64.rpm
 coreutils-8.32-3.cm2.aarch64.rpm
 coreutils-debuginfo-8.32-3.cm2.aarch64.rpm
 coreutils-lang-8.32-3.cm2.aarch64.rpm
-cpio-2.13-3.cm2.aarch64.rpm
-cpio-debuginfo-2.13-3.cm2.aarch64.rpm
-cpio-lang-2.13-3.cm2.aarch64.rpm
+cpio-2.13-4.cm2.aarch64.rpm
+cpio-debuginfo-2.13-4.cm2.aarch64.rpm
+cpio-lang-2.13-4.cm2.aarch64.rpm
 cracklib-2.9.7-4.cm2.aarch64.rpm
 cracklib-debuginfo-2.9.7-4.cm2.aarch64.rpm
 cracklib-devel-2.9.7-4.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -33,9 +33,9 @@ cmake-debuginfo-3.21.4-2.cm2.x86_64.rpm
 coreutils-8.32-3.cm2.x86_64.rpm
 coreutils-debuginfo-8.32-3.cm2.x86_64.rpm
 coreutils-lang-8.32-3.cm2.x86_64.rpm
-cpio-2.13-3.cm2.x86_64.rpm
-cpio-debuginfo-2.13-3.cm2.x86_64.rpm
-cpio-lang-2.13-3.cm2.x86_64.rpm
+cpio-2.13-4.cm2.x86_64.rpm
+cpio-debuginfo-2.13-4.cm2.x86_64.rpm
+cpio-lang-2.13-4.cm2.x86_64.rpm
 cracklib-2.9.7-4.cm2.x86_64.rpm
 cracklib-debuginfo-2.9.7-4.cm2.x86_64.rpm
 cracklib-devel-2.9.7-4.cm2.x86_64.rpm

--- a/toolkit/scripts/toolchain/container/Dockerfile
+++ b/toolkit/scripts/toolchain/container/Dockerfile
@@ -93,6 +93,7 @@ COPY [ "./toolchain_initial_chroot_setup.sh", \
        "./go14_bootstrap_aarch64.patch", \
        "./rpm-define-RPM-LD-FLAGS.patch", \
        "./cpio_extern_nocommon.patch", \
+       "./CVE-2021-38185.patch", \
        "./CVE-2021-36690.patch", \
        "$LFS/tools/" ]
 

--- a/toolkit/scripts/toolchain/container/toolchain_build_in_chroot.sh
+++ b/toolkit/scripts/toolchain/container/toolchain_build_in_chroot.sh
@@ -1043,6 +1043,7 @@ echo cpio-2.13
 tar xjf cpio-2.13.tar.bz2
 pushd cpio-2.13
 patch -Np1 -i /tools/cpio_extern_nocommon.patch
+patch -Np1 -i /tools/CVE-2021-38185.patch
 ./configure --prefix=/usr \
         --bindir=/bin \
         --enable-mt   \

--- a/toolkit/scripts/toolchain/create_toolchain_in_container.sh
+++ b/toolkit/scripts/toolchain/create_toolchain_in_container.sh
@@ -20,6 +20,7 @@ docker ps -a
 
 # CPIO patch
 cp -v $MARINER_SPECS_DIR/cpio/cpio_extern_nocommon.patch ./container
+cp -v $MARINER_SPECS_DIR/cpio/CVE-2021-38185.patch ./container
 # Coreutils aarch64 patch
 cp -v $MARINER_SPECS_DIR/coreutils/coreutils-fix-get-sys_getdents-aarch64.patch ./container
 # Binutils readonly patch
@@ -72,6 +73,7 @@ popd
 rm -vf ./container/rpm-define-RPM-LD-FLAGS.patch
 rm -vf ./container/coreutils-fix-get-sys_getdents-aarch64.patch
 rm -vf ./container/cpio_extern_nocommon.patch
+rm -vf ./container/CVE-2021-38185.patch
 rm -vf ./container/linker-script-readonly-keyword-support.patch
 rm -vf ./container/.bashrc
 rm -vf ./container/toolchain-local-wget-list


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
cpio: address CVE-2021-38185

Apply upstream fix and associated fixes for additional regressions found
upstream.

For more context, see mail thread:
https://lists.gnu.org/archive/html/bug-cpio/2021-08/msg00000.html

This patch file was sourced from #1365

Signed-off-by: Chris Co <chrco@microsoft.com>

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Apply patch CVE-2021-38185 to cpio package
- Update toolchain scripts to build with patched cpio
- Update manifest files

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2021-38185

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build
- Pipeline build x86_64 (195028), ARM64 (195038)