### PR TITLE
core-packages: Remove nspr, nss-libs from base container image

### DIFF
--- a/SPECS/core-packages/core-packages.spec
+++ b/SPECS/core-packages/core-packages.spec
@@ -1,7 +1,7 @@
 Summary:        Metapackage with core sets of packages
 Name:           core-packages
 Version:        2.0
-Release:        6%{?dist}
+Release:        7%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -64,8 +64,6 @@ Requires:       mariner-repos
 Requires:       mariner-repos-extras
 Requires:       mariner-repos-microsoft
 Requires:       ncurses-libs
-Requires:       nspr
-Requires:       nss-libs
 Requires:       openssl
 Requires:       readline
 Requires:       rpm
@@ -89,6 +87,9 @@ Requires:       zlib
 %files container
 
 %changelog
+* Fri Jun 17 2022 Olivia Crain <oliviacrain@microsoft.com> - 2.0-7
+- Remove nspr, nss-libs from base container image
+
 * Tue May 24 2022 Jon Slobodzian <joslobo@microsoft.com> - 2.0-6
 - Add rpm to base container image
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Our `core-packages` spec should ideally be treated as a listing of end goal packages for our images- a sort of API saying which packages should be expected in every image. Unfortunately, we've strayed from that, and we've put packages in that list that are _requirements_ of our goal packages. So, when we change the requirements of a goal package, we can be left with extraneous packages in our `core-packages` list.

This happened with the `rpm` package. We ideally want `rpm` in every image, which makes it one of our goal packages. At some point, our `rpm` package required `nss-libs` and `nspr` as dependencies. With our upgrade to `rpm 4.17.X` in Mariner 2.0, these packages are no longer required by `rpm`. However, `nss-libs` and `nspr` were added to the `core-packages` list at some point, so those packages didn't get pruned from our images when this upgrade happened. We definitely don't want those packages in every image for internal cryptography compliance reasons.

It'll take a more protracted effort to fully fix this issue, but we can start by taking out `nspr` and `nss-libs` from the `core-packages` set.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- `core-packages`: Remove requirements on `nss-libs` and `nspr`

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Full pipeline build passes
- All image BVTs pass