### PR TITLE
perl-Object-Accessor: add BR on `perl(ExtUtils::MakeMaker)` & check deps to enable ptest

### DIFF
--- a/SPECS/perl-Object-Accessor/perl-Object-Accessor.spec
+++ b/SPECS/perl-Object-Accessor/perl-Object-Accessor.spec
@@ -1,7 +1,7 @@
 Summary:        Interface to create per object accessors
 Name:           perl-Object-Accessor
 Version:        0.48
-Release:        8%{?dist}
+Release:        9%{?dist}
 Group:          Development/Libraries
 License:        GPL+ or Artistic
 URL:            https://metacpan.org/release/Object-Accessor
@@ -13,6 +13,14 @@ BuildArch:      noarch
 
 BuildRequires:  perl >= 5.28.0
 BuildRequires:  perl-generators
+BuildRequires:  perl(ExtUtils::MakeMaker)
+%if %{with_check}
+BuildRequires:  perl(Params::Check)
+BuildRequires:  perl(Test::More)
+BuildRequires:  perl(Tie::Scalar)
+BuildRequires:  perl(deprecate)
+%endif
+
 Requires:       perl-libs
 Requires:       perl(deprecate)
 
@@ -45,6 +53,9 @@ make test
 %{_mandir}/man3/*
 
 %changelog
+* Fri Jul 29 2022 Muhammad Falak <mwani@microsoft.com> - 0.48-9
+- Add BR on `perl(ExtUtils::MakeMaker)` & other check deps to enable ptest
+
 *   Wed Jan 19 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 0.48-8
 -   Adding 'BuildRequires: perl-generators'.
 

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -411,7 +411,7 @@ perl-NDBM_File-1.15-488.cm2.aarch64.rpm
 perl-Net-1.02-488.cm2.noarch.rpm
 perl-Net-Ping-2.74-488.cm2.noarch.rpm
 perl-NEXT-0.68-488.cm2.noarch.rpm
-perl-Object-Accessor-0.48-8.cm2.noarch.rpm
+perl-Object-Accessor-0.48-9.cm2.noarch.rpm
 perl-ODBM_File-1.17-488.cm2.aarch64.rpm
 perl-Opcode-1.50-488.cm2.aarch64.rpm
 perl-open-1.12-488.cm2.noarch.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -411,7 +411,7 @@ perl-NDBM_File-1.15-488.cm2.x86_64.rpm
 perl-Net-1.02-488.cm2.noarch.rpm
 perl-Net-Ping-2.74-488.cm2.noarch.rpm
 perl-NEXT-0.68-488.cm2.noarch.rpm
-perl-Object-Accessor-0.48-8.cm2.noarch.rpm
+perl-Object-Accessor-0.48-9.cm2.noarch.rpm
 perl-ODBM_File-1.17-488.cm2.x86_64.rpm
 perl-Opcode-1.50-488.cm2.x86_64.rpm
 perl-open-1.12-488.cm2.noarch.rpm


### PR DESCRIPTION
Signed-off-by: Muhammad Falak R Wani <falakreyaz@gmail.com>

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Fix ptest build. All tests pass!

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add BR on `perl(ExtUtils::MakeMaker)` & other check deps to enable ptest

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**Yes**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- NA

###### Links to CVEs  <!-- optional -->
- NA

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local Build with RUN_CHECK=y
