### PR TITLE
hyperv-daemons/hypervkvpd.service: fix service ordering

### DIFF
--- a/SPECS/hyperv-daemons/hyperv-daemons.spec
+++ b/SPECS/hyperv-daemons/hyperv-daemons.spec
@@ -9,7 +9,7 @@
 Summary:        Hyper-V daemons suite
 Name:           hyperv-daemons
 Version:        5.15.41.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -219,6 +219,10 @@ fi
 %{_sbindir}/lsvmbus
 
 %changelog
+* Thu Jun 02 2022 Chris Patterson <cpatterson@microsoft.com> - 5.15.41.1-2
+- Fix ordering to ensure kvpd is started prior to cloud-init-local.service
+- Only start service if running under Hyper-V
+
 * Tue May 24 2022 Cameron Baird <cameronbaird@microsoft.com> - 5.15.41.1-1
 - Update source to 5.15.41.1
 

--- a/SPECS/hyperv-daemons/hypervkvpd.service
+++ b/SPECS/hyperv-daemons/hypervkvpd.service
@@ -1,7 +1,9 @@
 [Unit]
 Description=Hyper-V KVP daemon
+ConditionVirtualization=microsoft
 BindsTo=sys-devices-virtual-misc-vmbus\x21hv_kvp.device
-After=network.target
+After=sys-devices-virtual-misc-vmbus\x21hv_kvp.device
+RequiresMountsFor=/var/lib/hyperv
 IgnoreOnIsolate=1
 
 [Service]


### PR DESCRIPTION
**No instances of Mariner 2 are currently emitting KVP telemetry for cloud-init.**

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?

kvpd must start before cloud-init-local which comes before network.target.

1. Add ConditionVirtualization=microsoft to only start under Hyper-V.

2. Remove After=network.target dependency.

3. Add After=sys-devices-virtual-misc-vmbus\x21hv_kvp.device which
   should be combined with BindTo=.

Signed-off-by: Chris Patterson <cpatterson@microsoft.com>

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Ensure hypervkvpd.service starts prior to cloud-init-local.service.


###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Mariner 2 Azure image rebooted multiple times with changes