### PR TITLE
Add MBR Partitioning Support in Mariner

### DIFF
--- a/toolkit/tools/imagegen/configuration/configuration.go
+++ b/toolkit/tools/imagegen/configuration/configuration.go
@@ -8,6 +8,8 @@ package configuration
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+	"strings"
 	"path/filepath"
 
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/file"
@@ -91,6 +93,27 @@ func (c *Config) GetDiskContainingPartition(partition *Partition) (disk *Disk) {
 		}
 	}
 	return nil
+}
+
+// GetKernelCmdLineValue returns the output of a specific option setting in /proc/cmdline
+func GetKernelCmdLineValue(option string, startIndex int) (cmdlineValue string, err error) {
+	const cmdlineFile = "/proc/cmdline"
+
+	content, err := os.ReadFile(cmdlineFile)
+	if err != nil {
+		logger.Log.Errorf("failed to read from %s", cmdlineFile)
+		return
+	}
+
+	cmdlineArgs := strings.Split(string(content), " ")
+	for _, cmdlineArg := range cmdlineArgs {
+		if strings.Contains(cmdlineArg, option) {
+			cmdlineValue = cmdlineArg[startIndex:len(cmdlineArg)]
+			return
+		}
+	}
+
+	return
 }
 
 // checkDeviceMapperFlags checks if Encryption and read-only roots have the required 'dmroot' flag.

--- a/toolkit/tools/imagegen/configuration/configuration.go
+++ b/toolkit/tools/imagegen/configuration/configuration.go
@@ -9,8 +9,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"strings"
 	"path/filepath"
+	"strings"
 
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/file"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/jsonutils"

--- a/toolkit/tools/imagegen/configuration/parse_partition_test.go
+++ b/toolkit/tools/imagegen/configuration/parse_partition_test.go
@@ -18,7 +18,7 @@ var (
 	ValidPartitionCommand2 = "part biosboot --fstype=biosboot --size=8 --ondisk=/dev/sda"
 
 	validTestParserDisk_OnePartition = Disk{
-		PartitionTableType: "gpt",
+		PartitionTableType: "mbr",
 		TargetDisk: TargetDisk{
 			Type:  "path",
 			Value: "/dev/sda",
@@ -34,7 +34,7 @@ var (
 	}
 
 	validTestParserDisk_TwoPartitions = Disk{
-		PartitionTableType: "gpt",
+		PartitionTableType: "mbr",
 		TargetDisk: TargetDisk{
 			Type:  "path",
 			Value: "/dev/sda",

--- a/toolkit/tools/imagegen/diskutils/diskutils.go
+++ b/toolkit/tools/imagegen/diskutils/diskutils.go
@@ -52,7 +52,6 @@ const (
 // Unit to byte conversion values
 // See https://www.gnu.org/software/parted/manual/parted.html#unit
 const (
-	s  = 512
 	B  = 1
 	KB = 1000
 	MB = 1000 * 1000
@@ -69,7 +68,6 @@ var (
 	sizeAndUnitRegexp = regexp.MustCompile(`(\d+)((Ki?|Mi?|Gi?|Ti?)?B)`)
 
 	unitToBytes = map[string]uint64{
-		"s":   s,
 		"B":   B,
 		"KB":  KB,
 		"MB":  MB,
@@ -343,7 +341,7 @@ func CreatePartitions(diskDevPath string, disk configuration.Disk, rootEncryptio
 		partitionNumber := idx + 1
 		partType := "primary"
 
-		// MBR only allows up to four primary partitions, thus check here whether 
+		// MBR only allows up to four primary partitions, thus check here whether
 		// we need to create extended partition or not in case more than four partitions are specified
 		if partitionNumber >= 4 && len(disk.Partitions) > 4 && partitionTableType == configuration.PartitionTableTypeMbr {
 			if partitionNumber == 4 {
@@ -354,12 +352,12 @@ func CreatePartitions(diskDevPath string, disk configuration.Disk, rootEncryptio
 				extendedPartition.ID = "extended"
 				extendedPartition.Start = partition.Start
 				extendedPartition.End = disk.Partitions[len(disk.Partitions)-1].End
-		
+
 				partDevPath, err := CreateSinglePartition(diskDevPath, partitionNumber, partitionTableType.String(), extendedPartition, partType)
 				if err != nil {
 					logger.Log.Warnf("Failed to create extended partition")
 					return partDevPathMap, partIDToFsTypeMap, encryptedRoot, readOnlyRoot, err
-				}	
+				}
 				partIDToFsTypeMap[extendedPartition.ID] = ""
 				partDevPathMap[extendedPartition.ID] = partDevPath
 			}
@@ -409,7 +407,7 @@ func CreateSinglePartition(diskDevPath string, partitionNumber int, partitionTab
 		fillToEndOption  = "100%"
 		sFmt             = "%ds"
 		timeoutInSeconds = "5"
-		MiBtoBytes		 = 1048576
+		MiBtoBytes       = 1048576
 	)
 
 	sectorSize, err := getSectorSize(diskDevPath)
@@ -418,13 +416,13 @@ func CreateSinglePartition(diskDevPath string, partitionNumber int, partitionTab
 	}
 
 	start := partition.Start * MiBtoBytes / sectorSize
-	end := partition.End * MiBtoBytes / sectorSize - 1
+	end := partition.End*MiBtoBytes/sectorSize - 1
 	if partition.End == 0 {
 		end = 0
 	}
 
 	if partType == "logical" {
-		start = partition.Start * MiBtoBytes / sectorSize + 1
+		start = partition.Start*MiBtoBytes/sectorSize + 1
 	}
 
 	// Check wehther the start sector is 4K-aligned
@@ -464,7 +462,7 @@ func CreateSinglePartition(diskDevPath string, partitionNumber int, partitionTab
 		logger.Log.Warnf("Failed to execute partprobe: %v", stderr)
 		return "", err
 	}
-	logger.Log.Debugf("Partprobe -s returned: %s", stdout)	
+	logger.Log.Debugf("Partprobe -s returned: %s", stdout)
 	return InitializeSinglePartition(diskDevPath, partitionNumber, partitionTableType, partition)
 }
 
@@ -739,10 +737,10 @@ func getSectorSize(diskDevPath string) (sectorSize uint64, err error) {
 func alignSectorAddress(sectorAddr uint64) (alignedSector uint64) {
 	const defaultBlockSize = 4096
 
-	if sectorAddr % defaultBlockSize == 0 || sectorAddr == (defaultBlockSize/2) {
+	if sectorAddr%defaultBlockSize == 0 || sectorAddr == (defaultBlockSize/2) {
 		alignedSector = sectorAddr
 	} else {
-		alignedSector = (sectorAddr / defaultBlockSize + 1) * defaultBlockSize
+		alignedSector = (sectorAddr/defaultBlockSize + 1) * defaultBlockSize
 	}
 
 	return


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?

Mariner's partitioning support does not fully support MBR scenario since we only supported primary partitions in the past. There are customers who requested MBR partitioning and also more than four partitions to be set. Thus, adding support to create extended and logical partitions in Mariner tooling.

Also add support to read from /proc/cmdline to determine whether the partition table type should be GPT or MBR within parse_partition.go. In kickstart-style install scenario, MBR is considered the default partition table type and only when users specify to use GPT thru cmdline will the installer set to GPT.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
NO

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local Image Build
