### PR TITLE
Overwrite 99-dhcp-en.network for marketplace img

### DIFF
--- a/toolkit/imageconfigs/additionalconfigs/configure-image.sh
+++ b/toolkit/imageconfigs/additionalconfigs/configure-image.sh
@@ -1,2 +1,6 @@
 echo Enabling service for Azure Serial Console
 systemctl enable serial-getty@ttyS0.service
+if [[ -f "/etc/systemd/network/99-dhcp-en.network" ]]; then
+    echo Removing 99-dhcp-en.network file
+    rm /etc/systemd/network/99-dhcp-en.network
+fi

--- a/toolkit/imageconfigs/additionalconfigs/configure-image.sh
+++ b/toolkit/imageconfigs/additionalconfigs/configure-image.sh
@@ -2,6 +2,5 @@ echo Enabling service for Azure Serial Console
 systemctl enable serial-getty@ttyS0.service
 if [[ -f "/etc/systemd/network/99-dhcp-en.network" ]]; then
     echo Removing contents of 99-dhcp-en.network file
-    rm /etc/systemd/network/99-dhcp-en.network
-    touch /etc/systemd/network/99-dhcp-en.network
+    truncate -s 0 /etc/systemd/network/99-dhcp-en.network
 fi

--- a/toolkit/imageconfigs/additionalconfigs/configure-image.sh
+++ b/toolkit/imageconfigs/additionalconfigs/configure-image.sh
@@ -1,6 +1,7 @@
 echo Enabling service for Azure Serial Console
 systemctl enable serial-getty@ttyS0.service
 if [[ -f "/etc/systemd/network/99-dhcp-en.network" ]]; then
-    echo Removing 99-dhcp-en.network file
+    echo Removing contents of 99-dhcp-en.network file
     rm /etc/systemd/network/99-dhcp-en.network
+    touch /etc/systemd/network/99-dhcp-en.network
 fi


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
Remove 99-dhcp-en.network for marketplace img

###### Change Log  <!-- REQUIRED -->
- Remove dhcp config file that assigns IP to all ethernet ports (by matching with e*) (https://github.com/microsoft/CBL-Mariner/blob/main/SPECS/systemd/99-dhcp-en.network) . Fixes bug in Azure VMs having accelerated networking enabled. We have netplan enabled which takes care of bringing up the correct network configuration in Azure VMs
- Removing contents rather than removing the file to ensure the file doesn't get reintroduced on systemd package updates

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Associated issues  <!-- optional -->
- https://microsoft.visualstudio.com/OS/_workitems/edit/39528347

###### Test Methodology
- Built a new image and verified that the file is deleted. On a separate VM with Accelerated Networking enabled, verified that removing the file and rebooting removes IP assigned to any other driver besides netvsc