### PR TITLE
Move bind server config files to base package from utils package

### DIFF
--- a/SPECS/bind/bind.spec
+++ b/SPECS/bind/bind.spec
@@ -1,4 +1,3 @@
-
 %global        bind_dir          %{_var}/named
 %global        chroot_prefix     %{bind_dir}/chroot
 %global        chroot_create_directories /dev /run/named %{_localstatedir}/{log,named,tmp} \\\

--- a/SPECS/bind/bind.spec
+++ b/SPECS/bind/bind.spec
@@ -1,3 +1,4 @@
+
 %global        bind_dir          %{_var}/named
 %global        chroot_prefix     %{bind_dir}/chroot
 %global        chroot_create_directories /dev /run/named %{_localstatedir}/{log,named,tmp} \\\
@@ -10,7 +11,7 @@
 Summary:        Domain Name System software
 Name:           bind
 Version:        9.16.29
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        ISC
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -431,12 +432,16 @@ fi;
 %dir %{_libdir}/named
 %{_libdir}/named/*.so
 %config(noreplace) %verify(not md5 size mtime) %{_sysconfdir}/sysconfig/named
+%config(noreplace) %attr(0644,root,named) %{_sysconfdir}/named.root.key
 %config(noreplace) %{_sysconfdir}/logrotate.d/named
+%{_sysconfdir}/rwtab.d/named
+%{_tmpfilesdir}/named.conf
 %{_sbindir}/named-journalprint
 %{_sbindir}/named-checkconf
 %{_bindir}/named-rrchecker
 %{_bindir}/mdig
 %{_sbindir}/named
+
 %{_sbindir}/rndc*
 %{_libexecdir}/generate-rndc-key.sh
 %{_mandir}/man1/mdig.1*
@@ -469,8 +474,9 @@ fi;
 %ghost %config(noreplace) %{_sysconfdir}/rndc.conf
 # ^- The default rndc.conf which uses rndc.key is in named's default internal config -
 # so rndc.conf is not necessary.
-%defattr(-,named,named,-)
 %dir /run/named
+%config(noreplace) %verify(not link) %{_sysconfdir}/named.conf
+%config(noreplace) %verify(not link) %{_sysconfdir}/named.rfc1912.zones
 
 %files dlz-filesystem
 %{_libdir}/{named,bind}/dlz_filesystem_dynamic.so
@@ -606,10 +612,12 @@ fi;
 %{_mandir}/man8/named-checkzone.8*
 %{_mandir}/man8/named-compilezone.8*
 %{_mandir}/man8/named-nzd2nzf.8*
-%{_sysconfdir}/*
-%{_tmpfilesdir}/named.conf
 
 %changelog
+* Mon Sep 12 2022 Olivia Crain <oliviacrain@microsoft.com - 9.16.29-2
+- Move named tmpfiles configuration to base package from utils subpackage
+- Move files under %%{_sysconfdir} in utils subpackage to base package 
+
 * Wed Jun 08 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 9.16.29-1
 - Updating to 9.16.29 to fix CVE-2021-25219.
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
The `utils` subpackage of `bind` contains a [systemd tmpfiles configuration](https://www.man7.org/linux/man-pages/man8/systemd-tmpfiles.8.html). This configuration requires the `named` user to exist, but that user is created by the main package's postinstall scripts. When the `utils` subpackage is installed without the main package, the missing user causes `systemd-tmpfiles-setup.service` to fail.

It's more appropriate for the tmpfiles config to be in the main package with the rest of the server stuff anyways, since we should only need `/run/named` when running the server. In the same spirit, this PR also moves some server configuration files from the `utils` subpackage to the main package.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Move named tmpfiles configuration to base package from utils subpackage
- Move files under `%{_sysconfdir}` in utils subpackage to base package 

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Buddy build succeeds
- Installs and upgrades of affected packages work
- `systemd-tmpfiles-setup.service` no longer fails!
