### PR TITLE
python-mako: revert to 1.0.7, patch CVE-2022-40023.

### DIFF
--- a/SPECS/python-mako/CVE-2022-40023.patch
+++ b/SPECS/python-mako/CVE-2022-40023.patch
@@ -1,0 +1,103 @@
+From cbd0165d1b3370aca2f19e64c872024aadd9deee Mon Sep 17 00:00:00 2001
+From: Pawel Winogrodzki <pawelwi@microsoft.com>
+Date: Thu, 29 Sep 2022 16:37:11 -0700
+Subject: [PATCH] Fixing CVE-2022-40023.
+
+---
+ mako/lexer.py      | 13 +++++++++----
+ test/test_lexer.py | 23 +++++++++++++++++------
+ 2 files changed, 26 insertions(+), 10 deletions(-)
+
+diff --git a/mako/lexer.py b/mako/lexer.py
+index cf4187f..90ddac5 100644
+--- a/mako/lexer.py
++++ b/mako/lexer.py
+@@ -271,21 +271,26 @@ class Lexer(object):
+         return self.template
+ 
+     def match_tag_start(self):
+-        match = self.match(r'''
++        reg = r"""
+             \<%     # opening tag
+ 
+             ([\w\.\:]+)   # keyword
+ 
+-            ((?:\s+\w+|\s*=\s*|".*?"|'.*?')*)  # attrname, = \
++            ((?:\s+\w+|\s*=\s*|"[^"]*?"|'[^']*?'|\s*,\s*)*)  # attrname, = \
+                                                #        sign, string expression
++                                               # comma is for backwards compat
++                                               # identified in #366
+ 
+             \s*     # more whitespace
+ 
+             (/)?>   # closing
+ 
+-            ''',
++        """
+ 
+-                           re.I | re.S | re.X)
++        match = self.match(
++            reg,
++            re.I | re.S | re.X,
++        )
+ 
+         if match:
+             keyword, attr, isend = match.groups()
+diff --git a/test/test_lexer.py b/test/test_lexer.py
+index 06ebb05..17bd7dd 100644
+--- a/test/test_lexer.py
++++ b/test/test_lexer.py
+@@ -3,7 +3,8 @@ from mako import exceptions, util, compat
+ from test.util import flatten_result
+ from mako.template import Template
+ import re
+-from test import TemplateTest, eq_, assert_raises_message
++import pytest
++from test import TemplateTest, eq_, assert_raises, assert_raises_message
+ 
+ # create fake parsetree classes which are constructed
+ # exactly as the repr() of a real parsetree object.
+@@ -105,6 +106,10 @@ class LexerTest(TemplateTest):
+         self.assertRaises(exceptions.CompileException,
+                           Lexer(template).parse)
+ 
++    def test_tag_many_quotes(self):
++        template = "<%0" + '"' * 3000
++        assert_raises(exceptions.SyntaxException, Lexer(template).parse)
++
+     def test_unmatched_tag(self):
+         template = \
+             """
+@@ -304,10 +309,16 @@ class LexerTest(TemplateTest):
+                       , {'expr': 'foo<bar and hoho>lala and "x" + "y"'
+                       }, (3, 13), []), Text('\n        ', (3, 64))]))
+ 
+-    def test_pagetag(self):
+-        template = \
+-            """
+-            <%page cached="True", args="a, b"/>
++    @pytest.mark.parametrize("comma,numchars", [(",", 48), ("", 47)])
++    def test_pagetag(self, comma, numchars):
++        # note that the comma here looks like:
++        # <%page cached="True", args="a, b"/>
++        # that's what this test has looked like for decades, however, the
++        # comma there is not actually the right syntax.  When issue #366
++        # was fixed, the reg was altered to accommodate for this comma to allow
++        # backwards compat
++        template = f"""
++            <%page cached="True"{comma} args="a, b"/>
+ 
+             some template
+         """
+@@ -319,7 +330,7 @@ class LexerTest(TemplateTest):
+ 
+             some template
+         ''',
+-                      (2, 48))]))
++                      (2, numchars))]))
+ 
+     def test_nesting(self):
+         template = \
+-- 
+2.34.1
+

--- a/SPECS/python-mako/CVE-2022-40023.patch
+++ b/SPECS/python-mako/CVE-2022-40023.patch
@@ -1,12 +1,12 @@
-From cbd0165d1b3370aca2f19e64c872024aadd9deee Mon Sep 17 00:00:00 2001
+From b7571c80f1694d2ddb366e7aab6276739e68bbe5 Mon Sep 17 00:00:00 2001
 From: Pawel Winogrodzki <pawelwi@microsoft.com>
 Date: Thu, 29 Sep 2022 16:37:11 -0700
 Subject: [PATCH] Fixing CVE-2022-40023.
 
 ---
  mako/lexer.py      | 13 +++++++++----
- test/test_lexer.py | 23 +++++++++++++++++------
- 2 files changed, 26 insertions(+), 10 deletions(-)
+ test/test_lexer.py | 13 ++++++++++++-
+ 2 files changed, 21 insertions(+), 5 deletions(-)
 
 diff --git a/mako/lexer.py b/mako/lexer.py
 index cf4187f..90ddac5 100644
@@ -44,7 +44,7 @@ index cf4187f..90ddac5 100644
          if match:
              keyword, attr, isend = match.groups()
 diff --git a/test/test_lexer.py b/test/test_lexer.py
-index 06ebb05..17bd7dd 100644
+index 06ebb05..f20997b 100644
 --- a/test/test_lexer.py
 +++ b/test/test_lexer.py
 @@ -3,7 +3,8 @@ from mako import exceptions, util, compat
@@ -68,36 +68,19 @@ index 06ebb05..17bd7dd 100644
      def test_unmatched_tag(self):
          template = \
              """
