### PR TITLE
Update python-jinja2 to v2.11.3 to fix CVE-2020-28493

### DIFF
--- a/SPECS/python-jinja2/python-jinja2.signatures.json
+++ b/SPECS/python-jinja2/python-jinja2.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "Jinja2-2.10.1.tar.gz": "065c4f02ebe7f7cf559e49ee5a95fb800a9e4528727aec6f24402a5374c65013"
+  "Jinja2-2.11.3.tar.gz": "a6d58433de0ae800347cab1fa3043cebbabe8baa9d29e668f1c768cb87a333c6"
  }
 }

--- a/SPECS/python-jinja2/python-jinja2.spec
+++ b/SPECS/python-jinja2/python-jinja2.spec
@@ -3,7 +3,7 @@
 %{!?python3_version: %define python3_version %(python3 -c "import sys; sys.stdout.write(sys.version[:3])")}
 
 Name:           python-jinja2
-Version:        2.10.1
+Version:        2.11.3
 Release:        1%{?dist}
 Url:            https://jinja.pocoo.org/
 Summary:        A fast and easy to use template engine written in pure Python
@@ -11,7 +11,7 @@ License:        BSD
 Group:          Development/Languages/Python
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
-Source0:        https://files.pythonhosted.org/packages/93/ea/d884a06f8c7f9b7afbc8138b762e80479fb17aedbbe2b06515a12de9378d/Jinja2-%{version}.tar.gz
+Source0:        https://files.pythonhosted.org/packages/4f/e7/65300e6b32e69768ded990494809106f87da1d436418d5f1367ed3966fd7/Jinja2-%{version}.tar.gz
 BuildRequires:  python2
 BuildRequires:  python2-libs
 BuildRequires:  python-setuptools
@@ -48,10 +48,10 @@ cp -a . ../p3dir
 
 %build
 python2 setup.py build
-sed -i 's/\r$//' LICENSE # Fix wrong EOL encoding
+sed -i 's/\r$//' LICENSE.rst # Fix wrong EOL encoding
 pushd ../p3dir
 python3 setup.py install --prefix=%{_prefix} --root=%{buildroot}
-sed -i 's/\r$//' LICENSE # Fix wrong EOL encoding
+sed -i 's/\r$//' LICENSE.rst # Fix wrong EOL encoding
 popd
 
 %install
@@ -65,36 +65,46 @@ make -k check |& tee %{_specdir}/%{name}-check-log || %{nocheck}
 
 %files
 %defattr(-,root,root)
-%doc AUTHORS
-%license LICENSE
+%license LICENSE.rst
 %{python2_sitelib}/jinja2
 %{python2_sitelib}/Jinja2-%{version}-py%{python_version}.egg-info
 
 %files -n python3-jinja2
 %defattr(-,root,root)
-%doc AUTHORS
-%license LICENSE
+%license LICENSE.rst
 %{python3_sitelib}/jinja2
 %{python3_sitelib}/Jinja2-%{version}-py%{python3_version}.egg-info
 
 %changelog
