### PR TITLE
`mysql`: update to version 8.0.29 to fix 17 CVEs

### DIFF
--- a/SPECS/mysql/mysql.signatures.json
+++ b/SPECS/mysql/mysql.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "mysql-boost-8.0.28.tar.gz": "6dd0303998e70066d36905bd8fef1c01228ea182dbfbabc6c22ebacdbf8b5941"
+  "mysql-boost-8.0.29.tar.gz": "fd34a84c65fc7b15609d55b1f5d128c4d5543a6b95fa638569c3277c5c7bb048"
  }
 }

--- a/SPECS/mysql/mysql.spec
+++ b/SPECS/mysql/mysql.spec
@@ -1,6 +1,6 @@
 Summary:        MySQL.
 Name:           mysql
-Version:        8.0.28
+Version:        8.0.29
 Release:        1%{?dist}
 License:        GPLv2 with exceptions AND LGPLv2 AND BSD
 Vendor:         Microsoft Corporation
@@ -31,7 +31,7 @@ Development headers for developing applications linking to maridb
 %build
 cmake . \
       -DCMAKE_INSTALL_PREFIX=%{_prefix}   \
-      -DWITH_BOOST=boost/boost_1_73_0 \
+      -DWITH_BOOST=boost/boost_1_77_0 \
       -DINSTALL_MANDIR=share/man \
       -DINSTALL_DOCDIR=share/doc \
       -DINSTALL_DOCREADMEDIR=share/doc \
@@ -80,6 +80,9 @@ make test
 %{_libdir}/pkgconfig/mysqlclient.pc
 
 %changelog
+* Thu Jun 23 2022 Henry Beberman <henry.beberman@microsoft.com> - 8.0.29-1
+- Upgrade to 8.0.29 to fix 17 CVEs
+
 * Wed Jan 26 2022 Neha Agarwal <thcrain@microsoft.com> - 8.0.28-1
 - Upgrade to 8.0.28 to fix 16 CVEs
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -11973,8 +11973,8 @@
         "type": "other",
         "other": {
           "name": "mysql",
-          "version": "8.0.28",
-          "downloadUrl": "https://dev.mysql.com/get/Downloads/MySQL-8.0/mysql-boost-8.0.28.tar.gz"
+          "version": "8.0.29",
+          "downloadUrl": "https://dev.mysql.com/get/Downloads/MySQL-8.0/mysql-boost-8.0.29.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Update mysql to version 8.0.29 to fix 17 CVEs

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Update mysql to version 8.0.29 to fix 17 CVEs
- Fixes CVE-2022-21460, CVE-2022-21454, CVE-2022-21427, CVE-2022-21425, CVE-2022-21417, CVE-2022-21412, CVE-2022-21489, CVE-2022-21444, CVE-2022-21451, CVE-2022-21485, CVE-2022-21484, CVE-2022-21483, CVE-2022-21482, CVE-2022-21479, CVE-2022-21478, CVE-2022-21486, CVE-2021-22570

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2022-21460
- https://nvd.nist.gov/vuln/detail/CVE-2022-21454
- https://nvd.nist.gov/vuln/detail/CVE-2022-21427
- https://nvd.nist.gov/vuln/detail/CVE-2022-21425
- https://nvd.nist.gov/vuln/detail/CVE-2022-21417
- https://nvd.nist.gov/vuln/detail/CVE-2022-21412
- https://nvd.nist.gov/vuln/detail/CVE-2022-21489
- https://nvd.nist.gov/vuln/detail/CVE-2022-21444
- https://nvd.nist.gov/vuln/detail/CVE-2022-21451
- https://nvd.nist.gov/vuln/detail/CVE-2022-21485
- https://nvd.nist.gov/vuln/detail/CVE-2022-21484
- https://nvd.nist.gov/vuln/detail/CVE-2022-21483
- https://nvd.nist.gov/vuln/detail/CVE-2022-21482
- https://nvd.nist.gov/vuln/detail/CVE-2022-21479
- https://nvd.nist.gov/vuln/detail/CVE-2022-21478
- https://nvd.nist.gov/vuln/detail/CVE-2022-21486
- https://nvd.nist.gov/vuln/detail/CVE-2021-22570

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local package build
- No significant regressions in the %check section tests