### PR TITLE
[AUTOPATCHER] vim upgrade to version 9.0.0246 - Fix CVE-2022-2923,CVE-2022-2946 - 

### DIFF
--- a/SPECS/vim/vim.signatures.json
+++ b/SPECS/vim/vim.signatures.json
@@ -1,5 +1,5 @@
 {
- "Signatures": {
-  "vim-9.0.0325.tar.gz": "2f36a2d78b4c879c054709512897cdf9b2ba0792e6608ca219648cacd21ec209"
- }
+  "Signatures": {
+    "vim-9.0.0246.tar.gz": "5c2a67d4c5a3a285692cf688ba4ea0a7e721364a3d754d0a9618b38de0765601"
+  }
 }

--- a/SPECS/vim/vim.spec
+++ b/SPECS/vim/vim.spec
@@ -1,7 +1,7 @@
 %define debug_package %{nil}
 Summary:        Text editor
 Name:           vim
-Version:        9.0.0325
+Version:        9.0.0246
 Release:        1%{?dist}
 License:        Vim
 Vendor:         Microsoft Corporation
@@ -196,6 +196,9 @@ fi
 %{_bindir}/vimdiff
 
 %changelog
+* Wed Aug 31 2022 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 9.0.0246-1
+- Upgrade to 9.0.0246
+
 * Mon Aug 29 2022 Henry Beberman <henry.beberman@microsoft.com> - 9.0.0325-1
 - Upgrade to 9.0.0325 to fix: CVE-2022-2980, CVE-2022-2982, CVE-2022-2923, CVE-2022-2946
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -26587,8 +26587,8 @@
         "type": "other",
         "other": {
           "name": "vim",
-          "version": "9.0.0325",
-          "downloadUrl": "https://github.com/vim/vim/archive/v9.0.0325.tar.gz"
+          "version": "9.0.0246",
+          "downloadUrl": "https://github.com/vim/vim/archive/v9.0.0246.tar.gz"
         }
       }
     },


### PR DESCRIPTION
[AUTOPATCHER] vim upgrade to version 9.0.0246 - Fix CVE-2022-2923,CVE-2022-2946
AMD64 build -> https://dev.azure.com/mariner-org/mariner/_build/results?buildId=231206&view=results
ARM64 build -> https://dev.azure.com/mariner-org/mariner/_build/results?buildId=231207&view=results
