### PR TITLE
Update `e2fsprogs`: running tests in a single thread to make them more consistent.

### DIFF
--- a/SPECS/e2fsprogs/e2fsprogs.spec
+++ b/SPECS/e2fsprogs/e2fsprogs.spec
@@ -1,7 +1,7 @@
 Summary:        Contains the utilities for the ext2 file system
 Name:           e2fsprogs
 Version:        1.46.5
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2 AND LGPLv2 AND BSD AND MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -62,7 +62,8 @@ rm -rf %{buildroot}%{_infodir}
 %find_lang %{name}
 
 %check
-make %{?_smp_mflags} check
+# Mult-threaded runs are flaky.
+make -j1 check
 
 %post -p /sbin/ldconfig
 %postun -p /sbin/ldconfig
@@ -128,6 +129,9 @@ make %{?_smp_mflags} check
 %defattr(-,root,root)
 
 %changelog
+* Mon Jul 18 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.46.5-2
+- Running package tests in a single thread.
+
 * Mon Feb 14 2022 Muhammad Falak <mwani@microsoft.com> - 1.46.5-1
 - Bump version to 1.46.5 to enable ptest
 

--- a/SPECS/e2fsprogs/e2fsprogs.spec
+++ b/SPECS/e2fsprogs/e2fsprogs.spec
@@ -66,9 +66,11 @@ rm -rf %{buildroot}%{_infodir}
 make -j1 check
 for failed_test in $(find tests -name "*.failed")
 do
-    echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
-    echo "Log '$failed_test':"
-    echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+    cat << EOF
+"!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+"Log '$failed_test':"
+"!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+EOF
     cat $file_test
 done
 
@@ -137,7 +139,7 @@ done
 
 %changelog
 * Mon Jul 18 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.46.5-2
-- Running package tests in a single thread.
+- Running package tests in a single thread and printing logs for failures.
 
 * Mon Feb 14 2022 Muhammad Falak <mwani@microsoft.com> - 1.46.5-1
 - Bump version to 1.46.5 to enable ptest

--- a/SPECS/e2fsprogs/e2fsprogs.spec
+++ b/SPECS/e2fsprogs/e2fsprogs.spec
@@ -73,7 +73,7 @@ do
 "Log '$failed_test':"
 "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
 EOF
-    cat $file_test
+    cat $failed_test
 done
 
 # Last command's status is how we determine if the tests failed or not.

--- a/SPECS/e2fsprogs/e2fsprogs.spec
+++ b/SPECS/e2fsprogs/e2fsprogs.spec
@@ -64,6 +64,13 @@ rm -rf %{buildroot}%{_infodir}
 %check
 # Mult-threaded runs are flaky.
 make -j1 check
+for failed_test in $(find tests -name "*.failed")
+do
+    echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+    echo "Log '$failed_test':"
+    echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+    cat $file_test
+done
 
 %post -p /sbin/ldconfig
 %postun -p /sbin/ldconfig

--- a/SPECS/e2fsprogs/e2fsprogs.spec
+++ b/SPECS/e2fsprogs/e2fsprogs.spec
@@ -62,8 +62,10 @@ rm -rf %{buildroot}%{_infodir}
 %find_lang %{name}
 
 %check
-# Mult-threaded runs are flaky.
+# Multi-threaded runs are flaky.
 make -j1 check
+test_status=$?
+
 for failed_test in $(find tests -name "*.failed")
 do
     cat << EOF
@@ -73,6 +75,9 @@ do
 EOF
     cat $file_test
 done
+
+# Last command's status is how we determine if the tests failed or not.
+[[ $test_status -eq 0 ]]
 
 %post -p /sbin/ldconfig
 %postun -p /sbin/ldconfig

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -183,7 +183,7 @@ rpm-lang-4.17.0-8.cm2.aarch64.rpm
 rpm-libs-4.17.0-8.cm2.aarch64.rpm
 cpio-2.13-4.cm2.aarch64.rpm
 cpio-lang-2.13-4.cm2.aarch64.rpm
