### PR TITLE
python-pexpect: disable flaky `spawn_uses_env` test.

### DIFF
--- a/SPECS/python-pexpect/python-pexpect.spec
+++ b/SPECS/python-pexpect/python-pexpect.spec
@@ -3,7 +3,7 @@
 Summary:        Unicode-aware Pure Python Expect-like module
 Name:           python-%{modname}
 Version:        4.8.0
-Release:        10%{?dist}
+Release:        11%{?dist}
 License:        ISC
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -68,19 +68,17 @@ python3 setup.py install --skip-build --prefix=%{_prefix} --root=%{buildroot}
 
 %check
 export PYTHONIOENCODING=UTF-8
-# workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1914843
-# upstream: https://github.com/pexpect/pexpect/issues/669
-# There's a patch upstream that we can presumable remove this after
-# it merges and is released.
-# Thx for the suggestion Miro: https://www.spinics.net/lists/fedora-devel/msg283026.html
-echo "set enable-bracketed-paste off" > .inputrc
-export INPUTRC=$PWD/.inputrc
 
 python3 ./tools/display-sighandlers.py
 python3 ./tools/display-terminalinfo.py
 
 pip3 install pytest
-TRAVIS=true python3 -m pytest -v
+
+# Disabling broken "spawn_uses_env" test.
+# See: https://github.com/pexpect/pexpect/issues/669
+# We can remove this once the GitHub issue is fixed and we update
+# the package to the version containing the fix.
+TRAVIS=true python3 -m pytest -v -k "not spawn_uses_env"
 
 %files -n python3-%{modname}
 %license LICENSE
@@ -89,6 +87,9 @@ TRAVIS=true python3 -m pytest -v
 %{python3_sitelib}/%{modname}-*.egg-info
 
 %changelog
+* Tue Aug 09 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 4.8.0-11
+- Disabling flaky "spawn_uses_env" test.
+
 * Wed Jun 23 2021 Thomas Crain <thcrain@microsoft.com> - 4.8.0-10
 - Fix package tests by using pip to install testing requirements
 - Fix package tests by taking sys_executable patch from upstream

--- a/SPECS/python-pexpect/python-pexpect.spec
+++ b/SPECS/python-pexpect/python-pexpect.spec
@@ -78,6 +78,8 @@ pip3 install pytest
 # See: https://github.com/pexpect/pexpect/issues/669
 # We can remove this once the GitHub issue is fixed and we update
 # the package to the version containing the fix.
+echo "set enable-bracketed-paste off" > .inputrc
+export INPUTRC=$PWD/.inputrc
 TRAVIS=true python3 -m pytest -v -k "not spawn_uses_env"
 
 %files -n python3-%{modname}


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

The `spawn_uses_env` test in `python-pexpect` is flaky (see: [here](https://github.com/pexpect/pexpect/issues/699)). I'm disabling it until the issue gets resolved in upstream.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Disabled the `spawn_uses_env` test.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline buddy build: 223552.