### PR TITLE
Enable package repo generation and network config for non-kickstart like ISO installation

### DIFF
--- a/toolkit/docs/formats/imageconfig.md
+++ b/toolkit/docs/formats/imageconfig.md
@@ -214,7 +214,7 @@ A sample PreInstallScripts entry pointing to two install scripts where one has i
 
 ### Networks
 
-Kickstart style unattended installations tends to perform network configurations during the installation process to set IP address, configure the hostname, DNS etc. Thus, the `Networks` entry is added to enable the users to specify the network config parameters. Currently, the Mariner tooling only supports a subset of the kickstart network command options: `bootproto`, `gateway`, `ip`, `net mask`, `DNS` and `device`. Hostname can be configured using the `Hostname` entry of the image config. 
+The `Networks` entry is added to enable the users to specify the network configuration parameters to enable users to set IP address, configure the hostname, DNS etc. Currently, the Mariner tooling only supports a subset of the kickstart network command options: `bootproto`, `gateway`, `ip`, `net mask`, `DNS` and `device`. Hostname can be configured using the `Hostname` entry of the image config. 
 
 A sample Networks entry pointing to one network configuration:
 ``` json

--- a/toolkit/tools/imagegen/configuration/networkconfig.go
+++ b/toolkit/tools/imagegen/configuration/networkconfig.go
@@ -75,7 +75,7 @@ func (n *Network) IsValid() (err error) {
 	return
 }
 
-// ConfigureNetwork performs network configuration during the kickstart unattended installation process
+// ConfigureNetwork performs network configuration during the installation process
 func ConfigureNetwork(installChroot *safechroot.Chroot, systemConfig SystemConfig) (err error) {
 	const squashErrors = false
 	var dnsUpdate bool

--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -388,13 +388,13 @@ func PopulateInstallRoot(installChroot *safechroot.Chroot, packagesToInstall []s
 	installRoot := filepath.Join(rootMountPoint, installChroot.RootDir())
 
 	if len(config.PackageRepos) > 0 {
-		if config.IsKickStartBoot && config.IsIsoInstall {
+		if config.IsIsoInstall {
 			err = configuration.UpdatePackageRepo(installChroot, config)
 			if err != nil {
 				return
 			}
 		} else {
-			return fmt.Errorf("custom package repos should not be specified unless performing kickstart ISO installation")
+			return fmt.Errorf("custom package repos should not be specified unless performing ISO installation")
 		}
 	}
 
@@ -497,11 +497,9 @@ func PopulateInstallRoot(installChroot *safechroot.Chroot, packagesToInstall []s
 		generateContainerManifests(installChroot)
 	}
 
-	if config.IsKickStartBoot {
-		err = configuration.ConfigureNetwork(installChroot, config)
-		if err != nil {
-			return
-		}
+	err = configuration.ConfigureNetwork(installChroot, config)
+	if err != nil {
+		return
 	}
 
 	// Run post-install scripts from within the installroot chroot


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?

- Enable performing adding custom package repo and network configuration for normal ISO installation instead of gating these behaviors for kickstart-like installation only


###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
NO


###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local Image Build
