### PR TITLE
Maven: For aarch64 builds

### DIFF
--- a/SPECS/maven/maven.signatures.json
+++ b/SPECS/maven/maven.signatures.json
@@ -3,6 +3,7 @@
   "apache-maven-3.8.4-licenses.tar.gz": "6b1f8f24bdf07694a7236929a8b852cdb48b103f9199e8cf81afc1019175fb90",
   "apache-maven-3.8.4-m2.tar.gz": "b0e31a296c59255d58a567f98ccd92bbfc4912acba250547b13f4a0b8eb89978",
   "apache-maven-3.8.4-src.tar.gz": "298bfb6172c134655f4f5608342f9c7bc798918ac165b8ded4af800be184ab9b",
+  "maven-3.5.4-13.cm1.aarch64.rpm": "b0fc1b184300bbb528c5187fd343b98309c75bbe3a602c357873a5f7b022b536",
   "maven-3.5.4-13.cm1.x86_64.rpm": "c445474a0fbce150f38840368c5693e2a24936ecf31837588c5b3addd6aedcc8"
  }
 }


### PR DESCRIPTION
Maven: Fix aarch64 builds by including 1.0 maven aarch64 rpm in sources list.

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Adding dependent maven binary from 1.0 PMC for aarch64 in sources list. This is needed for packages building using maven for aarch64.

###### Change Log  <!-- REQUIRED -->
- Fix aarch64 builds by including 1.0 maven aarch64 rpm also sources in spec file

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-YYYY-XXXX

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build
