### PR TITLE
Kernel CVE - nopatch kernel CVES 2022-2380, 2022-33743, 2021-4135, 2022-33744

### DIFF
--- a/SPECS/kernel/CVE-2021-4135.nopatch
+++ b/SPECS/kernel/CVE-2021-4135.nopatch
@@ -1,0 +1,4 @@
+CVE-2021-4135 - Already backported to 5.15.11:
+
+Upstream: 481221775d53d6215a6e5e9ce1cce6d2b4ab9a46
+Stable:  27358aa81a7d60e6bd36f0bb1db65cd084c2cad0

--- a/SPECS/kernel/CVE-2022-2380.nopatch
+++ b/SPECS/kernel/CVE-2022-2380.nopatch
@@ -1,0 +1,4 @@
+CVE-2022-2380 - Already backported to 5.15.33:
+
+Upstream: bd771cf5c4254511cc4abb88f3dab3bd58bdf8e8
+Stable:  46cdbff26c88fd75dccbf28df1d07cbe18007eac

--- a/SPECS/kernel/CVE-2022-33743.nopatch
+++ b/SPECS/kernel/CVE-2022-33743.nopatch
@@ -1,0 +1,4 @@
+CVE-2022-33743 - Already backported to 5.15.53:
+
+Upstream: f63c2c2032c2e3caad9add3b82cc6e91c376fd26
+Stable:  1052fc2b7391a43b25168ae69ad658fff5170f04

--- a/SPECS/kernel/CVE-2022-33744.nopatch
+++ b/SPECS/kernel/CVE-2022-33744.nopatch
@@ -1,0 +1,4 @@
+CVE-2022-33744 - Already backported to 5.15.53:
+
+Upstream: b75cd218274e01d026dc5240e86fdeb44bbed0c8
+Stable:  9f83c8f6ab14bbf4311b70bf1b7290d131059101


### PR DESCRIPTION
…22-33744

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
nopatch kernel CVES 2022-2380, 2022-33743, 2021-4135, 2022-33744

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- nopatch kernel CVES 2022-2380, 2022-33743, 2021-4135, 2022-33744

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
NO

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2022-2380
- https://nvd.nist.gov/vuln/detail/CVE-2022-33743
- https://nvd.nist.gov/vuln/detail/CVE-2021-4135
- https://nvd.nist.gov/vuln/detail/CVE-2022-33744
