### PR TITLE
libtar: Pull misc Fedora patches, fix CVE-2021-33643, CVE-2021-33644, CVE-2021-33645, CVE-2021-33646

### DIFF
--- a/SPECS/libtar/libtar-1.2.11-mem-deref.patch
+++ b/SPECS/libtar/libtar-1.2.11-mem-deref.patch
@@ -1,0 +1,24 @@
+--- libtar-1.2.11/lib/libtar.h.deref	2009-12-30 16:37:03.790121122 +0100
++++ libtar-1.2.11/lib/libtar.h	2009-12-30 16:37:35.521246633 +0100
+@@ -172,6 +172,7 @@ int th_write(TAR *t);
+ #define TH_ISDIR(t)	((t)->th_buf.typeflag == DIRTYPE \
+ 			 || S_ISDIR((mode_t)oct_to_int((t)->th_buf.mode)) \
+ 			 || ((t)->th_buf.typeflag == AREGTYPE \
++			     && strlen((t)->th_buf.name) \
+ 			     && ((t)->th_buf.name[strlen((t)->th_buf.name) - 1] == '/')))
+ #define TH_ISFIFO(t)	((t)->th_buf.typeflag == FIFOTYPE \
+ 			 || S_ISFIFO((mode_t)oct_to_int((t)->th_buf.mode)))
+--- libtar-1.2.11/lib/util.c.deref	2003-01-07 02:41:00.000000000 +0100
++++ libtar-1.2.11/lib/util.c	2009-12-30 17:35:51.860121660 +0100
+@@ -148,9 +148,7 @@ oct_to_int(char *oct)
+ {
+ 	int i;
+ 
+-	sscanf(oct, "%o", &i);
+-
+-	return i;
++	return sscanf(oct, "%o", &i) == 1 ? i : 0;
+ }
+ 
+ 
+

--- a/SPECS/libtar/libtar-1.2.11-mem-deref.patch
+++ b/SPECS/libtar/libtar-1.2.11-mem-deref.patch
@@ -1,6 +1,21 @@
---- libtar-1.2.11/lib/libtar.h.deref	2009-12-30 16:37:03.790121122 +0100
-+++ libtar-1.2.11/lib/libtar.h	2009-12-30 16:37:35.521246633 +0100
-@@ -172,6 +172,7 @@ int th_write(TAR *t);
+From 560911b694055b0c677431cf85d4d0d5ebd1a3fd Mon Sep 17 00:00:00 2001
+From: Huzaifa Sidhpurwala <huzaifas@fedoraproject.org>
+Date: Tue, 15 Oct 2013 14:39:05 +0200
+Subject: [PATCH] Fix invalid memory de-reference issue
+
+Bug: https://bugzilla.redhat.com/551415
+
+Signed-off-by: Kamil Dudka <kdudka@redhat.com>
+---
+ lib/libtar.h | 1 +
+ lib/util.c   | 4 +---
+ 2 files changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/lib/libtar.h b/lib/libtar.h
+index 3b46a13..616ca8f 100644
+--- a/lib/libtar.h
++++ b/lib/libtar.h
+@@ -173,6 +173,7 @@ int th_write(TAR *t);
  #define TH_ISDIR(t)	((t)->th_buf.typeflag == DIRTYPE \
  			 || S_ISDIR((mode_t)oct_to_int((t)->th_buf.mode)) \
  			 || ((t)->th_buf.typeflag == AREGTYPE \
@@ -8,8 +23,10 @@
  			     && ((t)->th_buf.name[strlen((t)->th_buf.name) - 1] == '/')))
  #define TH_ISFIFO(t)	((t)->th_buf.typeflag == FIFOTYPE \
  			 || S_ISFIFO((mode_t)oct_to_int((t)->th_buf.mode)))
---- libtar-1.2.11/lib/util.c.deref	2003-01-07 02:41:00.000000000 +0100
-+++ libtar-1.2.11/lib/util.c	2009-12-30 17:35:51.860121660 +0100
+diff --git a/lib/util.c b/lib/util.c
+index 31e8315..11438ef 100644
+--- a/lib/util.c
++++ b/lib/util.c
 @@ -148,9 +148,7 @@ oct_to_int(char *oct)
  {
  	int i;
@@ -21,4 +38,5 @@
  }
  
  
