### PR TITLE
Add `$schema` to `cgmanifest.json`

### DIFF
--- a/.github/workflows/cgmanifest.json
+++ b/.github/workflows/cgmanifest.json
@@ -1,14 +1,15 @@
 {
-    "Registrations": [
-      {
-        "Component": {
-          "Type": "git",
-          "Git": {
-            "RepositoryUrl": "https://github.com/rpm-software-management/spec-cleaner",
-            "CommitHash": "f24cd83e5e2775b061696d4fd7fcf47f63514b50"
-          }
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
+    {
+      "Component": {
+        "Type": "git",
+        "Git": {
+          "RepositoryUrl": "https://github.com/rpm-software-management/spec-cleaner",
+          "CommitHash": "f24cd83e5e2775b061696d4fd7fcf47f63514b50"
         }
       }
-    ],
-    "Version": 1
-  }
+    }
+  ],
+  "Version": 1
+}

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
   "Registrations": [
     {
       "component": {

--- a/toolkit/scripts/toolchain/cgmanifest.json
+++ b/toolkit/scripts/toolchain/cgmanifest.json
@@ -1,15 +1,16 @@
 {
-    "Registrations": [
-        {
-            "Component": {
-                "Type": "DockerImage",
-                "DockerImage": {
-                    "Name": "Ubuntu",
-                    "Digest": "sha256:bec5a2727be7fff3d308193cfde3491f8fba1a2ba392b7546b43a051853a341d",
-                    "Tag": "18.04"
-                }
-            }
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
+    {
+      "Component": {
+        "Type": "DockerImage",
+        "DockerImage": {
+          "Name": "Ubuntu",
+          "Digest": "sha256:bec5a2727be7fff3d308193cfde3491f8fba1a2ba392b7546b43a051853a341d",
+          "Tag": "18.04"
         }
-    ],
-    "Version": 1
+      }
+    }
+  ],
+  "Version": 1
 }

--- a/toolkit/tools/cgmanifest.json
+++ b/toolkit/tools/cgmanifest.json
@@ -1,374 +1,375 @@
 {
-    "Registrations": [
-        {
-            "Component": {
-                "Type": "Go",
-                "Go": {
-                    "Name": "github.com/alecthomas/template",
-                    "Version": "v0.0.0-20190718012654-fb15b899a751"
-                }
-            }
-        },
-        {
-            "Component": {
-                "Type": "Go",
-                "Go": {
-                    "Name": "github.com/alecthomas/units",
-                    "Version": "v0.0.0-20190924025748-f65c72e2690d"
-                }
-            }
-        },
-        {
-            "Component": {
-                "Type": "Go",
-                "Go": {
-                    "Name": "github.com/cavaliercoder/go-cpio",
-                    "Version": "v0.0.0-20180626203310-925f9528c45e"
-                }
-            }
-        },
-        {
-            "Component": {
-                "Type": "Go",
-                "Go": {
-                    "Name": "github.com/deckarep/golang-set",
-                    "Version": "v1.7.1"
-                }
-            }
-        },
-        {
-            "Component": {
-                "Type": "Go",
-                "Go": {
-                    "Name": "github.com/gdamore/tcell",
-                    "Version": "v1.3.0"
-                }
-            }
-        },
-        {
-            "Component": {
-                "Type": "Go",
-                "Go": {
-                    "Name": "github.com/klauspost/compress",
-                    "Version": "v1.10.5"
-                }
-            }
-        },
-        {
-            "Component": {
-                "Type": "Go",
-                "Go": {
-                    "Name": "github.com/klauspost/pgzip",
-                    "Version": "v1.2.3"
-                }
-            }
-        },
-        {
-            "Component": {
-                "Type": "Go",
-                "Go": {
-                    "Name": "github.com/muesli/crunchy",
-                    "Version": "v0.3.0"
-                }
-            }
-        },
-        {
-            "Component": {
-                "Type": "Go",
-                "Go": {
-                    "Name": "github.com/niemeyer/pretty",
-                    "Version": "v0.0.0-20200227124842-a10e7caefd8e"
-                }
-            }
-        },
-        {
-            "Component": {
-                "Type": "Go",
-                "Go": {
-                    "Name": "github.com/rivo/tview",
-                    "Version": "v0.0.0-20200219135020-0ba8301b415c"
-                }
-            }
-        },
-        {
-            "Component": {
-                "Type": "Go",
-                "Go": {
-                    "Name": "github.com/sirupsen/logrus",
-                    "Version": "v1.6.0"
-                }
-            }
-        },
-        {
-            "Component": {
-                "Type": "Go",
-                "Go": {
-                    "Name": "github.com/stretchr/testify",
-                    "Version": "v1.4.0"
-                }
-            }
-        },
-        {
-            "Component": {
-                "Type": "Go",
-                "Go": {
-                    "Name": "github.com/ulikunitz/xz",
-                    "Version": "v0.5.7"
-                }
-            }
-        },
-        {
-            "Component": {
-                "Type": "Go",
-                "Go": {
-                    "Name": "golang.org/x/sys",
-                    "Version": "v0.0.0-20200509044756-6aff5f38e54f"
-                }
-            }
-        },
-        {
-            "Component": {
-                "Type": "Go",
-                "Go": {
-                    "Name": "gonum.org/v1/gonum",
-                    "Version": "v0.6.2"
-                }
-            }
-        },
-        {
-            "Component": {
-                "Type": "Go",
-                "Go": {
-                    "Name": "github.com/bendahl/uinput",
-                    "Version": "v1.4.0"
-                }
-            }
-        },
-        {
-            "Component": {
-                "Type": "Go",
-                "Go": {
-                    "Name": "gopkg.in/alecthomas/kingpin.v2",
-                    "Version": "v2.2.6"
-                }
-            }
-        },
-        {
-            "Component": {
-                "Type": "Go",
-                "Go": {
-                    "Name": "gopkg.in/check.v1",
-                    "Version": "v1.0.0-20200227125254-8fa46927fb4f"
-                }
-            }
-        },
-        {
-            "Component": {
-                "Type": "Go",
-                "Go": {
-                    "Name": "github.com/DATA-DOG/go-sqlmock",
-                    "Version": "v1.3.3"
-                }
-            }
-        },
-        {
-            "Component": {
-                "Type": "Go",
-                "Go": {
-                    "Name": "github.com/ajstarks/svgo",
-                    "Version": "v0.0.0-20180226025133-644b8db467af"
-                }
-            }
-        },
-        {
-            "Component": {
-                "Type": "Go",
-                "Go": {
-                    "Name": "github.com/davecgh/go-spew",
-                    "Version": "v1.1.1"
-                }
-            }
-        },
-        {
-            "Component": {
-                "Type": "Go",
-                "Go": {
-                    "Name": "github.com/fogleman/gg",
-                    "Version": "v1.2.1-0.20190220221249-0403632d5b90"
-                }
-            }
-        },
-        {
-            "Component": {
-                "Type": "Go",
-                "Go": {
-                    "Name": "github.com/gdamore/encoding",
-                    "Version": "v1.0.0"
-                }
-            }
-        },
-        {
-            "Component": {
-                "Type": "Go",
-                "Go": {
-                    "Name": "github.com/golang/freetype",
-                    "Version": "v0.0.0-20170609003504-e2365dfdc4a0"
-                }
-            }
-        },
-        {
-            "Component": {
-                "Type": "Go",
-                "Go": {
-                    "Name": "github.com/jung-kurt/gofpdf",
-                    "Version": "v1.0.3-0.20190309125859-24315acbbda5"
-                }
-            }
-        },
-        {
-            "Component": {
-                "Type": "Go",
-                "Go": {
-                    "Name": "github.com/konsorten/go-windows-terminal-sequences",
-                    "Version": "v1.0.3"
-                }
-            }
-        },
-        {
-            "Component": {
-                "Type": "Go",
-                "Go": {
-                    "Name": "github.com/kr/pty",
-                    "Version": "v1.1.1"
-                }
-            }
-        },
-        {
-            "Component": {
-                "Type": "Go",
-                "Go": {
-                    "Name": "github.com/kr/text",
-                    "Version": "v0.1.0"
-                }
-            }
-        },
-        {
-            "Component": {
-                "Type": "Go",
-                "Go": {
-                    "Name": "github.com/lucasb-eyer/go-colorful",
-                    "Version": "v1.0.2"
-                }
-            }
-        },
-        {
-            "Component": {
-                "Type": "Go",
-                "Go": {
-                    "Name": "github.com/mattn/go-runewidth",
-                    "Version": "v0.0.4"
-                }
-            }
-        },
-        {
-            "Component": {
-                "Type": "Go",
-                "Go": {
-                    "Name": "github.com/pmezard/go-difflib",
-                    "Version": "v1.0.0"
-                }
-            }
-        },
-        {
-            "Component": {
-                "Type": "Go",
-                "Go": {
-                    "Name": "github.com/rivo/uniseg",
-                    "Version": "v0.1.0"
-                }
-            }
-        },
-        {
-            "Component": {
-                "Type": "Go",
-                "Go": {
-                    "Name": "github.com/xrash/smetrics",
-                    "Version": "v0.0.0-20170218160415-a3153f7040e9"
-                }
-            }
-        },
-        {
-            "Component": {
-                "Type": "Go",
-                "Go": {
-                    "Name": "golang.org/x/exp",
-                    "Version": "v0.0.0-20190125153040-c74c464bbbf2"
-                }
-            }
-        },
-        {
-            "Component": {
-                "Type": "Go",
-                "Go": {
-                    "Name": "golang.org/x/image",
-                    "Version": "v0.0.0-20180708004352-c73c2afc3b81"
-                }
-            }
-        },
-        {
-            "Component": {
-                "Type": "Go",
-                "Go": {
-                    "Name": "golang.org/x/text",
-                    "Version": "v0.3.2"
-                }
-            }
-        },
-        {
-            "Component": {
-                "Type": "Go",
-                "Go": {
-                    "Name": "golang.org/x/tools",
-                    "Version": "v0.0.0-20190206041539-40960b6deb8e"
-                }
-            }
-        },
-        {
-            "Component": {
-                "Type": "Go",
-                "Go": {
-                    "Name": "gonum.org/v1/netlib",
-                    "Version": "v0.0.0-20190313105609-8cb42192e0e0"
-                }
-            }
-        },
-        {
-            "Component": {
-                "Type": "Go",
-                "Go": {
-                    "Name": "gonum.org/v1/plot",
-                    "Version": "v0.0.0-20190515093506-e2840ee46a6b"
-                }
-            }
-        },
-        {
-            "Component": {
-                "Type": "Go",
-                "Go": {
-                    "Name": "gopkg.in/yaml.v2",
-                    "Version": "v2.2.2"
-                }
-            }
-        },
-        {
-            "Component": {
-                "Type": "Go",
-                "Go": {
-                    "Name": "rsc.io/pdf",
-                    "Version": "v0.1.1"
-                }
-            }
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
+    {
+      "Component": {
+        "Type": "Go",
+        "Go": {
+          "Name": "github.com/alecthomas/template",
+          "Version": "v0.0.0-20190718012654-fb15b899a751"
         }
-    ],
-    "Version": 1
+      }
+    },
+    {
+      "Component": {
+        "Type": "Go",
+        "Go": {
+          "Name": "github.com/alecthomas/units",
+          "Version": "v0.0.0-20190924025748-f65c72e2690d"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "Go",
+        "Go": {
+          "Name": "github.com/cavaliercoder/go-cpio",
+          "Version": "v0.0.0-20180626203310-925f9528c45e"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "Go",
+        "Go": {
+          "Name": "github.com/deckarep/golang-set",
+          "Version": "v1.7.1"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "Go",
+        "Go": {
+          "Name": "github.com/gdamore/tcell",
+          "Version": "v1.3.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "Go",
+        "Go": {
+          "Name": "github.com/klauspost/compress",
+          "Version": "v1.10.5"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "Go",
+        "Go": {
+          "Name": "github.com/klauspost/pgzip",
+          "Version": "v1.2.3"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "Go",
+        "Go": {
+          "Name": "github.com/muesli/crunchy",
+          "Version": "v0.3.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "Go",
+        "Go": {
+          "Name": "github.com/niemeyer/pretty",
+          "Version": "v0.0.0-20200227124842-a10e7caefd8e"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "Go",
+        "Go": {
+          "Name": "github.com/rivo/tview",
+          "Version": "v0.0.0-20200219135020-0ba8301b415c"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "Go",
+        "Go": {
+          "Name": "github.com/sirupsen/logrus",
+          "Version": "v1.6.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "Go",
+        "Go": {
+          "Name": "github.com/stretchr/testify",
+          "Version": "v1.4.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "Go",
+        "Go": {
+          "Name": "github.com/ulikunitz/xz",
+          "Version": "v0.5.7"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "Go",
+        "Go": {
+          "Name": "golang.org/x/sys",
+          "Version": "v0.0.0-20200509044756-6aff5f38e54f"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "Go",
+        "Go": {
+          "Name": "gonum.org/v1/gonum",
+          "Version": "v0.6.2"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "Go",
+        "Go": {
+          "Name": "github.com/bendahl/uinput",
+          "Version": "v1.4.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "Go",
+        "Go": {
+          "Name": "gopkg.in/alecthomas/kingpin.v2",
+          "Version": "v2.2.6"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "Go",
+        "Go": {
+          "Name": "gopkg.in/check.v1",
+          "Version": "v1.0.0-20200227125254-8fa46927fb4f"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "Go",
+        "Go": {
+          "Name": "github.com/DATA-DOG/go-sqlmock",
+          "Version": "v1.3.3"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "Go",
+        "Go": {
+          "Name": "github.com/ajstarks/svgo",
+          "Version": "v0.0.0-20180226025133-644b8db467af"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "Go",
+        "Go": {
+          "Name": "github.com/davecgh/go-spew",
+          "Version": "v1.1.1"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "Go",
+        "Go": {
+          "Name": "github.com/fogleman/gg",
+          "Version": "v1.2.1-0.20190220221249-0403632d5b90"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "Go",
+        "Go": {
+          "Name": "github.com/gdamore/encoding",
+          "Version": "v1.0.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "Go",
+        "Go": {
+          "Name": "github.com/golang/freetype",
+          "Version": "v0.0.0-20170609003504-e2365dfdc4a0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "Go",
+        "Go": {
+          "Name": "github.com/jung-kurt/gofpdf",
+          "Version": "v1.0.3-0.20190309125859-24315acbbda5"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "Go",
+        "Go": {
+          "Name": "github.com/konsorten/go-windows-terminal-sequences",
+          "Version": "v1.0.3"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "Go",
+        "Go": {
+          "Name": "github.com/kr/pty",
+          "Version": "v1.1.1"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "Go",
+        "Go": {
+          "Name": "github.com/kr/text",
+          "Version": "v0.1.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "Go",
+        "Go": {
+          "Name": "github.com/lucasb-eyer/go-colorful",
+          "Version": "v1.0.2"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "Go",
+        "Go": {
+          "Name": "github.com/mattn/go-runewidth",
+          "Version": "v0.0.4"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "Go",
+        "Go": {
+          "Name": "github.com/pmezard/go-difflib",
+          "Version": "v1.0.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "Go",
+        "Go": {
+          "Name": "github.com/rivo/uniseg",
+          "Version": "v0.1.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "Go",
+        "Go": {
+          "Name": "github.com/xrash/smetrics",
+          "Version": "v0.0.0-20170218160415-a3153f7040e9"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "Go",
+        "Go": {
+          "Name": "golang.org/x/exp",
+          "Version": "v0.0.0-20190125153040-c74c464bbbf2"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "Go",
+        "Go": {
+          "Name": "golang.org/x/image",
+          "Version": "v0.0.0-20180708004352-c73c2afc3b81"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "Go",
+        "Go": {
+          "Name": "golang.org/x/text",
+          "Version": "v0.3.2"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "Go",
+        "Go": {
+          "Name": "golang.org/x/tools",
+          "Version": "v0.0.0-20190206041539-40960b6deb8e"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "Go",
+        "Go": {
+          "Name": "gonum.org/v1/netlib",
+          "Version": "v0.0.0-20190313105609-8cb42192e0e0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "Go",
+        "Go": {
+          "Name": "gonum.org/v1/plot",
+          "Version": "v0.0.0-20190515093506-e2840ee46a6b"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "Go",
+        "Go": {
+          "Name": "gopkg.in/yaml.v2",
+          "Version": "v2.2.2"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "Go",
+        "Go": {
+          "Name": "rsc.io/pdf",
+          "Version": "v0.1.1"
+        }
+      }
+    }
+  ],
+  "Version": 1
 }


### PR DESCRIPTION
This pull request adds the JSON schema for `cgmanifest.json`.

## FAQ

### Why?

A JSON schema helps you to ensure that your `cgmanifest.json` file is valid.
JSON schema validation is a build-in feature in most modern IDEs like Visual Studio and Visual Studio Code.
Most modern IDEs also provide code-completion for JSON schemas.

### How can I validate my `cgmanifest.json` file?

Most modern IDEs like Visual Studio and Visual Studio Code have a built-in feature to validate JSON files.
You can also use [this small script](https://github.com/JamieMagee/verify-cgmanifest) to validate your `cgmanifest.json` file.

### Why does it suggest camel case for the properties?

Component Detection is able to read camel case and pascal case properties.
However, the JSON schema doesn't have a case-insensitive mode.
We therefore suggest camel case as it's the most common format for JSON.

### Why is the diff so large?

To deserialize the `cgmanifest.json` file, we use [`JSON.parse()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse).
However, to serialize the JSON again we use [`prettier`](https://prettier.io/).
We found that, in general, it gave smaller diffs than the default [`JSON.stringify()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) function.