### PR TITLE
selinux-policy: Allow unconfined domains to manipulate their own fds.

### DIFF
--- a/SPECS/selinux-policy/0039-unconfined-Manage-own-fds.patch
+++ b/SPECS/selinux-policy/0039-unconfined-Manage-own-fds.patch
@@ -1,0 +1,29 @@
+From d8884f88c40667c4b1118044b8e47f58bc54b92e Mon Sep 17 00:00:00 2001
+From: Chris PeBenito <Christopher.PeBenito@microsoft.com>
+Date: Wed, 15 Jun 2022 14:43:12 +0000
+Subject: [PATCH 39/39] unconfined: Manage own fds.
+
+Signed-off-by: Chris PeBenito <Christopher.PeBenito@microsoft.com>
+---
+ policy/modules/system/unconfined.if | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/policy/modules/system/unconfined.if b/policy/modules/system/unconfined.if
+index 4393242d5..c4818431c 100644
+--- a/policy/modules/system/unconfined.if
++++ b/policy/modules/system/unconfined.if
+@@ -48,8 +48,9 @@ interface(`unconfined_domain_noaudit',`
+ 	# Transition to myself, to make get_ordered_context_list happy.
+ 	allow $1 self:process transition;
+ 
+-	# Write access is for setting attributes under /proc/self/attr.
+-	allow $1 self:file rw_file_perms;
++	# Write access is for setting attributes under /proc/self/attr
++	# and to manipulate fds.
++	manage_files_pattern($1, self, self)
+ 
+ 	# Userland object managers
+ 	allow $1 self:nscd { getpwd getgrp gethost getstat admin shmempwd shmemgrp shmemhost getserv shmemserv };
+-- 
+2.25.1
+

--- a/SPECS/selinux-policy/selinux-policy.spec
+++ b/SPECS/selinux-policy/selinux-policy.spec
@@ -9,7 +9,7 @@
 Summary:        SELinux policy
 Name:           selinux-policy
 Version:        %{refpolicy_major}.%{refpolicy_minor}
-Release:        6%{?dist}
+Release:        7%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -56,6 +56,7 @@ Patch35:        0035-systemd-Fixes-for-coredumps-in-containers.patch
 Patch36:        0036-container-Allow-container-engines-to-connect-to-http.patch
 Patch37:        0037-container-Getattr-generic-device-nodes.patch
 Patch38:        0038-application-Allow-apps-to-use-init-fds.patch
+Patch39:        0039-unconfined-Manage-own-fds.patch
 BuildRequires:  bzip2
 BuildRequires:  checkpolicy >= %{CHECKPOLICYVER}
 BuildRequires:  m4
@@ -332,6 +333,9 @@ exit 0
 selinuxenabled && semodule -nB
 exit 0
 %changelog
+* Wed Jun 15 2022 Chris PeBenito <chpebeni@microsoft.com> - 2.20220106-7
+- Unconfined domains can manipulate thier own fds.
+
 * Mon May 23 2022 Chris PeBenito <chpebeni@microsoft.com> - 2.20220106-6
 - Fix previous multipath LVM changes.
 - Add types for devices.


### PR DESCRIPTION
Fixes SELinux BVTs.

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Allow unconfined domains to manipulate their own fds. Fixes SELinux BVTs.

###### Change Log  <!-- REQUIRED -->
-  Allow unconfined domains to manipulate their own fds.

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Static analysis, local build.
