### PR TITLE
Upgrade curl to fix CVE-2022-27779, CVE-2022-27780, CVE-2022-27781, C…

### DIFF
--- a/SPECS/curl/curl.signatures.json
+++ b/SPECS/curl/curl.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "curl-7.83.0.tar.gz": "c0e64302a33d2fb79e0fc4e674260a22941e92ee2f11b894bf94d32b8f5531af"
+  "curl-7.83.1.tar.gz": "93fb2cd4b880656b4e8589c912a9fd092750166d555166370247f09d18f5d0c0"
  }
 }

--- a/SPECS/curl/curl.spec
+++ b/SPECS/curl/curl.spec
@@ -1,6 +1,6 @@
 Summary:        An URL retrieval utility and library
 Name:           curl
-Version:        7.83.0
+Version:        7.83.1
 Release:        1%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
@@ -89,6 +89,11 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %{_libdir}/libcurl.so.*
 
 %changelog
+* Mon Jun 20 2022 Henry Beberman <henry.beberman@microsoft.com> - 7.83.1-1
+- Update to version 7.83.1
+- Address CVE-2022-27779, CVE-2022-27780, CVE-2022-27781
+- Address CVE-2022-30115, CVE-2022-27782, CVE-2022-27778
+
 * Wed May 25 2022 Suresh Babu Chalamalasetty <schalam@microsoft.com> - 7.83.0-1
 - Update to version 7.83.0
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -2007,8 +2007,8 @@
         "type": "other",
         "other": {
           "name": "curl",
-          "version": "7.83.0",
-          "downloadUrl": "https://curl.haxx.se/download/curl-7.83.0.tar.gz"
+          "version": "7.83.1",
+          "downloadUrl": "https://curl.haxx.se/download/curl-7.83.1.tar.gz"
         }
       }
     },

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -188,9 +188,9 @@ libsolv-devel-0.7.20-1.cm2.aarch64.rpm
 libssh2-1.9.0-2.cm2.aarch64.rpm
 libssh2-devel-1.9.0-2.cm2.aarch64.rpm
 krb5-1.19.3-1.cm2.aarch64.rpm
-curl-7.83.0-1.cm2.aarch64.rpm
-curl-devel-7.83.0-1.cm2.aarch64.rpm
-curl-libs-7.83.0-1.cm2.aarch64.rpm
+curl-7.83.1-1.cm2.aarch64.rpm
+curl-devel-7.83.1-1.cm2.aarch64.rpm
+curl-libs-7.83.1-1.cm2.aarch64.rpm
 tdnf-3.2.2-4.cm2.aarch64.rpm
 tdnf-cli-libs-3.2.2-4.cm2.aarch64.rpm
 tdnf-devel-3.2.2-4.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -188,9 +188,9 @@ libsolv-devel-0.7.20-1.cm2.x86_64.rpm
 libssh2-1.9.0-2.cm2.x86_64.rpm
 libssh2-devel-1.9.0-2.cm2.x86_64.rpm
 krb5-1.19.3-1.cm2.x86_64.rpm
-curl-7.83.0-1.cm2.x86_64.rpm
-curl-devel-7.83.0-1.cm2.x86_64.rpm
-curl-libs-7.83.0-1.cm2.x86_64.rpm
+curl-7.83.1-1.cm2.x86_64.rpm
+curl-devel-7.83.1-1.cm2.x86_64.rpm
+curl-libs-7.83.1-1.cm2.x86_64.rpm
 tdnf-3.2.2-4.cm2.x86_64.rpm
 tdnf-cli-libs-3.2.2-4.cm2.x86_64.rpm
 tdnf-devel-3.2.2-4.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -44,10 +44,10 @@ cracklib-lang-2.9.7-5.cm2.aarch64.rpm
 createrepo_c-0.17.5-1.cm2.aarch64.rpm
 createrepo_c-debuginfo-0.17.5-1.cm2.aarch64.rpm
 createrepo_c-devel-0.17.5-1.cm2.aarch64.rpm
-curl-7.83.0-1.cm2.aarch64.rpm
-curl-debuginfo-7.83.0-1.cm2.aarch64.rpm
-curl-devel-7.83.0-1.cm2.aarch64.rpm
-curl-libs-7.83.0-1.cm2.aarch64.rpm
+curl-7.83.1-1.cm2.aarch64.rpm
+curl-debuginfo-7.83.1-1.cm2.aarch64.rpm
+curl-devel-7.83.1-1.cm2.aarch64.rpm
+curl-libs-7.83.1-1.cm2.aarch64.rpm
 Cython-debuginfo-0.29.26-1.cm2.aarch64.rpm
 debugedit-5.0-1.cm2.aarch64.rpm
 debugedit-debuginfo-5.0-1.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -44,10 +44,10 @@ cracklib-lang-2.9.7-5.cm2.x86_64.rpm
 createrepo_c-0.17.5-1.cm2.x86_64.rpm
 createrepo_c-debuginfo-0.17.5-1.cm2.x86_64.rpm
 createrepo_c-devel-0.17.5-1.cm2.x86_64.rpm
-curl-7.83.0-1.cm2.x86_64.rpm
-curl-debuginfo-7.83.0-1.cm2.x86_64.rpm
-curl-devel-7.83.0-1.cm2.x86_64.rpm
-curl-libs-7.83.0-1.cm2.x86_64.rpm
+curl-7.83.1-1.cm2.x86_64.rpm
+curl-debuginfo-7.83.1-1.cm2.x86_64.rpm
+curl-devel-7.83.1-1.cm2.x86_64.rpm
+curl-libs-7.83.1-1.cm2.x86_64.rpm
 Cython-debuginfo-0.29.26-1.cm2.x86_64.rpm
 debugedit-5.0-1.cm2.x86_64.rpm
 debugedit-debuginfo-5.0-1.cm2.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Upgrading to curl 7.83.1 for 6 CVE fixes.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Upgrade curl to version 7.83.1
- Fixes CVE-2022-27779, CVE-2022-27780, CVE-2022-27781, CVE-2022-30115, CVE-2022-27782, CVE-2022-27778

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2022-27779
- https://nvd.nist.gov/vuln/detail/CVE-2022-27780
- https://nvd.nist.gov/vuln/detail/CVE-2022-27781
- https://nvd.nist.gov/vuln/detail/CVE-2022-30115
- https://nvd.nist.gov/vuln/detail/CVE-2022-27782
- https://nvd.nist.gov/vuln/detail/CVE-2022-27778

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Full local build succeeded
