### PR TITLE
Split the azure-iot-sdk-c package into base and devel

### DIFF
--- a/SPECS/azure-iot-sdk-c/azure-iot-sdk-c.spec
+++ b/SPECS/azure-iot-sdk-c/azure-iot-sdk-c.spec
@@ -7,7 +7,7 @@ Name:           azure-iot-sdk-c
 # Since we want to control the release number as thr distribution, this scheme is not applicable for us.
 # They also used to use a regular versioning scheme like 1.3.7 but they did not tag their latest LTS with a version like that.
 Version:        2022.01.21
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        MIT
 Group:          Applications/File
 URL:            https://github.com/Azure/azure-iot-sdk-c
@@ -41,6 +41,14 @@ interfaces that enable pluggability between stock and custom modules.
 To meet the wide range of device requirements in the Internet of Things space,
 the C libraries are provided in source code form to support multiple form factors,
 operating systems, tools sets, protocols and communications patterns widely in use today.
+
+%package devel
+Summary:        Azure IoT C SDK Dev
+Group:          Applications/File
+Requires:       %{name} = %{version}-%{release}
+
+%description devel
+This package contains the Azure IoT C SDK dev files
 
 %global debug_package %{nil}
 
@@ -80,12 +88,19 @@ install -p -m 755 provisioning_client/tools/tpm_device_provision/tpm_device_prov
 %files
 %defattr(-, root, root, -)
 %license LICENSE
-%{_includedir}/*
 %{_bindir}/tpm_device_provision
+
+%files devel
+%defattr(-,root,root)
+%{_includedir}/*
 %{_libdir}/*
 /usr/cmake/*
 
 %changelog
+*   Tue Aug 9 2022 Dallas Delaney <dadelan@microsoft.com> - 2022.08.09-10
+-   Split spec into base package and devel
+-   Bump version
+
 *   Mon Jan 24 2022 Nicolas Guibourge <nicolasg@microsoft.com> - 2022.01.21-1
 -   Upgrade to 2022.01.21.
 

--- a/SPECS/azure-iot-sdk-c/azure-iot-sdk-c.spec
+++ b/SPECS/azure-iot-sdk-c/azure-iot-sdk-c.spec
@@ -9,10 +9,10 @@ Name:           azure-iot-sdk-c
 Version:        2022.01.21
 Release:        2%{?dist}
 License:        MIT
-Group:          Applications/File
-URL:            https://github.com/Azure/azure-iot-sdk-c
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
+Group:          Applications/File
+URL:            https://github.com/Azure/azure-iot-sdk-c
 # Source0: https://github.com/Azure/%{name}/archive/LTS_01_2022_Ref01.tar.gz
 # The below tarball includes all submodules.
 
@@ -20,16 +20,15 @@ Distribution:   Mariner
 # git clone --recursive --single-branch --branch LTS_01_2022_Ref01 --depth 1 https://github.com/Azure/azure-iot-sdk-c.git
 # tar cjvf azure-iot-sdk-c-2022.01.21.tar.bz2 azure-iot-sdk-c/
 Source0:        %{name}-%{version}.tar.bz2
-
-BuildRequires:  cmake
 BuildRequires:  build-essential
+BuildRequires:  cmake
 BuildRequires:  curl-devel
 BuildRequires:  openssl-devel
 BuildRequires:  util-linux-devel
 BuildRequires:  valgrind
-Requires:       util-linux
 Requires:       curl
 Requires:       openssl
+Requires:       util-linux
 
 %description
 The Microsoft Azure IoT device libraries for C contain code that facilitates
@@ -53,7 +52,7 @@ This package contains the Azure IoT C SDK dev files
 %global debug_package %{nil}
 
 %prep
-%setup -qn %{name}
+%setup -q -n %{name}
 
 %build
 mkdir cmake
@@ -94,12 +93,13 @@ install -p -m 755 provisioning_client/tools/tpm_device_provision/tpm_device_prov
 %defattr(-,root,root)
 %{_includedir}/*
 %{_libdir}/*
-/usr/cmake/*
+%{_prefix}/cmake/*
 
 %changelog
-*   Tue Aug 9 2022 Dallas Delaney <dadelan@microsoft.com> - 2022.08.09-10
+*   Tue Aug 09 2022 Dallas Delaney <dadelan@microsoft.com> - 2022.01.21-2
 -   Split spec into base package and devel
 -   Bump version
+-   Lint spec
 
 *   Mon Jan 24 2022 Nicolas Guibourge <nicolasg@microsoft.com> - 2022.01.21-1
 -   Upgrade to 2022.01.21.
@@ -109,15 +109,21 @@ install -p -m 755 provisioning_client/tools/tpm_device_provision/tpm_device_prov
 
 *   Thu Nov 11 2021 Andrew Phelps <anphel@microsoft.com> 2020.02.04.1-7
 -   Fix build with gcc11
+
 *   Mon Jun 22 2020 Saravanan Somasundaram <sarsoma@microsoft.com> 2020.02.04.1-6
 -   Removing the Conflict reference to azure-iot-sdk-c-public-preview.
+
 *   Sun May 31 2020 Henry Beberman <henry.beberman@microsoft.com> 2020.02.04.1-5
 -   Add -Wno-error to cflags to fix compilation with updated -Werror default.
+
 *   Sat May 09 2020 Nick Samson <nisamson@microsoft.com> - 2020.02.04.1-4
 -   Added %%license line automatically
+
 *   Mon May 04 2020 Eric Li <eli@microsoft.com> 2020.02.04.1-3
 -   Add #Source0: and license verified.
+
 *   Wed Apr 29 2020 Emre Girgin <mrgirgin@microsoft.com> 2020.02.04.1-2
 -   Build the provisioning client, add tpm_device_provision to the package.
+
 *   Mon Apr 27 2020 Emre Girgin <mrgirgin@microsoft.com> 2020.02.04.1-1
 -   Original version for CBL-Mariner.


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Today, azure-iot-sdk-c produces a single RPM that contains the headers and libraries for development as well as the runtime artifact. This change modifies SPEC file to produce two separate RPMs: one for the headers/libraries and one for the runtime artifact.

This is important for Azure Sphere because we define one packagelist manually for the runtime image, but the sysroot's packagelist is automatically generated using a script. This script will take the image_deps.json from the runtime image and append "-devel" or "-headers" to each entry to create the sysroot's packagelist. In order to get the headers and libraries for the azure-iot-sdk-c into our sysroot, we need a package called azure-iot-sdk-c-devel. 

It looks like the [EFLOW project uses this package](https://dev.azure.com/mariner-org/mariner/_git/marineriotedge?path=/imageconfigs/packagelists/packages-gen.json&version=GBmaster&line=5&lineEnd=5&lineStartColumn=10&lineEndColumn=25&lineStyle=plain&_a=contents) and would potentially have to add the new -devel RPM

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Split the azure-iot-sdk-c RPM into azure-iot-sdk-c and azure-iot-sdk-c-devel
- Bump release version
- Lint spec

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #https://github.com/Azure/azure-sphere-are-fs/issues/28

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build
