### PR TITLE
cracklib: remove /usr/sbin/packer symlink due to conflict

### DIFF
--- a/SPECS/cracklib/cracklib.spec
+++ b/SPECS/cracklib/cracklib.spec
@@ -5,7 +5,7 @@
 Summary:          A password strength-checking library.
 Name:             cracklib
 Version:          2.9.7
-Release:          2%{?dist}
+Release:          3%{?dist}
 Group:            System Environment/Libraries
 URL:              https://github.com/cracklib/cracklib
 License:          LGPLv2+
@@ -134,7 +134,6 @@ util/cracklib-format dicts/cracklib* | util/cracklib-packer $RPM_BUILD_ROOT/%{_d
 echo password | util/cracklib-packer $RPM_BUILD_ROOT/%{_datadir}/cracklib/empty
 rm -f $RPM_BUILD_ROOT/%{_datadir}/cracklib/cracklib-small
 ln -s cracklib-format $RPM_BUILD_ROOT/%{_sbindir}/mkdict
-ln -s cracklib-packer $RPM_BUILD_ROOT/%{_sbindir}/packer
 
 pushd python
 python2 setup.py install --skip-build --root %{buildroot}
@@ -210,6 +209,9 @@ rm -f %{_datadir}/cracklib/pw_dict.pwi
 %{_datadir}/locale/*
 
 %changelog
+* Thu May 19 2022 Olivia Crain <oliviacrain@microsoft.com> - 2.9.7-3
+- Remove packer symlink- not necessary, conflicts with Hasicorp's Packer tool
+
 * Sat May 09 2020 Nick Samson <nisamson@microsoft.com> - 2.9.7-2
 - Added %%license line automatically
 

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -37,12 +37,12 @@ coreutils-lang-8.30-11.cm1.aarch64.rpm
 cpio-2.13-3.cm1.aarch64.rpm
 cpio-debuginfo-2.13-3.cm1.aarch64.rpm
 cpio-lang-2.13-3.cm1.aarch64.rpm
-cracklib-2.9.7-2.cm1.aarch64.rpm
-cracklib-debuginfo-2.9.7-2.cm1.aarch64.rpm
-cracklib-devel-2.9.7-2.cm1.aarch64.rpm
-cracklib-dicts-2.9.7-2.cm1.aarch64.rpm
-cracklib-lang-2.9.7-2.cm1.aarch64.rpm
-cracklib-python-2.9.7-2.cm1.aarch64.rpm
+cracklib-2.9.7-3.cm1.aarch64.rpm
+cracklib-debuginfo-2.9.7-3.cm1.aarch64.rpm
+cracklib-devel-2.9.7-3.cm1.aarch64.rpm
+cracklib-dicts-2.9.7-3.cm1.aarch64.rpm
+cracklib-lang-2.9.7-3.cm1.aarch64.rpm
+cracklib-python-2.9.7-3.cm1.aarch64.rpm
 createrepo_c-0.11.1-6.cm1.aarch64.rpm
 createrepo_c-debuginfo-0.11.1-6.cm1.aarch64.rpm
 createrepo_c-devel-0.11.1-6.cm1.aarch64.rpm
@@ -354,7 +354,7 @@ python2-libs-2.7.18-9.cm1.aarch64.rpm
 python2-test-2.7.18-9.cm1.aarch64.rpm
 python2-tools-2.7.18-9.cm1.aarch64.rpm
 python3-audit-3.0-15.cm1.aarch64.rpm
-python3-cracklib-2.9.7-2.cm1.aarch64.rpm
+python3-cracklib-2.9.7-3.cm1.aarch64.rpm
 python3-gpg-1.13.1-6.cm1.aarch64.rpm
 python3-libcap-ng-0.7.9-3.cm1.aarch64.rpm
 python3-libxml2-2.9.13-1.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -37,12 +37,12 @@ coreutils-lang-8.30-11.cm1.x86_64.rpm
 cpio-2.13-3.cm1.x86_64.rpm
 cpio-debuginfo-2.13-3.cm1.x86_64.rpm
 cpio-lang-2.13-3.cm1.x86_64.rpm
-cracklib-2.9.7-2.cm1.x86_64.rpm
-cracklib-debuginfo-2.9.7-2.cm1.x86_64.rpm
-cracklib-devel-2.9.7-2.cm1.x86_64.rpm
-cracklib-dicts-2.9.7-2.cm1.x86_64.rpm
-cracklib-lang-2.9.7-2.cm1.x86_64.rpm
-cracklib-python-2.9.7-2.cm1.x86_64.rpm
+cracklib-2.9.7-3.cm1.x86_64.rpm
+cracklib-debuginfo-2.9.7-3.cm1.x86_64.rpm
+cracklib-devel-2.9.7-3.cm1.x86_64.rpm
+cracklib-dicts-2.9.7-3.cm1.x86_64.rpm
+cracklib-lang-2.9.7-3.cm1.x86_64.rpm
+cracklib-python-2.9.7-3.cm1.x86_64.rpm
 createrepo_c-0.11.1-6.cm1.x86_64.rpm
 createrepo_c-debuginfo-0.11.1-6.cm1.x86_64.rpm
 createrepo_c-devel-0.11.1-6.cm1.x86_64.rpm
@@ -354,7 +354,7 @@ python2-libs-2.7.18-9.cm1.x86_64.rpm
 python2-test-2.7.18-9.cm1.x86_64.rpm
 python2-tools-2.7.18-9.cm1.x86_64.rpm
 python3-audit-3.0-15.cm1.x86_64.rpm
-python3-cracklib-2.9.7-2.cm1.x86_64.rpm
+python3-cracklib-2.9.7-3.cm1.x86_64.rpm
 python3-gpg-1.13.1-6.cm1.x86_64.rpm
 python3-libcap-ng-0.7.9-3.cm1.x86_64.rpm
 python3-libxml2-2.9.13-1.cm1.x86_64.rpm


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
The `cracklib` package has a symlink from `/usr/sbin/packer` to `/usr/sbin/cracklib-packer`. The symlink conflicts with the HashiCorp's Packer utility. Specifically, some users will install `packer` as `/usr/bin/packer` and call the `packer` binary without a fully qualified path. Due to the ordering of our default `PATH`, users will end up calling `cracklib-packer` when they really intend to .

Normally I would say we shouldn't change our package because of this... but I can't find any historical reason for this symlink. Fedora actually ended up removing this symlink for the exact same reason we are.

So, let's just remove the symlink in this case. 

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Remove `/usr/sbin/packer` symlink from `cracklib`

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-YYYY-XXXX

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Full pipeline build, inspected package to ensure symlink is no longer present.
