### PR TITLE
selinux-policy: (backport) additional container/kubernetes patches + fixes from baremetal testing. 

### DIFF
--- a/SPECS/selinux-policy/0017-Add-cloud-init.patch
+++ b/SPECS/selinux-policy/0017-Add-cloud-init.patch
@@ -24,16 +24,17 @@ index 4c18154ce..1257de820 100644
  /usr/lib/dhcpcd/dhcpcd-run-hooks --	gen_context(system_u:object_r:bin_t,s0)
  /usr/lib/dovecot/.+			gen_context(system_u:object_r:bin_t,s0)
 diff --git a/policy/modules/system/systemd.te b/policy/modules/system/systemd.te
-index 287e30b51..64f09b7fc 100644
+index 287e30b51..c2e841358 100644
 --- a/policy/modules/system/systemd.te
 +++ b/policy/modules/system/systemd.te
-@@ -1849,3 +1849,17 @@ userdom_relabelto_user_runtime_dirs(systemd_user_runtime_dir_t)
+@@ -1849,3 +1849,18 @@ userdom_relabelto_user_runtime_dirs(systemd_user_runtime_dir_t)
  optional_policy(`
  	dbus_system_bus_client(systemd_user_runtime_dir_t)
  ')
 +
 +
 +# Temporary rules until cloud-init policy is implemented.
++allow fsadm_t initrc_tmp_t:file { getattr ioctl write };
 +allow mount_t initrc_runtime_t:dir mounton;
 +allow rpm_script_t initrc_t:fd use;
 +allow rpm_script_t initrc_t:fifo_file rw_inherited_fifo_file_perms;
@@ -46,5 +47,5 @@ index 287e30b51..64f09b7fc 100644
 +allow systemd_networkd_t init_runtime_t:dir list_dir_perms;
 +allow udev_t init_runtime_t:dir read;
 -- 
-2.17.1
+2.25.1
 

--- a/SPECS/selinux-policy/0018-Add-compatibility-for-container-selinux.patch
+++ b/SPECS/selinux-policy/0018-Add-compatibility-for-container-selinux.patch
@@ -1,0 +1,631 @@
+From da4c16c5905fd5a295f2ffb5e2e49b4444d8cbfe Mon Sep 17 00:00:00 2001
+From: Chris PeBenito <Christopher.PeBenito@microsoft.com>
+Date: Mon, 18 Apr 2022 15:15:34 +0000
+Subject: [PATCH 18/28] Add compatibility for container-selinux
+
+MSFT_TAG: Not upstreamable
+---
+ policy/modules/services/container.if        | 337 ++++++++++++++++++++
+ policy/modules/services/container_compat.fc |   1 +
+ policy/modules/services/container_compat.if |   1 +
+ policy/modules/services/container_compat.te | 202 ++++++++++++
+ 4 files changed, 541 insertions(+)
+ create mode 100644 policy/modules/services/container_compat.fc
+ create mode 100644 policy/modules/services/container_compat.if
+ create mode 100644 policy/modules/services/container_compat.te
+
+diff --git a/policy/modules/services/container.if b/policy/modules/services/container.if
+index e9217f639..87e310b15 100644
+--- a/policy/modules/services/container.if
++++ b/policy/modules/services/container.if
+@@ -797,6 +797,65 @@ interface(`container_manage_dirs',`
+ 	manage_dirs_pattern($1, container_file_t, container_file_t)
+ ')
+ 
++########################################
++## <summary>
++##	Allow the specified domain to
++##	relabel from and to container file directory type.
++## </summary>
++## <param name="domain">
++##	<summary>
++##	Domain allowed access.
++##	</summary>
++## </param>
++#
++interface(`container_relabel_dirs',`
++	gen_require(`
++		type container_file_t;
++	')
++
++	relabel_dirs_pattern($1, container_file_t, container_file_t)
++')
++
++########################################
++## <summary>
++##	Allow the specified domain to mmap executable
++##	container files with text relocations.
++## </summary>
++## <param name="domain">
++##	<summary>
++##	Domain allowed access.
++##	</summary>
++## </param>
++#
++interface(`container_textrel_mmap_exec_files',`
++	gen_require(`
++		type container_file_t;
++	')
++
++  	mmap_exec_files_pattern($1, container_file_t, container_file_t)
++	allow $1 container_file_t:file execmod;
++')
++
++########################################
++## <summary>
++##	Allow the specified domain to execute
++##	container files.
++## </summary>
++## <param name="domain">
++##	<summary>
++##	Domain allowed access.
++##	</summary>
++## </param>
++#
++interface(`container_exec_files',`
++	gen_require(`
++		type container_file_t;
++	')
++
++  	can_exec($1, container_file_t)
++')
++
++
+ ########################################
+ ## <summary>
+ ##	Allow the specified domain to
+@@ -816,6 +875,44 @@ interface(`container_manage_files',`
+ 	manage_files_pattern($1, container_file_t, container_file_t)
+ ')
+ 
++########################################
++## <summary>
++##	Allow the specified domain to
++##	relabel from and to container file type.
++## </summary>
++## <param name="domain">
++##	<summary>
++##	Domain allowed access.
++##	</summary>
++## </param>
++#
++interface(`container_relabel_files',`
++	gen_require(`
++		type container_file_t;
++	')
++
++	relabel_files_pattern($1, container_file_t, container_file_t)
++')
++
++########################################
++## <summary>
++##	Allow the specified domain to use container files
++##	as an entrypoint.
++## </summary>
++## <param name="domain">
++##	<summary>
++##	Domain allowed access.
++##	</summary>
++## </param>
++#
++interface(`container_file_entrypoint',`
++	gen_require(`
++		type container_file_t;
++	')
++
++	allow $1 container_file_t:file entrypoint;
++')
++
+ ########################################
+ ## <summary>
+ ##	Allow the specified domain to
+@@ -873,6 +970,44 @@ interface(`container_manage_sock_files',`
+ 	manage_sock_files_pattern($1, container_file_t, container_file_t)
+ ')
+ 
++########################################
++## <summary>
++##	Allow the specified domain to set
++##	the attributes of container block files.
++## </summary>
++## <param name="domain">
++##	<summary>
++##	Domain allowed access.
++##	</summary>
++## </param>
++#
++interface(`container_setattr_blk_files',`
++	gen_require(`
++		type container_file_t;
++	')
++
++	allow $1 container_file_t:blk_file setattr;
++')
++
++########################################
++## <summary>
++##	Allow the specified domain to read
++##	and write container block files.
++## </summary>
++## <param name="domain">
++##	<summary>
++##	Domain allowed access.
++##	</summary>
++## </param>
++#
++interface(`container_rw_blk_files',`
++	gen_require(`
++		type container_file_t;
++	')
++
++	allow $1 container_file_t:blk_file rw_blk_file_perms;
++')
++
+ ########################################
+ ## <summary>
+ ##	Allow the specified domain to read
+@@ -930,6 +1065,102 @@ interface(`container_manage_chr_files',`
+ 	manage_chr_files_pattern($1, container_file_t, container_file_t)
+ ')
+ 
++########################################
++## <summary>
++##	Allow the specified domain to
++##	list read-only container file directories.
++## </summary>
++## <param name="domain">
++##	<summary>
++##	Domain allowed access.
++##	</summary>
++## </param>
++#
++interface(`container_list_ro_dirs',`
++	gen_require(`
++		type container_ro_file_t;
++	')
++
++  	list_dirs_pattern($1, container_ro_file_t, container_ro_file_t)
++')
++
++########################################
++## <summary>
++##	Allow the specified domain to
++##	read read-only container files.
++## </summary>
++## <param name="domain">
++##	<summary>
++##	Domain allowed access.
++##	</summary>
++## </param>
++#
++interface(`container_read_ro_files',`
++	gen_require(`
++		type container_ro_file_t;
++	')
++
++  	read_files_pattern($1, container_ro_file_t, container_ro_file_t)
++')
++
++########################################
++## <summary>
++##	Allow the specified domain to mmap executable
++##	read-only container files with text relocations.
++## </summary>
++## <param name="domain">
++##	<summary>
++##	Domain allowed access.
++##	</summary>
++## </param>
++#
++interface(`container_textrel_mmap_exec_ro_files',`
++	gen_require(`
++		type container_ro_file_t;
++	')
++
++  	mmap_exec_files_pattern($1, container_ro_file_t, container_ro_file_t)
++	allow $1 container_ro_file_t:file execmod;
++')
++
++########################################
++## <summary>
++##	Allow the specified domain to execute
++##	read-only container files.
++## </summary>
++## <param name="domain">
++##	<summary>
++##	Domain allowed access.
++##	</summary>
++## </param>
++#
++interface(`container_exec_ro_files',`
++	gen_require(`
++		type container_ro_file_t;
++	')
++
++  	can_exec($1, container_ro_file_t)
++')
++
++########################################
++## <summary>
++##	Allow the specified domain to
++##	read read-only container symlinks.
++## </summary>
++## <param name="domain">
++##	<summary>
++##	Domain allowed access.
++##	</summary>
++## </param>
++#
++interface(`container_read_ro_symlinks',`
++	gen_require(`
++		type container_ro_file_t;
++	')
++
++  	read_lnk_files_pattern($1, container_ro_file_t, container_ro_file_t)
++')
++
+ ########################################
+ ## <summary>
+ ##	Allow the specified domain to
+@@ -1235,6 +1466,25 @@ interface(`container_search_var_lib',`
+ 	allow $1 container_var_lib_t:dir search_dir_perms;
+ ')
+ 
++########################################
++## <summary>
++##	Allow the specified domain to read
++##	container files in /var/lib.
++## </summary>
++## <param name="domain">
++##	<summary>
++##	Domain allowed access.
++##	</summary>
++## </param>
++#
++interface(`container_read_var_lib_files',`
++	gen_require(`
++		type container_var_lib_t;
++	')
++
++	read_files_pattern($1, container_var_lib_t, container_var_lib_t)
++')
++
+ ########################################
+ ## <summary>
+ ##	Allow the specified domain to manage
+@@ -1292,6 +1542,37 @@ interface(`container_manage_var_lib_sock_files',`
+ 	manage_sock_files_pattern($1, container_var_lib_t, container_var_lib_t)
+ ')
+ 
++########################################
++## <summary>
++##	Allow the specified domain to create
++##	objects in container /var/lib directories with
++##	an automatic type transition to the
++##	specified type
++## </summary>
++## <param name="domain">
++##	<summary>
++##	Domain allowed access.
++##	</summary>
++## </param>
++## <param name="object">
++##	<summary>
++##	The class of the object being created.
++##	</summary>
++## </param>
++## <param name="name" optional="true">
++##	<summary>
++##	The name of the object being created.
++##	</summary>
++## </param>
++#
++interface(`container_var_lib_filetrans',`
++	gen_require(`
++		type container_var_lib_t;
++	')
++
++	filetrans_pattern($1, container_var_lib_t, $2, $3, $4)
++')
++
+ ########################################
+ ## <summary>
+ ##	Allow the specified domain to create
+@@ -1325,6 +1606,62 @@ interface(`container_unlabeled_var_lib_filetrans',`
+ 	kernel_unlabeled_filetrans($1, container_var_lib_t, $2, $3)
+ ')
+ 
++########################################
++## <summary>
++##	Write pipes inherited from dockerd.
++## </summary>
++## <param name="domain">
++##	<summary>
++##	Domain allowed access.
++##	</summary>
++## </param>
++#
++interface(`container_write_inherited_dockerd_pipes',`
++        gen_require(`
++                type dockerd_t;
++        ')
++
++        allow $1 dockerd_t:fd use;
++        allow $1 dockerd_t:fifo_file write_inherited_file_perms;
++')
++
++########################################
++## <summary>
++##	Connect to privileged containers using an abstract stream socket.
++## </summary>
++## <param name="domain">
++##	<summary>
++##	Domain allowed access.
++##	</summary>
++## </param>
++#
++interface(`container_abstract_connect_privileged',`
++        gen_require(`
++                type spc_t;
++        ')
++
++        allow $1 spc_t:unix_stream_socket connectto;
++')
++
++########################################
++## <summary>
++##	Write pipes inherited from privileged containers.
++## </summary>
++## <param name="domain">
++##	<summary>
++##	Domain allowed access.
++##	</summary>
++## </param>
++#
++interface(`container_write_inherited_privileged_pipes',`
++        gen_require(`
++                type spc_t;
++        ')
++
++        allow $1 spc_t:fd use;
++        allow $1 spc_t:fifo_file write_inherited_file_perms;
++')
++
+ ########################################
+ ## <summary>
+ ##	All of the rules required to
+diff --git a/policy/modules/services/container_compat.fc b/policy/modules/services/container_compat.fc
+new file mode 100644
+index 000000000..4a06a34d0
+--- /dev/null
++++ b/policy/modules/services/container_compat.fc
+@@ -0,0 +1 @@
++# No file contexts for this module.
+diff --git a/policy/modules/services/container_compat.if b/policy/modules/services/container_compat.if
+new file mode 100644
+index 000000000..0afc9662b
+--- /dev/null
++++ b/policy/modules/services/container_compat.if
+@@ -0,0 +1 @@
++## <summary>Compatibility policy for container-selinux.</summary>
+diff --git a/policy/modules/services/container_compat.te b/policy/modules/services/container_compat.te
+new file mode 100644
+index 000000000..945d86562
+--- /dev/null
++++ b/policy/modules/services/container_compat.te
+@@ -0,0 +1,202 @@
++policy_module(container_compat)
++
++gen_require(`
++        class passwd rootok;
++')
++
++# kubevirt expects these attributes in the policy module it deploys
++attribute sandbox_net_domain;
++attribute svirt_sandbox_domain;
++
++########################################
++#
++# sandbox_net_domain local policy
++#
++# This is derived from the Fedora SELinux policy,
++# revised for Reference Policy types and interfaces.
++
++kernel_read_network_state(sandbox_net_domain)
++
++allow sandbox_net_domain self:capability { net_raw net_admin net_bind_service };
++allow sandbox_net_domain self:cap_userns { net_raw net_admin net_bind_service };
++
++allow sandbox_net_domain self:udp_socket create_socket_perms;
++allow sandbox_net_domain self:tcp_socket create_stream_socket_perms;
++allow sandbox_net_domain self:netlink_route_socket create_netlink_socket_perms;
++allow sandbox_net_domain self:packet_socket create_socket_perms;
++allow sandbox_net_domain self:socket create_socket_perms;
++allow sandbox_net_domain self:rawip_socket create_stream_socket_perms;
++allow sandbox_net_domain self:netlink_kobject_uevent_socket create_socket_perms;
++
++corenet_tcp_bind_generic_node(sandbox_net_domain)
++corenet_udp_bind_generic_node(sandbox_net_domain)
++corenet_raw_bind_generic_node(sandbox_net_domain)
++corenet_udp_bind_all_ports(sandbox_net_domain)
++corenet_tcp_bind_all_ports(sandbox_net_domain)
++corenet_tcp_connect_all_ports(sandbox_net_domain)
++
++optional_policy(`
++        sssd_stream_connect(sandbox_net_domain)
++')
++
++optional_policy(`
++        systemd_dbus_chat_logind(sandbox_net_domain)
++')
++
++########################################
++#
++# svirt_sandbox_domain local policy
++#
++# This is derived from the Fedora SELinux policy,
++# revised for Reference Policy types and interfaces.
++
++allow svirt_sandbox_domain self:key manage_key_perms;
++dontaudit svirt_sandbox_domain svirt_sandbox_domain:key search;
++
++allow svirt_sandbox_domain self:process { getattr signal_perms getsched getpgid getcap setsched setcap setpgid setrlimit };
++allow svirt_sandbox_domain self:fifo_file manage_file_perms;
++allow svirt_sandbox_domain self:msg all_msg_perms;
++allow svirt_sandbox_domain self:sem create_sem_perms;
++allow svirt_sandbox_domain self:shm create_shm_perms;
++allow svirt_sandbox_domain self:msgq create_msgq_perms;
++allow svirt_sandbox_domain self:unix_stream_socket { create_stream_socket_perms connectto };
++allow svirt_sandbox_domain self:unix_dgram_socket { sendto create_socket_perms };
++allow svirt_sandbox_domain self:passwd rootok;
++allow svirt_sandbox_domain self:filesystem associate;
++allow svirt_sandbox_domain self:netlink_kobject_uevent_socket create_socket_perms;
++
++kernel_list_all_proc(svirt_sandbox_domain)
++kernel_read_all_sysctls(svirt_sandbox_domain)
++kernel_rw_net_sysctls(svirt_sandbox_domain)
++kernel_rw_unix_sysctls(svirt_sandbox_domain)
++kernel_dontaudit_search_kernel_sysctl(svirt_sandbox_domain)
++#kernel_dontaudit_access_check_proc(svirt_sandbox_domain)
++#kernel_dontaudit_setattr_proc_files(svirt_sandbox_domain)
++kernel_dontaudit_setattr_proc_dirs(svirt_sandbox_domain)
++#kernel_dontaudit_write_usermodehelper_state(svirt_sandbox_domain)
++
++corecmd_exec_all_executables(svirt_sandbox_domain)
++
++#domain_dontaudit_link_all_domains_keyrings(svirt_sandbox_domain)
++#domain_dontaudit_search_all_domains_keyrings(svirt_sandbox_domain)
++
++files_dontaudit_getattr_all_dirs(svirt_sandbox_domain)
++files_dontaudit_getattr_all_files(svirt_sandbox_domain)
++files_dontaudit_getattr_all_symlinks(svirt_sandbox_domain)
++files_dontaudit_getattr_all_pipes(svirt_sandbox_domain)
++files_dontaudit_getattr_all_sockets(svirt_sandbox_domain)
++files_search_all_mountpoints(svirt_sandbox_domain)
++files_dontaudit_list_all_mountpoints(svirt_sandbox_domain)
++files_dontaudit_write_etc_runtime_files(svirt_sandbox_domain)
++
++#files_entrypoint_all_mountpoint(svirt_sandbox_domain)
++#corecmd_entrypoint_all_executables(svirt_sandbox_domain)
++
++files_search_all(svirt_sandbox_domain)
++files_read_usr_symlinks(svirt_sandbox_domain)
++files_search_locks(svirt_sandbox_domain)
++#files_dontaudit_unmount_all_mountpoints(svirt_sandbox_domain)
++#fs_rw_cephfs_files(svirt_sandbox_domain)
++
++fs_getattr_all_fs(svirt_sandbox_domain)
++#fs_rw_inherited_tmpfs_files(svirt_sandbox_domain)
++#fs_read_hugetlbfs_files(svirt_sandbox_domain)
++fs_read_tmpfs_symlinks(svirt_sandbox_domain)
++fs_search_tmpfs(svirt_sandbox_domain)
++fs_rw_hugetlbfs_files(svirt_sandbox_domain)
++
++#auth_dontaudit_read_passwd(svirt_sandbox_domain)
++auth_dontaudit_read_login_records(svirt_sandbox_domain)
++auth_dontaudit_write_login_records(svirt_sandbox_domain)
++auth_search_pam_console_data(svirt_sandbox_domain)
++
++#init_dontaudit_read_utmp(svirt_sandbox_domain)
++init_dontaudit_write_utmp(svirt_sandbox_domain)
++
++libs_dontaudit_setattr_lib_files(svirt_sandbox_domain)
++
++#miscfiles_dontaudit_access_check_cert(svirt_sandbox_domain)
++miscfiles_dontaudit_setattr_fonts_cache_dirs(svirt_sandbox_domain)
++miscfiles_read_fonts(svirt_sandbox_domain)
++miscfiles_read_hwdata(svirt_sandbox_domain)
++
++userdom_use_inherited_user_terminals(svirt_sandbox_domain)
++#userdom_dontaudit_append_inherited_admin_home_file(svirt_sandbox_domain)
++#userdom_dontaudit_read_inherited_admin_home_files(svirt_sandbox_domain)
++
++tunable_policy(`virt_use_nfs',`
++        fs_manage_nfs_dirs(svirt_sandbox_domain)
++        fs_manage_nfs_files(svirt_sandbox_domain)
++        fs_manage_nfs_named_sockets(svirt_sandbox_domain)
++        fs_manage_nfs_symlinks(svirt_sandbox_domain)
++        fs_mount_nfs(svirt_sandbox_domain)
++        fs_unmount_nfs(svirt_sandbox_domain)
++        fs_exec_nfs_files(svirt_sandbox_domain)
++        kernel_rw_fs_sysctls(svirt_sandbox_domain)
++')
++
++tunable_policy(`virt_use_samba',`
++        fs_manage_cifs_files(svirt_sandbox_domain)
++        fs_manage_cifs_dirs(svirt_sandbox_domain)
++        fs_manage_cifs_named_sockets(svirt_sandbox_domain)
++        fs_manage_cifs_symlinks(svirt_sandbox_domain)
++        fs_exec_cifs_files(svirt_sandbox_domain)
++')
++
++optional_policy(`
++        tunable_policy(`virt_sandbox_share_apache_content',`
++                apache_exec_modules(svirt_sandbox_domain)
++                apache_read_sys_content(svirt_sandbox_domain)
++        ')
++')
++
++optional_policy(`
++        allow svirt_sandbox_domain self:capability { audit_write chown fowner fsetid sys_nice };
++        allow svirt_sandbox_domain self:netlink_audit_socket { create read write };
++
++        dev_read_sysfs(svirt_sandbox_domain)
++        dev_getattr_mtrr_dev(svirt_sandbox_domain)
++        #dev_dontaudit_mounton_sysfs(svirt_sandbox_domain)
++
++        fs_read_cgroup_files(svirt_sandbox_domain)
++        #fs_dontaudit_remount_tmpfs(svirt_sandbox_domain)
++
++        container_list_ro_dirs(svirt_sandbox_domain)
++        container_read_ro_files(svirt_sandbox_domain)
++        container_read_ro_symlinks(svirt_sandbox_domain)
++        container_textrel_mmap_exec_ro_files(svirt_sandbox_domain)
++        container_exec_ro_files(svirt_sandbox_domain)
++
++        container_manage_dirs(svirt_sandbox_domain)
++        container_manage_files(svirt_sandbox_domain)
++        container_textrel_mmap_exec_files(svirt_sandbox_domain)
++        container_exec_files(svirt_sandbox_domain)
++        container_manage_lnk_files(svirt_sandbox_domain)
++        container_manage_sock_files(svirt_sandbox_domain)
++        container_manage_fifo_files(svirt_sandbox_domain)
++        container_setattr_blk_files(svirt_sandbox_domain)
++        container_rw_blk_files(svirt_sandbox_domain)
++        container_relabel_dirs(svirt_sandbox_domain)
++        container_relabel_files(svirt_sandbox_domain)
++        container_var_lib_filetrans(svirt_sandbox_domain, container_file_t, sock_file)
++
++        #allow svirt_sandbox_domain container_file_t:dir mounton;
++        #allow svirt_sandbox_domain container_file_t:filesystem { getattr remount };
++
++        container_use_container_ptys(svirt_sandbox_domain)
++        container_file_entrypoint(svirt_sandbox_domain)
++        container_read_var_lib_files(svirt_sandbox_domain)
++        container_write_inherited_dockerd_pipes(svirt_sandbox_domain)
++        container_abstract_connect_privileged(svirt_sandbox_domain)
++        container_write_inherited_privileged_pipes(svirt_sandbox_domain)
++
++        allow spc_t svirt_sandbox_domain:process transition;
++')
++
++optional_policy(`
++        mta_dontaudit_read_spool_symlinks(svirt_sandbox_domain)
++')
++
++optional_policy(`
++        udev_read_runtime_files(svirt_sandbox_domain)
++')
+-- 
+2.25.1
+

--- a/SPECS/selinux-policy/0019-systemd-Remove-systemd-run-domain.patch
+++ b/SPECS/selinux-policy/0019-systemd-Remove-systemd-run-domain.patch
@@ -1,0 +1,57 @@
+From 89fa2f158aaa4c3b0eae51be35f40ffd30bfaab4 Mon Sep 17 00:00:00 2001
+From: Chris PeBenito <Christopher.PeBenito@microsoft.com>
+Date: Fri, 29 Apr 2022 14:37:24 +0000
+Subject: [PATCH 19/28] systemd: Remove systemd-run domain.
+
+This command should be run with the privs of the caller.
+
+Signed-off-by: Chris PeBenito <Christopher.PeBenito@microsoft.com>
+---
+ policy/modules/kernel/corecommands.te | 2 +-
+ policy/modules/system/systemd.fc      | 1 -
+ policy/modules/system/systemd.te      | 4 ----
+ 3 files changed, 1 insertion(+), 6 deletions(-)
+
+diff --git a/policy/modules/kernel/corecommands.te b/policy/modules/kernel/corecommands.te
+index 447cf17eb..dabd3b066 100644
+--- a/policy/modules/kernel/corecommands.te
++++ b/policy/modules/kernel/corecommands.te
+@@ -14,7 +14,7 @@ attribute exec_type;
+ # bin_t is the type of files in the system bin/sbin directories.
+ #
+ type bin_t alias { ls_exec_t sbin_t };
+-typealias bin_t alias systemd_detect_virt_t;
++typealias bin_t alias { systemd_detect_virt_t systemd_run_exec_t };
+ corecmd_executable_file(bin_t)
+ dev_associate(bin_t)	#For /dev/MAKEDEV
+ 
+diff --git a/policy/modules/system/systemd.fc b/policy/modules/system/systemd.fc
+index 756224dca..abe902636 100644
+--- a/policy/modules/system/systemd.fc
++++ b/policy/modules/system/systemd.fc
+@@ -10,7 +10,6 @@
+ /usr/bin/systemd-coredump		--	gen_context(system_u:object_r:systemd_coredump_exec_t,s0)
+ /usr/bin/systemd-hwdb			--	gen_context(system_u:object_r:systemd_hw_exec_t,s0)
+ /usr/bin/systemd-nspawn			--	gen_context(system_u:object_r:systemd_nspawn_exec_t,s0)
+-/usr/bin/systemd-run			--	gen_context(system_u:object_r:systemd_run_exec_t,s0)
+ /usr/bin/systemd-stdio-bridge		--	gen_context(system_u:object_r:systemd_stdio_bridge_exec_t,s0)
+ /usr/bin/systemd-sysusers		--	gen_context(system_u:object_r:systemd_sysusers_exec_t,s0)
+ /usr/bin/systemd-tmpfiles		--	gen_context(system_u:object_r:systemd_tmpfiles_exec_t,s0)
+diff --git a/policy/modules/system/systemd.te b/policy/modules/system/systemd.te
+index c2e841358..d3c2c3802 100644
+--- a/policy/modules/system/systemd.te
++++ b/policy/modules/system/systemd.te
+@@ -224,10 +224,6 @@ init_system_domain(systemd_resolved_t, systemd_resolved_exec_t)
+ type systemd_resolved_runtime_t alias systemd_resolved_var_run_t;
+ files_runtime_file(systemd_resolved_runtime_t)
+ 
+-type systemd_run_t;
+-type systemd_run_exec_t;
+-init_daemon_domain(systemd_run_t, systemd_run_exec_t)
+-
+ type systemd_stdio_bridge_t;
+ type systemd_stdio_bridge_exec_t;
+ init_system_domain(systemd_stdio_bridge_t, systemd_stdio_bridge_exec_t)
+-- 
+2.25.1
+

--- a/SPECS/selinux-policy/0020-unconfined-Add-missing-capability2-perms.patch
+++ b/SPECS/selinux-policy/0020-unconfined-Add-missing-capability2-perms.patch
@@ -1,0 +1,26 @@
+From ae67d4dec417a3a1e4ef4416c216cfe7d051d44c Mon Sep 17 00:00:00 2001
+From: Chris PeBenito <Christopher.PeBenito@microsoft.com>
+Date: Mon, 2 May 2022 15:17:40 +0000
+Subject: [PATCH 20/28] unconfined: Add missing capability2 perms.
+
+Signed-off-by: Chris PeBenito <Christopher.PeBenito@microsoft.com>
+---
+ policy/modules/system/unconfined.if | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/policy/modules/system/unconfined.if b/policy/modules/system/unconfined.if
+index d0e61c28a..4393242d5 100644
+--- a/policy/modules/system/unconfined.if
++++ b/policy/modules/system/unconfined.if
+@@ -38,7 +38,7 @@ interface(`unconfined_domain_noaudit',`
+ 
+ 	# Use most Linux capabilities
+ 	allow $1 self:{ capability cap_userns } { chown dac_override dac_read_search fowner fsetid kill setgid setuid setpcap linux_immutable net_bind_service net_broadcast net_admin net_raw ipc_lock ipc_owner sys_rawio sys_chroot sys_ptrace sys_pacct sys_admin sys_boot sys_nice sys_resource sys_time sys_tty_config mknod lease audit_write audit_control setfcap };
+-	allow $1 self:{ capability2 cap2_userns } { syslog wake_alarm };
++	allow $1 self:{ capability2 cap2_userns } { syslog wake_alarm bpf perfmon };
+ 	allow $1 self:fifo_file manage_fifo_file_perms;
+ 
+ 	# Manage most namespace capabilities
+-- 
+2.25.1
+

--- a/SPECS/selinux-policy/0021-lvm-Updates-for-multipath-LVM.patch
+++ b/SPECS/selinux-policy/0021-lvm-Updates-for-multipath-LVM.patch
@@ -1,15 +1,15 @@
-From 488c4d63d104ada4b950b7b344e2eaebd02c53ba Mon Sep 17 00:00:00 2001
+From f67295a29599a37bc4511e749d1475dc0d26fe7f Mon Sep 17 00:00:00 2001
 From: Chris PeBenito <Christopher.PeBenito@microsoft.com>
 Date: Mon, 2 May 2022 15:19:00 +0000
-Subject: [PATCH 21/28] lvm: Updates for multipath LVM.
+Subject: [PATCH 21/37] lvm: Updates for multipath LVM.
 
 Signed-off-by: Chris PeBenito <Christopher.PeBenito@microsoft.com>
 ---
  policy/modules/kernel/files.if | 18 ++++++++++++++++++
- policy/modules/system/lvm.if   | 18 ++++++++++++++++++
- policy/modules/system/lvm.te   |  8 +++++++-
- policy/modules/system/udev.te  |  5 +++--
- 4 files changed, 46 insertions(+), 3 deletions(-)
+ policy/modules/system/lvm.fc   |  1 +
+ policy/modules/system/lvm.te   | 10 +++++++++-
+ policy/modules/system/udev.te  |  5 ++++-
+ 4 files changed, 32 insertions(+), 2 deletions(-)
 
 diff --git a/policy/modules/kernel/files.if b/policy/modules/kernel/files.if
 index e3c22b94a..97a54d998 100644
@@ -40,37 +40,20 @@ index e3c22b94a..97a54d998 100644
  ########################################
  ## <summary>
  ##	Get etc_t service status.
-diff --git a/policy/modules/system/lvm.if b/policy/modules/system/lvm.if
-index 468cbcaa8..bab3d4784 100644
---- a/policy/modules/system/lvm.if
-+++ b/policy/modules/system/lvm.if
-@@ -81,6 +81,24 @@ interface(`lvm_signull',`
- 	allow $1 lvm_t:process signull;
- ')
- 
-+########################################
-+## <summary>
-+##      Connect to LVM via abstract UNIX stream socket.
-+## </summary>
-+## <param name="domain">
-+##	<summary>
-+##	Domain allowed access.
-+##	</summary>
-+## </param>
-+#
-+interface(`lvm_abstract_stream_connect',`
-+	gen_require(`
-+		type lvm_t;
-+	')
-+
-+	allow $1 lvm_t:unix_stream_socket connectto;
-+')
-+
- ########################################
- ## <summary>
- ##	Read LVM configuration files.
+diff --git a/policy/modules/system/lvm.fc b/policy/modules/system/lvm.fc
+index 4a77c2cc1..adffdb82a 100644
+--- a/policy/modules/system/lvm.fc
++++ b/policy/modules/system/lvm.fc
+@@ -104,6 +104,7 @@
+ /usr/sbin/lvresize		--	gen_context(system_u:object_r:lvm_exec_t,s0)
+ /usr/sbin/lvs			--	gen_context(system_u:object_r:lvm_exec_t,s0)
+ /usr/sbin/lvscan		--	gen_context(system_u:object_r:lvm_exec_t,s0)
++/usr/sbin/multipath     --  gen_context(system_u:object_r:lvm_exec_t,s0)
+ /usr/sbin/multipathd		--	gen_context(system_u:object_r:lvm_exec_t,s0)
+ /usr/sbin/multipath\.static	--	gen_context(system_u:object_r:lvm_exec_t,s0)
+ /usr/sbin/pvchange		--	gen_context(system_u:object_r:lvm_exec_t,s0)
 diff --git a/policy/modules/system/lvm.te b/policy/modules/system/lvm.te
-index 1cf6e1753..9937bce80 100644
+index 1cf6e1753..b0d1c02b7 100644
 --- a/policy/modules/system/lvm.te
 +++ b/policy/modules/system/lvm.te
 @@ -51,7 +51,7 @@ files_type(lvm_var_lib_t)
@@ -90,7 +73,16 @@ index 1cf6e1753..9937bce80 100644
  # for when /usr is not mounted:
  kernel_dontaudit_search_unlabeled(lvm_t)
  # it has no reason to need this
-@@ -159,6 +160,7 @@ domain_read_all_domains_state(lvm_t)
+@@ -123,6 +124,8 @@ kernel_use_fds(lvm_t)
+ # for systemd-cryptsetup
+ kernel_read_crypto_sysctls(lvm_t)
+ kernel_search_debugfs(lvm_t)
++# multipath
++kernel_read_vm_overcommit_sysctl(lvm_t)
+ 
+ corecmd_exec_bin(lvm_t)
+ corecmd_exec_shell(lvm_t)
+@@ -159,6 +162,7 @@ domain_read_all_domains_state(lvm_t)
  
  files_read_usr_files(lvm_t)
  files_read_etc_files(lvm_t)
@@ -98,7 +90,7 @@ index 1cf6e1753..9937bce80 100644
  files_read_etc_runtime_files(lvm_t)
  
  fs_getattr_xattr_fs(lvm_t)
-@@ -210,6 +212,10 @@ seutil_read_file_contexts(lvm_t)
+@@ -210,6 +214,10 @@ seutil_read_file_contexts(lvm_t)
  seutil_search_default_contexts(lvm_t)
  seutil_sigchld_newrole(lvm_t)
  
@@ -110,35 +102,28 @@ index 1cf6e1753..9937bce80 100644
  
  ifdef(`init_systemd',`
 diff --git a/policy/modules/system/udev.te b/policy/modules/system/udev.te
-index 1a692b1f4..d3105f245 100644
+index 1a692b1f4..19c7fd29b 100644
 --- a/policy/modules/system/udev.te
 +++ b/policy/modules/system/udev.te
-@@ -42,7 +42,7 @@ ifdef(`enable_mcs',`
+@@ -56,6 +56,8 @@ allow udev_t self:unix_stream_socket connectto;
+ allow udev_t self:netlink_kobject_uevent_socket create_socket_perms;
+ allow udev_t self:netlink_generic_socket create_socket_perms;
+ allow udev_t self:rawip_socket create_socket_perms;
++# rdma_rename
++allow udev_t self:netlink_rdma_socket create_socket_perms;
  
- allow udev_t self:capability { chown dac_override dac_read_search fowner fsetid mknod net_admin net_raw setgid setuid sys_admin sys_nice sys_ptrace sys_rawio sys_resource };
- allow udev_t self:capability2 { wake_alarm block_suspend };
--allow udev_t self:process { transition signal_perms ptrace getsched setsched getsession getpgid setpgid getcap setcap share getattr setfscreate noatsecure siginh rlimitinh dyntransition execmem setkeycreate setsockcreate getrlimit };
-+allow udev_t self:process { transition signal_perms ptrace getsched setsched getsession getpgid setpgid getcap setcap share getattr setfscreate noatsecure siginh rlimitinh dyntransition execmem setkeycreate setsockcreate getrlimit setrlimit };
- allow udev_t self:fd use;
- allow udev_t self:fifo_file rw_fifo_file_perms;
- allow udev_t self:sock_file read_sock_file_perms;
-@@ -101,7 +101,7 @@ kernel_rw_unix_dgram_sockets(udev_t)
+ ifdef(`init_systemd',`
+ 	# systemd-vconsole-setup will be called by udev during virtual terminal initialization
+@@ -101,7 +103,8 @@ kernel_rw_unix_dgram_sockets(udev_t)
  kernel_signal(udev_t)
  kernel_search_debugfs(udev_t)
  kernel_search_key(udev_t)
 -
-+kernel_read_fs_sysctls(udev_t)
++# kpartx:
++kernel_get_sysvipc_info(udev_t)
  #https://bugzilla.redhat.com/bugzilla/show_bug.cgi?id=235182
  kernel_rw_net_sysctls(udev_t)
  kernel_read_crypto_sysctls(udev_t)
-@@ -324,6 +324,7 @@ optional_policy(`
- 
- optional_policy(`
- 	lvm_domtrans(udev_t)
-+	lvm_abstract_stream_connect(udev_t)
- ')
- 
- optional_policy(`
 -- 
 2.25.1
 

--- a/SPECS/selinux-policy/0021-lvm-Updates-for-multipath-LVM.patch
+++ b/SPECS/selinux-policy/0021-lvm-Updates-for-multipath-LVM.patch
@@ -1,0 +1,144 @@
+From 488c4d63d104ada4b950b7b344e2eaebd02c53ba Mon Sep 17 00:00:00 2001
+From: Chris PeBenito <Christopher.PeBenito@microsoft.com>
+Date: Mon, 2 May 2022 15:19:00 +0000
+Subject: [PATCH 21/28] lvm: Updates for multipath LVM.
+
+Signed-off-by: Chris PeBenito <Christopher.PeBenito@microsoft.com>
+---
+ policy/modules/kernel/files.if | 18 ++++++++++++++++++
+ policy/modules/system/lvm.if   | 18 ++++++++++++++++++
+ policy/modules/system/lvm.te   |  8 +++++++-
+ policy/modules/system/udev.te  |  5 +++--
+ 4 files changed, 46 insertions(+), 3 deletions(-)
+
+diff --git a/policy/modules/kernel/files.if b/policy/modules/kernel/files.if
+index e3c22b94a..97a54d998 100644
+--- a/policy/modules/kernel/files.if
++++ b/policy/modules/kernel/files.if
+@@ -3213,6 +3213,24 @@ interface(`files_exec_etc_files',`
+ 	exec_files_pattern($1, etc_t, etc_t)
+ ')
+ 
++########################################
++## <summary>
++##	Watch /etc files.
++## </summary>
++## <param name="domain">
++##	<summary>
++##	Domain allowed access.
++##	</summary>
++## </param>
++#
++interface(`files_watch_etc_files', `
++	gen_require(`
++		type etc_t;
++	')
++
++	allow $1 etc_t:file watch;
++')
++
+ ########################################
+ ## <summary>
+ ##	Get etc_t service status.
+diff --git a/policy/modules/system/lvm.if b/policy/modules/system/lvm.if
+index 468cbcaa8..bab3d4784 100644
+--- a/policy/modules/system/lvm.if
++++ b/policy/modules/system/lvm.if
+@@ -81,6 +81,24 @@ interface(`lvm_signull',`
+ 	allow $1 lvm_t:process signull;
+ ')
+ 
++########################################
++## <summary>
++##      Connect to LVM via abstract UNIX stream socket.
++## </summary>
++## <param name="domain">
++##	<summary>
++##	Domain allowed access.
++##	</summary>
++## </param>
++#
++interface(`lvm_abstract_stream_connect',`
++	gen_require(`
++		type lvm_t;
++	')
++
++	allow $1 lvm_t:unix_stream_socket connectto;
++')
++
+ ########################################
+ ## <summary>
+ ##	Read LVM configuration files.
+diff --git a/policy/modules/system/lvm.te b/policy/modules/system/lvm.te
+index 1cf6e1753..9937bce80 100644
+--- a/policy/modules/system/lvm.te
++++ b/policy/modules/system/lvm.te
+@@ -51,7 +51,7 @@ files_type(lvm_var_lib_t)
+ # net_admin for multipath
+ allow lvm_t self:capability { chown dac_override fowner ipc_lock mknod net_admin sys_admin sys_nice sys_rawio sys_resource };
+ dontaudit lvm_t self:capability sys_tty_config;
+-allow lvm_t self:process { sigchld sigkill sigstop signull signal setfscreate };
++allow lvm_t self:process { sigchld sigkill sigstop signull signal setfscreate setrlimit };
+ # LVM will complain a lot if it cannot set its priority.
+ allow lvm_t self:process setsched;
+ allow lvm_t self:file rw_file_perms;
+@@ -115,6 +115,7 @@ kernel_get_sysvipc_info(lvm_t)
+ kernel_read_system_state(lvm_t)
+ # Read system variables in /proc/sys
+ kernel_read_kernel_sysctls(lvm_t)
++kernel_read_fs_sysctls(lvm_t)
+ # for when /usr is not mounted:
+ kernel_dontaudit_search_unlabeled(lvm_t)
+ # it has no reason to need this
+@@ -159,6 +160,7 @@ domain_read_all_domains_state(lvm_t)
+ 
+ files_read_usr_files(lvm_t)
+ files_read_etc_files(lvm_t)
++files_watch_etc_files(lvm_t)
+ files_read_etc_runtime_files(lvm_t)
+ 
+ fs_getattr_xattr_fs(lvm_t)
+@@ -210,6 +212,10 @@ seutil_read_file_contexts(lvm_t)
+ seutil_search_default_contexts(lvm_t)
+ seutil_sigchld_newrole(lvm_t)
+ 
++# multipath
++sysnet_read_config(lvm_t)
++sysnet_write_config(lvm_t)
++
+ userdom_use_inherited_user_terminals(lvm_t)
+ 
+ ifdef(`init_systemd',`
+diff --git a/policy/modules/system/udev.te b/policy/modules/system/udev.te
+index 1a692b1f4..d3105f245 100644
+--- a/policy/modules/system/udev.te
++++ b/policy/modules/system/udev.te
+@@ -42,7 +42,7 @@ ifdef(`enable_mcs',`
+ 
+ allow udev_t self:capability { chown dac_override dac_read_search fowner fsetid mknod net_admin net_raw setgid setuid sys_admin sys_nice sys_ptrace sys_rawio sys_resource };
+ allow udev_t self:capability2 { wake_alarm block_suspend };
+-allow udev_t self:process { transition signal_perms ptrace getsched setsched getsession getpgid setpgid getcap setcap share getattr setfscreate noatsecure siginh rlimitinh dyntransition execmem setkeycreate setsockcreate getrlimit };
++allow udev_t self:process { transition signal_perms ptrace getsched setsched getsession getpgid setpgid getcap setcap share getattr setfscreate noatsecure siginh rlimitinh dyntransition execmem setkeycreate setsockcreate getrlimit setrlimit };
+ allow udev_t self:fd use;
+ allow udev_t self:fifo_file rw_fifo_file_perms;
+ allow udev_t self:sock_file read_sock_file_perms;
+@@ -101,7 +101,7 @@ kernel_rw_unix_dgram_sockets(udev_t)
+ kernel_signal(udev_t)
+ kernel_search_debugfs(udev_t)
+ kernel_search_key(udev_t)
+-
++kernel_read_fs_sysctls(udev_t)
+ #https://bugzilla.redhat.com/bugzilla/show_bug.cgi?id=235182
+ kernel_rw_net_sysctls(udev_t)
+ kernel_read_crypto_sysctls(udev_t)
+@@ -324,6 +324,7 @@ optional_policy(`
+ 
+ optional_policy(`
+ 	lvm_domtrans(udev_t)
++	lvm_abstract_stream_connect(udev_t)
+ ')
+ 
+ optional_policy(`
+-- 
+2.25.1
+

--- a/SPECS/selinux-policy/0022-locallogin-Use-init-file-descriptors.patch
+++ b/SPECS/selinux-policy/0022-locallogin-Use-init-file-descriptors.patch
@@ -1,0 +1,28 @@
+From 01fa9706a4fb562f4314c3743ef26bcd62e63797 Mon Sep 17 00:00:00 2001
+From: Chris PeBenito <Christopher.PeBenito@microsoft.com>
+Date: Mon, 2 May 2022 15:20:36 +0000
+Subject: [PATCH 22/28] locallogin: Use init file descriptors.
+
+Without this, some systems have slow or broken console login.
+
+Signed-off-by: Chris PeBenito <Christopher.PeBenito@microsoft.com>
+---
+ policy/modules/system/locallogin.te | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/policy/modules/system/locallogin.te b/policy/modules/system/locallogin.te
+index 12d3ea67e..a87b0a10e 100644
+--- a/policy/modules/system/locallogin.te
++++ b/policy/modules/system/locallogin.te
+@@ -125,7 +125,7 @@ auth_manage_pam_runtime_files(local_login_t)
+ auth_manage_pam_console_data(local_login_t)
+ auth_domtrans_pam_console(local_login_t)
+ 
+-init_dontaudit_use_fds(local_login_t)
++init_use_fds(local_login_t)
+ 
+ miscfiles_read_localization(local_login_t)
+ 
+-- 
+2.25.1
+

--- a/SPECS/selinux-policy/0023-systemd-Misc-fixes.patch
+++ b/SPECS/selinux-policy/0023-systemd-Misc-fixes.patch
@@ -1,0 +1,97 @@
+From 25ebb9530f325f1ec8385088405ade691fff3858 Mon Sep 17 00:00:00 2001
+From: Chris PeBenito <Christopher.PeBenito@microsoft.com>
+Date: Mon, 2 May 2022 15:39:07 +0000
+Subject: [PATCH 23/28] systemd: Misc fixes.
+
+---
+ policy/modules/system/init.if    | 18 ++++++++++++++++++
+ policy/modules/system/logging.te |  1 +
+ policy/modules/system/systemd.te | 10 +++++++---
+ 3 files changed, 26 insertions(+), 3 deletions(-)
+
+diff --git a/policy/modules/system/init.if b/policy/modules/system/init.if
+index fda2faca5..8bc28e4ab 100644
+--- a/policy/modules/system/init.if
++++ b/policy/modules/system/init.if
+@@ -3361,6 +3361,24 @@ interface(`init_list_unit_dirs',`
+ 	init_search_units($1)
+ ')
+ 
++########################################
++## <summary>
++##	Get the attributes of systemd unit files
++## </summary>
++## <param name="domain">
++##	<summary>
++##	Domain allowed access.
++##	</summary>
++## </param>
++#
++interface(`init_getattr_generic_units_files',`
++	gen_require(`
++		type systemd_unit_t;
++	')
++
++	allow $1 systemd_unit_t:file read_file_perms;
++')
++
+ ########################################
+ ## <summary>
+ ##	Read systemd unit files
+diff --git a/policy/modules/system/logging.te b/policy/modules/system/logging.te
+index 2d16c0d47..261a68905 100644
+--- a/policy/modules/system/logging.te
++++ b/policy/modules/system/logging.te
+@@ -560,6 +560,7 @@ ifdef(`init_systemd',`
+ 	logging_send_syslog_msg(syslogd_t)
+ 
+ 	systemd_manage_journal_files(syslogd_t)
++	systemd_watch_journal_dirs(syslogd_t)
+ 
+ 	udev_read_runtime_files(syslogd_t)
+ 
+diff --git a/policy/modules/system/systemd.te b/policy/modules/system/systemd.te
+index d3c2c3802..8997f2ac1 100644
+--- a/policy/modules/system/systemd.te
++++ b/policy/modules/system/systemd.te
+@@ -482,6 +482,7 @@ init_search_runtime(systemd_generator_t)
+ init_setattr_runtime_files(systemd_generator_t)
+ init_write_runtime_files(systemd_generator_t)
+ init_list_unit_dirs(systemd_generator_t)
++init_getattr_generic_units_files(systemd_generator_t)
+ init_read_generic_units_symlinks(systemd_generator_t)
+ init_read_script_files(systemd_generator_t)
+ 
+@@ -994,6 +995,9 @@ dev_read_sysfs(systemd_modules_load_t)
+ files_mmap_read_kernel_modules(systemd_modules_load_t)
+ files_read_etc_files(systemd_modules_load_t)
+ 
++fs_getattr_all_fs(systemd_modules_load_t)
++fs_search_all(systemd_modules_load_t)
++
+ modutils_read_module_config(systemd_modules_load_t)
+ modutils_read_module_deps(systemd_modules_load_t)
+ 
+@@ -1460,8 +1464,8 @@ systemd_log_parse_environment(systemd_sessions_t)
+ 
+ # sys_admin for sysctls such as kernel.kptr_restrict and kernel.dmesg_restrict
+ # sys_ptrace for kernel.yama.ptrace_scope
+-allow systemd_sysctl_t self:capability { sys_admin sys_ptrace };
+-dontaudit systemd_sysctl_t self:capability net_admin;
++# net_admin for network sysctls
++allow systemd_sysctl_t self:capability { net_admin sys_admin sys_ptrace };
+ 
+ kernel_read_kernel_sysctls(systemd_sysctl_t)
+ kernel_request_load_module(systemd_sysctl_t)
+@@ -1480,7 +1484,7 @@ systemd_log_parse_environment(systemd_sysctl_t)
+ # Sysusers local policy
+ #
+ 
+-allow systemd_sysusers_t self:capability { chown fsetid };
++allow systemd_sysusers_t self:capability { dac_read_search chown fsetid };
+ allow systemd_sysusers_t self:process setfscreate;
+ allow systemd_sysusers_t self:unix_dgram_socket sendto;
+ 
+-- 
+2.25.1
+

--- a/SPECS/selinux-policy/0024-isns-Updates-from-testing.patch
+++ b/SPECS/selinux-policy/0024-isns-Updates-from-testing.patch
@@ -1,0 +1,34 @@
+From 56bfeed7c79aeccbacbda88eab97d09fe0b0da0d Mon Sep 17 00:00:00 2001
+From: Chris PeBenito <Christopher.PeBenito@microsoft.com>
+Date: Mon, 2 May 2022 15:39:28 +0000
+Subject: [PATCH 24/28] isns: Updates from testing.
+
+Signed-off-by: Chris PeBenito <Christopher.PeBenito@microsoft.com>
+---
+ policy/modules/services/isns.te | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/policy/modules/services/isns.te b/policy/modules/services/isns.te
+index 56be6ff98..2b18f97d3 100644
+--- a/policy/modules/services/isns.te
++++ b/policy/modules/services/isns.te
+@@ -27,6 +27,7 @@ allow isnsd_t self:capability kill;
+ allow isnsd_t self:process signal;
+ allow isnsd_t self:fifo_file rw_fifo_file_perms;
+ allow isnsd_t self:udp_socket { accept listen };
++allow isnsd_t self:tcp_socket create_stream_socket_perms;
+ allow isnsd_t self:unix_stream_socket { accept listen };
+ 
+ manage_dirs_pattern(isnsd_t, isnsd_var_lib_t, isnsd_var_lib_t)
+@@ -37,6 +38,8 @@ manage_sock_files_pattern(isnsd_t, isnsd_runtime_t, isnsd_runtime_t)
+ manage_files_pattern(isnsd_t, isnsd_runtime_t, isnsd_runtime_t)
+ files_runtime_filetrans(isnsd_t, isnsd_runtime_t, { file sock_file })
+ 
++kernel_read_crypto_sysctls(isnsd_t)
++
+ corenet_all_recvfrom_netlabel(isnsd_t)
+ corenet_tcp_sendrecv_generic_if(isnsd_t)
+ corenet_tcp_sendrecv_generic_node(isnsd_t)
+-- 
+2.25.1
+

--- a/SPECS/selinux-policy/0025-container-docker-Fixes-for-containerd-and-kubernetes.patch
+++ b/SPECS/selinux-policy/0025-container-docker-Fixes-for-containerd-and-kubernetes.patch
@@ -1,0 +1,120 @@
+From 42ecd92f9c1f2febdc6bfcfa9337bbd05b8d5078 Mon Sep 17 00:00:00 2001
+From: Chris PeBenito <Christopher.PeBenito@microsoft.com>
+Date: Mon, 2 May 2022 15:40:27 +0000
+Subject: [PATCH 25/28] container, docker: Fixes for containerd and kubernetes
+ testing.
+
+Signed-off-by: Chris PeBenito <Christopher.PeBenito@microsoft.com>
+---
+ policy/modules/kernel/corecommands.if | 18 ++++++++++++++++++
+ policy/modules/services/container.fc  |  5 +++++
+ policy/modules/services/container.te  |  3 +++
+ policy/modules/services/docker.te     |  5 +++++
+ 4 files changed, 31 insertions(+)
+
+diff --git a/policy/modules/kernel/corecommands.if b/policy/modules/kernel/corecommands.if
+index 2d7f27157..231aa69d9 100644
+--- a/policy/modules/kernel/corecommands.if
++++ b/policy/modules/kernel/corecommands.if
+@@ -142,6 +142,24 @@ interface(`corecmd_dontaudit_write_bin_dirs',`
+ 	dontaudit $1 bin_t:dir write;
+ ')
+ 
++########################################
++## <summary>
++##	Watch bin directories.
++## </summary>
++## <param name="domain">
++##	<summary>
++##	Domain allowed access.
++##	</summary>
++## </param>
++#
++interface(`corecmd_watch_bin_dirs',`
++	gen_require(`
++		type bin_t;
++	')
++
++	allow $1 bin_t:dir watch;
++')
++
+ ########################################
+ ## <summary>
+ ##	Get the attributes of files in bin directories.
+diff --git a/policy/modules/services/container.fc b/policy/modules/services/container.fc
+index ef5ad3b69..a4692c761 100644
+--- a/policy/modules/services/container.fc
++++ b/policy/modules/services/container.fc
+@@ -71,9 +71,14 @@ HOME_DIR/\.local/share/docker/volumes(/.*)?		gen_context(system_u:object_r:conta
+ /var/lib/docker/overlay2(/.*)?		gen_context(system_u:object_r:container_ro_file_t,s0)
+ /var/lib/docker/volumes/[^/]+/.*		gen_context(system_u:object_r:container_file_t,s0)
+ 
++/var/lib/etcd(/.*)?             gen_context(system_u:object_r:container_file_t,s0)
++
+ /var/lib/containerd(/.*)?		gen_context(system_u:object_r:container_var_lib_t,s0)
+ /var/lib/containerd/[^/]+/sandboxes(/.*)?		gen_context(system_u:object_r:container_ro_file_t,s0)
+ /var/lib/containerd/[^/]+/snapshots(/.*)?		gen_context(system_u:object_r:container_ro_file_t,s0)
+ 
++/var/lib/kubelet(/.*)?          gen_context(system_u:object_r:container_var_lib_t,s0)
++/var/lib/kubelet/pods(/.*)?     gen_context(system_u:object_r:container_file_t,s0)
++
+ /var/log/containers(/.*)?		gen_context(system_u:object_r:container_log_t,s0)
+ /var/log/pods(/.*)?		gen_context(system_u:object_r:container_log_t,s0)
+diff --git a/policy/modules/services/container.te b/policy/modules/services/container.te
+index d5f79b158..18cdc2dd5 100644
+--- a/policy/modules/services/container.te
++++ b/policy/modules/services/container.te
+@@ -175,6 +175,7 @@ allow container_domain container_ro_file_t:lnk_file read_lnk_file_perms;
+ allow container_domain container_ro_file_t:sock_file read_sock_file_perms;
+ 
+ can_exec(container_domain, container_file_t)
++corecmd_watch_bin_dirs(container_domain)
+ 
+ kernel_getattr_proc(container_domain)
+ kernel_list_all_proc(container_domain)
+@@ -471,6 +472,7 @@ can_exec(container_engine_domain, container_engine_exec_type)
+ list_dirs_pattern(container_engine_domain, container_config_t, container_config_t)
+ read_files_pattern(container_engine_domain, container_config_t, container_config_t)
+ read_lnk_files_pattern(container_engine_domain, container_config_t, container_config_t)
++allow container_engine_domain container_config_t:{ dir file } watch;
+ 
+ allow container_engine_domain container_engine_tmp_t:dir manage_dir_perms;
+ allow container_engine_domain container_engine_tmp_t:file manage_file_perms;
+@@ -493,6 +495,7 @@ allow container_engine_domain container_file_t:blk_file { manage_blk_file_perms
+ allow container_engine_domain container_file_t:chr_file { manage_chr_file_perms relabel_chr_file_perms };
+ allow container_engine_domain container_file_t:fifo_file { manage_fifo_file_perms relabel_fifo_file_perms };
+ allow container_engine_domain container_file_t:lnk_file { manage_lnk_file_perms relabel_lnk_file_perms };
++allow container_engine_domain container_file_t:sock_file { manage_sock_file_perms relabel_lnk_file_perms };
+ allow container_engine_domain container_file_t:filesystem { getattr relabelfrom relabelto mount unmount remount };
+ 
+ allow container_engine_domain container_ro_file_t:dir { manage_dir_perms relabel_dir_perms };
+diff --git a/policy/modules/services/docker.te b/policy/modules/services/docker.te
+index 7a657e15d..ba3d3ac66 100644
+--- a/policy/modules/services/docker.te
++++ b/policy/modules/services/docker.te
+@@ -34,17 +34,22 @@ application_domain(dockerc_user_t, dockerc_exec_t)
+ # Docker daemon local policy
+ #
+ 
++allow dockerd_t self:process getattr;
+ allow dockerd_t self:netlink_netfilter_socket create_socket_perms;
+ allow dockerd_t self:netlink_xfrm_socket create_socket_perms;
+ 
+ init_write_runtime_socket(dockerd_t)
+ container_runtime_named_socket_activation(dockerd_t)
+ 
++files_search_mnt(dockerd_t)
+ # docker fails to start if /proc/kallsyms is unreadable,
+ # but only when btrfs support is disabled
+ files_read_kernel_symbol_table(dockerd_t)
+ files_dontaudit_write_usr_dirs(dockerd_t)
+ 
++init_get_system_status(dockerd_t)
++init_stop_generic_units(dockerd_t)
++
+ kernel_relabelfrom_unlabeled_dirs(dockerd_t)
+ # docker wants to load binfmt_misc
+ kernel_request_load_module(dockerd_t)
+-- 
+2.25.1
+

--- a/SPECS/selinux-policy/0026-devices-Add-type-for-SAS-management-devices.patch
+++ b/SPECS/selinux-policy/0026-devices-Add-type-for-SAS-management-devices.patch
@@ -1,0 +1,43 @@
+From 2dbe298ecb2b0d2c13f7430127ca6233bda0c293 Mon Sep 17 00:00:00 2001
+From: Chris PeBenito <Christopher.PeBenito@microsoft.com>
+Date: Mon, 2 May 2022 15:41:51 +0000
+Subject: [PATCH 26/28] devices: Add type for SAS management devices.
+
+Signed-off-by: Chris PeBenito <Christopher.PeBenito@microsoft.com>
+---
+ policy/modules/kernel/devices.fc | 1 +
+ policy/modules/kernel/devices.te | 6 ++++++
+ 2 files changed, 7 insertions(+)
+
+diff --git a/policy/modules/kernel/devices.fc b/policy/modules/kernel/devices.fc
+index bd08f81d3..7a3fc08f5 100644
+--- a/policy/modules/kernel/devices.fc
++++ b/policy/modules/kernel/devices.fc
+@@ -77,6 +77,7 @@
+ /dev/mixer.*		-c	gen_context(system_u:object_r:sound_device_t,s0)
+ /dev/mmetfgrab		-c	gen_context(system_u:object_r:scanner_device_t,s0)
+ /dev/modem		-c	gen_context(system_u:object_r:modem_device_t,s0)
++/dev/mpt[2-9]*ctl   -c  gen_context(system_u:object_r:mptctl_device_t,s0)
+ /dev/mpu401.*		-c	gen_context(system_u:object_r:sound_device_t,s0)
+ /dev/msr.*		-c	gen_context(system_u:object_r:cpu_device_t,s0)
+ /dev/ndctl[0-9]		-c	gen_context(system_u:object_r:nvram_device_t,s0)
+diff --git a/policy/modules/kernel/devices.te b/policy/modules/kernel/devices.te
+index 8c949fb07..068419502 100644
+--- a/policy/modules/kernel/devices.te
++++ b/policy/modules/kernel/devices.te
+@@ -198,6 +198,12 @@ dev_node(modem_device_t)
+ type mouse_device_t;
+ dev_node(mouse_device_t)
+ 
++#
++# Serial Attached SCSI Management device
++#
++type mptctl_device_t;
++dev_node(mptctl_device_t)
++
+ #
+ # Type for /dev/cpu/mtrr and /proc/mtrr
+ #
+-- 
+2.25.1
+

--- a/SPECS/selinux-policy/0027-devices-Add-file-context-for-dev-vhost-vsock.patch
+++ b/SPECS/selinux-policy/0027-devices-Add-file-context-for-dev-vhost-vsock.patch
@@ -1,0 +1,25 @@
+From de2e9bf2f8cb47fd64ac746a1f34159ae1de6739 Mon Sep 17 00:00:00 2001
+From: Chris PeBenito <Christopher.PeBenito@microsoft.com>
+Date: Mon, 2 May 2022 15:42:15 +0000
+Subject: [PATCH 27/28] devices: Add file context for /dev/vhost-vsock.
+
+Signed-off-by: Chris PeBenito <Christopher.PeBenito@microsoft.com>
+---
+ policy/modules/kernel/devices.fc | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/policy/modules/kernel/devices.fc b/policy/modules/kernel/devices.fc
+index 7a3fc08f5..009887934 100644
+--- a/policy/modules/kernel/devices.fc
++++ b/policy/modules/kernel/devices.fc
+@@ -138,6 +138,7 @@ ifdef(`distro_suse', `
+ /dev/vhci			-c	gen_context(system_u:object_r:vhost_device_t,s0)
+ /dev/vhost-net		-c	gen_context(system_u:object_r:vhost_device_t,s0)
+ /dev/vhost-scsi		-c	gen_context(system_u:object_r:vhost_device_t,s0)
++/dev/vhost-vsock    -c  gen_context(system_u:object_r:vhost_device_t,s0)
+ /dev/video.*		-c	gen_context(system_u:object_r:v4l_device_t,s0)
+ /dev/vmmon		-c	gen_context(system_u:object_r:vmware_device_t,s0)
+ /dev/vmnet.*		-c	gen_context(system_u:object_r:vmware_device_t,s0)
+-- 
+2.25.1
+

--- a/SPECS/selinux-policy/0028-Add-dac_read_search-perms.patch
+++ b/SPECS/selinux-policy/0028-Add-dac_read_search-perms.patch
@@ -1,0 +1,40 @@
+From 383147602ac0a0e87103f4408376c44d637d953d Mon Sep 17 00:00:00 2001
+From: Chris PeBenito <Christopher.PeBenito@microsoft.com>
+Date: Mon, 2 May 2022 15:42:49 +0000
+Subject: [PATCH 28/28] Add dac_read_search perms.
+
+May be Mariner-specific.
+---
+ policy/modules/services/chronyd.te | 2 +-
+ policy/modules/system/authlogin.te | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/policy/modules/services/chronyd.te b/policy/modules/services/chronyd.te
+index fdc32c8df..ce0a5370c 100644
+--- a/policy/modules/services/chronyd.te
++++ b/policy/modules/services/chronyd.te
+@@ -131,7 +131,7 @@ optional_policy(`
+ # chronyc local policy
+ #
+ 
+-allow chronyc_t self:capability { dac_override };
++allow chronyc_t self:capability { dac_read_search dac_override };
+ allow chronyc_t self:process { signal };
+ allow chronyc_t self:udp_socket create_socket_perms;
+ allow chronyc_t self:netlink_route_socket create_netlink_socket_perms;
+diff --git a/policy/modules/system/authlogin.te b/policy/modules/system/authlogin.te
+index e8d2d128d..b57cdf273 100644
+--- a/policy/modules/system/authlogin.te
++++ b/policy/modules/system/authlogin.te
+@@ -106,7 +106,7 @@ optional_policy(`
+ # Check password local policy
+ #
+ 
+-allow chkpwd_t self:capability { dac_override setuid };
++allow chkpwd_t self:capability { dac_read_search dac_override setuid };
+ dontaudit chkpwd_t self:capability sys_tty_config;
+ allow chkpwd_t self:process { getattr signal };
+ 
+-- 
+2.25.1
+

--- a/SPECS/selinux-policy/0029-iptables-Ioctl-cgroup-dirs.patch
+++ b/SPECS/selinux-policy/0029-iptables-Ioctl-cgroup-dirs.patch
@@ -1,0 +1,60 @@
+From 1df72505f99a6f7bdf757ed044e6fd6d502efffe Mon Sep 17 00:00:00 2001
+From: Chris PeBenito <Christopher.PeBenito@microsoft.com>
+Date: Mon, 2 May 2022 18:14:55 +0000
+Subject: [PATCH 29/29] iptables: Ioctl cgroup dirs.
+
+avc:  denied  { ioctl } for  pid=7230 comm="ip6tables" path="/sys/fs/cgroup" dev="cgroup2" ino=1
+scontext=system_u:system_r:iptables_t:s0
+tcontext=system_u:object_r:cgroup_t:s0 tclass=dir
+
+Signed-off-by: Chris PeBenito <Christopher.PeBenito@microsoft.com>
+---
+ policy/modules/kernel/filesystem.if | 19 +++++++++++++++++++
+ policy/modules/system/iptables.te   |  1 +
+ 2 files changed, 20 insertions(+)
+
+diff --git a/policy/modules/kernel/filesystem.if b/policy/modules/kernel/filesystem.if
+index dd261be1f..abaf52626 100644
+--- a/policy/modules/kernel/filesystem.if
++++ b/policy/modules/kernel/filesystem.if
+@@ -770,6 +770,25 @@ interface(`fs_list_cgroup_dirs', `
+ 	dev_search_sysfs($1)
+ ')
+ 
++########################################
++## <summary>
++##	Ioctl cgroup directories.
++## </summary>
++## <param name="domain">
++##	<summary>
++##	Domain allowed access.
++##	</summary>
++## </param>
++#
++interface(`fs_ioctl_cgroup_dirs', `
++	gen_require(`
++		type cgroup_t;
++	')
++
++	allow $1 cgroup_t:dir ioctl;
++	dev_search_sysfs($1)
++')
++
+ ########################################
+ ## <summary>
+ ##	Delete cgroup directories.
+diff --git a/policy/modules/system/iptables.te b/policy/modules/system/iptables.te
+index 294f7bcf5..9a00811e7 100644
+--- a/policy/modules/system/iptables.te
++++ b/policy/modules/system/iptables.te
+@@ -74,6 +74,7 @@ dev_read_sysfs(iptables_t)
+ fs_getattr_xattr_fs(iptables_t)
+ fs_search_auto_mountpoints(iptables_t)
+ fs_list_inotifyfs(iptables_t)
++fs_ioctl_cgroup_dirs(iptables_t)
+ 
+ mls_file_read_all_levels(iptables_t)
+ 
+-- 
+2.25.1
+

--- a/SPECS/selinux-policy/0030-container-allow-containers-to-manipulate-own-fds.patch
+++ b/SPECS/selinux-policy/0030-container-allow-containers-to-manipulate-own-fds.patch
@@ -1,0 +1,34 @@
+From 7081fde476c41ded9847552addd807d57febaa14 Mon Sep 17 00:00:00 2001
+From: Kenton Groombridge <me@concord.sh>
+Date: Fri, 29 Apr 2022 21:36:10 -0400
+Subject: [PATCH 30/37] container: allow containers to manipulate own fds
+
+Signed-off-by: Kenton Groombridge <me@concord.sh>
+---
+ policy/modules/services/container.te | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/policy/modules/services/container.te b/policy/modules/services/container.te
+index 18cdc2dd5..ea76c1096 100644
+--- a/policy/modules/services/container.te
++++ b/policy/modules/services/container.te
+@@ -151,6 +151,8 @@ corenet_port(container_port_t)
+ allow container_domain self:capability { dac_override kill setgid setuid sys_boot sys_chroot };
+ allow container_domain self:cap_userns { chown dac_override fowner setgid setuid };
+ allow container_domain self:process { execstack execmem getattr getsched getsession setsched setcap setpgid signal_perms };
++allow container_domain self:dir rw_dir_perms;
++allow container_domain self:file create_file_perms;
+ allow container_domain self:fifo_file manage_fifo_file_perms;
+ allow container_domain self:sem create_sem_perms;
+ allow container_domain self:shm create_shm_perms;
+@@ -179,6 +181,7 @@ corecmd_watch_bin_dirs(container_domain)
+ 
+ kernel_getattr_proc(container_domain)
+ kernel_list_all_proc(container_domain)
++kernel_associate_proc(container_domain)
+ kernel_read_kernel_sysctls(container_domain)
+ kernel_rw_net_sysctls(container_domain)
+ kernel_read_system_state(container_domain)
+-- 
+2.25.1
+

--- a/SPECS/selinux-policy/0031-devices-Add-type-for-infiniband-devices.patch
+++ b/SPECS/selinux-policy/0031-devices-Add-type-for-infiniband-devices.patch
@@ -1,0 +1,44 @@
+From 4d47de6c6a302448e761e130d576bc2de1850277 Mon Sep 17 00:00:00 2001
+From: Chris PeBenito <Christopher.PeBenito@microsoft.com>
+Date: Mon, 23 May 2022 14:42:58 +0000
+Subject: [PATCH 31/37] devices: Add type for infiniband devices.
+
+Signed-off-by: Chris PeBenito <Christopher.PeBenito@microsoft.com>
+---
+ policy/modules/kernel/devices.fc | 2 ++
+ policy/modules/kernel/devices.te | 6 ++++++
+ 2 files changed, 8 insertions(+)
+
+diff --git a/policy/modules/kernel/devices.fc b/policy/modules/kernel/devices.fc
+index 009887934..78a2a09f2 100644
+--- a/policy/modules/kernel/devices.fc
++++ b/policy/modules/kernel/devices.fc
+@@ -165,6 +165,8 @@ ifdef(`distro_suse', `
+ 
+ /dev/dvb/.*		-c	gen_context(system_u:object_r:v4l_device_t,s0)
+ 
++/dev/infiniband/.*  -c  gen_context(system_u:object_r:infiniband_device_t,s0)
++
+ /dev/input/.*		-c	gen_context(system_u:object_r:event_device_t,s0)
+ /dev/input/m.*		-c	gen_context(system_u:object_r:mouse_device_t,s0)
+ /dev/input/.*mouse.*	-c	gen_context(system_u:object_r:mouse_device_t,s0)
+diff --git a/policy/modules/kernel/devices.te b/policy/modules/kernel/devices.te
+index 068419502..8ac7c212c 100644
+--- a/policy/modules/kernel/devices.te
++++ b/policy/modules/kernel/devices.te
+@@ -122,6 +122,12 @@ dev_node(freefall_device_t)
+ type gpiochip_device_t;
+ dev_node(gpiochip_device_t)
+ 
++#
++# Type for /dev/infiniband/*
++#
++type infiniband_device_t;
++dev_node(infiniband_device_t)
++
+ #
+ # Type for /dev/ipmi/0
+ #
+-- 
+2.25.1
+

--- a/SPECS/selinux-policy/0032-storage-Add-fc-for-dev-ng-n-devices.patch
+++ b/SPECS/selinux-policy/0032-storage-Add-fc-for-dev-ng-n-devices.patch
@@ -1,0 +1,25 @@
+From 626347b70d714d36f141967a6e16f4b4d16f22d6 Mon Sep 17 00:00:00 2001
+From: Chris PeBenito <Christopher.PeBenito@microsoft.com>
+Date: Mon, 23 May 2022 14:43:46 +0000
+Subject: [PATCH 32/37] storage: Add fc for /dev/ng*n* devices.
+
+Signed-off-by: Chris PeBenito <Christopher.PeBenito@microsoft.com>
+---
+ policy/modules/kernel/storage.fc | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/policy/modules/kernel/storage.fc b/policy/modules/kernel/storage.fc
+index 46395b8fc..3033ac4de 100644
+--- a/policy/modules/kernel/storage.fc
++++ b/policy/modules/kernel/storage.fc
+@@ -35,6 +35,7 @@
+ /dev/mtd.*		-b	gen_context(system_u:object_r:fixed_disk_device_t,mls_systemhigh)
+ /dev/mtd.*		-c	gen_context(system_u:object_r:fixed_disk_device_t,mls_systemhigh)
+ /dev/nb[^/]+		-b	gen_context(system_u:object_r:fixed_disk_device_t,mls_systemhigh)
++/dev/ng[0-9]+n[0-9]+	-c	gen_context(system_u:object_r:fixed_disk_device_t,mls_systemhigh)
+ /dev/nvme[0-9]+		-c	gen_context(system_u:object_r:fixed_disk_device_t,mls_systemhigh)
+ /dev/nvme[0-9]n[^/]+	-b	gen_context(system_u:object_r:fixed_disk_device_t,mls_systemhigh)
+ /dev/optcd		-b	gen_context(system_u:object_r:removable_device_t,s0)
+-- 
+2.25.1
+

--- a/SPECS/selinux-policy/0033-files-Add-prerequisite-access-for-files_mounton_non_.patch
+++ b/SPECS/selinux-policy/0033-files-Add-prerequisite-access-for-files_mounton_non_.patch
@@ -1,0 +1,29 @@
+From 345031d046d934e236ccab588f148c4b0e166066 Mon Sep 17 00:00:00 2001
+From: Chris PeBenito <Christopher.PeBenito@microsoft.com>
+Date: Mon, 23 May 2022 14:44:39 +0000
+Subject: [PATCH 33/37] files: Add prerequisite access for
+ files_mounton_non_security().
+
+Signed-off-by: Chris PeBenito <Christopher.PeBenito@microsoft.com>
+---
+ policy/modules/kernel/files.if | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/policy/modules/kernel/files.if b/policy/modules/kernel/files.if
+index 97a54d998..75fdaa872 100644
+--- a/policy/modules/kernel/files.if
++++ b/policy/modules/kernel/files.if
+@@ -568,8 +568,8 @@ interface(`files_mounton_non_security',`
+ 		attribute non_security_file_type;
+ 	')
+ 
+-	allow $1 non_security_file_type:dir mounton;
+-	allow $1 non_security_file_type:file mounton;
++	allow $1 non_security_file_type:dir { getattr search mounton };
++	allow $1 non_security_file_type:file { getattr mounton };
+ ')
+ 
+ ########################################
+-- 
+2.25.1
+

--- a/SPECS/selinux-policy/0034-files-Make-etc_runtime_t-a-config-file.patch
+++ b/SPECS/selinux-policy/0034-files-Make-etc_runtime_t-a-config-file.patch
@@ -1,0 +1,26 @@
+From 22df79fe65d1eb8199a6c7e50e569d2d21460ecb Mon Sep 17 00:00:00 2001
+From: Chris PeBenito <Christopher.PeBenito@microsoft.com>
+Date: Mon, 23 May 2022 14:45:00 +0000
+Subject: [PATCH 34/37] files: Make etc_runtime_t a config file.
+
+Signed-off-by: Chris PeBenito <Christopher.PeBenito@microsoft.com>
+---
+ policy/modules/kernel/files.te | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/policy/modules/kernel/files.te b/policy/modules/kernel/files.te
+index c1775f65d..2691a8611 100644
+--- a/policy/modules/kernel/files.te
++++ b/policy/modules/kernel/files.te
+@@ -72,7 +72,7 @@ optional_policy(`
+ # files in /etc that are automatically
+ # generated during initialization.
+ #
+-type etc_runtime_t;
++type etc_runtime_t, configfile;
+ files_type(etc_runtime_t)
+ 
+ #
+-- 
+2.25.1
+

--- a/SPECS/selinux-policy/0035-systemd-Fixes-for-coredumps-in-containers.patch
+++ b/SPECS/selinux-policy/0035-systemd-Fixes-for-coredumps-in-containers.patch
@@ -1,0 +1,91 @@
+From b938bbb30cd1d92b3a5993eff4e898b0fa16e1dd Mon Sep 17 00:00:00 2001
+From: Chris PeBenito <Christopher.PeBenito@microsoft.com>
+Date: Mon, 23 May 2022 14:56:55 +0000
+Subject: [PATCH 35/37] systemd: Fixes for coredumps in containers.
+
+Signed-off-by: Chris PeBenito <Christopher.PeBenito@microsoft.com>
+---
+ policy/modules/kernel/filesystem.if | 18 ++++++++++++++++++
+ policy/modules/system/systemd.te    | 18 ++++++++++++++----
+ 2 files changed, 32 insertions(+), 4 deletions(-)
+
+diff --git a/policy/modules/kernel/filesystem.if b/policy/modules/kernel/filesystem.if
+index abaf52626..b3e5817b1 100644
+--- a/policy/modules/kernel/filesystem.if
++++ b/policy/modules/kernel/filesystem.if
+@@ -3941,6 +3941,24 @@ interface(`fs_rw_nfsd_fs',`
+ 	rw_files_pattern($1, nfsd_fs_t, nfsd_fs_t)
+ ')
+ 
++########################################
++## <summary>
++##	Get the attributes of nsfs inodes (e.g. /proc/pid/ns/uts)
++## </summary>
++## <param name="domain">
++##	<summary>
++##	Domain allowed access.
++##	</summary>
++## </param>
++#
++interface(`fs_getattr_nsfs_files',`
++	gen_require(`
++		type nsfs_t;
++	')
++
++	allow $1 nsfs_t:file getattr_file_perms;
++')
++
+ ########################################
+ ## <summary>
+ ##	Read nsfs inodes (e.g. /proc/pid/ns/uts)
+diff --git a/policy/modules/system/systemd.te b/policy/modules/system/systemd.te
+index 8997f2ac1..48613bd20 100644
+--- a/policy/modules/system/systemd.te
++++ b/policy/modules/system/systemd.te
+@@ -410,29 +410,39 @@ ifdef(`enable_mls',`
+ # coredump local policy
+ #
+ 
+-allow systemd_coredump_t self:unix_dgram_socket { create write connect getopt setopt };
+-allow systemd_coredump_t self:capability { setgid setuid setpcap };
+-allow systemd_coredump_t self:cap_userns sys_ptrace;
++allow systemd_coredump_t self:capability { setgid setuid setpcap sys_ptrace };
++allow systemd_coredump_t self:cap_userns { sys_admin sys_ptrace };
+ allow systemd_coredump_t self:process { getcap setcap setfscreate };
++allow systemd_coredump_t self:unix_dgram_socket { create write connect getopt setopt };
++allow systemd_coredump_t self:unix_stream_socket { create_stream_socket_perms connectto };
++allow systemd_coredump_t self:fifo_file rw_inherited_fifo_file_perms;
++dontaudit systemd_coredump_t self:capability net_admin;
+ 
+-manage_files_pattern(systemd_coredump_t, systemd_coredump_var_lib_t, systemd_coredump_var_lib_t)
++mmap_manage_files_pattern(systemd_coredump_t, systemd_coredump_var_lib_t, systemd_coredump_var_lib_t)
+ 
+ kernel_domtrans_to(systemd_coredump_t, systemd_coredump_exec_t)
+ kernel_read_kernel_sysctls(systemd_coredump_t)
+ kernel_read_system_state(systemd_coredump_t)
+ kernel_rw_pipes(systemd_coredump_t)
+ kernel_use_fds(systemd_coredump_t)
++kernel_read_crypto_sysctls(systemd_coredump_t)
+ 
+ corecmd_exec_bin(systemd_coredump_t)
+ corecmd_read_all_executables(systemd_coredump_t)
+ 
+ dev_write_kmsg(systemd_coredump_t)
+ 
++domain_read_all_domains_state(systemd_coredump_t)
++
+ files_getattr_all_mountpoints(systemd_coredump_t)
+ files_read_etc_files(systemd_coredump_t)
+ files_search_var_lib(systemd_coredump_t)
++files_mounton_root(systemd_coredump_t)
+ 
+ fs_getattr_xattr_fs(systemd_coredump_t)
++fs_getattr_nsfs_files(systemd_coredump_t)
++fs_search_cgroup_dirs(systemd_coredump_t)
++fs_getattr_cgroup(systemd_coredump_t)
+ 
+ selinux_getattr_fs(systemd_coredump_t)
+ 
+-- 
+2.25.1
+

--- a/SPECS/selinux-policy/0036-container-Allow-container-engines-to-connect-to-http.patch
+++ b/SPECS/selinux-policy/0036-container-Allow-container-engines-to-connect-to-http.patch
@@ -1,0 +1,72 @@
+From b8b83e5c125f8389a26fd31fd0638af3c283359c Mon Sep 17 00:00:00 2001
+From: Chris PeBenito <Christopher.PeBenito@microsoft.com>
+Date: Mon, 23 May 2022 15:16:36 +0000
+Subject: [PATCH 36/37] container: Allow container engines to connect to http
+ cache ports.
+
+Signed-off-by: Chris PeBenito <Christopher.PeBenito@microsoft.com>
+---
+ policy/modules/kernel/files.if       | 19 +++++++++++++++++++
+ policy/modules/services/container.te |  1 +
+ policy/modules/system/systemd.te     |  3 +++
+ 3 files changed, 23 insertions(+)
+
+diff --git a/policy/modules/kernel/files.if b/policy/modules/kernel/files.if
+index 75fdaa872..12e427b45 100644
+--- a/policy/modules/kernel/files.if
++++ b/policy/modules/kernel/files.if
+@@ -5003,6 +5003,25 @@ interface(`files_purge_tmp',`
+ 	delete_sock_files_pattern($1, tmpfile, tmpfile)
+ ')
+ 
++########################################
++## <summary>
++##	Get the attributes of all tmpfs files.
++## </summary>
++## <param name="type">
++##	<summary>
++##	Domain allowed access.
++##	</summary>
++## </param>
++#
++interface(`files_getattr_all_tmpfs_files',`
++	gen_require(`
++		attribute tmpfsfile;
++	')
++
++	getattr_files_pattern($1, tmpfsfile, tmpfsfile)
++	fs_search_tmpfs($1)
++')
++
+ ########################################
+ ## <summary>
+ ##	Set the attributes of the /usr directory.
+diff --git a/policy/modules/services/container.te b/policy/modules/services/container.te
+index ea76c1096..64b1ad918 100644
+--- a/policy/modules/services/container.te
++++ b/policy/modules/services/container.te
+@@ -381,6 +381,7 @@ corecmd_dontaudit_exec_all_executables(container_engine_domain)
+ 
+ corenet_tcp_bind_generic_node(container_engine_domain)
+ corenet_tcp_connect_http_port(container_engine_domain)
++corenet_tcp_connect_http_cache_port(container_engine_domain)
+ corenet_tcp_bind_all_ports(container_engine_domain)
+ corenet_udp_bind_all_ports(container_engine_domain)
+ corenet_rw_tun_tap_dev(container_engine_domain)
+diff --git a/policy/modules/system/systemd.te b/policy/modules/system/systemd.te
+index 48613bd20..21932008d 100644
+--- a/policy/modules/system/systemd.te
++++ b/policy/modules/system/systemd.te
+@@ -809,6 +809,9 @@ dev_setattr_video_dev(systemd_logind_t)
+ domain_obj_id_change_exemption(systemd_logind_t)
+ 
+ files_search_runtime(systemd_logind_t)
++# Getattr all shm segments as part of cleaning up the
++# segments of deleted ephemeral users.
++files_getattr_all_tmpfs_files(systemd_logind_t)
+ 
+ fs_getattr_cgroup(systemd_logind_t)
+ fs_getattr_tmpfs(systemd_logind_t)
+-- 
+2.25.1
+

--- a/SPECS/selinux-policy/0037-container-Getattr-generic-device-nodes.patch
+++ b/SPECS/selinux-policy/0037-container-Getattr-generic-device-nodes.patch
@@ -1,0 +1,30 @@
+From c9669f332fb3095c3eb0681034959287312f2c3c Mon Sep 17 00:00:00 2001
+From: Chris PeBenito <Christopher.PeBenito@microsoft.com>
+Date: Mon, 23 May 2022 15:23:27 +0000
+Subject: [PATCH 37/37] container: Getattr generic device nodes.
+
+There should be no device_t device nodes, but add access in case they
+exist. Saw containerd fail to start containers if it couldn't stat() all
+devices.
+
+Signed-off-by: Chris PeBenito <Christopher.PeBenito@microsoft.com>
+---
+ policy/modules/services/container.te | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/policy/modules/services/container.te b/policy/modules/services/container.te
+index 64b1ad918..709f2e214 100644
+--- a/policy/modules/services/container.te
++++ b/policy/modules/services/container.te
+@@ -388,6 +388,8 @@ corenet_rw_tun_tap_dev(container_engine_domain)
+ 
+ dev_getattr_all_blk_files(container_engine_domain)
+ dev_getattr_all_chr_files(container_engine_domain)
++dev_getattr_generic_blk_files(container_engine_domain)
++dev_getattr_generic_chr_files(container_engine_domain)
+ dev_setattr_null_dev(container_engine_domain)
+ dev_getattr_fs(container_engine_domain)
+ dev_remount_fs(container_engine_domain)
+-- 
+2.25.1
+

--- a/SPECS/selinux-policy/0038-application-Allow-apps-to-use-init-fds.patch
+++ b/SPECS/selinux-policy/0038-application-Allow-apps-to-use-init-fds.patch
@@ -1,0 +1,36 @@
+From 3f78663febf3bcda679737b73b85bafba72b3639 Mon Sep 17 00:00:00 2001
+From: Chris PeBenito <Christopher.PeBenito@microsoft.com>
+Date: Mon, 23 May 2022 20:45:58 +0000
+Subject: [PATCH 38/38] application: Allow apps to use init fds.
+
+This is needed for console/serial logins:
+
+avc:  denied  { use } for  pid=767 comm="semodule" path="/dev/ttyS0"
+dev="devtmpfs" ino=83
+scontext=unconfined_u:unconfined_r:semanage_t:s0-s0:c0.c1023
+tcontext=system_u:system_r:init_t:s0 tclass=fd permissive=0
+
+Signed-off-by: Chris PeBenito <Christopher.PeBenito@microsoft.com>
+---
+ policy/modules/system/application.te | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/policy/modules/system/application.te b/policy/modules/system/application.te
+index 658aeed0a..810d8e6c6 100644
+--- a/policy/modules/system/application.te
++++ b/policy/modules/system/application.te
+@@ -6,6 +6,11 @@ attribute application_domain_type;
+ # Executables to be run by user
+ attribute application_exec_type;
+ 
++ifdef(`init_systemd',`
++	# Needed for console/serial logins.
++	init_use_fds(application_domain_type)
++')
++
+ optional_policy(`
+ 	cron_sigchld(application_domain_type)
+ ')
+-- 
+2.25.1
+

--- a/SPECS/selinux-policy/selinux-policy.spec
+++ b/SPECS/selinux-policy/selinux-policy.spec
@@ -9,7 +9,7 @@
 Summary:        SELinux policy
 Name:           selinux-policy
 Version:        %{refpolicy_major}.%{refpolicy_minor}
-Release:        5%{?dist}
+Release:        6%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -47,6 +47,15 @@ Patch26:        0026-devices-Add-type-for-SAS-management-devices.patch
 Patch27:        0027-devices-Add-file-context-for-dev-vhost-vsock.patch
 Patch28:        0028-Add-dac_read_search-perms.patch
 Patch29:        0029-iptables-Ioctl-cgroup-dirs.patch
+Patch30:        0030-container-allow-containers-to-manipulate-own-fds.patch
+Patch31:        0031-devices-Add-type-for-infiniband-devices.patch
+Patch32:        0032-storage-Add-fc-for-dev-ng-n-devices.patch
+Patch33:        0033-files-Add-prerequisite-access-for-files_mounton_non_.patch
+Patch34:        0034-files-Make-etc_runtime_t-a-config-file.patch
+Patch35:        0035-systemd-Fixes-for-coredumps-in-containers.patch
+Patch36:        0036-container-Allow-container-engines-to-connect-to-http.patch
+Patch37:        0037-container-Getattr-generic-device-nodes.patch
+Patch38:        0038-application-Allow-apps-to-use-init-fds.patch
 BuildRequires:  bzip2
 BuildRequires:  checkpolicy >= %{CHECKPOLICYVER}
 BuildRequires:  m4
@@ -323,6 +332,13 @@ exit 0
 selinuxenabled && semodule -nB
 exit 0
 %changelog
+* Mon May 23 2022 Chris PeBenito <chpebeni@microsoft.com> - 2.20220106-6
+- Fix previous multipath LVM changes.
+- Add types for devices.
+- Cherry pick upstream commit for container fds.
+- Allow container engines to connect to http cache ports.
+- Allow container engines to stat() generic (device_t) devices.
+
 * Mon May 02 2022 Chris PeBenito <chpebeni@microsoft.com> - 2.20220106-5
 - Additional compatibility for Fedora container-selinux.
 - Remove unneeded systemd_run_t domain

--- a/SPECS/selinux-policy/selinux-policy.spec
+++ b/SPECS/selinux-policy/selinux-policy.spec
@@ -9,7 +9,7 @@
 Summary:        SELinux policy
 Name:           selinux-policy
 Version:        %{refpolicy_major}.%{refpolicy_minor}
-Release:        4%{?dist}
+Release:        5%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -35,6 +35,18 @@ Patch14:        0014-systemd-Misc-updates.patch
 Patch15:        0015-rpm-Add-dnf-and-tdnf-labeling.patch
 Patch16:        0016-logging-Change-to-systemd-interface-for-tmpfilesd.patch
 Patch17:        0017-Add-cloud-init.patch
+Patch18:        0018-Add-compatibility-for-container-selinux.patch
+Patch19:        0019-systemd-Remove-systemd-run-domain.patch
+Patch20:        0020-unconfined-Add-missing-capability2-perms.patch
+Patch21:        0021-lvm-Updates-for-multipath-LVM.patch
+Patch22:        0022-locallogin-Use-init-file-descriptors.patch
+Patch23:        0023-systemd-Misc-fixes.patch
+Patch24:        0024-isns-Updates-from-testing.patch
+Patch25:        0025-container-docker-Fixes-for-containerd-and-kubernetes.patch
+Patch26:        0026-devices-Add-type-for-SAS-management-devices.patch
+Patch27:        0027-devices-Add-file-context-for-dev-vhost-vsock.patch
+Patch28:        0028-Add-dac_read_search-perms.patch
+Patch29:        0029-iptables-Ioctl-cgroup-dirs.patch
 BuildRequires:  bzip2
 BuildRequires:  checkpolicy >= %{CHECKPOLICYVER}
 BuildRequires:  m4
@@ -311,6 +323,16 @@ exit 0
 selinuxenabled && semodule -nB
 exit 0
 %changelog
+* Mon May 02 2022 Chris PeBenito <chpebeni@microsoft.com> - 2.20220106-5
+- Additional compatibility for Fedora container-selinux.
+- Remove unneeded systemd_run_t domain
+- Updates for multipath LVM
+- Fix for console logins
+- New type for SAS management devices
+
+* Fri Apr 29 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 2.20220106-4
+- Fixing source URL.
+
 * Wed Mar 30 2022 Max Brodeur-Urbas <maxbr@microsoft.com> - 2.20220106-4
 - chpebeni@microsoft.com, 2.20220106-3: Additional policy fixes for enforcing core images.
 

--- a/SPECS/selinux-policy/selinux-policy.spec
+++ b/SPECS/selinux-policy/selinux-policy.spec
@@ -14,7 +14,7 @@ License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 URL:            https://github.com/SELinuxProject/refpolicy
-Source0:        %{url}/releases/download/RELEASE_${refpolicy_major}_%{refpolicy_minor}/refpolicy-%{version}.tar.bz2
+Source0:        %{url}/releases/download/RELEASE_%{refpolicy_major}_%{refpolicy_minor}/refpolicy-%{version}.tar.bz2
 Source1:        Makefile.devel
 Source2:        booleans_targeted.conf
 Source3:        modules_targeted.conf

--- a/SPECS/selinux-policy/selinux-policy.spec
+++ b/SPECS/selinux-policy/selinux-policy.spec
@@ -14,7 +14,7 @@ License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 URL:            https://github.com/SELinuxProject/refpolicy
-Source0:        %{url}/releases/download/RELEASE_${refpolicy_major}_${refpolicy_minor}/refpolicy-%{version}.tar.bz2
+Source0:        %{url}/releases/download/RELEASE_${refpolicy_major}_%{refpolicy_minor}/refpolicy-%{version}.tar.bz2
 Source1:        Makefile.devel
 Source2:        booleans_targeted.conf
 Source3:        modules_targeted.conf

--- a/SPECS/selinux-policy/selinux-policy.spec
+++ b/SPECS/selinux-policy/selinux-policy.spec
@@ -9,7 +9,7 @@
 Summary:        SELinux policy
 Name:           selinux-policy
 Version:        %{refpolicy_major}.%{refpolicy_minor}
-Release:        6%{?dist}
+Release:        7%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -332,21 +332,21 @@ exit 0
 selinuxenabled && semodule -nB
 exit 0
 %changelog
-* Mon May 23 2022 Chris PeBenito <chpebeni@microsoft.com> - 2.20220106-6
+* Mon May 23 2022 Chris PeBenito <chpebeni@microsoft.com> - 2.20220106-7
 - Fix previous multipath LVM changes.
 - Add types for devices.
 - Cherry pick upstream commit for container fds.
 - Allow container engines to connect to http cache ports.
 - Allow container engines to stat() generic (device_t) devices.
 
-* Mon May 02 2022 Chris PeBenito <chpebeni@microsoft.com> - 2.20220106-5
+* Mon May 02 2022 Chris PeBenito <chpebeni@microsoft.com> - 2.20220106-6
 - Additional compatibility for Fedora container-selinux.
 - Remove unneeded systemd_run_t domain
 - Updates for multipath LVM
 - Fix for console logins
 - New type for SAS management devices
 
-* Fri Apr 29 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 2.20220106-4
+* Fri Apr 29 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 2.20220106-5
 - Fixing source URL.
 
 * Wed Mar 30 2022 Max Brodeur-Urbas <maxbr@microsoft.com> - 2.20220106-4


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Backporting:
[selinux-policy: Add additional patches from containers and kubernetes testing.
](https://github.com/microsoft/CBL-Mariner/pull/2937)
[selinux-policy: Fixes from baremetal testing](https://github.com/microsoft/CBL-Mariner/pull/3047)

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
SELinux policy

* Mon May 23 2022 Chris PeBenito <chpebeni@microsoft.com> - 2.20220106-6
- Fix previous multipath LVM changes.
- Add types for devices.
- Cherry pick upstream commit for container fds.
- Allow container engines to connect to http cache ports.
- Allow container engines to stat() generic (device_t) devices.

* Mon May 02 2022 Chris PeBenito <chpebeni@microsoft.com> - 2.20220106-5
- Additional compatibility for Fedora container-selinux.
- Remove unneeded systemd_run_t domain
- Updates for multipath LVM
- Fix for console logins
- New type for SAS management devices

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: running
