### PR TITLE
Revert "update cloud-init service to add sysinit.target dependency"

### DIFF
--- a/SPECS/cloud-init/add-mariner-distro-support.patch
+++ b/SPECS/cloud-init/add-mariner-distro-support.patch
@@ -359,9 +359,10 @@ index 6951a0e3..411065f9 100644
     # Other config here will be given to the distro class and/or path classes
     paths:
        cloud_dir: /var/lib/cloud/
-diff -ruN a/systemd/cloud-init.service.tmpl b/systemd/cloud-init.service.tmpl
---- a/systemd/cloud-init.service.tmpl	2022-05-18 08:23:24.000000000 -0700
-+++ b/systemd/cloud-init.service.tmpl	2022-08-03 21:51:14.862040213 -0700
+diff --git a/systemd/cloud-init.service.tmpl b/systemd/cloud-init.service.tmpl
+index c170aef7..20ff1daa 100644
+--- a/systemd/cloud-init.service.tmpl
++++ b/systemd/cloud-init.service.tmpl
 @@ -1,7 +1,7 @@
  ## template:jinja
  [Unit]
@@ -371,16 +372,6 @@ diff -ruN a/systemd/cloud-init.service.tmpl b/systemd/cloud-init.service.tmpl
  DefaultDependencies=no
  {% endif %}
  Wants=cloud-init-local.service
-@@ -26,8 +26,8 @@
- Before=network-online.target
- Before=sshd-keygen.service
- Before=sshd.service
--{% if variant in ["ubuntu", "unknown", "debian"] %}
- Before=sysinit.target
-+{% if variant in ["ubuntu", "unknown", "debian"] %}
- Before=shutdown.target
- Conflicts=shutdown.target
- {% endif %}
 diff --git a/templates/hosts.mariner.tmpl b/templates/hosts.mariner.tmpl
 new file mode 100644
 index 00000000..2e956382

--- a/SPECS/cloud-init/cloud-init.spec
+++ b/SPECS/cloud-init/cloud-init.spec
@@ -1,7 +1,7 @@
 Summary:        Cloud instance init scripts
 Name:           cloud-init
 Version:        22.2
-Release:        6%{?dist}
+Release:        5%{?dist}
 License:        GPLv3
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -146,9 +146,6 @@ make check %{?_smp_mflags}
 %config(noreplace) %{_sysconfdir}/cloud/cloud.cfg.d/10-azure-kvp.cfg
 
 %changelog
-* Wed Aug 03 2022 Minghe Ren <mingheren@microsoft.com> - 22.2-6
-- Update add-mariner-distro-support patch to add sysinit.target dependency
-
 * Tue Jul 12 2022 Muhammad Falak <mwani@microsoft.com> - 22.2-5
 - Install check requirements from `test-requirements.txt` to enable ptest
 


### PR DESCRIPTION
Reverts microsoft/CBL-Mariner#3485 trying to fix failed smoke tests on mairner 2.0.
