### PR TITLE
cloud-init: uprev to 22.2

### DIFF
--- a/SPECS/cloud-init/add-mariner-distro-support.patch
+++ b/SPECS/cloud-init/add-mariner-distro-support.patch
@@ -1,9 +1,38 @@
-Patch cloud-init 22.1 to add distro support for CBL-Mariner
+From cb170be483823fc21f05ed442877bdd22cae3b59 Mon Sep 17 00:00:00 2001
+From: Chris Patterson <cpatterson@microsoft.com>
+Date: Fri, 3 Jun 2022 11:15:26 +0000
+Subject: [PATCH] distros: add mariner support
 
-diff -Naur a/cloudinit/config/cc_ntp.py b/cloudinit/config/cc_ntp.py
---- a/cloudinit/config/cc_ntp.py	2022-02-15 10:02:23.000000000 -0800
-+++ b/cloudinit/config/cc_ntp.py	2022-03-28 20:35:46.924019452 -0700
-@@ -32,6 +32,7 @@
+Upstream-Status: Pending (backlog item)
+
+Signed-off-by: Chris Patterson <cpatterson@microsoft.com>
+---
+ cloudinit/config/cc_ntp.py                    |  11 ++
+ cloudinit/config/cc_resolv_conf.py            |  10 +-
+ cloudinit/config/cc_yum_add_repo.py           |   1 +
+ cloudinit/distros/__init__.py                 |   1 +
+ cloudinit/distros/mariner.py                  | 165 ++++++++++++++++++
+ cloudinit/util.py                             |   1 +
+ config/cloud.cfg.tmpl                         |  18 +-
+ systemd/cloud-init.service.tmpl               |   2 +-
+ templates/hosts.mariner.tmpl                  |  22 +++
+ .../unittests/config/test_cc_set_hostname.py  |  48 +++++
+ tests/unittests/distros/test_mariner.py       |  68 ++++++++
+ tests/unittests/distros/test_netconfig.py     | 125 +++++++++++++
+ tests/unittests/test_cli.py                   |   3 +-
+ tests/unittests/test_render_cloudcfg.py       |   3 +
+ tests/unittests/test_util.py                  |  21 +++
+ tools/render-cloudcfg                         |   1 +
+ 16 files changed, 489 insertions(+), 11 deletions(-)
+ create mode 100644 cloudinit/distros/mariner.py
+ create mode 100644 templates/hosts.mariner.tmpl
+ create mode 100644 tests/unittests/distros/test_mariner.py
+
+diff --git a/cloudinit/config/cc_ntp.py b/cloudinit/config/cc_ntp.py
+index 3bc1d303..9ba7d379 100644
+--- a/cloudinit/config/cc_ntp.py
++++ b/cloudinit/config/cc_ntp.py
+@@ -28,6 +28,7 @@ distros = [
      "debian",
      "eurolinux",
      "fedora",
@@ -11,60 +40,49 @@ diff -Naur a/cloudinit/config/cc_ntp.py b/cloudinit/config/cc_ntp.py
      "miraclelinux",
      "openEuler",
      "opensuse",
-@@ -96,6 +97,19 @@
+@@ -92,6 +93,16 @@ DISTRO_CLIENT_CONFIG = {
              "confpath": "/etc/chrony/chrony.conf",
          },
      },
