### PR TITLE
Police `glibc-static` versions

### DIFF
--- a/SPECS-EXTENDED/buildah/buildah.spec
+++ b/SPECS-EXTENDED/buildah/buildah.spec
@@ -40,7 +40,7 @@ BuildRequires: device-mapper-devel
 BuildRequires: golang
 BuildRequires: git
 BuildRequires: glib2-devel
-BuildRequires: glibc-static
+BuildRequires: glibc-static >= 2.35-2
 BuildRequires: go-md2man
 BuildRequires: go-rpm-macros
 BuildRequires: gpgme-devel

--- a/SPECS-EXTENDED/buildah/buildah.spec
+++ b/SPECS-EXTENDED/buildah/buildah.spec
@@ -31,7 +31,7 @@ Distribution:   Mariner
 
 Name: %{repo}
 Version: 1.18.0
-Release: 4%{?dist}
+Release: 5%{?dist}
 Summary: A command line tool used for creating OCI Images
 License: ASL 2.0
 URL: https://%{name}.io
@@ -146,6 +146,9 @@ cp imgtype %{buildroot}/%{_bindir}/%{name}-imgtype
 %{_datadir}/%{name}/test
 
 %changelog
+* Tue Sep 13 2022 Andy Caldwell <andycaldwell@microsoft.com> - 1.18.0-5
+- Rebuilt for glibc-static 2.35-2
+
 * Mon Aug 22 2022 Olivia Crain <oliviacrain@microsoft.com> - 1.18.0-4
 - Bump release to rebuild against Go 1.18.5
 

--- a/SPECS-EXTENDED/catatonit/catatonit.spec
+++ b/SPECS-EXTENDED/catatonit/catatonit.spec
@@ -13,7 +13,7 @@ BuildRequires: automake
 BuildRequires: file
 BuildRequires: gcc
 BuildRequires: git
-BuildRequires: glibc-static
+BuildRequires: glibc-static >= 2.35-2
 BuildRequires: libtool
 BuildRequires: make
 

--- a/SPECS-EXTENDED/catatonit/catatonit.spec
+++ b/SPECS-EXTENDED/catatonit/catatonit.spec
@@ -3,7 +3,7 @@ Distribution:   Mariner
 
 Name: catatonit
 Version: 0.1.7
-Release: 5%{?dist}
+Release: 6%{?dist}
 Summary: A signal-forwarding process manager for containers
 License: GPLv3+
 URL: https://github.com/openSUSE/catatonit
@@ -61,6 +61,9 @@ ln -s %{_libexecdir}/%{name}/%{name} %{buildroot}%{_libexecdir}/podman/%{name}
 %{_libexecdir}/podman/%{name}
 
 %changelog
+* Tue Sep 13 2022 Andy Caldwell <andycaldwell@microsoft.com> - 0.1.7-6
+- Rebuilt for glibc-static 2.35-2
+
 * Fri Mar 18 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 0.1.7-1
 - Updating to 0.1.7 using Fedora 35 spec (license: MIT) for guidance.
 - License verified.

--- a/SPECS-EXTENDED/dyninst/dyninst.spec
+++ b/SPECS-EXTENDED/dyninst/dyninst.spec
@@ -1,7 +1,7 @@
 Summary: An API for Run-time Code Generation
 License: LGPLv2+
 Name: dyninst
