### PR TITLE
Add retry logic in runliveinstaller to ensure network access during pxe boot

### DIFF
--- a/toolkit/resources/imageconfigs/additionalfiles/iso_initrd/root/runliveinstaller
+++ b/toolkit/resources/imageconfigs/additionalfiles/iso_initrd/root/runliveinstaller
@@ -38,15 +38,15 @@ mkdir -p $ISO_ROOT
 LABEL=CDROM
 
 function retry {
-    local RETRY=0
-    local LIMIT=10
-    local SLEEPSECONDS=15
-    while [ $RETRY -lt $LIMIT ]
+    local retry=0
+    local limit=10
+    local sleep_seconds=15
+    while [ $retry -lt $limit ]
     do
         "$@" && break
         echo "$@" failed. Retrying... 
-        ((RETRY++))
-        sleep $SLEEPSECONDS
+        ((retry++))
+        sleep $sleep_seconds
     done
 }
 

--- a/toolkit/resources/imageconfigs/additionalfiles/iso_initrd/root/runliveinstaller
+++ b/toolkit/resources/imageconfigs/additionalfiles/iso_initrd/root/runliveinstaller
@@ -62,7 +62,7 @@ elif grep -q "image-config" $CMDLINE; then
     # It is possible that the installation environment does not have network access yet when
     # this script is first run. So use a retry loop 
     PXE_SERVER_IP=$(echo "$IMAGE_CONFIG_VALUE" | sed -e 's|^[^/]*//||' -e 's|/.*$||')
-    Retry ping -c 1 $PXE_SERVER_IP
+    retry ping -c 1 $PXE_SERVER_IP
 
     # To disable generation of any extra directories and just download the contents within the directory, 
     # use -nH to disable genration of host-prefix, "PXE_SERVER_IP". 
@@ -76,7 +76,7 @@ else
     echo Attempt to mount the ISO root
     # It is possible that the partition isn't ready to be mounted when this script
     # is first run. So use a retry loop.
-    Retry mount -L $LABEL -o ro $ISO_ROOT
+    retry mount -L $LABEL -o ro $ISO_ROOT
 fi
 
 if [[ ! -f "$UNATTENDED_CONFIG_FILE" ]]; then

--- a/toolkit/resources/imageconfigs/additionalfiles/iso_initrd/root/runliveinstaller
+++ b/toolkit/resources/imageconfigs/additionalfiles/iso_initrd/root/runliveinstaller
@@ -10,7 +10,6 @@ CONFIG_ROOT=$ISO_ROOT/config
 UNATTENDED_CONFIG_FILE=$CONFIG_ROOT/unattended_config.json
 
 # PXE boot setup
-SERVER_CONFIG_PATH=""
 CMDLINE=/proc/cmdline
 
 # parse script parameters:
@@ -38,6 +37,19 @@ done
 mkdir -p $ISO_ROOT
 LABEL=CDROM
 
+function Retry {
+    local RETRY=0
+    local LIMIT=10
+    SLEEPSECONDS=15
+    while [ $RETRY -lt $LIMIT ]
+    do
+        "$@" && break
+        echo "$@" failed. Retrying... 
+        ((RETRY++))
+        sleep $SLEEPSECONDS
+    done
+}
+
 if grep -qs $ISO_ROOT /proc/mounts; then
     echo ISO root already mounted
 # Read from /proc/cmdline to get image configs from PXE server
@@ -46,6 +58,12 @@ elif grep -q "image-config" $CMDLINE; then
     # $IMAGE_CONFIG_VALUE will be in this fixed format: http://PXE_SERVER_IP/RANDOM_PATH
     # CUT_DIRS will be an array of strings separated by '/'
     IFS='/' read -ra CUT_DIRS <<< $IMAGE_CONFIG_VALUE
+    
+    # It is possible that the installation environment does not have network access yet when
+    # this script is first run. So use a retry loop 
+    PXE_SERVER_IP=$(echo "$IMAGE_CONFIG_VALUE" | sed -e 's|^[^/]*//||' -e 's|/.*$||')
+    Retry ping -c 1 $PXE_SERVER_IP
+
     # To disable generation of any extra directories and just download the contents within the directory, 
     # use -nH to disable genration of host-prefix, "PXE_SERVER_IP". 
     # To disable generation of "RANDOM_PATH", set --cut-dirs to the number of strings separated by '/'. 
@@ -58,16 +76,7 @@ else
     echo Attempt to mount the ISO root
     # It is possible that the partition isn't ready to be mounted when this script
     # is first run. So use a retry loop.
-    RETRY=0
-    LIMIT=5
-    SLEEPSECONDS=2
-    while [ $RETRY -lt $LIMIT ]
-    do
-        mount -L $LABEL -o ro $ISO_ROOT && break
-        echo Mount failed. Retrying...
-        ((RETRY++))
-        sleep $SLEEPSECONDS
-    done
+    Retry mount -L $LABEL -o ro $ISO_ROOT
 fi
 
 if [[ ! -f "$UNATTENDED_CONFIG_FILE" ]]; then

--- a/toolkit/resources/imageconfigs/additionalfiles/iso_initrd/root/runliveinstaller
+++ b/toolkit/resources/imageconfigs/additionalfiles/iso_initrd/root/runliveinstaller
@@ -37,7 +37,7 @@ done
 mkdir -p $ISO_ROOT
 LABEL=CDROM
 
-function Retry {
+function retry {
     local RETRY=0
     local LIMIT=10
     SLEEPSECONDS=15

--- a/toolkit/resources/imageconfigs/additionalfiles/iso_initrd/root/runliveinstaller
+++ b/toolkit/resources/imageconfigs/additionalfiles/iso_initrd/root/runliveinstaller
@@ -40,7 +40,7 @@ LABEL=CDROM
 function retry {
     local RETRY=0
     local LIMIT=10
-    SLEEPSECONDS=15
+    local SLEEPSECONDS=15
     while [ $RETRY -lt $LIMIT ]
     do
         "$@" && break


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?

For PXE boot scenario, the liveinstaller needs to download the image config file from the pxe server thru network and it is possible that the installation may not have network access yet when the script is run, especially on the first boot. Thus, add retry logic to ping the pxe server ip address to guard against the network timing condition to make sure that the pxe client is able to communicate with the pxe server.


###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
NO


###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local Image Build
