### PR TITLE
Update libxml2 to 2.9.14 to address CVE-2022-29824

### DIFF
--- a/SPECS/libxml2/libxml2.signatures.json
+++ b/SPECS/libxml2/libxml2.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
- "libxml2-v2.9.13.tar.gz": "0d676b10cfd13ab966907a3917bd86b17a1c22befdf42144cdc1ad5bb9e65c45"
+ "libxml2-v2.9.14.tar.gz": "80efe9e6b48f8aa7b9b0c47be427e2ef2dbfb2999124220ffbc0f43ca6adb98c"
  }
 }

--- a/SPECS/libxml2/libxml2.spec
+++ b/SPECS/libxml2/libxml2.spec
@@ -1,6 +1,6 @@
 Summary:        Libxml2
 Name:           libxml2
-Version:        2.9.13
+Version:        2.9.14
 Release:        1%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
@@ -80,6 +80,9 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %{_libdir}/cmake/libxml2/libxml2-config.cmake
 
 %changelog
+* Mon May 23 2022 Cameron Baird <cameronbaird@microsoft.com> - 2.9.14-1
+- Updating to version 2.9.14 to fix CVE-2022-29824.
+
 * Thu Mar 10 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 2.9.13-1
 - Updating to version 2.9.13 to fix CVE-2022-23308.
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -10381,8 +10381,8 @@
         "type": "other",
         "other": {
           "name": "libxml2",
-          "version": "2.9.13",
-          "downloadUrl": "https://gitlab.gnome.org/GNOME/libxml2/-/archive/v2.9.13/libxml2-v2.9.13.tar.gz"
+          "version": "2.9.14",
+          "downloadUrl": "https://gitlab.gnome.org/GNOME/libxml2/-/archive/v2.9.14/libxml2-v2.9.14.tar.gz"
         }
       }
     },

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -198,8 +198,8 @@ tdnf-cli-libs-3.2.2-4.cm2.aarch64.rpm
 tdnf-devel-3.2.2-4.cm2.aarch64.rpm
 tdnf-plugin-repogpgcheck-3.2.2-4.cm2.aarch64.rpm
 createrepo_c-0.17.5-1.cm2.aarch64.rpm
-libxml2-2.9.13-1.cm2.aarch64.rpm
-libxml2-devel-2.9.13-1.cm2.aarch64.rpm
+libxml2-2.9.14-1.cm2.aarch64.rpm
+libxml2-devel-2.9.14-1.cm2.aarch64.rpm
 libsepol-3.2-2.cm2.aarch64.rpm
 glib-2.71.0-1.cm2.aarch64.rpm
 libltdl-2.4.6-8.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -198,8 +198,8 @@ tdnf-cli-libs-3.2.2-4.cm2.x86_64.rpm
 tdnf-devel-3.2.2-4.cm2.x86_64.rpm
 tdnf-plugin-repogpgcheck-3.2.2-4.cm2.x86_64.rpm
 createrepo_c-0.17.5-1.cm2.x86_64.rpm
-libxml2-2.9.13-1.cm2.x86_64.rpm
-libxml2-devel-2.9.13-1.cm2.x86_64.rpm
+libxml2-2.9.14-1.cm2.x86_64.rpm
+libxml2-devel-2.9.14-1.cm2.x86_64.rpm
 libsepol-3.2-2.cm2.x86_64.rpm
 glib-2.71.0-1.cm2.x86_64.rpm
 libltdl-2.4.6-8.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -200,9 +200,9 @@ libtasn1-debuginfo-4.18.0-2.cm2.aarch64.rpm
 libtasn1-devel-4.18.0-2.cm2.aarch64.rpm
 libtool-2.4.6-8.cm2.aarch64.rpm
 libtool-debuginfo-2.4.6-8.cm2.aarch64.rpm
-libxml2-2.9.13-1.cm2.aarch64.rpm
-libxml2-debuginfo-2.9.13-1.cm2.aarch64.rpm
-libxml2-devel-2.9.13-1.cm2.aarch64.rpm
+libxml2-2.9.14-1.cm2.aarch64.rpm
+libxml2-debuginfo-2.9.14-1.cm2.aarch64.rpm
+libxml2-devel-2.9.14-1.cm2.aarch64.rpm
 libxslt-1.1.34-6.cm2.aarch64.rpm
 libxslt-debuginfo-1.1.34-6.cm2.aarch64.rpm
 libxslt-devel-1.1.34-6.cm2.aarch64.rpm
@@ -509,7 +509,7 @@ python3-devel-3.9.12-1.cm2.aarch64.rpm
 python3-gpg-1.16.0-1.cm2.aarch64.rpm
 python3-jinja2-3.0.3-2.cm2.noarch.rpm
 python3-libs-3.9.12-1.cm2.aarch64.rpm
-python3-libxml2-2.9.13-1.cm2.aarch64.rpm
+python3-libxml2-2.9.14-1.cm2.aarch64.rpm
 python3-lxml-4.8.0-1.cm2.aarch64.rpm
 python3-magic-5.40-2.cm2.noarch.rpm
 python3-markupsafe-2.1.0-1.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -200,9 +200,9 @@ libtasn1-debuginfo-4.18.0-2.cm2.x86_64.rpm
 libtasn1-devel-4.18.0-2.cm2.x86_64.rpm
 libtool-2.4.6-8.cm2.x86_64.rpm
 libtool-debuginfo-2.4.6-8.cm2.x86_64.rpm
-libxml2-2.9.13-1.cm2.x86_64.rpm
-libxml2-debuginfo-2.9.13-1.cm2.x86_64.rpm
-libxml2-devel-2.9.13-1.cm2.x86_64.rpm
+libxml2-2.9.14-1.cm2.x86_64.rpm
+libxml2-debuginfo-2.9.14-1.cm2.x86_64.rpm
+libxml2-devel-2.9.14-1.cm2.x86_64.rpm
 libxslt-1.1.34-6.cm2.x86_64.rpm
 libxslt-debuginfo-1.1.34-6.cm2.x86_64.rpm
 libxslt-devel-1.1.34-6.cm2.x86_64.rpm
@@ -509,7 +509,7 @@ python3-devel-3.9.12-1.cm2.x86_64.rpm
 python3-gpg-1.16.0-1.cm2.x86_64.rpm
 python3-jinja2-3.0.3-2.cm2.noarch.rpm
 python3-libs-3.9.12-1.cm2.x86_64.rpm
-python3-libxml2-2.9.13-1.cm2.x86_64.rpm
+python3-libxml2-2.9.14-1.cm2.x86_64.rpm
 python3-lxml-4.8.0-1.cm2.x86_64.rpm
 python3-magic-5.40-2.cm2.noarch.rpm
 python3-markupsafe-2.1.0-1.cm2.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Update libxml2 to 2.9.14 to address CVE-2022-29824
Addresses CVE-2022-29824 for both libxml2 and libxslt

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Update libxml2 to 2.9.14 

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
YES

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2022-29824

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- https://dev.azure.com/mariner-org/mariner/_build/results?buildId=196776&view=results
