### PR TITLE
Adding sed as a post install requirement in the vim spec

### DIFF
--- a/SPECS/vim/vim.spec
+++ b/SPECS/vim/vim.spec
@@ -2,7 +2,7 @@
 Summary:        Text editor
 Name:           vim
 Version:        9.0.0050
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        Vim
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -13,6 +13,8 @@ BuildRequires:  ncurses-devel
 BuildRequires:  python3-devel
 Provides:       vi = %{version}-%{release}
 Provides:       %{name}-minimal = %{version}-%{release}
+
+Requires:       sed
 
 %description
 The Vim package contains a powerful text editor.
@@ -195,6 +197,9 @@ fi
 %{_bindir}/vimdiff
 
 %changelog
+* Mon Jul 18 2022 Aadhar Agarwal <aadagarwal@microsoft.com> - 9.0.0050-2
+- Add sed requires as vim has an implicit dependency on sed in the post-install script.
+
 * Tue Jul 12 2022 Mandeep Plaha <mandeepplaha@microsoft.com> - 9.0.0050-1
 - Upgrade to 9.0.0050 to fix CVEs: 2022-2257, 2022-2264, 2022-2284, 2022-2285, 2022-2286, 2022-2287
 

--- a/SPECS/vim/vim.spec
+++ b/SPECS/vim/vim.spec
@@ -11,7 +11,7 @@ URL:            https://www.vim.org
 Source0:        https://github.com/%{name}/%{name}/archive/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
 BuildRequires:  ncurses-devel
 BuildRequires:  python3-devel
-Requires:       sed
+Requires(post): sed
 Provides:       vi = %{version}-%{release}
 Provides:       %{name}-minimal = %{version}-%{release}
 

--- a/SPECS/vim/vim.spec
+++ b/SPECS/vim/vim.spec
@@ -11,10 +11,9 @@ URL:            https://www.vim.org
 Source0:        https://github.com/%{name}/%{name}/archive/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
 BuildRequires:  ncurses-devel
 BuildRequires:  python3-devel
+Requires:       sed
 Provides:       vi = %{version}-%{release}
 Provides:       %{name}-minimal = %{version}-%{release}
-
-Requires:       sed
 
 %description
 The Vim package contains a powerful text editor.


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
- [Bug 40363041](https://microsoft.visualstudio.com/OS/_workitems/edit/40363041?src=WorkItemMention&src-action=artifact_link) indicates that when installing vim into a Mariner 2.0 container, the post-install script fails because the sed tool is not there by default.
- While working on this issue, I noticed that the sed package exists in the Mariner 2.0 container, but I have added `Requires(post): sed` in `SPECS/vim/vim.spec` file to ensure that the sed tool is present when the post-install script runs.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Added a `Requires(post): sed` in the `SPECS/vim/vim.spec` file

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build

- Using rpm to manually install the updated vim package (fails gracefully indicating that sed is required)
- Using tdnf to install vim successfully
<img width="1424" alt="vim_testing" src="https://user-images.githubusercontent.com/108542189/179863942-3c3128a5-d89d-4e3c-86f3-be85e07738bd.PNG">

