### PR TITLE
kata-containers: remove acrn config for arm64

### DIFF
--- a/SPECS/kata-containers/kata-containers.spec
+++ b/SPECS/kata-containers/kata-containers.spec
@@ -42,7 +42,7 @@
 Summary:        Kata Containers version 2.x repository
 Name:           kata-containers
 Version:        2.5.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 URL:            https://github.com/%{name}/%{name}
@@ -216,7 +216,10 @@ fi
 %{_prefix}/local/bin/containerd-shim-kata-v2
 %{_prefix}/local/bin/kata-monitor
 %{_prefix}/local/bin/kata-runtime
+%ifarch x86_64
+# acrn is not available for arm64 architecture
 %{katadefaults}/configuration-acrn.toml
+%endif
 %{katadefaults}/configuration-clh.toml
 %{katadefaults}/configuration-fc.toml
 %{katadefaults}/configuration-qemu.toml
@@ -253,6 +256,9 @@ fi
 %exclude %{kataosbuilderdir}/rootfs-builder/ubuntu
 
 %changelog
+* Wed Aug 31 2022 Andrew Phelps <anphel@microsoft.com> - 2.5.0-2
+- Fix arm64 build issue by excluding configuration-acrn.toml
+
 * Fri Aug 19 2022 Neha Agarwal <nehaagarwal@microsoft.com> - 2.5.0-1
 - Initial CBL-Mariner import from Fedora 37 (license: MIT).
 - License verified.


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Resolve arm64 build break of kata-containers package by excluding "configuration-acrn.toml" which is not available on arm64.

```
"Processing files: kata-containers-2.5.0-1.cm2.aarch64"
"error: File not found: /usr/src/mariner/BUILDROOT/kata-containers-2.5.0-1.cm2.aarch64/usr/share/kata-containers/defaults/configuration-acrn.toml"
```

Configuration for arm64:
```
"• hypervisors:"
="\tDefault: qemu"
="\tKnown: acrn cloud-hypervisor firecracker qemu"
="\tAvailable for this architecture: cloud-hypervisor firecracker qemu"
```

Configuration for x64:
```
"• hypervisors:"
="\tDefault: qemu"
="\tKnown: acrn cloud-hypervisor firecracker qemu"
="\tAvailable for this architecture: acrn cloud-hypervisor firecracker qemu"
```


###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Remove configuration-acrn.toml from arm64 kata-containers package

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: 231569 (arm64) 231570 (x64)
