### PR TITLE
`libftdi`: disabling docs building to stabilize the build.

### DIFF
--- a/SPECS-EXTENDED/libftdi/libftdi.spec
+++ b/SPECS-EXTENDED/libftdi/libftdi.spec
@@ -1,7 +1,7 @@
 Summary:        Library to program and control the FTDI USB controller
 Name:           libftdi
 Version:        1.5
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        BSD and GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -12,7 +12,6 @@ Patch0:         libftdi-1.5-fix_pkgconfig_path.patch
 
 BuildRequires:  boost-devel
 BuildRequires:  cmake
-BuildRequires:  doxygen
 BuildRequires:  gcc
 BuildRequires:  gcc-c++
 BuildRequires:  libconfuse-devel
@@ -73,7 +72,7 @@ sed -i -e 's/GROUP="plugdev"/TAG+="uaccess"/g' packages/99-libftdi.rules
 
 
 %build
-%cmake -DSTATICLIBS=off -DFTDIPP=on -DPYTHON_BINDINGS=on -DDOCUMENTATION=on -DLIB_SUFFIX:STRING="" .
+%cmake -DSTATICLIBS=off -DFTDIPP=on -DPYTHON_BINDINGS=on -DDOCUMENTATION=off -DLIB_SUFFIX:STRING="" .
 %cmake_build
 
 %install
@@ -137,6 +136,9 @@ rm -f %{buildroot}%{_docdir}/libftdipp1/example.conf
 %ldconfig_scriptlets c++
 
 %changelog
+* Fri Jul 08 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.5-2
+- Disabling doc building due to unstable builds.
+
 * Wed May 25 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.5-1
 - Updating to 1.5 using Fedora 36 (license: MIT) for guidance.
 - License verified.


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

Package builds for `libftdi` are flaky and they are breaking every now and then on building their docs. Since the file the build complain about is auto-generated during the build, I am suspecting some incorrect configuration causing a race condition where sometimes the file is parsed before it's flushed to the disk. Since we weren't installing the generated documentation anyway, only building it, I am disabling it completely now to stabilize the build.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Disabled building docs for `libftdi`.
- Removed BR on `doxygen`.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local package build.
