### PR TITLE
Merge updates for September 2.0 release 2

### DIFF
--- a/SPECS/cloud-init/add-mariner-distro-support.patch
+++ b/SPECS/cloud-init/add-mariner-distro-support.patch
@@ -359,33 +359,10 @@ index 6951a0e3..411065f9 100644
     # Other config here will be given to the distro class and/or path classes
     paths:
        cloud_dir: /var/lib/cloud/
-diff -ruN a/systemd/cloud-init-local.service.tmpl b/systemd/cloud-init-local.service.tmpl
---- a/systemd/cloud-init-local.service.tmpl     2022-05-18 08:23:24.000000000 -0700
-+++ b/systemd/cloud-init-local.service.tmpl     2022-08-23 16:23:57.854218334 -0700
-@@ -1,9 +1,7 @@
- ## template:jinja
- [Unit]
- Description=Initial cloud-init job (pre-networking)
--{% if variant in ["ubuntu", "unknown", "debian", "rhel" ] %}
- DefaultDependencies=no
--{% endif %}
- Wants=network-pre.target
- After=hv_kvp_daemon.service
- After=systemd-remount-fs.service
-@@ -21,10 +19,8 @@
- Before=firewalld.target
- Conflicts=shutdown.target
- {% endif %}
--{% if variant in ["ubuntu", "unknown", "debian"] %}
- Before=sysinit.target
- Conflicts=shutdown.target
--{% endif %}
- RequiresMountsFor=/var/lib/cloud
- {% if variant == "rhel" %}
- ConditionPathExists=!/etc/cloud/cloud-init.disabled
-diff -ruN a/systemd/cloud-init.service.tmpl b/systemd/cloud-init.service.tmpl
---- a/systemd/cloud-init.service.tmpl   2022-05-18 08:23:24.000000000 -0700
-+++ b/systemd/cloud-init.service.tmpl   2022-08-23 16:21:56.556071614 -0700
+diff --git a/systemd/cloud-init.service.tmpl b/systemd/cloud-init.service.tmpl
+index c170aef7..20ff1daa 100644
+--- a/systemd/cloud-init.service.tmpl
++++ b/systemd/cloud-init.service.tmpl
 @@ -1,7 +1,7 @@
  ## template:jinja
  [Unit]
@@ -395,18 +372,6 @@ diff -ruN a/systemd/cloud-init.service.tmpl b/systemd/cloud-init.service.tmpl
  DefaultDependencies=no
  {% endif %}
  Wants=cloud-init-local.service
-@@ -26,11 +26,9 @@
- Before=network-online.target
- Before=sshd-keygen.service
- Before=sshd.service
--{% if variant in ["ubuntu", "unknown", "debian"] %}
- Before=sysinit.target
- Before=shutdown.target
- Conflicts=shutdown.target
--{% endif %}
- {% if variant in ["suse"] %}
- Before=shutdown.target
- Conflicts=shutdown.target
 diff --git a/templates/hosts.mariner.tmpl b/templates/hosts.mariner.tmpl
 new file mode 100644
 index 00000000..2e956382

--- a/SPECS/cloud-init/cloud-init.spec
+++ b/SPECS/cloud-init/cloud-init.spec
@@ -1,7 +1,7 @@
 Summary:        Cloud instance init scripts
 Name:           cloud-init
 Version:        22.2
-Release:        7%{?dist}
+Release:        8%{?dist}
 License:        GPLv3
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -146,6 +146,9 @@ make check %{?_smp_mflags}
 %config(noreplace) %{_sysconfdir}/cloud/cloud.cfg.d/10-azure-kvp.cfg
 
 %changelog
+* Thu Sep 15 2022 Minghe Ren <mingheren@microsoft.com> - 22.2-8
+- Revert the change for adding sysinit.target dependency on previous two releases
+
 * Wed Aug 22 2022 Nan Liu <liunan@microsoft.com> - 22.2-7
 - Update add-mariner-distro-support patch to fix cloud-init dependency cycle
 

--- a/SPECS/libtirpc/CVE-2021-46828.nopatch
+++ b/SPECS/libtirpc/CVE-2021-46828.nopatch
@@ -1,0 +1,1 @@
+CVE-2021-46828 is not applicable to this version of libtirpc.

--- a/SPECS/mariner-release/mariner-release.spec
+++ b/SPECS/mariner-release/mariner-release.spec
@@ -1,7 +1,7 @@
 Summary:        CBL-Mariner release files
 Name:           mariner-release
 Version:        2.0
-Release:        19%{?dist}
+Release:        20%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -62,6 +62,9 @@ EOF
 %config(noreplace) %{_sysconfdir}/issue.net
 
 %changelog
+* Fri Sep 16 2022 Andrew Phelps <anphel@microsoft.com> - 2.0.20
+- Updating version for September update 2.
+
 * Thu Sep 08 2022 Andrew Phelps <anphel@microsoft.com> - 2.0-19
 - Updating version for September CVE update.
 


### PR DESCRIPTION
What does the PR accomplish, why was it needed?
Merge updates for September 2.0 release 2:

Bump mariner-release to 2.0-20
cloud-init: update to 22.2-8
libtirpc: add nopatch for CVE-2021-46828
