### PR TITLE
mariadb: Upgrade to 10.3.35 to fix 20 CVEs

### DIFF
--- a/SPECS/mariadb/mariadb.signatures.json
+++ b/SPECS/mariadb/mariadb.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "mariadb-10.3.34.tar.gz": "b832d6031eb4a9c7bd80e4c8d9f884f036df94bcc0a2611ee9c7267faed1160b"
+  "mariadb-10.3.35.tar.gz": "0bdc95ae4afd2af3c73b87577e3f21143b82695a0f13f8827d9649a0dcee1837"
  }
 }

--- a/SPECS/mariadb/mariadb.spec
+++ b/SPECS/mariadb/mariadb.spec
@@ -255,6 +255,7 @@ rm -rf %{buildroot}
 %{_bindir}/replace
 %{_bindir}/resolve_stack_dump
 %{_bindir}/resolveip
+%{_bindir}/wsrep_sst_backup
 %{_bindir}/wsrep_sst_common
 %{_bindir}/wsrep_sst_mariabackup
 %{_bindir}/wsrep_sst_mysqldump

--- a/SPECS/mariadb/mariadb.spec
+++ b/SPECS/mariadb/mariadb.spec
@@ -1,6 +1,6 @@
 Summary:        Database servers made by the original developers of MySQL.
 Name:           mariadb
-Version:        10.3.34
+Version:        10.3.35
 Release:        1%{?dist}
 License:        GPLv2 WITH exceptions AND LGPLv2 AND BSD
 Vendor:         Microsoft Corporation
@@ -371,6 +371,13 @@ rm -rf %{buildroot}
 %{_datadir}/mysql/hindi/errmsg.sys
 
 %changelog
+* Tue May 31 2022 Olivia Crain <oliviacrain@microsoft.com> - 10.3.35-1
+- Upgrade to latest 10.3.X release to fix 20 CVEs:
+- CVE-2021-46669, CVE-2022-21427, CVE-2022-27376, CVE-2022-27377, CVE-2022-27378,
+- CVE-2022-27379, CVE-2022-27379, CVE-2022-27380, CVE-2022-27381, CVE-2022-27383,
+- CVE-2022-27384, CVE-2022-27386, CVE-2022-27387, CVE-2022-27445, CVE-2022-27447,
+- CVE-2022-27448, CVE-2022-27449, CVE-2022-27452, CVE-2022-27456, CVE-2022-27458
+
 * Mon Feb 28 2022 Nicolas Guibourge <nicolasg@microsoft.com> - 10.3.34-1
 - Upgrading to version 10.3.34
 - patch CVE-2021-46661, CVE-2021-46662, CVE-2021-46663, CVE-2021-46664, CVE-2021-46665, CVE-2021-46668

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -4195,8 +4195,8 @@
         "type": "other",
         "other": {
           "name": "mariadb",
-          "version": "10.3.34",
-          "downloadUrl": "https://github.com/MariaDB/server/archive/mariadb-10.3.34.tar.gz"
+          "version": "10.3.35",
+          "downloadUrl": "https://github.com/MariaDB/server/archive/mariadb-10.3.35.tar.gz"
         }
       }
     },


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Upgrade to the latest release in `mariadb`'s 10.3 release series to fix 20 CVEs.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- `mariadb`: Version bump 10.3.34 -> 10.3.35

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2021-46669
- https://nvd.nist.gov/vuln/detail/CVE-2022-21427
- https://nvd.nist.gov/vuln/detail/CVE-2022-27376
- https://nvd.nist.gov/vuln/detail/CVE-2022-27377
- https://nvd.nist.gov/vuln/detail/CVE-2022-27378
- https://nvd.nist.gov/vuln/detail/CVE-2022-27379
- https://nvd.nist.gov/vuln/detail/CVE-2022-27379
- https://nvd.nist.gov/vuln/detail/CVE-2022-27380
- https://nvd.nist.gov/vuln/detail/CVE-2022-27381
- https://nvd.nist.gov/vuln/detail/CVE-2022-27383
- https://nvd.nist.gov/vuln/detail/CVE-2022-27384
- https://nvd.nist.gov/vuln/detail/CVE-2022-27386
- https://nvd.nist.gov/vuln/detail/CVE-2022-27387
- https://nvd.nist.gov/vuln/detail/CVE-2022-27445
- https://nvd.nist.gov/vuln/detail/CVE-2022-27447
- https://nvd.nist.gov/vuln/detail/CVE-2022-27448
- https://nvd.nist.gov/vuln/detail/CVE-2022-27449
- https://nvd.nist.gov/vuln/detail/CVE-2022-27452
- https://nvd.nist.gov/vuln/detail/CVE-2022-27456
- https://nvd.nist.gov/vuln/detail/CVE-2022-27458

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Internal buddy build 199237
