### PR TITLE
coreutils: Fix flaky env-signal-handler test

### DIFF
--- a/SPECS/coreutils/CVE-2013-0221.nopatch
+++ b/SPECS/coreutils/CVE-2013-0221.nopatch
@@ -1,0 +1,1 @@
+CVE-2013-0221 is fixed in coreutils-8.32-i18n-1.patch

--- a/SPECS/coreutils/CVE-2013-0222.nopatch
+++ b/SPECS/coreutils/CVE-2013-0222.nopatch
@@ -1,0 +1,1 @@
+CVE-2013-0221 is fixed in coreutils-8.32-i18n-1.patch

--- a/SPECS/coreutils/CVE-2013-0223.nopatch
+++ b/SPECS/coreutils/CVE-2013-0223.nopatch
@@ -1,0 +1,1 @@
+CVE-2013-0221 is fixed in coreutils-8.32-i18n-1.patch

--- a/SPECS/coreutils/CVE-2016-2781.nopatch
+++ b/SPECS/coreutils/CVE-2016-2781.nopatch
@@ -1,0 +1,1 @@
+# Upstream community agreed to not fix this

--- a/SPECS/coreutils/coreutils.spec
+++ b/SPECS/coreutils/coreutils.spec
@@ -1,7 +1,7 @@
 Summary:        Basic system utilities
 Name:           coreutils
 Version:        8.32
-Release:        4%{?dist}
+Release:        5%{?dist}
 License:        GPLv3
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -13,24 +13,15 @@ Source1:        serial-console.sh
 # The following two patches are sourced from RedHat via Photon
 Patch0:         coreutils-8.32-i18n-1.patch
 Patch1:         coreutils-8.10-uname-1.patch
-# Upstream community agreed to not fix this
-Patch2:         CVE-2016-2781.nopatch
-# CVE-2013-0221 is fixed in coreutils-8.32-i18n-1.patch
-Patch3:         CVE-2013-0221.nopatch
-# CVE-2013-0222 is fixed in coreutils-8.32-i18n-1.patch
-Patch4:         CVE-2013-0222.nopatch
-# CVE-2013-0223 is fixed in coreutils-8.32-i18n-1.patch
-Patch5:         CVE-2013-0223.nopatch
-Patch6:         skip_test_if_run_as_root.patch
+Patch2:         skip_test_if_run_as_root.patch
+Patch3:         fix_test_env_signal_handler.patch
+Patch4:         coreutils-fix-get-sys_getdents-aarch64.patch
 BuildRequires:  libselinux-devel
 BuildRequires:  libselinux-utils
 Requires:       gmp
 Requires:       libselinux
 Conflicts:      toybox
 Provides:       sh-utils
-%ifarch aarch64
-Patch7:         coreutils-fix-get-sys_getdents-aarch64.patch
-%endif
 %if %{with_check}
 BuildRequires:  perl
 BuildRequires:  perl(File::Find)
@@ -49,7 +40,14 @@ Requires:       coreutils >= %{version}
 These are the additional language files of coreutils.
 
 %prep
-%autosetup -p1
+%autosetup -N
+%patch0 -p1
+%patch1 -p1
+%patch2 -p1
+%patch3 -p1
+%ifarch aarch64
+%patch4 -p1
+%endif
 
 %build
 autoreconf -fi
@@ -105,6 +103,11 @@ LANGUAGE=en_US.UTF-8 LC_ALL=en_US.UTF-8 make -k check
 %defattr(-,root,root)
 
 %changelog
+* Mon Jul 11 2022 Olivia Crain <oliviacrain@microsoft.com> - 8.32-5
+- Add upstream patch to fix race in env-signal-handler test
+- Ensure SRPMs built on any architecture include all patches
+- Remove nopatch files from spec
+
 * Wed Jun 29 2022 Olivia Crain <oliviacrain@microsoft.com> - 8.32-4
 - Configure build to output `arch` binary (equivalent to `uname -m`)
 

