### PR TITLE
Update cloud-hypervisor to v26.0 and rust to v1.62.1

### DIFF
--- a/SPECS/cloud-hypervisor/cloud-hypervisor.signatures.json
+++ b/SPECS/cloud-hypervisor/cloud-hypervisor.signatures.json
@@ -1,6 +1,7 @@
 {
  "Signatures": {
-  "cloud-hypervisor-22.0-cargo.tar.gz": "550e2e2ad6c64ae7fa4786582c2357993cfad1f205566f6c80bcef7888cbd702",
-  "cloud-hypervisor-22.0.tar.gz": "5c5440435f78d4acdbb3ea91abe17d6704da6c18b6f52fe77f15835cfc60d17a"
+  "cloud-hypervisor-26.0-cargo.tar.gz": "2f5898a223104409aa764aebb3357af53669d29cc3587e72a96937efeb1c6654",
+  "cloud-hypervisor-26.0.tar.gz": "3acd6b2e1c3025b56108d61e478160e3a4dde668ada659f77eae3113e687fff8",
+  "config.toml": "5cd23bddef9b66cb66fb3a31b9b803fa415b8f3cc6a25564a6dc380ed2629c47"
  }
 }

--- a/SPECS/cloud-hypervisor/cloud-hypervisor.spec
+++ b/SPECS/cloud-hypervisor/cloud-hypervisor.spec
@@ -1,52 +1,170 @@
-Summary:        A Rust-VMM based cloud hypervisor from Intel
+%define using_rustup 0
+%define using_musl_libc 0
+%define using_vendored_crates 1
+
+Summary:        Cloud Hypervisor is an open source Virtual Machine Monitor (VMM) that runs on top of KVM.
 Name:           cloud-hypervisor
-Version:        22.0
+Version:        26.0
 Release:        1%{?dist}
-License:        ASL 2.0 or BSD
+License:        ASL 2.0 or BSD-3-clause
 URL:            https://github.com/cloud-hypervisor/cloud-hypervisor
-Group:          Development/Tools
+Group:          Applications/System
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
-Source0:       %{url}/archive/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
+Source0:        https://github.com/cloud-hypervisor/cloud-hypervisor/archive/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
+%if 0%{?using_vendored_crates}
 # Note: the %%{name}-%%{version}-cargo.tar.gz file contains a cache created by capturing the contents downloaded into $CARGO_HOME.
 # To update the cache run:
 #   [repo_root]/toolkit/scripts/build_cargo_cache.sh %%{name}-%%{version}.tar.gz
 Source1:        %{name}-%{version}-cargo.tar.gz
+Source2:        config.toml
+%endif
+
 BuildRequires:  binutils
 BuildRequires:  gcc
 BuildRequires:  git
 BuildRequires:  glibc-devel
-BuildRequires:  rust
-ExclusiveArch:  x86_64
+BuildRequires:  openssl-devel
+
+%if ! 0%{?using_rustup}
+BuildRequires:  rust >= 1.60.0
+BuildRequires:  cargo >= 1.60.0
+%endif
+
+Requires: bash
+Requires: glibc
+Requires: libgcc
+Requires: libcap
+
+ExclusiveArch:  x86_64 aarch64
+
+%ifarch x86_64
+%define rust_def_target x86_64-unknown-linux-gnu
+%define cargo_pkg_feature_opts --no-default-features --features "common,mshv,kvm"
+%endif
+%ifarch aarch64
+%define rust_def_target aarch64-unknown-linux-gnu
+%define cargo_pkg_feature_opts --all
+%endif
+
+%if 0%{?using_musl_libc}
+%ifarch x86_64
+%define rust_musl_target x86_64-unknown-linux-musl
+%endif
+%ifarch aarch64
+%define rust_musl_target aarch64-unknown-linux-musl
+%endif
+%endif
+
+%if 0%{?using_vendored_crates}
+%define cargo_offline --offline
+%endif
 
 %description
-A Rust-VMM based cloud hypervisor from Intel.
+Cloud Hypervisor is an open source Virtual Machine Monitor (VMM) that runs on top of KVM. The project focuses on exclusively running modern, cloud workloads, on top of a limited set of hardware architectures and platforms. Cloud workloads refers to those that are usually run by customers inside a cloud provider. For our purposes this means modern Linux* distributions with most I/O handled by paravirtualised devices (i.e. virtio), no requirement for legacy devices and recent CPUs and KVM.
 
 %prep
