### PR TITLE
[1.0] Add clang-libs subpackage to clang specfile

### DIFF
--- a/SPECS/clang/clang.spec
+++ b/SPECS/clang/clang.spec
@@ -3,24 +3,24 @@ Name:           clang
 Version:        8.0.1
 Release:        5%{?dist}
 License:        NCSA
-URL:            https://clang.llvm.org
-Source0:        https://github.com/llvm/llvm-project/releases/download/llvmorg-%{version}/cfe-%{version}.src.tar.xz
-Group:          Development/Tools
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
+Group:          Development/Tools
+URL:            https://clang.llvm.org
+Source0:        https://github.com/llvm/llvm-project/releases/download/llvmorg-%{version}/cfe-%{version}.src.tar.xz
 BuildRequires:  cmake
+BuildRequires:  libxml2-devel
 BuildRequires:  llvm-devel = %{version}
 BuildRequires:  ncurses-devel
-BuildRequires:  zlib-devel
-BuildRequires:  libxml2-devel
 BuildRequires:  python2-devel
+BuildRequires:  zlib-devel
 Requires:       %{name}-libs = %{version}-%{release}
 Requires:       libstdc++-devel
-Requires:       ncurses
-Requires:       llvm
-Requires:       zlib
 Requires:       libxml2
+Requires:       llvm
+Requires:       ncurses
 Requires:       python2
+Requires:       zlib
 
 %description
 The goal of the Clang project is to create a new C based language front-end: C, C++, Objective C/C++, OpenCL C and others for the LLVM compiler. You can get and build the source today.
@@ -49,7 +49,7 @@ export CXXFLAGS="`echo " %{build_cxxflags} " | sed 's/ -g//'`"
 
 mkdir -p build
 cd build
-cmake -DCMAKE_INSTALL_PREFIX=/usr   \
+cmake -DCMAKE_INSTALL_PREFIX=%{_prefix}   \
       -DCMAKE_BUILD_TYPE=Release    \
       -DLLVM_ENABLE_RTTI=ON         \
       -Wno-dev ..
@@ -68,7 +68,7 @@ make DESTDIR=%{buildroot} install
 cd build
 make clang-check
 
