### PR TITLE
Fix clamav

### DIFF
--- a/SPECS/clamav/clamav.spec
+++ b/SPECS/clamav/clamav.spec
@@ -1,7 +1,7 @@
 Summary:        Open source antivirus engine
 Name:           clamav
 Version:        0.104.2
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        ASL 2.0 AND BSD AND bzip2-1.0.4 AND GPLv2 AND LGPLv2+ AND MIT AND Public Domain AND UnRar
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -44,37 +44,60 @@ line scanner and an advanced tool for automatic database updates.
 %autosetup
 
 %build
-mkdir -p build
-cd build
-
 # Notes:
 # - milter must be disable because CBL-Mariner does not provide 'sendmail' packages 
 #   which provides the necessary pieces to build 'clamav-milter'
 # - systemd should be enabled because default value is off
-cmake .. \
-    -D CMAKE_INSTALL_LIBDIR=%{buildroot}%{_libdir} \
-    -D CMAKE_INSTALL_BINDIR=%{buildroot}%{_bindir} \
-    -D CMAKE_INSTALL_SBINDIR=%{buildroot}%{_sbindir} \
-    -D CMAKE_INSTALL_MANDIR=%{buildroot}%{_mandir} \
-    -D CMAKE_INSTALL_DOCDIR=%{buildroot}%{_docdir} \
-    -D CMAKE_INSTALL_INCLUDEDIR=%{buildroot}%{_includedir} \
-    -D SYSTEMD_UNIT_DIR=%{buildroot}%{_libdir}/systemd/system \
-    -D APP_CONFIG_DIRECTORY=%{buildroot}%{_sysconfdir}/clamav \
-    -D DATABASE_DIRECTORY=%{buildroot}%{_sharedstatedir}/clamav \
+cmake \
+    -D CMAKE_INSTALL_LIBDIR=%{_libdir} \
+    -D CMAKE_INSTALL_BINDIR=%{_bindir} \
+    -D CMAKE_INSTALL_SBINDIR=%{_sbindir} \
+    -D CMAKE_INSTALL_MANDIR=%{_mandir} \
+    -D CMAKE_INSTALL_DOCDIR=%{_docdir} \
+    -D CMAKE_INSTALL_INCLUDEDIR=%{_includedir} \
+    -D SYSTEMD_UNIT_DIR=%{_libdir}/systemd/system \
+    -D APP_CONFIG_DIRECTORY=%{_sysconfdir}/clamav \
+    -D DATABASE_DIRECTORY=%{_sharedstatedir}/clamav \
     -D ENABLE_SYSTEMD=ON \
     -D ENABLE_MILTER=OFF \
     -D ENABLE_EXAMPLES=OFF
-cmake --build .
+%cmake_build
 
 %check
 cd build
 ctest --verbose
 
 %install
-cd build
-cmake --build . --target install
+%cmake_install
 # do not install html doc ('clamav' cmake has no flag to specify that => remove the doc)
 rm -rf %{buildroot}%{_docdir}
+mkdir -p %{buildroot}%{_sharedstatedir}/clamav
+
+### freshclam config processing (from Fedora)
+sed -ri \
+    -e 's!^Example!#Example!' \
+    -e 's!^#?(UpdateLogFile )!#\1!g;' %{buildroot}%{_sysconfdir}/clamav/freshclam.conf.sample
+ 
+mv %{buildroot}%{_sysconfdir}/clamav/freshclam.conf{.sample,}
+# Can contain HTTPProxyPassword (bugz#1733112)
+chmod 600 %{buildroot}%{_sysconfdir}/clamav/freshclam.conf
+
+%pre
+if ! getent group clamav >/dev/null; then
+    groupadd -r clamav
+fi
+if ! getent passwd clamav >/dev/null; then
+    useradd -g clamav -d %{_sharedstatedir}/clamav\
+        -s /bin/false -M -r clamav
+fi
+
+%postun
+if getent passwd clamav >/dev/null; then
+    userdel clamav
+fi
+if getent group clamav >/dev/null; then
+    groupdel clamav
+fi
 
 %files
 %defattr(-,root,root)
