### PR TITLE
`ruby-augeas`: fixing build by adding missing BR.

### DIFF
--- a/SPECS-EXTENDED/ruby-augeas/ruby-augeas.spec
+++ b/SPECS-EXTENDED/ruby-augeas/ruby-augeas.spec
@@ -1,21 +1,24 @@
+Summary:        Ruby bindings for Augeas
 Name:           ruby-augeas
 Version:        0.5.0
-Release:        29%{?dist}
-Summary:        Ruby bindings for Augeas
-Vendor:		Microsoft Corporation
-Distribution:	Mariner
+Release:        30%{?dist}
 License:        LGPLv2+
+Vendor:         Microsoft Corporation
+Distribution:   Mariner
 URL:            https://augeas.net
-Source0:        https://download.augeas.net/ruby/ruby-augeas-%{version}.tgz
+Source0:        https://download.augeas.net/ruby/%{name}-%{version}.tgz
 
-BuildRequires:  ruby rubygem(test-unit)
+BuildRequires:  augeas-devel >= 1.0.0
+BuildRequires:  gcc
+BuildRequires:  pkg-config
 BuildRequires:  ruby
 BuildRequires:  ruby-devel
-BuildRequires:  augeas-devel >= 1.0.0
-BuildRequires:  pkgconfig
-BuildRequires:  gcc
-Requires:       ruby(release)
+BuildRequires:  rubygem(rake)
+BuildRequires:  rubygem(test-unit)
+
 Requires:       augeas-libs >= 1.0.0
+Requires:       ruby(release)
+
 Provides:       ruby(augeas) = %{version}
 
 %description
@@ -24,13 +27,11 @@ Ruby bindings for augeas.
 %prep
 %setup -q
 
-
 %build
 export CONFIGURE_ARGS="--with-cflags='%{optflags}'"
 rake build
 
 %install
-rm -rf %{buildroot}
 install -d -m0755 %{buildroot}%{ruby_vendorlibdir}
 install -d -m0755 %{buildroot}%{ruby_vendorarchdir}
 install -p -m0644 lib/augeas.rb %{buildroot}%{ruby_vendorlibdir}
@@ -39,14 +40,16 @@ install -p -m0755 ext/augeas/_augeas.so %{buildroot}%{ruby_vendorarchdir}
 %check
 ruby tests/tc_augeas.rb
 
-
 %files
-%doc COPYING README.rdoc NEWS
+%license COPYING
+%doc README.rdoc NEWS
 %{ruby_vendorlibdir}/augeas.rb
 %{ruby_vendorarchdir}/_augeas.so
 
-
 %changelog
+* Wed Jun 08 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 0.5.0-30
+- Adding missed BR on 'rubygem(rake)'.
+
 * Thu Dec 30 2021 Suresh Babu Chalamalasetty <schalam@microsoft.com> - 0.5.0-29
 - Initial CBL-Mariner import from Fedora 35 (license: MIT)
 - License verified

--- a/SPECS-EXTENDED/ruby-augeas/ruby-augeas.spec
+++ b/SPECS-EXTENDED/ruby-augeas/ruby-augeas.spec
@@ -6,7 +6,7 @@ License:        LGPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 URL:            https://augeas.net
-Source0:        https://download.augeas.net/ruby/%{name}-%{version}.tgz
+Source0:        http://download.augeas.net/ruby/%{name}-%{version}.tgz
 
 BuildRequires:  augeas-devel >= 1.0.0
 BuildRequires:  gcc
@@ -49,6 +49,7 @@ ruby tests/tc_augeas.rb
 %changelog
 * Wed Jun 08 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 0.5.0-30
 - Adding missed BR on 'rubygem(rake)'.
+- Fixed source URL.
 
 * Thu Dec 30 2021 Suresh Babu Chalamalasetty <schalam@microsoft.com> - 0.5.0-29
 - Initial CBL-Mariner import from Fedora 35 (license: MIT)

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -22976,7 +22976,7 @@
         "other": {
           "name": "ruby-augeas",
           "version": "0.5.0",
-          "downloadUrl": "https://download.augeas.net/ruby/ruby-augeas-0.5.0.tgz"
+          "downloadUrl": "http://download.augeas.net/ruby/ruby-augeas-0.5.0.tgz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

After recent extraction of built-in gems from `ruby` into separate packages `ruby-augeas` stopped building because it depends on `rubygem-rake` but it didn't mention that in the spec. Fixing this now.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Added explicit `BuildRequires: rubygem(rake)` to `ruby-augeas.spec`.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local package build.
