### PR TITLE
Support Mariner 1.0 build on Mariner 2.0 host

### DIFF
--- a/toolkit/tools/pkggen/worker/create_worker_chroot.sh
+++ b/toolkit/tools/pkggen/worker/create_worker_chroot.sh
@@ -54,6 +54,31 @@ while read -r package || [ -n "$package" ]; do
     install_one_toolchain_rpm "$package"
 done < "$packages"
 
+# If the host machine rpm version is >= 4.16 (such as Mariner 2.0), it will create an "sqlite" rpm database backend incompatible with Mariner 1.0 (which uses "bdb")
+# To resolve this, enter the 1.0 chroot after the packages are installed, and use the older rpm tool in the chroot to re-create the database in "bdb" format.
+TEMP_DB_PATH=/temp_db
+echo "Setting up a clean RPM bdb (Berkeley DB) database in the chroot under '$TEMP_DB_PATH'."  | tee -a "$chroot_log"
+
+# These nodes are required in the chroot for certain tools (most importantly, the NSS library initialization required by rpm)
+sudo mkdir -pv $chroot_builder_folder/{dev,proc,sys,run}
+sudo mknod -m 600 $chroot_builder_folder/dev/console c 5 1
+sudo mknod -m 666 $chroot_builder_folder/dev/null c 1 3
+sudo mknod -m 444 $chroot_builder_folder/dev/urandom c 1 9
+
+chroot "$chroot_builder_folder" mkdir -pv "$TEMP_DB_PATH"
+chroot "$chroot_builder_folder" rpm --initdb --dbpath="$TEMP_DB_PATH"
+# Populating the bdb database with package info.
+while read -r package || [ -n "$package" ]; do
+    full_rpm_path=$(find "$rpm_path" -name "$package" -type f 2>>"$chroot_log")
+    cp $full_rpm_path $chroot_builder_folder/$package
+    echo "Adding RPM DB entry to worker chroot: $package."  | tee -a "$chroot_log"
+    chroot "$chroot_builder_folder" rpm -i -v --nodeps --noorder --force --dbpath="$TEMP_DB_PATH" --justdb "$package" &>> "$chroot_log"
+    chroot "$chroot_builder_folder" rm $package
+done < "$packages"
+echo "Overwriting old RPM database with the results of the conversion." | tee -a "$chroot_log"
+chroot "$chroot_builder_folder" rm -rf /var/lib/rpm
+chroot "$chroot_builder_folder" mv "$TEMP_DB_PATH" /var/lib/rpm
+
 HOME=$ORIGINAL_HOME
 
 # In case of Docker based build do not add the below folders into chroot tarball 