-
+-- 
+2.11.4.GIT

--- a/SPECS/libtar/libtar-1.2.20-CVE-2021-33643-CVE-2021-33644.patch
+++ b/SPECS/libtar/libtar-1.2.20-CVE-2021-33643-CVE-2021-33644.patch
@@ -1,0 +1,40 @@
+From 3936c7aa74d89e7a91dfbb2c1b7bfcad58a0355d Mon Sep 17 00:00:00 2001
+From: shixuantong <1726671442@qq.com>
+Date: Wed, 6 Apr 2022 17:40:57 +0800
+Subject: [PATCH 1/2] Ensure that sz is greater than 0.
+
+---
+ lib/block.c | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/lib/block.c b/lib/block.c
+index 092bc28..f12c4bc 100644
+--- a/lib/block.c
++++ b/lib/block.c
+@@ -118,6 +118,11 @@ th_read(TAR *t)
+ 	if (TH_ISLONGLINK(t))
+ 	{
+ 		sz = th_get_size(t);
++		if ((int)sz <= 0)
++		{
++			errno = EINVAL;
++			return -1;
++		}
+ 		blocks = (sz / T_BLOCKSIZE) + (sz % T_BLOCKSIZE ? 1 : 0);
+ 		if (blocks > ((size_t)-1 / T_BLOCKSIZE))
+ 		{
+@@ -168,6 +173,11 @@ th_read(TAR *t)
+ 	if (TH_ISLONGNAME(t))
+ 	{
+ 		sz = th_get_size(t);
++		if ((int)sz <= 0)
++		{
++			errno = EINVAL;
++			return -1;
++		}
+ 		blocks = (sz / T_BLOCKSIZE) + (sz % T_BLOCKSIZE ? 1 : 0);
+ 		if (blocks > ((size_t)-1 / T_BLOCKSIZE))
+ 		{
+-- 
+2.37.1
+

--- a/SPECS/libtar/libtar-1.2.20-CVE-2021-33645-CVE-2021-33646.patch
+++ b/SPECS/libtar/libtar-1.2.20-CVE-2021-33645-CVE-2021-33646.patch
@@ -1,0 +1,119 @@
+From 3c7b1fd9bb63d74ecd38b71ffc876dca3ac87a8b Mon Sep 17 00:00:00 2001
+From: shixuantong <shixuantong@h-partners.com>
+Date: Sat, 7 May 2022 17:04:46 +0800
+Subject: [PATCH 2/2] fix memory leak
+
+---
+ lib/libtar.h    |  1 +
+ lib/util.c      |  9 ++++++++-
+ lib/wrapper.c   | 11 +++++++++++
+ libtar/libtar.c |  3 +++
+ 4 files changed, 23 insertions(+), 1 deletion(-)
+
+diff --git a/lib/libtar.h b/lib/libtar.h
+index 08a8e0f..8b00e93 100644
+--- a/lib/libtar.h
++++ b/lib/libtar.h
+@@ -285,6 +285,7 @@ int oct_to_int(char *oct);
+ /* integer to string-octal conversion, no NULL */
+ void int_to_oct_nonull(int num, char *oct, size_t octlen);
+ 
++void free_longlink_longname(struct tar_header th_buf);
+ 
+ /***** wrapper.c **********************************************************/
+ 
+diff --git a/lib/util.c b/lib/util.c
+index 11438ef..8a42e62 100644
+--- a/lib/util.c
++++ b/lib/util.c
+@@ -15,6 +15,7 @@
+ #include <stdio.h>
+ #include <sys/param.h>
+ #include <errno.h>
++#include <stdlib.h>
+ 
+ #ifdef STDC_HEADERS
+ # include <string.h>
+@@ -160,4 +161,10 @@ int_to_oct_nonull(int num, char *oct, size_t octlen)
+ 	oct[octlen - 1] = ' ';
+ }
+ 
+-
++void free_longlink_longname(struct tar_header th_buf)
++{
++	if (th_buf.gnu_longname != NULL)
++		free(th_buf.gnu_longname);
++	if (th_buf.gnu_longlink !=NULL)
++		free(th_buf.gnu_longlink);
++}
+diff --git a/lib/wrapper.c b/lib/wrapper.c
+index 2d3f5b9..9d2f3bf 100644
+--- a/lib/wrapper.c
++++ b/lib/wrapper.c
+@@ -36,7 +36,10 @@ tar_extract_glob(TAR *t, char *globname, char *prefix)
+ 		if (fnmatch(globname, filename, FNM_PATHNAME | FNM_PERIOD))
+ 		{
+ 			if (TH_ISREG(t) && tar_skip_regfile(t))
++			{
++				free_longlink_longname(t->th_buf);
+ 				return -1;
++			}
+ 			continue;
+ 		}
+ 		if (t->options & TAR_VERBOSE)
+@@ -46,9 +49,13 @@ tar_extract_glob(TAR *t, char *globname, char *prefix)
+ 		else
+ 			strlcpy(buf, filename, sizeof(buf));
+ 		if (tar_extract_file(t, buf) != 0)
++		{
++			free_longlink_longname(t->th_buf);
+ 			return -1;
++		}
+ 	}
+ 
++	free_longlink_longname(t->th_buf);
+ 	return (i == 1 ? 0 : -1);
+ }
+ 
+@@ -82,9 +89,13 @@ tar_extract_all(TAR *t, char *prefix)
+ 		       "\"%s\")\n", buf);
+ #endif
+ 		if (tar_extract_file(t, buf) != 0)
++		{
++			free_longlink_longname(t->th_buf);
+ 			return -1;
++		}
+ 	}
+ 
++	free_longlink_longname(t->th_buf);
+ 	return (i == 1 ? 0 : -1);
+ }
+ 
+diff --git a/libtar/libtar.c b/libtar/libtar.c
+index ac339e7..b992abb 100644
+--- a/libtar/libtar.c
++++ b/libtar/libtar.c
+@@ -197,6 +197,7 @@ list(char *tarfile)
+ 		{
+ 			fprintf(stderr, "tar_skip_regfile(): %s\n",
+ 				strerror(errno));
++			free_longlink_longname(t->th_buf);
+ 			return -1;
+ 		}
+ 	}
+@@ -218,10 +219,12 @@ list(char *tarfile)
+ 
+ 	if (tar_close(t) != 0)
+ 	{
++		free_longlink_longname(t->th_buf);
+ 		fprintf(stderr, "tar_close(): %s\n", strerror(errno));
+ 		return -1;
+ 	}
+ 
++	free_longlink_longname(t->th_buf);
+ 	return 0;
+ }
+ 
+-- 
+2.37.1
+

