### PR TITLE
[2.0] Rebuild worker chroot rpm db only when necessary

### DIFF
--- a/toolkit/tools/pkggen/worker/create_worker_chroot.sh
+++ b/toolkit/tools/pkggen/worker/create_worker_chroot.sh
@@ -54,32 +54,50 @@ while read -r package || [ -n "$package" ]; do
     install_one_toolchain_rpm "$package"
 done < "$packages"
 
-TEMP_DB_PATH=/temp_db
-echo "Setting up a clean RPM database before the Berkeley DB -> SQLite conversion under '$TEMP_DB_PATH'." | tee -a "$chroot_log"
-chroot "$chroot_builder_folder" mkdir -p "$TEMP_DB_PATH"
-chroot "$chroot_builder_folder" rpm --initdb --dbpath="$TEMP_DB_PATH"
+# If the host machine rpm version is >= 4.16 (such as Mariner 2.0), it will create an "sqlite" rpm database backend incompatible with Mariner 1.0 (which uses "bdb")
+# To resolve this, enter the 1.0 chroot after the packages are installed, and use the older rpm tool in the chroot to re-create the database in "bdb" format.
+HOST_RPM_VERSION="$(rpm --version)"
+HOST_RPM_DB_BACKEND="$(rpm -E '%{_db_backend}')"
+echo "Current host machine has '$HOST_RPM_VERSION' and backend rpm database '$HOST_RPM_DB_BACKEND'" | tee -a "$chroot_log"
 
-# Popularing the SQLite database with package info.
-while read -r package || [ -n "$package" ]; do
-    full_rpm_path=$(find "$rpm_path" -name "$package" -type f 2>>"$chroot_log")
-    cp $full_rpm_path $chroot_builder_folder/$package
+if [[ "$HOST_RPM_DB_BACKEND" == "sqlite" ]]; then
+    echo "The host rpm database backend version is 'sqlite', which is compatible with Mariner 2.0. Not rebuilding the database." | tee -a "$chroot_log"
+else
+    echo "The host rpm database backend version is '$HOST_RPM_DB_BACKEND'. Rebuilding an 'sqlite' database to be compatible with Mariner 2.0" | tee -a "$chroot_log"
+    TEMP_DB_PATH="/temp_db"
 
-    echo "Adding RPM DB entry to worker chroot: $package." | tee -a "$chroot_log"
+    # These nodes are required in the chroot for certain tools (most importantly, gpg key import when installing 'mariner-repos-shared' package)
+    sudo mkdir -pv $chroot_builder_folder/dev
+    sudo mknod -m 600 $chroot_builder_folder/dev/console c 5 1
+    sudo mknod -m 666 $chroot_builder_folder/dev/null c 1 3
+    sudo mknod -m 444 $chroot_builder_folder/dev/urandom c 1 9
 
-    chroot "$chroot_builder_folder" rpm -i -v --nodeps --noorder --force --dbpath="$TEMP_DB_PATH" --justdb "$package" &>> "$chroot_log"
-    chroot "$chroot_builder_folder" rm $package
-done < "$packages"
+    echo "Setting up a clean RPM database before the Berkeley DB -> SQLite conversion under '$TEMP_DB_PATH'." | tee -a "$chroot_log"
+    chroot "$chroot_builder_folder" mkdir -p "$TEMP_DB_PATH"
+    chroot "$chroot_builder_folder" rpm --initdb --dbpath="$TEMP_DB_PATH"
 
-echo "Overwriting old RPM database with the results of the conversion." | tee -a "$chroot_log"
-chroot "$chroot_builder_folder" rm -rf /var/lib/rpm
-chroot "$chroot_builder_folder" mv "$TEMP_DB_PATH" /var/lib/rpm
+    # Popularing the SQLite database with package info.
+    while read -r package || [ -n "$package" ]; do
+        full_rpm_path=$(find "$rpm_path" -name "$package" -type f 2>>"$chroot_log")
+        cp $full_rpm_path $chroot_builder_folder/$package
 
-echo "Importing CBL-Mariner GPG keys." | tee -a "$chroot_log"
-for gpg_key in $(chroot "$chroot_builder_folder" rpm -q -l mariner-repos-shared | grep "rpm-gpg")
-do
-    echo "Importing GPG key: $gpg_key" | tee -a "$chroot_log"
-    chroot "$chroot_builder_folder" rpm --import "$gpg_key"
-done
+        echo "Adding RPM DB entry to worker chroot: $package." | tee -a "$chroot_log"
+
+        chroot "$chroot_builder_folder" rpm -i -v --nodeps --noorder --force --dbpath="$TEMP_DB_PATH" --justdb "$package" &>> "$chroot_log"
+        chroot "$chroot_builder_folder" rm $package
+    done < "$packages"
+
+    echo "Overwriting old RPM database with the results of the conversion." | tee -a "$chroot_log"
+    chroot "$chroot_builder_folder" rm -rf /var/lib/rpm
+    chroot "$chroot_builder_folder" mv "$TEMP_DB_PATH" /var/lib/rpm
+
+    echo "Importing CBL-Mariner GPG keys." | tee -a "$chroot_log"
+    for gpg_key in $(chroot "$chroot_builder_folder" rpm -q -l mariner-repos-shared | grep "rpm-gpg")
+    do
+        echo "Importing GPG key: $gpg_key" | tee -a "$chroot_log"
+        chroot "$chroot_builder_folder" rpm --import "$gpg_key"
+    done
+fi
 
 HOME=$ORIGINAL_HOME
 

