### PR TITLE
Upgrade Vim version to 8.2.5154 to fix CVEs (cherry-pick from 1.0-dev)

### DIFF
--- a/SPECS/vim/vim.signatures.json
+++ b/SPECS/vim/vim.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "vim-8.2.5064.tar.gz": "3e3f9f073ea9470482476db2c0a12a85af0a9e9d34478f3c4f924e33bb267c46"
+  "vim-8.2.5154.tar.gz": "43bc45d305cf93fb4ba8f6619c7ac02209daee1f8f3ae071c2dbd635d9f587e3"
  }
 }

--- a/SPECS/vim/vim.spec
+++ b/SPECS/vim/vim.spec
@@ -1,7 +1,7 @@
 %define debug_package %{nil}
 Summary:        Text editor
 Name:           vim
-Version:        8.2.5064
+Version:        8.2.5154
 Release:        1%{?dist}
 License:        Vim
 Vendor:         Microsoft Corporation
@@ -193,6 +193,9 @@ fi
 %{_bindir}/vimdiff
 
 %changelog
+* Tue Jun 28 2022 Suresh Babu Chalamalasetty <schalam@microsoft.com> - 8.2.5154-1
+- Upgrade to 8.2.5154 to fix CVEs: 2022-2124, 2022-2125, 2022-2126 and 2022-2129
+
 * Mon Jun 06 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 8.2.5064-1
 - Update to version 8.2.5064 to fix CVEs: 2022-1851, 2022-1886, and 2022-1898.
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -26117,8 +26117,8 @@
         "type": "other",
         "other": {
           "name": "vim",
-          "version": "8.2.5064",
-          "downloadUrl": "https://github.com/vim/vim/archive/v8.2.5064.tar.gz"
+          "version": "8.2.5154",
+          "downloadUrl": "https://github.com/vim/vim/archive/v8.2.5154.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Cherrypick the fix from 1.0-dev: Upgrade Vim version to 8.2.5154 to fix CVEs: CVE-2022-2124, CVE-2022-2125, CVE-2022-2126 and CVE-2022-2129

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Upgrade to 8.2.5154 to fix CVEs: 2022-2124, 2022-2125, 2022-2126 and 2022-2129

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2022-2124
- https://nvd.nist.gov/vuln/detail/CVE-2022-2125
- https://nvd.nist.gov/vuln/detail/CVE-2022-2126
- https://nvd.nist.gov/vuln/detail/CVE-2022-2129

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build
