### PR TITLE
Clear CVE's against finger source

### DIFF
--- a/SPECS/finger/CVE-1999-0150.nopatch
+++ b/SPECS/finger/CVE-1999-0150.nopatch
@@ -1,0 +1,2 @@
+This CVE is for the "Perl" fingerd program, not the BSD version offered here.
+See https://exchange.xforce.ibmcloud.com/vulnerabilities/625

--- a/SPECS/finger/CVE-1999-0612.nopatch
+++ b/SPECS/finger/CVE-1999-0612.nopatch
@@ -1,0 +1,2 @@
+Marking this CVE as nopatch. The version included here is the BSD version of finger.
+But the CVE-1999-0612 refers to the Gnu edition of finger.


### PR DESCRIPTION
This is a nopatch of two CVE's against the finger utility.  Neither CVE-1999-0150 nor CVE-1999-0612 apply to the version in c-based BSD version provided by Mariner.