--- a/toolkit/tools/pkggen/worker/create_worker_chroot.sh
+++ b/toolkit/tools/pkggen/worker/create_worker_chroot.sh
@@ -77,10 +77,9 @@ if [[ "$HOST_RPM_DB_BACKEND" == "$GUEST_RPM_DB_BACKEND" ]]; then
 else
     echo "The host rpm db ('$HOST_RPM_DB_BACKEND') differs from the guest ('$GUEST_RPM_DB_BACKEND'). Rebuilding database for compatibility" | tee -a "$chroot_log"
     TEMP_DB_PATH="/temp_db"
-    echo "Setting up a clean RPM database before the Berkeley DB -> SQLite conversion under '$TEMP_DB_PATH'." | tee -a "$chroot_log"
     chroot "$chroot_builder_folder" mkdir -p "$TEMP_DB_PATH"
     chroot "$chroot_builder_folder" rpm --initdb --dbpath="$TEMP_DB_PATH"
-    # Popularing the SQLite database with package info.
+    # Populating the SQLite database with package info.
     while read -r package || [ -n "$package" ]; do
         full_rpm_path=$(find "$rpm_path" -name "$package" -type f 2>>"$chroot_log")
         cp $full_rpm_path $chroot_builder_folder/$package


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?

Optimize the create_worker_chroot.sh script to only rebuild the rpm backend database when necessary. The host machine rpm version creates the rpm database in the chroot, which could be incompatible. Common scenarios are as follows:
- Mariner 2.0 host creates sqlite database, which is compatible with Mariner 2.0 being built (rpm db is not rebuilt)
- Mariner 1.0 host creates bdb database, which is not compatible with Mariner 2.0 being built (rpm db is rebuilt in sqlite format)
- Ubuntu 18.04 host creates bdb database, which is not compatible with Mariner 2.0 being built (rpm db is rebuilt in sqlite format)

Also create /dev/null and other nodes in the chroot, which are required when gpg keys are imported while installing the `mariner-repos-shared` package. This resolves the following error seen in worker_chroot.log:
```
Adding RPM to worker chroot: mariner-repos-shared-2.0-8.cm2.noarch.rpm.
...
Preparing packages...
mariner-repos-shared-2.0-8.cm2.noarch
gpg: directory '/root/.gnupg' created
gpg: keybox '/root/.gnupg/pubring.kbx' created
gpg: /root/.gnupg/trustdb.gpg: trustdb created
gpg: key EB3E94ADBE1229CF: public key "Microsoft (Release signing) <gpgsecurity@microsoft.com>" imported
gpg: Fatal: failed to open '/dev/null': No such file or directory
gpg: release_dotlock: not our lock (pid=7919)
gpg: error running '/usr/bin/gpg-agent': exit status 2
gpg: failed to start gpg-agent '/usr/bin/gpg-agent': General error
gpg: can't connect to the gpg-agent: General error
gpg: Total number processed: 1
gpg:               imported: 1
gpg: error opening lockfile '/root/.gnupg/trustdb.gpg.lock': No such file or directory
gpg: release_dotlock: lockfile error
gpg: key 0CD9FED33135CE90: public key "Mariner RPM Release Signing <marinerrpmprod@microsoft.com>" imported
gpg: Fatal: failed to open '/dev/null': No such file or directory
gpg: error running '/usr/bin/gpg-agent': exit status 2
gpg: failed to start gpg-agent '/usr/bin/gpg-agent': General error
gpg: can't connect to the gpg-agent: General error
gpg: Total number processed: 1
gpg:               imported: 1
warning: %posttrans(mariner-repos-shared-2.0-8.cm2.noarch) scriptlet failed, exit status 2
Adding RPM to worker chroot: mariner-repos-2.0-8.cm2.noarch.rpm.
```

Some of these changes are similar to PR #4024 which changes this script for Mariner 1.0.

Current Host OS/rpm/db versions (checked by running `rpm -E '%{_db_backend}'` in the latest containers)
```
Mariner 1.0: RPM version 4.14.2 - bdb
Mariner 2.0: RPM version 4.18.0 - sqlite
Ubuntu 18.04: RPM version 4.14.1 - bdb
Ubuntu 20.04: RPM version 4.14.2.1 - bdb
Ubuntu 22.04: RPM version 4.17.0 - sqlite
```

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change create_worker_chroot.sh to only rebuild rpm db when necessary
- Create /dev/null and other nodes in chroot required for importing gpg keys
- Set -e and -o pipefail in the script to catch unexpected errors

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: 250933 (Amd64 main package build on Ubuntu 18.04 host)
- Pipeline build id: 250936 (Amd64 main package build on Mariner 2.0 host)
- Pipeline build id: 250983 (Amd64 main Image build on Ubuntu 18.04 host)