### PR TITLE
update cloud-init service to add sysinit.target dependency

### DIFF
--- a/SPECS/cloud-init/add-mariner-distro-support.patch
+++ b/SPECS/cloud-init/add-mariner-distro-support.patch
@@ -359,10 +359,9 @@ index 6951a0e3..411065f9 100644
     # Other config here will be given to the distro class and/or path classes
     paths:
        cloud_dir: /var/lib/cloud/
-diff --git a/systemd/cloud-init.service.tmpl b/systemd/cloud-init.service.tmpl
-index c170aef7..20ff1daa 100644
---- a/systemd/cloud-init.service.tmpl
-+++ b/systemd/cloud-init.service.tmpl
+diff -ruN a/systemd/cloud-init.service.tmpl b/systemd/cloud-init.service.tmpl
+--- a/systemd/cloud-init.service.tmpl	2022-05-18 08:23:24.000000000 -0700
++++ b/systemd/cloud-init.service.tmpl	2022-08-03 21:51:14.862040213 -0700
 @@ -1,7 +1,7 @@
  ## template:jinja
  [Unit]
@@ -372,6 +371,16 @@ index c170aef7..20ff1daa 100644
  DefaultDependencies=no
  {% endif %}
  Wants=cloud-init-local.service
+@@ -26,8 +26,8 @@
+ Before=network-online.target
+ Before=sshd-keygen.service
+ Before=sshd.service
+-{% if variant in ["ubuntu", "unknown", "debian"] %}
+ Before=sysinit.target
++{% if variant in ["ubuntu", "unknown", "debian"] %}
+ Before=shutdown.target
+ Conflicts=shutdown.target
+ {% endif %}
 diff --git a/templates/hosts.mariner.tmpl b/templates/hosts.mariner.tmpl
 new file mode 100644
 index 00000000..2e956382

--- a/SPECS/cloud-init/cloud-init.spec
+++ b/SPECS/cloud-init/cloud-init.spec
@@ -1,7 +1,7 @@
 Summary:        Cloud instance init scripts
 Name:           cloud-init
 Version:        22.2
-Release:        5%{?dist}
+Release:        6%{?dist}
 License:        GPLv3
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -146,6 +146,9 @@ make check %{?_smp_mflags}
 %config(noreplace) %{_sysconfdir}/cloud/cloud.cfg.d/10-azure-kvp.cfg
 
 %changelog
+* Wed Aug 03 2022 Minghe Ren <mingheren@microsoft.com> - 22.2-6
+- Update add-mariner-distro-support patch to add sysinit.target dependency
+
 * Tue Jul 12 2022 Muhammad Falak <mwani@microsoft.com> - 22.2-5
 - Install check requirements from `test-requirements.txt` to enable ptest
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Update cloud-init service to add sysinit.target as one of its dependencies. 

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add sysinit.target as dependency for cloud-init.service on Mariner
- Change is made by modify add-mariner-distro-support patch. After the change, the line "Before=sysinit.target" is in cloud-init.service 


###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
NO

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- [Bug 39862391](https://microsoft.visualstudio.com/OS/_workitems/edit/39862391): [2.0] Update cloud-init systemd units to ensure that sysinit.target means cloud-init.service has finished

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: local package build