### PR TITLE
dnf-plugins-core: Add patch to fix wrong boot time

### DIFF
--- a/SPECS/dnf-plugins-core/Fix-wrong-boot-time-RhBug-1960437.patch
+++ b/SPECS/dnf-plugins-core/Fix-wrong-boot-time-RhBug-1960437.patch
@@ -1,0 +1,25 @@
+From 23cad14789fc8d2c327b9350c25c9edb7929a83c Mon Sep 17 00:00:00 2001
+From: Nicola Sella <nsella@redhat.com>
+Date: Thu, 8 Jul 2021 15:54:21 +0200
+Subject: [PATCH] Fix wrong boot time (RhBug:1960437)
+
+---
+ plugins/needs_restarting.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/plugins/needs_restarting.py b/plugins/needs_restarting.py
+index 1fedb73..91dbe66 100644
+--- a/plugins/needs_restarting.py
++++ b/plugins/needs_restarting.py
+@@ -199,7 +199,7 @@ class ProcessStart(object):
+ 
+     @staticmethod
+     def get_boot_time():
+-        return int(os.stat('/proc/1/cmdline').st_mtime)
++        return int(os.stat('/proc/1').st_mtime)
+ 
+     @staticmethod
+     def get_sc_clk_tck():
+-- 
+2.17.1
+

--- a/SPECS/dnf-plugins-core/dnf-plugins-core.spec
+++ b/SPECS/dnf-plugins-core/dnf-plugins-core.spec
@@ -6,7 +6,7 @@
 Summary:        Core Plugins for DNF
 Name:           dnf-plugins-core
 Version:        4.0.22
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        GPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -14,6 +14,7 @@ Group:          Applications/System
 URL:            https://github.com/rpm-software-management/dnf-plugins-core
 #Source0:        https://github.com/rpm-software-management/dnf-plugins-core/archive/refs/tags/%{version}.tar.gz
 Source0:        %{name}-%{version}.tar.gz
+Patch0:         Fix-wrong-boot-time-RhBug-1960437.patch
 
 BuildRequires:  cmake
 BuildRequires:  git
@@ -99,7 +100,7 @@ repoquery, reposync, repotrack, repodiff, builddep, config-manager, debug,
 download and yum-groups-manager that use new implementations using DNF.
 
 %prep
-%autosetup
+%autosetup -p1
 mkdir build
 mkdir build-py3
 
@@ -222,6 +223,9 @@ ln -sf %{_libexecdir}/dnf-utils %{buildroot}%{_bindir}/yumdownloader
 %{_mandir}/man1/yum-utils.*
 
 %changelog
+* Thu May 19 2022 Chris Co <chrco@microsoft.com> - 4.0.22-3
+- Add patch to fix wrong boot time for needs-restarting
+
 * Fri Jul 30 2021 Neha Agarwal <nehaagarwal@microsoft.com> - 4.0.22-2
 - Initial CBL-Mariner import from rpm-software-management (license: GPLv2+). License verified.
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
dnf-plugins-core: Add patch to fix wrong boot time

Current needs-restarting relies on the stat mtime from /proc/1/cmdline
to determine when the system booted. However this value can update over
the lifetime of the VM for various reasons, causing needs-restarting to
think that a kernel/systemd package was installed before the system
rebooted, so it won't try to trigger a reboot when it is actually
required.

Backport upstream fix for this issue:
https://github.com/rpm-software-management/dnf-plugins-core/commit/ece8e77155919409d344d405ec4ed19d16a522aa

Signed-off-by: Chris Co <chrco@microsoft.com>

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://microsoft.visualstudio.com/OS/_workitems/edit/39382859

###### Links to CVEs  <!-- optional -->

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build
