### PR TITLE
Add patch for libcdio to build with ncurses 6.3

### DIFF
--- a/SPECS-EXTENDED/libcdio/fix_format_security.patch
+++ b/SPECS-EXTENDED/libcdio/fix_format_security.patch
@@ -1,0 +1,50 @@
+http://git.savannah.gnu.org/cgit/libcdio.git/patch/?id=2adb43c60afc6e98e94d86dad9f93d3df52862b1
+
+From 2adb43c60afc6e98e94d86dad9f93d3df52862b1 Mon Sep 17 00:00:00 2001
+From: Sergei Trofimovich <slyich@gmail.com>
+Date: Mon, 1 Nov 2021 08:00:30 +0000
+Subject: src/cdda-player.c: always use "%s"-style format for printf()-style
+ functions
+
+`ncuses-6.3` added printf-style function attributes and now makes
+it easier to catch cases when user input is used in palce of format
+string when built with CFLAGS=-Werror=format-security:
+
+    cdda-player.c:1032:31:
+      error: format not a string literal and no format arguments [-Werror=format-security]
+     1032 |         mvprintw(i_line++, 0, line);
+          |                               ^~~~
+
+Let's wrap all the missing places with "%s" format.
+---
+ src/cdda-player.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/cdda-player.c b/src/cdda-player.c
+index 69eddee..8834d60 100644
+--- a/src/cdda-player.c
++++ b/src/cdda-player.c
+@@ -298,7 +298,7 @@ action(const char *psz_action)
+              psz_action);
+   else
+     snprintf(psz_action_line, sizeof(psz_action_line), "%s", "" );
+-  mvprintw(LINE_ACTION, 0, psz_action_line);
++  mvprintw(LINE_ACTION, 0, "%s", psz_action_line);
+   clrtoeol();
+   refresh();
+ }
+@@ -1029,10 +1029,10 @@ display_tracks(void)
+       }
+       if (sub.track == i) {
+         attron(A_STANDOUT);
+-        mvprintw(i_line++, 0, line);
++        mvprintw(i_line++, 0, "%s", line);
+         attroff(A_STANDOUT);
+       } else
+-        mvprintw(i_line++, 0, line);
++        mvprintw(i_line++, 0, "%s", line);
+       clrtoeol();
+     }
+   }
+-- 
+cgit v1.1

--- a/SPECS-EXTENDED/libcdio/libcdio.spec
+++ b/SPECS-EXTENDED/libcdio/libcdio.spec
@@ -2,7 +2,7 @@ Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Name: libcdio
 Version: 2.0.0
-Release: 7%{?dist}
+Release: 8%{?dist}
 Summary: CD-ROM input and control library
 License: GPLv3+
 URL: http://www.gnu.org/software/libcdio/
@@ -16,6 +16,7 @@ BuildRequires: ncurses-devel
 BuildRequires: help2man
 BuildRequires: gettext-devel
 BuildRequires: chrpath
+Patch0: fix_format_security.patch
 
 
 # ABI compatibility package dropped in F23
@@ -38,6 +39,7 @@ This package contains header files and libraries for %{name}.
 
 %prep
 %setup -q
+%patch0 -p1
 
 iconv -f ISO88591 -t utf-8 -o THANKS.utf8 THANKS && mv THANKS.utf8 THANKS
 
@@ -121,6 +123,9 @@ make check
 
 
 %changelog
+* Tue Jun 21 2022 Andrew Phelps <anphel@microsoft.com> - 2.0.0-8
+- Add patch to fix build error with ncurses 6.3
+
 * Fri Oct 15 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 2.0.0-7
 - Initial CBL-Mariner import from Fedora 32 (license: MIT).
 

--- a/SPECS-EXTENDED/libcdio/libcdio.spec
+++ b/SPECS-EXTENDED/libcdio/libcdio.spec
@@ -125,6 +125,7 @@ make check
 %changelog
 * Tue Jun 21 2022 Andrew Phelps <anphel@microsoft.com> - 2.0.0-8
 - Add patch to fix build error with ncurses 6.3
+- License verified
 
 * Fri Oct 15 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 2.0.0-7
 - Initial CBL-Mariner import from Fedora 32 (license: MIT).


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Add patch for libcdio to build with ncurses 6.3.
Resolves error:
```
"cdda-player.c: In function 'action':"
"cdda-player.c:296:28: error: format not a string literal and no format arguments [-Werror=format-security]"
"  296 |   mvprintw(LINE_ACTION, 0, psz_action_line);"
"      |                            ^~~~~~~~~~~~~~~"
"cdda-player.c: In function 'display_tracks':"
"cdda-player.c:1023:31: error: format not a string literal and no format arguments [-Werror=format-security]"
" 1023 |         mvprintw(i_line++, 0, line);"
"      |                               ^~~~"
"cdda-player.c:1026:31: error: format not a string literal and no format arguments [-Werror=format-security]"
" 1026 |         mvprintw(i_line++, 0, line);"
"      |                               ^~~~"
```

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Patch libcdio

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build