-+    'mariner': {
-+        'chrony': {
-+            'service_name': 'chronyd',
++    "mariner": {
++        "chrony": {
++            "service_name": "chronyd",
 +        },
-+        'ntp': {
-+            'service_name': 'ntpd',
-+            'confpath': '/etc/ntp.conf'
-+        },
-+        'systemd-timesyncd': {
-+            'check_exe': '/usr/lib/systemd/systemd-timesyncd',
-+            'confpath': '/etc/systemd/timesyncd.conf',
++        "ntp": {"service_name": "ntpd", "confpath": "/etc/ntp.conf"},
++        "systemd-timesyncd": {
++            "check_exe": "/usr/lib/systemd/systemd-timesyncd",
++            "confpath": "/etc/systemd/timesyncd.conf",
 +        },
 +    },
      "opensuse": {
          "chrony": {
              "service_name": "chronyd",
-diff -Naur a/cloudinit/config/cc_resolv_conf.py b/cloudinit/config/cc_resolv_conf.py
---- a/cloudinit/config/cc_resolv_conf.py	2022-02-15 10:02:23.000000000 -0800
-+++ b/cloudinit/config/cc_resolv_conf.py	2022-03-28 20:35:46.924019452 -0700
-@@ -30,7 +30,7 @@
- 
- **Module frequency:** per instance
- 
--**Supported distros:** alpine, fedora, photon, rhel, sles
-+**Supported distros:** alpine, fedora, mariner, photon, rhel, sles
- 
- **Config keys**::
- 
-@@ -54,7 +54,7 @@
- 
- frequency = PER_INSTANCE
- 
--distros = ["alpine", "fedora", "opensuse", "photon", "rhel", "sles"]
-+distros = ["alpine", "fedora", "mariner", "opensuse", "photon", "rhel", "sles"]
- 
- RESOLVE_CONFIG_TEMPLATE_MAP = {
-     "/etc/resolv.conf": "resolv.conf",
-diff -Naur a/cloudinit/config/cc_yum_add_repo.py b/cloudinit/config/cc_yum_add_repo.py
---- a/cloudinit/config/cc_yum_add_repo.py	2022-02-15 10:02:23.000000000 -0800
-+++ b/cloudinit/config/cc_yum_add_repo.py	2022-03-28 20:35:46.924019452 -0700
-@@ -18,7 +18,7 @@
- 
- **Module frequency:** always
- 
--**Supported distros:** almalinux, centos, cloudlinux, eurolinux, fedora,
-+**Supported distros:** almalinux, centos, cloudlinux, eurolinux, fedora, mariner,
-                        miraclelinux, openEuler, photon, rhel, rocky, virtuozzo
- 
- **Config keys**::
-@@ -43,6 +43,7 @@
+diff --git a/cloudinit/config/cc_resolv_conf.py b/cloudinit/config/cc_resolv_conf.py
+index bbf68079..b2ba7741 100644
+--- a/cloudinit/config/cc_resolv_conf.py
++++ b/cloudinit/config/cc_resolv_conf.py
+@@ -52,7 +52,15 @@ meta: MetaSchema = {
+     "name": "Resolv Conf",
+     "title": "Configure resolv.conf",
+     "description": MODULE_DESCRIPTION,
+-    "distros": ["alpine", "fedora", "opensuse", "photon", "rhel", "sles"],
++    "distros": [
++        "alpine",
++        "fedora",
++        "mariner",
++        "opensuse",
++        "photon",
++        "rhel",
++        "sles",
++    ],
+     "frequency": PER_INSTANCE,
+     "examples": [
+         dedent(
+diff --git a/cloudinit/config/cc_yum_add_repo.py b/cloudinit/config/cc_yum_add_repo.py
+index f7357192..769460ef 100644
+--- a/cloudinit/config/cc_yum_add_repo.py
++++ b/cloudinit/config/cc_yum_add_repo.py
+@@ -28,6 +28,7 @@ distros = [
      "cloudlinux",
      "eurolinux",
      "fedora",
@@ -72,10 +90,11 @@ diff -Naur a/cloudinit/config/cc_yum_add_repo.py b/cloudinit/config/cc_yum_add_r
      "openEuler",
      "photon",
      "rhel",
-diff -Naur a/cloudinit/distros/__init__.py b/cloudinit/distros/__init__.py
---- a/cloudinit/distros/__init__.py	2022-02-15 10:02:23.000000000 -0800
-+++ b/cloudinit/distros/__init__.py	2022-03-28 20:35:46.924019452 -0700
-@@ -45,6 +45,7 @@
+diff --git a/cloudinit/distros/__init__.py b/cloudinit/distros/__init__.py
+index b034e2c8..a8a3feaf 100644
+--- a/cloudinit/distros/__init__.py
++++ b/cloudinit/distros/__init__.py
+@@ -45,6 +45,7 @@ OSFAMILIES = {
          "cloudlinux",
          "eurolinux",
          "fedora",
@@ -83,10 +102,12 @@ diff -Naur a/cloudinit/distros/__init__.py b/cloudinit/distros/__init__.py
          "miraclelinux",
          "openEuler",
          "photon",
-diff -Naur a/cloudinit/distros/mariner.py b/cloudinit/distros/mariner.py
---- a/cloudinit/distros/mariner.py	1969-12-31 16:00:00.000000000 -0800
-+++ b/cloudinit/distros/mariner.py	2022-03-28 20:41:15.351781928 -0700
-@@ -0,0 +1,157 @@
+diff --git a/cloudinit/distros/mariner.py b/cloudinit/distros/mariner.py
+new file mode 100644
+index 00000000..2f1bcf80
+--- /dev/null
++++ b/cloudinit/distros/mariner.py
+@@ -0,0 +1,165 @@
 +#!/usr/bin/env python3
 +# vi: ts=4 expandtab
 +#
@@ -94,14 +115,11 @@ diff -Naur a/cloudinit/distros/mariner.py b/cloudinit/distros/mariner.py
 +#
 +# This file is part of cloud-init. See LICENSE file for license information.
 +
-+from cloudinit import net
-+from cloudinit import util
-+from cloudinit import subp
-+from cloudinit import distros
-+from cloudinit import helpers
++from cloudinit import distros, helpers
 +from cloudinit import log as logging
-+from cloudinit.settings import PER_INSTANCE
++from cloudinit import net, subp, util
 +from cloudinit.distros import rhel_util as rhutil
++from cloudinit.settings import PER_INSTANCE
 +
 +LOG = logging.getLogger(__name__)
 +
@@ -113,25 +131,24 @@ diff -Naur a/cloudinit/distros/mariner.py b/cloudinit/distros/mariner.py
 +# network: {config: disabled}
 +"""
 +
-+class Distro(distros.Distro):
-+    systemd_hostname_conf_fn = '/etc/hostname'
-+    network_conf_dir = '/etc/systemd/network/'
-+    systemd_locale_conf_fn = '/etc/locale.conf'
-+    resolve_conf_fn = '/etc/systemd/resolved.conf'
 +
-+    network_conf_fn = {
-+        "netplan": "/etc/netplan/50-cloud-init.yaml"
-+    }
++class Distro(distros.Distro):
++    systemd_hostname_conf_fn = "/etc/hostname"
++    network_conf_dir = "/etc/systemd/network/"
++    systemd_locale_conf_fn = "/etc/locale.conf"
++    resolve_conf_fn = "/etc/systemd/resolved.conf"
++
++    network_conf_fn = {"netplan": "/etc/netplan/50-cloud-init.yaml"}
 +    renderer_configs = {
-+        'networkd': {
-+            'resolv_conf_fn': resolve_conf_fn,
-+            'network_conf_dir': network_conf_dir,
++        "networkd": {
++            "resolv_conf_fn": resolve_conf_fn,
++            "network_conf_dir": network_conf_dir,
 +        },
 +        "netplan": {
 +            "netplan_path": network_conf_fn["netplan"],
 +            "netplan_header": NETWORK_FILE_HEADER,
-+            "postcmds": True
-+        }
++            "postcmds": True,
++        },
 +    }
 +
 +    # Should be fqdn if we can use it
@@ -143,33 +160,34 @@ diff -Naur a/cloudinit/distros/mariner.py b/cloudinit/distros/mariner.py
 +        # calls from repeatly happening (when they
 +        # should only happen say once per instance...)
 +        self._runner = helpers.Runners(paths)
-+        self.osfamily = 'mariner'
-+        self.init_cmd = ['systemctl']
++        self.osfamily = "mariner"
++        self.init_cmd = ["systemctl"]
 +
 +    def exec_cmd(self, cmd, capture=True):
-+        LOG.debug('Attempting to run: %s', cmd)
++        LOG.debug("Attempting to run: %s", cmd)
 +        try:
 +            (out, err) = subp.subp(cmd, capture=capture)
 +            if err:
-+                LOG.warning('Running %s resulted in stderr output: %s',
-+                            cmd, err)
++                LOG.warning(
++                    "Running %s resulted in stderr output: %s", cmd, err
++                )
 +                return True, out, err
 +            return False, out, err
 +        except subp.ProcessExecutionError:
-+            util.logexc(LOG, 'Command %s failed', cmd)
++            util.logexc(LOG, "Command %s failed", cmd)
 +            return True, None, None
 +
 +    def generate_fallback_config(self):
-+        key = 'disable_fallback_netcfg'
++        key = "disable_fallback_netcfg"
 +        disable_fallback_netcfg = self._cfg.get(key, True)
-+        LOG.debug('%s value is: %s', key, disable_fallback_netcfg)
++        LOG.debug("%s value is: %s", key, disable_fallback_netcfg)
 +
 +        if not disable_fallback_netcfg:
 +            return net.generate_fallback_config()
 +
 +        LOG.info(
-+            'Skipping generate_fallback_config. Rely on MarinerOS default '
-+            'network config'
++            "Skipping generate_fallback_config. Rely on MarinerOS default "
++            "network config"
 +        )
 +        return None
 +
@@ -180,7 +198,7 @@ diff -Naur a/cloudinit/distros/mariner.py b/cloudinit/distros/mariner.py
 +            out_fn = self.systemd_locale_conf_fn
 +
 +        locale_cfg = {
-+            'LANG': locale,
++            "LANG": locale,
 +        }
 +
 +        rhutil.update_sysconfig_file(out_fn, locale_cfg)
@@ -188,36 +206,43 @@ diff -Naur a/cloudinit/distros/mariner.py b/cloudinit/distros/mariner.py
 +        # rhutil will modify /etc/locale.conf
 +        # For locale change to take effect, reboot is needed or we can restart
 +        # systemd-localed. This is equivalent of localectl
-+        cmd = ['systemctl', 'restart', 'systemd-localed']
++        cmd = ["systemctl", "restart", "systemd-localed"]
 +        self.exec_cmd(cmd)
 +
 +    def install_packages(self, pkglist):
 +        # self.update_package_sources()
-+        self.package_command('install', pkgs=pkglist)
++        self.package_command("install", pkgs=pkglist)
 +
 +    def _write_hostname(self, hostname, filename):
-+        if filename and filename.endswith('/previous-hostname'):
++        if filename and filename.endswith("/previous-hostname"):
 +            util.write_file(filename, hostname)
 +        else:
-+            ret, _out, err = self.exec_cmd(['hostnamectl', 'set-hostname',
-+                                            str(hostname)])
++            ret, _out, err = self.exec_cmd(
++                ["hostnamectl", "set-hostname", str(hostname)]
++            )
 +            if ret:
-+                LOG.warning(('Error while setting hostname: %s\n'
-+                             'Given hostname: %s', err, hostname))
++                LOG.warning(
++                    (
++                        "Error while setting hostname: %s\n"
++                        "Given hostname: %s",
++                        err,
++                        hostname,
++                    )
++                )
 +
 +    def _read_system_hostname(self):
 +        sys_hostname = self._read_hostname(self.systemd_hostname_conf_fn)
 +        return (self.systemd_hostname_conf_fn, sys_hostname)
 +
 +    def _read_hostname(self, filename, default=None):
-+        if filename and filename.endswith('/previous-hostname'):
++        if filename and filename.endswith("/previous-hostname"):
 +            return util.load_file(filename).strip()
 +
-+        _ret, out, _err = self.exec_cmd(['hostname', '-f'])
++        _ret, out, _err = self.exec_cmd(["hostname", "-f"])
 +        return out.strip() if out else default
 +
 +    def _get_localhost_ip(self):
-+        return '127.0.1.1'
++        return "127.0.1.1"
 +
 +    def set_timezone(self, tz):
 +        distros.set_etc_timezone(tz=tz, tz_file=self._find_tz_file(tz))
@@ -226,7 +251,7 @@ diff -Naur a/cloudinit/distros/mariner.py b/cloudinit/distros/mariner.py
 +        if not pkgs:
 +            pkgs = []
 +
-+        cmd = ['tdnf', '-y']
++        cmd = ["tdnf", "-y"]
 +        if args and isinstance(args, str):
 +            cmd.append(args)
 +        elif args and isinstance(args, list):
@@ -234,21 +259,25 @@ diff -Naur a/cloudinit/distros/mariner.py b/cloudinit/distros/mariner.py
 +
 +        cmd.append(command)
 +
-+        pkglist = util.expand_package_list('%s-%s', pkgs)
++        pkglist = util.expand_package_list("%s-%s", pkgs)
 +        cmd.extend(pkglist)
 +
 +        ret, _out, err = self.exec_cmd(cmd)
 +        if ret:
-+            LOG.error('Error while installing packages: %s', err)
++            LOG.error("Error while installing packages: %s", err)
 +
 +    def update_package_sources(self):
-+        self._runner.run('update-sources', self.package_command,
-+                         ['makecache'], freq=PER_INSTANCE)
-\ No newline at end of file
-diff -Naur a/cloudinit/util.py b/cloudinit/util.py
---- a/cloudinit/util.py	2022-02-15 10:02:23.000000000 -0800
-+++ b/cloudinit/util.py	2022-03-28 20:35:46.924019452 -0700
-@@ -583,6 +583,7 @@
++        self._runner.run(
++            "update-sources",
++            self.package_command,
++            ["makecache"],
++            freq=PER_INSTANCE,
++        )
+diff --git a/cloudinit/util.py b/cloudinit/util.py
+index 2639478a..b7866f19 100644
+--- a/cloudinit/util.py
++++ b/cloudinit/util.py
+@@ -599,6 +599,7 @@ def _get_variant(info):
              "debian",
              "eurolinux",
              "fedora",
@@ -256,10 +285,11 @@ diff -Naur a/cloudinit/util.py b/cloudinit/util.py
              "miraclelinux",
              "openeuler",
              "photon",
-diff -Naur a/config/cloud.cfg.tmpl b/config/cloud.cfg.tmpl
---- a/config/cloud.cfg.tmpl	2022-02-15 10:02:23.000000000 -0800
-+++ b/config/cloud.cfg.tmpl	2022-03-28 20:35:46.924019452 -0700
-@@ -11,7 +11,7 @@
+diff --git a/config/cloud.cfg.tmpl b/config/cloud.cfg.tmpl
+index 6951a0e3..411065f9 100644
+--- a/config/cloud.cfg.tmpl
++++ b/config/cloud.cfg.tmpl
+@@ -11,7 +11,7 @@ syslog_fix_perms: root:root
  # when a 'default' entry is found it will reference the 'default_user'
  # from the distro configuration specified below
  users:
@@ -268,7 +298,7 @@ diff -Naur a/config/cloud.cfg.tmpl b/config/cloud.cfg.tmpl
     - name: root
       lock_passwd: false
  {% else %}
-@@ -85,11 +85,11 @@
+@@ -97,11 +97,11 @@ cloud_init_modules:
   - set_hostname
   - update_hostname
   - update_etc_hosts
@@ -282,17 +312,19 @@ diff -Naur a/config/cloud.cfg.tmpl b/config/cloud.cfg.tmpl
   - ca-certs
  {% endif %}
   - rsyslog
-@@ -105,14 +105,14 @@
-  - emit_upstart
+@@ -114,7 +114,7 @@ cloud_config_modules:
+ {% if variant in ["ubuntu", "unknown", "debian"] %}
   - snap
  {% endif %}
 -{% if variant not in ["photon"] %}
 +{% if variant not in ["mariner", "photon"] %}
   - ssh-import-id
+ {% if variant not in ["rhel"] %}
   - keyboard
-  - locale
+@@ -125,8 +125,8 @@ cloud_config_modules:
+ {% if variant in ["rhel"] %}
+  - rh_subscription
  {% endif %}
-  - set-passwords
 -{% if variant in ["rhel", "fedora", "photon"] %}
 -{% if variant not in ["photon"] %}
 +{% if variant in ["rhel", "fedora", "mariner", "photon"] %}
@@ -300,7 +332,7 @@ diff -Naur a/config/cloud.cfg.tmpl b/config/cloud.cfg.tmpl
   - spacewalk
  {% endif %}
   - yum-add-repo
-@@ -177,7 +177,7 @@
+@@ -191,7 +191,7 @@ cloud_final_modules:
  system_info:
     # This will affect which distro class gets used
  {% if variant in ["almalinux", "alpine", "amazon", "arch", "centos", "cloudlinux", "debian",
@@ -309,7 +341,7 @@ diff -Naur a/config/cloud.cfg.tmpl b/config/cloud.cfg.tmpl
                    "photon", "rhel", "rocky", "suse", "ubuntu", "virtuozzo"] %}
     distro: {{ variant }}
  {% elif variant in ["dragonfly"] %}
-@@ -302,7 +302,8 @@
+@@ -321,7 +321,8 @@ system_info:
       groups: [wheel]
       sudo: ["ALL=(ALL) NOPASSWD:ALL"]
       shell: /bin/ksh
@@ -319,7 +351,7 @@ diff -Naur a/config/cloud.cfg.tmpl b/config/cloud.cfg.tmpl
     default_user:
       name: photon
       lock_passwd: True
-@@ -310,6 +311,7 @@
+@@ -329,6 +330,7 @@ system_info:
       groups: [wheel]
       sudo: ["ALL=(ALL) NOPASSWD:ALL"]
       shell: /bin/bash
@@ -327,21 +359,24 @@ diff -Naur a/config/cloud.cfg.tmpl b/config/cloud.cfg.tmpl
     # Other config here will be given to the distro class and/or path classes
     paths:
        cloud_dir: /var/lib/cloud/
-diff -Naur a/systemd/cloud-init.service.tmpl b/systemd/cloud-init.service.tmpl
---- a/systemd/cloud-init.service.tmpl	2022-02-15 10:02:23.000000000 -0800
-+++ b/systemd/cloud-init.service.tmpl	2022-03-28 20:35:46.924019452 -0700
+diff --git a/systemd/cloud-init.service.tmpl b/systemd/cloud-init.service.tmpl
+index c170aef7..20ff1daa 100644
+--- a/systemd/cloud-init.service.tmpl
++++ b/systemd/cloud-init.service.tmpl
 @@ -1,7 +1,7 @@
  ## template:jinja
  [Unit]
  Description=Initial cloud-init job (metadata service crawler)
--{% if variant not in ["photon"] %}
-+{% if variant not in ["mariner", "photon"] %}
+-{% if variant not in ["photon", "rhel"] %}
++{% if variant not in ["mariner", "photon", "rhel"] %}
  DefaultDependencies=no
  {% endif %}
  Wants=cloud-init-local.service
-diff -Naur a/templates/hosts.mariner.tmpl b/templates/hosts.mariner.tmpl
---- a/templates/hosts.mariner.tmpl	1969-12-31 16:00:00.000000000 -0800
-+++ b/templates/hosts.mariner.tmpl	2022-03-28 20:35:46.924019452 -0700
+diff --git a/templates/hosts.mariner.tmpl b/templates/hosts.mariner.tmpl
+new file mode 100644
+index 00000000..2e956382
+--- /dev/null
++++ b/templates/hosts.mariner.tmpl
 @@ -0,0 +1,22 @@
 +## template:jinja
 +{#
@@ -366,91 +401,102 @@ diff -Naur a/templates/hosts.mariner.tmpl b/templates/hosts.mariner.tmpl
 +::1 {{fqdn}} {{hostname}}
 +::1 localhost6.localdomain6 localhost6
 \ No newline at end of file
-diff -Naur a/tests/unittests/config/test_cc_set_hostname.py b/tests/unittests/config/test_cc_set_hostname.py
---- a/tests/unittests/config/test_cc_set_hostname.py	2022-02-15 10:02:23.000000000 -0800
-+++ b/tests/unittests/config/test_cc_set_hostname.py	2022-03-28 20:35:46.924019452 -0700
-@@ -153,6 +153,46 @@
+diff --git a/tests/unittests/config/test_cc_set_hostname.py b/tests/unittests/config/test_cc_set_hostname.py
+index fd994c4e..462fe83b 100644
+--- a/tests/unittests/config/test_cc_set_hostname.py
++++ b/tests/unittests/config/test_cc_set_hostname.py
+@@ -153,6 +153,54 @@ class TestHostname(t_help.FilesystemMockingTestCase):
                      )
                  ] not in m_subp.call_args_list
  
-+    @mock.patch('cloudinit.distros.mariner.subp.subp')
++    @mock.patch("cloudinit.distros.mariner.subp.subp")
 +    def test_mariner_hostname(self, m_subp):
 +        cfg1 = {
-+            'hostname': 'mariner',
-+            'prefer_fqdn_over_hostname': True,
-+            'fqdn': 'test1.vmware.com',
++            "hostname": "mariner",
++            "prefer_fqdn_over_hostname": True,
++            "fqdn": "test1.vmware.com",
 +        }
 +        cfg2 = {
-+            'hostname': 'mariner',
-+            'prefer_fqdn_over_hostname': False,
-+            'fqdn': 'test2.vmware.com',
++            "hostname": "mariner",
++            "prefer_fqdn_over_hostname": False,
++            "fqdn": "test2.vmware.com",
 +        }
 +
 +        ds = None
 +        m_subp.return_value = (None, None)
-+        distro = self._fetch_distro('mariner', cfg1)
-+        paths = helpers.Paths({'cloud_dir': self.tmp})
++        distro = self._fetch_distro("mariner", cfg1)
++        paths = helpers.Paths({"cloud_dir": self.tmp})
 +        cc = cloud.Cloud(ds, paths, {}, distro, None)
 +        for c in [cfg1, cfg2]:
-+            cc_set_hostname.handle('cc_set_hostname', c, cc, LOG, [])
++            cc_set_hostname.handle("cc_set_hostname", c, cc, LOG, [])
 +            print("\n", m_subp.call_args_list)
-+            if c['prefer_fqdn_over_hostname']:
++            if c["prefer_fqdn_over_hostname"]:
 +                assert [
-+                    mock.call(['hostnamectl', 'set-hostname', c['fqdn']],
-+                              capture=True)
++                    mock.call(
++                        ["hostnamectl", "set-hostname", c["fqdn"]],
++                        capture=True,
++                    )
 +                ] in m_subp.call_args_list
 +                assert [
-+                    mock.call(['hostnamectl', 'set-hostname', c['hostname']],
-+                              capture=True)
++                    mock.call(
++                        ["hostnamectl", "set-hostname", c["hostname"]],
++                        capture=True,
++                    )
 +                ] not in m_subp.call_args_list
 +            else:
 +                assert [
-+                    mock.call(['hostnamectl', 'set-hostname', c['hostname']],
-+                              capture=True)
++                    mock.call(
++                        ["hostnamectl", "set-hostname", c["hostname"]],
++                        capture=True,
++                    )
 +                ] in m_subp.call_args_list
 +                assert [
-+                    mock.call(['hostnamectl', 'set-hostname', c['fqdn']],
-+                              capture=True)
++                    mock.call(
++                        ["hostnamectl", "set-hostname", c["fqdn"]],
++                        capture=True,
++                    )
 +                ] not in m_subp.call_args_list
 +
      def test_multiple_calls_skips_unchanged_hostname(self):
          """Only new hostname or fqdn values will generate a hostname call."""
          distro = self._fetch_distro("debian")
-diff -Naur a/tests/unittests/distros/test_mariner b/tests/unittests/distros/test_mariner
---- a/tests/unittests/distros/test_mariner	1969-12-31 16:00:00.000000000 -0800
-+++ b/tests/unittests/distros/test_mariner	2022-03-28 20:35:46.924019452 -0700
+diff --git a/tests/unittests/distros/test_mariner.py b/tests/unittests/distros/test_mariner.py
+new file mode 100644
+index 00000000..6acbaba1
+--- /dev/null
++++ b/tests/unittests/distros/test_mariner.py
 @@ -0,0 +1,68 @@
 +# This file is part of cloud-init. See LICENSE file for license information.
 +
-+from . import _get_distro
 +from cloudinit import util
-+from cloudinit.tests.helpers import mock
-+from cloudinit.tests.helpers import CiTestCase
++from tests.unittests.helpers import CiTestCase, mock
++
++from . import _get_distro
 +
 +SYSTEM_INFO = {
-+    'paths': {
-+        'cloud_dir': '/var/lib/cloud/',
-+        'templates_dir': '/etc/cloud/templates/',
++    "paths": {
++        "cloud_dir": "/var/lib/cloud/",
++        "templates_dir": "/etc/cloud/templates/",
 +    },
-+    'network': {'renderers': 'networkd'},
++    "network": {"renderers": "networkd"},
 +}
 +
 +
 +class TestMariner(CiTestCase):
 +    with_logs = True
-+    distro = _get_distro('mariner', SYSTEM_INFO)
-+    expected_log_line = 'Rely on MarinerOS default network config'
++    distro = _get_distro("mariner", SYSTEM_INFO)
++    expected_log_line = "Rely on MarinerOS default network config"
 +
 +    def test_network_renderer(self):
-+        self.assertEqual(self.distro._cfg['network']['renderers'], 'networkd')
++        self.assertEqual(self.distro._cfg["network"]["renderers"], "networkd")
 +
 +    def test_get_distro(self):
-+        self.assertEqual(self.distro.osfamily, 'mariner')
++        self.assertEqual(self.distro.osfamily, "mariner")
 +
 +    @mock.patch("cloudinit.distros.mariner.subp.subp")
 +    def test_write_hostname(self, m_subp):
-+        hostname = 'myhostname'
-+        hostfile = self.tmp_path('previous-hostname')
++        hostname = "myhostname"
++        hostfile = self.tmp_path("previous-hostname")
 +        self.distro._write_hostname(hostname, hostfile)
 +        self.assertEqual(hostname, util.load_file(hostfile))
 +
@@ -458,7 +504,7 @@ diff -Naur a/tests/unittests/distros/test_mariner b/tests/unittests/distros/test
 +        self.assertEqual(ret, hostname)
 +
 +        m_subp.return_value = (None, None)
-+        hostfile += 'hostfile'
++        hostfile += "hostfile"
 +        self.distro._write_hostname(hostname, hostfile)
 +
 +        m_subp.return_value = (hostname, None)
@@ -466,48 +512,47 @@ diff -Naur a/tests/unittests/distros/test_mariner b/tests/unittests/distros/test
 +        self.assertEqual(ret, hostname)
 +
 +        self.logs.truncate(0)
-+        m_subp.return_value = (None, 'bla')
++        m_subp.return_value = (None, "bla")
 +        self.distro._write_hostname(hostname, None)
-+        self.assertIn('Error while setting hostname', self.logs.getvalue())
++        self.assertIn("Error while setting hostname", self.logs.getvalue())
 +
-+    @mock.patch('cloudinit.net.generate_fallback_config')
++    @mock.patch("cloudinit.net.generate_fallback_config")
 +    def test_fallback_netcfg(self, m_fallback_cfg):
 +
-+        key = 'disable_fallback_netcfg'
++        key = "disable_fallback_netcfg"
 +        # Don't use fallback if no setting given
 +        self.logs.truncate(0)
-+        assert(self.distro.generate_fallback_config() is None)
++        assert self.distro.generate_fallback_config() is None
 +        self.assertIn(self.expected_log_line, self.logs.getvalue())
 +
 +        self.logs.truncate(0)
 +        self.distro._cfg[key] = True
-+        assert(self.distro.generate_fallback_config() is None)
++        assert self.distro.generate_fallback_config() is None
 +        self.assertIn(self.expected_log_line, self.logs.getvalue())
 +
 +        self.logs.truncate(0)
 +        self.distro._cfg[key] = False
-+        assert(self.distro.generate_fallback_config() is not None)
++        assert self.distro.generate_fallback_config() is not None
 +        self.assertNotIn(self.expected_log_line, self.logs.getvalue())
-\ No newline at end of file
-diff -Naur a/tests/unittests/distros/test_netconfig.py b/tests/unittests/distros/test_netconfig.py
---- a/tests/unittests/distros/test_netconfig.py	2022-02-15 10:02:23.000000000 -0800
-+++ b/tests/unittests/distros/test_netconfig.py	2022-03-28 20:35:46.924019452 -0700
-@@ -1005,6 +1005,124 @@
-             self.distro.apply_network_config, net_cfg, expected_cfgs.copy()
+diff --git a/tests/unittests/distros/test_netconfig.py b/tests/unittests/distros/test_netconfig.py
+index a25be481..d472f15d 100644
+--- a/tests/unittests/distros/test_netconfig.py
++++ b/tests/unittests/distros/test_netconfig.py
+@@ -1006,6 +1006,131 @@ class TestNetCfgDistroPhoton(TestNetCfgDistroBase):
          )
  
+ 
 +class TestNetCfgDistroMariner(TestNetCfgDistroBase):
-+
 +    def setUp(self):
 +        super(TestNetCfgDistroMariner, self).setUp()
-+        self.distro = self._get_distro('mariner', renderers=['networkd'])
++        self.distro = self._get_distro("mariner", renderers=["networkd"])
 +
 +    def create_conf_dict(self, contents):
 +        content_dict = {}
 +        for line in contents:
 +            if line:
 +                line = line.strip()
-+                if line and re.search(r'^\[(.+)\]$', line):
++                if line and re.search(r"^\[(.+)\]$", line):
 +                    content_dict[line] = []
 +                    key = line
 +                elif line:
@@ -520,13 +565,14 @@ diff -Naur a/tests/unittests/distros/test_netconfig.py b/tests/unittests/distros
 +        for k, v in actual.items():
 +            self.assertEqual(sorted(expected[k]), sorted(v))
 +
-+    def _apply_and_verify(self, apply_fn, config, expected_cfgs=None,
-+                          bringup=False):
++    def _apply_and_verify(
++        self, apply_fn, config, expected_cfgs=None, bringup=False
++    ):
 +        if not expected_cfgs:
-+            raise ValueError('expected_cfg must not be None')
++            raise ValueError("expected_cfg must not be None")
 +
 +        tmpd = None
-+        with mock.patch('cloudinit.net.networkd.available') as m_avail:
++        with mock.patch("cloudinit.net.networkd.available") as m_avail:
 +            m_avail.return_value = True
 +            with self.reRooted(tmpd) as tmpd:
 +                apply_fn(config, bringup)
@@ -538,10 +584,11 @@ diff -Naur a/tests/unittests/distros/test_netconfig.py b/tests/unittests/distros
 +            self.assertEqual(0o644, get_mode(cfgpath, tmpd))
 +
 +    def nwk_file_path(self, ifname):
-+        return '/etc/systemd/network/10-cloud-init-%s.network' % ifname
++        return "/etc/systemd/network/10-cloud-init-%s.network" % ifname
 +
 +    def net_cfg_1(self, ifname):
-+        ret = """\
++        ret = (
++            """\
 +        [Match]
 +        Name=%s
 +        [Network]
@@ -549,48 +596,53 @@ diff -Naur a/tests/unittests/distros/test_netconfig.py b/tests/unittests/distros
 +        [Address]
 +        Address=192.168.1.5/24
 +        [Route]
-+        Gateway=192.168.1.254""" % ifname
++        Gateway=192.168.1.254"""
++            % ifname
++        )
 +        return ret
 +
 +    def net_cfg_2(self, ifname):
-+        ret = """\
++        ret = (
++            """\
 +        [Match]
 +        Name=%s
 +        [Network]
-+        DHCP=ipv4""" % ifname
++        DHCP=ipv4"""
++            % ifname
++        )
 +        return ret
 +
 +    def test_mariner_network_config_v1(self):
-+        tmp = self.net_cfg_1('eth0').splitlines()
++        tmp = self.net_cfg_1("eth0").splitlines()
 +        expected_eth0 = self.create_conf_dict(tmp)
 +
-+        tmp = self.net_cfg_2('eth1').splitlines()
++        tmp = self.net_cfg_2("eth1").splitlines()
 +        expected_eth1 = self.create_conf_dict(tmp)
 +
 +        expected_cfgs = {
-+            self.nwk_file_path('eth0'): expected_eth0,
-+            self.nwk_file_path('eth1'): expected_eth1,
++            self.nwk_file_path("eth0"): expected_eth0,
++            self.nwk_file_path("eth1"): expected_eth1,
 +        }
 +
-+        self._apply_and_verify(self.distro.apply_network_config,
-+                               V1_NET_CFG,
-+                               expected_cfgs.copy())
++        self._apply_and_verify(
++            self.distro.apply_network_config, V1_NET_CFG, expected_cfgs.copy()
++        )
 +
 +    def test_mariner_network_config_v2(self):
-+        tmp = self.net_cfg_1('eth7').splitlines()
++        tmp = self.net_cfg_1("eth7").splitlines()
 +        expected_eth7 = self.create_conf_dict(tmp)
 +
-+        tmp = self.net_cfg_2('eth9').splitlines()
++        tmp = self.net_cfg_2("eth9").splitlines()
 +        expected_eth9 = self.create_conf_dict(tmp)
 +
 +        expected_cfgs = {
-+            self.nwk_file_path('eth7'): expected_eth7,
-+            self.nwk_file_path('eth9'): expected_eth9,
++            self.nwk_file_path("eth7"): expected_eth7,
++            self.nwk_file_path("eth9"): expected_eth9,
 +        }
 +
-+        self._apply_and_verify(self.distro.apply_network_config,
-+                               V2_NET_CFG,
-+                               expected_cfgs.copy())
++        self._apply_and_verify(
++            self.distro.apply_network_config, V2_NET_CFG, expected_cfgs.copy()
++        )
 +
 +    def test_mariner_network_config_v1_with_duplicates(self):
 +        expected = """\
@@ -607,32 +659,36 @@ diff -Naur a/tests/unittests/distros/test_netconfig.py b/tests/unittests/distros
 +
 +        expected = self.create_conf_dict(expected.splitlines())
 +        expected_cfgs = {
-+            self.nwk_file_path('eth0'): expected,
++            self.nwk_file_path("eth0"): expected,
 +        }
 +
-+        self._apply_and_verify(self.distro.apply_network_config,
-+                               net_cfg,
-+                               expected_cfgs.copy())
++        self._apply_and_verify(
++            self.distro.apply_network_config, net_cfg, expected_cfgs.copy()
++        )
 +
- 
++
  def get_mode(path, target=None):
      return os.stat(subp.target_path(target, path)).st_mode & 0o777
-diff -Naur a/tests/unittests/test_cli.py b/tests/unittests/test_cli.py
---- a/tests/unittests/test_cli.py	2022-02-15 10:02:23.000000000 -0800
-+++ b/tests/unittests/test_cli.py	2022-03-28 20:35:46.924019452 -0700
-@@ -256,7 +256,7 @@
+ 
+diff --git a/tests/unittests/test_cli.py b/tests/unittests/test_cli.py
+index 7846d0d3..151c8079 100644
+--- a/tests/unittests/test_cli.py
++++ b/tests/unittests/test_cli.py
+@@ -259,7 +259,8 @@ class TestCLI(test_helpers.FilesystemMockingTestCase):
              expected_doc_sections = [
                  "**Supported distros:** all",
                  "**Supported distros:** almalinux, alpine, centos, "
 -                "cloudlinux, debian, eurolinux, fedora, miraclelinux, "
-+                "cloudlinux, debian, eurolinux, fedora, mariner, miraclelinux, "
++                "cloudlinux, debian, eurolinux, fedora, "
++                "mariner, miraclelinux, "
                  "openEuler, opensuse, photon, rhel, rocky, sles, ubuntu, "
                  "virtuozzo",
                  "**Config schema**:\n    **resize_rootfs:** "
-diff -Naur a/tests/unittests/test_render_cloudcfg.py b/tests/unittests/test_render_cloudcfg.py
---- a/tests/unittests/test_render_cloudcfg.py	2022-02-15 10:02:23.000000000 -0800
-+++ b/tests/unittests/test_render_cloudcfg.py	2022-03-28 20:35:46.924019452 -0700
-@@ -17,6 +17,7 @@
+diff --git a/tests/unittests/test_render_cloudcfg.py b/tests/unittests/test_render_cloudcfg.py
+index 9f95d448..69e302c5 100644
+--- a/tests/unittests/test_render_cloudcfg.py
++++ b/tests/unittests/test_render_cloudcfg.py
+@@ -17,6 +17,7 @@ DISTRO_VARIANTS = [
      "fedora",
      "freebsd",
      "gentoo",
@@ -640,19 +696,20 @@ diff -Naur a/tests/unittests/test_render_cloudcfg.py b/tests/unittests/test_rend
      "netbsd",
      "openbsd",
      "photon",
-@@ -60,6 +61,8 @@
+@@ -60,6 +61,8 @@ class TestRenderCloudCfg:
          """Testing parametrized inputs with imported function saves ~0.5s per
          call versus calling as subp
          """
-+        if variant == 'mariner':
++        if variant == "mariner":
 +            return
          outfile = tmpdir.join("outcfg").strpath
          templater.render_cloudcfg(variant, self.tmpl_path, outfile)
          with open(outfile) as stream:
-diff -Naur a/tests/unittests/test_util.py b/tests/unittests/test_util.py
---- a/tests/unittests/test_util.py	2022-02-15 10:02:23.000000000 -0800
-+++ b/tests/unittests/test_util.py	2022-03-28 20:35:46.924019452 -0700
-@@ -316,6 +316,19 @@
+diff --git a/tests/unittests/test_util.py b/tests/unittests/test_util.py
+index bcb63787..9fcb8295 100644
+--- a/tests/unittests/test_util.py
++++ b/tests/unittests/test_util.py
+@@ -321,6 +321,19 @@ OS_RELEASE_PHOTON = """\
          BUG_REPORT_URL="https://github.com/vmware/photon/issues"
  """
  
@@ -672,26 +729,26 @@ diff -Naur a/tests/unittests/test_util.py b/tests/unittests/test_util.py
  
  class FakeCloud(object):
      def __init__(self, hostname, fqdn):
-@@ -895,6 +908,15 @@
+@@ -1027,6 +1040,14 @@ class TestGetLinuxDistro(CiTestCase):
          dist = util.get_linux_distro()
          self.assertEqual(("photon", "4.0", "VMware Photon OS/Linux"), dist)
  
-+    @mock.patch('cloudinit.util.load_file')
++    @mock.patch("cloudinit.util.load_file")
 +    def test_get_linux_mariner_os_release(self, m_os_release, m_path_exists):
 +        """Verify we get the correct name and machine arch on MarinerOS"""
 +        m_os_release.return_value = OS_RELEASE_MARINER
 +        m_path_exists.side_effect = TestGetLinuxDistro.os_release_exists
 +        dist = util.get_linux_distro()
-+        self.assertEqual(
-+            ('mariner', '2.0', ''), dist)
++        self.assertEqual(("mariner", "2.0", ""), dist)
 +
      @mock.patch("platform.system")
      @mock.patch("platform.dist", create=True)
      def test_get_linux_distro_no_data(
-diff -Naur a/tools/render-cloudcfg b/tools/render-cloudcfg
---- a/tools/render-cloudcfg	2022-02-15 10:02:23.000000000 -0800
-+++ b/tools/render-cloudcfg	2022-03-28 20:35:46.924019452 -0700
-@@ -21,6 +21,7 @@
+diff --git a/tools/render-cloudcfg b/tools/render-cloudcfg
+index 176df36b..10e47343 100755
+--- a/tools/render-cloudcfg
++++ b/tools/render-cloudcfg
+@@ -21,6 +21,7 @@ def main():
          "fedora",
          "freebsd",
          "gentoo",
@@ -699,3 +756,6 @@ diff -Naur a/tools/render-cloudcfg b/tools/render-cloudcfg
          "miraclelinux",
          "netbsd",
          "openbsd",
+-- 
+2.25.1
+

--- a/SPECS/cloud-init/cloud-init.signatures.json
+++ b/SPECS/cloud-init/cloud-init.signatures.json
@@ -1,6 +1,6 @@
 {
  "Signatures": {
   "10-azure-kvp.cfg": "79e0370c010be5cd4717960e4b414570c9ec6e6d29aede77ccecc43d2b03bb9a",
-  "cloud-init-22.1.tar.gz": "a3738cb7ce95454fae5ffd5589f9e45d7109ffbbc38313213ca478ecb831ae2c"
+  "cloud-init-22.2.tar.gz": "240b170d0241f10fd1eb0d09c8584ee4ec68ef71418af41bdef8b32ea37856dd"
  }
 }

--- a/SPECS/cloud-init/cloud-init.spec
+++ b/SPECS/cloud-init/cloud-init.spec
@@ -1,7 +1,7 @@
 %define cl_services cloud-config.service cloud-config.target cloud-final.service cloud-init.service cloud-init.target cloud-init-local.service
 Summary:        Cloud instance init scripts
 Name:           cloud-init
-Version:        22.1
+Version:        22.2
 Release:        2%{?dist}
 License:        GPLv3
 Vendor:         Microsoft Corporation
@@ -10,8 +10,7 @@ Group:          System Environment/Base
 URL:            https://launchpad.net/cloud-init
 Source0:        https://launchpad.net/cloud-init/trunk/%{version}/+download/%{name}-%{version}.tar.gz
 Source1:        10-azure-kvp.cfg
-# Add Mariner distro support to cloud-init 22.1
-Patch0:         mariner-22.1.patch
+Patch0:         add-mariner-distro-support.patch
 BuildRequires:  automake
 BuildRequires:  dbus
 BuildRequires:  iproute
@@ -142,6 +141,9 @@ make check %{?_smp_mflags}
 %config(noreplace) %{_sysconfdir}/cloud/cloud.cfg.d/10-azure-kvp.cfg
 
 %changelog
+* Fri Jun 03 2022 Chris Patterson <cpatterson@microsoft.com> - 22.2-1
+- Update to cloud-init 22.2
+
 * Mon Mar 28 2022 Henry Beberman <henry.beberman@microsoft.com> - 22.1-2
 - Add netplan defaults to Mariner distro config patch
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -1537,8 +1537,8 @@
         "type": "other",
         "other": {
           "name": "cloud-init",
-          "version": "22.1",
-          "downloadUrl": "https://launchpad.net/cloud-init/trunk/22.1/+download/cloud-init-22.1.tar.gz"
+          "version": "22.2",
+          "downloadUrl": "https://launchpad.net/cloud-init/trunk/22.2/+download/cloud-init-22.2.tar.gz"
         }
       }
     },


### PR DESCRIPTION
Minor fixes to distro patch:

- formatting, etc. to comply with upstream linting

- add .py extension to tests/unittests/distros/test_mariner

- fixup broken imports for test_mariner module

Cloud-init 22.2 includes several fixes/improvements for Azure's
datasource, full changelog is here:
https://github.com/canonical/cloud-init/blob/22.2/ChangeLog

Signed-off-by: Chris Patterson <cpatterson@microsoft.com>

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---
###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Created image based off latest Azure image with latest RPMs and provisioned new instance.
