### PR TITLE
kata : add patch to avoid memory hotplug timeout, fix systemd service

### DIFF
--- a/SPECS/kata-containers/0005-Merged-PR-9956-shim-avoid-memory-hotplug-timeout.patch
+++ b/SPECS/kata-containers/0005-Merged-PR-9956-shim-avoid-memory-hotplug-timeout.patch
@@ -1,0 +1,28 @@
+From 7fab743a43e4f2063d560161753f2b6390c7add6 Mon Sep 17 00:00:00 2001
+From: Dan Mihai <dmihai@microsoft.com>
+Date: Thu, 15 Sep 2022 20:50:12 +0000
+Subject: [PATCH] Merged PR 9956: shim: avoid memory hotplug timeout
+
+Wait up to 10 seconds for cloud-hypervisor memory hotplug.
+---
+ src/runtime/virtcontainers/clh.go | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/src/runtime/virtcontainers/clh.go b/src/runtime/virtcontainers/clh.go
+index 118e1b4d..f18b6c6f 100644
+--- a/src/runtime/virtcontainers/clh.go
++++ b/src/runtime/virtcontainers/clh.go
+@@ -918,7 +918,9 @@ func (clh *cloudHypervisor) ResizeMemory(ctx context.Context, reqMemMB uint32, m
+ 	}
+ 
+ 	cl := clh.client()
+-	ctx, cancelResize := context.WithTimeout(ctx, clhAPITimeout*time.Second)
++	// FIXME: memory hotplug sometimes takes longer than 1 second.
++	// ctx, cancelResize := context.WithTimeout(ctx, clhAPITimeout*time.Second)
++	ctx, cancelResize := context.WithTimeout(ctx, 10*time.Second)
+ 	defer cancelResize()
+ 
+ 	resize := *chclient.NewVmResize()
+-- 
+2.17.1
+

--- a/SPECS/kata-containers/kata-containers.signatures.json
+++ b/SPECS/kata-containers/kata-containers.signatures.json
@@ -5,6 +5,6 @@
   "kata-containers-2.5.0-vendor.tar.gz": "cc5b061c34aebd49f88f284182e230b923e8b3c37124ea1405a6a42fcdcf68e7",
   "kata-containers-2.5.0.tar.gz": "fd57a23ab552001f2cb467458e87a8b01d7353bcdda18b44ec76a4fbee971716",
   "kata-osbuilder-generate.service": "4438c39799297efbf88cfc549964432a41506a3c89e13073fa908658a5bd6376",
-  "kata-osbuilder.sh": "c2fc6506645fcb2d61e07dad4942fe1ca931b1825df106a11417d882e44dab1e"
+  "kata-osbuilder.sh": "b2a0510933f36860c16447400119488a035a7cb579a6f8adc4925fff54f1883b"
  }
 }

--- a/SPECS/kata-containers/kata-containers.spec
+++ b/SPECS/kata-containers/kata-containers.spec
@@ -73,6 +73,7 @@ BuildRequires:  rust
 Requires:       busybox
 Requires:       dracut
 Requires:       kernel
+Requires:       libseccomp
 Requires:       qemu-kvm-core >= 4.2.0-4
 Requires:       %{_libexecdir}/virtiofsd
 
@@ -220,7 +221,7 @@ ln -sf %{_bindir}/kata-runtime %{buildroot}%{_prefix}/local/bin/kata-runtime
 
 %changelog
 * Thu Sep 15 2022 Neha Agarwal <nehaagarwal@microsoft.com> - 2.5.0-6
-- Add patch to avoid memory hotplug timeout.
+- Add patch to avoid memory hotplug timeout, add libseccomp.
 
 * Mon Sep 12 2022 Neha Agarwal <nehaagarwal@microsoft.com> - 2.5.0-5
 - Generate initrd on reload.

--- a/SPECS/kata-containers/kata-containers.spec
+++ b/SPECS/kata-containers/kata-containers.spec
@@ -39,7 +39,7 @@
 Summary:        Kata Containers version 2.x repository
 Name:           kata-containers
 Version:        2.5.0
-Release:        5%{?dist}
+Release:        6%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 URL:            https://github.com/%{name}/%{name}
@@ -53,6 +53,7 @@ Patch0:         0001-Merged-PR-9607-Allow-10-seconds-for-VM-creation-star.patch
 Patch1:         0002-Merged-PR-9671-Wait-for-a-possibly-slow-Guest.patch
 Patch2:         0003-Merged-PR-9805-Add-support-for-MSHV.patch
 Patch3:         0004-Merged-PR-9806-Fix-enable_debug-for-hypervisor.clh.patch
