### PR TITLE
busybox: patch CVE-2022-30065

### DIFF
--- a/SPECS/busybox/CVE-2022-30065.patch
+++ b/SPECS/busybox/CVE-2022-30065.patch
@@ -1,0 +1,53 @@
+From e63d7cdfdac78c6fd27e9e63150335767592b85e Mon Sep 17 00:00:00 2001
+From: Natanael Copa <ncopa@alpinelinux.org>
+Date: Fri, 17 Jun 2022 17:45:34 +0200
+Subject: [PATCH] awk: fix use after free (CVE-2022-30065)
+
+fixes https://bugs.busybox.net/show_bug.cgi?id=14781
+
+function                                             old     new   delta
+evaluate                                            3343    3357     +14
+
+Backported by @mfrw from upstream on 2022-08-10
+Applies on v1.35.0 cleanly
+
+Signed-off-by: Natanael Copa <ncopa@alpinelinux.org>
+Signed-off-by: Denys Vlasenko <vda.linux@googlemail.com>
+Signed-off-by: Muhammad Falak R Wani <falakreyaz@gmail.com>
+---
+ editors/awk.c       | 3 +++
+ testsuite/awk.tests | 6 ++++++
+ 2 files changed, 9 insertions(+)
+
+diff --git a/editors/awk.c b/editors/awk.c
+index 079d0bde5..728ee8685 100644
+--- a/editors/awk.c
++++ b/editors/awk.c
+@@ -3128,6 +3128,9 @@ static var *evaluate(node *op, var *res)
+ 
+ 		case XC( OC_MOVE ):
+ 			debug_printf_eval("MOVE\n");
++			/* make sure that we never return a temp var */
++			if (L.v == TMPVAR0)
++				L.v = res;
+ 			/* if source is a temporary string, jusk relink it to dest */
+ 			if (R.v == TMPVAR1
+ 			 && !(R.v->type & VF_NUMBER)
+diff --git a/testsuite/awk.tests b/testsuite/awk.tests
+index 93e25d8c1..bbf0fbff1 100755
+--- a/testsuite/awk.tests
++++ b/testsuite/awk.tests
+@@ -479,4 +479,10 @@ testing 'awk backslash+newline eaten with no trace' \
+ 	"Hello world\n" \
+ 	'' ''
+ 
++testing 'awk assign while test' \
++	"awk '\$1==\$1=\"foo\" {print \$1}'" \
++	"foo\n" \
++	"" \
++	"foo"
++
+ exit $FAILCOUNT
+-- 
+2.37.1
+

--- a/SPECS/busybox/ash-fix-use-after-free-in-bash-pattern-substitution.patch
+++ b/SPECS/busybox/ash-fix-use-after-free-in-bash-pattern-substitution.patch
@@ -1,0 +1,42 @@
+From 7c2a3bdde0a1316771fdd07ff03413f00383f70e Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?S=C3=B6ren=20Tempel?= <soeren@soeren-tempel.net>
+Date: Tue, 2 Aug 2022 18:23:32 +0200
+Subject: [PATCH] ash: fix use-after-free in bash pattern substitution
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+function                                             old     new   delta
+subevalvar                                          1566    1564      -2
+
+Backported by @mfrw from upstream on 2022-08-10
+Applies on v1.35.0 cleanly
+
+Signed-off-by: Sören Tempel <soeren@soeren-tempel.net>
+Signed-off-by: Denys Vlasenko <vda.linux@googlemail.com>
+Signed-off-by: Muhammad Falak R Wani <falakreyaz@gmail.com>
+---
+ shell/ash.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/shell/ash.c b/shell/ash.c
+index 105edd4c8..55c1034f5 100644
+--- a/shell/ash.c
++++ b/shell/ash.c
+@@ -7357,6 +7357,13 @@ subevalvar(char *start, char *str, int strloc,
+ 				idx = loc;
+ 			}
+ 
++			/* The STPUTC invocations above may resize and move the
++			 * stack via realloc(3). Since repl is a pointer into the
++			 * stack, we need to reconstruct it relative to stackblock().
++			 */
++			if (slash_pos >= 0)
++				repl = (char *)stackblock() + strloc + slash_pos + 1;
++
+ 			//bb_error_msg("repl:'%s'", repl);
+ 			for (loc = (char*)repl; *loc; loc++) {
+ 				char *restart_detect = stackblock();
+-- 
+2.37.1
+

--- a/SPECS/busybox/ash-fix-use-after-free-in-pattern-substituon-code.patch
+++ b/SPECS/busybox/ash-fix-use-after-free-in-pattern-substituon-code.patch
@@ -1,0 +1,49 @@
+From daa66ed62c79684219088cc0361d5b316d5d1295 Mon Sep 17 00:00:00 2001
+From: Denys Vlasenko <vda.linux@googlemail.com>
+Date: Tue, 2 Aug 2022 12:41:18 +0200
+Subject: [PATCH] ash: fix use-after-free in pattern substituon code
+
+Patch by soeren@soeren-tempel.net
+
+The idx variable points to a value in the stack string (as managed
+by STPUTC). STPUTC may resize this stack string via realloc(3). If
+this happens, the idx pointer needs to be updated. Otherwise,
+dereferencing idx may result in a use-after free.
+
+function                                             old     new   delta
+subevalvar                                          1562    1566      +4
+
+Backported by @mfrw from upstream on 2022-08-10
+Applies on v1.35.0 cleanly
+
+Signed-off-by: Denys Vlasenko <vda.linux@googlemail.com>
+Signed-off-by: Muhammad Falak R Wani <falakreyaz@gmail.com>
+---
+ shell/ash.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/shell/ash.c b/shell/ash.c
+index c731a333b..105edd4c8 100644
+--- a/shell/ash.c
++++ b/shell/ash.c
+@@ -7324,13 +7324,15 @@ subevalvar(char *start, char *str, int strloc,
+ 				if (idx >= end)
+ 					break;
+ 				STPUTC(*idx, expdest);
++				if (stackblock() != restart_detect)
++					goto restart;
+ 				if (quotes && (unsigned char)*idx == CTLESC) {
+ 					idx++;
+ 					len++;
+ 					STPUTC(*idx, expdest);
++					if (stackblock() != restart_detect)
++						goto restart;
+ 				}
+-				if (stackblock() != restart_detect)
+-					goto restart;
+ 				idx++;
+ 				len++;
+ 				rmesc++;
+-- 
+2.37.1
+

--- a/SPECS/busybox/awk-input-numbers-are-never-octal-or-hex-only-progra.patch
+++ b/SPECS/busybox/awk-input-numbers-are-never-octal-or-hex-only-progra.patch
@@ -1,0 +1,148 @@
+From e2952dfaff67f3641d3a6d3226753356170ff808 Mon Sep 17 00:00:00 2001
+From: Denys Vlasenko <vda.linux@googlemail.com>
+Date: Sat, 8 Jan 2022 22:42:35 +0100
+Subject: [PATCH] awk: input numbers are never octal or hex (only program
+ consts can be)
+
+function                                             old     new   delta
+next_token                                           825     930    +105
+getvar_i                                             114     129     +15
+nextchar                                              49      53      +4
+my_strtod                                            138       -    -138
+------------------------------------------------------------------------------
+(add/remove: 0/1 grow/shrink: 3/0 up/down: 124/-138)          Total: -14 bytes
+
+Backported by @mfrw from upstream on 2022-08-10
+Applies on v1.35.0 cleanly
+
+Signed-off-by: Denys Vlasenko <vda.linux@googlemail.com>
+Signed-off-by: Muhammad Falak R Wani <falakreyaz@gmail.com>
+---
+ editors/awk.c       | 29 ++++++++++++++++++++++-------
+ testsuite/awk.tests | 12 +++++++++++-
+ 2 files changed, 33 insertions(+), 8 deletions(-)
+
+diff --git a/editors/awk.c b/editors/awk.c
+index f6314ac72..079d0bde5 100644
+--- a/editors/awk.c
++++ b/editors/awk.c
+@@ -848,7 +848,7 @@ static char *nextword(char **s)
+ static char nextchar(char **s)
+ {
+ 	char c, *pps;
+-
++ again:
+ 	c = *(*s)++;
+ 	pps = *s;
+ 	if (c == '\\')
+@@ -859,8 +859,11 @@ static char nextchar(char **s)
+ 	 */
+ 	if (c == '\\' && *s == pps) { /* unrecognized \z? */
+ 		c = *(*s); /* yes, fetch z */
+-		if (c)
+-			(*s)++; /* advance unless z = NUL */
++		if (c) { /* advance unless z = NUL */
++			(*s)++;
++			if (c == '\n') /* \<newline>? eat it */
++				goto again;
++		}
+ 	}
+ 	return c;
+ }
+@@ -882,7 +885,13 @@ static ALWAYS_INLINE int isalnum_(int c)
+ static double my_strtod(char **pp)
+ {
+ 	char *cp = *pp;
+-	if (ENABLE_DESKTOP && cp[0] == '0') {
++	return strtod(cp, pp);
++}
++#if ENABLE_DESKTOP
++static double my_strtod_or_hexoct(char **pp)
++{
++	char *cp = *pp;
++	if (cp[0] == '0') {
+ 		/* Might be hex or octal integer: 0x123abc or 07777 */
+ 		char c = (cp[1] | 0x20);
+ 		if (c == 'x' || isdigit(cp[1])) {
+@@ -901,6 +910,9 @@ static double my_strtod(char **pp)
+ 	}
+ 	return strtod(cp, pp);
+ }
++#else
++# define my_strtod_or_hexoct(p) my_strtod(p)
++#endif
+ 
+ /* -------- working with variables (set/get/copy/etc) -------- */
+ 
+@@ -1014,6 +1026,7 @@ static double getvar_i(var *v)
+ 		if (s && *s) {
+ 			debug_printf_eval("getvar_i: '%s'->", s);
+ 			v->number = my_strtod(&s);
++			/* ^^^ hex/oct NOT allowed here! */
+ 			debug_printf_eval("%f (s:'%s')\n", v->number, s);
+ 			if (v->type & VF_USER) {
+ //TODO: skip_spaces() also skips backslash+newline, is it intended here?
+@@ -1125,10 +1138,10 @@ static uint32_t next_token(uint32_t expected)
+ 		if (*p == '\0') {
+ 			tc = TC_EOF;
+ 			debug_printf_parse("%s: token found: TC_EOF\n", __func__);
+-		} else if (*p == '\"') {
++		} else if (*p == '"') {
+ 			/* it's a string */
+ 			char *s = t_string = ++p;
+-			while (*p != '\"') {
++			while (*p != '"') {
+ 				char *pp;
+ 				if (*p == '\0' || *p == '\n')
+ 					syntax_error(EMSG_UNEXP_EOS);
+@@ -1166,7 +1179,8 @@ static uint32_t next_token(uint32_t expected)
+ 		} else if (*p == '.' || isdigit(*p)) {
+ 			/* it's a number */
+ 			char *pp = p;
+-			t_double = my_strtod(&pp);
++			t_double = my_strtod_or_hexoct(&pp);
++			/* ^^^ awk only allows hex/oct consts in _program_, not in _input_ */
+ 			p = pp;
+ 			if (*p == '.')
+ 				syntax_error(EMSG_UNEXP_TOKEN);
+@@ -3503,6 +3517,7 @@ static var *evaluate(node *op, var *res)
+ 				i = (Ld == 0);
+ 				break;
+ 			}
++			debug_printf_eval("COMPARE result: %d\n", (i == 0) ^ (opn & 1));
+ 			setvar_i(res, (i == 0) ^ (opn & 1));
+ 			break;
+ 		}
+diff --git a/testsuite/awk.tests b/testsuite/awk.tests
+index bcaafe8fd..93e25d8c1 100755
+--- a/testsuite/awk.tests
++++ b/testsuite/awk.tests
+@@ -102,9 +102,13 @@ testing "awk unused function args are evaluated" \
+ optional DESKTOP
+ testing "awk hex const 1" "awk '{ print or(0xffffffff,1) }'" "4294967295\n" "" "\n"
+ testing "awk hex const 2" "awk '{ print or(0x80000000,1) }'" "2147483649\n" "" "\n"
+-testing "awk oct const"   "awk '{ print or(01234,1) }'"      "669\n"         "" "\n"
++testing "awk oct const"   "awk '{ print or(01234,1) }'"      "669\n"        "" "\n"
+ SKIP=
+ 
++# check that "hex/oct integer" heuristic doesn't kick in on input
++# (must be done only when parsing program text)
++testing "awk input is never oct" "awk '{ print \$1, \$1+1 }'" "011 12\n"    "" "011\n"
++
+ # check that "hex/oct integer" heuristic doesn't kick in on 00NN.NNN
+ testing "awk floating const with leading zeroes" \
+ 	"awk '{ printf \"%f %f\n\", \"000.123\", \"009.123\" }'" \
+@@ -469,4 +473,10 @@ testing 'awk printf %% prints one %' \
+ 	"%\n" \
+ 	'' ''
+ 
++testing 'awk backslash+newline eaten with no trace' \
++	"awk 'BEGIN { printf \"Hello\\
++ world\n\" }'" \
++	"Hello world\n" \
++	'' ''
++
+ exit $FAILCOUNT
+-- 
+2.37.1
+

--- a/SPECS/busybox/busybox.spec
+++ b/SPECS/busybox/busybox.spec
@@ -1,7 +1,7 @@
 Summary:        Statically linked binary providing simplified versions of system commands
 Name:           busybox
 Version:        1.35.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -11,6 +11,10 @@ Source1:        busybox-static.config
 Source2:        busybox-petitboot.config
 Patch0:         busybox-1.31.1-stime-fix.patch
 Patch1:         CVE-2022-28391.patch
+Patch2:         awk-input-numbers-are-never-octal-or-hex-only-progra.patch
+Patch3:         CVE-2022-30065.patch
+Patch4:         ash-fix-use-after-free-in-pattern-substituon-code.patch
+Patch5:         ash-fix-use-after-free-in-bash-pattern-substitution.patch
 BuildRequires:  gcc
 BuildRequires:  glibc-devel
 BuildRequires:  libselinux-devel >= 1.27.7-2
@@ -128,6 +132,12 @@ install -m 644 docs/busybox.petitboot.1 %{buildroot}/%{_mandir}/man1/busybox.pet
 %{_mandir}/man1/busybox.petitboot.1.gz
 
 %changelog
+* Wed Aug 10 2022 Muhammad Falak <mwani@microsoft.com> - 1.35.0-3
+- Patch CVE-2022-30065
+- Introduce patch for: awk: input numbers are never octal or hex
+- Introduce patch for: use-after-free in pattern substituon code
+- Introduce patch for: use-after-free in bash pattern substitution
+
 * Fri May 20 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.35.0-2
 - Patch CVE-2022-28391.
 


### PR DESCRIPTION
Reference: https://bugs.busybox.net/show_bug.cgi?id=14781
Signed-off-by: Muhammad Falak R Wani <falakreyaz@gmail.com>

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Patch CVE-2022-30065

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Patch CVE-2022-30065

Also introduce three more fixes from upstream:
- e2952dfaf awk: input numbers are never octal or hex
- daa66ed62 ash: fix use-after-free in pattern substituon code
- 7c2a3bdde ash: fix use-after-free in bash pattern substitution

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- NA

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2022-30065

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local Build with RUN_CHECK=y
- Buddy Build: [223682](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=223682&view=results)
