### PR TITLE
`vim`: updating to version 8.2.5064 to fix CVE-2022-1851, CVE-2022-1886, and CVE-2022-1898.

### DIFF
--- a/SPECS/vim/vim.signatures.json
+++ b/SPECS/vim/vim.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "vim-8.2.4979.tar.gz": "7f8b709039480ebceb0f0d089183bedf48f2a51f56292537c69c00c19d87fbde"
+  "vim-8.2.5064.tar.gz": "3e3f9f073ea9470482476db2c0a12a85af0a9e9d34478f3c4f924e33bb267c46"
  }
 }

--- a/SPECS/vim/vim.spec
+++ b/SPECS/vim/vim.spec
@@ -1,7 +1,7 @@
 %define debug_package %{nil}
 Summary:        Text editor
 Name:           vim
-Version:        8.2.4979
+Version:        8.2.5064
 Release:        1%{?dist}
 License:        Vim
 Vendor:         Microsoft Corporation
@@ -191,6 +191,9 @@ fi
 %{_bindir}/vimdiff
 
 %changelog
+* Mon Jun 06 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 8.2.5064-1
+- Update to version 8.2.5064 to fix CVEs: 2022-1851, 2022-1886, and 2022-1898.
+
 * Fri May 27 2022 Max Brodeur-Urbas <maxbr@microsoft.com> - 8.2.4979-1
 - Update version to 8.2.4979 to fix CVE-2022-1619, CVE-2022-1621, CVE-2022-1629, 
   CVE-2022-1616, CVE-2022-1733, CVE-2022-1735, CVE-2022-1769, CVE-2022-1620, 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -8615,8 +8615,8 @@
         "type": "other",
         "other": {
           "name": "vim",
-          "version": "8.2.4979",
-          "downloadUrl": "https://github.com/vim/vim/archive/v8.2.4979.tar.gz"
+          "version": "8.2.5064",
+          "downloadUrl": "https://github.com/vim/vim/archive/v8.2.5064.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

**Cherry-pick of #3112**.

Fixing 3 CVEs in `vim` by updating it to the latest version (8.2.5064).

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Updated `vim` to version 8.2.5064.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #3112

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2022-1851
- https://nvd.nist.gov/vuln/detail/CVE-2022-1886
- https://nvd.nist.gov/vuln/detail/CVE-2022-1898

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local package build.
