### PR TITLE
Upgrade libjpeg-turbo version to 2.1.4 to fix CVE-2020-35538

### DIFF
--- a/SPECS/libjpeg-turbo/libjpeg-turbo.signatures.json
+++ b/SPECS/libjpeg-turbo/libjpeg-turbo.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "libjpeg-turbo-2.1.2.tar.gz": "09b96cb8cbff9ea556a9c2d173485fd19488844d55276ed4f42240e1e2073ce5"
+  "libjpeg-turbo-2.1.4.tar.gz": "d3ed26a1131a13686dfca4935e520eb7c90ae76fbc45d98bb50a8dc86230342b"
  }
 }

--- a/SPECS/libjpeg-turbo/libjpeg-turbo.spec
+++ b/SPECS/libjpeg-turbo/libjpeg-turbo.spec
@@ -63,8 +63,8 @@ popd
 %{_libdir}/cmake/%{name}/%{name}*.cmake
 
 %changelog
-*  Tue Sep 13 2022 Nan Liu <liunan@microsoft.com> - 2.1.4-1
--  Upgrade to version 2.1.4 to fix CVE-2020-35538
+* Tue Sep 13 2022 Nan Liu <liunan@microsoft.com> - 2.1.4-1
+- Upgrade to version 2.1.4 to fix CVE-2020-35538
 
 * Fri Jan 07 2022 Henry Li <lihl@microsoft.com> - 2.1.2-1
 - Upgrade to version 2.1.2

--- a/SPECS/libjpeg-turbo/libjpeg-turbo.spec
+++ b/SPECS/libjpeg-turbo/libjpeg-turbo.spec
@@ -1,6 +1,6 @@
 Summary:        fork of the original IJG libjpeg which uses SIMD.
 Name:           libjpeg-turbo
-Version:        2.1.2
+Version:        2.1.4
 Release:        1%{?dist}
 License:        IJG
 Vendor:         Microsoft Corporation
@@ -63,6 +63,9 @@ popd
 %{_libdir}/cmake/%{name}/%{name}*.cmake
 
 %changelog
+*  Tue Sep 13 2022 Nan Liu <liunan@microsoft.com> - 2.1.4-1
+-  Upgrade to version 2.1.4 to fix CVE-2020-35538
+
 * Fri Jan 07 2022 Henry Li <lihl@microsoft.com> - 2.1.2-1
 - Upgrade to version 2.1.2
 - Add related cmake files to libjpeg-turbo-devel pacakge

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -8831,8 +8831,8 @@
         "type": "other",
         "other": {
           "name": "libjpeg-turbo",
-          "version": "2.1.2",
-          "downloadUrl": "http://downloads.sourceforge.net/libjpeg-turbo/libjpeg-turbo-2.1.2.tar.gz"
+          "version": "2.1.4",
+          "downloadUrl": "http://downloads.sourceforge.net/libjpeg-turbo/libjpeg-turbo-2.1.4.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Upgrade libjpeg-turbo version to 2.1.4 to fix [CVE-2020-35538](https://github.com/advisories/GHSA-grwc-h387-x9h2)

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change
Upgrade libjpeg-turbo version to 2.1.4 to fix [CVE-2020-35538](https://github.com/advisories/GHSA-grwc-h387-x9h2)

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**


###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2020-35538

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- local build