### PR TITLE
Update expat CVE and mariner-release bump for 2.0 September update 3

### DIFF
--- a/SPECS/expat/CVE-2022-40674.patch
+++ b/SPECS/expat/CVE-2022-40674.patch
@@ -1,0 +1,177 @@
+From 4a32da87e931ba54393d465bb77c40b5c33d343b Mon Sep 17 00:00:00 2001
+From: Rhodri James <rhodri@wildebeest.org.uk>
+Date: Wed, 17 Aug 2022 18:26:18 +0100
+Subject: [PATCH] Ensure raw tagnames are safe exiting internalEntityParser
+
+It is possible to concoct a situation in which parsing is
+suspended while substituting in an internal entity, so that
+XML_ResumeParser directly uses internalEntityProcessor as
+its processor.  If the subsequent parse includes some unclosed
+tags, this will return without calling storeRawNames to ensure
+that the raw versions of the tag names are stored in memory other
+than the parse buffer itself.  If the parse buffer is then changed
+or reallocated (for example if processing a file line by line),
+badness will ensue.
+
+This patch ensures storeRawNames is always called when needed
+after calling doContent.  The earlier call do doContent does
+not need the same protection; it only deals with entity
+substitution, which cannot leave unbalanced tags, and in any
+case the raw names will be pointing into the stored entity
+value not the parse buffer.
+---
+ expat/lib/xmlparse.c | 13 +++++++++----
+ 1 file changed, 9 insertions(+), 4 deletions(-)
+
+diff --git a/expat/lib/xmlparse.c b/expat/lib/xmlparse.c
+index 7bcabf7f4..d73f419cf 100644
+--- a/expat/lib/xmlparse.c
++++ b/expat/lib/xmlparse.c
+@@ -5826,10 +5826,15 @@ internalEntityProcessor(XML_Parser parser, const char *s, const char *end,
+   {
+     parser->m_processor = contentProcessor;
+     /* see externalEntityContentProcessor vs contentProcessor */
+-    return doContent(parser, parser->m_parentParser ? 1 : 0, parser->m_encoding,
+-                     s, end, nextPtr,
+-                     (XML_Bool)! parser->m_parsingStatus.finalBuffer,
+-                     XML_ACCOUNT_DIRECT);
++    result = doContent(parser, parser->m_parentParser ? 1 : 0,
++                       parser->m_encoding, s, end, nextPtr,
++                       (XML_Bool)! parser->m_parsingStatus.finalBuffer,
++                       XML_ACCOUNT_DIRECT);
++    if (result == XML_ERROR_NONE) {
++      if (! storeRawNames(parser))
++        return XML_ERROR_NO_MEMORY;
++    }
++    return result;
+   }
+ }
+ 
+From a7ce80a013f2a08cb1ac4aac368f2250eea03ebf Mon Sep 17 00:00:00 2001
+From: Sebastian Pipping <sebastian@pipping.org>
+Date: Sun, 11 Sep 2022 19:34:33 +0200
+Subject: [PATCH 1/2] tests: Cover heap use-after-free issue in doContent
+
+---
+ expat/tests/runtests.c | 74 ++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 74 insertions(+)
+
+diff --git a/expat/tests/runtests.c b/expat/tests/runtests.c
+index ea371b42f..ab3aff65b 100644
+--- a/expat/tests/runtests.c
++++ b/expat/tests/runtests.c
+@@ -4990,6 +4990,78 @@ START_TEST(test_suspend_resume_internal_entity) {
+ }
+ END_TEST
+ 
++void
++suspending_comment_handler(void *userData, const XML_Char *data) {
++  UNUSED_P(data);
++  XML_Parser parser = (XML_Parser)userData;
++  XML_StopParser(parser, XML_TRUE);
++}
++
++START_TEST(test_suspend_resume_internal_entity_issue_629) {
++  const char *const text
++      = "<!DOCTYPE a [<!ENTITY e '<!--COMMENT-->a'>]><a>&e;<b>\n"
++        "<"
++        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
++        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
++        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
++        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
++        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
++        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
++        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
++        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
++        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
++        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
++        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
++        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
++        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
++        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
++        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
++        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
++        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
++        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
++        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
++        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
++        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
++        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
++        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
++        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
++        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
++        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
++        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
++        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
++        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
++        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
++        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
++        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
++        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
++        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
++        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
++        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
++        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
++        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
++        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
++        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
++        "/>"
++        "</b></a>";
++  const size_t firstChunkSizeBytes = 54;
++
++  XML_Parser parser = XML_ParserCreate(NULL);
++  XML_SetUserData(parser, parser);
++  XML_SetCommentHandler(parser, suspending_comment_handler);
++
++  if (XML_Parse(parser, text, (int)firstChunkSizeBytes, XML_FALSE)
++      != XML_STATUS_SUSPENDED)
++    xml_failure(parser);
++  if (XML_ResumeParser(parser) != XML_STATUS_OK)
++    xml_failure(parser);
++  if (XML_Parse(parser, text + firstChunkSizeBytes,
++                (int)(strlen(text) - firstChunkSizeBytes), XML_TRUE)
++      != XML_STATUS_OK)
++    xml_failure(parser);
++  XML_ParserFree(parser);
++}
++END_TEST
++
+ /* Test syntax error is caught at parse resumption */
+ START_TEST(test_resume_entity_with_syntax_error) {
+   const char *text = "<!DOCTYPE doc [\n"
+@@ -12016,6 +12088,8 @@ make_suite(void) {
+   tcase_add_test(tc_basic, test_partial_char_in_epilog);
+   tcase_add_test(tc_basic, test_hash_collision);
+   tcase_add_test__ifdef_xml_dtd(tc_basic, test_suspend_resume_internal_entity);
++  tcase_add_test__ifdef_xml_dtd(tc_basic,
++                                test_suspend_resume_internal_entity_issue_629);
+   tcase_add_test__ifdef_xml_dtd(tc_basic, test_resume_entity_with_syntax_error);
+   tcase_add_test__ifdef_xml_dtd(tc_basic, test_suspend_resume_parameter_entity);
+   tcase_add_test(tc_basic, test_restart_on_error);
+
+diff -Naur a/expat/Changes b/expat/Changes
+--- a/expat/Changes	2022-03-28 21:11:43.000000000 +0000
++++ b/expat/Changes	2022-09-20 01:08:23.484300828 +0000
+@@ -3,6 +3,11 @@
+       If you can help, please get in touch.  Thanks!
+ 
+ Release 2.4.8 Mon March 28 2022
++        Security fixes:
++                #629 #640  CVE-2022-40674 -- Heap use-after-free vulnerability in
++                    function doContent. Expected impact is denial of service
++                    or potentially arbitrary code execution.
++
+         Other changes:
+             #587  pkg-config: Move "-lm" to section "Libs.private"
+             #587  CMake|MSVC: Fix pkg-config section "Libs"
+@@ -20,6 +25,10 @@
+             evpobr
+             Kai Pastor
+             Sam James
++            Felix Wilhelm
++            Rhodri James
++                 and
++            Google Project Zero
+ 
+ Release 2.4.7 Fri March 4 2022
+         Bug fixes:

--- a/SPECS/expat/expat.spec
+++ b/SPECS/expat/expat.spec
@@ -2,13 +2,14 @@
 Summary:        An XML parser library
 Name:           expat
 Version:        2.4.8
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Group:          System Environment/GeneralLibraries
 URL:            https://libexpat.github.io/
 Source0:        https://github.com/libexpat/libexpat/releases/download/R_%{underscore_version}/%{name}-%{version}.tar.bz2
+Patch0:         CVE-2022-40674.patch
 Requires:       %{name}-libs = %{version}-%{release}
 
 %description
@@ -29,7 +30,7 @@ Group:          System Environment/Libraries
 This package contains minimal set of shared expat libraries.
 
 %prep
-%setup -q
+%autosetup -p2
 
 %build
 %configure \
@@ -65,6 +66,9 @@ rm -rf %{buildroot}/%{_docdir}/%{name}
 %{_libdir}/libexpat.so.1*
 
 %changelog
+* Mon Sep 19 2022 Betty Lakes <bettylakes@microsoft.com> - 2.4.8-2
+- Add the patch to address CVE-2022-40674
+
 * Wed Apr 13 2022 Rachel Menge <rachelmenge@microsoft.com> - 2.4.8-1
 - Update source to 2.4.8 to address CVE-2022-23852, CVE-2022-23990,
   CVE-2022-25235, CVE-2022-25236

--- a/SPECS/mariner-release/mariner-release.spec
+++ b/SPECS/mariner-release/mariner-release.spec
@@ -1,7 +1,7 @@
 Summary:        CBL-Mariner release files
 Name:           mariner-release
 Version:        2.0
-Release:        20%{?dist}
+Release:        21%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -62,6 +62,9 @@ EOF
 %config(noreplace) %{_sysconfdir}/issue.net
 
 %changelog
+* Wed Sep 21 2022 Andrew Phelps <anphel@microsoft.com> - 2.0-21
+- Updating version for September update 3.
+
 * Fri Sep 16 2022 Andrew Phelps <anphel@microsoft.com> - 2.0.20
 - Updating version for September update 2.
 

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -95,9 +95,9 @@ elfutils-libelf-0.186-1.cm2.aarch64.rpm
 elfutils-libelf-devel-0.186-1.cm2.aarch64.rpm
 elfutils-libelf-devel-static-0.186-1.cm2.aarch64.rpm
 elfutils-libelf-lang-0.186-1.cm2.aarch64.rpm
-expat-2.4.8-1.cm2.aarch64.rpm
-expat-devel-2.4.8-1.cm2.aarch64.rpm
-expat-libs-2.4.8-1.cm2.aarch64.rpm
+expat-2.4.8-2.cm2.aarch64.rpm
+expat-devel-2.4.8-2.cm2.aarch64.rpm
+expat-libs-2.4.8-2.cm2.aarch64.rpm
 libpipeline-1.5.5-2.cm2.aarch64.rpm
 libpipeline-devel-1.5.5-2.cm2.aarch64.rpm
 gdbm-1.21-1.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -95,9 +95,9 @@ elfutils-libelf-0.186-1.cm2.x86_64.rpm
 elfutils-libelf-devel-0.186-1.cm2.x86_64.rpm
 elfutils-libelf-devel-static-0.186-1.cm2.x86_64.rpm
 elfutils-libelf-lang-0.186-1.cm2.x86_64.rpm
-expat-2.4.8-1.cm2.x86_64.rpm
-expat-devel-2.4.8-1.cm2.x86_64.rpm
-expat-libs-2.4.8-1.cm2.x86_64.rpm
+expat-2.4.8-2.cm2.x86_64.rpm
+expat-devel-2.4.8-2.cm2.x86_64.rpm
+expat-libs-2.4.8-2.cm2.x86_64.rpm
 libpipeline-1.5.5-2.cm2.x86_64.rpm
 libpipeline-devel-1.5.5-2.cm2.x86_64.rpm
 gdbm-1.21-1.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -71,10 +71,10 @@ elfutils-libelf-0.186-1.cm2.aarch64.rpm
 elfutils-libelf-devel-0.186-1.cm2.aarch64.rpm
 elfutils-libelf-devel-static-0.186-1.cm2.aarch64.rpm
 elfutils-libelf-lang-0.186-1.cm2.aarch64.rpm
-expat-2.4.8-1.cm2.aarch64.rpm
-expat-debuginfo-2.4.8-1.cm2.aarch64.rpm
-expat-devel-2.4.8-1.cm2.aarch64.rpm
-expat-libs-2.4.8-1.cm2.aarch64.rpm
+expat-2.4.8-2.cm2.aarch64.rpm
+expat-debuginfo-2.4.8-2.cm2.aarch64.rpm
+expat-devel-2.4.8-2.cm2.aarch64.rpm
+expat-libs-2.4.8-2.cm2.aarch64.rpm
 file-5.40-2.cm2.aarch64.rpm
 file-debuginfo-5.40-2.cm2.aarch64.rpm
 file-devel-5.40-2.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -71,10 +71,10 @@ elfutils-libelf-0.186-1.cm2.x86_64.rpm
 elfutils-libelf-devel-0.186-1.cm2.x86_64.rpm
 elfutils-libelf-devel-static-0.186-1.cm2.x86_64.rpm
 elfutils-libelf-lang-0.186-1.cm2.x86_64.rpm
-expat-2.4.8-1.cm2.x86_64.rpm
-expat-debuginfo-2.4.8-1.cm2.x86_64.rpm
-expat-devel-2.4.8-1.cm2.x86_64.rpm
-expat-libs-2.4.8-1.cm2.x86_64.rpm
+expat-2.4.8-2.cm2.x86_64.rpm
+expat-debuginfo-2.4.8-2.cm2.x86_64.rpm
+expat-devel-2.4.8-2.cm2.x86_64.rpm
+expat-libs-2.4.8-2.cm2.x86_64.rpm
 file-5.40-2.cm2.x86_64.rpm
 file-debuginfo-5.40-2.cm2.x86_64.rpm
 file-devel-5.40-2.cm2.x86_64.rpm


### PR DESCRIPTION
###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?

Pull CVE-2022-40674 fix for expat
Bump mariner-release to 2.0-21
