### PR TITLE
Nopatch CVE-2022-29824 the libxslt issue is fixed by libxml2 patch

### DIFF
--- a/SPECS/libxslt/CVE-2022-29824.nopatch
+++ b/SPECS/libxslt/CVE-2022-29824.nopatch
@@ -1,0 +1,1 @@
+This CVE is fixed by the CVE-2022-29824 patch to libxml2


### PR DESCRIPTION
Clearing CVE-2022-29824 against libxslt.  Libxslt takes a depenency on libxml2.  As libxml2 is fixed, the specific finding against libxslt is also now resolved. See commit  https://github.com/microsoft/CBL-Mariner/commit/66338d14261b3aeb4649e29048ec3ec11287eb29