-@@ -304,10 +309,16 @@ class LexerTest(TemplateTest):
-                       , {'expr': 'foo<bar and hoho>lala and "x" + "y"'
+@@ -305,6 +310,12 @@ class LexerTest(TemplateTest):
                        }, (3, 13), []), Text('\n        ', (3, 64))]))
  
--    def test_pagetag(self):
--        template = \
--            """
--            <%page cached="True", args="a, b"/>
-+    @pytest.mark.parametrize("comma,numchars", [(",", 48), ("", 47)])
-+    def test_pagetag(self, comma, numchars):
+     def test_pagetag(self):
 +        # note that the comma here looks like:
 +        # <%page cached="True", args="a, b"/>
 +        # that's what this test has looked like for decades, however, the
 +        # comma there is not actually the right syntax.  When issue #366
 +        # was fixed, the reg was altered to accommodate for this comma to allow
 +        # backwards compat
-+        template = f"""
-+            <%page cached="True"{comma} args="a, b"/>
- 
-             some template
-         """
-@@ -319,7 +330,7 @@ class LexerTest(TemplateTest):
- 
-             some template
-         ''',
--                      (2, 48))]))
-+                      (2, numchars))]))
- 
-     def test_nesting(self):
          template = \
+             """
+             <%page cached="True", args="a, b"/>
 -- 
 2.34.1
 

--- a/SPECS/python-mako/python-mako.signatures.json
+++ b/SPECS/python-mako/python-mako.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "Mako-1.2.2.tar.gz": "3724869b363ba630a272a5f89f68c070352137b8fd1757650017b7e06fda163f"
+  "Mako-1.0.7.tar.gz": "4e02fde57bd4abb5ec400181e4c314f56ac3e49ba4fb8b0d50bba18cb27d25ae"
  }
 }

--- a/SPECS/python-mako/python-mako.spec
+++ b/SPECS/python-mako/python-mako.spec
@@ -9,6 +9,8 @@ License:        MIT
 Group:          Development/Languages/Python
 Url:            https://www.makotemplates.org/
 Source0:        https://files.pythonhosted.org/packages/eb/f3/67579bb486517c0d49547f9697e36582cd19dafb5df9e687ed8e22de57fa/Mako-1.0.7.tar.gz
+# Back-ported from 1.2.2: https://github.com/sqlalchemy/mako/commit/925760291d6efec64fda6e9dd1fd9cfbd5be068c?diff=split
+Patch0:         CVE-2022-40023.patch
 
 BuildRequires:  python2
 BuildRequires:  python2-libs
@@ -72,6 +74,8 @@ popd
 %{_bindir}/mako-render3
 
 %changelog
+*   Thu Sep 29 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.0.7-4
+-   Adding a patch for CVE-2022-40023.
 *   Sat May 09 2020 Nick Samson <nisamson@microsoft.com> 1.0.7-4
 -   Added %%license line automatically
 *   Thu Apr 30 2020 Emre Girgin <mrgirgin@microsoft.com> 1.0.7-3

--- a/SPECS/python-mako/python-mako.spec
+++ b/SPECS/python-mako/python-mako.spec
@@ -3,7 +3,7 @@
 
 Name:           python-mako
 Version:        1.0.7
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        Python templating language
 License:        MIT
 Group:          Development/Languages/Python
@@ -74,7 +74,7 @@ popd
 %{_bindir}/mako-render3
 
 %changelog
-*   Thu Sep 29 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.0.7-4
+*   Thu Sep 29 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.0.7-5
 -   Adding a patch for CVE-2022-40023.
 *   Sat May 09 2020 Nick Samson <nisamson@microsoft.com> 1.0.7-4
 -   Added %%license line automatically

