### PR TITLE
toolchain: Remove openssl-debuginfo from the worker chroot

### DIFF
--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -164,7 +164,6 @@ gtk-doc-1.33.2-1.cm2.noarch.rpm
 autoconf-2.71-3.cm2.noarch.rpm
 automake-1.16.5-1.cm2.noarch.rpm
 openssl-1.1.1k-16.cm2.aarch64.rpm
-openssl-debuginfo-1.1.1k-16.cm2.aarch64.rpm
 openssl-devel-1.1.1k-16.cm2.aarch64.rpm
 openssl-libs-1.1.1k-16.cm2.aarch64.rpm
 openssl-perl-1.1.1k-16.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -168,7 +168,6 @@ openssl-devel-1.1.1k-16.cm2.x86_64.rpm
 openssl-libs-1.1.1k-16.cm2.x86_64.rpm
 openssl-perl-1.1.1k-16.cm2.x86_64.rpm
 openssl-static-1.1.1k-16.cm2.x86_64.rpm
-openssl-debuginfo-1.1.1k-16.cm2.x86_64.rpm
 libcap-2.60-1.cm2.x86_64.rpm
 libcap-devel-2.60-1.cm2.x86_64.rpm
 debugedit-5.0-1.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/update_manifests.sh
+++ b/toolkit/resources/manifests/package/update_manifests.sh
@@ -316,11 +316,8 @@ generate_toolchain
 # Create a temp file that can be edited to remove the unnecessary files
 cp "$ToolchainManifest" $TmpPkgGen
 
-# Remove all *-debuginfo except openssl
-R=$(grep openssl-debuginfo "$ToolchainManifest")
+# Remove all *-debuginfo subpackages
 sed -i '/debuginfo/d' $TmpPkgGen
-# Add the openssl-debuginfo file back
-echo "$R" >> $TmpPkgGen
 
 # Modify the temp file by removing other unneeded packages
 remove_packages_for_pkggen_core


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
We generally want to keep the worker chroot as small as we can. With this goal in mind, we should keep `debuginfo` subpackages out of there as much as possible. Today, we explicitly exclude all `debuginfo` subpackages from the worker chroot except for the `openssl-debuginfo` subpackage. I can't find any documented reason why the `openssl-debuginfo` package would be included.

I asked around with people who were around in the pre-1.0 days, and the consensus from those folks was "Who knows, try and rip it out". I tried looking in our old, pre-1.0 private repo, but there isn't any reason accompanying the introduction of this exception.

So, absent a good reason to keep it there, we should remove `openssl-debuginfo` from the worker chroot.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- toolchain: Remove openssl-debuginfo from worker chroot in the manifests and the `update_manifests.sh` script
- 
###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Performed a full pipeline build, no issues