### PR TITLE
Add CVE-2022-39227 nopatch file for python-jwt

### DIFF
--- a/SPECS/python-jwt/CVE-2022-39227.nopatch
+++ b/SPECS/python-jwt/CVE-2022-39227.nopatch
@@ -1,0 +1,7 @@
+CVE-2022-39227 - This CVE does not impact us since this CVE is for davedoesdev/python-jwt, and we are using jpadilla/pyjwt
+
+NIST
+https://nvd.nist.gov/vuln/detail/CVE-2022-39227
+
+Fix
+n/a

--- a/SPECS/python-jwt/python-jwt.spec
+++ b/SPECS/python-jwt/python-jwt.spec
@@ -22,7 +22,7 @@ encrypted JSON objects.}
 
 Name:           python-%{pkgname}
 Version:        2.4.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        JSON Web Token implementation in Python
 License:        MIT
 Vendor:         Microsoft Corporation
@@ -74,6 +74,10 @@ PYTHONPATH=%{buildroot}%{python3_sitelib} \
 %endif
 
 %changelog
+* Fri Sep 30 2022 Aadhar Agarwal <aadagarwal@microsoft.com> - 2.4.0-2
+- Add a comment at the top of the spec file - This package refers to PyJWT and not python-jwt
+- Nopatch CVE-2022-39227
+
 * Thu Jun 23 2022 Minghe Ren <mingheren@microsoft.com> - 2.4.0-1
 - Update to v2.4.0 to fix CVE-2022-29217
 

--- a/SPECS/python-jwt/python-jwt.spec
+++ b/SPECS/python-jwt/python-jwt.spec
@@ -1,3 +1,6 @@
+# This package refers to PyJWT(https://github.com/jpadilla/pyjwt)
+# Not to be confused with python-jwt(https://github.com/davedoesdev/python-jwt)
+
 %{!?python3_sitelib: %define python3_sitelib %(python3 -c "from distutils.sysconfig import get_python_lib;print(get_python_lib())")}
 # what it's called on pypi
 %global srcname PyJWT


### PR DESCRIPTION


<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
- To address CVE-2022-39227

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add a clarifying statement in python-jwt.spec file noting the difference between PyJWT and python-jwt
- Add a nopatch file indicating why CVE-2022-39227 does not apply

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://microsoft.visualstudio.com/OS/_workitems/edit/41568697

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2022-39227

