### PR TITLE
Update fish to 3.5.0 to resolve CVE-2022-20001

### DIFF
--- a/SPECS-EXTENDED/python-argcomplete/python-argcomplete.spec
+++ b/SPECS-EXTENDED/python-argcomplete/python-argcomplete.spec
@@ -7,7 +7,7 @@ Distribution:   Mariner
 Name:          python-%{modname}
 Summary:       Bash tab completion for argparse
 Version:       1.10.0
-Release:       5%{?dist}
+Release:       6%{?dist}
 License:       ASL 2.0
 URL:           https://github.com/kislyuk/argcomplete
 Source0:       %pypi_source argcomplete
@@ -84,6 +84,9 @@ install -p -m0644 %{buildroot}%{python3_sitelib}/%{modname}/bash_completion.d/py
 %{_sysconfdir}/bash_completion.d/python-argcomplete.sh
 
 %changelog
+* Mon Jul 05 2022 Daniel McIlvaney <damcilva@microsoft.com> - 1.10.0-6
+- Bump release due to bump in fish to 3.5.0.
+
 * Fri Oct 15 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.10.0-5
 - Initial CBL-Mariner import from Fedora 32 (license: MIT).
 

--- a/SPECS-EXTENDED/python-argcomplete/python-argcomplete.spec
+++ b/SPECS-EXTENDED/python-argcomplete/python-argcomplete.spec
@@ -86,6 +86,7 @@ install -p -m0644 %{buildroot}%{python3_sitelib}/%{modname}/bash_completion.d/py
 %changelog
 * Mon Jul 05 2022 Daniel McIlvaney <damcilva@microsoft.com> - 1.10.0-6
 - Bump release due to bump in fish to 3.5.0.
+- License verified.
 
 * Fri Oct 15 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.10.0-5
 - Initial CBL-Mariner import from Fedora 32 (license: MIT).

--- a/SPECS/fish/fish.signatures.json
+++ b/SPECS/fish/fish.signatures.json
@@ -1,5 +1,5 @@
 {
- "Signatures": {
-  "fish-3.1.2.tar.gz": "d5b927203b5ca95da16f514969e2a91a537b2f75bec9b21a584c4cd1c7aa74ed"
- }
-}
+    "Signatures": {
+     "fish-3.5.0.tar.xz": "291e4ec7c6c3fea54dc1aed057ce3d42b356fa6f70865627b2c7dfcecaefd210"
+    }
+   }

--- a/SPECS/fish/fish.spec
+++ b/SPECS/fish/fish.spec
@@ -2,8 +2,8 @@
 # https://fedoraproject.org/wiki/Changes/No_more_automagic_Python_bytecompilation_phase_2
 %global _python_bytecompile_extra 1
 Name:           fish
-Version:        3.1.2
-Release:        5%{?dist}
+Version:        3.5.0
+Release:        1%{?dist}
 Summary:        Friendly interactive shell
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -28,7 +28,7 @@ Distribution:   Mariner
 #   - user_doc/html/_static/underscore.js
 License:        GPLv2 and BSD and ISC and LGPLv2+ and MIT
 URL:            https://fishshell.com
-Source0:        https://github.com/fish-shell/fish-shell/releases/download/%{version}/%{name}-%{version}.tar.gz
+Source0:        https://github.com/fish-shell/fish-shell/releases/download/%{version}/%{name}-%{version}.tar.xz
 
 BuildRequires:  cmake >= 3.2
 BuildRequires:  ninja-build
@@ -45,6 +45,9 @@ BuildRequires:  python3-devel
 Recommends:     man-db
 Recommends:     man-pages
 Recommends:     groff-base
+
+# Expects the `kill` command to be available
+Requires:       util-linux
 
 Provides:       bundled(js-angular) = 1.0.8
 Provides:       bundled(js-jquery) = 3.3.1
@@ -85,8 +88,8 @@ sed -i 's^/usr/local/^/usr/^g' %{_vpath_builddir}/*.pc
 %ninja_install -C %{_vpath_builddir}
 
 # Install docs from tarball root
-cp -a README.md %{buildroot}%{_pkgdocdir}
-cp -a CONTRIBUTING.md %{buildroot}%{_pkgdocdir}
+cp -a README.rst %{buildroot}%{_pkgdocdir}
+cp -a CONTRIBUTING.rst %{buildroot}%{_pkgdocdir}
 
 %find_lang %{name}
 
@@ -115,11 +118,16 @@ fi
 %{_mandir}/man1/fish*.1*
 %{_bindir}/fish*
 %config(noreplace) %{_sysconfdir}/fish/
+%{_datadir}/applications/fish.desktop
 %{_datadir}/fish/
+%{_datadir}/pixmaps/fish.png
 %{_datadir}/pkgconfig/fish.pc
 %{_pkgdocdir}
 
 %changelog
+* Fri Jul 01 2022 Daniel McIlvaney <damcilva@microsft.com> -  3.5.0-1
+- Update to 3.5.0 to reslove CVE-2022-20001
+
 * Thu Jun 30 2022 Suresh Babu Chalamalasetty <schalam@microsoft.com> - 3.1.2-5
 - Mariner has sha256 check so remove not required gpg and asc files.
 - Align vendor and distribution entries

--- a/SPECS/fish/fish.spec
+++ b/SPECS/fish/fish.spec
@@ -125,7 +125,7 @@ fi
 %{_pkgdocdir}
 
 %changelog
-* Fri Jul 01 2022 Daniel McIlvaney <damcilva@microsft.com> -  3.5.0-1
+* Fri Jul 01 2022 Daniel McIlvaney <damcilva@microsft.com> - 3.5.0-1
 - Update to 3.5.0 to reslove CVE-2022-20001
 
 * Thu Jun 30 2022 Suresh Babu Chalamalasetty <schalam@microsoft.com> - 3.1.2-5

--- a/SPECS/gh/gh.spec
+++ b/SPECS/gh/gh.spec
@@ -1,7 +1,7 @@
 Summary:        GitHub official command line tool
 Name:           gh
 Version:        2.13.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -75,6 +75,9 @@ make test
 %{_datadir}/zsh/site-functions/_gh
 
 %changelog
+* Mon Jul 05 2022 Daniel McIlvaney <damcilva@microsoft.com> - 2.13.0-2
+- Bump release due to bump in fish to 3.5.0.
+
 * Thu Jun 30 2022 Suresh Babu Chalamalasetty <schalam@microsoft.com> - 2.13.0-1
 - Original version for CBL-Mariner.
 - License verified.

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -3188,8 +3188,8 @@
         "type": "other",
         "other": {
           "name": "fish",
-          "version": "3.1.2",
-          "downloadUrl": "https://github.com/fish-shell/fish-shell/releases/download/3.1.2/fish-3.1.2.tar.gz"
+          "version": "3.5.0",
+          "downloadUrl": "https://github.com/fish-shell/fish-shell/releases/download/3.5.0/fish-3.5.0.tar.xz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Fish is a new package, updating to the latest version to resolve a CVE rather than patching since it is so new.

Note: I tried to bump to the latest RHEL spec but it is fairly incompatible with our current environment. Went with piecemeal updates to the spec instead.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Update Fish to 3.5.0 to resolve CVE-2022-20001
- Add a runtime requirement on `util-linux` to fix an error in Fish

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**


###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2022-20001

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build and testing.
- Waiting on check build
