### PR TITLE
`uclibc-ng`: upgrade to 1.0.41 to fix CVE-2022-30295

### DIFF
--- a/SPECS/uclibc-ng/uclibc-ng.signatures.json
+++ b/SPECS/uclibc-ng/uclibc-ng.signatures.json
@@ -1,6 +1,6 @@
 {
  "Signatures": {
-  "uClibc-ng-1.0.39.tar.xz": "cb089dfe14867a38f222d6428e85d0e1191dcbb66dd9b1a671484f6bc7c81920",
+  "uClibc-ng-1.0.41.tar.xz": "b32a92a0218d95922d6976464e6ef51e2ebacfbcdb605820458d9dbb8a61e025",
   "uClibc.config": "5cd0bebdcc29597e6abdcfcbb0d7309633dd843b273b0baca718e6d5f2fb0f1f"
  }
 }

--- a/SPECS/uclibc-ng/uclibc-ng.spec
+++ b/SPECS/uclibc-ng/uclibc-ng.spec
@@ -3,7 +3,7 @@
 %global debug_package %{nil}
 Summary:        C library for embedded Linux
 Name:           uclibc-ng
-Version:        1.0.39
+Version:        1.0.41
 Release:        1%{?dist}
 License:        LGPLv2
 Vendor:         Microsoft Corporation
@@ -82,6 +82,9 @@ rm -rf  %{buildroot}/include/
 %{_libdir}/uClibc
 
 %changelog
+* Fri Jun 24 2022 Henry Beberman <henry.beberman@microsoft.com> - 1.0.41-1
+- Updating to version 1.0.41 to fix CVE-2022-30295.
+
 * Mon Jan 03 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.0.39-1
 - Updating to version 1.0.39.
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -25717,8 +25717,8 @@
         "type": "other",
         "other": {
           "name": "uclibc-ng",
-          "version": "1.0.39",
-          "downloadUrl": "https://downloads.uclibc-ng.org/releases/1.0.39/uClibc-ng-1.0.39.tar.xz"
+          "version": "1.0.41",
+          "downloadUrl": "https://downloads.uclibc-ng.org/releases/1.0.41/uClibc-ng-1.0.41.tar.xz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Update uclibc-ng to version 1.0.41 to fix CVE-2022-30295

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Update uclibc-ng to version 1.0.41 to fix CVE-2022-30295

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2022-30295

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build