--- a/SPECS/coreutils/fix_test_env_signal_handler.patch
+++ b/SPECS/coreutils/fix_test_env_signal_handler.patch
@@ -1,0 +1,105 @@
+From 2378a531432d21c574830f0e24f7f46fe7daceca Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?P=C3=A1draig=20Brady?= <P@draigBrady.com>
+Date: Sat, 13 Nov 2021 12:15:17 +0000
+Subject: [PATCH] tests: avoid false failure in env-signal-handler.sh
+
+* tests/misc/env-signal-handler.sh: Use retry_delay_ to
+avoid a false failure under load, where env hasn't setup
+the SIGINT handling before timeout(1) sends the SIGINT.
+Fixes https://bugs.gnu.org/51793
+---
+ tests/misc/env-signal-handler.sh | 68 ++++++++++++--------------------
+ 1 file changed, 25 insertions(+), 43 deletions(-)
+
+diff --git a/tests/misc/env-signal-handler.sh b/tests/misc/env-signal-handler.sh
+index aa6ec8dacf..e3d6fe6a12 100755
+--- a/tests/misc/env-signal-handler.sh
++++ b/tests/misc/env-signal-handler.sh
+@@ -82,62 +82,44 @@ compare /dev/null err4 || fail=1
+ # env test - block signal handler
+ env --block-signal true || fail=1
+ 
++env_ignore_delay_()
++{
++  local delay="$1"
++
++  # The first 'env' is just to ensure timeout is not a shell built-in.
++  env timeout --verbose --kill-after=.1 --signal=INT $delay \
++    env $env_opt sleep 10 > /dev/null 2>outt
++  # check only the first two lines from stderr, which are printed by timeout.
++  # (operating systems might add more messages, like "killed").
++  sed -n '1,2p' outt > out || framework_failure_
++  compare exp out
++}
++
+ # Baseline test - ignore signal handler
+ # -------------------------------------
+-# Kill 'sleep' after 1 second with SIGINT - it should terminate (as SIGINT's
+-# default action is to terminate a program).
+-# (The first 'env' is just to ensure timeout is not the shell's built-in.)
+-env timeout --verbose --kill-after=.1 --signal=INT .1 \
+-    sleep 10 > /dev/null 2>err5
+-
+-printf "timeout: sending signal INT to command 'sleep'\n" > exp-err5 \
+-    || framework_failure_
+-
+-compare exp-err5 err5 || fail=1
+-
++# Terminate 'sleep' with SIGINT
++# (SIGINT's default action is to terminate a program).
++cat <<\EOF >exp || framework_failure_
++timeout: sending signal INT to command 'env'
++EOF
++env_opt='' retry_delay_ env_ignore_delay_ .1 6 || fail=1
+ 
+ # env test - ignore signal handler
+ # --------------------------------
+-# Use env to silence (ignore) SIGINT - "seq" should continue running
+-# after timeout sends SIGINT, and be killed after 1 second using SIGKILL.
+-
+-cat>exp-err6 <<EOF
++# Use env to ignore SIGINT - "sleep" should continue running
++# after timeout sends SIGINT, and be killed using SIGKILL.
++cat <<\EOF >exp || framework_failure_
+ timeout: sending signal INT to command 'env'
+ timeout: sending signal KILL to command 'env'
+ EOF
+-
+-env timeout --verbose --kill-after=.1 --signal=INT .1 \
+-    env --ignore-signal=INT \
+-    sleep 10 > /dev/null 2>err6t
+-
+-# check only the first two lines from stderr, which are printed by timeout.
+-# (operating systems might add more messages, like "killed").
+-sed -n '1,2p' err6t > err6 || framework_failure_
+-
+-compare exp-err6 err6 || fail=1
+-
+-
+-# env test - ignore signal handler (2)
+-# ------------------------------------
+-# Repeat the previous test with "--ignore-signals" and no signal names,
+-# i.e., all signals.
+-
+-env timeout --verbose --kill-after=.1 --signal=INT .1 \
+-    env --ignore-signal \
+-    sleep 10 > /dev/null 2>err7t
+-
+-# check only the first two lines from stderr, which are printed by timeout.
+-# (operating systems might add more messages, like "killed").
+-sed -n '1,2p' err7t > err7 || framework_failure_
+-
+-compare exp-err6 err7 || fail=1
+-
++env_opt='--ignore-signal=INT' retry_delay_ env_ignore_delay_ .1 6 || fail=1
++env_opt='--ignore-signal' retry_delay_ env_ignore_delay_ .1 6 || fail=1
+ 
+ # env test --list-signal-handling
+ env --default-signal --ignore-signal=INT --list-signal-handling true \
+   2> err8t || fail=1
+ sed 's/(.*)/()/' err8t > err8 || framework_failure_
+-env printf 'INT        (): IGNORE\n' > exp-err8
++env printf 'INT        (): IGNORE\n' > exp-err8 || framework_failure_
+ compare exp-err8 err8 || fail=1
+ 
+ 

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -40,8 +40,8 @@ ncurses-libs-6.3-1.cm2.aarch64.rpm
 ncurses-term-6.3-1.cm2.aarch64.rpm
 readline-8.1-1.cm2.aarch64.rpm
 readline-devel-8.1-1.cm2.aarch64.rpm
