### PR TITLE
libguestfs: require qemu-img package instead of binary

### DIFF
--- a/SPECS/libguestfs/libguestfs.spec
+++ b/SPECS/libguestfs/libguestfs.spec
@@ -25,7 +25,7 @@
 Summary:        Access and modify virtual machine disk images
 Name:           libguestfs
 Version:        1.44.0
-Release:        7%{?dist}
+Release:        8%{?dist}
 License:        LGPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -50,7 +50,6 @@ Patch2:         libguestfs-file-5.40.patch
 
 BuildRequires:  %{_bindir}/ping
 BuildRequires:  %{_bindir}/pod2text
-BuildRequires:  %{_bindir}/qemu-img
 BuildRequires:  %{_bindir}/wget
 # Build requirements for the appliance.
 #
@@ -236,7 +235,7 @@ BuildRequires:  zfs-fuse
 %endif
 
 # For core disk-create API.
-Requires:       %{_bindir}/qemu-img
+Requires:       qemu-img
 # The daemon dependencies are not included automatically, because it
 # is buried inside the appliance, so list them here.
 Requires:       augeas-libs >= 1.7.0
@@ -1235,6 +1234,10 @@ rm ocaml/html/.gitignore
 %endif
 
 %changelog
+* Thu Sep 01 2022 Andrew Phelps <anphel@microsoft.com> - 1.44.0-8
+- Remove duplicate BR on qemu-img
+- Change runtime requires from qemu-img binary to qemu-img package
+
 * Mon Aug 22 2022 Olivia Crain <oliviacrain@microsoft.com> - 1.44.0-7
 - Bump release to rebuild against Go 1.18.5
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Resolve issue delta building libguestfs

```
1. cannot install both qemu-img-6.2.0-6.cm2.x86_64 and qemu-img-6.2.0-5.cm2.x86_64
2. Found 1 problem(s) while resolving
3. Error(1301) : Solv general runtime error
```

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change libguestfs to require qemu-img package

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: xxxx