--- a/SPECS/libtar/libtar-1.2.20-fix-resource-leaks.patch
+++ b/SPECS/libtar/libtar-1.2.20-fix-resource-leaks.patch
@@ -1,0 +1,241 @@
+From abd0274e6b2f708e9eaa29414b07b3f542cec694 Mon Sep 17 00:00:00 2001
+From: Kamil Dudka <kdudka@redhat.com>
+Date: Tue, 15 Oct 2013 19:48:41 -0400
+Subject: [PATCH 1/3] fix file descriptor leaks reported by cppcheck
+
+Bug: https://bugzilla.redhat.com/785760
+---
+ lib/append.c    |   14 +++++++++-----
+ lib/extract.c   |    4 ++++
+ libtar/libtar.c |    3 +++
+ 3 files changed, 16 insertions(+), 5 deletions(-)
+
+diff --git a/lib/append.c b/lib/append.c
+index e8bd89d..ff58532 100644
+--- a/lib/append.c
++++ b/lib/append.c
+@@ -216,6 +216,7 @@ tar_append_regfile(TAR *t, const char *realname)
+ 	int filefd;
+ 	int i, j;
+ 	size_t size;
++	int rv = -1;
+ 
+ 	filefd = open(realname, O_RDONLY);
+ 	if (filefd == -1)
+@@ -234,25 +235,28 @@ tar_append_regfile(TAR *t, const char *realname)
+ 		{
+ 			if (j != -1)
+ 				errno = EINVAL;
+-			return -1;
++			goto fail;
+ 		}
+ 		if (tar_block_write(t, &block) == -1)
+-			return -1;
++			goto fail;
+ 	}
+ 
+ 	if (i > 0)
+ 	{
+ 		j = read(filefd, &block, i);
+ 		if (j == -1)
+-			return -1;
++			goto fail;
+ 		memset(&(block[i]), 0, T_BLOCKSIZE - i);
+ 		if (tar_block_write(t, &block) == -1)
+-			return -1;
++			goto fail;
+ 	}
+ 
++	/* success! */
++	rv = 0;
++fail:
+ 	close(filefd);
+ 
+-	return 0;
++	return rv;
+ }
+ 
+ 
+diff --git a/lib/extract.c b/lib/extract.c
+index 36357e7..9fc6ad5 100644
+--- a/lib/extract.c
++++ b/lib/extract.c
+@@ -228,13 +228,17 @@ tar_extract_regfile(TAR *t, char *realname)
+ 		{
+ 			if (k != -1)
+ 				errno = EINVAL;
++			close(fdout);
+ 			return -1;
+ 		}
+ 
+ 		/* write block to output file */
+ 		if (write(fdout, buf,
+ 			  ((i > T_BLOCKSIZE) ? T_BLOCKSIZE : i)) == -1)
++		{
++			close(fdout);
+ 			return -1;
++		}
+ 	}
+ 
+ 	/* close output file */
+diff --git a/libtar/libtar.c b/libtar/libtar.c
+index 9fa92b2..bb5644c 100644
+--- a/libtar/libtar.c
++++ b/libtar/libtar.c
+@@ -83,7 +83,10 @@ gzopen_frontend(char *pathname, int oflags, int mode)
+ 		return -1;
+ 
+ 	if ((oflags & O_CREAT) && fchmod(fd, mode))
++	{
++		close(fd);
+ 		return -1;
++	}
+ 
+ 	gzf = gzdopen(fd, gzoflags);
+ 	if (!gzf)
+-- 
+1.7.1
+
+
+From 36629a41208375f5105427e98078127551692028 Mon Sep 17 00:00:00 2001
+From: Huzaifa Sidhpurwala <huzaifas@fedoraproject.org>
+Date: Tue, 15 Oct 2013 20:02:58 -0400
+Subject: [PATCH 2/3] fix memleak on tar_open() failure
+
+---
+ lib/handle.c |    1 +
+ 1 files changed, 1 insertions(+), 0 deletions(-)
+
+diff --git a/lib/handle.c b/lib/handle.c
+index 33a262c..002d23c 100644
+--- a/lib/handle.c
++++ b/lib/handle.c
+@@ -82,6 +82,7 @@ tar_open(TAR **t, const char *pathname, tartype_t *type,
+ 	(*t)->fd = (*((*t)->type->openfunc))(pathname, oflags, mode);
+ 	if ((*t)->fd == -1)
+ 	{
++		libtar_hash_free((*t)->h, NULL);
+ 		free(*t);
+ 		return -1;
+ 	}
+-- 
+1.7.1
+
+
+From f3c711cf3054ff366a1a3500cdc8c64ecc2d2da6 Mon Sep 17 00:00:00 2001
+From: Huzaifa Sidhpurwala <huzaifas@fedoraproject.org>
+Date: Tue, 15 Oct 2013 20:05:04 -0400
+Subject: [PATCH 3/3] fix memleaks in libtar sample program
+
+---
+ libtar/libtar.c |   29 ++++++++++++++++++-----------
+ 1 files changed, 18 insertions(+), 11 deletions(-)
+
+diff --git a/libtar/libtar.c b/libtar/libtar.c
+index bb5644c..23f8741 100644
+--- a/libtar/libtar.c
++++ b/libtar/libtar.c
+@@ -253,6 +253,7 @@ extract(char *tarfile, char *rootdir)
+ 	if (tar_extract_all(t, rootdir) != 0)
+ 	{
+ 		fprintf(stderr, "tar_extract_all(): %s\n", strerror(errno));
++		tar_close(t);
+ 		return -1;
+ 	}
+ 
+@@ -270,12 +271,13 @@ extract(char *tarfile, char *rootdir)
+ 
+ 
+ void
+-usage()
++usage(void *rootdir)
+ {
+ 	printf("Usage: %s [-C rootdir] [-g] [-z] -x|-t filename.tar\n",
+ 	       progname);
+ 	printf("       %s [-C rootdir] [-g] [-z] -c filename.tar ...\n",
+ 	       progname);
++	free(rootdir);
+ 	exit(-1);
+ }
+ 
+@@ -292,6 +294,7 @@ main(int argc, char *argv[])
+ 	int c;
+ 	int mode = 0;
+ 	libtar_list_t *l;
++	int return_code = -2;
+ 
+ 	progname = basename(argv[0]);
+ 
+@@ -313,17 +316,17 @@ main(int argc, char *argv[])
+ 			break;
+ 		case 'c':
+ 			if (mode)
+-				usage();
++				usage(rootdir);
+ 			mode = MODE_CREATE;
+ 			break;
+ 		case 'x':
+ 			if (mode)
+-				usage();
++				usage(rootdir);
+ 			mode = MODE_EXTRACT;
+ 			break;
+ 		case 't':
+ 			if (mode)
+-				usage();
++				usage(rootdir);
+ 			mode = MODE_LIST;
+ 			break;
+ #ifdef HAVE_LIBZ
+@@ -332,7 +335,7 @@ main(int argc, char *argv[])
+ 			break;
+ #endif /* HAVE_LIBZ */
+ 		default:
+-			usage();
++			usage(rootdir);
+ 		}
+ 
+ 	if (!mode || ((argc - optind) < (mode == MODE_CREATE ? 2 : 1)))
+@@ -341,7 +344,7 @@ main(int argc, char *argv[])
+ 		printf("argc - optind == %d\tmode == %d\n", argc - optind,
+ 		       mode);
+ #endif
+-		usage();
++		usage(rootdir);
+ 	}
+ 
+ #ifdef DEBUG
+@@ -351,21 +354,25 @@ main(int argc, char *argv[])
+ 	switch (mode)
+ 	{
+ 	case MODE_EXTRACT:
+-		return extract(argv[optind], rootdir);
++		return_code = extract(argv[optind], rootdir);
++		break;
+ 	case MODE_CREATE:
+ 		tarfile = argv[optind];
+ 		l = libtar_list_new(LIST_QUEUE, NULL);
+ 		for (c = optind + 1; c < argc; c++)
+ 			libtar_list_add(l, argv[c]);
+-		return create(tarfile, rootdir, l);
++		return_code = create(tarfile, rootdir, l);
++		libtar_list_free(l, NULL);
++		break;
+ 	case MODE_LIST:
+-		return list(argv[optind]);
++		return_code = list(argv[optind]);
++		break;
+ 	default:
+ 		break;
+ 	}
+ 
+-	/* NOTREACHED */
+-	return -2;
++	free(rootdir);
++	return return_code;
+ }
+ 
+ 
+-- 
+1.7.1
+

