### PR TITLE
kernel: Address cve-2022-34494 and cve-2022-34495

### DIFF
--- a/SPECS/kernel/CVE-2022-34494.nopatch
+++ b/SPECS/kernel/CVE-2022-34494.nopatch
@@ -1,0 +1,3 @@
+CVE-2022-34494 - Introducing commit not in stable tree. No fix necessary at this time.
+Upstream introducing commit: c486682ae1e2b149add22f44cf413b3103e3ef39
+Upstream fix commit: 1680939e9ecf7764fba8689cfb3429c2fe2bb23c

--- a/SPECS/kernel/CVE-2022-34495.nopatch
+++ b/SPECS/kernel/CVE-2022-34495.nopatch
@@ -1,0 +1,3 @@
+CVE-2022-34495 - Introducing commit not in stable tree. No fix necessary at this time.
+Upstream introducing commit: c486682ae1e2b149add22f44cf413b3103e3ef39
+Upstream fix commit: c2eecefec5df1306eafce28ccdf1ca159a552ecc


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Address cve-2022-34494 and cve-2022-34495

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
Address cve-2022-34494 and cve-2022-34495

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2022-34494
- https://nvd.nist.gov/vuln/detail/CVE-2022-34495

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- local build
