### PR TITLE
xterm: bump version to 372 to address CVE-2021-27135

### DIFF
--- a/SPECS-EXTENDED/xterm/xterm-defaults.patch
+++ b/SPECS-EXTENDED/xterm/xterm-defaults.patch
@@ -1,7 +1,18 @@
-diff -up xterm-333/XTerm.ad.defaults xterm-333/XTerm.ad
---- xterm-333/XTerm.ad.defaults	2016-12-22 03:07:39.000000000 +0100
-+++ xterm-333/XTerm.ad	2018-05-30 15:44:53.325426803 +0200
-@@ -259,3 +259,11 @@
+From dcfa97b04779f5680e7ad17dbe75020bb36de04f Mon Sep 17 00:00:00 2001
+From: Muhammad Falak R Wani <falakreyaz@gmail.com>
+Date: Fri, 12 Aug 2022 07:27:06 +0530
+Subject: [PATCH 1/3] xterm defaults
+
+Signed-off-by: Muhammad Falak R Wani <falakreyaz@gmail.com>
+---
+ XTerm.ad | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/XTerm.ad b/XTerm.ad
+index 6d347a1..e4b1828 100644
+--- a/XTerm.ad
++++ b/XTerm.ad
+@@ -270,3 +270,11 @@
  !*allowTcapOps: false
  !*allowTitleOps: false
  !*allowWindowOps: false
@@ -13,3 +24,6 @@ diff -up xterm-333/XTerm.ad.defaults xterm-333/XTerm.ad
 +*VT100*scrollBar: true
 +*VT100*utf8Title: true
 +*termName: xterm-256color
+-- 
+2.37.1
+

--- a/SPECS-EXTENDED/xterm/xterm-desktop.patch
+++ b/SPECS-EXTENDED/xterm/xterm-desktop.patch
@@ -1,6 +1,17 @@
-diff -up xterm-323/xterm.desktop.desk xterm-323/xterm.desktop
---- xterm-323/xterm.desktop.desk	2016-03-08 14:32:15.633422051 +0100
-+++ xterm-323/xterm.desktop	2016-03-08 14:33:31.231604288 +0100
+From 67509cf49144a602430d0ee0918770919616f461 Mon Sep 17 00:00:00 2001
+From: Muhammad Falak R Wani <falakreyaz@gmail.com>
+Date: Fri, 12 Aug 2022 07:29:12 +0530
+Subject: [PATCH 2/3] xterm desktop
+
+Signed-off-by: Muhammad Falak R Wani <falakreyaz@gmail.com>
+---
+ xterm.desktop | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/xterm.desktop b/xterm.desktop
+index 61dcd2c..401b03a 100644
+--- a/xterm.desktop
++++ b/xterm.desktop
 @@ -32,12 +32,12 @@
  # -----------------------------------------------------------------------------
  [Desktop Entry]
@@ -16,3 +27,6 @@ diff -up xterm-323/xterm.desktop.desk xterm-323/xterm.desktop
 +Icon=xterm-color
  Categories=System;TerminalEmulator;
  Keywords=shell;prompt;command;commandline;cmd;
+-- 
+2.37.1
+