-%clean
+%{clean}
 rm -rf %{buildroot}/*
 
 %files
@@ -91,21 +91,32 @@ rm -rf %{buildroot}/*
 %{_includedir}/*
 
 %changelog
-*   Tue Feb 09 2021 Henry Beberman <henry.beberman@microsoft.com> 8.0.1-4
--   Enable RTTI (runtime type information) so other packages can depend on it.
-*   Fri Jun 12 2020 Henry Beberman <henry.beberman@microsoft.com> 8.0.1-3
--   Temporarily disable generation of debug symbols.
-*   Sat May 09 2020 Nick Samson <nisamson@microsoft.com> - 8.0.1-2
--   Added %%license line automatically
-*   Tue Mar 17 2020 Henry Beberman <henry.beberman@microsoft.com> 8.0.1-1
--   Update to 8.0.1. Fix Source0 URL. License verified.
-*   Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 6.0.1-2
--   Initial CBL-Mariner import from Photon (license: Apache2).
-*   Thu Aug 09 2018 Srivatsa S. Bhat <srivatsa@csail.mit.edu> 6.0.1-1
--   Update to version 6.0.1 to get it to build with gcc 7.3
-*   Wed Jun 28 2017 Chang Lee <changlee@vmware.com> 4.0.0-2
--   Updated %check
-*   Fri Apr 7 2017 Alexey Makhalov <amakhalov@vmware.com> 4.0.0-1
--   Version update
-*   Wed Jan 11 2017 Xiaolin Li <xiaolinl@vmware.com>  3.9.1-1
--   Initial build.
+* Sun Jul 10 2022 onalante-msft <89409054+onalante-msft@users.noreply.github.com> - 8.0.1-5
+- Include runtime libraries in base package.
+
+* Tue Feb 09 2021 Henry Beberman <henry.beberman@microsoft.com> - 8.0.1-4
+- Enable RTTI (runtime type information) so other packages can depend on it.
+
+* Fri Jun 12 2020 Henry Beberman <henry.beberman@microsoft.com> - 8.0.1-3
+- Temporarily disable generation of debug symbols.
+
+* Sat May 09 2020 Nick Samson <nisamson@microsoft.com> - 8.0.1-2
+- Added %%license line automatically
+
+* Tue Mar 17 2020 Henry Beberman <henry.beberman@microsoft.com> - 8.0.1-1
+- Update to 8.0.1. Fix Source0 URL. License verified.
+
+* Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> - 6.0.1-2
+- Initial CBL-Mariner import from Photon (license: Apache2).
+
+* Thu Aug 09 2018 Srivatsa S. Bhat <srivatsa@csail.mit.edu> - 6.0.1-1
+- Update to version 6.0.1 to get it to build with gcc 7.3
+
+* Wed Jun 28 2017 Chang Lee <changlee@vmware.com> - 4.0.0-2
+- Updated %check
+
+* Fri Apr 7 2017 Alexey Makhalov <amakhalov@vmware.com> - 4.0.0-1
+- Version update
+
+* Wed Jan 11 2017 Xiaolin Li <xiaolinl@vmware.com> - 3.9.1-1
+- Initial build.

--- a/SPECS/clang/clang.spec
+++ b/SPECS/clang/clang.spec
@@ -68,18 +68,15 @@ make DESTDIR=%{buildroot} install
 cd build
 make clang-check
 
-%{clean}
-rm -rf %{buildroot}/*
-
 %files
 %defattr(-,root,root)
-%license LICENSE.TXT
 %{_bindir}/*
 %{_libexecdir}/*
 %{_datadir}/*
 
 %files libs
 %defattr(-,root,root)
+%license LICENSE.TXT
 %{_libdir}/clang/*
 %{_libdir}/*.so.*
 

--- a/SPECS/clang/clang.spec
+++ b/SPECS/clang/clang.spec
@@ -14,6 +14,7 @@ BuildRequires:  ncurses-devel
 BuildRequires:  zlib-devel
 BuildRequires:  libxml2-devel
 BuildRequires:  python2-devel
+Requires:       %{name}-libs = %{version}-%{release}
 Requires:       libstdc++-devel
 Requires:       ncurses
 Requires:       llvm
@@ -23,6 +24,12 @@ Requires:       python2
 
 %description
 The goal of the Clang project is to create a new C based language front-end: C, C++, Objective C/C++, OpenCL C and others for the LLVM compiler. You can get and build the source today.
+
+%package libs
+Summary:        Runtime library for clang
+
+%description libs
+Runtime library for clang.
 
 %package devel
 Summary:        Development headers for clang
@@ -69,15 +76,18 @@ rm -rf %{buildroot}/*
 %license LICENSE.TXT
 %{_bindir}/*
 %{_libexecdir}/*
-%{_libdir}/*.so.*
 %{_datadir}/*
+
+%files libs
+%defattr(-,root,root)
+%{_libdir}/clang/*
+%{_libdir}/*.so.*
 
 %files devel
 %defattr(-,root,root)
 %{_libdir}/*.so
 %{_libdir}/*.a
 %{_libdir}/cmake/*
-%{_libdir}/clang/*
 %{_includedir}/*
 
 %changelog

--- a/SPECS/clang/clang.spec
+++ b/SPECS/clang/clang.spec
@@ -1,7 +1,7 @@
 Summary:        C, C++, Objective C and Objective C++ front-end for the LLVM compiler.
 Name:           clang
 Version:        8.0.1
-Release:        4%{?dist}
+Release:        5%{?dist}
 License:        NCSA
 URL:            https://clang.llvm.org
 Source0:        https://github.com/llvm/llvm-project/releases/download/llvmorg-%{version}/cfe-%{version}.src.tar.xz


### PR DESCRIPTION
###### Merge Checklist
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary
`clang` currently fails to compile basic C programs on Mariner 1.0 due to missing runtime headers: the necessary headers are only included in the `clang-devel` package. This PR backports the `clang-libs` subpackage from Mariner 2.0's `clang` specfile that provides the necessary libraries and headers for normal operation of `clang`.

###### Change Log
- `clang`
  - add dependency on `clang-libs`
  - remove "%{_libdir}/*.so.*" from "%files"
- `clang-devel`
  - remove "%{_libdir}/clang/*" from "%files"
- `clang-libs`
  - create package
  - add "%{_libdir}/clang/*" and "%{_libdir}/*.so.*" to "%files"
  

###### Does this affect the toolchain?
**NO**

###### Associated issues
- Fixes #3351

###### Links to CVEs

###### Test Methodology
- Local build: https://github.com/onalante-msft/mariner-clang/tree/clang-spec