### PR TITLE
Add runtime requirement on iana-etc to fping

### DIFF
--- a/SPECS/fping/fping.spec
+++ b/SPECS/fping/fping.spec
@@ -1,15 +1,16 @@
-Summary:       Utility to send ICMP echo probes to network hosts
-Name:          fping
-Version:       4.2
-Release:       2%{?dist}
-License:       BSD with advertising
-Group:         Productivity/Networking/Diagnostic
+Summary:        Utility to send ICMP echo probes to network hosts
+Name:           fping
+Version:        4.2
+Release:        3%{?dist}
+License:        BSD with advertising
+Group:          Productivity/Networking/Diagnostic
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
-URL:           https://www.fping.org/
-Source0:       https://fping.org/dist/%{name}-%{version}.tar.gz
-BuildRequires: autoconf
-BuildRequires: automake
+URL:            https://www.fping.org/
+Source0:        https://fping.org/dist/%{name}-%{version}.tar.gz
+BuildRequires:  autoconf
+BuildRequires:  automake
+Requires:       iana-etc
 
 %description
 fping is a ping like program which uses the Internet Control Message Protocol
@@ -27,9 +28,6 @@ make DESTDIR=%{buildroot} install
 ln -sf fping %{buildroot}%{_sbindir}/fping6
 rm -rf %{buildroot}%{_infodir}
 
-%clean
-rm -rf %{buildroot}
-
 %files
 %defattr(-, root, root)
 %license COPYING
@@ -39,12 +37,17 @@ rm -rf %{buildroot}
 %doc %{_mandir}/man8/fping.8*
 
 %changelog
+* Tue Oct 04 2022 Olivia Crain <oliviacrain@microsoft.com> - 4.2-3
+- Add runtime requirement on iana-etc
+
 * Sat May 09 2020 Nick Samson <nisamson@microsoft.com> - 4.2-2
 - Added %%license line automatically
 
-*   Mon Mar 16 2020 Henry Beberman <henry.beberman@microsoft.com> 4.2-1
--   Updated to 4.2. Updated License.
-*   Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 4.1-2
--   Initial CBL-Mariner import from Photon (license: Apache2).
+* Mon Mar 16 2020 Henry Beberman <henry.beberman@microsoft.com> 4.2-1
+- Updated to 4.2. Updated License.
+
+* Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 4.1-2
+- Initial CBL-Mariner import from Photon (license: Apache2).
+
 * Wed Jan 23 2019 Dweep Advani <dadvani@vmware.com> 4.1-1
 - Added fping package to Photon 2.0


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Cherry-pick of #2994 to the 1.0-dev branch. 

User reported that calls to `fping` consistently fail in a container without `iana-etc` installed.

As Eric said in that PR- "`fping` code uses `getprotobyname()` library call which rely on `/etc/protocols` as protocols database. `/etc/protocols` is provided by `iana-etc` pkg." So, let's reflect this dependency in the spec by adding a runtime requirement on `iana-etc` to `fping`.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- `fping`: Add runtime requirement on iana-etc

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Buddy build passes
- Installing `fping` now installs `iana-etc`, and `/usr/sbin/fping 8.8.4.4` works after install out-of-the-box in a fresh container without `iana-etc` pre-installed.
