### PR TITLE
`virglrenderer`: fix CVE-2022-0135

### DIFF
--- a/.github/workflows/validate-cg-manifest.sh
+++ b/.github/workflows/validate-cg-manifest.sh
@@ -59,6 +59,10 @@ ignore_signed_package=" \
   kernel-signed-x86_64 \
   shim"
 
+# Specs where cgmanifest validation has known issues checking URLs.
+ignore_known_issues=" \
+  virglrenderer"
+
 alt_source_tag="Source9999"
 
 rm -f bad_registrations.txt
@@ -103,7 +107,7 @@ do
   fi
 
   # Skipping specs from the ignore lists.
-  if echo "$ignore_multiple_sources $ignore_signed_package $ignore_no_source_tarball" | grep -P "(^|\s)$name($|\s)" > /dev/null
+  if echo "$ignore_multiple_sources $ignore_signed_package $ignore_no_source_tarball $ignore_known_issues" | grep -P "(^|\s)$name($|\s)" > /dev/null
   then
     echo "    $name is being ignored, skipping"
     continue

--- a/SPECS/virglrenderer/CVE-2022-0135.patch
+++ b/SPECS/virglrenderer/CVE-2022-0135.patch
@@ -1,0 +1,95 @@
+From 95e581fd181b213c2ed7cdc63f2abc03eaaa77ec Mon Sep 17 00:00:00 2001
+From: Gert Wollny <gert.wollny@collabora.com>
+Date: Tue, 30 Nov 2021 10:17:26 +0100
+Subject: [PATCH] vrend: Add test to resource OOB write and fix it
+
+v2: Also check that no depth != 1 has been send when none is due
+
+Closes: #250
+Signed-off-by: Gert Wollny <gert.wollny@collabora.com>
+Reviewed-by: Chia-I Wu <olvaffe@gmail.com>
+---
+ src/vrend_renderer.c        |  3 +++
+ tests/test_fuzzer_formats.c | 43 +++++++++++++++++++++++++++++++++++++
+ 2 files changed, 46 insertions(+)
+
+diff --git a/src/vrend_renderer.c b/src/vrend_renderer.c
+index 28f669727..357b81b20 100644
+--- a/src/vrend_renderer.c
++++ b/src/vrend_renderer.c
+@@ -7833,8 +7833,11 @@ static int vrend_renderer_transfer_write_iov(struct vrend_context *ctx,
+                                           info->box->height) * elsize;
+       if (res->target == GL_TEXTURE_3D ||
+           res->target == GL_TEXTURE_2D_ARRAY ||
++          res->target == GL_TEXTURE_2D_MULTISAMPLE_ARRAY ||
+           res->target == GL_TEXTURE_CUBE_MAP_ARRAY)
+           send_size *= info->box->depth;
++      else if (need_temp && info->box->depth != 1)
++         return EINVAL;
+ 
+       if (need_temp) {
+          data = malloc(send_size);
+diff --git a/tests/test_fuzzer_formats.c b/tests/test_fuzzer_formats.c
+index 59d6fb671..2de9a9a3f 100644
+--- a/tests/test_fuzzer_formats.c
++++ b/tests/test_fuzzer_formats.c
+@@ -957,6 +957,48 @@ static void test_vrend_set_signle_abo_heap_overflow() {
+     virgl_renderer_submit_cmd((void *) cmd, ctx_id, 0xde);
+ }
+ 
++/* Test adapted from yaojun8558363@gmail.com:
++ * https://gitlab.freedesktop.org/virgl/virglrenderer/-/issues/250
++*/
++static void test_vrend_3d_resource_overflow() {
++
++    struct virgl_renderer_resource_create_args resource;
++    resource.handle = 0x4c474572;
++    resource.target = PIPE_TEXTURE_2D_ARRAY;
++    resource.format = VIRGL_FORMAT_Z24X8_UNORM;
++    resource.nr_samples = 2;
++    resource.last_level = 0;
++    resource.array_size = 3;
++    resource.bind = VIRGL_BIND_SAMPLER_VIEW;
++    resource.depth = 1;
++    resource.width = 8;
++    resource.height = 4;
++    resource.flags = 0;
++
++    virgl_renderer_resource_create(&resource, NULL, 0);
++    virgl_renderer_ctx_attach_resource(ctx_id, resource.handle);
++
++    uint32_t size = 0x400;
++    uint32_t cmd[size];
++    int i = 0;
++    cmd[i++] = (size - 1) << 16 | 0 << 8 | VIRGL_CCMD_RESOURCE_INLINE_WRITE;
++    cmd[i++] = resource.handle;
++    cmd[i++] = 0; // level
++    cmd[i++] = 0; // usage
++    cmd[i++] = 0; // stride
++    cmd[i++] = 0; // layer_stride
++    cmd[i++] = 0; // x
++    cmd[i++] = 0; // y
++    cmd[i++] = 0; // z
++    cmd[i++] = 8; // w
++    cmd[i++] = 4; // h
++    cmd[i++] = 3; // d
++    memset(&cmd[i], 0, size - i);
++
++    virgl_renderer_submit_cmd((void *) cmd, ctx_id, size);
++}
++
++
+ int main()
+ {
+    initialize_environment();
+@@ -979,6 +1021,7 @@ int main()
+    test_cs_nullpointer_deference();
+    test_vrend_set_signle_abo_heap_overflow();
+ 
++   test_vrend_3d_resource_overflow();
+ 
+    virgl_renderer_context_destroy(ctx_id);
+    virgl_renderer_cleanup(&cookie);
+-- 
+GitLab
+

--- a/SPECS/virglrenderer/virglrenderer.signatures.json
+++ b/SPECS/virglrenderer/virglrenderer.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "virglrenderer-virglrenderer-0.9.1.tar.gz": "dd4a8008ca7bcaaf56666c94fcd738d705cdeda6313a82b3cea78bc3fb1b1ba5"
+  "virglrenderer-0.9.1.tar.gz": "8db70c178bbf1f1d8a2c823174d8f5d5e4120a4d3dbb61861e27441e41d67c95"
  }
 }

