### PR TITLE
numatop: Fix format-security errors caused by ncurses-6.3 upgrade

### DIFF
--- a/SPECS-EXTENDED/numatop/fix-format-security.patch
+++ b/SPECS-EXTENDED/numatop/fix-format-security.patch
@@ -1,0 +1,55 @@
+From eda86237c1c3dd4f1cac82b2e164698f16d879dd Mon Sep 17 00:00:00 2001
+From: Olivia Crain <oliviacrain@microsoft.com>
+Date: Tue, 21 Jun 2022 16:33:24 +0000
+Subject: [PATCH] common/reg.c: Fix format-security warnings
+
+Version 6.3 of ncurses introduced function attributes that cause
+GCC to recognize more instances of format-security warnings.
+
+In this case, `mvwprintw` is used with strings that have no format
+arguments. These strings are effectively handed off to `printf`,
+which triggers the format-security warnings.
+
+The proper function to use here is `mvwaddstr`, which serves the
+same purpose without passing the string through `printf`.
+---
+ common/reg.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/common/reg.c b/common/reg.c
+index 1a87161..8a66706 100644
+--- a/common/reg.c
++++ b/common/reg.c
+@@ -240,7 +240,7 @@ reg_line_write(win_reg_t *r, int line, reg_align_t align, char *content)
+ 	}
+ 
+ 	if (len > 0) {
+-		(void) mvwprintw(r->hdl, line, pos_x, content);
++		(void) mvwaddstr(r->hdl, line, pos_x, content);
+ 	}
+ 
+ 	if (r->mode != 0) {
+@@ -267,7 +267,7 @@ reg_highlight_write(win_reg_t *r, int line, int align, char *content)
+ 	}
+ 
+ 	if (len > 0) {
+-		(void) mvwprintw(r->hdl, line, pos_x, content);
++		(void) mvwaddstr(r->hdl, line, pos_x, content);
+ 	}
+ 
+ 	(void) wattroff(r->hdl, A_REVERSE | A_BOLD);
+@@ -420,9 +420,9 @@ reg_curses_init(boolean_t first_load)
+ 
+ 	if ((g_scr_height < 24 || g_scr_width < 80)) {
+ 		if (!first_load) {
+-			(void) mvwprintw(stdscr, 0, 0,
++			(void) mvwaddstr(stdscr, 0, 0,
+ 			    "Terminal size is too small.");
+-			(void) mvwprintw(stdscr, 1, 0,
++			(void) mvwaddstr(stdscr, 1, 0,
+ 			    "Please resize it to 80x24 or larger.");
+ 			(void) refresh();
+ 		} else {
+-- 
+2.34.1
+

--- a/SPECS-EXTENDED/numatop/numatop.spec
+++ b/SPECS-EXTENDED/numatop/numatop.spec
@@ -3,7 +3,7 @@ Distribution:   Mariner
 
 Name:           numatop
 Version:        2.1
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        Memory access locality characterization and analysis
 
 License:        BSD
@@ -11,6 +11,7 @@ URL:            https://01.org/numatop
 Source:         https://github.com/intel/%{name}/releases/download/v%{version}/%{name}-v%{version}.tar.xz
 # https://github.com/intel/numatop/pull/53
 Patch0:         as-needed.patch
+Patch1:         fix-format-security.patch
 
 BuildRequires:  autoconf
 BuildRequires:  automake
@@ -34,8 +35,7 @@ NumaTOP supports the Intel Xeon processors and PowerPC processors.
 
 
 %prep
-%autosetup -n %{name}-v%{version}
-
+%autosetup -p1 -n %{name}-v%{version}
 
 %build
 autoreconf -ivf
@@ -59,6 +59,10 @@ autoreconf -ivf
 
 
 %changelog
+* Tue Jun 21 2022 Olivia Crain <oliviacrain@microsoft.com> - 2.1-5
+- Add patch to fix format-security wanings with ncurses 6.3
+- License verified
+
 * Wed Aug 11 2021 Thomas Crain <thcrain@microsoft.com> - 2.1-4
 - Initial CBL-Mariner import from Fedora 32 (license: MIT).
 - Add patch to fix linking error


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
#3160 upgraded ncurses to version 6.3. This update changed some function attributes that are causing GCC to recognize more instances of -Werror=format-security in packages utilizing ncurses. So, we fix these errors in `numatop` by taking the relevant patches from upstream.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- `numatop`: Add patch to fix -Werror=format-security errors after ncurses 6.3 upgrade

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build
