### PR TITLE
Bug fix for `ResolveCompetingPackages` when building on RPM-based distro

### DIFF
--- a/toolkit/tools/graphpkgfetcher/graphpkgfetcher.go
+++ b/toolkit/tools/graphpkgfetcher/graphpkgfetcher.go
@@ -242,7 +242,7 @@ func assignRPMPath(node *pkggraph.PkgNode, outDir string, resolvedPackages []str
 		var resolvedRPMs []string
 		logger.Log.Debugf("Found %d candidates. Resolving.", len(rpmPaths))
 
-		resolvedRPMs, err = rpm.ResolveCompetingPackages(rpmPaths...)
+		resolvedRPMs, err = rpm.ResolveCompetingPackages(*tmpDir, rpmPaths...)
 		if err != nil {
 			logger.Log.Errorf("Failed while trying to pick an RPM providing '%s' from the following RPMs: %v", node.VersionedPkg.Name, rpmPaths)
 			return

--- a/toolkit/tools/internal/rpm/rpm.go
+++ b/toolkit/tools/internal/rpm/rpm.go
@@ -280,7 +280,7 @@ func QueryRPMProvides(rpmFile string) (provides []string, err error) {
 
 // ResolveCompetingPackages takes in a list of RPMs and returns only the ones, which would
 // end up being installed after resolving outdated, obsoleted, or conflicting packages.
-func ResolveCompetingPackages(rpmPaths ...string) (resolvedRPMs []string, err error) {
+func ResolveCompetingPackages(rootDir string, rpmPaths ...string) (resolvedRPMs []string, err error) {
 	const (
 		queryFormat       = ""
 		installedRPMIndex = 1
@@ -290,6 +290,8 @@ func ResolveCompetingPackages(rpmPaths ...string) (resolvedRPMs []string, err er
 	args := []string{
 		"-Uvvh",
 		"--nodeps",
+		"--root",
+		rootDir,
 		"--test",
 	}
 	args = append(args, rpmPaths...)


### PR DESCRIPTION
###### Merge Checklist

**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary

The current implementation of `ResolveCompetingPackages` assumes it is running on a
distro that doesn't use RPM. Specifically, it doesn't set the root directory which
allows for confusion between the packages being built for CBL-Mariner and the packages
installed on the build system. This change fix this problem by setting the root
directory when calling the `rpm` command.

###### Change Log

- Bug fix for `ResolveCompetingPackages` when building on RPM-based distro

###### Does this affect the toolchain?

NO

###### Test Methodology

- Local build
