### PR TITLE
Add an additional chrony config with updated version

### DIFF
--- a/toolkit/imageconfigs/additionalconfigs/chrony.cfg
+++ b/toolkit/imageconfigs/additionalconfigs/chrony.cfg
@@ -1,0 +1,53 @@
+# CLOUD_IMG: This file was created/modified by the Cloud Image build process
+# Welcome to the chrony configuration file. See chrony.conf(5) for more
+# information about usable directives.
+# Include configuration files found in /etc/chrony.conf.d.
+confdir /etc/chrony.conf.d
+# This will use (up to):
+# - 4 sources from ntp.ubuntu.com which some are ipv6 enabled
+# - 2 sources from 2.ubuntu.pool.ntp.org which is ipv6 enabled as well
+# - 1 source from [01].ubuntu.pool.ntp.org each (ipv4 only atm)
+# This means by default, up to 6 dual-stack and up to 2 additional IPv4-only
+# sources will be used.
+# At the same time it retains some protection against one of the entries being
+# down (compare to just using one of the lines). See (LP: #1754358) for the
+# discussion.
+#
+# About using servers from the NTP Pool Project in general see (LP: #104525).
+# Approved by Ubuntu Technical Board on 2011-02-08.
+# See http://www.pool.ntp.org/join.html for more information.
+#pool ntp.ubuntu.com        iburst maxsources 4
+#pool 0.ubuntu.pool.ntp.org iburst maxsources 1
+#pool 1.ubuntu.pool.ntp.org iburst maxsources 1
+#pool 2.ubuntu.pool.ntp.org iburst maxsources 2
+# Use time sources from DHCP.
+sourcedir /run/chrony-dhcp
+# This directive specify the location of the file containing ID/key pairs for
+# NTP authentication.
+keyfile /etc/chrony.keys
+# This directive specify the file into which chronyd will store the rate
+# information.
+driftfile /var/lib/chrony/drift
+# Save NTS keys and cookies.
+ntsdumpdir /var/lib/chrony
+# Uncomment the following line to turn logging on.
+#log tracking measurements statistics
+# Log files location.
+logdir /var/log/chrony
+# Stop bad estimates upsetting machine clock.
+maxupdateskew 100.0
+# This directive enables kernel synchronisation (every 11 minutes) of the
+# real-time clock. Note that it can’t be used along with the 'rtcfile' directive.
+rtcsync
+# Step the system clock instead of slewing it if the adjustment is larger than
+# one second, but only in the first three clock updates.
+makestep 1 3
+# Get TAI-UTC offset and leap seconds from the system tz database.
+# This directive must be commented out when using time sources serving
+# leap-smeared time.
+leapsectz right/UTC
+# Azure hosts are synchronized to internal Microsoft time servers
+# that take their time from Microsoft-owned Stratum 1 devices.
+# The Hyper-V drivers surface this time source as a PTP-based
+# time source in the guest. This configures chrony to use it.
+refclock PHC /dev/ptp_hyperv poll 3 dpoll -2 offset 0

--- a/toolkit/imageconfigs/marketplace-gen1.json
+++ b/toolkit/imageconfigs/marketplace-gen1.json
@@ -58,7 +58,8 @@
                 "packagelists/azurevm-packages.json"
             ],
             "AdditionalFiles": {
-                "additionalconfigs/cloud-init.cfg": "/etc/cloud/cloud.cfg"
+                "additionalconfigs/cloud-init.cfg": "/etc/cloud/cloud.cfg",
+                "additionalconfigs/chrony.cfg": "/etc/chrony.conf"
             },
             "PostInstallScripts": [
                 {

--- a/toolkit/imageconfigs/marketplace-gen2-aarch64.json
+++ b/toolkit/imageconfigs/marketplace-gen2-aarch64.json
@@ -60,7 +60,8 @@
                 "packagelists/azurevm-packages.json"
             ],
             "AdditionalFiles": {
-                "additionalconfigs/cloud-init.cfg": "/etc/cloud/cloud.cfg"
+                "additionalconfigs/cloud-init.cfg": "/etc/cloud/cloud.cfg",
+                "additionalconfigs/chrony.cfg": "/etc/chrony.conf"
             },
             "PostInstallScripts": [
                 {

--- a/toolkit/imageconfigs/marketplace-gen2.json
+++ b/toolkit/imageconfigs/marketplace-gen2.json
@@ -60,7 +60,8 @@
                 "packagelists/azurevm-packages.json"
             ],
             "AdditionalFiles": {
-                "additionalconfigs/cloud-init.cfg": "/etc/cloud/cloud.cfg"
+                "additionalconfigs/cloud-init.cfg": "/etc/cloud/cloud.cfg",
+                "additionalconfigs/chrony.cfg": "/etc/chrony.conf"
             },
             "PostInstallScripts": [
                 {


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Add a new crony config into additional configs folder and start using the new configurations in gen1, gen2 and gen2 aarch64. The new configurations include the [new configurations](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/time-sync) for chrony starting from ubuntu 19.10.

###### Change Log  <!-- REQUIRED -->
- Change marketplace jsons to start using new chrony config

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Associated issues  <!-- optional -->
- [#Task](https://microsoft.visualstudio.com/OS/_sprints/taskboard/Mariner%20Platform/OS/2208?workitem=39161704)

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Created 3 Mariner virtual machines (gen1, gen2 and aarch64) and run chrony commands, compared the timing results with ubuntu machine.
