### PR TITLE
Update gnupg2 to 2.3.7 to resolve CVE-2022-34903

### DIFF
--- a/SPECS/gnupg2/gnupg2.signatures.json
+++ b/SPECS/gnupg2/gnupg2.signatures.json
@@ -1,5 +1,5 @@
 {
     "Signatures": {
-        "gnupg-2.3.3.tar.bz2": "5789b86da6a1a6752efb38598f16a77af51170a8494039c3842b085032e8e937"
+        "gnupg-2.3.7.tar.bz2": "ee163a5fb9ec99ffc1b18e65faef8d086800c5713d15a672ab57d3799da83669"
     }
 }

--- a/SPECS/gnupg2/gnupg2.spec
+++ b/SPECS/gnupg2/gnupg2.spec
@@ -1,7 +1,7 @@
 Summary:        OpenPGP standard implementation used for encrypted communication and data storage.
 Name:           gnupg2
-Version:        2.3.3
-Release:        3%{?dist}
+Version:        2.3.7
+Release:        1%{?dist}
 License:        BSD and CC0 and GPLv2+ and LGPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -89,6 +89,9 @@ ln -s $(pwd)/bin/gpg $(pwd)/bin/gpg2
 %defattr(-,root,root)
 
 %changelog
+* Tue Aug 09 2022 Andrew Phelps <anphel@microsoft.com> - 2.3.7-1
+- Update to version 2.3.7 to resolve CVE-2022-34903
+
 * Wed Apr 13 2022 Suresh Babu Chalamalasetty <schalam@microsoft.com> - 2.3.3-3
 - Create lang sub package for locales
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -3960,8 +3960,8 @@
         "type": "other",
         "other": {
           "name": "gnupg2",
-          "version": "2.3.3",
-          "downloadUrl": "https://gnupg.org/ftp/gcrypt/gnupg/gnupg-2.3.3.tar.bz2"
+          "version": "2.3.7",
+          "downloadUrl": "https://gnupg.org/ftp/gcrypt/gnupg/gnupg-2.3.7.tar.bz2"
         }
       }
     },

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -217,8 +217,8 @@ libksba-1.6.0-1.cm2.aarch64.rpm
 libksba-devel-1.6.0-1.cm2.aarch64.rpm
 npth-1.6-4.cm2.aarch64.rpm
 pinentry-1.2.0-1.cm2.aarch64.rpm
-gnupg2-2.3.3-3.cm2.aarch64.rpm
-gnupg2-lang-2.3.3-3.cm2.aarch64.rpm
+gnupg2-2.3.7-1.cm2.aarch64.rpm
+gnupg2-lang-2.3.7-1.cm2.aarch64.rpm
 gpgme-1.16.0-1.cm2.aarch64.rpm
 mariner-repos-shared-2.0-8.cm2.noarch.rpm
 mariner-repos-2.0-8.cm2.noarch.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -217,8 +217,8 @@ libksba-1.6.0-1.cm2.x86_64.rpm
 libksba-devel-1.6.0-1.cm2.x86_64.rpm
 npth-1.6-4.cm2.x86_64.rpm
 pinentry-1.2.0-1.cm2.x86_64.rpm
-gnupg2-2.3.3-3.cm2.x86_64.rpm
-gnupg2-lang-2.3.3-3.cm2.x86_64.rpm
+gnupg2-2.3.7-1.cm2.x86_64.rpm
+gnupg2-lang-2.3.7-1.cm2.x86_64.rpm
 gpgme-1.16.0-1.cm2.x86_64.rpm
 mariner-repos-shared-2.0-8.cm2.noarch.rpm
 mariner-repos-2.0-8.cm2.noarch.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -113,9 +113,9 @@ glibc-tools-2.35-2.cm2.aarch64.rpm
 gmp-6.2.1-2.cm2.aarch64.rpm
 gmp-debuginfo-6.2.1-2.cm2.aarch64.rpm
 gmp-devel-6.2.1-2.cm2.aarch64.rpm
-gnupg2-2.3.3-3.cm2.aarch64.rpm
-gnupg2-debuginfo-2.3.3-3.cm2.aarch64.rpm
-gnupg2-lang-2.3.3-3.cm2.aarch64.rpm
+gnupg2-2.3.7-1.cm2.aarch64.rpm
+gnupg2-debuginfo-2.3.7-1.cm2.aarch64.rpm
+gnupg2-lang-2.3.7-1.cm2.aarch64.rpm
 gperf-3.1-4.cm2.aarch64.rpm
 gperf-debuginfo-3.1-4.cm2.aarch64.rpm
 gpgme-1.16.0-1.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -113,9 +113,9 @@ glibc-tools-2.35-2.cm2.x86_64.rpm
 gmp-6.2.1-2.cm2.x86_64.rpm
 gmp-debuginfo-6.2.1-2.cm2.x86_64.rpm
 gmp-devel-6.2.1-2.cm2.x86_64.rpm
-gnupg2-2.3.3-3.cm2.x86_64.rpm
-gnupg2-debuginfo-2.3.3-3.cm2.x86_64.rpm
-gnupg2-lang-2.3.3-3.cm2.x86_64.rpm
+gnupg2-2.3.7-1.cm2.x86_64.rpm
+gnupg2-debuginfo-2.3.7-1.cm2.x86_64.rpm
+gnupg2-lang-2.3.7-1.cm2.x86_64.rpm
 gperf-3.1-4.cm2.x86_64.rpm
 gperf-debuginfo-3.1-4.cm2.x86_64.rpm
 gpgme-1.16.0-1.cm2.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Update gnupg2 to 2.3.7 to resolve CVE-2022-34903

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change gnupg2 to version 2.3.7

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2022-34903

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: 22361 (AMD64), 223605 (ARM64)
