### PR TITLE
revert cloud-init dependency

### DIFF
--- a/SPECS/cloud-init/add-mariner-distro-support.patch
+++ b/SPECS/cloud-init/add-mariner-distro-support.patch
@@ -359,33 +359,10 @@ index 6951a0e3..411065f9 100644
     # Other config here will be given to the distro class and/or path classes
     paths:
        cloud_dir: /var/lib/cloud/
-diff -ruN a/systemd/cloud-init-local.service.tmpl b/systemd/cloud-init-local.service.tmpl
---- a/systemd/cloud-init-local.service.tmpl     2022-05-18 08:23:24.000000000 -0700
-+++ b/systemd/cloud-init-local.service.tmpl     2022-08-23 16:23:57.854218334 -0700
-@@ -1,9 +1,7 @@
- ## template:jinja
- [Unit]
- Description=Initial cloud-init job (pre-networking)
--{% if variant in ["ubuntu", "unknown", "debian", "rhel" ] %}
- DefaultDependencies=no
--{% endif %}
- Wants=network-pre.target
- After=hv_kvp_daemon.service
- After=systemd-remount-fs.service
-@@ -21,10 +19,8 @@
- Before=firewalld.target
- Conflicts=shutdown.target
- {% endif %}
--{% if variant in ["ubuntu", "unknown", "debian"] %}
- Before=sysinit.target
- Conflicts=shutdown.target
--{% endif %}
- RequiresMountsFor=/var/lib/cloud
- {% if variant == "rhel" %}
- ConditionPathExists=!/etc/cloud/cloud-init.disabled
-diff -ruN a/systemd/cloud-init.service.tmpl b/systemd/cloud-init.service.tmpl
---- a/systemd/cloud-init.service.tmpl   2022-05-18 08:23:24.000000000 -0700
-+++ b/systemd/cloud-init.service.tmpl   2022-08-23 16:21:56.556071614 -0700
+diff --git a/systemd/cloud-init.service.tmpl b/systemd/cloud-init.service.tmpl
+index c170aef7..20ff1daa 100644
+--- a/systemd/cloud-init.service.tmpl
++++ b/systemd/cloud-init.service.tmpl
 @@ -1,7 +1,7 @@
  ## template:jinja
  [Unit]
@@ -395,18 +372,6 @@ diff -ruN a/systemd/cloud-init.service.tmpl b/systemd/cloud-init.service.tmpl
  DefaultDependencies=no
  {% endif %}
  Wants=cloud-init-local.service
-@@ -26,11 +26,9 @@
- Before=network-online.target
- Before=sshd-keygen.service
- Before=sshd.service
--{% if variant in ["ubuntu", "unknown", "debian"] %}
- Before=sysinit.target
- Before=shutdown.target
- Conflicts=shutdown.target
--{% endif %}
- {% if variant in ["suse"] %}
- Before=shutdown.target
- Conflicts=shutdown.target
 diff --git a/templates/hosts.mariner.tmpl b/templates/hosts.mariner.tmpl
 new file mode 100644
 index 00000000..2e956382

--- a/SPECS/cloud-init/cloud-init.spec
+++ b/SPECS/cloud-init/cloud-init.spec
@@ -1,7 +1,7 @@
 Summary:        Cloud instance init scripts
 Name:           cloud-init
 Version:        22.2
-Release:        7%{?dist}
+Release:        8%{?dist}
 License:        GPLv3
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -146,6 +146,9 @@ make check %{?_smp_mflags}
 %config(noreplace) %{_sysconfdir}/cloud/cloud.cfg.d/10-azure-kvp.cfg
 
 %changelog
+* Thu Sep 15 2022 Minghe Ren <mingheren@microsoft.com> - 22.2-8
+- Revert the change for adding sysinit.target dependency on previous two releases
+
 * Wed Aug 22 2022 Nan Liu <liunan@microsoft.com> - 22.2-7
 - Update add-mariner-distro-support patch to fix cloud-init dependency cycle
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
This is PR is aimed to revert the recent changes that adding sysinit.target dependency on cloud-init as it introduced issues on Mariner derivative builds. See [Bug 41171461](https://microsoft.visualstudio.com/OS/_workitems/edit/41171461): GCS services starts 2 mins late in Mariner2.0 (5.15.57.1-3.cm2) causing VM create to fail and [Bug 41238224](https://microsoft.visualstudio.com/OS/_workitems/edit/41238224): Performance regression, takes a long time to start the VM, used to be faster

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Revert change made on https://github.com/microsoft/CBL-Mariner/pull/3485 and https://github.com/microsoft/CBL-Mariner/pull/3606
- Bump cloud-init version to 22.2-8

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
NO

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- [Bug 39862391](https://microsoft.visualstudio.com/OS/_workitems/edit/39862391): [2.0] Update cloud-init systemd units to ensure that sysinit.target means cloud-init.service has finished
- [Bug 41171461](https://microsoft.visualstudio.com/OS/_workitems/edit/41171461): GCS services starts 2 mins late in Mariner2.0 (5.15.57.1-3.cm2) causing VM create to fail
- [Bug 41238224](https://microsoft.visualstudio.com/OS/_workitems/edit/41238224): Performance regression, takes a long time to start the VM, used to be faster


###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local package build
