### PR TITLE
livepatching: make exclusive to x86_64.

### DIFF
--- a/SPECS/livepatching/livepatching.spec
+++ b/SPECS/livepatching/livepatching.spec
@@ -12,7 +12,7 @@ URL:            https://aka.ms/cbl-mariner
 Source0:        livepatching.service
 Source1:        livepatching.systemd
 
-BuildArch:      noarch
+ExclusiveArch:  x86_64
 
 BuildRequires:  systemd
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

Disabling building of `livepatching.spec` for ARM64 - the package depends on AMD64-only `kpatch` and there's no livepatching available for ARM64 anyway. At least not yet.

**NOTE**: not updating the `Release` tag, since the package hasn't been released or even built properly, yet.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Made `livepatching.spec` build only under x86_64.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- N/A