--- a/SPECS/libtar/libtar-1.2.20-static-analysis.patch
+++ b/SPECS/libtar/libtar-1.2.20-static-analysis.patch
@@ -1,0 +1,90 @@
+From a4e32c3d29e93866c180b5837f8aee3989dac3e9 Mon Sep 17 00:00:00 2001
+From: Kamil Dudka <kdudka@redhat.com>
+Date: Tue, 6 Nov 2018 17:24:05 +0100
+Subject: [PATCH] libtar: fix programming mistakes detected by static analysis
+
+---
+ lib/append.c    |  7 +++++++
+ lib/wrapper.c   | 11 +++++++----
+ libtar/libtar.c |  1 +
+ 3 files changed, 15 insertions(+), 4 deletions(-)
+
+diff --git a/lib/append.c b/lib/append.c
+index ff58532..6386a50 100644
+--- a/lib/append.c
++++ b/lib/append.c
+@@ -110,9 +110,16 @@ tar_append_file(TAR *t, const char *realname, const char *savename)
+ 		td->td_dev = s.st_dev;
+ 		td->td_h = libtar_hash_new(256, (libtar_hashfunc_t)ino_hash);
+ 		if (td->td_h == NULL)
++		{
++			free(td);
+ 			return -1;
++		}
+ 		if (libtar_hash_add(t->h, td) == -1)
++		{
++			libtar_hash_free(td->td_h, free);
++			free(td);
+ 			return -1;
++		}
+ 	}
+ 	libtar_hashptr_reset(&hp);
+ 	if (libtar_hash_getkey(td->td_h, &hp, &(s.st_ino),
+diff --git a/lib/wrapper.c b/lib/wrapper.c
+index 44cc435..2d3f5b9 100644
+--- a/lib/wrapper.c
++++ b/lib/wrapper.c
+@@ -97,6 +97,7 @@ tar_append_tree(TAR *t, char *realdir, char *savedir)
+ 	struct dirent *dent;
+ 	DIR *dp;
+ 	struct stat s;
++	int ret = -1;
+ 
+ #ifdef DEBUG
+ 	printf("==> tar_append_tree(0x%lx, \"%s\", \"%s\")\n",
+@@ -130,24 +131,26 @@ tar_append_tree(TAR *t, char *realdir, char *savedir)
+ 				 dent->d_name);
+ 
+ 		if (lstat(realpath, &s) != 0)
+-			return -1;
++			goto fail;
+ 
+ 		if (S_ISDIR(s.st_mode))
+ 		{
+ 			if (tar_append_tree(t, realpath,
+ 					    (savedir ? savepath : NULL)) != 0)
+-				return -1;
++				goto fail;
+ 			continue;
+ 		}
+ 
+ 		if (tar_append_file(t, realpath,
+ 				    (savedir ? savepath : NULL)) != 0)
+-			return -1;
++			goto fail;
+ 	}
+ 
++	ret = 0;
++fail:
+ 	closedir(dp);
+ 
+-	return 0;
++	return ret;
+ }
+ 
+ 
+diff --git a/libtar/libtar.c b/libtar/libtar.c
+index 23f8741..ac339e7 100644
+--- a/libtar/libtar.c
++++ b/libtar/libtar.c
+@@ -92,6 +92,7 @@ gzopen_frontend(char *pathname, int oflags, int mode)
+ 	if (!gzf)
+ 	{
+ 		errno = ENOMEM;
++		close(fd);
+ 		return -1;
+ 	}
+ 
+-- 
+2.17.2
+

