### PR TITLE
libsemanage: Do not ignore /root.

### DIFF
--- a/SPECS/libsemanage/libsemanage.signatures.json
+++ b/SPECS/libsemanage/libsemanage.signatures.json
@@ -1,6 +1,6 @@
 {
  "Signatures": {
   "libsemanage-3.2.tar.gz": "d722a55ca4fe2d4e2b30527720db657e6238b28079e69e2e4affeb8e733ee511",
-  "semanage.conf": "68d403bca3d7bd2e90d00cf44622dc0598817197994812e06367df0c239b1204"
+  "semanage.conf": "ae4a61523757b63ff456c90c75c325db715dd69289943cedb1f3a2f242b4361b"
  }
 }

--- a/SPECS/libsemanage/libsemanage.spec
+++ b/SPECS/libsemanage/libsemanage.spec
@@ -53,9 +53,9 @@ needed for developing applications that manipulate binary policies.
 
 %package python3
 Summary:        semanage python 3 bindings for libsemanage
-Provides:       python3-%{name} = %{version}-%{release}
 Requires:       %{name}%{?_isa} = %{version}-%{release}
 Requires:       libselinux-python3 >= %{libselinuxver}
+Provides:       python3-%{name} = %{version}-%{release}
 
 %description python3
 The libsemanage-python3 package contains the python 3 bindings for developing
@@ -110,7 +110,7 @@ ln -sf  %{_libdir}/libsemanage.so.2 %{buildroot}/%{_libdir}/libsemanage.so
 %changelog
 * Wed Aug 10 2022 Chris PeBenito <chpebeni@microsoft.com> - 3.2-2
 - Do not ignore /root for genhomedircon, otherwise it will not
-  get correct labeling.
+- get correct labeling.
 
 * Fri Aug 13 2021 Thomas Crain <thcrain@microsoft.com> - 3.2-1
 - Upgrade to latest upstream version and rebase patch

--- a/SPECS/libsemanage/libsemanage.spec
+++ b/SPECS/libsemanage/libsemanage.spec
@@ -3,7 +3,7 @@
 Summary:        SELinux binary policy manipulation library
 Name:           libsemanage
 Version:        3.2
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        LGPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -108,6 +108,10 @@ ln -sf  %{_libdir}/libsemanage.so.2 %{buildroot}/%{_libdir}/libsemanage.so
 %{_libexecdir}/selinux/semanage_migrate_store
 
 %changelog
+* Wed Aug 10 2022 Chris PeBenito <chpebeni@microsoft.com> - 3.2-2
+- Do not ignore /root for genhomedircon, otherwise it will not
+  get correct labeling.
+
 * Fri Aug 13 2021 Thomas Crain <thcrain@microsoft.com> - 3.2-1
 - Upgrade to latest upstream version and rebase patch
 - Add -fno-semantic-interposition to CFLAGS as recommended by upstream

--- a/SPECS/libsemanage/semanage.conf
+++ b/SPECS/libsemanage/semanage.conf
@@ -49,7 +49,6 @@ expand-check=0
 usepasswd=False
 bzip-small=true
 bzip-blocksize=5
-ignoredirs=/root
 
 [sefcontext_compile]
 path = /usr/sbin/sefcontext_compile


### PR DESCRIPTION
This will cause /root to get inappropriate default_t labels.

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Change semanage.conf not to ignore `/root`. With this ignored, /root gets the wrong SELinux labels.

###### Change Log  <!-- REQUIRED -->
- Remove ignoredirs from semanage.conf.

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: 228350
- Local builds