+Patch4:         0005-Merged-PR-9956-shim-avoid-memory-hotplug-timeout.patch
 
 BuildRequires:  golang
 BuildRequires:  git-core
@@ -241,6 +242,9 @@ fi
 %exclude %{kataosbuilderdir}/rootfs-builder/ubuntu
 
 %changelog
+* Thu Sep 15 2022 Neha Agarwal <nehaagarwal@microsoft.com> - 2.5.0-6
+- Add patch to avoid memory hotplug timeout.
+
 * Mon Sep 12 2022 Neha Agarwal <nehaagarwal@microsoft.com> - 2.5.0-5
 - Generate initrd on reload.
 

--- a/SPECS/kata-containers/kata-containers.spec
+++ b/SPECS/kata-containers/kata-containers.spec
@@ -169,18 +169,6 @@ ln -sf %{_bindir}/containerd-shim-kata-v2 %{buildroot}%{_prefix}/local/bin/conta
 ln -sf %{_bindir}/kata-monitor %{buildroot}%{_prefix}/local/bin/kata-monitor
 ln -sf %{_bindir}/kata-runtime %{buildroot}%{_prefix}/local/bin/kata-runtime
 
-# We could be run in a mock chroot, where uname will report
-# different kernel than what we have installed in the chroot.
-# So we need to determine a valid kernel version to test against.
-for kernelpath in /lib/modules/*/vmlinu*; do
-    KVERSION="$(echo $kernelpath | cut -d "/" -f 4)"
-    break
-done
-TEST_MODE=1 %{buildroot}%{kataosbuilderdir}/kata-osbuilder.sh \
-    -o %{buildroot}%{kataosbuilderdir} \
-    -k "$KVERSION" \
-    -a %{buildroot}
-
 %preun
 %systemd_preun kata-osbuilder-generate.service
 
@@ -189,17 +177,6 @@ TEST_MODE=1 %{buildroot}%{kataosbuilderdir}/kata-osbuilder.sh \
 
 %post
 %systemd_post kata-osbuilder-generate.service
-# Skip running this on Fedora CoreOS / Red Hat CoreOS
-if test -w %{katalocalstatecachedir}; then
-    TMPOUT="$(mktemp -t kata-rpm-post-XXXXXX.log)"
-    echo "Creating kata appliance initrd..."
-    %{kataosbuilderdir}/kata-osbuilder.sh > ${TMPOUT} 2>&1
-    if test "$?" != "0" ; then
-        echo "Building failed. Here is the log details:"
-        cat ${TMPOUT}
-        exit 1
-    fi
-fi
 
 %files
 # runtime

--- a/SPECS/kata-containers/kata-osbuilder.sh
+++ b/SPECS/kata-containers/kata-osbuilder.sh
@@ -245,8 +245,8 @@ update_config()
     local image_osbuilder_dir="${IMAGE_TOPDIR}/osbuilder-images"
     local image_dir="${image_osbuilder_dir}/$KVERSION"
     local initrd_dest_path="${image_dir}/${DISTRO}-kata-${KVERSION}.initrd"
-    sed -i -e "s|kernel = \"/usr/share/kata-containers/vmlinux.container\"|kernel = \"/boot/vmlinux.bin\"|" /usr/share/defaults/kata-containers/configuration.toml
-    sed -i -e "s|image = \"/usr/share/kata-containers/kata-containers.img\"|initrd = \"$initrd_dest_path\"|" /usr/share/defaults/kata-containers/configuration.toml
+    sed -i -e "s|kernel = .*$|kernel = \"/boot/vmlinux.bin\"|" /usr/share/defaults/kata-containers/configuration.toml
+    sed -i -e "s|image = .*$|initrd = \"$initrd_dest_path\"|" /usr/share/defaults/kata-containers/configuration.toml
 }
 
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
add patch to avoid memory hotplug timeout, fix systemd service, add libseccomp to requires

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- add patch to avoid memory hotplug timeout
- fix service to start osbuilder on installation
- remove unnecessary testing of osbuilder from spec
- Add libseccomp to requires

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build with testing on AKS/hyper-v