-# Setup .cargo directory
-mkdir -p $HOME
-pushd $HOME
-tar xf %{SOURCE1} --no-same-owner
-popd
-%setup -q
 
-%build
-cargo build --release
+%setup -q
+%if 0%{?using_vendored_crates}
+tar xf %{SOURCE1}
+mkdir -p .cargo
+cp %{SOURCE2} .cargo/
+%endif
 
 %install
+rm -rf %{buildroot}
 install -d %{buildroot}%{_bindir}
-install -D -m755 target/release/ch-remote %{buildroot}%{_bindir}
-install -D -m755 target/release/cloud-hypervisor %{buildroot}%{_bindir}
+install -D -m755  ./target/%{rust_def_target}/release/cloud-hypervisor %{buildroot}%{_bindir}
+install -D -m755  ./target/%{rust_def_target}/release/ch-remote %{buildroot}%{_bindir}
 install -d %{buildroot}%{_libdir}
 install -d %{buildroot}%{_libdir}/cloud-hypervisor
+install -D -m755 target/%{rust_def_target}/release/vhost_user_block %{buildroot}%{_libdir}/cloud-hypervisor
+install -D -m755 target/%{rust_def_target}/release/vhost_user_net %{buildroot}%{_libdir}/cloud-hypervisor
+
+%if 0%{?using_musl_libc}
+install -d %{buildroot}%{_libdir}/cloud-hypervisor/static
+install -D -m755 target/%{rust_musl_target}/release/cloud-hypervisor %{buildroot}%{_libdir}/cloud-hypervisor/static
+install -D -m755 target/%{rust_musl_target}/release/vhost_user_block %{buildroot}%{_libdir}/cloud-hypervisor/static
+install -D -m755 target/%{rust_musl_target}/release/vhost_user_net %{buildroot}%{_libdir}/cloud-hypervisor/static
+install -D -m755 target/%{rust_musl_target}/release/ch-remote %{buildroot}%{_libdir}/cloud-hypervisor/static
+%endif
+
+
+%build
+cargo_version=$(cargo --version)
+if [[ $? -ne 0 ]]; then
+	echo "Cargo not found, please install cargo. exiting"
+	exit 0
+fi
+
+%if 0%{?using_rustup}
+which rustup
+if [[ $? -ne 0 ]]; then
+	echo "Rustup not found please install rustup #curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh"
+fi
+%endif
+
+echo ${cargo_version}
+
+%if 0%{?using_rustup}
+rustup target list --installed | grep x86_64-unknown-linux-gnu
+if [[ $? -ne 0 ]]; then
+         echo "Target  x86_64-unknown-linux-gnu not found, please install(#rustup target add x86_64-unknown-linux-gnu). exiting"
+fi
+	%if 0%{?using_musl_libc}
+rustup target list --installed | grep x86_64-unknown-linux-musl
+if [[ $? -ne 0 ]]; then
+         echo "Target  x86_64-unknown-linux-musl not found, please install(#rustup target add x86_64-unknown-linux-musl). exiting"
+fi
+	%endif
+%endif
+
+%if 0%{?using_vendored_crates}
+# For vendored build, prepend this so openssl-sys doesn't trigger full OpenSSL build
+export OPENSSL_NO_VENDOR=1
+%endif
+cargo build --release --target=%{rust_def_target} %{cargo_pkg_feature_opts} %{cargo_offline}
+cargo build --release --target=%{rust_def_target} --package vhost_user_net %{cargo_offline}
+cargo build --release --target=%{rust_def_target} --package vhost_user_block %{cargo_offline}
+%if 0%{?using_musl_libc}
+cargo build --release --target=%{rust_musl_target} %{cargo_pkg_feature_opts} %{cargo_offline}
+cargo build --release --target=%{rust_musl_target} --package vhost_user_net %{cargo_offline}
+cargo build --release --target=%{rust_musl_target} --package vhost_user_block %{cargo_offline}
+%endif
+
+
+%clean
+rm -rf %{buildroot}
 
 %files