-e2fsprogs-libs-1.46.5-1.cm2.aarch64.rpm
+e2fsprogs-libs-1.46.5-2.cm2.aarch64.rpm
 libsolv-0.7.20-1.cm2.aarch64.rpm
 libsolv-devel-0.7.20-1.cm2.aarch64.rpm
 libssh2-1.9.0-2.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -183,7 +183,7 @@ rpm-lang-4.17.0-8.cm2.x86_64.rpm
 rpm-libs-4.17.0-8.cm2.x86_64.rpm
 cpio-2.13-4.cm2.x86_64.rpm
 cpio-lang-2.13-4.cm2.x86_64.rpm
-e2fsprogs-libs-1.46.5-1.cm2.x86_64.rpm
+e2fsprogs-libs-1.46.5-2.cm2.x86_64.rpm
 libsolv-0.7.20-1.cm2.x86_64.rpm
 libsolv-devel-0.7.20-1.cm2.x86_64.rpm
 libssh2-1.9.0-2.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -57,11 +57,11 @@ docbook-dtd-xml-4.5-11.cm2.noarch.rpm
 docbook-style-xsl-1.79.1-13.cm2.noarch.rpm
 dwz-0.14-1.cm2.aarch64.rpm
 dwz-debuginfo-0.14-1.cm2.aarch64.rpm
-e2fsprogs-1.46.5-1.cm2.aarch64.rpm
-e2fsprogs-debuginfo-1.46.5-1.cm2.aarch64.rpm
-e2fsprogs-devel-1.46.5-1.cm2.aarch64.rpm
-e2fsprogs-lang-1.46.5-1.cm2.aarch64.rpm
-e2fsprogs-libs-1.46.5-1.cm2.aarch64.rpm
+e2fsprogs-1.46.5-2.cm2.aarch64.rpm
+e2fsprogs-debuginfo-1.46.5-2.cm2.aarch64.rpm
+e2fsprogs-devel-1.46.5-2.cm2.aarch64.rpm
+e2fsprogs-lang-1.46.5-2.cm2.aarch64.rpm
+e2fsprogs-libs-1.46.5-2.cm2.aarch64.rpm
 elfutils-0.186-1.cm2.aarch64.rpm
 elfutils-debuginfo-0.186-1.cm2.aarch64.rpm
 elfutils-default-yama-scope-0.186-1.cm2.noarch.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -57,11 +57,11 @@ docbook-dtd-xml-4.5-11.cm2.noarch.rpm
 docbook-style-xsl-1.79.1-13.cm2.noarch.rpm
 dwz-0.14-1.cm2.x86_64.rpm
 dwz-debuginfo-0.14-1.cm2.x86_64.rpm
-e2fsprogs-1.46.5-1.cm2.x86_64.rpm
-e2fsprogs-debuginfo-1.46.5-1.cm2.x86_64.rpm
-e2fsprogs-devel-1.46.5-1.cm2.x86_64.rpm
-e2fsprogs-lang-1.46.5-1.cm2.x86_64.rpm
-e2fsprogs-libs-1.46.5-1.cm2.x86_64.rpm
+e2fsprogs-1.46.5-2.cm2.x86_64.rpm
+e2fsprogs-debuginfo-1.46.5-2.cm2.x86_64.rpm
+e2fsprogs-devel-1.46.5-2.cm2.x86_64.rpm
+e2fsprogs-lang-1.46.5-2.cm2.x86_64.rpm
+e2fsprogs-libs-1.46.5-2.cm2.x86_64.rpm
 elfutils-0.186-1.cm2.x86_64.rpm
 elfutils-debuginfo-0.186-1.cm2.x86_64.rpm
 elfutils-default-yama-scope-0.186-1.cm2.noarch.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

Some of the `e2fsprogs` ptests are failing inconsistently and running them in a single thread seems to make them more stable. They still fail every now and then, but it doesn't look like a regression. I've added a few lines to print more logs for failing tests to make it easier for us to debug in the future.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Running `e2fsprogs` tests in a single thread.
- Printing logs for failing tests to ease debugging.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
Yes.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build 215120.
