### PR TITLE
`mariadb`: update to v10.6.9 to fix CVE-2022-32091, CVE-2022-32081

### DIFF
--- a/SPECS/mariadb/mariadb.signatures.json
+++ b/SPECS/mariadb/mariadb.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "mariadb-10.6.8.tar.gz": "ce5297cb8fc0875a29bba4cff90a09090f0bfccf788e8d04d9361ba955d4ee41"
+  "mariadb-10.6.9.tar.gz": "2ebcd66bc18211db9bdb4beb3445852d1ee2f212bc4d7de55a40907542c1b3c1"
  }
 }

--- a/SPECS/mariadb/mariadb.spec
+++ b/SPECS/mariadb/mariadb.spec
@@ -1,6 +1,6 @@
 Summary:        Database servers made by the original developers of MySQL.
 Name:           mariadb
-Version:        10.6.8
+Version:        10.6.9
 Release:        1%{?dist}
 License:        GPLv2 WITH exceptions AND LGPLv2 AND BSD
 Vendor:         Microsoft Corporation
@@ -457,6 +457,9 @@ fi
 %{_datadir}/mysql/hindi/errmsg.sys
 
 %changelog
+* Tue Aug 30 2022 Henry Beberman <henry.beberman@microsoft.com> - 10.6.9-1
+- Upgrade to v10.6.9 to address CVE-2022-32091, CVE-2022-32081
+
 * Fri May 20 2022 Chris Co <chrco@microsoft.com> - 10.6.8-1
 - Upgrade to v10.6.8 to address CVE-2022-27448, CVE-2022-27449,
   CVE-2022-27451, CVE-2022-27457, CVE-2022-27458

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -11391,8 +11391,8 @@
         "type": "other",
         "other": {
           "name": "mariadb",
-          "version": "10.6.8",
-          "downloadUrl": "https://github.com/MariaDB/server/archive/mariadb-10.6.8.tar.gz"
+          "version": "10.6.9",
+          "downloadUrl": "https://github.com/MariaDB/server/archive/mariadb-10.6.9.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Update mariadb to v10.6.9 to fix CVE-2022-32091, CVE-2022-32081

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Update mariadb to v10.6.9
- Fix CVE-2022-32091, CVE-2022-32081

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**


###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2022-32091
- https://nvd.nist.gov/vuln/detail/CVE-2022-32081

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Full local build succeeded
- Check section ran successfully in individual package build
