### PR TITLE
[AUTOPATCHER-EXTENDED] wireshark upgrade to version 3.4.16 - CVE-2022-3190 - 

### DIFF
--- a/SPECS-EXTENDED/wireshark/wireshark.signatures.json
+++ b/SPECS-EXTENDED/wireshark/wireshark.signatures.json
@@ -1,6 +1,6 @@
 {
- "Signatures": {
-  "90-wireshark-usbmon.rules": "31310c5e45835563ee9daba99bc09849cc004e8d9c712d0860211d5fa5563bcb",
-  "wireshark-3.4.14.tar.xz": "32b0d0772e942d2d66cb3757bfb5027e53a6ddfbc908b65be5f3048f7a082dee"
- }
+  "Signatures": {
+    "90-wireshark-usbmon.rules": "31310c5e45835563ee9daba99bc09849cc004e8d9c712d0860211d5fa5563bcb",
+    "wireshark-3.4.16.tar.xz": "6acb3155b89b65bcdbcdac7a9e6a59013a6e21d8ae6a8249a9af4fe9ce3d91ba"
+  }
 }

--- a/SPECS-EXTENDED/wireshark/wireshark.spec
+++ b/SPECS-EXTENDED/wireshark/wireshark.spec
@@ -6,7 +6,7 @@ Summary:        Network traffic analyzer
 Name:           wireshark
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
-Version:        3.4.14
+Version:        3.4.16
 Release:        1%{?dist}
 License:        BSD and GPLv2
 Url:            https://www.wireshark.org/
@@ -236,6 +236,9 @@ fi
 %{_libdir}/pkgconfig/%{name}.pc
 
 %changelog
+* Wed Oct 05 2022 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 3.4.16-1
+- Upgrade to 3.4.16
+
 * Fri Jun 10 2022 Jon Slobodzian <joslobo@microsoft.com> - 3.4.14-1
 - Update to resolves CVEs
 - Disabled Android Dump.

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -26967,8 +26967,8 @@
         "type": "other",
         "other": {
           "name": "wireshark",
-          "version": "3.4.14",
-          "downloadUrl": "https://2.na.dl.wireshark.org/src/all-versions/wireshark-3.4.14.tar.xz"
+          "version": "3.4.16",
+          "downloadUrl": "https://2.na.dl.wireshark.org/src/all-versions/wireshark-3.4.16.tar.xz"
         }
       }
     },


### PR DESCRIPTION
[AUTOPATCHER-EXTENDED] wireshark upgrade to version 3.4.16 - CVE-2022-3190
Upgrade pipeline run -> 

AMD64 build -> https://dev.azure.com/mariner-org/mariner/_build/results?buildId=246721&view=results
ARM64 build -> https://dev.azure.com/mariner-org/mariner/_build/results?buildId=246722&view=results
