### PR TITLE
Resolve /etc/my.cnf conflict

### DIFF
--- a/SPECS/mariadb-connector-c/mariadb-connector-c.spec
+++ b/SPECS/mariadb-connector-c/mariadb-connector-c.spec
@@ -3,7 +3,7 @@
 Summary:        The MariaDB Native Client library (C driver)
 Name:           mariadb-connector-c
 Version:        3.1.10
-Release:        4%{?dist}
+Release:        5%{?dist}
 License:        LGPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -20,7 +20,7 @@ BuildRequires:  krb5-devel
 BuildRequires:  libcurl-devel
 BuildRequires:  openssl-devel
 BuildRequires:  zlib-devel
-Requires:       %{_sysconfdir}/my.cnf
+Requires:       %{name}-config = %{version}-%{release}
 # More information: https://mariadb.com/kb/en/mariadb/building-connectorc-from-source/
 Patch1:         testsuite.patch
 
@@ -194,6 +194,9 @@ popd
 #      NEW:         PR submitted, problem explained, waiting on upstream response
 
 %changelog
+* Fri Jun 17 2022 Andrew Phelps <anphel@microsoft.com> - 3.1.10-5
+- Change Requires to -config package to resolve /etc/my.cnf conflict
+
 * Wed Dec 08 2021 Thomas Crain <thcrain@microsoft.com> - 3.1.10-4
 - Remove testsuite conditionals
 - License verified

--- a/SPECS/mariadb-connector-c/mariadb-connector-c.spec
+++ b/SPECS/mariadb-connector-c/mariadb-connector-c.spec
@@ -8,7 +8,7 @@ License:        LGPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 URL:            https://mariadb.org/
-Source0:        https://downloads.mariadb.org/interstitial/connector-c-%{version}/%{name}-%{version}-src.tar.gz
+Source0:        https://archive.mariadb.org/connector-c-%{version}/%{name}-%{version}-src.tar.gz
 Source2:        my.cnf
 Source3:        client.cnf
 Patch0:         cmake_3.21.4_fix.patch

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -11232,7 +11232,7 @@
         "other": {
           "name": "mariadb-connector-c",
           "version": "3.1.10",
-          "downloadUrl": "https://downloads.mariadb.org/interstitial/connector-c-3.1.10/mariadb-connector-c-3.1.10-src.tar.gz"
+          "downloadUrl": "https://archive.mariadb.org/connector-c-3.1.10/mariadb-connector-c-3.1.10-src.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Resolve /etc/my.cnf conflict seen in full core package builds. mariadb-connector-c requries /etc/my.cnf, which is provided by mariadb-connector-c-config. Require this package explicitly instead of requiring the file "%{_sysconfdir}/my.cnf".

```
INFO[16450] Unresolved dependencies: 
INFO[16450] --> /etc/my.cnf:C:''V:'',C2:''V2:'' 
INFO[16450] Writing DOT graph to /tmp/mariner/build/pkg_artifacts/built_graph.dot 
FATA[16451] Unable to build package graph. 

file /etc/my.cnf conflicts between attempted installs of mariadb-server-10.6.7-1.cm2.x86_64 and mariadb-connector-c-config-3.1.10-4.cm2.noarch
ERRO[1593] Failed while trying to pick an RPM providing '/etc/my.cnf' from the following RPMs: [/tmp/mariner/build/rpm_cache/cache/mariadb-server-10.6.7-1.cm2.x86_64.rpm /tmp/mariner/build/rpm_cache/cache/mariadb-connector-c-config-3.1.10-4.cm2.noarch.rpm] 
ERRO[1593] Failed to find an RPM to provide '/etc/my.cnf'. Error: exit status 2

$ rpm -q --requires mariadb-connector-c-3.1.10-4.cm2.x86_64.rpm
...
/etc/my.cnf
...
```

This change also should remove one of the reasons for the following warning when building current main core packages.
```
WARN[0002] Could not create solvable subgraph, forcing full package build
```

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change mariadb-connector-c.spec to resolve conflict
- Fix URL

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: 204699 (AMD64)
- Pipeline build id: 204724 (ARM64)