@@ -86,12 +109,17 @@ rm -rf %{buildroot}%{_docdir}
 %{_bindir}/*
 %{_sbindir}/*
 %{_sysconfdir}/clamav/*.sample
+%{_sysconfdir}/clamav/freshclam.conf
 %{_includedir}/*.h
 %{_mandir}/man1/*
 %{_mandir}/man5/*
 %{_mandir}/man8/*
+%dir %attr(-,clamav,clamav) %{_sharedstatedir}/clamav
 
 %changelog
+* Wed Jun 08 2022 Tom Fay <tomfay@microsoft.com> - 0.104.2-2
+- Fix freshclam DB download
+
 * Fri Jan 14 2022 Nicolas Guibourge <nicolasg@microsoft.com> - 0.104.2-1
 - Upgrade to 0.104.2
 

--- a/SPECS/clamav/clamav.spec
+++ b/SPECS/clamav/clamav.spec
@@ -8,7 +8,6 @@ Distribution:   Mariner
 Group:          System Environment/Security
 URL:            https://www.clamav.net
 Source0:        https://github.com/Cisco-Talos/clamav/archive/refs/tags/%{name}-%{version}.tar.gz
-
 BuildRequires:  bzip2-devel
 BuildRequires:  check-devel
 BuildRequires:  cmake
@@ -27,10 +26,8 @@ BuildRequires:  python3-pytest
 BuildRequires:  systemd-devel
 BuildRequires:  valgrind
 BuildRequires:  zlib-devel
-
 Requires:       openssl
 Requires:       zlib
-
 Provides:       %{name}-devel = %{version}-%{release}
 Provides:       %{name}-lib = %{version}-%{release}
 
@@ -45,7 +42,7 @@ line scanner and an advanced tool for automatic database updates.
 
 %build
 # Notes:
-# - milter must be disable because CBL-Mariner does not provide 'sendmail' packages 
+# - milter must be disable because CBL-Mariner does not provide 'sendmail' packages
 #   which provides the necessary pieces to build 'clamav-milter'
 # - systemd should be enabled because default value is off
 cmake \
@@ -77,7 +74,7 @@ mkdir -p %{buildroot}%{_sharedstatedir}/clamav
 sed -ri \
     -e 's!^Example!#Example!' \
     -e 's!^#?(UpdateLogFile )!#\1!g;' %{buildroot}%{_sysconfdir}/clamav/freshclam.conf.sample
- 
+
 mv %{buildroot}%{_sysconfdir}/clamav/freshclam.conf{.sample,}
 # Can contain HTTPProxyPassword (bugz#1733112)
 chmod 600 %{buildroot}%{_sysconfdir}/clamav/freshclam.conf


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Various fixes to clamav
https://microsoft.visualstudio.com/OS/_queries/edit/39607373

###### Change Log  <!-- REQUIRED -->
ClamAV fixes:
- don't look in buildroot for config/data at runtime
- create clamav data dir and user/group so freshclam can download clamav db
- add default config for freshclam so it runs without error by default

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No


###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
local build:
```bash
root [ /src ]# freshclam
ClamAV update process started at Wed Jun  8 18:16:12 2022
daily database available for download (remote version: 26566)
Time:    5.8s, ETA:    0.0s [========================>]   56.03MiB/56.03MiB
Testing database: '/var/lib/clamav/tmp.e8bddd1b6f/clamav-0511a9c7e4b14c4c181af44406dcb3fc.tmp-daily.cvd' ...
Database test passed.
daily.cvd updated (version: 26566, sigs: 1985565, f-level: 90, builder: raynman)
main database available for download (remote version: 62)
Time:   17.2s, ETA:    0.0s [========================>]  162.58MiB/162.58MiB
Testing database: '/var/lib/clamav/tmp.e8bddd1b6f/clamav-7102ab7320d470976d75d9ffadfa443c.tmp-main.cvd' ...
Database test passed.
main.cvd updated (version: 62, sigs: 6647427, f-level: 90, builder: sigmgr)
bytecode database available for download (remote version: 333)
Time:    1.5s, ETA:    0.0s [========================>]  286.79KiB/286.79KiB
Testing database: '/var/lib/clamav/tmp.e8bddd1b6f/clamav-17552ce44aa6d58e4671283917b58206.tmp-bytecode.cvd' ...
Database test passed.
bytecode.cvd updated (version: 333, sigs: 92, f-level: 63, builder: awillia2)

root [ /src ]# clamscan
Loading:    35s, ETA:   0s [========================>]    8.62M/8.62M sigs       
Compiling:   6s, ETA:   0s [========================>]       41/41 tasks 

/src/.gitignore: OK
/src/CODE_OF_CONDUCT.md: OK
/src/LICENSE: OK
/src/README.md: OK
/src/libyang.spec: OK
/src/SUPPORT.md: OK
/src/floki.yaml: OK
/src/libyang.signatures.json: OK
/src/SECURITY.md: OK
/src/cgmanifest.json: OK
/src/floki-mock.yaml: OK
/src/CONTRIBUTING.md: OK

----------- SCAN SUMMARY -----------
Known viruses: 8617628
Engine version: 0.104.2
Scanned directories: 1
Scanned files: 12
Infected files: 0
Data scanned: 1.25 MB
Data read: 0.69 MB (ratio 1.82:1)
Time: 43.127 sec (0 m 43 s)
Start Date: 2022:06:08 18:17:13
End Date:   2022:06:08 18:17:56
```
