### PR TITLE
Introducing `mariner_rpmspec` function.

### DIFF
--- a/.github/workflows/validate-cg-manifest.sh
+++ b/.github/workflows/validate-cg-manifest.sh
@@ -117,7 +117,7 @@ do
     continue
   fi
 
-  parsed_spec="$(mariner_rpmspec --parse "$spec")"
+  parsed_spec="$(mariner_rpmspec --parse "$spec" 2>/dev/null)"
 
   # Reading the source0 file/URL.
   source0=$(echo "$parsed_spec" | grep -P "^\s*Source0?:" | cut -d: -f2- | xargs)

--- a/toolkit/scripts/rpmops.sh
+++ b/toolkit/scripts/rpmops.sh
@@ -24,6 +24,7 @@ function mariner_rpmspec {
         if [[ "$arg" == *.spec && -f "$arg" ]]
         then
             sourcedir="$(dirname "$arg")"
+            break
         fi
     done
 

--- a/toolkit/scripts/rpmops.sh
+++ b/toolkit/scripts/rpmops.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# Helper functions for working with RPM tools in Mariner's context.
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+# Additional macros required to parse spec files.
+DEFINES=(-D "with_check 1" -D "dist $(grep -P "DIST_TAG" "$REPO_ROOT"/toolkit/Makefile | grep -oP "\.cm\d+")")
+
+# Mariner macro files used during spec parsing.
+MACROS=()
+for macro_file in "$REPO_ROOT"/SPECS/mariner-rpm-macros/macros*
+do
+  MACROS+=("--load=$macro_file")
+done
+
+function mariner_rpmspec {
+    # Looking for spec path in the argument list to extract its directory.
+    local sourcedir
+    for arg in "$@"
+    do
+        if [[ "$arg" == *.spec && -f "$arg" ]]
+        then
+            sourcedir="$(dirname "$arg")"
+        fi
+    done
+
+    if [[ -z $sourcedir ]]
+    then        
+        echo "Must pass valid spec path to 'mariner_rpmspec'!"
+        return 1
+    fi
+
+    rpmspec "${DEFINES[@]}" -D "_sourcedir $sourcedir" "${MACROS[@]}" "$@"
+}

--- a/toolkit/scripts/update_spec.sh
+++ b/toolkit/scripts/update_spec.sh
@@ -8,6 +8,9 @@
 # $1 - Changelog message.
 # ${@:2} - Paths to spec files to update.
 
+# shellcheck source=../../toolkit/scripts/rpmops.sh
+source "$(git rev-parse --show-toplevel)"/toolkit/scripts/rpmops.sh
+
 changelog_message="$1"
 
 if [[ $# -lt 2 ]]
@@ -41,14 +44,11 @@ do
 
     echo "Updating '$spec_path'."
 
-    spec_dir="$(dirname "$spec_path")"
-    defines=(-D "py3_dist X" -D "with_check 1" -D "dist .cm1" -D "__python3 python3" -D "_sourcedir '$spec_dir'")
-
     release=$(grep -oP "^Release:\s*\d+" "$spec_path" | grep -oP "\d+$")
     release=$((release+1))
-    version=$(rpmspec --srpm -q "$spec_path" --qf "%{VERSION}\n" "${defines[@]}" 2>/dev/null)
+    version=$(mariner_rpmspec --srpm -q "$spec_path" --qf "%{VERSION}\n" 2>/dev/null)
 
-    epoch="$(rpmspec --srpm -q "$spec_path" --qf "%{EPOCH}\n" "${defines[@]}" 2>/dev/null):"
+    epoch="$(mariner_rpmspec --srpm -q "$spec_path" --qf "%{EPOCH}\n" 2>/dev/null):"
     if [[ "$epoch" == "(none):" ]]
     then
         epoch=""


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

Another step towards making our tools and GitHub checks more reliable. Up until now, calls to `rpmspec` from our scripts didn't take into account the macros we use during spec parsing for package builds. This sometimes caused parsing issues, because RPM didn't understand some macros.

Example: GitHub checks for multiple Python specs (see: [check](https://github.com/microsoft/CBL-Mariner/runs/7083367370?check_suite_focus=true) for #3251) will fail because `rpmspec` cannot expand `pypi_source` used for the `Source0` tag and thus the check will claim that `%{pypi_source}` doesn't match the entry inside `cgmanifest.json`.

The change introduces a `mariner_rpmspec` wrapper, which passes all Mariner macro files to `rpmspec` as well as sets `with_check`, `dist`, and `_sourcedir`, which need to be passed manually (we don't define them in any macro file).

**NOTE**: there are w few places in toolchain build script still calling the raw `rpmspec`. I am not changing these yet - I want to first test-run the change with scripts that don't influence our pipeline builds.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Added a new `mariner_rpmspec` Bash function.
- Switched `validate-cg-manifest.sh` and `update_spec.sh` to use the new function instead of raw `rpmspec`.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #3251

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local script runs.
