### PR TITLE
python-kdcproxy: add BR on python-pip and drop BR on pytest to enable ptest

### DIFF
--- a/SPECS-EXTENDED/python-kdcproxy/python-kdcproxy.spec
+++ b/SPECS-EXTENDED/python-kdcproxy/python-kdcproxy.spec
@@ -4,7 +4,7 @@ Distribution:   Mariner
 
 Name:           python-%{realname}
 Version:        0.4.2
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        MS-KKDCP (kerberos proxy) WSGI module
 
 License:        MIT
@@ -14,12 +14,14 @@ Source0:        https://github.com/npmccallum/%{realname}/archive/%{realname}-%{
 BuildArch:      noarch
 BuildRequires:  git
 
-BuildRequires:  python3-devel
-BuildRequires:  python3-pytest
-BuildRequires:  python3-coverage
 BuildRequires:  python3-asn1crypto
+BuildRequires:  python3-devel
 BuildRequires:  python3-dns
+%if %{with_check}
+BuildRequires:  python3-coverage
 BuildRequires:  python3-mock
+BuildRequires:  python3-pip
+%endif
 
 
 %description
@@ -49,6 +51,7 @@ minimal configuration.
 %py3_install
 
 %check
+%{__python3} -m pip install pytest==7.1.2
 KDCPROXY_ASN1MOD=asn1crypto %{__python3} -m pytest
 
 %files -n python3-%{realname}
@@ -58,6 +61,9 @@ KDCPROXY_ASN1MOD=asn1crypto %{__python3} -m pytest
 %{python3_sitelib}/%{realname}-%{version}-*.egg-info
 
 %changelog
+* Tue Aug 30 2022 Muhammad Falak <mwani@microsoft.com> - 0.4.2-5
+- Add BR on python-pip and drop BR on pytest to enable ptest
+
 * Fri Oct 15 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 0.4.2-4
 - Initial CBL-Mariner import from Fedora 32 (license: MIT).
 

--- a/SPECS-EXTENDED/python-kdcproxy/python-kdcproxy.spec
+++ b/SPECS-EXTENDED/python-kdcproxy/python-kdcproxy.spec
@@ -8,8 +8,8 @@ Release:        5%{?dist}
 Summary:        MS-KKDCP (kerberos proxy) WSGI module
 
 License:        MIT
-URL:            https://github.com/npmccallum/%{realname}
-Source0:        https://github.com/npmccallum/%{realname}/archive/%{realname}-%{version}.tar.gz#/python-%{realname}-%{version}.tar.gz
+URL:            https://github.com/latchset/%{realname}
+Source0:        https://github.com/latchset/%{realname}/releases/download/v%{version}/%{realname}-%{version}.tar.gz#/python-%{realname}-%{version}.tar.gz
 
 BuildArch:      noarch
 BuildRequires:  git

--- a/SPECS-EXTENDED/python-kdcproxy/python-kdcproxy.spec
+++ b/SPECS-EXTENDED/python-kdcproxy/python-kdcproxy.spec
@@ -63,6 +63,7 @@ KDCPROXY_ASN1MOD=asn1crypto %{__python3} -m pytest
 %changelog
 * Tue Aug 30 2022 Muhammad Falak <mwani@microsoft.com> - 0.4.2-5
 - Add BR on python-pip and drop BR on pytest to enable ptest
+- License verified
 
 * Fri Oct 15 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 0.4.2-4
 - Initial CBL-Mariner import from Fedora 32 (license: MIT).

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -20915,7 +20915,7 @@
         "other": {
           "name": "python-kdcproxy",
           "version": "0.4.2",
-          "downloadUrl": "https://github.com/npmccallum/kdcproxy/archive/kdcproxy-0.4.2.tar.gz"
+          "downloadUrl": "https://github.com/latchset/kdcproxy/releases/download/v0.4.2/kdcproxy-0.4.2.tar.gz"
         }
       }
     },


### PR DESCRIPTION
Signed-off-by: Muhammad Falak R Wani <falakreyaz@gmail.com>

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Fix ptest build. All tests pass!

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add BR on python-pip and drop BR on pytest to enable ptest

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- NA

###### Links to CVEs  <!-- optional -->
- NA

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local Build with RUN_CHECK=y && RUN_CHECK=n
- BuddyBuild: [235687](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=235687&view=logs&j=75cba72d-09cb-503a-3927-4ab61ac4a179&t=246631ef-4e63-576d-3b21-bc52cd4b0a93&l=2070)
