### PR TITLE
[2.0] `mariadb`: update to v10.6.9 to fix CVE-2022-32091, CVE-2022-32081

### DIFF
--- a/SPECS/mariadb/mariadb.signatures.json
+++ b/SPECS/mariadb/mariadb.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "mariadb-10.6.8.tar.gz": "ce5297cb8fc0875a29bba4cff90a09090f0bfccf788e8d04d9361ba955d4ee41"
+  "mariadb-10.6.9.tar.gz": "2ebcd66bc18211db9bdb4beb3445852d1ee2f212bc4d7de55a40907542c1b3c1"
  }
 }

--- a/SPECS/mariadb/mariadb.spec
+++ b/SPECS/mariadb/mariadb.spec
@@ -1,6 +1,6 @@
 Summary:        Database servers made by the original developers of MySQL.
 Name:           mariadb
-Version:        10.6.8
+Version:        10.6.9
 Release:        1%{?dist}
 License:        GPLv2 WITH exceptions AND LGPLv2 AND BSD
 Vendor:         Microsoft Corporation
@@ -457,6 +457,9 @@ fi
 %{_datadir}/mysql/hindi/errmsg.sys
 
 %changelog
+* Tue Aug 30 2022 Henry Beberman <henry.beberman@microsoft.com> - 10.6.9-1
+- Upgrade to v10.6.9 to address CVE-2022-32091, CVE-2022-32081
+
 * Fri May 20 2022 Chris Co <chrco@microsoft.com> - 10.6.8-1
 - Upgrade to v10.6.8 to address CVE-2022-27448, CVE-2022-27449,
   CVE-2022-27451, CVE-2022-27457, CVE-2022-27458

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -11381,8 +11381,8 @@
         "type": "other",
         "other": {
           "name": "mariadb",
-          "version": "10.6.8",
-          "downloadUrl": "https://github.com/MariaDB/server/archive/mariadb-10.6.8.tar.gz"
+          "version": "10.6.9",
+          "downloadUrl": "https://github.com/MariaDB/server/archive/mariadb-10.6.9.tar.gz"
         }
       }
     },


### PR DESCRIPTION
Pulling to 2.0 branch to release fix for this high CVE