### PR TITLE
SELinux backport for (interactive container use, fds manipulation and minor fixes)

### DIFF
--- a/SPECS/selinux-policy/0039-unconfined-Manage-own-fds.patch
+++ b/SPECS/selinux-policy/0039-unconfined-Manage-own-fds.patch
@@ -1,0 +1,29 @@
+From d8884f88c40667c4b1118044b8e47f58bc54b92e Mon Sep 17 00:00:00 2001
+From: Chris PeBenito <Christopher.PeBenito@microsoft.com>
+Date: Wed, 15 Jun 2022 14:43:12 +0000
+Subject: [PATCH 39/39] unconfined: Manage own fds.
+
+Signed-off-by: Chris PeBenito <Christopher.PeBenito@microsoft.com>
+---
+ policy/modules/system/unconfined.if | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/policy/modules/system/unconfined.if b/policy/modules/system/unconfined.if
+index 4393242d5..c4818431c 100644
+--- a/policy/modules/system/unconfined.if
++++ b/policy/modules/system/unconfined.if
+@@ -48,8 +48,9 @@ interface(`unconfined_domain_noaudit',`
+ 	# Transition to myself, to make get_ordered_context_list happy.
+ 	allow $1 self:process transition;
+ 
+-	# Write access is for setting attributes under /proc/self/attr.
+-	allow $1 self:file rw_file_perms;
++	# Write access is for setting attributes under /proc/self/attr
++	# and to manipulate fds.
++	manage_files_pattern($1, self, self)
+ 
+ 	# Userland object managers
+ 	allow $1 self:nscd { getpwd getgrp gethost getstat admin shmempwd shmemgrp shmemhost getserv shmemserv };
+-- 
+2.25.1
+

--- a/SPECS/selinux-policy/0040-usermanage-Add-sysctl-access-for-groupadd-to-get-num.patch
+++ b/SPECS/selinux-policy/0040-usermanage-Add-sysctl-access-for-groupadd-to-get-num.patch
@@ -1,0 +1,29 @@
+From 3a4a1e8f5d5b070f17487439c85cb2f192d66aff Mon Sep 17 00:00:00 2001
+From: Chris PeBenito <Christopher.PeBenito@microsoft.com>
+Date: Thu, 7 Jul 2022 13:43:07 +0000
+Subject: [PATCH 40/42] usermanage: Add sysctl access for groupadd to get
+ number of groups.
+
+Signed-off-by: Chris PeBenito <Christopher.PeBenito@microsoft.com>
+---
+ policy/modules/admin/usermanage.te | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/policy/modules/admin/usermanage.te b/policy/modules/admin/usermanage.te
+index 17c8f080c..0b3013181 100644
+--- a/policy/modules/admin/usermanage.te
++++ b/policy/modules/admin/usermanage.te
+@@ -202,6 +202,10 @@ allow groupadd_t self:unix_stream_socket create_stream_socket_perms;
+ allow groupadd_t self:unix_dgram_socket sendto;
+ allow groupadd_t self:unix_stream_socket connectto;
+ 
++# for getting the number of groups
++kernel_read_kernel_sysctls(groupadd_t)
++kernel_dontaudit_getattr_proc(groupadd_t)
++
+ fs_getattr_xattr_fs(groupadd_t)
+ fs_search_auto_mountpoints(groupadd_t)
+ 
+-- 
+2.25.1
+

--- a/SPECS/selinux-policy/0041-systemd-systemd-cgroups-reads-kernel.cap_last_cap-sy.patch
+++ b/SPECS/selinux-policy/0041-systemd-systemd-cgroups-reads-kernel.cap_last_cap-sy.patch
@@ -1,0 +1,28 @@
+From 626c8371c24a32967208b8cb16cf229bf46645be Mon Sep 17 00:00:00 2001
+From: Chris PeBenito <Christopher.PeBenito@microsoft.com>
+Date: Thu, 7 Jul 2022 13:45:12 +0000
+Subject: [PATCH 41/42] systemd: systemd-cgroups reads kernel.cap_last_cap
+ sysctl.
+
+Signed-off-by: Chris PeBenito <Christopher.PeBenito@microsoft.com>
+---
+ policy/modules/system/systemd.te | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/policy/modules/system/systemd.te b/policy/modules/system/systemd.te
+index 96ffdc19b..019948b54 100644
+--- a/policy/modules/system/systemd.te
++++ b/policy/modules/system/systemd.te
+@@ -384,6 +384,9 @@ fs_register_binary_executable_type(systemd_binfmt_t)
+ allow systemd_cgroups_t self:capability net_admin;
+ 
+ kernel_domtrans_to(systemd_cgroups_t, systemd_cgroups_exec_t)
++# read kernel.cap_last_cap
++kernel_read_kernel_sysctls(systemd_cgroups_t)
++kernel_dontaudit_getattr_proc(systemd_cgroups_t)
+ # for /proc/cmdline
+ kernel_read_system_state(systemd_cgroups_t)
+ 
+-- 
+2.25.1
+

--- a/SPECS/selinux-policy/0042-kernel-hv_utils-shutdown-on-systemd-systems.patch
+++ b/SPECS/selinux-policy/0042-kernel-hv_utils-shutdown-on-systemd-systems.patch
@@ -1,0 +1,29 @@
+From 8ad2e4301730bc7a5a07a7ca101f6e114abc1fe6 Mon Sep 17 00:00:00 2001
+From: Chris PeBenito <Christopher.PeBenito@microsoft.com>
+Date: Thu, 7 Jul 2022 13:58:15 +0000
+Subject: [PATCH 42/42] kernel: hv_utils shutdown on systemd systems.
+
+Signed-off-by: Chris PeBenito <Christopher.PeBenito@microsoft.com>
+---
+ policy/modules/kernel/kernel.te | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/policy/modules/kernel/kernel.te b/policy/modules/kernel/kernel.te
+index 30e34bec5..00d49136c 100644
+--- a/policy/modules/kernel/kernel.te
++++ b/policy/modules/kernel/kernel.te
+@@ -380,6 +380,11 @@ ifdef(`init_systemd',`
+ 		dev_filetrans_input_dev(kernel_t)
+ 	')
+ 
++	optional_policy(`
++		systemd_start_power_units(kernel_t)
++		systemd_status_power_units(kernel_t)
++	')
++
+ 	optional_policy(`
+ 		selinux_compute_create_context(kernel_t)
+ 	')
+-- 
+2.25.1
+

--- a/SPECS/selinux-policy/0043-Container-Minor-fixes-from-interactive-container-use.patch
+++ b/SPECS/selinux-policy/0043-Container-Minor-fixes-from-interactive-container-use.patch
@@ -1,0 +1,106 @@
+From 15d7214f7675e96440abb01a2db2ea2df78902b4 Mon Sep 17 00:00:00 2001
+From: Chris PeBenito <Christopher.PeBenito@microsoft.com>
+Date: Tue, 19 Jul 2022 19:29:16 +0000
+Subject: [PATCH 43/43] Container: Minor fixes from interactive container use.
+
+Signed-off-by: Chris PeBenito <Christopher.PeBenito@microsoft.com>
+---
+ policy/modules/kernel/filesystem.if  | 19 +++++++++++++++++++
+ policy/modules/kernel/kernel.te      |  4 ++++
+ policy/modules/services/container.te |  7 ++++++-
+ 3 files changed, 29 insertions(+), 1 deletion(-)
+
+diff --git a/policy/modules/kernel/filesystem.if b/policy/modules/kernel/filesystem.if
+index b3e5817b1..4913e969d 100644
+--- a/policy/modules/kernel/filesystem.if
++++ b/policy/modules/kernel/filesystem.if
+@@ -906,6 +906,25 @@ interface(`fs_watch_cgroup_files',`
+ 	allow $1 cgroup_t:file watch;
+ ')
+ 
++########################################
++## <summary>
++##     Read cgroup symlnks.
++## </summary>
++## <param name="domain">
++##	<summary>
++##	Domain allowed access.
++##	</summary>
++## </param>
++#
++interface(`fs_read_cgroup_symlinks',`
++	gen_require(`
++		type cgroup_t;
++	')
++
++	read_lnk_files_pattern($1, cgroup_t, cgroup_t)
++	dev_search_sysfs($1)
++')
++
+ ########################################
+ ## <summary>
+ ##     Create cgroup lnk_files.
+diff --git a/policy/modules/kernel/kernel.te b/policy/modules/kernel/kernel.te
+index 00d49136c..55abaa062 100644
+--- a/policy/modules/kernel/kernel.te
++++ b/policy/modules/kernel/kernel.te
+@@ -99,6 +99,10 @@ type proc_kcore_t, proc_type;
+ neverallow ~{ can_dump_kernel kern_unconfined } proc_kcore_t:file ~{ getattr mounton };
+ genfscon proc /kcore gen_context(system_u:object_r:proc_kcore_t,mls_systemhigh)
+ 
++optional_policy(`
++	container_mountpoint(proc_kcore_t)
++')
++
+ optional_policy(`
+ 	init_mountpoint(proc_kcore_t)
+ ')
+diff --git a/policy/modules/services/container.te b/policy/modules/services/container.te
+index 709f2e214..0b62f1de8 100644
+--- a/policy/modules/services/container.te
++++ b/policy/modules/services/container.te
+@@ -364,6 +364,9 @@ allow container_engine_domain self:icmp_socket create_socket_perms;
+ allow container_engine_domain self:netlink_route_socket create_netlink_socket_perms;
+ allow container_engine_domain self:packet_socket create_socket_perms;
+ 
++allow container_engine_domain container_devpts_t:chr_file { rw_chr_file_perms setattr };
++term_create_pty(container_engine_domain, container_devpts_t)
++
+ allow container_engine_domain container_port_t:tcp_socket name_bind;
+ 
+ dontaudit container_engine_domain container_domain:process { noatsecure rlimitinh siginh };
+@@ -426,6 +429,7 @@ fs_mount_xattr_fs(container_engine_domain)
+ fs_remount_xattr_fs(container_engine_domain)
+ fs_unmount_xattr_fs(container_engine_domain)
+ fs_relabelfrom_xattr_fs(container_engine_domain)
++fs_get_xattr_fs_quotas(container_engine_domain)
+ 
+ fs_getattr_cgroup(container_engine_domain)
+ fs_manage_cgroup_dirs(container_engine_domain)
+@@ -434,6 +438,7 @@ fs_watch_cgroup_files(container_engine_domain)
+ fs_mount_cgroup(container_engine_domain)
+ fs_remount_cgroup(container_engine_domain)
+ fs_mounton_cgroup(container_engine_domain)
++fs_read_cgroup_symlinks(container_engine_domain)
+ 
+ fs_list_hugetlbfs(container_engine_domain)
+ 
+@@ -445,6 +450,7 @@ kernel_read_network_state(container_engine_domain)
+ kernel_read_system_state(container_engine_domain)
+ kernel_rw_net_sysctls(container_engine_domain)
+ kernel_dontaudit_search_kernel_sysctl(container_engine_domain)
++kernel_getattr_core_if(container_engine_domain)
+ 
+ selinux_get_fs_mount(container_engine_domain)
+ selinux_mount_fs(container_engine_domain)
+@@ -453,7 +459,6 @@ selinux_unmount_fs(container_engine_domain)
+ seutil_read_config(container_engine_domain)
+ seutil_read_default_contexts(container_engine_domain)
+ 
+-term_create_pty(container_engine_domain, container_devpts_t)
+ term_mount_devpts(container_engine_domain)
+ term_relabel_pty_fs(container_engine_domain)
+ 
+-- 
+2.25.1
+

--- a/SPECS/selinux-policy/selinux-policy.spec
+++ b/SPECS/selinux-policy/selinux-policy.spec
@@ -9,7 +9,7 @@
 Summary:        SELinux policy
 Name:           selinux-policy
 Version:        %{refpolicy_major}.%{refpolicy_minor}
-Release:        7%{?dist}
+Release:        8%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -57,6 +57,9 @@ Patch36:        0036-container-Allow-container-engines-to-connect-to-http.patch
 Patch37:        0037-container-Getattr-generic-device-nodes.patch
 Patch38:        0038-application-Allow-apps-to-use-init-fds.patch
 Patch39:        0039-unconfined-Manage-own-fds.patch
+Patch40:        0040-usermanage-Add-sysctl-access-for-groupadd-to-get-num.patch
+Patch41:        0041-systemd-systemd-cgroups-reads-kernel.cap_last_cap-sy.patch
+Patch42:        0042-kernel-hv_utils-shutdown-on-systemd-systems.patch
 BuildRequires:  bzip2
 BuildRequires:  checkpolicy >= %{CHECKPOLICYVER}
 BuildRequires:  m4
@@ -333,6 +336,10 @@ exit 0
 selinuxenabled && semodule -nB
 exit 0
 %changelog
+* Thu Jul 07 2022 Chris PeBenito <chpebeni@microsoft.com> - 2.20220106-9
+- Add sysctl access for groupadd and systemd-cgroups
+- Allow access for hv_utils shutdown sequence access to poweroff.target.
+
 * Wed Jun 15 2022 Chris PeBenito <chpebeni@microsoft.com> - 2.20220106-8
 - Unconfined domains can manipulate thier own fds.
 

--- a/SPECS/selinux-policy/selinux-policy.spec
+++ b/SPECS/selinux-policy/selinux-policy.spec
@@ -56,6 +56,7 @@ Patch35:        0035-systemd-Fixes-for-coredumps-in-containers.patch
 Patch36:        0036-container-Allow-container-engines-to-connect-to-http.patch
 Patch37:        0037-container-Getattr-generic-device-nodes.patch
 Patch38:        0038-application-Allow-apps-to-use-init-fds.patch
+Patch39:        0039-unconfined-Manage-own-fds.patch
 BuildRequires:  bzip2
 BuildRequires:  checkpolicy >= %{CHECKPOLICYVER}
 BuildRequires:  m4
@@ -332,6 +333,9 @@ exit 0
 selinuxenabled && semodule -nB
 exit 0
 %changelog
+* Wed Jun 15 2022 Chris PeBenito <chpebeni@microsoft.com> - 2.20220106-8
+- Unconfined domains can manipulate thier own fds.
+
 * Mon May 23 2022 Chris PeBenito <chpebeni@microsoft.com> - 2.20220106-7
 - Fix previous multipath LVM changes.
 - Add types for devices.

--- a/SPECS/selinux-policy/selinux-policy.spec
+++ b/SPECS/selinux-policy/selinux-policy.spec
@@ -9,7 +9,7 @@
 Summary:        SELinux policy
 Name:           selinux-policy
 Version:        %{refpolicy_major}.%{refpolicy_minor}
-Release:        8%{?dist}
+Release:        10%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -60,6 +60,7 @@ Patch39:        0039-unconfined-Manage-own-fds.patch
 Patch40:        0040-usermanage-Add-sysctl-access-for-groupadd-to-get-num.patch
 Patch41:        0041-systemd-systemd-cgroups-reads-kernel.cap_last_cap-sy.patch
 Patch42:        0042-kernel-hv_utils-shutdown-on-systemd-systems.patch
+Patch43:        0043-Container-Minor-fixes-from-interactive-container-use.patch
 BuildRequires:  bzip2
 BuildRequires:  checkpolicy >= %{CHECKPOLICYVER}
 BuildRequires:  m4
@@ -336,6 +337,9 @@ exit 0
 selinuxenabled && semodule -nB
 exit 0
 %changelog
+* Tue Jul 19 2022 Chris PeBenito <chpebeni@microsoft.com> - 2.20220106-10
+- Fixes for interactive container use.
+
 * Thu Jul 07 2022 Chris PeBenito <chpebeni@microsoft.com> - 2.20220106-9
 - Add sysctl access for groupadd and systemd-cgroups
 - Allow access for hv_utils shutdown sequence access to poweroff.target.


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Backporting 3 SELinux patch PRs to maintain parity between 1.0 and 2.0 SELinux policy. 
https://github.com/microsoft/CBL-Mariner/pull/3176
https://github.com/microsoft/CBL-Mariner/pull/3331
https://github.com/microsoft/CBL-Mariner/pull/3397

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Fixes for interactive container use.
- Add sysctl access for groupadd and systemd-cgroups
- Allow access for hv_utils shutdown sequence access to poweroff.target.
- Unconfined domains can manipulate thier own fds.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build running now
