### PR TITLE
Upgrade exiv2 to 0.27.5 to fix CVE-2019-13504 CVE-2019-17402 CVE-2019…

### DIFF
--- a/SPECS-EXTENDED/exiv2/exiv2.signatures.json
+++ b/SPECS-EXTENDED/exiv2/exiv2.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "exiv2-0.27.2-Source.tar.gz": "2652f56b912711327baff6dc0c90960818211cf7ab79bb5e1eb59320b78d153f"
+  "exiv2-0.27.5.tar.gz": "1da1721f84809e4d37b3f106adb18b70b1b0441c860746ce6812bb3df184ed6c"
  }
 }

--- a/SPECS-EXTENDED/exiv2/exiv2.spec
+++ b/SPECS-EXTENDED/exiv2/exiv2.spec
@@ -59,7 +59,7 @@ BuildArch:      noarch
 %{summary}.
 
 %prep
-%autosetup -n %{name}-%{version} -p1
+%autosetup -p1
 
 %build
 

--- a/SPECS-EXTENDED/exiv2/exiv2.spec
+++ b/SPECS-EXTENDED/exiv2/exiv2.spec
@@ -8,18 +8,16 @@ Vendor:         Microsoft Corporation
 Distribution:   Mariner
 URL:            http://www.exiv2.org/
 Source0:        https://github.com/Exiv2/exiv2/archive/refs/tags/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
-
 BuildRequires:  cmake
 BuildRequires:  curl-devel
-BuildRequires:  doxygen 
+BuildRequires:  doxygen
 BuildRequires:  expat-devel
 BuildRequires:  gcc-c++
 BuildRequires:  gettext
-BuildRequires:  graphviz 
+BuildRequires:  graphviz
 BuildRequires:  libssh2-devel
 BuildRequires:  libxslt
 BuildRequires:  zlib-devel
-
 Requires:       %{name}-libs%{?_isa} = %{version}-%{release}
 
 %description
@@ -35,25 +33,28 @@ A command line utility to access image metadata, allowing one to:
   Iptc metadata and Jpeg comments
 
 %package      devel
-Summary:      Header files, libraries and development documentation for %{name}
-Requires:     %{name}-libs%{?_isa} = %{version}-%{release}
+Summary:        Header files, libraries and development documentation for %{name}
+Requires:       %{name}-libs%{?_isa} = %{version}-%{release}
 # FIXME/TODO: probably overlinking --rex
 # exiv2/exiv2Config.cmake:  INTERFACE_LINK_LIBRARIES "/usr/lib64/libexpat.so"
-Requires:     expat-devel%{?_isa} 
+Requires:       expat-devel%{?_isa}
+
 %description  devel
 %{summary}.
 
 %package      libs
-Summary:      Exif and Iptc metadata manipulation library
-Recommends:   %{name} = %{version}-%{release}
+Summary:        Exif and Iptc metadata manipulation library
+Recommends:     %{name} = %{version}-%{release}
+
 %description  libs
 A C++ library to access image metadata, supporting full read and write access
 to the Exif and Iptc metadata, Exif MakerNote support, extract and delete
 methods for Exif thumbnails, classes to access Ifd and so on.
 
 %package      doc
-Summary:      Api documentation for %{name}
-BuildArch:    noarch
+Summary:        Api documentation for %{name}
+BuildArch:      noarch
+
 %description  doc
 %{summary}.
 

--- a/SPECS-EXTENDED/exiv2/exiv2.spec
+++ b/SPECS-EXTENDED/exiv2/exiv2.spec
@@ -1,36 +1,26 @@
 
-Summary: Exif and Iptc metadata manipulation library
-Name:    exiv2
-Version: 0.27.2
-%global internal_ver %{version}
-Release: 3%{?dist}
-
-License: GPLv2+
+Summary:        Exif and Iptc metadata manipulation library
+Name:           exiv2
+Version:        0.27.5
+Release:        1%{?dist}
+License:        GPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
-URL:     http://www.exiv2.org/
-%if 0%{?beta:1}
-Source0: https://github.com/Exiv2/%{name}/archive/v%{version}-%{beta}.tar.gz
-%else
-Source0: http://exiv2.org/builds/%{name}-%{version}-Source.tar.gz
-%endif
+URL:            http://www.exiv2.org/
+Source0:        https://github.com/Exiv2/exiv2/archive/refs/tags/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
 
-## upstream patches
+BuildRequires:  cmake
+BuildRequires:  curl-devel
+BuildRequires:  doxygen 
+BuildRequires:  expat-devel
+BuildRequires:  gcc-c++
+BuildRequires:  gettext
+BuildRequires:  graphviz 
+BuildRequires:  libssh2-devel
+BuildRequires:  libxslt
+BuildRequires:  zlib-devel
 
-## upstreamable patches
-
-BuildRequires: cmake
-BuildRequires: expat-devel
-BuildRequires: gcc-c++
-BuildRequires: gettext
-BuildRequires: pkgconfig
-BuildRequires: pkgconfig(libcurl)
-BuildRequires: pkgconfig(libssh)
-BuildRequires: zlib-devel
-# docs
-BuildRequires: doxygen graphviz libxslt
-
-Requires: %{name}-libs%{?_isa} = %{version}-%{release}
+Requires:       %{name}-libs%{?_isa} = %{version}-%{release}
 
 %description
 A command line utility to access image metadata, allowing one to:
