### PR TITLE
set crash kernel memory based on host memory

### DIFF
--- a/SPECS-SIGNED/kernel-signed/kernel-signed.spec
+++ b/SPECS-SIGNED/kernel-signed/kernel-signed.spec
@@ -10,7 +10,7 @@
 Summary:        Signed Linux Kernel for %{buildarch} systems
 Name:           kernel-signed-%{buildarch}
 Version:        5.15.57.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -153,6 +153,9 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %exclude /module_info.ld
 
 %changelog
+* Wed Aug 31 2022 Saul Paredes <saulparedes@microsoft.com> - 5.15.57.1-4
+- Bump release number to match kernel release
+
 * Tue Aug 02 2022 Rachel Menge <rachelmenge@microsoft.com> - 5.15.57.1-3
 - Bump release number to match kernel release
 

--- a/SPECS/kernel-headers/kernel-headers.spec
+++ b/SPECS/kernel-headers/kernel-headers.spec
@@ -1,7 +1,7 @@
 Summary:        Linux API header files
 Name:           kernel-headers
 Version:        5.15.57.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -36,6 +36,9 @@ cp -rv usr/include/* /%{buildroot}%{_includedir}
 %{_includedir}/*
 
 %changelog
+* Wed Aug 31 2022 Saul Paredes <saulparedes@microsoft.com> - 5.15.57.1-4
+- Bump release number to match kernel release
+
 * Tue Aug 02 2022 Rachel Menge <rachelmenge@microsoft.com> - 5.15.57.1-3
 - Bump release number to match kernel release
 

--- a/SPECS/kernel-rt/kernel-rt.spec
+++ b/SPECS/kernel-rt/kernel-rt.spec
@@ -13,7 +13,7 @@
 Summary:        Realtime Linux Kernel
 Name:           kernel-rt
 Version:        5.15.44.1
-Release:        6%{?dist}
+Release:        7%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -379,6 +379,9 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %{_sysconfdir}/bash_completion.d/bpftool
 
 %changelog
+* Wed Aug 31 2022 Saul Paredes <saulparedes@microsoft.com> - 5.15.44.1-7
+- Adjust crashkernel param based on host's memory
+
 * Mon Aug 08 2022 Sriram Nambakam <snambakam@microsoft.com> - 5.15.44.1-6
 - Enable CONFIG_PCI_PF_STUB
 

--- a/SPECS/kernel-rt/kernel-rt.spec
+++ b/SPECS/kernel-rt/kernel-rt.spec
@@ -226,7 +226,7 @@ ln -s vmlinux-%{uname_r} %{buildroot}%{_libdir}/debug/lib/modules/%{uname_r}/vml
 
 cat > %{buildroot}/boot/linux-%{uname_r}.cfg << "EOF"
 # GRUB Environment Block
-mariner_cmdline=init=/lib/systemd/systemd ro loglevel=3 quiet no-vmw-sta crashkernel=128M
+mariner_cmdline=init=/lib/systemd/systemd ro loglevel=3 quiet no-vmw-sta crashkernel=0M-1G:128M,1G-6G:256M,6G-8G:512M,8G-:768M
 mariner_linux=vmlinuz-%{uname_r}
 mariner_initrd=initrd.img-%{uname_r}
 EOF

--- a/SPECS/kernel/kernel.spec
+++ b/SPECS/kernel/kernel.spec
@@ -18,7 +18,7 @@
 Summary:        Linux Kernel
 Name:           kernel
 Version:        5.15.57.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -391,6 +391,9 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %{_sysconfdir}/bash_completion.d/bpftool
 
 %changelog
+* Wed Aug 31 2022 Saul Paredes <saulparedes@microsoft.com> - 5.15.57.1-4
+- Adjust crashkernel param based on host's memory
+
 * Tue Aug 02 2022 Rachel Menge <rachelmenge@microsoft.com> - 5.15.57.1-3
 - Turn on CONFIG_SECURITY_LANDLOCK
 

--- a/SPECS/kernel/kernel.spec
+++ b/SPECS/kernel/kernel.spec
@@ -222,7 +222,7 @@ ln -s vmlinux-%{uname_r} %{buildroot}%{_libdir}/debug/lib/modules/%{uname_r}/vml
 
 cat > %{buildroot}/boot/linux-%{uname_r}.cfg << "EOF"
 # GRUB Environment Block
-mariner_cmdline=init=/lib/systemd/systemd ro loglevel=3 no-vmw-sta crashkernel=128M
+mariner_cmdline=init=/lib/systemd/systemd ro loglevel=3 no-vmw-sta crashkernel=0M-1G:128M,1G-6G:256M,6G-8G:512M,8G-:768M
 mariner_linux=vmlinuz-%{uname_r}
 mariner_initrd=initrd.img-%{uname_r}
 EOF

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -1,5 +1,5 @@
 filesystem-1.1-10.cm2.aarch64.rpm
-kernel-headers-5.15.57.1-3.cm2.noarch.rpm
+kernel-headers-5.15.57.1-4.cm2.noarch.rpm
 glibc-2.35-2.cm2.aarch64.rpm
 glibc-devel-2.35-2.cm2.aarch64.rpm
 glibc-i18n-2.35-2.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -1,5 +1,5 @@
 filesystem-1.1-10.cm2.x86_64.rpm
-kernel-headers-5.15.57.1-3.cm2.noarch.rpm
+kernel-headers-5.15.57.1-4.cm2.noarch.rpm
 glibc-2.35-2.cm2.x86_64.rpm
 glibc-devel-2.35-2.cm2.x86_64.rpm
 glibc-i18n-2.35-2.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -131,7 +131,7 @@ intltool-0.51.0-7.cm2.noarch.rpm
 itstool-2.0.6-4.cm2.noarch.rpm
 kbd-2.2.0-1.cm2.aarch64.rpm
 kbd-debuginfo-2.2.0-1.cm2.aarch64.rpm
-kernel-headers-5.15.57.1-3.cm2.noarch.rpm
+kernel-headers-5.15.57.1-4.cm2.noarch.rpm
 kmod-29-1.cm2.aarch64.rpm
 kmod-debuginfo-29-1.cm2.aarch64.rpm
 kmod-devel-29-1.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -131,7 +131,7 @@ intltool-0.51.0-7.cm2.noarch.rpm
 itstool-2.0.6-4.cm2.noarch.rpm
 kbd-2.2.0-1.cm2.x86_64.rpm
 kbd-debuginfo-2.2.0-1.cm2.x86_64.rpm
-kernel-headers-5.15.57.1-3.cm2.noarch.rpm
+kernel-headers-5.15.57.1-4.cm2.noarch.rpm
 kmod-29-1.cm2.x86_64.rpm
 kmod-debuginfo-29-1.cm2.x86_64.rpm
 kmod-devel-29-1.cm2.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Set crashkernel param in kernel.spec based on host memory. This makes kernel crash recovery work consistently. Using less memory than needed causes kdump to take longer to create the vmcore file (memory dump)

Based on a few sources ([1](https://www.suse.com/support/kb/doc/?id=000016171), [2](https://www.golinuxhub.com/2018/08/how-to-configure-and-install-kdump-rhel7-crashkernel/)), the memory allocated to crash kernel ought to be based on the total memory available to the host. There's a crashkernel=auto option that tries to do this and I think ideally, we would like to use this. However, on a 2gb ram hyper vm machine, the auto option will still assign 128mb to the crash kernel, and this will cause kdump issues. So, we'd want to do something similar to the auto option, but with higher memory allocated to crash kernel. The range I use is based on a [recommended config for RHEL6.0 and RHEL6.1](https://access.redhat.com/solutions/59432) where I slightly modify the lower range of the values (2gb-6gb -> 1gb-6gb) to be able to get consistent kernel recoveries on my hyper vm instance(128mb wasn't enough for 1.8gb of ram available) Using this range, I was able to recover consistently with 6gb and 9gb of ram as well, showing this range works for higher ram values. 

Follow up: 
Why does mariner crashkernel requires more than 128mb ([default recommended by canonical](https://ubuntu.com/server/docs/kernel-crash-dump) and assigned by auto option)for kernel crashes to recover consistently

Do higher ram values really require a bigger crashkernel, maybe we can use crashkernel=256mb(or lower) for higher values as well. 
A: Further testing on hyper v suggest we could stick to 256m for everything. I was able to crash and recover logs fast and consecutively using 256m on a vm with 10gb of ram

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Updated crashkernel param

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://microsoft.visualstudio.com/OS/_workitems/edit/40870902?src=WorkItemMention&src-action=artifact_link

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- tested on hypervm
- used `echo c > /proc/sysrq-trigger` to trigger a kernel crash and noticed inconsistent results. (Sometimes it would recover after a few minutes, sometimes it would hang and not recover)
- modified crashkernel param to allocate more memory
- Verified that kernel crash recovery happens fast and consistently now (about 15 seconds to get back to login prompt) and vmcore file gets created every time
-  Full local image build succeeded
-  AMD image build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=231743&view=results