### PR TITLE
xmlsec1: update to 1.2.34 to fix openscap build break

### DIFF
--- a/SPECS/xmlsec1/xmlsec1.signatures.json
+++ b/SPECS/xmlsec1/xmlsec1.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "xmlsec1-1.2.26.tar.gz": "8d8276c9c720ca42a3b0023df8b7ae41a2d6c5f9aa8d20ed1672d84cc8982d50"
+  "xmlsec1-1.2.34.tar.gz": "52ced4943f35bd7d0818a38298c1528ca4ac8a54440fd71134a07d2d1370a262"
  }
 }

--- a/SPECS/xmlsec1/xmlsec1.spec
+++ b/SPECS/xmlsec1/xmlsec1.spec
@@ -13,16 +13,16 @@ BuildRequires:  libgcrypt-devel
 BuildRequires:  libltdl-devel
 BuildRequires:  libxml2-devel
 BuildRequires:  nss-devel
-%if %{with_check}
-BuildRequires:  nss-tools
-%endif
 Requires:       libltdl
-Requires:       nss
 Requires:       libxml2
+Requires:       nss
 Provides:       %{name}-gcrypt = %{release}-%{version}
 Provides:       %{name}-gnutls = %{release}-%{version}
 Provides:       %{name}-openssl = %{release}-%{version}
 Provides:       %{name}-nss = %{release}-%{version}
+%if %{with_check}
+BuildRequires:  nss-tools
+%endif
 
 %description
 XML Security Library is a C library based on LibXML2  and OpenSSL.

--- a/SPECS/xmlsec1/xmlsec1.spec
+++ b/SPECS/xmlsec1/xmlsec1.spec
@@ -1,13 +1,13 @@
 Summary:        Library providing support for "XML Signature" and "XML Encryption" standards
 Name:           xmlsec1
-Version:        1.2.26
-Release:        8%{?dist}
+Version:        1.2.34
+Release:        1%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Group:          Applications/System
 URL:            https://www.aleksey.com/xmlsec/
-Source0:        %{url}/download/older-releases/%{name}-%{version}.tar.gz
+Source0:        %{url}/download/%{name}-%{version}.tar.gz
 BuildRequires:  gnutls-devel
 BuildRequires:  libgcrypt-devel
 BuildRequires:  libltdl-devel
@@ -65,13 +65,13 @@ make -k check |& tee %{_specdir}/%{name}-check-log || %{nocheck}
 %license COPYING
 
 %{_libdir}/libxmlsec1.so.1
-%{_libdir}/libxmlsec1.so.1.2.26
+%{_libdir}/libxmlsec1.so.%{version}
 %{_libdir}/libxmlsec1.so
 %{_libdir}/libxmlsec1-nss.so.1
-%{_libdir}/libxmlsec1-nss.so.1.2.26
+%{_libdir}/libxmlsec1-nss.so.%{version}
 %{_libdir}/libxmlsec1-nss.so
 %{_libdir}/libxmlsec1-openssl.so.1
-%{_libdir}/libxmlsec1-openssl.so.1.2.26
+%{_libdir}/libxmlsec1-openssl.so.%{version}
 %{_libdir}/libxmlsec1-openssl.so
 %{_libdir}/libxmlsec1-gnutls*
 %{_libdir}/libxmlsec1-gcrypt*
@@ -82,7 +82,6 @@ make -k check |& tee %{_specdir}/%{name}-check-log || %{nocheck}
 
 %{_bindir}/xmlsec1-config
 %{_includedir}/xmlsec1/xmlsec/*.h
-%{_includedir}/xmlsec1/xmlsec/private/*.h
 %{_includedir}/xmlsec1/xmlsec/nss/*.h
 %{_includedir}/xmlsec1/xmlsec/openssl/*.h
 %{_includedir}/xmlsec1/xmlsec/gcrypt/*
@@ -102,6 +101,9 @@ make -k check |& tee %{_specdir}/%{name}-check-log || %{nocheck}
 %{_mandir}/man1/xmlsec1-config.1.gz
 
 %changelog
+* Fri Sep 23 2022 Andrew Phelps <anphel@microsoft.com> - 1.2.34-1
+- Update to version 1.2.34
+
 * Tue Nov 30 2021 Mateusz Malisz <mamalisz@microsoft.com> - 1.2.26-8
 - Add nss as an explicit requirement.
 

--- a/SPECS/xmlsec1/xmlsec1.spec
+++ b/SPECS/xmlsec1/xmlsec1.spec
@@ -6,7 +6,7 @@ License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Group:          Applications/System
-URL:            https://www.aleksey.com/xmlsec/
+URL:            https://www.aleksey.com/xmlsec
 Source0:        %{url}/download/%{name}-%{version}.tar.gz
 BuildRequires:  gnutls-devel
 BuildRequires:  libgcrypt-devel

--- a/SPECS/xmlsec1/xmlsec1.spec
+++ b/SPECS/xmlsec1/xmlsec1.spec
@@ -13,6 +13,9 @@ BuildRequires:  libgcrypt-devel
 BuildRequires:  libltdl-devel
 BuildRequires:  libxml2-devel
 BuildRequires:  nss-devel
+%if %{with_check}
+BuildRequires:  nss-tools
+%endif
 Requires:       libltdl
 Requires:       nss
 Requires:       libxml2
@@ -103,6 +106,7 @@ make -k check |& tee %{_specdir}/%{name}-check-log || %{nocheck}
 %changelog
 * Fri Sep 23 2022 Andrew Phelps <anphel@microsoft.com> - 1.2.34-1
 - Update to version 1.2.34
+- Add nss-tools to fix check tests
 
 * Tue Nov 30 2021 Mateusz Malisz <mamalisz@microsoft.com> - 1.2.26-8
 - Add nss as an explicit requirement.

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -27498,8 +27498,8 @@
         "type": "other",
         "other": {
           "name": "xmlsec1",
-          "version": "1.2.26",
-          "downloadUrl": "https://www.aleksey.com/xmlsec//download/older-releases/xmlsec1-1.2.26.tar.gz"
+          "version": "1.2.34",
+          "downloadUrl": "https://www.aleksey.com/xmlsec/download/xmlsec1-1.2.34.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?

Fix for error building openscap, by updating xmlsec1 to latest version 1.2.34.
```
"make[2]: Leaving directory '/usr/src/mariner/BUILD/openscap-1.3.5/build'"
"/usr/bin/ld: /usr/lib/libxmlsec1.so: undefined reference to `xmlNanoFTPInit@LIBXML2_2.4.30'"
"/usr/bin/ld: /usr/lib/libxmlsec1.so: undefined reference to `xmlNanoFTPCleanup@LIBXML2_2.4.30'"
"/usr/bin/ld: /usr/lib/libxmlsec1.so: undefined reference to `xmlIOFTPRead@LIBXML2_2.4.30'"
"/usr/bin/ld: /usr/lib/libxmlsec1.so: undefined reference to `xmlIOFTPOpen@LIBXML2_2.4.30'"
"/usr/bin/ld: /usr/lib/libxmlsec1.so: undefined reference to `xmlIOFTPMatch@LIBXML2_2.4.30'"
"/usr/bin/ld: /usr/lib/libxmlsec1.so: undefined reference to `xmlIOFTPClose@LIBXML2_2.4.30'"
"collect2: error: ld returned 1 exit status"
```

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change xmlsec1 to version 1.2.34

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: 241847 (x64) 241858 (arm64)
