### PR TITLE
Add large file support to unzip

### DIFF
--- a/SPECS/unzip/CVE-2008-0888.nopatch
+++ b/SPECS/unzip/CVE-2008-0888.nopatch
@@ -1,0 +1,1 @@
+Upstream has fixed CVE-2008-0888 in 6.0

--- a/SPECS/unzip/unzip.spec
+++ b/SPECS/unzip/unzip.spec
@@ -1,14 +1,13 @@
 Summary:        Unzip-6.0
 Name:           unzip
 Version:        6.0
-Release:        19%{?dist}
+Release:        20%{?dist}
 License:        BSD
-URL:            http://infozip.sourceforge.net/UnZip.html
-Source0:        https://downloads.sourceforge.net/infozip/unzip60.tar.gz
-Group:          System Environment/Utilities
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
-
+Group:          System Environment/Utilities
+URL:            https://infozip.sourceforge.net/UnZip.html
+Source0:        https://downloads.sourceforge.net/infozip/unzip60.tar.gz
 Patch0:         CVE-2014-9636.patch
 Patch1:         CVE-2015-1315.patch
 Patch2:         CVE-2015-7696.patch
@@ -23,10 +22,7 @@ Patch10:        unzip-zipbomb-part2.patch
 Patch11:        unzip-zipbomb-part3.patch
 Patch12:        unzip-zipbomb-manpage.patch
 Patch13:        CVE-2015-7697.patch
-# Fixes CVE-2018-1000035
 Patch14:        CVE-2018-1000035.patch
-# Upstream has fixed CVE-2008-0888 in 6.0
-Patch15:        CVE-2008-0888.nopatch
 
 %description
 The UnZip package contains ZIP extraction utilities. These are useful
@@ -37,23 +33,15 @@ with PKZIP or Info-ZIP utilities, primarily in a DOS environment.
 %autosetup -p1 -n unzip60
 
 %build
-case `uname -m` in
-  i?86)
-    sed -i -e 's/DASM_CRC"/DASM_CRC -DNO_LCHMOD"/' unix/Makefile
-    make -f unix/Makefile linux %{?_smp_mflags}
-    ;;
-  *)
-    sed -i -e 's/CFLAGS="-O -Wall/& -DNO_LCHMOD/' unix/Makefile
-    sed -i 's/CFLAGS="-O -Wall/CFLAGS="-O -g -Wall/' unix/Makefile
-    sed -i 's/LF2 = -s/LF2 =/' unix/Makefile
-    sed -i 's|STRIP = strip|STRIP = /bin/true|' unix/Makefile
-    make -f unix/Makefile linux_noasm %{?_smp_mflags}
-    ;;
-esac
+sed -i -e 's/CFLAGS="-O -Wall/& -DNO_LCHMOD -DLARGE_FILE_SUPPORT -DZIP64_SUPPORT/' unix/Makefile
+sed -i 's/CFLAGS="-O -Wall/CFLAGS="-O -g -Wall/' unix/Makefile
+sed -i 's/LF2 = -s/LF2 =/' unix/Makefile
+sed -i 's|STRIP = strip|STRIP = /bin/true|' unix/Makefile
+%make_build -f unix/Makefile linux_noasm 
 
 %install
 install -v -m755 -d %{buildroot}%{_bindir}
-make DESTDIR=%{buildroot} prefix=%{_prefix} install
+%make_install prefix=%{_prefix}
 cp %{_builddir}/unzip60/funzip %{buildroot}%{_bindir}
 cp %{_builddir}/unzip60/unzip %{buildroot}%{_bindir}
 cp %{_builddir}/unzip60/unzipsfx %{buildroot}%{_bindir}
@@ -61,7 +49,7 @@ cp %{_builddir}/unzip60/unix/zipgrep %{buildroot}%{_bindir}
 ln -sf unzip %{buildroot}%{_bindir}/zipinfo
 
 %check
-make %{?_smp_mflags}  check
+%make_build  check
 
 %files
 %defattr(-,root,root)