--- a/SPECS/libtar/libtar-gen-debuginfo.patch
+++ b/SPECS/libtar/libtar-gen-debuginfo.patch
@@ -1,5 +1,5 @@
---- lib/Makefile.in	2013-10-09 16:59:44.000000000 +0000
-+++ lib/Makefile.in.1	2017-04-25 07:08:57.225642841 +0000
+--- a/lib/Makefile.in	2013-10-09 16:59:44.000000000 +0000
++++ b/lib/Makefile.in.1	2017-04-25 07:08:57.225642841 +0000
 @@ -20,7 +20,7 @@
  
  ### Installation programs and flags
@@ -9,8 +9,8 @@
  INSTALL_DATA	= @INSTALL_DATA@
  LN_S		= @LN_S@
  MKDIR		= @MKDIR@
---- libtar/Makefile.in	2013-10-09 16:59:44.000000000 +0000
-+++ libtar/Makefile.in.1	2017-04-25 07:06:50.598826545 +0000
+--- a/libtar/Makefile.in	2013-10-09 16:59:44.000000000 +0000
++++ b/libtar/Makefile.in.1	2017-04-25 07:06:50.598826545 +0000
 @@ -20,7 +20,7 @@
  
  ### Installation programs and flags

--- a/SPECS/libtar/libtar.spec
+++ b/SPECS/libtar/libtar.spec
@@ -1,7 +1,7 @@
 Summary:        C library for manipulating tar files
 Name:           libtar
 Version:        1.2.20
