### PR TITLE
livepatch spec generation: unifying naming with other core specs

### DIFF
--- a/toolkit/scripts/livepatching/generate_livepatch-signed_spec.sh
+++ b/toolkit/scripts/livepatching/generate_livepatch-signed_spec.sh
@@ -45,7 +45,8 @@ declare -A TEMPLATE_PLACEHOLDERS=(
     ["@CHANGELOG@"]="$CHANGELOG"
 )
 
-LIVEPATCH_SIGNED_SPEC_PATH="$REPO_ROOT/SPECS-SIGNED/livepatch-signed/livepatch-$KERNEL_VERSION_RELEASE-signed.spec"
+LIVEPATCH_SIGNED_NAME="livepatch-$KERNEL_VERSION_RELEASE-signed"
+LIVEPATCH_SIGNED_SPEC_PATH="$REPO_ROOT/SPECS-SIGNED/$LIVEPATCH_SIGNED_NAME/$LIVEPATCH_SIGNED_NAME.spec"
 create_new_file_from_template "$SCRIPT_FOLDER/template_livepatch-signed.spec" "$LIVEPATCH_SIGNED_SPEC_PATH" TEMPLATE_PLACEHOLDERS
 
 # Cgmanifest.json update skipped - already handled by the unsigned version.

--- a/toolkit/scripts/livepatching/generate_livepatch-signed_spec.sh
+++ b/toolkit/scripts/livepatching/generate_livepatch-signed_spec.sh
@@ -21,9 +21,15 @@ then
     exit 1
 fi
 
+if ! grep -qP "Patch.*:.*CVE.*\.patch$" "$LIVEPATCH_SPEC_PATH"
+then
+    echo "Spec ($LIVEPATCH_SPEC_PATH) doesn't build any patch modules. Skipping signed spec generation."
+    exit 0
+fi
+
 echo "Generating signed spec for ($LIVEPATCH_SPEC_PATH)."
 
-KERNEL_VERSION_RELEASE="$(grep -oP "(?<=kernel_version_release ).*" "$LIVEPATCH_SPEC_PATH")"
+KERNEL_VERSION_RELEASE="$(grep -oP "(?<=define kernel_version_release ).*" "$LIVEPATCH_SPEC_PATH")"
 
 DESCRIPTION="$(spec_query_srpm "$LIVEPATCH_SPEC_PATH" "%{DESCRIPTION}\n")"
 
@@ -39,7 +45,7 @@ declare -A TEMPLATE_PLACEHOLDERS=(
     ["@CHANGELOG@"]="$CHANGELOG"
 )
 
-LIVEPATCH_SIGNED_SPEC_PATH="$REPO_ROOT/SPECS-SIGNED/livepatch-signed/livepatch-signed-$KERNEL_VERSION_RELEASE.spec"
+LIVEPATCH_SIGNED_SPEC_PATH="$REPO_ROOT/SPECS-SIGNED/livepatch-signed/livepatch-$KERNEL_VERSION_RELEASE-signed.spec"
 create_new_file_from_template "$SCRIPT_FOLDER/template_livepatch-signed.spec" "$LIVEPATCH_SIGNED_SPEC_PATH" TEMPLATE_PLACEHOLDERS
 
 # Cgmanifest.json update skipped - already handled by the unsigned version.

