### PR TITLE
mariadb: update to v10.6.8 to address CVE-2022-27448, CVE-2022-27449, CVE-2022-27451, CVE-2022-27457, CVE-2022-27458

### DIFF
--- a/SPECS/mariadb/CVE-2022-27448.nopatch
+++ b/SPECS/mariadb/CVE-2022-27448.nopatch
@@ -1,0 +1,3 @@
+CVE-2022-27448 - Fixed in v10.6.8
+
+https://jira.mariadb.org/browse/MDEV-28095

--- a/SPECS/mariadb/CVE-2022-27449.nopatch
+++ b/SPECS/mariadb/CVE-2022-27449.nopatch
@@ -1,0 +1,3 @@
+CVE-2022-27449 - Fixed in v10.6.8
+
+https://jira.mariadb.org/browse/MDEV-28089

--- a/SPECS/mariadb/CVE-2022-27451.nopatch
+++ b/SPECS/mariadb/CVE-2022-27451.nopatch
@@ -1,0 +1,3 @@
+CVE-2022-27451 - Fixed in v10.6.8
+
+https://jira.mariadb.org/browse/MDEV-28094

--- a/SPECS/mariadb/CVE-2022-27457.nopatch
+++ b/SPECS/mariadb/CVE-2022-27457.nopatch
@@ -1,0 +1,3 @@
+CVE-2022-27457 - Fixed in v10.6.8
+
+https://jira.mariadb.org/browse/MDEV-28098

--- a/SPECS/mariadb/CVE-2022-27458.nopatch
+++ b/SPECS/mariadb/CVE-2022-27458.nopatch
@@ -1,0 +1,3 @@
+CVE-2022-27458 - Fixed in v10.6.8
+
+https://jira.mariadb.org/browse/MDEV-28099

--- a/SPECS/mariadb/mariadb.signatures.json
+++ b/SPECS/mariadb/mariadb.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "mariadb-10.6.7.tar.gz": "e1814b386a1f2b42506f7bb332a8ddcbe3521d79c363282de18329892911b912"
+  "mariadb-10.6.8.tar.gz": "ce5297cb8fc0875a29bba4cff90a09090f0bfccf788e8d04d9361ba955d4ee41"
  }
 }

--- a/SPECS/mariadb/mariadb.spec
+++ b/SPECS/mariadb/mariadb.spec
@@ -1,7 +1,7 @@
 Summary:        Database servers made by the original developers of MySQL.
 Name:           mariadb
-Version:        10.6.7
-Release:        2%{?dist}
+Version:        10.6.8
+Release:        1%{?dist}
 License:        GPLv2 WITH exceptions AND LGPLv2 AND BSD
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -454,6 +454,10 @@ fi
 %{_datadir}/mysql/hindi/errmsg.sys
 
 %changelog
+* Fri May 20 2022 Chris Co <chrco@microsoft.com> - 10.6.8-1
+- Upgrade to v10.6.8 to address CVE-2022-27448, CVE-2022-27449,
+  CVE-2022-27451, CVE-2022-27457, CVE-2022-27458
+
 * Fri Apr 29 2022 Olivia Crain <oliviacrain@microsoft.com> - 10.6.7-2
 - Fix conflicts with mariadb-connector-c
 

--- a/SPECS/mariadb/mariadb.spec
+++ b/SPECS/mariadb/mariadb.spec
@@ -302,6 +302,7 @@ fi
 %{_bindir}/replace
 %{_bindir}/resolve_stack_dump
 %{_bindir}/resolveip
+%{_bindir}/wsrep_sst_backup
 %{_bindir}/wsrep_sst_common
 %{_bindir}/wsrep_sst_mariabackup
 %{_bindir}/wsrep_sst_mysqldump
@@ -427,6 +428,8 @@ fi
 %{_mandir}/man3/*.3.gz
 
 %files errmsg
+%{_datadir}/mysql/bulgarian/errmsg.sys
+%{_datadir}/mysql/chinese/errmsg.sys
 %{_datadir}/mysql/czech/errmsg.sys
 %{_datadir}/mysql/danish/errmsg.sys
 %{_datadir}/mysql/dutch/errmsg.sys
@@ -457,6 +460,7 @@ fi
 * Fri May 20 2022 Chris Co <chrco@microsoft.com> - 10.6.8-1
 - Upgrade to v10.6.8 to address CVE-2022-27448, CVE-2022-27449,
   CVE-2022-27451, CVE-2022-27457, CVE-2022-27458
+- Add new files bulgarian errmsg.sys, chinese errmsg.sys, wsrep_sst_backup
 
 * Fri Apr 29 2022 Olivia Crain <oliviacrain@microsoft.com> - 10.6.7-2
 - Fix conflicts with mariadb-connector-c

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -11191,8 +11191,8 @@
         "type": "other",
         "other": {
           "name": "mariadb",
-          "version": "10.6.7",
-          "downloadUrl": "https://github.com/MariaDB/server/archive/mariadb-10.6.7.tar.gz"
+          "version": "10.6.8",
+          "downloadUrl": "https://github.com/MariaDB/server/archive/mariadb-10.6.8.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
mariadb: update to v10.6.8 

v10.6.8 addresses CVE-2022-27448, CVE-2022-27449, CVE-2022-27451,
CVE-2022-27457, CVE-2022-27458

Signed-off-by: Chris Co <chrco@microsoft.com>

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add new unpackaged files
- Update cgmanifest entry for mariadb

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2022-27448
- https://nvd.nist.gov/vuln/detail/CVE-2022-27449
- https://nvd.nist.gov/vuln/detail/CVE-2022-27451
- https://nvd.nist.gov/vuln/detail/CVE-2022-27457
- https://nvd.nist.gov/vuln/detail/CVE-2022-27458

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
Local build