@@ -44,38 +34,31 @@ A command line utility to access image metadata, allowing one to:
 * extract, insert and delete Exif metadata (including thumbnails),
   Iptc metadata and Jpeg comments
 
-%package devel
-Summary: Header files, libraries and development documentation for %{name}
-Requires: %{name}-libs%{?_isa} = %{version}-%{release}
+%package      devel
+Summary:      Header files, libraries and development documentation for %{name}
+Requires:     %{name}-libs%{?_isa} = %{version}-%{release}
 # FIXME/TODO: probably overlinking --rex
 # exiv2/exiv2Config.cmake:  INTERFACE_LINK_LIBRARIES "/usr/lib64/libexpat.so"
-Requires: expat-devel%{?_isa} 
-%description devel
+Requires:     expat-devel%{?_isa} 
+%description  devel
 %{summary}.
 
-%package libs
-Summary: Exif and Iptc metadata manipulation library
-# not strictly required, but convenient and expected
-%if 0%{?rhel} && 0%{?rhel} <= 7
-Requires: %{name} = %{version}-%{release}
-%else
-Recommends: %{name} = %{version}-%{release}
-%endif
-%description libs
+%package      libs
+Summary:      Exif and Iptc metadata manipulation library
+Recommends:   %{name} = %{version}-%{release}
+%description  libs
 A C++ library to access image metadata, supporting full read and write access
 to the Exif and Iptc metadata, Exif MakerNote support, extract and delete
 methods for Exif thumbnails, classes to access Ifd and so on.
 
-%package doc
-Summary: Api documentation for %{name}
-BuildArch: noarch
-%description doc
+%package      doc
+Summary:      Api documentation for %{name}
+BuildArch:    noarch
+%description  doc
 %{summary}.
 
-
 %prep
-%autosetup -n %{name}-%{version}-%{?beta}%{!?beta:Source} -p1
-
+%autosetup -n %{name}-%{version} -p1
 
 %build
 
@@ -96,12 +79,10 @@ make install/fast DESTDIR=%{buildroot}
 
 ## unpackaged files
 rm -fv %{buildroot}%{_libdir}/libexiv2.la
-#rm -fv %{buildroot}%{_libdir}/pkgconfig/exiv2.lsm
-
 
 %check
 export PKG_CONFIG_PATH="%{buildroot}%{_libdir}/pkgconfig${PKG_CONFIG_PATH:+:}${PKG_CONFIG_PATH}"
-test "$(pkg-config --modversion exiv2)" = "%{internal_ver}"
+test "$(pkg-config --modversion exiv2)" = "%{version}"
 test "$(pkg-config --variable=libdir exiv2)" = "%{_libdir}"
 test -x %{buildroot}%{_libdir}/libexiv2.so
 
@@ -118,7 +99,7 @@ test -x %{buildroot}%{_libdir}/libexiv2.so
 
 %files libs
 %{_libdir}/libexiv2.so.27*
-%{_libdir}/libexiv2.so.%{internal_ver}
+%{_libdir}/libexiv2.so.%{version}
 
 %files devel
 %{_includedir}/exiv2/
@@ -133,6 +114,9 @@ test -x %{buildroot}%{_libdir}/libexiv2.so
 
 
 %changelog
+* Thu Jun 09 2022 Jon Slobodzian <joslobo@microsoft.com> - 0.27.5-1
+- Fixing CVEs
+
 * Fri Oct 15 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 0.27.2-3
 - Initial CBL-Mariner import from Fedora 32 (license: MIT).
 

--- a/SPECS-EXTENDED/exiv2/exiv2.spec
+++ b/SPECS-EXTENDED/exiv2/exiv2.spec
@@ -116,6 +116,7 @@ test -x %{buildroot}%{_libdir}/libexiv2.so
 %changelog
 * Thu Jun 09 2022 Jon Slobodzian <joslobo@microsoft.com> - 0.27.5-1
 - Fixing CVEs
+- License Verified.
 
 * Fri Oct 15 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 0.27.2-3
 - Initial CBL-Mariner import from Fedora 32 (license: MIT).

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -2949,7 +2949,7 @@
         "other": {
           "name": "exiv2",
           "version": "0.27.5",
-          "downloadUrl": "http://exiv2.org/builds/exiv2-0.27.5.tar.gz"
+          "downloadUrl": "https://github.com/Exiv2/exiv2/archive/refs/tags/v0.27.5.tar.gz"
         }
       }
     },

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -2948,8 +2948,8 @@
         "type": "other",
         "other": {
           "name": "exiv2",
-          "version": "0.27.2",
-          "downloadUrl": "http://exiv2.org/builds/exiv2-0.27.2-Source.tar.gz"
+          "version": "0.27.5",
+          "downloadUrl": "http://exiv2.org/builds/exiv2-0.27.5.tar.gz"
         }
       }
     },


### PR DESCRIPTION
…-20421 CVE-2021-3482 CVE-2021-29457 CVE-2021-29458 CVE-2021-29463 CVE-2021-29464 CVE-2021-29470 CVE-2021-29473 CVE-2021-29623 CVE-2021-32617 CVE-2021-32815 CVE-2021-34334 CVE-2021-34335 CVE-2021-37615 CVE-2021-37616 CVE-2021-37618 CVE-2021-37619 CVE-2021-37620 CVE-2021-37621 CVE-2021-37622 CVE-2021-37623

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Fixes 23 CVEs


###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
Rebuilt package and ran self-test.