--- a/SPECS-EXTENDED/xterm/xterm-man-paths.patch
+++ b/SPECS-EXTENDED/xterm/xterm-man-paths.patch
@@ -1,9 +1,21 @@
-diff -up xterm-328/minstall.in.man-paths xterm-328/minstall.in
---- xterm-328/minstall.in.man-paths	2016-10-25 00:29:20.000000000 +0200
-+++ xterm-328/minstall.in	2017-06-01 16:36:26.544065282 +0200
-@@ -138,6 +138,11 @@ USE_chr1=`echo "$USE_name" | sed -e 's/^
+From bd87b44049dd383d6139b2b756dbfc3167ad4937 Mon Sep 17 00:00:00 2001
+From: Muhammad Falak R Wani <falakreyaz@gmail.com>
+Date: Fri, 12 Aug 2022 07:34:42 +0530
+Subject: [PATCH 3/3] xterm man paths
+
+Signed-off-by: Muhammad Falak R Wani <falakreyaz@gmail.com>
+---
+ minstall.in | 8 ++++++++
+ xterm.man   | 7 +++----
+ 2 files changed, 11 insertions(+), 4 deletions(-)
+
+diff --git a/minstall.in b/minstall.in
+index cd15775..0228db7 100644
+--- a/minstall.in
++++ b/minstall.in
+@@ -141,6 +141,11 @@ USE_chr1=`echo "$USE_name" | sed -e 's/^.//'`
  USE_Name=${USE_chr0}${USE_chr1}
- USE_NAME=`echo "$USE_name" | tr '[a-z]' '[A-Z]'`
+ USE_NAME=`echo "$USE_name" | tr "$lower" "$upper"`
  
 +fontpath=/usr/share/X11/fonts
 +xorgcfgdir=/etc/X11
@@ -11,22 +23,23 @@ diff -up xterm-328/minstall.in.man-paths xterm-328/minstall.in
 +X_MANSECT=7
 +
  sed	-e 's%__vendorversion__%"X Window System"%' \
- 	-e 's%__app_version__%Patch\ \#'$PATCH_NUM% \
- 	-e 's%__app_date__%'$PATCH_YMD% \
-@@ -163,6 +168,9 @@ sed	-e 's%__vendorversion__%"X Window Sy
- 	-e s%fIwtmp'\\%fI'$WTMP_NAME'\\%g' \
- 	-e s%/etc/wtmp%$WTMP_PATH%g \
+ 	-e 's%__app_version__%Patch\ \#'"$PATCH_NUM"% \
+ 	-e 's%__app_date__%'"$PATCH_YMD"% \
+@@ -166,6 +171,9 @@ sed	-e 's%__vendorversion__%"X Window System"%' \
+ 	-e "s%/etc/utmp%$UTMP_PATH%g" \
+ 	-e 's%fIwtmp\\%fI'$WTMP_NAME'\\%g' \
+ 	-e "s%/etc/wtmp%$WTMP_PATH%g" \
++	-e s%__fontpath__%$fontpath%g \
++	-e s%__xorgcfgdir__%$xorgcfgdir%g \
++	-e s%__xorgcfgfil__%$xorgcfgfil%g \
  	-e 's%/\\(\*\*%/*%g' \
-+ 	-e s%__fontpath__%$fontpath%g \
-+ 	-e s%__xorgcfgdir__%$xorgcfgdir%g \
-+ 	-e s%__xorgcfgfil__%$xorgcfgfil%g \
- 	$OLD_FILE >$NEW_FILE
+ 	"$OLD_FILE" >$NEW_FILE
  # diff -u $OLD_FILE $NEW_FILE
- 
-diff -up xterm-328/xterm.man.man-paths xterm-328/xterm.man
---- xterm-328/xterm.man.man-paths	2017-05-31 00:57:12.000000000 +0200
-+++ xterm-328/xterm.man	2017-06-01 16:33:16.493512367 +0200
-@@ -2328,19 +2328,18 @@ Since X11R6, bitmap fonts have been scal
+diff --git a/xterm.man b/xterm.man
+index f5f510f..fdc4990 100644
+--- a/xterm.man
++++ b/xterm.man
+@@ -2551,19 +2551,18 @@ Since X11R6, bitmap fonts have been scaled.
  The font server claims to provide the bold font that \fI\*n\fP requests,
  but the result is not always readable.
  XFree86 introduced a feature which can be used to suppress the scaling.
@@ -49,3 +62,6 @@ diff -up xterm-328/xterm.man.man-paths xterm-328/xterm.man
  .NE
  .IP
  Depending on your configuration, the font server may have its own configuration
+-- 
+2.37.1
+

--- a/SPECS-EXTENDED/xterm/xterm.signatures.json
+++ b/SPECS-EXTENDED/xterm/xterm.signatures.json
@@ -1,6 +1,6 @@
 {
  "Signatures": {
   "16colors.txt": "a2342029672532256110ef28a0ea1addb7f6fd1f08aacc382d0fbe2308f178c2",
-  "xterm-351.tgz": "760a8a10221c9c9744afd86db87c7ad95bbf9be4f5f525fecf39125f0d2a6e16"
+  "xterm-372.tgz": "c6d08127cb2409c3a04bcae559b7025196ed770bb7bf26630abcb45d95f60ab1"
  }
 }

--- a/SPECS-EXTENDED/xterm/xterm.spec
+++ b/SPECS-EXTENDED/xterm/xterm.spec
@@ -1,23 +1,23 @@
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
-Summary: Terminal emulator for the X Window System
-Name: xterm
-Version: 351
-Release: 3%{?dist}
-URL: https://invisible-island.net/xterm
-License: MIT
-BuildRequires: gcc pkgconfig ncurses-devel libutempter-devel
-BuildRequires: libXft-devel libXaw-devel libXext-devel desktop-file-utils
-BuildRequires: libxkbfile-devel xorg-x11-apps
-Requires: xterm-resize = %{version}-%{release}
-Recommends: xorg-x11-fonts-misc
+Summary:        Terminal emulator for the X Window System
+Name:           xterm
+Version:        372
+Release:        1%{?dist}
+URL:            https://invisible-island.net/xterm
+License:        MIT
+BuildRequires:  gcc pkgconfig ncurses-devel libutempter-devel
+BuildRequires:  libXft-devel libXaw-devel libXext-devel desktop-file-utils
+BuildRequires:  libxkbfile-devel xorg-x11-apps
+Requires:       xterm-resize = %{version}-%{release}
+Recommends:     xorg-x11-fonts-misc
 
-Source0: ftp://ftp.invisible-island.net/xterm/%{name}-%{version}.tgz
-Source1: ftp://ftp.invisible-island.net/xterm/16colors.txt
+Source0:        ftp://ftp.invisible-island.net/xterm/%{name}-%{version}.tgz
+Source1:        ftp://ftp.invisible-island.net/xterm/16colors.txt
 
-Patch1: xterm-defaults.patch
-Patch2: xterm-desktop.patch
-Patch3: xterm-man-paths.patch
+Patch1:         xterm-defaults.patch
+Patch2:         xterm-desktop.patch
+Patch3:         xterm-man-paths.patch
 
 %bcond_with trace
 
@@ -103,6 +103,11 @@ install -m644 -p xterm.appdata.xml $RPM_BUILD_ROOT%{_datadir}/appdata
 %{_mandir}/man1/resize.1*
 
 %changelog
+* Fri Aug 12 2022 Muhammad Falak <mwani@microsoft.com> - 372-1
+- Bump version to address CVE-2021-27135
+- Refresh all patches to apply cleanly
+- Cosmetic changes to spec formating
+
 * Fri Oct 15 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 351-3
 - Initial CBL-Mariner import from Fedora 32 (license: MIT).
 

--- a/SPECS-EXTENDED/xterm/xterm.spec
+++ b/SPECS-EXTENDED/xterm/xterm.spec
@@ -12,8 +12,8 @@ BuildRequires:  libxkbfile-devel xorg-x11-apps
 Requires:       xterm-resize = %{version}-%{release}
 Recommends:     xorg-x11-fonts-misc
 
-Source0:        https://ftp.invisible-island.net/xterm/%{name}-%{version}.tgz
-Source1:        https://ftp.invisible-island.net/xterm/16colors.txt
+Source0:        http://ftp.invisible-island.net/archives/xterm/%{name}-%{version}.tgz
+Source1:        http://ftp.invisible-island.net/archives/xterm/16colors.txt
 
 Patch1:         xterm-defaults.patch
 Patch2:         xterm-desktop.patch
@@ -106,7 +106,7 @@ install -m644 -p xterm.appdata.xml $RPM_BUILD_ROOT%{_datadir}/appdata
 * Fri Aug 12 2022 Muhammad Falak <mwani@microsoft.com> - 372-1
 - Bump version to address CVE-2021-27135
 - Refresh all patches to apply cleanly
-- Switch url to `https` instead of `ftp`
+- Switch url to `http` instead of `ftp`
 - Cosmetic changes to spec formating
 - License verified
 

--- a/SPECS-EXTENDED/xterm/xterm.spec
+++ b/SPECS-EXTENDED/xterm/xterm.spec
@@ -12,8 +12,8 @@ BuildRequires:  libxkbfile-devel xorg-x11-apps
 Requires:       xterm-resize = %{version}-%{release}
 Recommends:     xorg-x11-fonts-misc
 
-Source0:        ftp://ftp.invisible-island.net/xterm/%{name}-%{version}.tgz
-Source1:        ftp://ftp.invisible-island.net/xterm/16colors.txt
+Source0:        https://ftp.invisible-island.net/xterm/%{name}-%{version}.tgz
+Source1:        https://ftp.invisible-island.net/xterm/16colors.txt
 
 Patch1:         xterm-defaults.patch
 Patch2:         xterm-desktop.patch
@@ -106,7 +106,9 @@ install -m644 -p xterm.appdata.xml $RPM_BUILD_ROOT%{_datadir}/appdata
 * Fri Aug 12 2022 Muhammad Falak <mwani@microsoft.com> - 372-1
 - Bump version to address CVE-2021-27135
 - Refresh all patches to apply cleanly
+- Switch url to `https` instead of `ftp`
 - Cosmetic changes to spec formating
+- License verified
 
 * Fri Oct 15 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 351-3
 - Initial CBL-Mariner import from Fedora 32 (license: MIT).

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -27688,7 +27688,7 @@
         "other": {
           "name": "xterm",
           "version": "372",
-          "downloadUrl": "https://ftp.invisible-island.net/xterm/xterm-372.tgz"
+          "downloadUrl": "http://ftp.invisible-island.net/archives/xterm/xterm-372.tgz"
         }
       }
     },

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -27687,8 +27687,8 @@
         "type": "other",
         "other": {
           "name": "xterm",
-          "version": "351",
-          "downloadUrl": "ftp://ftp.invisible-island.net/xterm/xterm-351.tgz"
+          "version": "372",
+          "downloadUrl": "https://ftp.invisible-island.net/xterm/xterm-372.tgz"
         }
       }
     },


### PR DESCRIPTION
`NOTE: The tarball for this download has a certificate issue :(` 
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Address CVE-2021-27135

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Bump version to 372 to address CVE-2021-27135
- Refresh all patches to apply cleanly
- Switch url to `https` instead of `ftp`
- Cosmetic changes to spec formating
- License verified

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- NA

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2021-27135

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local Build with RUN_CHECK=y
