### PR TITLE
python3: Fix bad shabang for easy_install

### DIFF
--- a/SPECS/python3/python3.spec
+++ b/SPECS/python3/python3.spec
@@ -168,10 +168,9 @@ ln -sf libpython3.7m.so %{buildroot}%{_libdir}/libpython3.7.so
 cp -p Tools/scripts/pathfix.py %{buildroot}%{_bindir}/pathfix3.7.py
 ln -s ./pathfix3.7.py %{buildroot}%{_bindir}/pathfix.py
 
-# unversioned python is for python2, so update pip3/pip3.7 with python3.7
+# unversioned python is for python2, so update pip3/pip3.7/easy_install-3.7 with python3.7
 # this patch needs update when python3.7 version bump up
-sed -i 's|#!/usr/bin/python|#!/usr/bin/python3.7|' %{buildroot}%{_bindir}/pip3
-sed -i 's|#!/usr/bin/python|#!/usr/bin/python3.7|' %{buildroot}%{_bindir}/pip3.7
+sed -i 's|#!/usr/bin/python|#!%{_bindir}/python3.7|' %{buildroot}%{_bindir}/{pip3,pip3.7,easy_install-3.7}
 
 # Remove unused stuff
 find %{buildroot}%{_libdir} -name '*.pyc' -delete


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
The bad interpreter fix from #3328 and #3333 is incomplete- it fixes `/usr/bin/pip3` and `/usr/bin/pip3.7`, but not `/usr/bin/easy_install-3.7`. So, let's apply the fix from those PRs to `/usr/bin/easy_install-3.7`.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Apply #3328 interpreter fix to `/usr/bin/easy_install-3.7`
- Not bumping the release number, as this release has not been built yet.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build