### PR TITLE
patch qemu-kvm for CVE-2021-3750

### DIFF
--- a/SPECS/qemu-kvm/CVE-2021-3750.patch
+++ b/SPECS/qemu-kvm/CVE-2021-3750.patch
@@ -1,0 +1,53 @@
+diff -ruN a/hw/intc/arm_gicv3_redist.c b/hw/intc/arm_gicv3_redist.c
+--- a/hw/intc/arm_gicv3_redist.c	2019-12-12 10:20:47.000000000 -0800
++++ b/hw/intc/arm_gicv3_redist.c	2022-06-27 15:58:13.914229178 -0700
+@@ -450,7 +450,7 @@
+         break;
+     }
+ 
+-    if (r == MEMTX_ERROR) {
++    if (r != MEMTX_OK) {
+         qemu_log_mask(LOG_GUEST_ERROR,
+                       "%s: invalid guest read at offset " TARGET_FMT_plx
+                       "size %u\n", __func__, offset, size);
+@@ -507,7 +507,7 @@
+         break;
+     }
+ 
+-    if (r == MEMTX_ERROR) {
++    if (r != MEMTX_OK) {
+         qemu_log_mask(LOG_GUEST_ERROR,
+                       "%s: invalid guest write at offset " TARGET_FMT_plx
+                       "size %u\n", __func__, offset, size);
+--
+1.8.3.1
+
+diff -ruN a/include/exec/memattrs.h b/include/exec/memattrs.h
+--- a/include/exec/memattrs.h	2019-12-12 10:20:47.000000000 -0800
++++ b/include/exec/memattrs.h	2022-06-27 16:16:55.164152752 -0700
+@@ -35,6 +35,14 @@
+     unsigned int secure:1;
+     /* Memory access is usermode (unprivileged) */
+     unsigned int user:1;
++    /*
++     * Bus interconnect and peripherals can access anything (memories,
++     * devices) by default. By setting the 'memory' bit, bus transaction
++     * are restricted to "normal" memories (per the AMBA documentation)
++     * versus devices. Access to devices will be logged and rejected
++     * (see MEMTX_ACCESS_ERROR).
++     */
++    unsigned int memory:1;
+     /* Requester ID (for MSI for example) */
+     unsigned int requester_id:16;
+     /* Invert endianness for this page */
+@@ -66,6 +74,7 @@
+ #define MEMTX_OK 0
+ #define MEMTX_ERROR             (1U << 0) /* device returned an error */
+ #define MEMTX_DECODE_ERROR      (1U << 1) /* nothing at that address */
++#define MEMTX_ACCESS_ERROR      (1U << 2) /* access denied */
+ typedef uint32_t MemTxResult;
+ 
+ #endif
+
+ --
+ 2.33.1

--- a/SPECS/qemu-kvm/qemu-kvm.spec
+++ b/SPECS/qemu-kvm/qemu-kvm.spec
@@ -1,7 +1,7 @@
 Summary:        QEMU is a machine emulator and virtualizer
 Name:           qemu-kvm
 Version:        4.2.0
-Release:        39%{?dist}
+Release:        40%{?dist}
 License:        GPLv2 AND GPLv2+ AND CC-BY AND BSD
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -60,6 +60,7 @@ Patch42:        CVE-2021-3608.patch
 Patch43:        CVE-2021-20257.patch
 Patch44:        CVE-2021-3748.patch
 Patch45:        CVE-2021-3638.patch
+Patch46:        CVE-2021-3750.patch
 # Range 1001+ reserved for nopatch files
 Patch1001:      CVE-2020-7039.nopatch
 # CVE-2020-12829 affects the sm501 video driver, which is only used for powerpc and SuperH emulation
@@ -205,6 +206,9 @@ fi
 %{_bindir}/qemu-nbd
 
 %changelog
+* Mon Jun 27 2022 Minghe Ren <mingheren@microsoft.com> - 4.2.0-40
+- Patch CVE-2021-3750 
+
 * Fri May 06 2022 Nick Samson <nisamson@microsoft.com> - 4.2.0-39
 - Patch CVE-2021-20257, CVE-2021-3638, CVE-2021-3748
 - Nopatch CVE-2022-1050, CVE-2021-20295


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
patch qemu-kvm for CVE-2021-3750

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Partially patch qemu-kvm for CVE-2021-3750 according to [upstream](https://bugzilla.redhat.com/show_bug.cgi?id=1999073) 
- For those upstream patches that are not in our QEMU version, they are ignored although the changes are meant to solve the CVE. These upstream changes related to some functions that are not in our version of QEMU.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
NO

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
-[Bug 39601650](https://microsoft.visualstudio.com/OS/_workitems/edit/39601650): [CVE][Patching] Patching CVE-2021-3750 for the 1.0 branch - Score: 8.2 [qemu-kvm 4.2.0]

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2021-3750

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- local build with RUN_CHECK=y
