### PR TITLE
Build Rust as a stable release and disable unstable features

### DIFF
--- a/SPECS-EXTENDED/ripgrep/ripgrep.spec
+++ b/SPECS-EXTENDED/ripgrep/ripgrep.spec
@@ -20,7 +20,7 @@
 
 Name:           ripgrep
 Version:        13.0.0
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        A search tool that combines ag with grep
 License:        MIT AND Unlicense
 Vendor:         Microsoft Corporation
@@ -104,6 +104,9 @@ install -Dm 644 complete/_rg %{buildroot}%{_datadir}/zsh/site-functions/_rg
 %{_datadir}/zsh
 
 %changelog
+* Wed Aug 31 2022 Olivia Crain <oliviacrain@microsoft.com> - 13.0.0-4
+- Bump package to rebuild with stable Rust compiler
+
 * Tue Dec 28 2021 Suresh Babu Chalamalasetty <schalam@microsoft.com> - 13.0.0-3
 - Initial CBL-Mariner import from openSUSE Tumbleweed (license: same as "License" tag).
 - License verified

--- a/SPECS/clamav/clamav.spec
+++ b/SPECS/clamav/clamav.spec
@@ -1,7 +1,7 @@
 Summary:        Open source antivirus engine
 Name:           clamav
 Version:        0.105.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        ASL 2.0 AND BSD AND bzip2-1.0.4 AND GPLv2 AND LGPLv2+ AND MIT AND Public Domain AND UnRar
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -126,6 +126,9 @@ fi
 %dir %attr(-,clamav,clamav) %{_sharedstatedir}/clamav
 
 %changelog
+* Wed Aug 31 2022 Olivia Crain <oliviacrain@microsoft.com> - 0.105.0-2
+- Bump package to rebuild with stable Rust compiler
+
 * Mon Jun 13 2022 Andrew Phelps <anphel@microsoft.com> - 0.105.0-1
 - Upgrade to version 0.105.0
 

