### PR TITLE
Added patch to fix compilation with ncurses 6.3 for hunspell and liboping

### DIFF
--- a/SPECS-EXTENDED/hunspell/hunspell-1.7.0-print-format.patch
+++ b/SPECS-EXTENDED/hunspell/hunspell-1.7.0-print-format.patch
@@ -1,0 +1,24 @@
+diff -urN a/hunspell-1.7.0/src/tools/hunspell.cxx b/hunspell-1.7.0/src/tools/hunspell.cxx
+--- a/hunspell-1.7.0/src/tools/hunspell.cxx	2022-06-22 17:41:40.025754800 -0700
++++ b/hunspell-1.7.0/src/tools/hunspell.cxx	2022-06-27 16:35:13.916216700 -0700
+@@ -581,7 +581,7 @@
+ #ifdef HAVE_CURSES_H
+ char* scanline(char* message) {
+   char input[INPUTLEN];
+-  printw(message);
++  printw("%c",message);
+   echo();
+   getnstr(input, INPUTLEN);
+   noecho();
+@@ -1180,9 +1180,9 @@
+   mvprintw(MAXPREVLINE + 2, 0, "\n");
+   for (size_t i = 0; i < wlst.size(); ++i) {
+     if ((wlst.size() > 10) && (i < 10)) {
+-      printw(" 0%d: %s\n", i, chenc(wlst[i], io_enc, ui_enc).c_str());
++      printw(" 0%zu: %s\n", i, chenc(wlst[i], io_enc, ui_enc).c_str());
+     } else {
+-      printw(" %d: %s\n", i, chenc(wlst[i], io_enc, ui_enc).c_str());
++      printw(" %u: %s\n", i, chenc(wlst[i], io_enc, ui_enc).c_str());
+     }
+   }
+ 

--- a/SPECS-EXTENDED/hunspell/hunspell.spec
+++ b/SPECS-EXTENDED/hunspell/hunspell.spec
@@ -3,7 +3,7 @@
 Name:      hunspell
 Summary:   A spell checker and morphological analyzer library
 Version:   1.7.0
-Release:   6%{?dist}
+Release:   7%{?dist}
 # Source:  https://github.com/hunspell/hunspell/archive/refs/tags/v1.7.0.tar.gz
 Source:    https://github.com/hunspell/hunspell/archive/refs/tags/%{name}-%{version}.tar.gz
 URL:       https://github.com/hunspell/hunspell
@@ -22,6 +22,7 @@ BuildRequires: words
 Requires:  hunspell-en-US
 
 Patch0: 0001-invalid-read-memory-access-624.patch
+Patch1: hunspell-1.7.0-print-format.patch
 
 %description
 Hunspell is a spell checker and morphological analyzer library and program 
@@ -39,6 +40,7 @@ Includes and definitions for developing with hunspell
 %prep
 %setup -q
 %patch0 -p1 -b .CVE-2019-16707
+%patch1 -p2 
 
 %build
 autoreconf -vfi
@@ -120,6 +122,10 @@ mkdir $RPM_BUILD_ROOT/%{_datadir}/myspell
 %{_mandir}/man5/hunspell.5.gz
 
 %changelog
+* Wed Jun 22 2022 Riken Maharjan <rmaharjan@microsoft.com> - 1.7.0-7
+- Patch for the print format issue.
+- License verified
+
 * Fri Oct 15 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.7.0-6
 - Initial CBL-Mariner import from Fedora 32 (license: MIT).
 

--- a/SPECS-EXTENDED/hunspell/hunspell.spec
+++ b/SPECS-EXTENDED/hunspell/hunspell.spec
@@ -4,7 +4,6 @@ Name:      hunspell
 Summary:   A spell checker and morphological analyzer library
 Version:   1.7.0
 Release:   7%{?dist}
-# Source:  https://github.com/hunspell/hunspell/archive/refs/tags/v1.7.0.tar.gz
 Source0:  https://github.com/hunspell/hunspell/archive/refs/tags/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
 URL:       https://github.com/hunspell/hunspell
 License:   LGPLv2+ or GPLv2+ or MPLv1.1 or BSD

--- a/SPECS-EXTENDED/hunspell/hunspell.spec
+++ b/SPECS-EXTENDED/hunspell/hunspell.spec
@@ -5,9 +5,9 @@ Summary:   A spell checker and morphological analyzer library
 Version:   1.7.0
 Release:   7%{?dist}
 # Source:  https://github.com/hunspell/hunspell/archive/refs/tags/v1.7.0.tar.gz
-Source:    https://github.com/hunspell/hunspell/archive/refs/tags/%{name}-%{version}.tar.gz
+Source0:  https://github.com/hunspell/hunspell/archive/refs/tags/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
 URL:       https://github.com/hunspell/hunspell
-License:   LGPLv2+ or GPLv2+ or MPLv1.1
+License:   LGPLv2+ or GPLv2+ or MPLv1.1 or BSD
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 BuildRequires:  gcc-c++
@@ -94,7 +94,8 @@ mkdir $RPM_BUILD_ROOT/%{_datadir}/myspell
 %ldconfig_scriptlets
 
 %files -f %{name}.lang
-%doc README COPYING COPYING.LESSER COPYING.MPL AUTHORS license.hunspell license.myspell THANKS
+%license  COPYING COPYING.LESSER COPYING.MPL license.hunspell license.myspell
+%doc README AUTHORS THANKS
 %{_libdir}/*.so.*
 %{_datadir}/myspell
 %{_bindir}/hunspell

--- a/SPECS-EXTENDED/hunspell/hunspell.spec
+++ b/SPECS-EXTENDED/hunspell/hunspell.spec
@@ -6,7 +6,7 @@ Version:   1.7.0
 Release:   7%{?dist}
 Source0:  https://github.com/hunspell/hunspell/archive/refs/tags/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
 URL:       https://github.com/hunspell/hunspell
-License:   LGPLv2+ or GPLv2+ or MPLv1.1 or BSD
+License:   (LGPLv2+ or GPLv2+ or MPLv1.1) and BSD
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 BuildRequires:  gcc-c++

--- a/SPECS-EXTENDED/liboping/liboping-1.10-fix-format-ncurses63.patch
+++ b/SPECS-EXTENDED/liboping/liboping-1.10-fix-format-ncurses63.patch
@@ -1,0 +1,32 @@
+diff -urN b/liboping-1.10.0/src/oping.c a/liboping-1.10.0/src/oping.c
+--- liboping-1.10.0/src/oping.c	2022-06-23 11:26:09.897532500 -0700
++++ liboping-1.10.0/src/oping.c	2022-06-23 11:53:44.215025100 -0700
+@@ -1125,7 +1125,7 @@
+ 			wattron (ctx->window, COLOR_PAIR(color));
+ 
+ 		if (has_utf8())
+-			mvwprintw (ctx->window, /* y = */ 3, /* x = */ x + 2, symbol);
++			mvwprintw (ctx->window, /* y = */ 3, /* x = */ x + 2, "%s", symbol);
+ 		else
+ 			mvwaddch (ctx->window, /* y = */ 3, /* x = */ x + 2, symbolc);
+ 
+@@ -1223,7 +1223,7 @@
+ 			mvwaddch (ctx->window, /* y = */ 3, /* x = */ x + 2, ' ');
+ 		else if (has_utf8 ())
+ 			mvwprintw (ctx->window, /* y = */ 3, /* x = */ x + 2,
+-					hist_symbols_utf8[index]);
++					"%s", hist_symbols_utf8[index]);
+ 		else
+ 			mvwaddch (ctx->window, /* y = */ 3, /* x = */ x + 2,
+ 					hist_symbols_acs[index] | A_ALTCHARSET);
+@@ -1600,8 +1600,8 @@
+ 
+ 			HOST_PRINTF ("%zu bytes from %s (%s): icmp_seq=%u ttl=%i ",
+ 					data_len, context->host, context->addr,
+-					sequence, recv_ttl,
+-					format_qos (recv_qos, recv_qos_str, sizeof (recv_qos_str)));
++					sequence, recv_ttl);
++					
+ 			if ((recv_qos != 0) || (opt_send_qos != 0))
+ 			{
+ 				HOST_PRINTF ("qos=%s ",

--- a/SPECS-EXTENDED/liboping/liboping.spec
+++ b/SPECS-EXTENDED/liboping/liboping.spec
@@ -2,7 +2,7 @@ Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Name:           liboping
 Version:        1.10.0
-Release:        13%{?dist}
+Release:        14%{?dist}
 Summary:        A C library to generate ICMP echo requests
 
 License:        GPLv2
@@ -10,6 +10,7 @@ URL:            https://noping.cc/
 Source0:        https://noping.cc/files/%{name}-%{version}.tar.bz2
 # Disable -Werror to avoid https://github.com/octo/liboping/issues/38
 Patch0:         liboping-1.10.0-no-werror.patch
+Patch1:         liboping-1.10-fix-format-ncurses63.patch
 
 BuildRequires:  gcc
 BuildRequires:  perl-devel
@@ -85,6 +86,10 @@ LD_LIBRARY_PATH=../../src/.libs make -C bindings/perl test
 %{_mandir}/man3/ping_setopt.3*
 
 %changelog
+* Thu Jun 23 2022 Riken Maharjan <pawelwi@microsoft.com> - 1.10.0-14
+- Patch for ncurses6.3 format issue.
+- License verified
+
 * Fri Oct 15 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.10.0-13
 - Initial CBL-Mariner import from Fedora 32 (license: MIT).
 

--- a/SPECS-EXTENDED/liboping/liboping.spec
+++ b/SPECS-EXTENDED/liboping/liboping.spec
@@ -86,7 +86,7 @@ LD_LIBRARY_PATH=../../src/.libs make -C bindings/perl test
 %{_mandir}/man3/ping_setopt.3*
 
 %changelog
-* Thu Jun 23 2022 Riken Maharjan <pawelwi@microsoft.com> - 1.10.0-14
+* Thu Jun 23 2022 Riken Maharjan <rmaharjan@microsoft.com> - 1.10.0-14
 - Patch for ncurses6.3 format issue.
 - License verified
 

--- a/SPECS-EXTENDED/liboping/liboping.spec
+++ b/SPECS-EXTENDED/liboping/liboping.spec
@@ -5,7 +5,7 @@ Version:        1.10.0
 Release:        14%{?dist}
 Summary:        A C library to generate ICMP echo requests
 
-License:        GPLv2
+License:        GPLv2+
 URL:            https://noping.cc/
 Source0:        https://noping.cc/files/%{name}-%{version}.tar.bz2
 # Disable -Werror to avoid https://github.com/octo/liboping/issues/38

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -4621,7 +4621,7 @@
         "other": {
           "name": "hunspell",
           "version": "1.7.0",
-          "downloadUrl": "https://github.com/hunspell/hunspell/archive/refs/tags/hunspell-1.7.0.tar.gz"
+          "downloadUrl": "https://github.com/hunspell/hunspell/archive/refs/tags/v1.7.0.tar.gz"
         }
       }
     },


### PR DESCRIPTION


<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Added patch to fix compliation with ncurses 6.3.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change: ncurses [6.3__2.13-3](https://github.com/microsoft/CBL-Mariner/commit/f73c0ea84b87cd3f0352822878941d01d21c2522) patch files for hunspell and liboping




###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
local build