-Release:        8%{?dist}
+Release:        9%{?dist}
 URL:            https://github.com/tklauser/libtar/
 License:        BSD
 Group:          System Environment/Libraries
@@ -9,8 +9,16 @@ Vendor:         Microsoft Corporation
 Distribution:   Mariner
 #Source0:       https://github.com/tklauser/%{name}/archive/v%{version}.tar.gz
 Source0:        %{name}-%{version}.tar.gz
+# This patch appears to replicate Fedora's ' libtar-1.2.11-bz729009.patch'
 Patch0:         libtar-gen-debuginfo.patch
-patch1:         libtar-CVE-2013-4420.patch
+# This patch appears to fix the same issue as Fedora's 'libtar-1.2.20-no-static-buffer.patch'
+Patch1:         libtar-CVE-2013-4420.patch
+# CVE patches + other fixes from Redhat
+Patch2:         libtar-1.2.11-mem-deref.patch
+Patch3:         libtar-1.2.20-CVE-2021-33643-CVE-2021-33644.patch
+Patch4:         libtar-1.2.20-CVE-2021-33645-CVE-2021-33646.patch
+Patch5:         libtar-1.2.20-fix-resource-leaks.patch
+Patch6:         libtar-1.2.20-static-analysis.patch
 Provides:       libtar.so.0()(64bit)
 
 %description