--- a/SPECS/cloud-hypervisor/cloud-hypervisor.spec
+++ b/SPECS/cloud-hypervisor/cloud-hypervisor.spec
@@ -5,7 +5,7 @@
 Summary:        Cloud Hypervisor is an open source Virtual Machine Monitor (VMM) that runs on top of KVM.
 Name:           cloud-hypervisor
 Version:        26.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        ASL 2.0 OR BSD-3-clause
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -148,6 +148,9 @@ cargo build --release --target=%{rust_musl_target} --package vhost_user_block %{
 %license LICENSE-BSD-3-Clause
 
 %changelog
+* Wed Aug 31 2022 Olivia Crain <oliviacrain@microsoft.com> - 26.0-2
+- Bump package to rebuild with stable Rust compiler
+
 * Thu Aug 18 2022 Chris Co <chrco@microsoft.com> - 26.0-1
 - anbelski@linux.microsoft.com, 26.0-1 - Pull release 26.0 for Mariner from upstream
 - anbelski@linux.microsoft.com, 23.1-0 - Initial import 23.1 for Mariner from upstream

--- a/SPECS/librsvg2/librsvg2.spec
+++ b/SPECS/librsvg2/librsvg2.spec
@@ -8,7 +8,7 @@
 Summary:        An SVG library based on cairo
 Name:           librsvg2
 Version:        2.50.3
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        LGPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -111,6 +111,9 @@ rm -vrf %{buildroot}%{_docdir}
 %{_mandir}/man1/rsvg-convert.1*
 
 %changelog
+* Wed Aug 31 2022 Olivia Crain <oliviacrain@microsoft.com> - 2.50.3-3
+- Bump package to rebuild with stable Rust compiler
+
 * Thu Jul 08 2021 Vinicius Jarina <vinja@microsoft.com> - 2.50.3-2
 - Initial CBL-Mariner import from Fedora 33 (license: MIT).
 - License verified.

--- a/SPECS/mozjs/mozjs.spec
+++ b/SPECS/mozjs/mozjs.spec
@@ -3,7 +3,7 @@
 Summary:        Mozilla's JavaScript engine.
 Name:           mozjs
 Version:        78.10.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        BSD AND MIT AND MPLv2.0 AND Unicode
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -127,6 +127,9 @@ fi
 %{_libdir}/pkgconfig/mozjs-%{major}.pc
 
 %changelog
+* Wed Aug 31 2022 Olivia Crain <oliviacrain@microsoft.com> - 78.10.0-3
+- Bump package to rebuild with stable Rust compiler
+
 * Wed Sep 22 2021 Jon Slobodzian <joslobo@microsoft.com> - 78.10.0-2
 - Initial CBL-Mariner import from Photon (license: Apache2)
 - Fixing minor changelog formatting issues.

--- a/SPECS/rpm-ostree/rpm-ostree.spec
+++ b/SPECS/rpm-ostree/rpm-ostree.spec
@@ -1,7 +1,7 @@
 Summary:        Commit RPMs to an OSTree repository
 Name:           rpm-ostree
 Version:        2022.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        LGPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -45,6 +45,7 @@ BuildRequires:  ostree-devel
 BuildRequires:  polkit-devel
 BuildRequires:  popt-devel
 BuildRequires:  python3-devel
+BuildRequires:  python3-pygments
 BuildRequires:  rpm-devel
 BuildRequires:  rust
 BuildRequires:  sqlite-devel
@@ -153,6 +154,10 @@ make check
 %{_datadir}/gir-1.0/*-1.0.gir
 
 %changelog
+* Wed Aug 31 2022 Olivia Crain <oliviacrain@microsoft.com> - 2022.1-2
+- Bump package to rebuild with stable Rust compiler
+- Add missing dependency on python3-pygments (needed to build docs)
+
 * Thu Jan 27 2022 Henry Li <lihl@microsoft.com> - 2022.1-1
 - Upgrade to version 2022.1
 - Remove patches that no longer apply

--- a/SPECS/rust/rust.spec
+++ b/SPECS/rust/rust.spec
@@ -9,8 +9,8 @@
 Summary:        Rust Programming Language
 Name:           rust
 Version:        1.62.1
-Release:        1%{?dist}
-License:        ASL 2.0 AND MIT
+Release:        2%{?dist}
+License:        ASL 2.0 OR MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Group:          Applications/System
@@ -33,11 +33,10 @@ BuildRequires:  git
 BuildRequires:  glibc
 BuildRequires:  ninja-build
 BuildRequires:  python3
-
-%if %{with_check}
-BuildRequires:  python3-xml
-%endif
-
+# rustc uses a C compiler to invoke the linker, and links to glibc in most cases
+Requires:       binutils
+Requires:       gcc
+Requires:       glibc-devel
 Provides:       cargo = %{version}-%{release}
 
 %description
@@ -75,7 +74,13 @@ mv %{SOURCE7} "$BUILD_CACHE_DIR"
 export CFLAGS="`echo " %{build_cflags} " | sed 's/ -g//'`"
 export CXXFLAGS="`echo " %{build_cxxflags} " | sed 's/ -g//'`"
 
-sh ./configure --prefix=%{_prefix} --enable-extended --tools="cargo,rustfmt"
+sh ./configure \
+    --prefix=%{_prefix} \
+    --enable-extended \
+    --tools="cargo,rustfmt" \
+    --release-channel="stable" \
+    --release-description="CBL-Mariner %{version}-%{release}"
+
 # SUDO_USER=root bypasses a check in the python bootstrap that
 # makes rust refuse to pull sources from the internet
 USER=root SUDO_USER=root %make_build
@@ -92,7 +97,7 @@ rm %{buildroot}%{_docdir}/%{name}/*.old
 %ldconfig_scriptlets
 
 %files
-%license LICENSE-MIT
+%license LICENSE-MIT LICENSE-APACHE COPYRIGHT
 %doc CONTRIBUTING.md README.md RELEASES.md
 %{_bindir}/rustc
 %{_bindir}/rustdoc
@@ -119,6 +124,13 @@ rm %{buildroot}%{_docdir}/%{name}/*.old
 %{_sysconfdir}/bash_completion.d/cargo
 
 %changelog
+* Wed Aug 31 2022 Olivia Crain <oliviacrain@microsoft.com> - 1.62.1-2
+- Breaking change: Configure as a stable release, which disables unstable features
+- Add runtime requirements on gcc, binutils, glibc-devel
+- Package ASL 2.0 license, additional copyright information
+- Fix licensing info- dual-licensed, not multiply-licensed
+- License verified
+
 * Thu Aug 18 2022 Chris Co <chrco@microsoft.com> - 1.62.1-1
 - Updating to version 1.62.1
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Currently, our version of `rustc` is shipped in a development release mode with unstable features enabled. Oops! That's unintentional and goes against what most customers would expect. This PR sets up our `rust` package to build as a stable release.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
Rust:
- Configure as a stable release, which disables unstable features
- Add runtime requirements on gcc, binutils, glibc-devel
- Package ASL 2.0 license, additional copyright information
- Fix licensing info- dual-licensed, not multiply-licensed
- License verified

Other packages:
- Bump release to rebuild with new Rust package

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Test build of affected packages- no regressions in package tests