### PR TITLE
filesystem: Fix issues when upgrading in container

### DIFF
--- a/SPECS/filesystem/filesystem.spec
+++ b/SPECS/filesystem/filesystem.spec
@@ -1,7 +1,7 @@
 Summary:      Default file system
 Name:         filesystem
 Version:      1.1
-Release:      9%{?dist}
+Release:      10%{?dist}
 License:      GPLv3
 Group:        System Environment/Base
 Vendor:       Microsoft Corporation
@@ -19,7 +19,7 @@ for the directories. This version is for a system configured with systemd.
 #
 #	6.5.  Creating Directories
 #
-install -vdm 755 %{buildroot}/{dev,proc,run/{media/{floppy,cdrom},lock},sys}
+install -vdm 755 %{buildroot}/{dev,run/{media/{floppy,cdrom},lock}}
 install -vdm 755 %{buildroot}/{etc/{opt,sysconfig},home,mnt}
 install -vdm 700 %{buildroot}/boot
 install -vdm 755 %{buildroot}/{var}
@@ -430,6 +430,13 @@ posix.symlink("../lib", "/usr/lib/debug/usr/lib64")
 posix.symlink("../.dwz", "/usr/lib/debug/usr/.dwz")
 return 0
 
+%pretrans -p <lua>
+posix.mkdir("/proc")
+posix.mkdir("/sys")
+posix.chmod("/proc", 0555)
+posix.chmod("/sys", 0555)
+return 0
+
 %files
 %defattr(-,root,root)
 #	Root filesystem
@@ -442,12 +449,12 @@ return 0
 
 /media
 %dir /mnt
-%dir /proc
+%ghost %attr(555,root,root) /proc
 %dir /root
 %dir /run
 /sbin
 /srv
-%dir /sys
+%ghost %attr(555,root,root) /sys
 %dir /tmp
 %dir /usr
 %dir /var
@@ -566,6 +573,10 @@ return 0
 /usr/local/lib64
 
 %changelog
+* Thu Jun 16 2022 Olivia Crain <oliviacrain@microsoft.com> - 1.1-10
+- Mark /proc and /sys as %%ghost
+- Create /proc and /sys as a pretransaction step
+
 *   Wed May 18 2022 Brendan Kerrigan <bkerrigan@microsoft.com> 1.1-9
 -   Update /etc/inputrc to enable Ctrl+LeftArrow and Ctrl+RightArrow word jumping binds.
 -   License Verified.

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -1,4 +1,4 @@
-filesystem-1.1-9.cm2.aarch64.rpm
+filesystem-1.1-10.cm2.aarch64.rpm
 kernel-headers-5.15.45.1-2.cm2.noarch.rpm
 glibc-2.35-2.cm2.aarch64.rpm
 glibc-devel-2.35-2.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -1,4 +1,4 @@
-filesystem-1.1-9.cm2.x86_64.rpm
+filesystem-1.1-10.cm2.x86_64.rpm
 kernel-headers-5.15.45.1-2.cm2.noarch.rpm
 glibc-2.35-2.cm2.x86_64.rpm
 glibc-devel-2.35-2.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -79,7 +79,7 @@ file-5.40-2.cm2.aarch64.rpm
 file-debuginfo-5.40-2.cm2.aarch64.rpm
 file-devel-5.40-2.cm2.aarch64.rpm
 file-libs-5.40-2.cm2.aarch64.rpm
-filesystem-1.1-9.cm2.aarch64.rpm
+filesystem-1.1-10.cm2.aarch64.rpm
 findutils-4.8.0-3.cm2.aarch64.rpm
 findutils-debuginfo-4.8.0-3.cm2.aarch64.rpm
 findutils-lang-4.8.0-3.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -79,7 +79,7 @@ file-5.40-2.cm2.x86_64.rpm
 file-debuginfo-5.40-2.cm2.x86_64.rpm
 file-devel-5.40-2.cm2.x86_64.rpm
 file-libs-5.40-2.cm2.x86_64.rpm
-filesystem-1.1-9.cm2.x86_64.rpm
+filesystem-1.1-10.cm2.x86_64.rpm
 findutils-4.8.0-3.cm2.x86_64.rpm
 findutils-debuginfo-4.8.0-3.cm2.x86_64.rpm
 findutils-lang-4.8.0-3.cm2.x86_64.rpm


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Package `filesystem` fails to upgrade in a container from versions `1.1-8` to `1.1-9`. The culprit is an interaction between rootless containers' population of `/proc` and `/sys`

Repro: `docker run --rm -it mcr.microsoft.com/cbl-mariner/base/core:2.0.20220426 tdnf --rpmverbosity info upgrade -y`

I've personally seen two different errors:

```
error: unpacking of archive failed on file /proc: cpio: chown failed - Directory not empty
error: filesystem-1.1-9.cm2.x86_64: install failed
```

```
...
Installing/Updating: filesystem-1.1-9.cm2.x86_64
error: unpacking of archive failed on file /sys: cpio: chmod failed - Device or resource busy
error: filesystem-1.1-9.cm2.x86_64: install failed
...
error: filesystem-1.1-8.cm2.x86_64: erase skipped
Error(1525) : rpm transaction failed
```

This is actually a bug [Fedora encountered and figured out a couple years ago](https://bugzilla.redhat.com/show_bug.cgi?id=1548403). We decided to borrow their solution from [this commit](https://src.fedoraproject.org/rpms/filesystem/c/bceee1afe19a83bf101c95fdc3517c3f704d93c1?branch=rawhide) (license: MIT, many thanks to Pavel Raiskup for the fix).

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- `filesystem`: Populate `/proc` and /sys` during pretransaction phase of install, mark directories as `%ghost`

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Fix built and validated in a container. Awaiting full pipeline results