--- a/SPECS/python-mako/python-mako.spec
+++ b/SPECS/python-mako/python-mako.spec
@@ -2,13 +2,13 @@
 %{!?python3_sitelib: %define python3_sitelib %(python3 -c "from distutils.sysconfig import get_python_lib;print(get_python_lib())")}
 
 Name:           python-mako
-Version:        1.2.2
-Release:        1%{?dist}
+Version:        1.0.7
+Release:        4%{?dist}
 Summary:        Python templating language
 License:        MIT
 Group:          Development/Languages/Python
 Url:            https://www.makotemplates.org/
-Source0:        https://files.pythonhosted.org/packages/6d/f2/8ad2ec3d531c97c4071572a4104e00095300e278a7449511bee197ca22c9/Mako-1.2.2.tar.gz
+Source0:        https://files.pythonhosted.org/packages/eb/f3/67579bb486517c0d49547f9697e36582cd19dafb5df9e687ed8e22de57fa/Mako-1.0.7.tar.gz
 
 BuildRequires:  python2
 BuildRequires:  python2-libs
@@ -72,33 +72,22 @@ popd
 %{_bindir}/mako-render3
 
 %changelog
-*   Thu Sep 22 2022 Adit Jha <aditjha@microsoft.com> 1.2.2-1
--   Upgrade to 1.2.2 to fix CVE-2022-40023
-
 *   Sat May 09 2020 Nick Samson <nisamson@microsoft.com> 1.0.7-4
 -   Added %%license line automatically
-
 *   Thu Apr 30 2020 Emre Girgin <mrgirgin@microsoft.com> 1.0.7-3
 -   Renaming python-pytest to pytest
-
 *   Mon Apr 13 2020 Jon Slobodzian <joslobo@microsoft.com> 1.0.7-2
 -   Initial CBL-Mariner import from Photon (license: Apache2).
 -   Verified license. Removed sha1. Fixed Source0 URL comment. Fixed URL.
-
 *   Sun Sep 09 2018 Tapas Kundu <tkundu@vmware.com> 1.0.7-1
 -   Update to version 1.0.7
-
 *   Thu Jul 06 2017 Xiaolin Li <xiaolinl@vmware.com> 1.0.6-5
 -   Fix make check issues.
-
 *   Wed Jun 07 2017 Xiaolin Li <xiaolinl@vmware.com> 1.0.6-4
 -   Add python3-setuptools and python3-xml to python3 sub package Buildrequires.
-
 *   Thu Jun 01 2017 Dheeraj Shetty <dheerajs@vmware.com> 1.0.6-3
 -   Separate the python2 and python3 specific scripts in the bin directory
-
 *   Fri Mar 03 2017 Xiaolin Li <xiaolinl@vmware.com> 1.0.6-2
 -   Added python3 package.
-
 *   Fri Feb 03 2017 Vinay Kulkarni <kulkarniv@vmware.com> 1.0.6-1
 -   Initial version of python-mako package for Photon.

--- a/SPECS/python-mako/python-mako.spec
+++ b/SPECS/python-mako/python-mako.spec
@@ -39,8 +39,7 @@ Requires:       python3-libs
 %description -n python3-mako
 Python 3 version.
 %prep
-%setup -n Mako-%{version}
-rm -rf ../p3dir
+%autosetup -p1 -n Mako-%{version}
 cp -a . ../p3dir
 
 %build

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -6316,8 +6316,8 @@
         "type": "other",
         "other": {
           "name": "python-mako",
-          "version": "1.2.2",
-          "downloadUrl": "https://files.pythonhosted.org/packages/6d/f2/8ad2ec3d531c97c4071572a4104e00095300e278a7449511bee197ca22c9/Mako-1.2.2.tar.gz"
+          "version": "1.0.7",
+          "downloadUrl": "https://files.pythonhosted.org/packages/eb/f3/67579bb486517c0d49547f9697e36582cd19dafb5df9e687ed8e22de57fa/Mako-1.0.7.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

In #3828 we've updated `python-mako` to version 1.2.2 in order to fix CVE-20220-40023. It turns out, however, that [since version 1.2.0](https://docs.makotemplates.org/en/latest/changelog.html#change-1.2.0) this project depends on either Python 3.8+ (we're below that at the moment) or on the `python3-importlib-metadata` package, which we don't have in for Mariner 1.0. Updating Python or adding the missing package turned out to be a larger change, which we need to schedule for after we're done with this month's release, so for the time being I'm reverting the version bump and backporting the [CVE fix](https://github.com/sqlalchemy/mako/commit/925760291d6efec64fda6e9dd1fd9cfbd5be068c) instead.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Reverted #3828.
- Backported a [CVE patch](https://github.com/sqlalchemy/mako/commit/925760291d6efec64fda6e9dd1fd9cfbd5be068c).

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #3828

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2022-40023

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Buddy build with tests (build ID: 244050).
