### PR TITLE
Updating `fakeroot` to version 1.29 to fix a ptest.

### DIFF
--- a/SPECS/fakeroot/fakeroot.signatures.json
+++ b/SPECS/fakeroot/fakeroot.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "fakeroot_1.28.orig.tar.gz": "56d405e36ff685f83879be08fdd654255ab9aa38632b4605a98e896ad63990c2"
+  "fakeroot_1.29.orig.tar.gz": "8fbbafb780c9173e3ace4a04afbc1d900f337f3216883939f5c7db3431be7c20"
  }
 }

--- a/SPECS/fakeroot/fakeroot.spec
+++ b/SPECS/fakeroot/fakeroot.spec
@@ -2,7 +2,7 @@
 
 Summary:        Gives a fake root environment
 Name:           fakeroot
-Version:        1.28
+Version:        1.29
 Release:        1%{?dist}
 # setenv.c: LGPLv2+
 # contrib/Fakeroot-Stat-1.8.8: Perl (GPL+ or Artistic)
@@ -179,6 +179,9 @@ fi
 %ghost %{_libdir}/libfakeroot/libfakeroot-0.so
 
 %changelog
+* Mon Jun 27 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.29-1
+- Updating to 1.29 to fix a test.
+
 * Fri Mar 18 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.28-1
 - Updating to version 1.28 using Fedora 36 spec (license: MIT) for guidance.
 - Switching to using upstream fix for tartest.

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -3028,8 +3028,8 @@
         "type": "other",
         "other": {
           "name": "fakeroot",
-          "version": "1.28",
-          "downloadUrl": "https://cdn-aws.deb.debian.org/debian/pool/main/f/fakeroot/fakeroot_1.28.orig.tar.gz"
+          "version": "1.29",
+          "downloadUrl": "https://cdn-aws.deb.debian.org/debian/pool/main/f/fakeroot/fakeroot_1.29.orig.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

We've recently noticed a ptest failure in `fakeroot`. Updating to 1.29 to resolve the issue.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Updated `fakeroot` to 1.29.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local package build with `RUN_CHECK=y`.
