### PR TITLE
Patch CVE-2022-37434 in zlib

### DIFF
--- a/SPECS/zlib/CVE-2022-37434.patch
+++ b/SPECS/zlib/CVE-2022-37434.patch
@@ -1,0 +1,62 @@
+From eff308af425b67093bab25f80f1ae950166bece1 Mon Sep 17 00:00:00 2001
+From: Mark Adler <fork@madler.net>
+Date: Sat, 30 Jul 2022 15:51:11 -0700
+Subject: [PATCH] Fix a bug when getting a gzip header extra field with
+ inflate().
+
+If the extra field was larger than the space the user provided with
+inflateGetHeader(), and if multiple calls of inflate() delivered
+the extra header data, then there could be a buffer overflow of the
+provided space. This commit assures that provided space is not
+exceeded.
+---
+ inflate.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/inflate.c b/inflate.c
+index 7be8c6366..7a7289749 100644
+--- a/inflate.c
++++ b/inflate.c
+@@ -763,9 +763,10 @@ int flush;
+                 copy = state->length;
+                 if (copy > have) copy = have;
+                 if (copy) {
++                    len = state->head->extra_len - state->length;
+                     if (state->head != Z_NULL &&
+-                        state->head->extra != Z_NULL) {
+-                        len = state->head->extra_len - state->length;
++                        state->head->extra != Z_NULL &&
++                        len < state->head->extra_max) {
+                         zmemcpy(state->head->extra + len, next,
+                                 len + copy > state->head->extra_max ?
+                                 state->head->extra_max - len : copy);
+
+From 1eb7682f845ac9e9bf9ae35bbfb3bad5dacbd91d Mon Sep 17 00:00:00 2001
+From: Mark Adler <fork@madler.net>
+Date: Mon, 8 Aug 2022 10:50:09 -0700
+Subject: [PATCH] Fix extra field processing bug that dereferences NULL
+ state->head.
+
+The recent commit to fix a gzip header extra field processing bug
+introduced the new bug fixed here.
+---
+ inflate.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/inflate.c b/inflate.c
+index 7a7289749..2a3c4fe98 100644
+--- a/inflate.c
++++ b/inflate.c
+@@ -763,10 +763,10 @@ int flush;
+                 copy = state->length;
+                 if (copy > have) copy = have;
+                 if (copy) {
+-                    len = state->head->extra_len - state->length;
+                     if (state->head != Z_NULL &&
+                         state->head->extra != Z_NULL &&
+-                        len < state->head->extra_max) {
++                        (len = state->head->extra_len - state->length) <
++                            state->head->extra_max) {
+                         zmemcpy(state->head->extra + len, next,
+                                 len + copy > state->head->extra_max ?
+                                 state->head->extra_max - len : copy);

--- a/SPECS/zlib/zlib.spec
+++ b/SPECS/zlib/zlib.spec
@@ -1,13 +1,14 @@
 Summary:        Compression and decompression routines
 Name:           zlib
 Version:        1.2.12
-Release:        1%{?dist}
+Release:        2%{?dist}
 URL:            http://www.zlib.net/
 License:        zlib
 Group:          Applications/System
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Source0:        http://www.zlib.net/%{name}-%{version}.tar.xz
+Patch0:         CVE-2022-37434.patch
 %define sha1    zlib=e1cb0d5c92da8e9a8c2635dfa249c341dfd00322
 %description
 Compression and decompression routines
@@ -35,7 +36,7 @@ make  %{?_smp_mflags} check
 %postun -p /sbin/ldconfig
 %files
 %defattr(-,root,root)
-%license contrib/dotzlib/LICENSE_1_0.txt
+%license README
 %{_libdir}/libz.so.*
 
 %files devel
@@ -47,6 +48,11 @@ make  %{?_smp_mflags} check
 %{_mandir}/man3/zlib.3.gz
 
 %changelog
+* Tue Aug 16 2022 Olivia Crain <oliviacrain@microsoft.com> - 1.2.12-2
+- Add upstream patches for CVE-2022-37434
+- Fix packaged license- actual license is contained within README
+- License verified
+
 *   Wed May 04 2022 Nick Samson <nisamson@microsoft.com> - 1.2.12-1
 -   Upgraded to 1.2.12 to fix CVE-2018-25032
 *   Sat May 09 2020 Nick Samson <nisamson@microsoft.com> - 1.2.11-3

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -7,8 +7,8 @@ glibc-iconv-2.28-23.cm1.aarch64.rpm
 glibc-lang-2.28-23.cm1.aarch64.rpm
 glibc-nscd-2.28-23.cm1.aarch64.rpm
 glibc-tools-2.28-23.cm1.aarch64.rpm
-zlib-1.2.12-1.cm1.aarch64.rpm
-zlib-devel-1.2.12-1.cm1.aarch64.rpm
+zlib-1.2.12-2.cm1.aarch64.rpm
+zlib-devel-1.2.12-2.cm1.aarch64.rpm
 file-5.38-1.cm1.aarch64.rpm
 file-devel-5.38-1.cm1.aarch64.rpm
 file-libs-5.38-1.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -7,8 +7,8 @@ glibc-iconv-2.28-23.cm1.x86_64.rpm
 glibc-lang-2.28-23.cm1.x86_64.rpm
 glibc-nscd-2.28-23.cm1.x86_64.rpm
 glibc-tools-2.28-23.cm1.x86_64.rpm
-zlib-1.2.12-1.cm1.x86_64.rpm
-zlib-devel-1.2.12-1.cm1.x86_64.rpm
+zlib-1.2.12-2.cm1.x86_64.rpm
+zlib-devel-1.2.12-2.cm1.x86_64.rpm
 file-5.38-1.cm1.x86_64.rpm
 file-devel-5.38-1.cm1.x86_64.rpm
 file-libs-5.38-1.cm1.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -425,9 +425,9 @@ xz-lang-5.2.4-3.cm1.aarch64.rpm
 xz-libs-5.2.4-3.cm1.aarch64.rpm
 zip-3.0-5.cm1.aarch64.rpm
 zip-debuginfo-3.0-5.cm1.aarch64.rpm
-zlib-1.2.12-1.cm1.aarch64.rpm
-zlib-debuginfo-1.2.12-1.cm1.aarch64.rpm
-zlib-devel-1.2.12-1.cm1.aarch64.rpm
+zlib-1.2.12-2.cm1.aarch64.rpm
+zlib-debuginfo-1.2.12-2.cm1.aarch64.rpm
+zlib-devel-1.2.12-2.cm1.aarch64.rpm
 zstd-1.4.9-1.cm1.aarch64.rpm
 zstd-debuginfo-1.4.9-1.cm1.aarch64.rpm
 zstd-devel-1.4.9-1.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -425,9 +425,9 @@ xz-lang-5.2.4-3.cm1.x86_64.rpm
 xz-libs-5.2.4-3.cm1.x86_64.rpm
 zip-3.0-5.cm1.x86_64.rpm
 zip-debuginfo-3.0-5.cm1.x86_64.rpm
-zlib-1.2.12-1.cm1.x86_64.rpm
-zlib-debuginfo-1.2.12-1.cm1.x86_64.rpm
-zlib-devel-1.2.12-1.cm1.x86_64.rpm
+zlib-1.2.12-2.cm1.x86_64.rpm
+zlib-debuginfo-1.2.12-2.cm1.x86_64.rpm
+zlib-devel-1.2.12-2.cm1.x86_64.rpm
 zstd-1.4.9-1.cm1.x86_64.rpm
 zstd-debuginfo-1.4.9-1.cm1.x86_64.rpm
 zstd-devel-1.4.9-1.cm1.x86_64.rpm


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Use upstream patches to fix CVE-2022-37434 in the `zlib` package.

The upstream commits used are as follows: madler/zlib@eff308af425b67093bab25f80f1ae950166bece1 (original fix), madler/zlib@1eb7682f845ac9e9bf9ae35bbfb3bad5dacbd91d (fixes [segfaults](https://github.com/madler/zlib/commit/eff308af425b67093bab25f80f1ae950166bece1#commitcomment-80589094) caused by original fix)

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- `zlib`: Add upstream patches for CVE-2022-37434
- `zlib`: Fix packaged license- actual license is contained within README
- `zlib`: License verified

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2022-37434

###### Test Methodology
- Check and non-check buddy builds outside toolchain pass
- Full toolchain build succeeds