--- a/toolkit/scripts/livepatching/generate_livepatch_spec.sh
+++ b/toolkit/scripts/livepatching/generate_livepatch_spec.sh
@@ -41,7 +41,7 @@ function generate_livepatch_signatures {
         --arg pem_hash "$public_key_hash" \
         --arg pem_name "$LIVEPATCH_PUBLIC_KEY_FILE" \
         '{"Signatures": {($config_name): $config_hash, ($kernel_name): $kernel_hash, ($pem_name): $pem_hash}}' \
-        > "$LIVEPATCH_SPECS_DIR/livepatch-$KERNEL_VERSION_RELEASE.signatures.json"
+        > "$LIVEPATCH_SPECS_DIR/$LIVEPATCH_NAME.signatures.json"
 }
 
 function generate_livepatch_spec {
@@ -82,8 +82,9 @@ KERNEL_VERSION_RELEASE="$(spec_query_srpm "$KERNEL_SPEC_PATH" "%{VERSION}-%{RELE
 
 LIVEPATCH_CONFIG_FILE="config-$KERNEL_VERSION_RELEASE"
 LIVEPATCH_PUBLIC_KEY_FILE="mariner-$KERNEL_VERSION_RELEASE.pem"
-LIVEPATCH_SPECS_DIR="$REPO_ROOT/SPECS/livepatch"
-LIVEPATCH_SPEC_PATH="$LIVEPATCH_SPECS_DIR/livepatch-$KERNEL_VERSION_RELEASE.spec"
+LIVEPATCH_NAME="livepatch-$KERNEL_VERSION_RELEASE"
+LIVEPATCH_SPECS_DIR="$REPO_ROOT/SPECS/$LIVEPATCH_NAME"
+LIVEPATCH_SPEC_PATH="$LIVEPATCH_SPECS_DIR/$LIVEPATCH_NAME.spec"
 
 if [[ -f "$LIVEPATCH_SPEC_PATH" ]]
 then

--- a/toolkit/scripts/livepatching/template_livepatch.spec
+++ b/toolkit/scripts/livepatching/template_livepatch.spec
@@ -74,15 +74,9 @@ Source0:        https://github.com/microsoft/CBL-Mariner-Linux-Kernel/archive/ro
 Source1:        config-%{kernel_version_release}
 Source2:        mariner-%{kernel_version_release}.pem
 @PATCHES@
-
 ExclusiveArch:  x86_64
 
 Provides:       livepatch = %{kernel_version_release}
-
-%description
-A set of kernel livepatches addressing CVEs present in Mariner's
-kernel version %{kernel_version_release}.
-%{patches_description}
 
 # Must be kept below the "Patch" tags to correctly evaluate %%builds_module.
 %if %{builds_module}
@@ -120,6 +114,11 @@ Requires(post): coreutils
 Requires(post): kpatch
 
 Requires(preun): kpatch
+
+%description
+A set of kernel livepatches addressing CVEs present in Mariner's
+%{kernel_version_release} kernel.
+%{patches_description}
 
 %prep
 %setup -q -n CBL-Mariner-Linux-Kernel-rolling-lts-mariner-2-%{kernel_version}
@@ -174,6 +173,10 @@ install -m 744 %{livepatch_module_name} %{buildroot}%{livepatch_module_path}
 # else builds_module
 %else
 %global debug_package %{nil}
+
+%description
+Empty package enabling subscription to future kernel livepatches
+addressing CVEs present in Mariner's %{kernel_version_release} kernel.
 
 %files
 

--- a/toolkit/scripts/livepatching/template_livepatch.spec
+++ b/toolkit/scripts/livepatching/template_livepatch.spec
@@ -10,6 +10,38 @@
 %define livepatch_module_name %{livepatch_name}.ko
 %define livepatch_module_path %{livepatch_install_dir}/%{livepatch_module_name}
 
+%define patch_applicable_for_kernel [[ -f "%{livepatch_module_path}" && "$(uname -r)" == "%{kernel_version_release}" ]]
+%define patch_installed kpatch list | grep -qP "%{livepatch_name}.*%{kernel_version_release}"
+%define patch_loaded    kpatch list | grep -qP "%{livepatch_name}.*enabled"
+
+# Install patch if the RUNNING kernel matches.
+# No-op for initial (empty) livepatch.
+%define install_if_should \
+if %{patch_applicable_for_kernel} && ! %{patch_installed} \
+then \
+    kpatch install %{livepatch_module_path} \
+fi
+
+# Load patch, if the RUNNING kernel matches.
+# No-op for initial (empty) livepatch.
+%define load_if_should \
+if %{patch_applicable_for_kernel} && ! %{patch_loaded} \
+then \
+    kpatch load %{livepatch_module_path} \
+fi
+
+%define uninstall_if_should \
+if %{patch_installed} \
+then \
+    kpatch uninstall %{livepatch_name} \
+fi
+
+%define unload_if_should \
+if %{patch_loaded} \
+then \
+    kpatch unload %{livepatch_name} \
+fi
+
 %define patches_description \
 %(
     echo "Patches list ('*' - fixed, '!' - unfixable through livepatching, kernel update required):"
@@ -45,6 +77,13 @@ Source2:        mariner-%{kernel_version_release}.pem
 
 ExclusiveArch:  x86_64
 
+Provides:       livepatch = %{kernel_version_release}
+
+%description
+A set of kernel livepatches addressing CVEs present in Mariner's
+kernel version %{kernel_version_release}.
+%{patches_description}
+
 # Must be kept below the "Patch" tags to correctly evaluate %%builds_module.
 %if %{builds_module}
 BuildRequires:  audit-devel
@@ -73,19 +112,14 @@ BuildRequires:  pam-devel
 BuildRequires:  procps-ng-devel
 BuildRequires:  python3-devel
 BuildRequires:  rpm-build
-%else
-%global debug_package %{nil}
-# endif builds_module
-%endif
 
-Provides:       livepatch = %{kernel_version_release}
+Requires:       coreutils
+Requires:       livepatching-filesystem
 
-%description
-A set of kernel livepatches addressing CVEs present in Mariner's
-kernel version %{kernel_version_release}.
-%{patches_description}
+Requires(post): coreutils
+Requires(post): kpatch
 
-%if %{builds_module}
+Requires(preun): kpatch
 
 %prep
 %setup -q -n CBL-Mariner-Linux-Kernel-rolling-lts-mariner-2-%{kernel_version}
@@ -114,14 +148,36 @@ kpatch-build -ddd \
 install -dm 755 %{buildroot}%{livepatch_install_dir}
 install -m 744 %{livepatch_module_name} %{buildroot}%{livepatch_module_path}
 
-# endif builds_module
-%endif
+%post
+%load_if_should
+%install_if_should
+
+%preun
+%uninstall_if_should
+%unload_if_should
+
+# Re-enable patch on rollbacks to supported kernel.
+%triggerin -- kernel = %{kernel_version_release}
+%load_if_should
+%install_if_should
+
+# Prevent the patch from being loaded after a reboot to a different kernel.
+# Previous kernel is still running, do NOT unload the livepatch.
+%triggerin -- kernel > %{kernel_version_release}, kernel < %{kernel_version_release}
+%uninstall_if_should
 
 %files
 %defattr(-,root,root)
-%if %{builds_module}
 %dir %{livepatch_install_dir}
 %{livepatch_module_path}
+
+# else builds_module
+%else
+%global debug_package %{nil}
+
+%files
+
+# endif builds_module
 %endif
 
 %changelog

--- a/toolkit/scripts/livepatching/update_livepatches.sh
+++ b/toolkit/scripts/livepatching/update_livepatches.sh
@@ -11,7 +11,7 @@ echo "Updating livepatch specs."
 
 "$SCRIPT_FOLDER"/generate_livepatch_spec.sh
 
-for livepatch_spec in "$SPECS_DIR/livepatch/"livepatch-*.spec
+for livepatch_spec in "$SPECS_DIR"/livepatch-*/livepatch-*.spec
 do
     "$SCRIPT_FOLDER"/generate_livepatch-signed_spec.sh "$livepatch_spec"
 done

--- a/toolkit/scripts/livepatching/update_livepatches.sh
+++ b/toolkit/scripts/livepatching/update_livepatches.sh
@@ -11,7 +11,7 @@ echo "Updating livepatch specs."
 
 "$SCRIPT_FOLDER"/generate_livepatch_spec.sh
 
-for livepatch_spec in "$SPECS_DIR"/livepatch-*/livepatch-*.spec
+for livepatch_spec in "$SPECS_DIR"/livepatch-*/*.spec
 do
     "$SCRIPT_FOLDER"/generate_livepatch-signed_spec.sh "$livepatch_spec"
 done


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

In order to stick to our conventions of keeping a single package spec per spec subdirectory, I'm updating the livepatch generation scripts, since previously all livepatch specs were generated under `SPECS/livepatch` and `SPECS-SIGNED/liveptach-signed`.

In addition to that I'm skipping generation of specs for signed livepatches, if the unsigned version doesn't generate any signable content (e.g. it generates only an "empty" livepatch without any CVE patches).

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Generate each livepatch in its own specs subdirectory.
- Generate signed specs only for signable livepatches.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local scripts run.
