### PR TITLE
backported redis 6.2.7 to 1.0 to fix CVE-2021-24736

### DIFF
--- a/SPECS/redis/disable_active_defrag_big_keys.patch
+++ b/SPECS/redis/disable_active_defrag_big_keys.patch
@@ -10,19 +10,21 @@ Reading through comments on the following, this appears to be a test issue and n
 https://github.com/redis/redis/issues/2126
 
 diff -ruN a/tests/unit/memefficiency.tcl b/tests/unit/memefficiency.tcl
---- a/tests/unit/memefficiency.tcl	2021-03-03 09:39:16.028741917 -0800
-+++ b/tests/unit/memefficiency.tcl	2021-03-03 09:45:37.207401387 -0800
-@@ -87,6 +87,7 @@
-             }
-         } {}
- 
+--- a/tests/unit/memefficiency.tcl	2021-07-21 11:06:49.000000000 -0700
++++ b/tests/unit/memefficiency.tcl	2022-01-19 12:08:18.218560014 -0800
+@@ -158,6 +158,7 @@
+         r config set appendonly no
+         r config set key-load-delay 0
+
 +    if {0} {
          test "Active defrag big keys" {
              r flushdb
              r config resetstat
-@@ -210,4 +211,5 @@
+@@ -286,6 +287,7 @@
+             assert {$digest eq $newdigest}
              r save ;# saving an rdb iterates over all the data / pointers
          } {OK}
-     }
 +    }
- }
+
+         test "Active defrag big list" {
+             r flushdb

--- a/SPECS/redis/redis.signatures.json
+++ b/SPECS/redis/redis.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "redis-5.0.14.tar.gz": "3ea5024766d983249e80d4aa9457c897a9f079957d0fb1f35682df233f997f32"
+  "redis-6.2.7.tar.gz": "b7a79cc3b46d3c6eb52fa37dde34a4a60824079ebdfb3abfbbfa035947c55319"
  }
 }

--- a/SPECS/redis/redis.spec
+++ b/SPECS/redis/redis.spec
@@ -1,24 +1,24 @@
 Summary:        advanced key-value store
 Name:           redis
-Version:        5.0.14
+Version:        6.2.7
 Release:        1%{?dist}
 License:        BSD
-URL:            https://redis.io/
-Group:          Applications/Databases
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
+Group:          Applications/Databases
+URL:            https://redis.io/
 Source0:        https://download.redis.io/releases/%{name}-%{version}.tar.gz
 Patch0:         redis-conf.patch
-Patch2:         disable_active_defrag_big_keys.patch
-
+Patch1:         disable_active_defrag_big_keys.patch
 BuildRequires:  gcc
-BuildRequires:  systemd
 BuildRequires:  make
-BuildRequires:  which
+BuildRequires:  systemd
 BuildRequires:  tcl
 BuildRequires:  tcl-devel
+BuildRequires:  which
 Requires:       systemd
-Requires(pre):  /usr/sbin/useradd /usr/sbin/groupadd
+Requires(pre):  %{_sbindir}/groupadd
+Requires(pre):  %{_sbindir}/useradd
 
 %description
 Redis is an in-memory data structure store, used as database, cache and message broker.
@@ -31,12 +31,12 @@ make %{?_smp_mflags}
 
 %install
 install -vdm 755 %{buildroot}
-make PREFIX=%{buildroot}/usr install
+make PREFIX=%{buildroot}%{_prefix} install
 install -D -m 0640 %{name}.conf %{buildroot}%{_sysconfdir}/%{name}.conf
-mkdir -p %{buildroot}/var/lib/redis
-mkdir -p %{buildroot}/var/log
-mkdir -p %{buildroot}/var/opt/%{name}/log
-ln -sfv /var/opt/%{name}/log %{buildroot}/var/log/%{name}
+mkdir -p %{buildroot}%{_sharedstatedir}/redis
+mkdir -p %{buildroot}%{_var}/log
+mkdir -p %{buildroot}%{_var}/opt/%{name}/log
+ln -sfv %{_var}/opt/%{name}/log %{buildroot}%{_var}/log/%{name}
 mkdir -p %{buildroot}/usr/lib/systemd/system
 cat << EOF >>  %{buildroot}/usr/lib/systemd/system/redis.service
 [Unit]
