### PR TITLE
perl-Config-IniFiles: add BR on `perl(blib)` to enable ptest

### DIFF
--- a/SPECS-EXTENDED/perl-Config-IniFiles/perl-Config-IniFiles.spec
+++ b/SPECS-EXTENDED/perl-Config-IniFiles/perl-Config-IniFiles.spec
@@ -2,7 +2,7 @@ Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Name:           perl-Config-IniFiles
 Version:        3.000002
-Release:        5%{?dist}
+Release:        6%{?dist}
 Summary:        A module for reading .ini-style configuration files
 # LICENSE:                              GPL+ or Artistic
 # lib/Config/IniFiles.pm:               GPL+ or Artistic
@@ -32,17 +32,20 @@ BuildRequires:  perl(List::Util) >= 1.33
 BuildRequires:  perl(Symbol)
 BuildRequires:  perl(vars)
 # Tests:
-BuildRequires:  perl(base)
+%if %{with_check}
 BuildRequires:  perl(English)
 BuildRequires:  perl(Exporter)
 BuildRequires:  perl(File::Spec)
 BuildRequires:  perl(IO::File)
 BuildRequires:  perl(IO::Handle)
 BuildRequires:  perl(IPC::Open3)
-BuildRequires:  perl(lib)
-BuildRequires:  perl(parent)
 BuildRequires:  perl(Scalar::Util)
 BuildRequires:  perl(Test::More)
+BuildRequires:  perl(base)
+BuildRequires:  perl(blib)
+BuildRequires:  perl(lib)
+BuildRequires:  perl(parent)
+%endif
 BuildArch:      noarch
 Requires:       perl(:MODULE_COMPAT_%(eval "`perl -V:version`"; echo $version))
 # Not autodetected. Found in lib/Config/IniFiles.pm:2761
@@ -82,6 +85,9 @@ perl Build.PL installdirs=vendor
 %{_mandir}/man3/*.3pm*
 
 %changelog
+* Thu Sep 01 2022 Muhammad Falak <mwani@microsoft.com> - 3.000002-6
+- Add BR on `perl(blib)` to enable ptest
+
 * Fri Oct 15 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 3.000002-5
 - Initial CBL-Mariner import from Fedora 32 (license: MIT).
 

--- a/SPECS-EXTENDED/perl-Config-IniFiles/perl-Config-IniFiles.spec
+++ b/SPECS-EXTENDED/perl-Config-IniFiles/perl-Config-IniFiles.spec
@@ -87,6 +87,7 @@ perl Build.PL installdirs=vendor
 %changelog
 * Thu Sep 01 2022 Muhammad Falak <mwani@microsoft.com> - 3.000002-6
 - Add BR on `perl(blib)` to enable ptest
+- License verified
 
 * Fri Oct 15 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 3.000002-5
 - Initial CBL-Mariner import from Fedora 32 (license: MIT).


### PR DESCRIPTION
Signed-off-by: Muhammad Falak R Wani <falakreyaz@gmail.com>

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Fix ptest build. All tests pass!

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add BR on `perl(blib)` to enable ptest

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- NA

###### Links to CVEs  <!-- optional -->
- NA

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local Build with RUN_CHECK=y & RUN_CHECK=n
- BuddyBuild: [235712](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=235712&view=logs&j=75cba72d-09cb-503a-3927-4ab61ac4a179&t=246631ef-4e63-576d-3b21-bc52cd4b0a93&l=2144)
