### PR TITLE
Do not print a warning when config file is explicitly defined as empty

### DIFF
--- a/toolkit/Makefile
+++ b/toolkit/Makefile
@@ -9,10 +9,10 @@
 ######## DEFINITIONS ########
 
 # Build targets
-ifndef CONFIG_FILE
-$(warning CONFIG_FILE is empty, defaulting to toolkit's core-efi.json unless CONFIG_FILE="" was set explicitly.)
+ifeq ($(origin CONFIG_FILE), undefined)
+CONFIG_FILE             = $(toolkit_root)/imageconfigs/core-efi.json
+$(warning CONFIG_FILE is undefined, defaulting to toolkit's core-efi.json.)
 endif
-CONFIG_FILE            ?= $(toolkit_root)/imageconfigs/core-efi.json
 CONFIG_BASE_DIR        ?= $(dir $(CONFIG_FILE))
 PACKAGE_BUILD_LIST     ?=
 PACKAGE_REBUILD_LIST   ?=


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge
---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Currently, our root `Makefile` conditionally prints a warning message telling the user that `CONFIG_FILE` will be set to a default value if not explicitly defined by the user. This is printed even in cases where the user explicitly defines `CONFIG_FILE` as empty, which I find to be quite annoying.

So, this PR replaces the `?=` variable definition syntax with the equivalent evaluation of the origin of the variable, and only prints a warning if `CONFIG_FILE` is actually undefined.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Makefile: only print config file warning when `CONFIG_FILE` is actually undefined

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Manual testing calling targets with `CONFIG_FILE` undefined, defined as a valid config file, and defined as empty.