-coreutils-8.32-4.cm2.aarch64.rpm
-coreutils-lang-8.32-4.cm2.aarch64.rpm
+coreutils-8.32-5.cm2.aarch64.rpm
+coreutils-lang-8.32-5.cm2.aarch64.rpm
 bash-5.1.8-1.cm2.aarch64.rpm
 bash-devel-5.1.8-1.cm2.aarch64.rpm
 bash-lang-5.1.8-1.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -40,8 +40,8 @@ ncurses-libs-6.3-1.cm2.x86_64.rpm
 ncurses-term-6.3-1.cm2.x86_64.rpm
 readline-8.1-1.cm2.x86_64.rpm
 readline-devel-8.1-1.cm2.x86_64.rpm
-coreutils-8.32-4.cm2.x86_64.rpm
-coreutils-lang-8.32-4.cm2.x86_64.rpm
+coreutils-8.32-5.cm2.x86_64.rpm
+coreutils-lang-8.32-5.cm2.x86_64.rpm
 bash-5.1.8-1.cm2.x86_64.rpm
 bash-devel-5.1.8-1.cm2.x86_64.rpm
 bash-lang-5.1.8-1.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -30,9 +30,9 @@ chkconfig-debuginfo-1.20-3.cm2.aarch64.rpm
 chkconfig-lang-1.20-3.cm2.aarch64.rpm
 cmake-3.21.4-2.cm2.aarch64.rpm
 cmake-debuginfo-3.21.4-2.cm2.aarch64.rpm
-coreutils-8.32-4.cm2.aarch64.rpm
-coreutils-debuginfo-8.32-4.cm2.aarch64.rpm
-coreutils-lang-8.32-4.cm2.aarch64.rpm
+coreutils-8.32-5.cm2.aarch64.rpm
+coreutils-debuginfo-8.32-5.cm2.aarch64.rpm
+coreutils-lang-8.32-5.cm2.aarch64.rpm
 cpio-2.13-4.cm2.aarch64.rpm
 cpio-debuginfo-2.13-4.cm2.aarch64.rpm
 cpio-lang-2.13-4.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -30,9 +30,9 @@ chkconfig-debuginfo-1.20-3.cm2.x86_64.rpm
 chkconfig-lang-1.20-3.cm2.x86_64.rpm
 cmake-3.21.4-2.cm2.x86_64.rpm
 cmake-debuginfo-3.21.4-2.cm2.x86_64.rpm
-coreutils-8.32-4.cm2.x86_64.rpm
-coreutils-debuginfo-8.32-4.cm2.x86_64.rpm
-coreutils-lang-8.32-4.cm2.x86_64.rpm
+coreutils-8.32-5.cm2.x86_64.rpm
+coreutils-debuginfo-8.32-5.cm2.x86_64.rpm
+coreutils-lang-8.32-5.cm2.x86_64.rpm
 cpio-2.13-4.cm2.x86_64.rpm
 cpio-debuginfo-2.13-4.cm2.x86_64.rpm
 cpio-lang-2.13-4.cm2.x86_64.rpm


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
`Coreutils` package tests have failed a couple of times in our pipelines due to a [known race condition](https://bugs.gnu.org/51793) in the `env-signal-handler` test. This PR adds the upstream patch fixing this race.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- `coreutils`: Add upstream patch to fix race in env-signal-handler test
- `coreutils`: Ensure SRPMs built on any architecture include all patches
- `coreutils`: Remove nopatch files from spec

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local toolchain build
- Ran 3 check runs with my machine under load and didn't encounter the flaky test issue- here's hoping it's fully fixed!