-Release: 7%{?dist}
+Release: 8%{?dist}
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 URL: http://www.dyninst.org
@@ -194,6 +194,9 @@ echo "%{_libdir}/dyninst" > %{buildroot}/etc/ld.so.conf.d/%{name}-%{_arch}.conf
 %attr(644,root,root) %{_libdir}/dyninst/testsuite/*.a
 
 %changelog
+* Tue Sep 13 2022 Andy Caldwell <andycaldwell@microsoft.com> - 10.1.0-8
+- Rebuilt for glibc-static 2.35-2
+
 * Thu Mar 03 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 10.1.0-7
 - Adding a patch to enable compilation for GCC 11.
 - License verified.

--- a/SPECS-EXTENDED/dyninst/dyninst.spec
+++ b/SPECS-EXTENDED/dyninst/dyninst.spec
@@ -30,7 +30,8 @@ BuildRequires: libtirpc-devel
 BuildRequires: tbb tbb-devel
 
 # Extra requires just for the testsuite
-BuildRequires: gcc-gfortran glibc-static libstdc++-static libxml2-devel
+BuildRequires: gcc-gfortran libstdc++-static libxml2-devel
+BuildRequires: glibc-static >= 2.35-2
 
 # Testsuite files should not provide/require anything
 %{?filter_setup:

--- a/SPECS-EXTENDED/podman/podman.spec
+++ b/SPECS-EXTENDED/podman/podman.spec
@@ -50,8 +50,7 @@ BuildRequires:  go-md2man
 BuildRequires:  golang
 BuildRequires:  gcc
 BuildRequires:  glib2-devel
-BuildRequires:  glibc-devel
-BuildRequires:  glibc-static
+BuildRequires:  glibc-static >= 2.35-2
 BuildRequires:  git
 BuildRequires:  go-rpm-macros
 BuildRequires:  gpgme-devel

--- a/SPECS-EXTENDED/podman/podman.spec
+++ b/SPECS-EXTENDED/podman/podman.spec
@@ -36,7 +36,7 @@
 
 Name:           podman
 Version:        4.1.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        ASL 2.0 and BSD and ISC and MIT and MPLv2.0
 Summary:        Manage Pods, Containers and Container Images
 Vendor:         Microsoft Corporation
@@ -386,6 +386,9 @@ cp -pav test/system %{buildroot}/%{_datadir}/%{name}/test/
 
 # rhcontainerbot account currently managed by lsm5
 %changelog
+* Tue Sep 13 2022 Andy Caldwell <andycaldwell@microsoft.com> - 4.1.1-3
+- Rebuilt for glibc-static 2.35-2
+
 * Mon Aug 22 2022 Olivia Crain <oliviacrain@microsoft.com> - 4.1.1-2
 - Bump release to rebuild against Go 1.18.5
 

--- a/SPECS/glibc/glibc.spec
+++ b/SPECS/glibc/glibc.spec
@@ -49,11 +49,18 @@ Summary:        Header files for glibc
 Group:          Applications/System
 Requires:       %{name} = %{version}-%{release}
 Provides:       %{name}-headers = %{version}-%{release}
-Provides:       %{name}-static = %{version}-%{release}
-Provides:       %{name}-static%{?_isa} = %{version}-%{release}
 
 %description devel
 These are the header files of glibc.
+
+%package static
+Summary:        Static glibc library and runtimes
+Group:          Applications/System
+Requires:       %{name}-devel = %{version}-%{release}
+Provides:       %{name}-static%{?_isa} = %{version}-%{release}
+
+%description static
+These are the static artefacts for glibc.
 
 %package lang
 Summary:        Additional language files for glibc
@@ -288,9 +295,15 @@ grep "^FAIL: nptl/tst-eintr1" tests.sum >/dev/null && n=$((n+1)) ||:
 %defattr(-,root,root)
 # TODO: Excluding for now to remove dependency on PERL
 # /usr/bin/mtrace
-%{_lib64dir}/*.a
-%{_lib64dir}/*.o
+%{_lib64dir}/{g,M,S}crt1.o
+%{_lib64dir}/crti.o
+%{_lib64dir}/crtn.o
 %{_includedir}/*
+
+%files static
+%defattr(-,root,root)
+%{_lib64dir}/{,r,gr}crt1.o
+%{_lib64dir}/*.a
 
 %files -f %{name}.lang lang
 %defattr(-,root,root)

--- a/SPECS/libguestfs/libguestfs.spec
+++ b/SPECS/libguestfs/libguestfs.spec
@@ -89,7 +89,7 @@ BuildRequires:  gcc-c++
 BuildRequires:  gdisk
 BuildRequires:  genisoimage
 BuildRequires:  gfs2-utils
-BuildRequires:  glibc-static
+BuildRequires:  glibc-static >= 2.35-2
 BuildRequires:  gobject-introspection-devel
 BuildRequires:  gperf
 BuildRequires:  grep

--- a/SPECS/libguestfs/libguestfs.spec
+++ b/SPECS/libguestfs/libguestfs.spec
@@ -25,7 +25,7 @@
 Summary:        Access and modify virtual machine disk images
 Name:           libguestfs
 Version:        1.44.0
-Release:        8%{?dist}
+Release:        9%{?dist}
 License:        LGPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -1234,6 +1234,9 @@ rm ocaml/html/.gitignore
 %endif
 
 %changelog
+* Tue Sep 13 2022 Andy Caldwell <andycaldwell@microsoft.com> - 1.44.0-9
+- Rebuilt for glibc-static 2.35-2
+
 * Thu Sep 01 2022 Andrew Phelps <anphel@microsoft.com> - 1.44.0-8
 - Remove duplicate BR on qemu-img
 - Change runtime requires from qemu-img binary to qemu-img package

--- a/SPECS/supermin/supermin.spec
+++ b/SPECS/supermin/supermin.spec
@@ -21,7 +21,7 @@
 Summary:        Tool for creating supermin appliances
 Name:           supermin
 Version:        5.2.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        GPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -129,6 +129,9 @@ make check || {
 %{_rpmconfigdir}/supermin-find-requires
 
 %changelog
+* Tue Sep 13 2022 Andy Caldwell <andycaldwell@microsoft.com> - 5.2.1-4
+- Rebuilt for glibc-static 2.35-2
+
 * Tue Apr 26 2022 Olivia Crain <oliviacrain@microsoft.com> - 5.2.1-3
 - Explicitly require mariner-release at run-time
 

--- a/SPECS/supermin/supermin.spec
+++ b/SPECS/supermin/supermin.spec
@@ -54,7 +54,7 @@ BuildRequires:  systemd-udev
 %if %{with dietlibc}
 BuildRequires:  dietlibc-devel
 %else
-BuildRequires:  glibc-static
+BuildRequires:  glibc-static >= 2.35-2
 %endif
 
 %if %{with_check}

--- a/SPECS/tini/tini.spec
+++ b/SPECS/tini/tini.spec
@@ -1,7 +1,7 @@
 Summary:        A tiny but valid init for containers
 Name:           tini
 Version:        0.19.0
-Release:        7%{?dist}
+Release:        8%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -66,6 +66,9 @@ ln -s %{_bindir}/tini-static %{buildroot}%{_bindir}/docker-init
 %{_bindir}/docker-init
 
 %changelog
+* Tue Sep 13 2022 Andy Caldwell <andycaldwell@microsoft.com> - 0.19.0-8
+- Rebuilt for glibc-static 2.35-2
+
 * Mon Feb 21 2022 Andy Caldwell <andycaldwell@microsoft.com> - 0.19.0-7
 - Re-enable `tini-static` package
 - Enable binary hardening flag (`-static-pie`)

--- a/SPECS/tini/tini.spec
+++ b/SPECS/tini/tini.spec
@@ -12,7 +12,8 @@ BuildRequires:  cmake
 BuildRequires:  diffutils
 BuildRequires:  file
 BuildRequires:  gcc
-BuildRequires:  glibc-devel >= 2.34-3
+BuildRequires:  glibc-devel
+BuildRequires:  glibc-static >= 2.35-2
 BuildRequires:  kernel-headers
 BuildRequires:  make
 BuildRequires:  sed

--- a/toolkit/scripts/check_static_glibc.py
+++ b/toolkit/scripts/check_static_glibc.py
@@ -1,0 +1,67 @@
+#!/usr/bin/python3
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+from pyrpm.spec import Spec
+from os.path import dirname, realpath
+
+import argparse
+import re
+import sys
+
+def get_glibc_version():
+    glibc_spec = Spec.from_file("SPECS/glibc/glibc.spec")
+    epoch_prefix = "{}:".format(glibc_spec.epoch) if glibc_spec.epoch else ""
+    release_without_dist = glibc_spec.release.replace("%{?dist}", "")
+    release_suffix = "-{}".format(release_without_dist)
+    glibc_version = epoch_prefix + glibc_spec.version + release_suffix
+    return glibc_version
+
+def check_spec(path, glibc_version):
+    spec = Spec.from_file(path)
+    for br in spec.build_requires:
+        if br.name == "glibc-static":
+            issues = []
+            if not br.version:
+                issues.append(f"  * Does not specify a minimum version for its `glibc-static` BuildRequires")
+            if br.version and br.version != glibc_version:
+                issues.append(f"  * Does not specify the latest `glibc-static` version in its BuildRequires")
+            if br.operator and br.operator != ">=":
+                issues.append(f"  * Uses bad BuildRequire `glibc-static` comparison operator `{br.operator}`")
+
+            if issues:
+                print(f"Specfile {spec.name} (at {path}):")
+                for issue in issues:
+                    print(issue)
+                print(f"  Suggestion: Use `glibc-static >= {glibc_version}`")
+                print()
+                return False
+    return True
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description="Tool for checking if an RPM spec file follows CBL-Mariner's guidelines.")
+    parser.add_argument('specs',
+                        metavar='spec_path',
+                        nargs='+',
+                        help='path to an RPM spec file')
+    args = parser.parse_args()
+
+    glibc_version = get_glibc_version()
+
+    print(f"glibc-static version detected: {glibc_version}")
+    print()
+
+    specs_correct = True
+    for spec in args.specs:
+        if not check_spec(spec, glibc_version):
+            specs_correct = False
+
+    if specs_correct:
+        print("====================== Spec verification PASSED ======================")
+    else:
+        print("""====================== Spec verification FAILED ======================
+
+Please update the spec files listed above.
+""")
+        sys.exit(1)

--- a/toolkit/scripts/check_static_glibc.py
+++ b/toolkit/scripts/check_static_glibc.py
@@ -40,7 +40,7 @@ def check_spec(path, glibc_version):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
-        description="Tool for checking if an RPM spec file follows CBL-Mariner's guidelines.")
+        description="Tool for checking if an RPM spec file correctly handles dependencies for statically linked glibc.")
     parser.add_argument('specs',
                         metavar='spec_path',
                         nargs='+',


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.  ❤️ 
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
As per the 4th bullet above it's important that when glibc-static (and other paclkages) are released that other packages that depend on those static artefacts are also rebuilt and released at the same time.

This PR attempts to police this for `glibc-static` in two stages:

* Splitting `glibc-static` out as a real package (rahter than an alias to `glibc-devel`) that contains the `.a` and static runtime files - this means that packages that wish to build statically against glibc will have to name `glibc-static` in their `BuildRequires`.
* Adding a script that checks that every instance of `glibc-static` in a `BuildRequires` has a version bound of `>=` the current version of the `glibc` packages - this means that they can't miss any `glibc` releases.

I'm raising this PR now to kick of discussions around the approach, along with any discussions about how we want to run this script (Github action?  On PR branches or just main/release branches?  Official build pipeline?  Other?).  Obviously if the pattern is deemed a good idea we can also apply it to other similar packages (e.g. `golang` as a `BuildRequire`, or `dietlibc`/`ulibc`) too.

If a specfile fails the test you get output similar to:

```
glibc-static version detected: 2.35-2

Specfile tini (at SPECS/tini/tini.spec):
  * Does not specify the latest `glibc-static` version in its BuildRequires
  Suggestion: Use `glibc-static >= 2.35-2`

====================== Spec verification FAILED ======================

Please update the spec files listed above.
```

###### Change Log
- Rebuild statically linked packages for the `glibc 2.35-2` release

###### Does this affect the toolchain?
YES - though exactly how is still up for debate

###### Links to CVEs
- https://nvd.nist.gov/vuln/detail/CVE-2022-23218
- https://nvd.nist.gov/vuln/detail/CVE-2022-23219

###### Test Methodology
Local builds
