### PR TITLE
`ocaml-ctypes`: changing test dependencies to `ounit2`.

### DIFF
--- a/SPECS/ocaml-ctypes/ocaml-ctypes.spec
+++ b/SPECS/ocaml-ctypes/ocaml-ctypes.spec
@@ -1,7 +1,7 @@
 Summary:        Combinators for binding to C libraries without writing any C
 Name:           ocaml-ctypes
 Version:        0.18.0
-Release:        4%{?dist}
+Release:        5%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -69,6 +69,10 @@ sed -i 's/^DOCFLAGS=/&-I $(shell ocamlfind query bigarray-compat) /' Makefile
 sed -i 's|-add ctypes|& -ldconf %{buildroot}%{_libdir}/ocaml/ld.conf|' Makefile
 
 %build
+# Fixing test build dependencies.
+sed -i -e "s/ounit/ounit2/" ctypes.opam
+sed -i -e "s/oUnit/ounit2/" Makefile.tests
+
 # FIXME: Infrequent build failures with parallel build
 # It looks like the configuration step isn't done before its results are needed
 make all XEN=disable
@@ -123,6 +127,9 @@ make test
 %doc *.html *.css
 
 %changelog
+* Wed Jun 01 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 0.18.0-5
+- Fixing ptests.
+
 * Thu Mar 31 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 0.18.0-4
 - Cleaning-up spec. License verified.
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

Ptests for `ocaml-ctypes` claim to be missing the `ocaml` package. It seems to be [a know but not yet fully understood issue](https://github.com/exercism/ocaml/issues/364) with a simple workaround to require `ounit2` instead of `ounit`.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Switched test dependencies from `ounit`/`oUnit` to `ounit2`.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local package build with `RUN_CHECK=y`.