--- a/toolkit/tools/pkggen/worker/create_worker_chroot.sh
+++ b/toolkit/tools/pkggen/worker/create_worker_chroot.sh
@@ -22,7 +22,7 @@ chroot_log="$log_path"/$chroot_name.log
 install_one_toolchain_rpm () {
     error_msg_tail="Inspect $chroot_log for more info. Did you hydrate the toolchain?"
 
-    echo "Adding RPM to worker chroot: $1."  | tee -a "$chroot_log"
+    echo "Adding RPM to worker chroot: $1." | tee -a "$chroot_log"
 
     full_rpm_path=$(find "$rpm_path" -name "$1" -type f 2>>"$chroot_log")
     if [ ! $? -eq 0 ] || [ -z "$full_rpm_path" ]
@@ -56,28 +56,36 @@ done < "$packages"
 
 # If the host machine rpm version is >= 4.16 (such as Mariner 2.0), it will create an "sqlite" rpm database backend incompatible with Mariner 1.0 (which uses "bdb")
 # To resolve this, enter the 1.0 chroot after the packages are installed, and use the older rpm tool in the chroot to re-create the database in "bdb" format.
-TEMP_DB_PATH=/temp_db
-echo "Setting up a clean RPM bdb (Berkeley DB) database in the chroot under '$TEMP_DB_PATH'."  | tee -a "$chroot_log"
+HOST_RPM_VERSION="$(rpm --version)"
+HOST_RPM_DB_BACKEND="$(rpm -E '%{_db_backend}')"
+echo "Current host machine has '$HOST_RPM_VERSION' and backend rpm database '$HOST_RPM_DB_BACKEND'" | tee -a "$chroot_log"
 
-# These nodes are required in the chroot for certain tools (most importantly, the NSS library initialization required by rpm)
-sudo mkdir -pv $chroot_builder_folder/{dev,proc,sys,run}
-sudo mknod -m 600 $chroot_builder_folder/dev/console c 5 1
-sudo mknod -m 666 $chroot_builder_folder/dev/null c 1 3
-sudo mknod -m 444 $chroot_builder_folder/dev/urandom c 1 9
+if [[ "$HOST_RPM_DB_BACKEND" == "bdb" ]]; then
+    echo "The host rpm database backend version is 'bdb', which is compatible with Mariner 1.0. Not rebuilding the database." | tee -a "$chroot_log"
+else
+    echo "The host rpm database backend version is '$HOST_RPM_DB_BACKEND'. Rebuilding a 'bdb' database to be compatible with Mariner 1.0" | tee -a "$chroot_log"
+    TEMP_DB_PATH="/temp_db"
 
-chroot "$chroot_builder_folder" mkdir -pv "$TEMP_DB_PATH"
-chroot "$chroot_builder_folder" rpm --initdb --dbpath="$TEMP_DB_PATH"
-# Populating the bdb database with package info.
-while read -r package || [ -n "$package" ]; do
-    full_rpm_path=$(find "$rpm_path" -name "$package" -type f 2>>"$chroot_log")
-    cp $full_rpm_path $chroot_builder_folder/$package
-    echo "Adding RPM DB entry to worker chroot: $package."  | tee -a "$chroot_log"
-    chroot "$chroot_builder_folder" rpm -i -v --nodeps --noorder --force --dbpath="$TEMP_DB_PATH" --justdb "$package" &>> "$chroot_log"
-    chroot "$chroot_builder_folder" rm $package
-done < "$packages"
-echo "Overwriting old RPM database with the results of the conversion." | tee -a "$chroot_log"
-chroot "$chroot_builder_folder" rm -rf /var/lib/rpm
-chroot "$chroot_builder_folder" mv "$TEMP_DB_PATH" /var/lib/rpm
+    # These nodes are required in the chroot for certain tools (most importantly, the NSS library initialization required by rpm)
+    sudo mkdir -pv $chroot_builder_folder/dev
+    sudo mknod -m 600 $chroot_builder_folder/dev/console c 5 1
+    sudo mknod -m 666 $chroot_builder_folder/dev/null c 1 3
+    sudo mknod -m 444 $chroot_builder_folder/dev/urandom c 1 9
+
+    chroot "$chroot_builder_folder" mkdir -pv "$TEMP_DB_PATH"
+    chroot "$chroot_builder_folder" rpm --initdb --dbpath="$TEMP_DB_PATH"
+    # Populating the bdb database with package info.
+    while read -r package || [ -n "$package" ]; do
+        full_rpm_path=$(find "$rpm_path" -name "$package" -type f 2>>"$chroot_log")
+        cp $full_rpm_path $chroot_builder_folder/$package
+        echo "Adding RPM DB entry to worker chroot: $package." | tee -a "$chroot_log"
+        chroot "$chroot_builder_folder" rpm -i -v --nodeps --noorder --force --dbpath="$TEMP_DB_PATH" --justdb "$package" &>> "$chroot_log"
+        chroot "$chroot_builder_folder" rm $package
+    done < "$packages"
+    echo "Overwriting old RPM database with the results of the conversion." | tee -a "$chroot_log"
+    chroot "$chroot_builder_folder" rm -rf /var/lib/rpm
+    chroot "$chroot_builder_folder" mv "$TEMP_DB_PATH" /var/lib/rpm
+fi
 
 HOME=$ORIGINAL_HOME
 

--- a/toolkit/tools/pkggen/worker/create_worker_chroot.sh
+++ b/toolkit/tools/pkggen/worker/create_worker_chroot.sh
@@ -67,10 +67,10 @@ else
     TEMP_DB_PATH="/temp_db"
 
     # These nodes are required in the chroot for certain tools (most importantly, the NSS library initialization required by rpm)
-    sudo mkdir -pv $chroot_builder_folder/dev
-    sudo mknod -m 600 $chroot_builder_folder/dev/console c 5 1
-    sudo mknod -m 666 $chroot_builder_folder/dev/null c 1 3
-    sudo mknod -m 444 $chroot_builder_folder/dev/urandom c 1 9
+    mkdir -pv $chroot_builder_folder/dev
+    mknod -m 600 $chroot_builder_folder/dev/console c 5 1
+    mknod -m 666 $chroot_builder_folder/dev/null c 1 3
+    mknod -m 444 $chroot_builder_folder/dev/urandom c 1 9
 
     chroot "$chroot_builder_folder" mkdir -pv "$TEMP_DB_PATH"
     chroot "$chroot_builder_folder" rpm --initdb --dbpath="$TEMP_DB_PATH"


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Support Mariner 1.0 build on Mariner 2.0 host
As of today, Mariner 1.0 package build environment does not work on Mariner 2.0 hosts. This is due to the rpm version (4.17+) in Mariner 2.0 which defaults to an sqlite database backend and does not support bdb (Berkeley DB) database. Mariner 1.0 has rpm version 4.14 which only supports bdb. When the package worker chroot is created, the host machine's rpm tool is used to install the packages and create the database. I've modified the create_worker_chroot.sh script re-created the database using the rpm version in the chroot (which creates a valid bdb database).

Various symptoms seen when the sqlite database is created when building Mariner 1.0 on a host with incompatible rpm version:
```
Error(1022) : distroverpkg config entry is set to a package that is not installed. Check /etc/tdnf/tdnf.conf

INFO[0016] Initializing repository configurations       
ERRO[0016] Failed to clone kernel(,):<ID:13 Type:Remote State:Unresolved> from '<NO_SRPM_PATH>' in '<NO_REPO>' from RPM repo. Error: exit status 254 
ERRO[0016] Failed to resolve all nodes in the graph while resolving 'kernel(,):<ID:13 Type:Remote State:Unresolved> from '<NO_SRPM_PATH>' in '<NO_REPO>''

error: Failed to initialize NSS library
```

Note that on Mariner 2.0, this script (create_worker_chroot.sh) has a similar problem and similar solution. In that case, the typical host machine is Ubuntu 18.04 (with rpm 4.14 creating a bdb database) and Mariner 2.0 in the chroot expects an sqlite database.

Current Host OS/rpm/db versions (checked by running `rpm -E "%{_db_backend}"` in the latest containers)
```
Mariner 1.0: RPM version 4.14.2 - bdb
Mariner 2.0: RPM version 4.18.0 - sqlite
Ubuntu 18.04: RPM version 4.14.1 - bdb
Ubuntu 20.04: RPM version 4.14.2.1 - bdb
Ubuntu 22.04: RPM version 4.17.0 - sqlite
```

For relevant information see: https://rpm.org/user_doc/db_recovery.html and https://fedoraproject.org/wiki/Changes/RPM-4.16

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change create_worker_chroot.sh to rebuild the rpm database inside of the chroot after the host machine installs the packages

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: 250896 (rebuild 1.0-dev AMD64 packages)
- Pipeline build id: 250895 (trigger end-2-end AMD64 1.0-dev build)
- Pipeline build id: 250982 (rebuild 1.0-dev AMD64 images)
- Pipeline build id: 250987 (rebuild 1.0-dev Arm64 images)