@@ -27,8 +35,7 @@ developing applications that use libtar.
 
 %prep
 %setup
-%patch0
-%patch1 -p1
+%autopatch -p1
 autoreconf -iv
 
 %build
@@ -59,6 +66,10 @@ chmod +x %{buildroot}/%{_libdir}/libtar.so.*
 %{_libdir}/libtar.la
 
 %changelog
+* Mon Sep 05 2022 Daniel McIlvaney <damcilva@microsoft.com> - 1.2.20-9
+- Add various CVE and correctness patches from Fedora 37
+- Fixes CVE-2021-33643, CVE-2021-33644, CVE-2021-33645, CVE-2021-33646
+
 * Sat May 09 2020 Nick Samson <nisamson@microsoft.com> - 1.2.20-8
 - Added %%license line automatically
 

--- a/SPECS/libtar/libtar.spec
+++ b/SPECS/libtar/libtar.spec
@@ -2,11 +2,11 @@ Summary:        C library for manipulating tar files
 Name:           libtar
 Version:        1.2.20
 Release:        9%{?dist}
-URL:            https://github.com/tklauser/libtar/
 License:        BSD
-Group:          System Environment/Libraries
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
+Group:          System Environment/Libraries
+URL:            https://github.com/tklauser/libtar/
 #Source0:       https://github.com/tklauser/%{name}/archive/v%{version}.tar.gz
 Source0:        %{name}-%{version}.tar.gz
 # This patch appears to replicate Fedora's ' libtar-1.2.11-bz729009.patch'
@@ -34,7 +34,7 @@ The litar-devel package contains libraries and header files for
 developing applications that use libtar.
 
 %prep
-%setup
+%setup -q
 %autopatch -p1
 autoreconf -iv
 
@@ -75,15 +75,21 @@ chmod +x %{buildroot}/%{_libdir}/libtar.so.*
 
 *   Thu Apr 23 2020 Nick Samson <nisamson@microsoft.com> 1.2.20-7
 -   Updated Source0, URL, removed sha1 line. License verified.
+
 *   Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 1.2.20-6
 -   Initial CBL-Mariner import from Photon (license: Apache2).
+
 *   Thu Nov 02 2017 Xiaolin Li <xiaolinl@vmware.com> 1.2.20-5
 -   Fix CVE-2013-4420
+
 *   Thu Jun 29 2017 Chang Lee <changlee@vmware.com> 1.2.20-4
 -   Removed %check due to no test existence.
+
 *   Tue Apr 25 2017 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 1.2.20-3
 -   Ensure non empty debuginfo
+
 *   Fri Mar 10 2017 Xiaolin Li <xiaolinl@vmware.com> 1.2.20-2
 -   Provides libtar.so.0()(64bit).
+
 *   Fri Mar 03 2017 Xiaolin Li <xiaolinl@vmware.com> 1.2.20-1
 -   Initial packaging for Photon


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
The NIST database does not mark these fixes as available, however Redhat has patched them in Fedora along with several other correctness issues.

We already had analogues to a pair of the patches were left in place. 

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Apply Fedora patches for CVE-2021-33643, CVE-2021-33644, CVE-2021-33645, CVE-2021-33646
- Apply misc. Fedora patches for other correctness issues

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
-  https://nvd.nist.gov/vuln/detail/CVE-2021-33643
-  https://nvd.nist.gov/vuln/detail/CVE-2021-33644
-  https://nvd.nist.gov/vuln/detail/CVE-2021-33645
-  https://nvd.nist.gov/vuln/detail/CVE-2021-33646

###### Test Methodology
Local build, full pipeline queued
pipeline passed: 233004