-*   Wed Mar 18 2020 Henry Beberman <henry.beberman@microsoft.com> 2.10.1-1
--   Update to 2.10.1. License verified.
-*   Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 2.10-2
--   Initial CBL-Mariner import from Photon (license: Apache2).
-*   Sun Sep 09 2018 Tapas Kundu <tkundu@vmware.com> 2.10-1
--   Update to version 2.10
-*   Tue Jun 20 2017 Xiaolin Li <xiaolinl@vmware.com> 2.9.5-6
--   Add python3-setuptools and python3-xml to python3 sub package Buildrequires.
-*   Thu Jun 15 2017 Dheeraj Shetty <dheerajs@vmware.com> 2.9.5-5
--   Change python to python2
-*   Mon Jun 12 2017 Kumar Kaushik <kaushikk@vmware.com> 2.9.5-4
--   Fixing import error in python3.
-*   Wed Apr 26 2017 Dheeraj Shetty <dheerajs@vmware.com> 2.9.5-3
--   BuildRequires python-markupsafe , creating subpackage python3-jinja2
-*   Tue Apr 25 2017 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 2.9.5-2
--   Fix arch
-*   Mon Mar 27 2017 Sarah Choi <sarahc@vmware.com> 2.9.5-1
--   Upgrade version to 2.9.5
-*   Tue Dec 13 2016 Dheeraj Shetty <dheerajs@vmware.com> 2.8-1
--   Initial packaging for Photon
+* Tue Jul 26 2022 Neha Agarwal <nehaagarwal@microsoft.com> - 2.11.3-1
+- Update to v2.11.3 resolve CVE-2020-28493.
+
+* Wed Mar 18 2020 Henry Beberman <henry.beberman@microsoft.com> 2.10.1-1
+- Update to 2.10.1. License verified.
+
+* Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 2.10-2
+- Initial CBL-Mariner import from Photon (license: Apache2).
+
+* Sun Sep 09 2018 Tapas Kundu <tkundu@vmware.com> 2.10-1
+- Update to version 2.10
+
+* Tue Jun 20 2017 Xiaolin Li <xiaolinl@vmware.com> 2.9.5-6
+- Add python3-setuptools and python3-xml to python3 sub package Buildrequires.
+
+* Thu Jun 15 2017 Dheeraj Shetty <dheerajs@vmware.com> 2.9.5-5
+- Change python to python2
+
+* Mon Jun 12 2017 Kumar Kaushik <kaushikk@vmware.com> 2.9.5-4
+- Fixing import error in python3.
+
+* Wed Apr 26 2017 Dheeraj Shetty <dheerajs@vmware.com> 2.9.5-3
+- BuildRequires python-markupsafe , creating subpackage python3-jinja2
+
+* Tue Apr 25 2017 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 2.9.5-2
+- Fix arch
+
+* Mon Mar 27 2017 Sarah Choi <sarahc@vmware.com> 2.9.5-1
+- Upgrade version to 2.9.5
+
+* Tue Dec 13 2016 Dheeraj Shetty <dheerajs@vmware.com> 2.8-1
+- Initial packaging for Photon

--- a/SPECS/python-jinja2/python-jinja2.spec
+++ b/SPECS/python-jinja2/python-jinja2.spec
@@ -11,7 +11,7 @@ License:        BSD
 Group:          Development/Languages/Python
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
-Source0:        https://files.pythonhosted.org/packages/4f/e7/65300e6b32e69768ded990494809106f87da1d436418d5f1367ed3966fd7/Jinja2-%{version}.tar.gz
+Source0:        https://files.pythonhosted.org/packages/source/J/Jinja2/Jinja2-%{version}.tar.gz
 BuildRequires:  python2
 BuildRequires:  python2-libs
 BuildRequires:  python-setuptools

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -6206,7 +6206,7 @@
         "other": {
           "name": "python-jinja2",
           "version": "2.11.3",
-          "downloadUrl": "https://files.pythonhosted.org/packages/4f/e7/65300e6b32e69768ded990494809106f87da1d436418d5f1367ed3966fd7/Jinja2-2.11.3.tar.gz"
+          "downloadUrl": "https://files.pythonhosted.org/packages/source/J/Jinja2/Jinja2-2.11.3.tar.gz"
         }
       }
     },

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -6205,8 +6205,8 @@
         "type": "other",
         "other": {
           "name": "python-jinja2",
-          "version": "2.10.1",
-          "downloadUrl": "https://files.pythonhosted.org/packages/93/ea/d884a06f8c7f9b7afbc8138b762e80479fb17aedbbe2b06515a12de9378d/Jinja2-2.10.1.tar.gz"
+          "version": "2.11.3",
+          "downloadUrl": "https://files.pythonhosted.org/packages/4f/e7/65300e6b32e69768ded990494809106f87da1d436418d5f1367ed3966fd7/Jinja2-2.11.3.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Update python-jinja2 to v2.11.3 to fix CVE-2020-28493

###### Change Log  <!-- REQUIRED -->
- Update python-jinja2 to v2.11.3 to fix CVE-2020-28493

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2020-28493

###### Test Methodology
- Local build with RUN_CHECK=y