### PR TITLE
mock: add BR on `python3-pip` & drop un-needed deps to enable ptest

### DIFF
--- a/SPECS-EXTENDED/mock/mock.spec
+++ b/SPECS-EXTENDED/mock/mock.spec
@@ -1,4 +1,3 @@
-%bcond_without tests
 # mock group id allocate (Must not overlap with any other gid in Mariner)
 %global mockgid 135
 %global __python %{__python3}
@@ -7,7 +6,7 @@
 Summary:        Builds packages inside chroots
 Name:           mock
 Version:        2.16
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2+
 # Source is created by
 # git clone https://github.com/rpm-software-management/mock.git
@@ -39,12 +38,11 @@ Requires:       usermode
 # hwinfo plugin
 Requires:       util-linux
 BuildArch:      noarch
-%if %{with tests}
+%if %{with_check}
 BuildRequires:  python3-distro
 BuildRequires:  python3-jinja2
+BuildRequires:  python3-pip
 BuildRequires:  python3-pyroute2
-BuildRequires:  python3-pytest
-BuildRequires:  python3-pytest-cov
 BuildRequires:  python3-requests
 BuildRequires:  python3-templated-dictionary
 %endif
@@ -134,9 +132,8 @@ getent group mock > /dev/null || groupadd -f -g %mockgid -r mock
 exit 0
 
 %check
-%if %{with tests}
+%{__python3} -m pip install pytest==7.1.2 pytest-cov==3.0.0
 ./run-tests.sh
-%endif
 
 
 %files
@@ -192,6 +189,9 @@ exit 0
 %dir  %{_datadir}/cheat
 
 %changelog
+* Fri Aug 26 2022 Muhammad Falak <mwani@microsoft.com> - 2.16-2
+- Add BR on `python3-pip` & drop un-needed deps to enable ptest
+
 * Tue Feb 08 2022 Cameron Baird <cameronbaird@microsoft.com> - 2.16-1
 - Initial CBL-Mariner import from Fedora 33 (license: MIT).
 - Update to 2.16 source


### PR DESCRIPTION
Signed-off-by: Muhammad Falak R Wani <falakreyaz@gmail.com>

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Fix ptest build. All tests pass!

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add BR on `python3-pip` & drop un-needed deps to enable ptest

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- NA

###### Links to CVEs  <!-- optional -->
- NA

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local Build with RUN_CHECK=y & RUN_CHECK=n
- BuddyBuild: [PR-3678](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=236249&view=logs&j=75cba72d-09cb-503a-3927-4ab61ac4a179&t=246631ef-4e63-576d-3b21-bc52cd4b0a93&l=1893)
