### PR TITLE
KeysInUse-OpenSSL: reintroduce keysinuseutil & simplify package install

### DIFF
--- a/SPECS/KeysInUse-OpenSSL/KeysInUse-OpenSSL.spec
+++ b/SPECS/KeysInUse-OpenSSL/KeysInUse-OpenSSL.spec
@@ -1,7 +1,7 @@
 Summary:        The KeysInUse Engine for OpenSSL allows the logging of private key usage through OpenSSL
 Name:           KeysInUse-OpenSSL
 Version:        0.3.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -29,28 +29,13 @@ export GO111MODULE=off
 cmake -DCMAKE_TOOLCHAIN_FILE=./cmake-toolchains/linux-amd64-glibc.cmake -H./ -B./build
 cmake --build ./build --target keysinuse
 
-cd ./packaging/util
-make $(realpath ../../bin/keysinuseutil)
-
-%define keysinuse_dir %{buildroot}/%{_libdir}/keysinuse/
-
 %install
-mkdir -p %{keysinuse_dir}
-mkdir -p %{buildroot}%{_bindir}/
-
-install -m 0644 ./bin/keysinuse.so %{keysinuse_dir}
-install -m 0744 ./bin/keysinuseutil %{buildroot}%{_bindir}/
+mkdir -p %{buildroot}/%{_libdir}/engines-1.1/
+install -m 0755 ./bin/keysinuse.so %{buildroot}/%{_libdir}/engines-1.1/keysinuse.so
 
 %files
 %license LICENSE
-%{_libdir}/keysinuse/keysinuse.so
-%{_bindir}/keysinuseutil
-
-%pre
-if [ -x %{_bindir}/keysinuseutil ]; then
-  echo "Disabling version $2 of keysinuse engine for OpenSSL"
-  %{_bindir}/keysinuseutil uninstall || echo "Failed to deconfigure old version"
-fi
+%{_libdir}/engines-1.1/keysinuse.so
 
 %post
 if [ ! -e %{_var}/log/keysinuse ]; then
@@ -59,25 +44,11 @@ fi
 chown root:root %{_var}/log/keysinuse
 chmod 1733 %{_var}/log/keysinuse
 
-ln -s %{_lib}/keysinuse/keysinuse.so $(%{_bindir}/openssl version -e | awk '{gsub(/"/, "", $2); print $2}')/keysinuse.so
-
-if [ -x %{_bindir}/keysinuseutil ]; then
-  echo "Enabling keysinuse engine for OpenSSL"
-  %{_bindir}/keysinuseutil install || echo "Configuring engine failed"
-fi
-
-%preun
-if [ -x %{_bindir}/keysinuseutil ]; then
-  echo "Disabling keysinuse engine for OpenSSL"
-  %{_bindir}/keysinuseutil uninstall || echo "Deconfiguring keysinuse engine failed"
-fi
-with
-engine_link=$(%{_bindir}/openssl version -e | awk '{gsub(/"/, "", $2); print $2}')/keysinuse.so
-if [ -e $engine_link ]; then
-  rm $engine_link
-fi
-
 %changelog
+* Thu Sep 01 2022 Maxwell Moyer-McKee <mamckee@microsoft.com> - 0.3.1-3
+- Fix bad permissions on engine library during package install
+- Simplify package installation strategy
+
 * Mon Aug 22 2022 Olivia Crain <oliviacrain@microsoft.com> - 0.3.1-2
 - Bump release to rebuild against Go 1.18.5
 

--- a/SPECS/KeysInUse-OpenSSL/KeysInUse-OpenSSL.spec
+++ b/SPECS/KeysInUse-OpenSSL/KeysInUse-OpenSSL.spec
@@ -29,13 +29,25 @@ export GO111MODULE=off
 cmake -DCMAKE_TOOLCHAIN_FILE=./cmake-toolchains/linux-amd64-glibc.cmake -H./ -B./build
 cmake --build ./build --target keysinuse
 
+cd ./packaging/util
+make $(realpath ../../bin/keysinuseutil)
+
 %install
 mkdir -p %{buildroot}/%{_libdir}/engines-1.1/
+mkdir -p %{buildroot}%{_bindir}/
 install -m 0755 ./bin/keysinuse.so %{buildroot}/%{_libdir}/engines-1.1/keysinuse.so
+install -m 0744 ./bin/keysinuseutil %{buildroot}%{_bindir}/
 
 %files
 %license LICENSE
 %{_libdir}/engines-1.1/keysinuse.so
+%{_bindir}/keysinuseutil
+
+%pre
+if [ -x %{_bindir}/keysinuseutil ]; then
+  echo "Disabling version $2 of keysinuse engine for OpenSSL"
+  %{_bindir}/keysinuseutil uninstall || echo "Failed to deconfigure old version"
+fi
 
 %post
 if [ ! -e %{_var}/log/keysinuse ]; then
@@ -43,6 +55,16 @@ if [ ! -e %{_var}/log/keysinuse ]; then
 fi
 chown root:root %{_var}/log/keysinuse
 chmod 1733 %{_var}/log/keysinuse
+
+if [ -x %{_bindir}/keysinuseutil ]; then
+  echo "Enabling keysinuse engine for OpenSSL"
+  %{_bindir}/keysinuseutil install || echo "Configuring engine failed"
+fi
+
+%preun
+if [ -x %{_bindir}/keysinuseutil ]; then
+  %{_bindir}/keysinuseutil uninstall || echo "Deconfiguring keysinuse engine failed"
+fi
 
 %changelog
 * Thu Sep 01 2022 Maxwell Moyer-McKee <mamckee@microsoft.com> - 0.3.1-3


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
The permissions applied to keysinuse.so during KeysInUse-OpenSSL package install were not consistent with other OpenSSL engines. This prevented using the KeysInUse engine in user mode, until the engine's permissions were corrected.


###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Simplified KeysInUse-OpenSSL installation
- Fixed permissions issue present in KeysInUse-OpenSSL package

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- local build, manual test
