### PR TITLE
Updating `pygobject3` to fix ptest.

### DIFF
--- a/SPECS/pygobject3/pygobject3.spec
+++ b/SPECS/pygobject3/pygobject3.spec
@@ -1,46 +1,47 @@
 %{!?python3_sitelib: %define python3_sitelib %(python3 -c "from distutils.sysconfig import get_python_lib;print(get_python_lib())")}
-
+Summary:        Python Bindings for GObject
 Name:           pygobject3
 Version:        3.30.1
-Release:        6%{?dist}
-Summary:        Python Bindings for GObject
-Group:          Development/Languages
+Release:        7%{?dist}
 License:        LGPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
+Group:          Development/Languages
 URL:            https://pypi.org/project/PyGObject
 Source0:        https://files.pythonhosted.org/packages/00/17/198a9d0eb0e89b5c7d2a9b4437eb40d62702ab771030cd79fc7141cb0d30/PyGObject-3.30.1.tar.gz
 Patch0:         pygobject-makecheck-fixes.patch
 Patch1:         build_without_cairo.patch
-Requires:       gobject-introspection
-Requires:       glib
+
 BuildRequires:  glib-devel
 BuildRequires:  gobject-introspection-devel
-BuildRequires:  which
 BuildRequires:  python3
 BuildRequires:  python3-devel
 BuildRequires:  python3-libs
+BuildRequires:  which
 %if %{with_check}
-BuildRequires:  python-setuptools
-BuildRequires:  python3-setuptools
-BuildRequires:  gobject-introspection-python
-BuildRequires:  python3-test
-BuildRequires:  glib-schemas
-BuildRequires:  dbus
 BuildRequires:  curl-devel
+BuildRequires:  dbus
+BuildRequires:  glib-schemas
+BuildRequires:  gobject-introspection-python
 BuildRequires:  openssl-devel
+BuildRequires:  python3-setuptools
+BuildRequires:  python3-test
 BuildRequires:  python3-xml
 %endif
+
+Requires:       glib
+Requires:       gobject-introspection
 
 %description
 Python bindings for GLib and GObject.
 
 %package -n     python3-pygobject
 Summary:        python3-pygobject
+
+Requires:       glib
+Requires:       gobject-introspection
 Requires:       python3
 Requires:       python3-libs
-Requires:       gobject-introspection
-Requires:       glib
 
 %description -n python3-pygobject
 Python 3 version.
@@ -64,7 +65,7 @@ python3 setup.py build
 python3 setup.py install --prefix=%{_prefix} --root=%{buildroot}
 
 %check
-easy_install_3=$(ls /usr/bin |grep easy_install |grep 3)
+easy_install_3=$(ls %{_bindir} |grep easy_install |grep 3)
 $easy_install_3 pytest
 python3 setup.py test
 
@@ -76,34 +77,47 @@ rm -rf %{buildroot}
 %license COPYING
 %{python3_sitelib}/*
 
-%files  devel
+%files devel
 %{_libdir}/pkgconfig/*.pc
 %{_includedir}/*
 
 %changelog
-* Sat May 09 2020 Nick Samson <nisamson@microsoft.com>
+* Fri Jul 08 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 3.30.1-7
+- Removing BR on Python 2 version of "setuptools".
+
+* Sat May 09 2020 Nick Samson <nisamson@microsoft.com> - 3.30.1-6
 - Added %%license line automatically
 
-*   Wed Apr 29 2020 Nicolas Ontiveros <niontive@microsoft.com> 3.30.1-5
--   Rename to pygobject3.
--   Remove python2 build. 
-*   Tue Mar 31 2020 Paul Monson <paulmon@microsoft.com> 3.30.1-4
--   Fix Source0 URL. License verified.
-*   Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 3.30.1-3
--   Initial CBL-Mariner import from Photon (license: Apache2).
-*   Thu Dec 06 2018 Tapas Kundu <tkundu@vmware.com> 3.30.1-2
--   Fix makecheck
-*   Thu Sep 27 2018 Tapas Kundu <tkundu@vmware.com> 3.30.1-1
--   Updated to release 3.30.1
-*   Tue Sep 19 2017 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 3.24.1-3
--   Skip some ui make check paths that failed.
-*   Thu Aug 10 2017 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 3.24.1-2
--   Fix make check
-*   Fri Apr 14 2017 Xiaolin Li <xiaolinl@vmware.com> 3.24.1-1
--   Updated to version 3.24.1 and added python3 package.
-*   Mon Oct 03 2016 ChangLee <changLee@vmware.com> 3.10.2-3
--   Modified %check
-*   Tue May 24 2016 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 3.10.2-2
--   GA - Bump release of all rpms
-*   Sat Jan 24 2015 Touseef Liaqat <tliaqat@vmware.com> 7.19.5.1
--   Initial build.  First version
+* Wed Apr 29 2020 Nicolas Ontiveros <niontive@microsoft.com> - 3.30.1-5
+- Rename to pygobject3.
+- Remove python2 build.
+
+* Tue Mar 31 2020 Paul Monson <paulmon@microsoft.com> - 3.30.1-4
+- Fix Source0 URL. License verified.
+
+* Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> - 3.30.1-3
+- Initial CBL-Mariner import from Photon (license: Apache2).
+
+* Thu Dec 06 2018 Tapas Kundu <tkundu@vmware.com> - 3.30.1-2
+- Fix makecheck
+
+* Thu Sep 27 2018 Tapas Kundu <tkundu@vmware.com> - 3.30.1-1
+- Updated to release 3.30.1
+
+* Tue Sep 19 2017 Priyesh Padmavilasom <ppadmavilasom@vmware.com> - 3.24.1-3
+- Skip some ui make check paths that failed.
+
+* Thu Aug 10 2017 Priyesh Padmavilasom <ppadmavilasom@vmware.com> - 3.24.1-2
+- Fix make check
+
+* Fri Apr 14 2017 Xiaolin Li <xiaolinl@vmware.com> - 3.24.1-1
+- Updated to version 3.24.1 and added python3 package.
+
+* Mon Oct 03 2016 ChangLee <changLee@vmware.com> - 3.10.2-3
+- Modified %check
+
+* Tue May 24 2016 Priyesh Padmavilasom <ppadmavilasom@vmware.com> - 3.10.2-2
+- GA - Bump release of all rpms
+
+* Sat Jan 24 2015 Touseef Liaqat <tliaqat@vmware.com> - 7.19.5.1
+- Initial build.  First version

--- a/SPECS/pygobject3/pygobject3.spec
+++ b/SPECS/pygobject3/pygobject3.spec
@@ -24,6 +24,7 @@ BuildRequires:  dbus
 BuildRequires:  glib-schemas
 BuildRequires:  gobject-introspection-python
 BuildRequires:  openssl-devel
+BuildRequires:  python3-pip
 BuildRequires:  python3-setuptools
 BuildRequires:  python3-test
 BuildRequires:  python3-xml
@@ -65,8 +66,7 @@ python3 setup.py build
 python3 setup.py install --prefix=%{_prefix} --root=%{buildroot}
 
 %check
-easy_install_3=$(ls %{_bindir} |grep easy_install |grep 3)
-$easy_install_3 pytest
+pip3 install pytest
 python3 setup.py test
 
 %clean


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

The package has a BR on both `python-setuptools` and `python3-setuptools`. I believe this is causing issues on the `$easy_install_3 pytest` line where the tool tries to install a Python module written for Python 3 but is using Python 2. Removing the Python 2 package and switching to `pip3` from `easy_install`.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Removed BR on `python-setuptools`.
- Running `pip3 install` instead of `easy_install`.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build: 211188.