@@ -44,8 +44,8 @@ Description=Redis in-memory key-value database
 After=network.target
 
 [Service]
-ExecStart=/usr/bin/redis-server /etc/redis.conf --daemonize no
-ExecStop=/usr/bin/redis-cli shutdown
+ExecStart=%{_bindir}/redis-server %{_sysconfdir}/redis.conf --daemonize no
+ExecStop=%{_bindir}/redis-cli shutdown
 User=redis
 Group=redis
 
@@ -75,14 +75,24 @@ exit 0
 %files
 %defattr(-,root,root)
 %license COPYING
-%dir %attr(0750, redis, redis) /var/lib/redis
-%dir %attr(0750, redis, redis) /var/opt/%{name}/log
+%dir %attr(0750, redis, redis) %{_sharedstatedir}/redis
+%dir %attr(0750, redis, redis) %{_var}/opt/%{name}/log
 %attr(0750, redis, redis) %{_var}/log/%{name}
 %{_bindir}/*
 %{_libdir}/systemd/*
 %config(noreplace) %attr(0640, %{name}, %{name}) %{_sysconfdir}/redis.conf
 
 %changelog
+* Wed Jun 15 2022 Muhammad Falak <mwani@microsoft.com> - 6.2.7-1
+- Bump version to 6.2.7 to address CVE-2022-24736
+
+* Mon Feb 07 2022 Muhammad Falak <mwani@microsoft.com> - 6.2.6-1
+- Bump version to 6.2.6 to fix ptest
+
+* Mon Jan 24 2022 Neha Agarwal <nehaagarwal@microsoft.com> - 6.2.5-1
+- Update to version 6.2.5.
+- Modified patch to apply to new version.
+
 * Mon Oct 18 2021 Neha Agarwal <nehaagarwal@microsoft.com> 5.0.14-1
 - Update version for CVE-2021-32626, CVE-2021-32627, CVE-2021-32628, CVE-2021-32675, CVE-2021-32687, CVE-2021-32762, CVE-2021-41099
 

--- a/SPECS/redis/redis.spec
+++ b/SPECS/redis/redis.spec
@@ -83,15 +83,8 @@ exit 0
 %config(noreplace) %attr(0640, %{name}, %{name}) %{_sysconfdir}/redis.conf
 
 %changelog
-* Wed Jun 15 2022 Muhammad Falak <mwani@microsoft.com> - 6.2.7-1
-- Bump version to 6.2.7 to address CVE-2022-24736
-
-* Mon Feb 07 2022 Muhammad Falak <mwani@microsoft.com> - 6.2.6-1
-- Bump version to 6.2.6 to fix ptest
-
-* Mon Jan 24 2022 Neha Agarwal <nehaagarwal@microsoft.com> - 6.2.5-1
-- Update to version 6.2.5.
-- Modified patch to apply to new version.
+* Thu Jul 07 2022 Nick Samson <nisamson@microsoft.com> - 6.2.7-1
+- Backport version 6.2.7 to address CVE-2022-24736
 
 * Mon Oct 18 2021 Neha Agarwal <nehaagarwal@microsoft.com> 5.0.14-1
 - Update version for CVE-2021-32626, CVE-2021-32627, CVE-2021-32628, CVE-2021-32675, CVE-2021-32687, CVE-2021-32762, CVE-2021-41099

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -7025,8 +7025,8 @@
         "type": "other",
         "other": {
           "name": "redis",
-          "version": "5.0.14",
-          "downloadUrl": "http://download.redis.io/releases/redis-5.0.14.tar.gz"
+          "version": "6.2.7",
+          "downloadUrl": "http://download.redis.io/releases/redis-6.2.7.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Backport of redis 6.2.7 fixes from 2.0 to 1.0 to address CVEs.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: local build
