### PR TITLE
1.0 toolkit: skip ARCHIVE_TOOL on extraction

### DIFF
--- a/toolkit/scripts/pkggen.mk
+++ b/toolkit/scripts/pkggen.mk
@@ -202,5 +202,5 @@ compress-srpms:
 # Seed the RPMs folder with the any missing files from the archive.
 hydrate-rpms:
 	$(if $(PACKAGE_ARCHIVE),,$(error Must set PACKAGE_ARCHIVE=))
-	@echo Updating missing RPMs from $(PACKAGE_ARCHIVE) into $(RPMS_DIR)
-	tar -I $(ARCHIVE_TOOL) -xf $(PACKAGE_ARCHIVE) -C $(RPMS_DIR) --strip-components 1 --skip-old-files --touch --checkpoint=100000 --checkpoint-action=echo="%T"
+	@echo Unpacking RPMs from $(PACKAGE_ARCHIVE) into $(RPMS_DIR)
+	tar -xf $(PACKAGE_ARCHIVE) -C $(RPMS_DIR) --strip-components 1 --skip-old-files --touch --checkpoint=100000 --checkpoint-action=echo="%T"

--- a/toolkit/scripts/toolchain.mk
+++ b/toolkit/scripts/toolchain.mk
@@ -204,7 +204,7 @@ $(toolchain_rpms):
 	mkdir -p $$rpm_dir && \
 	cd $$rpm_dir && \
 	for url in $(PACKAGE_URL_LIST); do \
-		wget $$url/$$rpm_filename \
+		wget -nv --no-clobber $$url/$$rpm_filename \
 			$(if $(TLS_CERT),--certificate=$(TLS_CERT)) \
 			$(if $(TLS_KEY),--private-key=$(TLS_KEY)) \
 			-a $$log_file && \

--- a/toolkit/scripts/toolchain.mk
+++ b/toolkit/scripts/toolchain.mk
@@ -103,9 +103,9 @@ hydrate-toolchain:
 	$(if $(TOOLCHAIN_ARCHIVE),,$(error Must set TOOLCHAIN_ARCHIVE=))
 	sudo mkdir -vp $(toolchain_build_dir)
 	sudo cp $(TOOLCHAIN_CONTAINER_ARCHIVE) $(raw_toolchain)
-	tar -I $(ARCHIVE_TOOL) -xf $(TOOLCHAIN_CONTAINER_ARCHIVE) -C $(toolchain_build_dir) --skip-old-files --touch --checkpoint=100000 --checkpoint-action=echo="%T"
+	tar -xf $(TOOLCHAIN_CONTAINER_ARCHIVE) -C $(toolchain_build_dir) --skip-old-files --touch --checkpoint=100000 --checkpoint-action=echo="%T"
 	sudo cp $(TOOLCHAIN_ARCHIVE) $(final_toolchain)
-	tar -I $(ARCHIVE_TOOL) -xf $(TOOLCHAIN_ARCHIVE) -C $(toolchain_build_dir) --skip-old-files --touch --checkpoint=100000 --checkpoint-action=echo="%T"
+	tar -xf $(TOOLCHAIN_ARCHIVE) -C $(toolchain_build_dir) --skip-old-files --touch --checkpoint=100000 --checkpoint-action=echo="%T"
 	sudo touch $(final_toolchain)
 	sudo mkdir -vp $(RPMS_DIR)/noarch
 	sudo mkdir -vp $(RPMS_DIR)/$(build_arch)
@@ -169,7 +169,7 @@ $(toolchain_rpms): $(TOOLCHAIN_MANIFEST) | $(final_toolchain)
 	@echo Extracting RPM $@ from toolchain && \
 	if [ ! -f $@ -o $(final_toolchain) -nt $@ ]; then \
 		mkdir -p $(dir $@) && \
-		tar -I $(ARCHIVE_TOOL) -xvf $(final_toolchain) -C $(dir $@) --strip-components 1 built_rpms_all/$(notdir $@) && \
+		tar -xvf $(final_toolchain) -C $(dir $@) --strip-components 1 built_rpms_all/$(notdir $@) && \
 		touch $@ ; \
 	fi || $(call print_error, $@ failed) ;
 else
@@ -181,7 +181,7 @@ $(toolchain_local_temp): $(STATUS_FLAGS_DIR)/toolchain_local_temp.flag
 $(toolchain_local_temp)%: ;
 $(STATUS_FLAGS_DIR)/toolchain_local_temp.flag: $(TOOLCHAIN_ARCHIVE) $(shell find $(toolchain_local_temp)/* 2>/dev/null)
 	mkdir -p $(BUILD_DIR)/toolchain_temp/ && \
-	tar -I $(ARCHIVE_TOOL) -xvf $(TOOLCHAIN_ARCHIVE) -C $(BUILD_DIR)/toolchain_temp/ --strip-components 1 && \
+	tar -xvf $(TOOLCHAIN_ARCHIVE) -C $(BUILD_DIR)/toolchain_temp/ --strip-components 1 && \
 	touch $(BUILD_DIR)/toolchain_temp/* && \
 	touch $@
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Change toolkit scripts to not use ARCHIVE_TOOL when extracting tarballs (rpms.tar.gz, srpms.tar.gz, toolchain_built_rpms_all.tar.gz, toolchain_built_srpms_all.tar.gz). The tar command is smart enough to figure out which decompression library to use (see [gnu tar](https://www.gnu.org/software/tar/manual/tar.html#gzip) "Reading compressed archive is even simpler: you don’t need to specify any additional options as GNU tar recognizes its format automatically.". Removing the explicit ARCHIVE_TOOL makes the scripts more flexible, and they can handle cases where these tarballs might not be compressed.

Relevant example below. In this case the "-z" flag is equivalent to "-I $(ARCHIVE_TOOL)"
```
tar -xf compressed_rpms.tar.gz
    OK
tar -xzf compressed_rpms.tar.gz
    OK
tar -xf uncompressed_rpms.tar.gz
    OK
tar -xzf uncompressed_rpms.tar.gz
    gzip: stdin: not in gzip format
```

Also changed the toolchain download to use wget's "-nv --no-clobber" options. "-nv" cleans up the logs by making the output no-verbose. "--no-clobber" speeds up local builds by not downloading toolchain packages that have already been downloaded. This change is already present in 2.0

See related PR #3683 from the 2.0 branch. This change is related, but for 1.0 I'm not removing the compression of the archives (to avoid unnecessary risk), just making the toolkit more flexible.

I've run some performance testing locally and the time required to extract a 5GB compressed rpms.tar.gz with gzip compared to pigz seems negligible.
```
$ time tar -I pigz -xf rpms.tar.gz
39 seconds
$ time tar -I gzip -xf rpms.tar.gz
41 seconds
$ time tar -xf rpms.tar.gz
41 seconds
$ time tar -xzf rpms.tar.gz
41 seconds
``` 

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change toolkit scripts to not use ARCHIVE_TOOL when extracting tarballs
- Change toolchain.mk to download toolchain rpms with "-nv --no-clobber" options

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: 251070 (full AMD64 1.0-dev build)