@@ -69,6 +57,13 @@ make %{?_smp_mflags}  check
 %{_bindir}/*
 
 %changelog
+* Thu Oct 06 2022 Olivia Crain <oliviacrain@microsoft.com> - 6.0-20
+- Compile with large file support, zip64 support
+- Remove i*86 configuration- Mariner doesn't build for those architectures
+- Lint spec
+- Remove nopatch files from spec
+- License verified
+
 * Tue Apr 27 2021 Thomas Crain <thcrain@microsoft.com> - 6.0-19
 - Remove contents of nopatch files
 

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -232,7 +232,7 @@ ca-certificates-tools-2.0.0-7.cm2.noarch.rpm
 ca-certificates-base-2.0.0-7.cm2.noarch.rpm
 ca-certificates-2.0.0-7.cm2.noarch.rpm
 dwz-0.14-1.cm2.aarch64.rpm
-unzip-6.0-19.cm2.aarch64.rpm
+unzip-6.0-20.cm2.aarch64.rpm
 python3-3.9.14-1.cm2.aarch64.rpm
 python3-devel-3.9.14-1.cm2.aarch64.rpm
 python3-libs-3.9.14-1.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -232,7 +232,7 @@ ca-certificates-tools-2.0.0-7.cm2.noarch.rpm
 ca-certificates-base-2.0.0-7.cm2.noarch.rpm
 ca-certificates-2.0.0-7.cm2.noarch.rpm
 dwz-0.14-1.cm2.x86_64.rpm
-unzip-6.0-19.cm2.x86_64.rpm
+unzip-6.0-20.cm2.x86_64.rpm
 python3-3.9.14-1.cm2.x86_64.rpm
 python3-devel-3.9.14-1.cm2.x86_64.rpm
 python3-libs-3.9.14-1.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -559,8 +559,8 @@ tdnf-plugin-repogpgcheck-3.2.2-4.cm2.aarch64.rpm
 tdnf-python-3.2.2-4.cm2.aarch64.rpm
 texinfo-6.8-1.cm2.aarch64.rpm
 texinfo-debuginfo-6.8-1.cm2.aarch64.rpm
-unzip-6.0-19.cm2.aarch64.rpm
-unzip-debuginfo-6.0-19.cm2.aarch64.rpm
+unzip-6.0-20.cm2.aarch64.rpm
+unzip-debuginfo-6.0-20.cm2.aarch64.rpm
 util-linux-2.37.4-4.cm2.aarch64.rpm
 util-linux-libs-2.37.4-4.cm2.aarch64.rpm
 util-linux-debuginfo-2.37.4-4.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -559,8 +559,8 @@ tdnf-plugin-repogpgcheck-3.2.2-4.cm2.x86_64.rpm
 tdnf-python-3.2.2-4.cm2.x86_64.rpm
 texinfo-6.8-1.cm2.x86_64.rpm
 texinfo-debuginfo-6.8-1.cm2.x86_64.rpm
-unzip-6.0-19.cm2.x86_64.rpm
-unzip-debuginfo-6.0-19.cm2.x86_64.rpm
+unzip-6.0-20.cm2.x86_64.rpm
+unzip-debuginfo-6.0-20.cm2.x86_64.rpm
 util-linux-2.37.4-4.cm2.x86_64.rpm
 util-linux-libs-2.37.4-4.cm2.x86_64.rpm
 util-linux-debuginfo-2.37.4-4.cm2.x86_64.rpm


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
User observed that our version of `unzip` doesn't support files over 4GB- indeed, we don't compile with the right feature flags for that currently. So, let's add the `LARGE_FILE_SUPPORT` and `ZIP64_SUPPORT` flags when we compile `unzip`.

###### Change Log  <!-- REQUIRED -->
- Compile with large file support, zip64 support
- Remove i*86 configuration- Mariner doesn't build for those architectures
- Lint spec
- Remove nopatch files from spec
- License verified

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Installed buddy-built package, piped 10GB of /dev/random into a file, zipped the garbage (final size was about the same), and was able to successfully unzip the garbage!
