### PR TITLE
Add patch for openvswtich to fix CVE-2021-3905

### DIFF
--- a/SPECS/openvswitch/CVE-2021-3905
+++ b/SPECS/openvswitch/CVE-2021-3905
@@ -1,0 +1,53 @@
+Since 640d4db ("ipf: Fix a use-after-free error, ...") the ipf
+framework unconditionally allocates a new dp_packet to track
+individual fragments.  This prevents a use-after-free.  However, an
+additional issue was present - even when the packet buffer is cloned,
+if the ip fragment handling code keeps it, the original buffer is
+leaked during the refill loop.  Even in the original processing code,
+the hardcoded dnsteal branches would always leak a packet buffer from
+the refill loop.
+
+This can be confirmed with valgrind:
+
+==717566== 16,672 (4,480 direct, 12,192 indirect) bytes in 8 blocks are definitely lost in loss record 390 of 390
+==717566==    at 0x484086F: malloc (vg_replace_malloc.c:380)
+==717566==    by 0x537BFD: xmalloc__ (util.c:137)
+==717566==    by 0x537BFD: xmalloc (util.c:172)
+==717566==    by 0x46DDD4: dp_packet_new (dp-packet.c:153)
+==717566==    by 0x46DDD4: dp_packet_new_with_headroom (dp-packet.c:163)
+==717566==    by 0x550AA6: netdev_linux_batch_rxq_recv_sock.constprop.0 (netdev-linux.c:1262)
+==717566==    by 0x5512AF: netdev_linux_rxq_recv (netdev-linux.c:1511)
+==717566==    by 0x4AB7E0: netdev_rxq_recv (netdev.c:727)
+==717566==    by 0x47F00D: dp_netdev_process_rxq_port (dpif-netdev.c:4699)
+==717566==    by 0x47FD13: dpif_netdev_run (dpif-netdev.c:5957)
+==717566==    by 0x4331D2: type_run (ofproto-dpif.c:370)
+==717566==    by 0x41DFD8: ofproto_type_run (ofproto.c:1768)
+==717566==    by 0x40A7FB: bridge_run__ (bridge.c:3245)
+==717566==    by 0x411269: bridge_run (bridge.c:3310)
+==717566==    by 0x406E6C: main (ovs-vswitchd.c:127)
+
+The fix is to delete the original packet when it isn't able to be
+reinserted into the packet batch.  Subsequent valgrind runs show that
+the packets are not leaked from the batch any longer.
+
+Fixes: 640d4db ("ipf: Fix a use-after-free error, and remove the 'do_not_steal' flag.")
+Fixes: 4ea9669 ("Userspace datapath: Add fragmentation handling.")
+Reported-by: Wan Junjie <wanjunjie@bytedance.com>
+Reported-at: openvswitch/ovs-issues#226
+Signed-off-by: Aaron Conole <aconole@redhat.com>
+Reviewed-by: David Marchand <david.marchand@redhat.com>
+Tested-by: Wan Junjie <wanjunjie@bytedance.com>
+Signed-off-by: Alin-Gabriel Serdean <aserdean@ovn.org>
+
+diff -ruN a/lib/ipf.c b/lib/ipf.c
+--- a/lib/ipf.c	2021-07-01 13:01:44.286314749 -0700
++++ b/lib/ipf.c	2022-09-02 11:59:47.584489219 -0700
+@@ -940,6 +940,8 @@
+             ovs_mutex_lock(&ipf->ipf_lock);
+             if (!ipf_handle_frag(ipf, pkt, dl_type, zone, now, hash_basis)) {
+                 dp_packet_batch_refill(pb, pkt, pb_idx);
++            } else {
++                dp_packet_delete(pkt);
+             }
+             ovs_mutex_unlock(&ipf->ipf_lock);
+         } else {

--- a/SPECS/openvswitch/openvswitch.spec
+++ b/SPECS/openvswitch/openvswitch.spec
@@ -6,13 +6,14 @@
 Summary:        Open vSwitch daemon/database/utilities
 Name:           openvswitch
 Version:        2.15.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        ASL 2.0 AND LGPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Group:          System Environment/Daemons
 URL:            https://www.openvswitch.org/
 Source0:        https://www.openvswitch.org/releases/%{name}-%{version}.tar.gz
+Patch0:         CVE-2021-3905
 BuildRequires:  gcc >= 4.0.0
 BuildRequires:  libcap-ng
 BuildRequires:  libcap-ng-devel
@@ -181,6 +182,9 @@ make -k check |& tee %{_specdir}/%{name}-check-log || %{nocheck}
 %{_mandir}/man8/vtep-ctl.8.gz
 
 %changelog
+* Thu Sep 01 2022 Minghe Ren <mingheren@microsoft.com> - 2.15.1-2
+- Add patch to fix CVE-2021-3905
+
 * Wed Aug 11 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 2.15.1-1
 - Updating to version 2.15.1 to fix CVE-2021-36980.
 - Removing no longer present OVN components and subpackages:


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Add patch for openvswtich to fix CVE-2021-3905

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add patch for openvswtich to fix CVE-2021-3905

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
NO

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2021-3905

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local package build with RUN_TEST=y
