### PR TITLE
Update golang versions from 1.17.10 to 1.17.12 and 1.18.3 to 1.18.4

### DIFF
--- a/SPECS/golang/golang-1.17.signatures.json
+++ b/SPECS/golang/golang-1.17.signatures.json
@@ -1,6 +1,6 @@
 {
  "Signatures": {
-  "go1.17.10.src.tar.gz": "299e55af30f15691b015d8dcf8ecae72412412569e5b2ece20361753a456f2f9",
+  "go1.17.12.src.tar.gz": "0d51b5b3f280c0f01f534598c0219db5878f337da6137a9ee698777413607209",
   "go1.4-bootstrap-20171003.tar.gz": "f4ff5b5eb3a3cae1c993723f3eab519c5bae18866b5e5f96fe1102f0cb5c3e52"
  }
 }

--- a/SPECS/golang/golang-1.17.spec
+++ b/SPECS/golang/golang-1.17.spec
@@ -12,7 +12,7 @@
 %define __find_requires %{nil}
 Summary:        Go
 Name:           golang
-Version:        1.17.10
+Version:        1.17.12
 Release:        1%{?dist}
 License:        BSD
 Vendor:         Microsoft Corporation
@@ -116,6 +116,10 @@ fi
 %{_bindir}/*
 
 %changelog
+* Wed Jul 13 2022 Mandeep Plaha <mandeepplaha@microsoft.com> - 1.17.12-1
+- Updated to version 1.17.12 to fix the following CVEs:
+- 2022-1705, 2022-28131, 2022-30630, 2022-30631, 2022-30632, 2022-30633, 2022-30635, 2022-32148
+
 * Tue Apr 12 2022 Muhammad Falak <mwani@microsoft.com> - 1.17.10-1
 - Bump version to 1.17.10 to address CVE-2021-44716
 

--- a/SPECS/golang/golang-1.17.spec
+++ b/SPECS/golang/golang-1.17.spec
@@ -118,7 +118,7 @@ fi
 %changelog
 * Wed Jul 13 2022 Mandeep Plaha <mandeepplaha@microsoft.com> - 1.17.12-1
 - Updated to version 1.17.12 to fix the following CVEs:
-- 2022-1705, 2022-28131, 2022-30630, 2022-30631, 2022-30632, 2022-30633, 2022-30635, 2022-32148
+- 2022-1705, 2022-1962, 2022-28131, 2022-30630, 2022-30631, 2022-30632, 2022-30633, 2022-30635, 2022-32148
 
 * Tue Apr 12 2022 Muhammad Falak <mwani@microsoft.com> - 1.17.10-1
 - Bump version to 1.17.10 to address CVE-2021-44716

--- a/SPECS/golang/golang.signatures.json
+++ b/SPECS/golang/golang.signatures.json
@@ -1,6 +1,6 @@
 {
  "Signatures": {
-  "go1.18.3.src.tar.gz": "0012386ddcbb5f3350e407c679923811dbd283fcdc421724931614a842ecbc2d",
+  "go1.18.4.src.tar.gz": "4525aa6b0e3cecb57845f4060a7075aafc9ab752bb7b6b4cf8a212d43078e1e4",
   "go1.4-bootstrap-20171003.tar.gz": "f4ff5b5eb3a3cae1c993723f3eab519c5bae18866b5e5f96fe1102f0cb5c3e52"
  }
 }

--- a/SPECS/golang/golang.spec
+++ b/SPECS/golang/golang.spec
@@ -12,7 +12,7 @@
 %define __find_requires %{nil}
 Summary:        Go
 Name:           golang
-Version:        1.18.3
+Version:        1.18.4
 Release:        1%{?dist}
 License:        BSD
 Vendor:         Microsoft Corporation
@@ -116,6 +116,10 @@ fi
 %{_bindir}/*
 
 %changelog
+* Wed Jul 13 2022 Mandeep Plaha <mandeepplaha@microsoft.com> - 1.18.4-1
+- Updated to version 1.18.4 to fix the following CVEs:
+- 2022-1705, 2022-28131, 2022-30630, 2022-30631, 2022-30632, 2022-30633, 2022-30635, 2022-32148
+
 * Mon Jun 06 2022 Andrew Phelps <anphel@microsoft.com> - 1.18.3-1
 - Upgrade to version 1.18.3
 

--- a/SPECS/golang/golang.spec
+++ b/SPECS/golang/golang.spec
@@ -118,7 +118,7 @@ fi
 %changelog
 * Wed Jul 13 2022 Mandeep Plaha <mandeepplaha@microsoft.com> - 1.18.4-1
 - Updated to version 1.18.4 to fix the following CVEs:
-- 2022-1705, 2022-28131, 2022-30630, 2022-30631, 2022-30632, 2022-30633, 2022-30635, 2022-32148
+- 2022-1705, 2022-1962, 2022-28131, 2022-30630, 2022-30631, 2022-30632, 2022-30633, 2022-30635, 2022-32148
 
 * Mon Jun 06 2022 Andrew Phelps <anphel@microsoft.com> - 1.18.3-1
 - Upgrade to version 1.18.3

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -1875,8 +1875,8 @@
         "type": "other",
         "other": {
           "name": "golang",
-          "version": "1.17.10",
-          "downloadUrl": "https://golang.org/dl/go1.17.10.src.tar.gz"
+          "version": "1.17.12",
+          "downloadUrl": "https://golang.org/dl/go1.17.12.src.tar.gz"
         }
       }
     },
@@ -1885,8 +1885,8 @@
         "type": "other",
         "other": {
           "name": "golang",
-          "version": "1.18.3",
-          "downloadUrl": "https://golang.org/dl/go1.18.3.src.tar.gz"
+          "version": "1.18.4",
+          "downloadUrl": "https://golang.org/dl/go1.18.4.src.tar.gz"
         }
       }
     },

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -127,7 +127,7 @@ gmp-debuginfo-6.1.2-6.cm1.aarch64.rpm
 gmp-devel-6.1.2-6.cm1.aarch64.rpm
 gnupg2-2.2.20-3.cm1.aarch64.rpm
 gnupg2-debuginfo-2.2.20-3.cm1.aarch64.rpm
-golang-1.18.3-1.cm1.aarch64.rpm
+golang-1.18.4-1.cm1.aarch64.rpm
 gperf-3.1-3.cm1.aarch64.rpm
 gperf-debuginfo-3.1-3.cm1.aarch64.rpm
 gpgme-1.13.1-6.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -127,7 +127,7 @@ gmp-debuginfo-6.1.2-6.cm1.x86_64.rpm
 gmp-devel-6.1.2-6.cm1.x86_64.rpm
 gnupg2-2.2.20-3.cm1.x86_64.rpm
 gnupg2-debuginfo-2.2.20-3.cm1.x86_64.rpm
-golang-1.18.3-1.cm1.x86_64.rpm
+golang-1.18.4-1.cm1.x86_64.rpm
 gperf-3.1-3.cm1.x86_64.rpm
 gperf-debuginfo-3.1-3.cm1.x86_64.rpm
 gpgme-1.13.1-6.cm1.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Fixes the following CVEs in the golang packages:
2022-1705, 2022-1962, 2022-28131, 2022-30630, 2022-30631, 2022-30632, 2022-30633, 2022-30635, 2022-32148

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
From the security announcement: https://groups.google.com/g/golang-announce/c/nqrv9fbR0zE

CVE-2022-1705
CVE-2022-1962
CVE-2022-28131
CVE-2022-30630
CVE-2022-30631
CVE-2022-30632
CVE-2022-30633
CVE-2022-30635
CVE-2022-32148

###### Packages uploaded to blob storage  <!-- optional -->
[core/go1.17.12.src.tar.gz](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=212896&view=logs&j=67da4c17-a18b-5c48-5cd0-dce235a264ea&t=aed30cd1-418f-54ed-5ec6-2a5143ce4f18&l=78)
[core/go1.18.4.src.tar.gz](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=212895&view=logs&j=67da4c17-a18b-5c48-5cd0-dce235a264ea&t=aed30cd1-418f-54ed-5ec6-2a5143ce4f18&l=74)

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Links to CVEs  <!-- optional -->
https://nvd.nist.gov/vuln/detail/CVE-2022-1705
https://nvd.nist.gov/vuln/detail/CVE-2022-1962
https://nvd.nist.gov/vuln/detail/CVE-2022-28131
https://nvd.nist.gov/vuln/detail/CVE-2022-30630
https://nvd.nist.gov/vuln/detail/CVE-2022-30631
https://nvd.nist.gov/vuln/detail/CVE-2022-30632
https://nvd.nist.gov/vuln/detail/CVE-2022-30633
https://nvd.nist.gov/vuln/detail/CVE-2022-30635
https://nvd.nist.gov/vuln/detail/CVE-2022-32148

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Toolchain build: [213065](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=213065&view=results) succeeded
- Buddy build: [212961](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=212961&view=results) succeeded