-%defattr(-,root,root)
+%defattr(-,root,root,-)
+%{_bindir}/ch-remote
+%caps(cap_net_admin=ep) %{_bindir}/cloud-hypervisor
+%{_libdir}/cloud-hypervisor/vhost_user_block
+%caps(cap_net_admin=ep) %{_libdir}/cloud-hypervisor/vhost_user_net
+%if 0%{?using_musl_libc}
+%{_libdir}/cloud-hypervisor/static/ch-remote
+%caps(cap_net_admim=ep) %{_libdir}/cloud-hypervisor/static/cloud-hypervisor
+%{_libdir}/cloud-hypervisor/static/vhost_user_block
+%caps(cap_net_admin=ep) %{_libdir}/cloud-hypervisor/static/vhost_user_net
+%endif
 %license LICENSE-APACHE
-%{_bindir}/*
-%exclude %{_libdir}/debug
+%license LICENSE-BSD-3-Clause
+
 
 %changelog
+* Thu Aug 18 2022 Chris Co <chrco@microsoft.com> - 26.0-1
+- anbelski@linux.microsoft.com, 26.0-1 - Pull release 26.0 for Mariner from upstream
+- anbelski@linux.microsoft.com, 23.1-0 - Initial import 23.1 for Mariner from upstream
+- robert.bradford@intel.com, 23.0-0 - Update to 23.0
+- robert.bradford@intel.com, 22.0-0 - Update to 22.0
+- robert.bradford@intel.com, 21.0-0 - Update to 21.0
+- sebastien.boeuf@intel.com, 20.0-0 - Update to 20.0
+- fabiano.fidencio@intel.com, 19.0-0 - Update to 19.0
+- muislam@microsoft.com, 15.0-0 - Update version to 15.0
+- muislam@microsoft.com, 0.8.0-0 - Initial version
+
 * Wed Mar 09 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 22.0-1
 - Updating to version 22.0 to build with 'rust' 1.59.0.
 

--- a/SPECS/cloud-hypervisor/cloud-hypervisor.spec
+++ b/SPECS/cloud-hypervisor/cloud-hypervisor.spec
@@ -6,11 +6,11 @@ Summary:        Cloud Hypervisor is an open source Virtual Machine Monitor (VMM)
 Name:           cloud-hypervisor
 Version:        26.0
 Release:        1%{?dist}
-License:        ASL 2.0 or BSD-3-clause
-URL:            https://github.com/cloud-hypervisor/cloud-hypervisor
-Group:          Applications/System
+License:        ASL 2.0 OR BSD-3-clause
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
+Group:          Applications/System
+URL:            https://github.com/cloud-hypervisor/cloud-hypervisor
 Source0:        https://github.com/cloud-hypervisor/cloud-hypervisor/archive/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
 %if 0%{?using_vendored_crates}
 # Note: the %%{name}-%%{version}-cargo.tar.gz file contains a cache created by capturing the contents downloaded into $CARGO_HOME.
@@ -36,7 +36,7 @@ Requires: glibc
 Requires: libgcc
 Requires: libcap
 
-ExclusiveArch:  x86_64 aarch64
+ExclusiveArch:  x86_64
 
 %ifarch x86_64
 %define rust_def_target x86_64-unknown-linux-gnu
@@ -73,7 +73,6 @@ cp %{SOURCE2} .cargo/
 %endif
 
 %install
-rm -rf %{buildroot}
 install -d %{buildroot}%{_bindir}
 install -D -m755  ./target/%{rust_def_target}/release/cloud-hypervisor %{buildroot}%{_bindir}
 install -D -m755  ./target/%{rust_def_target}/release/ch-remote %{buildroot}%{_bindir}
@@ -133,10 +132,6 @@ cargo build --release --target=%{rust_musl_target} --package vhost_user_net %{ca
 cargo build --release --target=%{rust_musl_target} --package vhost_user_block %{cargo_offline}
 %endif
 
-
-%clean
-rm -rf %{buildroot}
-
 %files
 %defattr(-,root,root,-)
 %{_bindir}/ch-remote
@@ -151,7 +146,6 @@ rm -rf %{buildroot}
 %endif
 %license LICENSE-APACHE
 %license LICENSE-BSD-3-Clause
-
 
 %changelog
 * Thu Aug 18 2022 Chris Co <chrco@microsoft.com> - 26.0-1

--- a/SPECS/cloud-hypervisor/config.toml
+++ b/SPECS/cloud-hypervisor/config.toml
@@ -1,0 +1,41 @@
+
+[source.crates-io]
+replace-with = "vendored-sources"
+
+[source."https://github.com/cloud-hypervisor/kvm-bindings"]
+git = "https://github.com/cloud-hypervisor/kvm-bindings"
+branch = "ch-v0.5.0-tdx"
+replace-with = "vendored-sources"
+
+[source."https://github.com/cloud-hypervisor/versionize_derive"]
+git = "https://github.com/cloud-hypervisor/versionize_derive"
+branch = "ch"
+replace-with = "vendored-sources"
+
+[source."https://github.com/firecracker-microvm/micro-http"]
+git = "https://github.com/firecracker-microvm/micro-http"
+branch = "main"
+replace-with = "vendored-sources"
+
+[source."https://github.com/rust-vmm/kvm-ioctls"]
+git = "https://github.com/rust-vmm/kvm-ioctls"
+branch = "main"
+replace-with = "vendored-sources"
+
+[source."https://github.com/rust-vmm/mshv"]
+git = "https://github.com/rust-vmm/mshv"
+branch = "main"
+replace-with = "vendored-sources"
+
+[source."https://github.com/rust-vmm/vfio"]
+git = "https://github.com/rust-vmm/vfio"
+branch = "main"
+replace-with = "vendored-sources"
+
+[source."https://github.com/rust-vmm/vm-fdt"]
+git = "https://github.com/rust-vmm/vm-fdt"
+branch = "main"
+replace-with = "vendored-sources"
+
+[source.vendored-sources]
+directory = "vendor"

--- a/SPECS/rust/rust.signatures.json
+++ b/SPECS/rust/rust.signatures.json
@@ -1,12 +1,12 @@
 {
  "Signatures": {
-  "cargo-1.58.0-aarch64-unknown-linux-gnu.tar.gz": "68e2e7493af55c5792636c2b2b0b497b1e43b12eb2e91da71e92426701884c24",
-  "cargo-1.58.0-x86_64-unknown-linux-gnu.tar.gz": "940aa91ad2de39c18749e8d789d88846de2debbcf6207247225b42c6c3bf731a",
-  "rust-1.59.0-cargo.tar.gz": "8d2076b86d6cafe4181bf0738cc52e4490c5c0bcffffd86c087dfc710acae198",
-  "rust-std-1.58.0-aarch64-unknown-linux-gnu.tar.gz": "3a1283a2dce7abf2816dc70d622215f5769c416abf3e94dd94dd6a5d1109f506",
-  "rust-std-1.58.0-x86_64-unknown-linux-gnu.tar.gz": "0517b0cb57a311bbe1997e9b87fc6bae1f9e1eadec4f7d97374740f17f890842",
-  "rustc-1.58.0-aarch64-unknown-linux-gnu.tar.gz": "34d8fdaec504efe6e9448ad5a118ac0e7ef3bd9a8f6c49ea68204f2f9a9dae4e",
-  "rustc-1.58.0-x86_64-unknown-linux-gnu.tar.gz": "94e3a5e6dca2ae2516d6496568b6791b9501ac500c3e5faf6f42baaead41d404",
-  "rustc-1.59.0-src.tar.xz": "375996ead731cab2203ec10a66a3c4568ab6997d7e5d3ae597658164fe27be3d"
+  "cargo-1.61.0-aarch64-unknown-linux-gnu.tar.gz": "0d31d5a050e41f8b56c920527538886db96c09824a8ff619d0fc4c410dbf7e5a",
+  "cargo-1.61.0-x86_64-unknown-linux-gnu.tar.gz": "c6e108e13ef5e08e71d70685861590f8683090368cab1f4eacfe97677333b2c7",
+  "rust-1.62.1-src-cargo.tar.gz": "dd1e50effae87bd784daaf6ac9e1326c27c300ccabae4c73551d18e56456c0bb",
+  "rust-std-1.61.0-aarch64-unknown-linux-gnu.tar.gz": "2cc8cfc5cc60e0c6a473bb609b54251c561d8d12a986fda8a7ca86dc1d36b4df",
+  "rust-std-1.61.0-x86_64-unknown-linux-gnu.tar.gz": "27383bf7b39d2ff1298fc0dfcd70ac70e1c01e70d7d0c60a2002c266a25b2015",
+  "rustc-1.61.0-aarch64-unknown-linux-gnu.tar.gz": "cec2afb78b5f0d3303cd6629232dcbd9f9dfa0d5e99b8ca0a95b77d570b1d591",
+  "rustc-1.61.0-x86_64-unknown-linux-gnu.tar.gz": "708a8f8b9ebda188e133695a12c96ef7875723bb3ad2ed2a2b6a20ebfcd57ff3",
+  "rustc-1.62.1-src.tar.xz": "02066a93c2f6596cc046a897d5716c86e3607c1cd0f54db9a867ae8c8265072e"
  }
 }

--- a/SPECS/rust/rust.spec
+++ b/SPECS/rust/rust.spec
@@ -26,7 +26,6 @@ Source4:        https://static.rust-lang.org/dist/%{release_date}/rust-std-%{sta
 Source5:        https://static.rust-lang.org/dist/%{release_date}/cargo-%{stage0_version}-aarch64-unknown-linux-gnu.tar.gz
 Source6:        https://static.rust-lang.org/dist/%{release_date}/rustc-%{stage0_version}-aarch64-unknown-linux-gnu.tar.gz
 Source7:        https://static.rust-lang.org/dist/%{release_date}/rust-std-%{stage0_version}-aarch64-unknown-linux-gnu.tar.gz
-
 BuildRequires:  binutils
 BuildRequires:  cmake
 BuildRequires:  curl-devel

--- a/SPECS/rust/rust.spec
+++ b/SPECS/rust/rust.spec
@@ -3,12 +3,12 @@
 
 # Release date and version of stage 0 compiler can be found in "src/stage0.txt" inside the extracted "Source0".
 # Look for "date:" and "rustc:".
-%define release_date 2022-01-13
-%define stage0_version 1.58.0
+%define release_date 2022-05-19
+%define stage0_version 1.61.0
 
 Summary:        Rust Programming Language
 Name:           rust
-Version:        1.59.0
+Version:        1.62.1
 Release:        1%{?dist}
 License:        ASL 2.0 AND MIT
 Vendor:         Microsoft Corporation
@@ -19,7 +19,7 @@ Source0:        https://static.rust-lang.org/dist/rustc-%{version}-src.tar.xz
 # Note: the rust-%%{version}-cargo.tar.gz file contains a cache created by capturing the contents downloaded into $CARGO_HOME.
 # To update the cache run:
 #   [repo_root]/toolkit/scripts/build_cargo_cache.sh rustc-%%{version}-src.tar.gz
-Source1:        %{name}-%{version}-cargo.tar.gz
+Source1:        %{name}-%{version}-src-cargo.tar.gz
 Source2:        https://static.rust-lang.org/dist/%{release_date}/cargo-%{stage0_version}-x86_64-unknown-linux-gnu.tar.gz
 Source3:        https://static.rust-lang.org/dist/%{release_date}/rustc-%{stage0_version}-x86_64-unknown-linux-gnu.tar.gz
 Source4:        https://static.rust-lang.org/dist/%{release_date}/rust-std-%{stage0_version}-x86_64-unknown-linux-gnu.tar.gz
@@ -120,6 +120,9 @@ rm %{buildroot}%{_docdir}/%{name}/*.old
 %{_sysconfdir}/bash_completion.d/cargo
 
 %changelog
+* Thu Aug 18 2022 Chris Co <chrco@microsoft.com> - 1.62.1-1
+- Updating to version 1.62.1
+
 * Mon Mar 07 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.59.0-1
 - Updating to version 1.59.0 to fix CVE-2022-21658.
 - Updating build instructions to fix tests.

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -1547,8 +1547,8 @@
         "type": "other",
         "other": {
           "name": "cloud-hypervisor",
-          "version": "22.0",
-          "downloadUrl": "https://github.com/cloud-hypervisor/cloud-hypervisor/archive/v22.0.tar.gz"
+          "version": "26.0",
+          "downloadUrl": "https://github.com/cloud-hypervisor/cloud-hypervisor/archive/v26.0.tar.gz"
         }
       }
     },

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -24515,8 +24515,8 @@
         "type": "other",
         "other": {
           "name": "rust",
-          "version": "1.59.0",
-          "downloadUrl": "https://static.rust-lang.org/dist/rustc-1.59.0-src.tar.xz"
+          "version": "1.62.1",
+          "downloadUrl": "https://static.rust-lang.org/dist/rustc-1.62.1-src.tar.xz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
This change upgrades cloud-hypervisor package to v26.0. This version of cloud-hypervisor requires a higher version of rust, so this change set also updates rust to v1.62.1

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Update cloud-hypervisor to v26.0
- Update rust to v1.62.1
- Update cgmanifest entries for rust and cloud-hypervisor

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->

###### Links to CVEs  <!-- optional -->

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
Local build
