### PR TITLE
Remove `TestShouldPassCreatingNetworkFile_Network`

### DIFF
--- a/toolkit/Makefile
+++ b/toolkit/Makefile
@@ -193,7 +193,7 @@ include $(SCRIPTS_DIR)/pkggen.mk
 #   image, iso, clean-imggen
 include $(SCRIPTS_DIR)/imggen.mk
 
-# Create self contained toolkit archive contianing all the required tools with:
+# Create self contained toolkit archive containing all the required tools with:
 #   package-toolkit, clean-package-toolkit
 include $(SCRIPTS_DIR)/toolkit.mk
 

--- a/toolkit/tools/imagegen/configuration/networkconfig_test.go
+++ b/toolkit/tools/imagegen/configuration/networkconfig_test.go
@@ -4,10 +4,8 @@
 package configuration
 
 import (
-	"os"
 	"testing"
 
-	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/file"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -131,20 +129,4 @@ func TestShouldFailParsingInvalidDevice_Network(t *testing.T) {
 	err = remarshalJSON(testNetwork, &checkedNetwork)
 	assert.Error(t, err)
 	assert.Equal(t, "failed to parse [Network]: invalid input for device, device cannot be empty", err.Error())
-}
-
-func TestShouldPassCreatingNetworkFile_Network(t *testing.T) {
-	const networkFile = "/etc/systemd/network/10-static-eth1.network"
-	testNetwork := validNetworks[0]
-
-	err := createNetworkConfigFile(nil, testNetwork, "eth1")
-	assert.NoError(t, err)
-	t.Cleanup(func() {
-		os.Remove(networkFile)
-	})
-
-	// Check whether the contents in the network file is correct
-	testContents, err := file.ReadLines(networkFile)
-	assert.NoError(t, err)
-	assert.Equal(t, testContents, validNetworkFileContent)
 }


### PR DESCRIPTION
###### Merge Checklist
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary
`TestShouldPassCreatingNetworkFile_Network` fails on systems without `systemd-networkd`. This PR removes the failing test until there is a suitable workaround. Some possible workarounds:
- Permanently remove the test
- Conditionally enable the test depending on the presence of
  /etc/systemd/network
- Change createNetworkConfigFile to accept a target directory instead of
  unconditionally using /etc/systemd/network

###### Change Log
- Remove `TestShouldPassCreatingNetworkFile_Network`

###### Does this affect the toolchain?
YES

###### Associated issues
- #3483

###### Links to CVEs

###### Test Methodology

