### PR TITLE
Print all unsolvable nodes blocking subgraph

### DIFF
--- a/toolkit/tools/scheduler/schedulerutils/depsolver.go
+++ b/toolkit/tools/scheduler/schedulerutils/depsolver.go
@@ -17,7 +17,10 @@ import (
 func CanSubGraph(pkgGraph *pkggraph.PkgGraph, node *pkggraph.PkgNode, useCachedImplicit bool) bool {
 	search := traverse.BreadthFirst{}
 
-	unresolvedImplicitNode := search.Walk(pkgGraph, node, func(n graph.Node, d int) (stopSearch bool) {
+	foundUnsolvableNode := false
+
+	// Walk entire graph and print list of any/all unsolvable nodes
+	search.Walk(pkgGraph, node, func(n graph.Node, d int) (stopSearch bool) {
 		pkgNode := n.(*pkggraph.PkgNode)
 
 		// Non-implicit nodes are solvable
@@ -36,11 +39,12 @@ func CanSubGraph(pkgGraph *pkggraph.PkgGraph, node *pkggraph.PkgNode, useCachedI
 		}
 
 		// This node is not yet solvable
-		logger.Log.Debugf("Could not subgraph due to node: %v", pkgNode)
-		return true
+		logger.Log.Warnf("Could not subgraph due to node: %v", pkgNode)
+		foundUnsolvableNode = true
+		return
 	})
 
-	return unresolvedImplicitNode == nil
+	return foundUnsolvableNode == false
 }
 
 // LeafNodes returns a slice of all leaf nodes in the graph.


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
When the scheduler determines whether a node can be subgraphed, it currently stops at the first unsolvable node. This change will allow it to print the full set of unsolvable nodes. We can then track the amount of unsolvable nodes in daily builds, with the goal of reducing them over time to speed up builds.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change depsolver to print all nodes blocking subgraph

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build
