### PR TITLE
coreutils: Build arch binary

### DIFF
--- a/SPECS/coreutils/coreutils.spec
+++ b/SPECS/coreutils/coreutils.spec
@@ -1,7 +1,7 @@
 Summary:        Basic system utilities
 Name:           coreutils
 Version:        8.32
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        GPLv3
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -55,6 +55,7 @@ These are the additional language files of coreutils.
 autoreconf -fi
 export FORCE_UNSAFE_CONFIGURE=1 &&  ./configure \
     --prefix=%{_prefix} \
+    --enable-install-program=arch \
     --enable-no-install-program=kill,uptime \
     --disable-silent-rules
 make %{?_smp_mflags}
@@ -64,7 +65,7 @@ make DESTDIR=%{buildroot} install
 install -vdm 755 %{buildroot}/bin
 install -vdm 755 %{buildroot}%{_sbindir}
 install -vdm 755 %{buildroot}%{_mandir}/man8
-mv -v %{buildroot}%{_bindir}/{cat,chgrp,chmod,chown,cp,date,dd,df,echo} %{buildroot}/bin
+mv -v %{buildroot}%{_bindir}/{arch,cat,chgrp,chmod,chown,cp,date,dd,df,echo} %{buildroot}/bin
 mv -v %{buildroot}%{_bindir}/{false,ln,ls,mkdir,mknod,mv,pwd,rm} %{buildroot}/bin
 mv -v %{buildroot}%{_bindir}/{rmdir,stty,sync,true,uname,test,[} %{buildroot}/bin
 mv -v %{buildroot}%{_bindir}/chroot %{buildroot}%{_sbindir}
@@ -104,6 +105,9 @@ LANGUAGE=en_US.UTF-8 LC_ALL=en_US.UTF-8 make -k check
 %defattr(-,root,root)
 
 %changelog
+* Wed Jun 29 2022 Olivia Crain <oliviacrain@microsoft.com> - 8.32-4
+- Configure build to output `arch` binary (equivalent to `uname -m`)
+
 * Wed Mar 23 2022 Chris PeBenito <chpebeni@microsoft.com> 8.32-3
 - Add missing BuildRequires needed to correctly enable SELinux support.
 

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -40,8 +40,8 @@ ncurses-libs-6.3-1.cm2.aarch64.rpm
 ncurses-term-6.3-1.cm2.aarch64.rpm
 readline-8.1-1.cm2.aarch64.rpm
 readline-devel-8.1-1.cm2.aarch64.rpm
-coreutils-8.32-3.cm2.aarch64.rpm
-coreutils-lang-8.32-3.cm2.aarch64.rpm
+coreutils-8.32-4.cm2.aarch64.rpm
+coreutils-lang-8.32-4.cm2.aarch64.rpm
 bash-5.1.8-1.cm2.aarch64.rpm
 bash-devel-5.1.8-1.cm2.aarch64.rpm
 bash-lang-5.1.8-1.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -40,8 +40,8 @@ ncurses-libs-6.3-1.cm2.x86_64.rpm
 ncurses-term-6.3-1.cm2.x86_64.rpm
 readline-8.1-1.cm2.x86_64.rpm
 readline-devel-8.1-1.cm2.x86_64.rpm
-coreutils-8.32-3.cm2.x86_64.rpm
-coreutils-lang-8.32-3.cm2.x86_64.rpm
+coreutils-8.32-4.cm2.x86_64.rpm
+coreutils-lang-8.32-4.cm2.x86_64.rpm
 bash-5.1.8-1.cm2.x86_64.rpm
 bash-devel-5.1.8-1.cm2.x86_64.rpm
 bash-lang-5.1.8-1.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -30,9 +30,9 @@ chkconfig-debuginfo-1.20-3.cm2.aarch64.rpm
 chkconfig-lang-1.20-3.cm2.aarch64.rpm
 cmake-3.21.4-2.cm2.aarch64.rpm
 cmake-debuginfo-3.21.4-2.cm2.aarch64.rpm
-coreutils-8.32-3.cm2.aarch64.rpm
-coreutils-debuginfo-8.32-3.cm2.aarch64.rpm
-coreutils-lang-8.32-3.cm2.aarch64.rpm
+coreutils-8.32-4.cm2.aarch64.rpm
+coreutils-debuginfo-8.32-4.cm2.aarch64.rpm
+coreutils-lang-8.32-4.cm2.aarch64.rpm
 cpio-2.13-4.cm2.aarch64.rpm
 cpio-debuginfo-2.13-4.cm2.aarch64.rpm
 cpio-lang-2.13-4.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -30,9 +30,9 @@ chkconfig-debuginfo-1.20-3.cm2.x86_64.rpm
 chkconfig-lang-1.20-3.cm2.x86_64.rpm
 cmake-3.21.4-2.cm2.x86_64.rpm
 cmake-debuginfo-3.21.4-2.cm2.x86_64.rpm
-coreutils-8.32-3.cm2.x86_64.rpm
-coreutils-debuginfo-8.32-3.cm2.x86_64.rpm
-coreutils-lang-8.32-3.cm2.x86_64.rpm
+coreutils-8.32-4.cm2.x86_64.rpm
+coreutils-debuginfo-8.32-4.cm2.x86_64.rpm
+coreutils-lang-8.32-4.cm2.x86_64.rpm
 cpio-2.13-4.cm2.x86_64.rpm
 cpio-debuginfo-2.13-4.cm2.x86_64.rpm
 cpio-lang-2.13-4.cm2.x86_64.rpm


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
The `coreutils` package is able to ship an `arch` program, which is equivalent to running `uname -m`. Other distros ship `arch`, but we don't (since building it is off by default). This PR opts-in to building `arch`, to satisfy a customer request and reduce friction for those migrating from other distros.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- `coreutils`: Ship the `arch` binary

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline delta build 207969
- Package install succeeds in container, and `arch` output matches that of `uname -m`