--- a/SPECS/virglrenderer/virglrenderer.spec
+++ b/SPECS/virglrenderer/virglrenderer.spec
@@ -6,7 +6,7 @@ License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 URL:            https://gitlab.freedesktop.org/virgl/virglrenderer
-Source0:        %{url}/-/archive/%{name}-%{version}/%{name}-%{name}-%{version}.tar.gz
+Source0:        %{url}/-/archive/%{version}/%{name}-%{version}.tar.gz
 Patch0:         CVE-2022-0135.patch
 
 BuildRequires:  libdrm-devel
@@ -39,7 +39,7 @@ that can be used along with the mesa virgl
 driver to test virgl rendering without GL.
 
 %prep
-%autosetup -p1 -n %{name}-%{name}-%{version}
+%autosetup -p1
 
 %build
 %meson
@@ -67,6 +67,7 @@ driver to test virgl rendering without GL.
 %changelog
 * Thu Sep 01 2022 Henry Beberman <henry.beberman@microsoft.com> - 0.9.1-2
 - Apply CVE-2022-0135 patch from upstream.
+- Update "Source0" URL.
 
 * Tue Nov 30 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 0.9.1-1
 - Updating to version 0.9.1.

--- a/SPECS/virglrenderer/virglrenderer.spec
+++ b/SPECS/virglrenderer/virglrenderer.spec
@@ -1,12 +1,13 @@
 Summary:        Virgl Rendering library.
 Name:           virglrenderer
 Version:        0.9.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 URL:            https://gitlab.freedesktop.org/virgl/virglrenderer
 Source0:        %{url}/-/archive/%{name}-%{version}/%{name}-%{name}-%{version}.tar.gz
+Patch0:         CVE-2022-0135.patch
 
 BuildRequires:  libdrm-devel
 BuildRequires:  libepoxy-devel
@@ -38,7 +39,7 @@ that can be used along with the mesa virgl
 driver to test virgl rendering without GL.
 
 %prep
-%autosetup -n %{name}-%{name}-%{version}
+%autosetup -p1 -n %{name}-%{name}-%{version}
 
 %build
 %meson
@@ -64,6 +65,9 @@ driver to test virgl rendering without GL.
 %{_bindir}/virgl_test_server
 
 %changelog
+* Thu Sep 01 2022 Henry Beberman <henry.beberman@microsoft.com> - 0.9.1-2
+- Apply CVE-2022-0135 patch from upstream.
+
 * Tue Nov 30 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 0.9.1-1
 - Updating to version 0.9.1.
 - License verified.

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -26618,7 +26618,7 @@
         "other": {
           "name": "virglrenderer",
           "version": "0.9.1",
-          "downloadUrl": "https://gitlab.freedesktop.org/virgl/virglrenderer/-/archive/virglrenderer-0.9.1/virglrenderer-virglrenderer-0.9.1.tar.gz"
+          "downloadUrl": "https://gitlab.freedesktop.org/virgl/virglrenderer/-/archive/0.9.1/virglrenderer-0.9.1.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Patch CVE-2022-0135 in virglrenderer

###### Change Log  <!-- REQUIRED -->
- Patch CVE-2022-0135 in virglrenderer

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2022-0135

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Individual local build succeeded
- Full local build succeeded