### PR TITLE
Fixes the k3s install to allow VHDX integration.

### DIFF
--- a/SPECS/k3s/install.patch
+++ b/SPECS/k3s/install.patch
@@ -1,0 +1,47 @@
+diff --git a/package/rpm/install.sh b/package/rpm/install.sh
+old mode 100755
+new mode 100644
+index bd3a459d..73f65c9b
+--- a/package/rpm/install.sh
++++ b/package/rpm/install.sh
+@@ -43,12 +43,8 @@ set -e
+ #     Commit of k3s to download from temporary cloud storage.
+ #     * (for developer & QA use)
+ #
+-#   - INSTALL_K3S_BIN_DIR
+-#     Directory to install k3s binary, links, and uninstall script to, or use
+-#     /usr/local/bin as the default
+-#
+ #   - INSTALL_K3S_BIN_DIR_READ_ONLY
+-#     If set to true will not write files to INSTALL_K3S_BIN_DIR, forces
++#     If set to true will not write files to BIN_DIR, forces
+ #     setting INSTALL_K3S_SKIP_DOWNLOAD=true
+ #
+ #   - INSTALL_K3S_SYSTEMD_DIR
+@@ -114,15 +110,8 @@ fatal()
+
+ # --- fatal if no systemd or openrc ---
+ verify_system() {
+-    if [ -x /sbin/openrc-run ]; then
+-        HAS_OPENRC=true
+-        return
+-    fi
+-    if [ -d /run/systemd ]; then
+-        HAS_SYSTEMD=true
+-        return
+-    fi
+-    fatal 'Can not find systemd or openrc to use as a process supervisor for k3s'
++    HAS_SYSTEMD=true
++    return
+ }
+
+ # --- add quotes to command arguments ---
+@@ -219,7 +208,7 @@ setup_env() {
+     fi
+
+     # --- use binary install directory if defined or create default ---
+-    BIN_DIR=${INSTALL_K3S_BIN_DIR:-/usr/local/bin}
++    BIN_DIR=/usr/local/bin
+     DATA_DIR=/var/lib/rancher/k3s
+
+     # --- set related files from system name ---

--- a/SPECS/k3s/install.patch
+++ b/SPECS/k3s/install.patch
@@ -1,7 +1,14 @@
+From bd240e73ab1f815dcd2aac4b1bcd5d022c581aa9 Mon Sep 17 00:00:00 2001
+From: Lior Lustgarten <lilustg@microsoft.com>
+Date: Fri, 22 Jul 2022 05:39:08 -0700
+Subject: [PATCH] fix for install while building VHDX
+
+---
+ package/rpm/install.sh | 19 ++++---------------
+ 1 file changed, 4 insertions(+), 15 deletions(-)
+
 diff --git a/package/rpm/install.sh b/package/rpm/install.sh
-old mode 100755
-new mode 100644
-index bd3a459d..73f65c9b
+index bd3a459d97..73f65c9b19 100755
 --- a/package/rpm/install.sh
 +++ b/package/rpm/install.sh
 @@ -43,12 +43,8 @@ set -e
@@ -19,7 +26,7 @@ index bd3a459d..73f65c9b
  #
  #   - INSTALL_K3S_SYSTEMD_DIR
 @@ -114,15 +110,8 @@ fatal()
-
+ 
  # --- fatal if no systemd or openrc ---
  verify_system() {
 -    if [ -x /sbin/openrc-run ]; then
@@ -34,14 +41,17 @@ index bd3a459d..73f65c9b
 +    HAS_SYSTEMD=true
 +    return
  }
-
+ 
  # --- add quotes to command arguments ---
 @@ -219,7 +208,7 @@ setup_env() {
      fi
-
+ 
      # --- use binary install directory if defined or create default ---
 -    BIN_DIR=${INSTALL_K3S_BIN_DIR:-/usr/local/bin}
 +    BIN_DIR=/usr/local/bin
      DATA_DIR=/var/lib/rancher/k3s
-
+ 
      # --- set related files from system name ---
+-- 
+2.17.1
+

--- a/SPECS/k3s/k3s.spec
+++ b/SPECS/k3s/k3s.spec
@@ -7,7 +7,7 @@
 
 Name:    k3s
 Version: 1.23.6
-Release: 2%{?dist}
+Release: 3%{?dist}
 Summary: Lightweight Kubernetes
 
 Group:   System Environment/Base
@@ -30,6 +30,7 @@ Source0: https://github.com/k3s-io/%{name}/archive/refs/tags/v%{version}+k3s1.ta
 # 10. tar -cf %%{name}-%%{version}-vendor.tar.gz vendor
 Source1: %{name}-%{version}-vendor.tar.gz
 Patch0:  vendor_build.patch
+Patch1:  install.patch
 
 # K3s on Mariner is supported on x86_64 only:
 ExclusiveArch: x86_64
@@ -82,6 +83,8 @@ exit 0
 %{install_sh}
 
 %changelog
+* Thu Jul 21 2022 Lior Lustgarten <lilustga@microsoft.com> 1.23.6-3
+- Fixes the install section. Allows integration of k3s at runtime in the Mariner build environment.
 * Wed Jun 29 2022 Lior Lustgarten <lilustga@microsoft.com> 1.23.6-2
 - Fixed uninstall path
 - Added exclusivity for x86_64


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
This change patches the rpm install. Without this patch you will not be able to properly integrate k3s at build time. It will work via the package manager on a live system. However, it will fail in the Mariner build environment while building a VHDX when systemd is not up and running in the chroot environment.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
- Fixes the install section. Allows integration of k3s at runtime in the Mariner build environment.
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->



###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES/NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-YYYY-XXXX

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- build locally
