### PR TITLE
Only build crash-gcore-command on x86_64

### DIFF
--- a/SPECS/crash-gcore-command/crash-gcore-command.spec
+++ b/SPECS/crash-gcore-command/crash-gcore-command.spec
@@ -1,6 +1,6 @@
 Name:          crash-gcore-command
 Version:       1.6.1
-Release:       1%{?dist}
+Release:       2%{?dist}
 Summary:       gcore extension module for crash utility
 Group:         Development/Tools
 Vendor:        Microsoft Corporation
@@ -13,6 +13,7 @@ BuildRequires: zlib-devel
 BuildRequires: crash-devel >= 7.2.5
 Requires:      crash >= 7.2.5
 BuildRoot:     %{_tmppath}/%{name}-%{version}-root
+ExclusiveArch: x86_64
 
 %description
 Command for creating a core dump file of a user-space task that was
@@ -41,6 +42,8 @@ install -pm 755 gcore.so %{buildroot}%{_libdir}/crash/extensions/
 %doc COPYING
 
 %changelog
+*   Fri Jul 08 2022 Andrew Phelps <anphel@microsoft.com> 1.6.1-2
+-   Add ExclusiveArch: x86_64
 *   Fri Mar 04 2022 Andrew Phelps <anphel@microsoft.com> 1.6.1-1
 -   Update to version 1.6.1
 *   Thu Dec 16 2021 Pawel Winogrodzki <pawelwi@microsoft.com> 1.5.1-2


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
crash-gcore-command seems to have started failing on aarch64 builds after the "arch" command was added to coreutils in #3270 
```
"./libgcore/gcore_defs.h:596:34: error: 'ELF_NGREG' undeclared here (not in a function); did you mean 'ELF_NOTES'?"
```
Disable for aarch64 to unblock our release builds until this can be further investigated and fixed.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change crash-gcore-command to build only on x86_64

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: 211180
