### PR TITLE
Update nodejs to v14.20.0 to fix CVEs 2022-32213, 2022-32214, 2022-32215

### DIFF
--- a/SPECS/nodejs/nodejs.signatures.json
+++ b/SPECS/nodejs/nodejs.signatures.json
@@ -1,6 +1,6 @@
 {
  "Signatures": {
-  "node-v14.18.3-clean.tar.xz": "51fa0865b597e131219e6a6398961b372d773b72d28e3c75524154bd2792e0bd",
-  "clean-source-tarball.sh": "ab579872ec2f4e85a00fc1651b40a26876012256c722c3701ef3cdcb378c93d5"
+    "node-v14.20.0-clean.tar.xz": "ef614adf3a42e8aedefd374c3cd6f1510c3ee8d5cd3e6ea959763fe64c41adbb",
+    "clean-source-tarball.sh": "ab579872ec2f4e85a00fc1651b40a26876012256c722c3701ef3cdcb378c93d5"
  }
 }

--- a/SPECS/nodejs/nodejs.spec
+++ b/SPECS/nodejs/nodejs.spec
@@ -1,6 +1,6 @@
 Summary:        A JavaScript runtime built on Chrome's V8 JavaScript engine.
 Name:           nodejs
-Version:        14.18.3
+Version:        14.20.0
 Release:        1%{?dist}
 License:        BSD and MIT and Public Domain and naist-2003
 Vendor:         Microsoft Corporation
@@ -80,6 +80,9 @@ make cctest
 %{_datadir}/systemtap/tapset/node.stp
 
 %changelog
+* Wed Jul 27 2022 Neha Agarwal <nehaagarwal@microsoft.com> - 14.20.0-1
+- Update to v14.20.0 to fix CVE-2022-32213, CVE-2022-32214, CVE-2022-32215.
+
 * Wed Mar 09 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 14.18.3-1
 - Update to version 14.18.3 to fix CVE-2021-44531.
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -4585,8 +4585,8 @@
         "type": "other",
         "other": {
           "name": "nodejs",
-          "version": "14.18.3",
-          "downloadUrl": "https://nodejs.org/download/release/v14.18.3/node-v14.18.3.tar.xz"
+          "version": "14.20.0",
+          "downloadUrl": "https://nodejs.org/download/release/v14.20.0/node-v14.20.0.tar.xz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Update nodejs to v14.20.0 to fix CVEs 2022-32213, 2022-32214, 2022-32215

###### Change Log  <!-- REQUIRED -->
- Update nodejs to v14.20.0 to fix CVEs 2022-32213, 2022-32214, 2022-32215

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2022-32213
- https://nvd.nist.gov/vuln/detail/CVE-2022-32214
- https://nvd.nist.gov/vuln/detail/CVE-2022-32215

###### Test Methodology
- Local build with RUN_CHECK=y