### PR TITLE
ruby: Upgrade to 2.6.10 to fix CVE-2022-28739

### DIFF
--- a/SPECS/ruby/ruby.signatures.json
+++ b/SPECS/ruby/ruby.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "ruby-2.6.9.tar.xz": "6a041d82ae6e0f02ccb1465e620d94a7196489d8a13d6018a160da42ebc1eece"
+  "ruby-2.6.10.tar.xz": "5fd8ded51321b88fdc9c1b4b0eb1b951d2eddbc293865da0151612c2e814c1f2"
  }
 }

--- a/SPECS/ruby/ruby.spec
+++ b/SPECS/ruby/ruby.spec
@@ -1,6 +1,6 @@
 Summary:        Ruby
 Name:           ruby
-Version:        2.6.9
+Version:        2.6.10
 Release:        1%{?dist}
 License:        (Ruby OR BSD) AND Public Domain AND MIT AND CC0 AND zlib AND UCD
 Vendor:         Microsoft Corporation
@@ -62,6 +62,9 @@ sudo -u test make test TESTS="-v"
 %{_mandir}/man5/*
 
 %changelog
+* Tue May 31 2022 Olivia Crain <oliviacrain@microsoft.com> - 2.6.10-1
+- Upgrade to 2.6.10 to fix CVE-2022-28739
+
 * Tue Mar 01 2022 Nicolas Guibourge <nicolasg@microsoft.com> - 2.6.9-1
 - Upgrade to 2.6.9 to fix CVE-2021-41817, CVE-2021-41819
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -7135,8 +7135,8 @@
         "type": "other",
         "other": {
           "name": "ruby",
-          "version": "2.6.9",
-          "downloadUrl": "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.9.tar.xz"
+          "version": "2.6.10",
+          "downloadUrl": "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.10.tar.xz"
         }
       }
     },


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Upgrade `ruby` to the latest release in the 2.6 branch to fix CVE-2022-28739.

###### Change Log  <!-- REQUIRED -->
- `ruby`: Version bump 2.6.9 -> 2.6.10

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2022-28739

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Internal buddy build 199189
