### PR TITLE
systemd: gpt-auto fixes for backing device detection

### DIFF
--- a/SPECS/systemd/gpt-auto-devno-not-determined.patch
+++ b/SPECS/systemd/gpt-auto-devno-not-determined.patch
@@ -1,0 +1,45 @@
+From d5cb053cd93d516f516e0b748271b55f9dfb3a29 Mon Sep 17 00:00:00 2001
+From: Lennart Poettering <lennart@poettering.net>
+Date: Mon, 14 Feb 2022 13:35:27 +0100
+Subject: [PATCH 1/2] gpt-auto: properly handle case where we can't determine
+ devno of /usr/ fs
+
+get_block_device_harder() returns == 0 if the fs is valid, but it is not
+backed by a single devno. (As opposed to returning > 0 if the devno is
+valid). Let's catch this case and log a clear message, and don't bother
+open the device in that case.
+
+This is mostly cosmetical, as either way, systemd-gpt-auto-generator
+doesn't work in scenarios like that.
+
+Prompted-by: #22504
+---
+ src/gpt-auto-generator/gpt-auto-generator.c | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/src/gpt-auto-generator/gpt-auto-generator.c b/src/gpt-auto-generator/gpt-auto-generator.c
+index 64ca9bb2f9..28982a4c34 100644
+--- a/src/gpt-auto-generator/gpt-auto-generator.c
++++ b/src/gpt-auto-generator/gpt-auto-generator.c
+@@ -779,12 +779,16 @@ static int add_mounts(void) {
+                         return btrfs_log_dev_root(LOG_ERR, r, "root file system");
+                 if (r < 0)
+                         return log_error_errno(r, "Failed to determine block device of root file system: %m");
+-                if (r == 0) { /* Not backed by block device */
++                if (r == 0) { /* Not backed by a single block device. (Could be NFS or so, or could be multi-device RAID or so) */
+                         r = get_block_device_harder("/usr", &devno);
+                         if (r == -EUCLEAN)
+                                 return btrfs_log_dev_root(LOG_ERR, r, "/usr");
+                         if (r < 0)
+-                                return log_error_errno(r, "Failed to determine block device of /usr file system: %m");
++                                return log_error_errno(r, "Failed to determine block device of /usr/ file system: %m");
++                        if (r == 0) { /* /usr/ not backed by single block device, either. */
++                                log_debug("Neither root nor /usr/ file system are on a (single) block device.");
++                                return 0;
++                        }
+                 }
+         } else if (r < 0)
+                 return log_error_errno(r, "Failed to read symlink /run/systemd/volatile-root: %m");
+--
+2.37.3
+

--- a/SPECS/systemd/systemd-bootstrap.signatures.json
+++ b/SPECS/systemd/systemd-bootstrap.signatures.json
@@ -1,7 +1,5 @@
 {
  "Signatures": {
-  "add-fsync-sysusers-passwd.patch": "c86c20c9bf0d79faeb99c454e8fb79df1b81d9243f45a209f7c8f58924ec7dba",
-  "gpt-auto-devno-not-determined.patch": "b75ee0a9b0e4f978d039cfbe9e5c9fd9314f99c3cd5e29f0d79752f9fc628c",
   "50-security-hardening.conf": "c9fc6624a3178cc0980ec3495ac2d5f02a8a1f3a4cdadb8770628d7394b92e2c",
   "99-dhcp-en.network": "158c0003826cef9d780799c6edb2814800d4518f85f884710550f4c46d14be67",
   "systemd-250.3.tar.gz": "87b0eee7b6e5aaab2ab56d158f9536daa6bfd5de011f2a5fc6ccdd81ee1e7a24",

--- a/SPECS/systemd/systemd-bootstrap.signatures.json
+++ b/SPECS/systemd/systemd-bootstrap.signatures.json
@@ -1,6 +1,7 @@
 {
  "Signatures": {
   "add-fsync-sysusers-passwd.patch": "c86c20c9bf0d79faeb99c454e8fb79df1b81d9243f45a209f7c8f58924ec7dba",
+  "gpt-auto-devno-not-determined.patch": "b75ee0a9b0e4f978d039cfbe9e5c9fd9314f99c3cd5e29f0d79752f9fc628c",
   "50-security-hardening.conf": "c9fc6624a3178cc0980ec3495ac2d5f02a8a1f3a4cdadb8770628d7394b92e2c",
   "99-dhcp-en.network": "158c0003826cef9d780799c6edb2814800d4518f85f884710550f4c46d14be67",
   "systemd-250.3.tar.gz": "87b0eee7b6e5aaab2ab56d158f9536daa6bfd5de011f2a5fc6ccdd81ee1e7a24",

--- a/SPECS/systemd/systemd-bootstrap.spec
+++ b/SPECS/systemd/systemd-bootstrap.spec
@@ -16,7 +16,7 @@ Patch0:         fix-journald-audit-logging.patch
 # https://github.com/systemd/systemd/commit/19193b489841a7bcccda7122ac0849cf6efe59fd
 Patch1:         add-fsync-sysusers-passwd.patch
 # Patch2 can be removed once we update systemd to a version containing the following commit:
-# https://github.com/systemd/systemd/commit/d74da762a3b1edbb7935c3b3a229db601f734125
+# https://github.com/systemd/systemd/commit/d5cb053cd93d516f516e0b748271b55f9dfb3a29
 Patch2:         gpt-auto-devno-not-determined.patch
 BuildRequires:  docbook-dtd-xml
 BuildRequires:  docbook-style-xsl

--- a/SPECS/systemd/systemd-bootstrap.spec
+++ b/SPECS/systemd/systemd-bootstrap.spec
@@ -1,7 +1,7 @@
 Summary:        Bootstrap version of systemd. Workaround for systemd circular dependency.
 Name:           systemd-bootstrap
 Version:        250.3
-Release:        5%{?dist}
+Release:        6%{?dist}
 License:        LGPLv2+ AND GPLv2+ AND MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -12,9 +12,12 @@ Source1:        50-security-hardening.conf
 Source2:        systemd.cfg
 Source3:        99-dhcp-en.network
 Patch0:         fix-journald-audit-logging.patch
-# Can be removed once we update systemd to a version containing the following commit:
+# Patch1 can be removed once we update systemd to a version containing the following commit:
 # https://github.com/systemd/systemd/commit/19193b489841a7bcccda7122ac0849cf6efe59fd
 Patch1:         add-fsync-sysusers-passwd.patch
+# Patch2 can be removed once we update systemd to a version containing the following commit:
+# https://github.com/systemd/systemd/commit/d74da762a3b1edbb7935c3b3a229db601f734125
+Patch2:         gpt-auto-devno-not-determined.patch
 BuildRequires:  docbook-dtd-xml
 BuildRequires:  docbook-style-xsl
 BuildRequires:  gettext
@@ -231,6 +234,9 @@ systemctl preset-all
 %{_datadir}/pkgconfig/udev.pc
 
 %changelog
+* Tue Sep 27 2022 Avram Lubkin <avramlubkin@microsoft.com> - 250.3-6
+- Add patch to improve fs detection in gpt-auto (systemd #22506)
+
 * Tue Aug 16 2022 Avram Lubkin <avramlubkin@microsoft.com> - 250.3-5
 - Add patch to fsync passwd file (systemd #24324)
 

--- a/SPECS/systemd/systemd.signatures.json
+++ b/SPECS/systemd/systemd.signatures.json
@@ -1,7 +1,5 @@
 {
  "Signatures": {
-  "add-fsync-sysusers-passwd.patch": "c86c20c9bf0d79faeb99c454e8fb79df1b81d9243f45a209f7c8f58924ec7dba",
-  "gpt-auto-devno-not-determined.patch": "b75ee0a9b0e4f978d039cfbe9e5c9fd9314f99c3cd5e29f0d79752f9fc628c0d",
   "50-security-hardening.conf": "c9fc6624a3178cc0980ec3495ac2d5f02a8a1f3a4cdadb8770628d7394b92e2c",
   "99-dhcp-en.network": "158c0003826cef9d780799c6edb2814800d4518f85f884710550f4c46d14be67",
   "systemd-250.3.tar.gz": "87b0eee7b6e5aaab2ab56d158f9536daa6bfd5de011f2a5fc6ccdd81ee1e7a24",

--- a/SPECS/systemd/systemd.signatures.json
+++ b/SPECS/systemd/systemd.signatures.json
@@ -1,5 +1,7 @@
 {
  "Signatures": {
+  "add-fsync-sysusers-passwd.patch": "c86c20c9bf0d79faeb99c454e8fb79df1b81d9243f45a209f7c8f58924ec7dba",
+  "gpt-auto-devno-not-determined.patch": "b75ee0a9b0e4f978d039cfbe9e5c9fd9314f99c3cd5e29f0d79752f9fc628c0d",
   "50-security-hardening.conf": "c9fc6624a3178cc0980ec3495ac2d5f02a8a1f3a4cdadb8770628d7394b92e2c",
   "99-dhcp-en.network": "158c0003826cef9d780799c6edb2814800d4518f85f884710550f4c46d14be67",
   "systemd-250.3.tar.gz": "87b0eee7b6e5aaab2ab56d158f9536daa6bfd5de011f2a5fc6ccdd81ee1e7a24",

--- a/SPECS/systemd/systemd.spec
+++ b/SPECS/systemd/systemd.spec
@@ -16,7 +16,7 @@ Patch0:         fix-journald-audit-logging.patch
 # https://github.com/systemd/systemd/commit/19193b489841a7bcccda7122ac0849cf6efe59fd
 Patch1:         add-fsync-sysusers-passwd.patch
 # Patch2 can be removed once we update systemd to a version containing the following commit:
-# https://github.com/systemd/systemd/commit/d74da762a3b1edbb7935c3b3a229db601f734125
+# https://github.com/systemd/systemd/commit/d5cb053cd93d516f516e0b748271b55f9dfb3a29
 Patch2:         gpt-auto-devno-not-determined.patch
 BuildRequires:  cryptsetup-devel
 BuildRequires:  docbook-dtd-xml

--- a/SPECS/systemd/systemd.spec
+++ b/SPECS/systemd/systemd.spec
@@ -1,7 +1,7 @@
 Summary:        Systemd-250
 Name:           systemd
 Version:        250.3
-Release:        7%{?dist}
+Release:        8%{?dist}
 License:        LGPLv2+ AND GPLv2+ AND MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -12,9 +12,12 @@ Source1:        50-security-hardening.conf
 Source2:        systemd.cfg
 Source3:        99-dhcp-en.network
 Patch0:         fix-journald-audit-logging.patch
-# Can be removed once we update systemd to a version containing the following commit:
+# Patch1 can be removed once we update systemd to a version containing the following commit:
 # https://github.com/systemd/systemd/commit/19193b489841a7bcccda7122ac0849cf6efe59fd
 Patch1:         add-fsync-sysusers-passwd.patch
+# Patch2 can be removed once we update systemd to a version containing the following commit:
+# https://github.com/systemd/systemd/commit/d74da762a3b1edbb7935c3b3a229db601f734125
+Patch2:         gpt-auto-devno-not-determined.patch
 BuildRequires:  cryptsetup-devel
 BuildRequires:  docbook-dtd-xml
 BuildRequires:  docbook-style-xsl
@@ -261,6 +264,9 @@ systemctl preset-all
 %files lang -f %{name}.lang
 
 %changelog
+* Tue Sep 27 2022 Avram Lubkin <avramlubkin@microsoft.com> - 250.3-8
+- Add patch to improve fs detection in gpt-auto (systemd #22506)
+
 * Tue Aug 16 2022 Avram Lubkin <avramlubkin@microsoft.com> - 250.3-7
 - Add patch to fsync passwd file (systemd #24324)
 

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -544,10 +544,10 @@ sqlite-devel-3.39.2-1.cm2.aarch64.rpm
 sqlite-libs-3.39.2-1.cm2.aarch64.rpm
 swig-4.0.2-3.cm2.aarch64.rpm
 swig-debuginfo-4.0.2-3.cm2.aarch64.rpm
-systemd-bootstrap-250.3-5.cm2.aarch64.rpm
-systemd-bootstrap-debuginfo-250.3-5.cm2.aarch64.rpm
-systemd-bootstrap-devel-250.3-5.cm2.aarch64.rpm
-systemd-bootstrap-rpm-macros-250.3-5.cm2.noarch.rpm
+systemd-bootstrap-250.3-6.cm2.aarch64.rpm
+systemd-bootstrap-debuginfo-250.3-6.cm2.aarch64.rpm
+systemd-bootstrap-devel-250.3-6.cm2.aarch64.rpm
+systemd-bootstrap-rpm-macros-250.3-6.cm2.noarch.rpm
 tar-1.34-1.cm2.aarch64.rpm
 tar-debuginfo-1.34-1.cm2.aarch64.rpm
 tdnf-3.2.2-4.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -544,10 +544,10 @@ sqlite-devel-3.39.2-1.cm2.x86_64.rpm
 sqlite-libs-3.39.2-1.cm2.x86_64.rpm
 swig-4.0.2-3.cm2.x86_64.rpm
 swig-debuginfo-4.0.2-3.cm2.x86_64.rpm
-systemd-bootstrap-250.3-5.cm2.x86_64.rpm
-systemd-bootstrap-debuginfo-250.3-5.cm2.x86_64.rpm
-systemd-bootstrap-devel-250.3-5.cm2.x86_64.rpm
-systemd-bootstrap-rpm-macros-250.3-5.cm2.noarch.rpm
+systemd-bootstrap-250.3-6.cm2.x86_64.rpm
+systemd-bootstrap-debuginfo-250.3-6.cm2.x86_64.rpm
+systemd-bootstrap-devel-250.3-6.cm2.x86_64.rpm
+systemd-bootstrap-rpm-macros-250.3-6.cm2.noarch.rpm
 tar-1.34-1.cm2.x86_64.rpm
 tar-debuginfo-1.34-1.cm2.x86_64.rpm
 tdnf-3.2.2-4.cm2.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
gpt-auto-generator returns 1 on Sphere because the backing block device or `/` and `/usr` can't be determined. In systemd >= 251  this error is better handled. This applies the fix from later versions to 250.3.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- systemd and systemd-bootstrap specs updated to include patch for https://github.com/systemd/systemd/pull/22506

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://github.com/Azure/azure-sphere-v2-are-fs/issues/114

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build
- [Sphere pipeline](https://dev.azure.com/msazuresphere/Public/_build/results?buildId=298232&view=results)