### PR TITLE
upgrade python-jwt to 2.4.0 to fix 2022-29217

### DIFF
--- a/SPECS/python-jwt/python-jwt.signatures.json
+++ b/SPECS/python-jwt/python-jwt.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "PyJWT-1.7.1.tar.gz": "8d59a976fb773f3e6a39c85636357c4f0e242707394cadadd9814f5cbaa20e96"
+  "PyJWT-2.4.0.tar.gz": "d42908208c699b3b973cbeb01a969ba6a96c821eefb1c5bfe4c390c01d67abba"
  }
 }

--- a/SPECS/python-jwt/python-jwt.spec
+++ b/SPECS/python-jwt/python-jwt.spec
@@ -18,14 +18,14 @@ claims to be transferred between two parties encoded as digitally signed and
 encrypted JSON objects.}
 
 Name:           python-%{pkgname}
-Version:        1.7.1
-Release:        9%{?dist}
+Version:        2.4.0
+Release:        1%{?dist}
 Summary:        JSON Web Token implementation in Python
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 URL:            https://github.com/jpadilla/pyjwt
-Source0:        https://files.pythonhosted.org/packages/2f/38/ff37a24c0243c5f45f5798bd120c0f873eeed073994133c084e1cf13b95c/%{srcname}-%{version}.tar.gz
+Source0:        https://files.pythonhosted.org/packages/d8/6b/6287745054dbcccf75903630346be77d4715c594402cec7c2518032416c2/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 
 %description %{common_description}
@@ -49,8 +49,6 @@ BuildRequires:  python3-atomicwrites
 %prep
 %autosetup -n %{srcname}-%{version}
 rm -rf %{eggname}.egg-info
-# prevent pullng in `addopts` for pytest run later
-rm setup.cfg
 
 %build
 %{?with_python3:python3 setup.py build}
@@ -66,15 +64,16 @@ PYTHONPATH=%{buildroot}%{python3_sitelib} \
 
 %if %{with python3}
 %files -n python3-%{pkgname}
-%doc README.rst AUTHORS
+%doc README.rst AUTHORS.rst
 %license LICENSE
 %{python3_sitelib}/%{libname}
 %{python3_sitelib}/%{eggname}-%{version}-py%{python3_version}.egg-info
-#%{python3_sitelib}/%{eggname}-%{version}-py3.7.egg-info
-%{_bindir}/pyjwt
 %endif
 
 %changelog
+* Thu Jun 23 2022 Minghe Ren <mingheren@microsoft.com> - 2.4.0-1
+- Update to v2.4.0 to fix CVE-2022-29217
+
 * Wed Jun 23 2021 Neha Agarwal <nehaagarwal@microsoft.com> - 1.7.1-9
 - Pass check section
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -6245,8 +6245,8 @@
         "type": "other",
         "other": {
           "name": "python-jwt",
-          "version": "1.7.1",
-          "downloadUrl": "https://files.pythonhosted.org/packages/2f/38/ff37a24c0243c5f45f5798bd120c0f873eeed073994133c084e1cf13b95c/PyJWT-1.7.1.tar.gz"
+          "version": "2.4.0",
+          "downloadUrl": "https://files.pythonhosted.org/packages/d8/6b/6287745054dbcccf75903630346be77d4715c594402cec7c2518032416c2/PyJWT-2.4.0.tar.gz"
         }
       }
     },
@@ -7315,8 +7315,8 @@
         "type": "other",
         "other": {
           "name": "rubygem-elasticsearch",
-          "version": "8.2.2",
-          "downloadUrl": "https://rubygems.org/downloads/elasticsearch-8.2.2.gem"
+          "version": "8.2.0",
+          "downloadUrl": "https://rubygems.org/downloads/elasticsearch-8.2.0.gem"
         }
       }
     },

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -7315,8 +7315,8 @@
         "type": "other",
         "other": {
           "name": "rubygem-elasticsearch",
-          "version": "8.2.0",
-          "downloadUrl": "https://rubygems.org/downloads/elasticsearch-8.2.0.gem"
+          "version": "8.2.2",
+          "downloadUrl": "https://rubygems.org/downloads/elasticsearch-8.2.2.gem"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
upgrade python-jwt to 2.4.0 to fix 2022-29217

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- upgrade python-jwt to 2.4.0 to fix 2022-29217
- remove setup.cfg as it causes a bug resulting egg package name is UNKNOWN-0.0.0 (mariner 2.0 also removes it)
- remove non-exist files in %file section from previous version 

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
NO

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- [Bug 39916509](https://microsoft.visualstudio.com/OS/_workitems/edit/39916509): [CVE][Patching] Patching CVE-2022-29217 for the 1.0 branch - Score: 7.5 [python-jwt 1.7.1]

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2022-29217

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local package build