### PR TITLE
Fix gpg key import in worker chroot

### DIFF
--- a/toolkit/tools/pkggen/worker/create_worker_chroot.sh
+++ b/toolkit/tools/pkggen/worker/create_worker_chroot.sh
@@ -90,14 +90,14 @@ else
     echo "Overwriting old RPM database with the results of the conversion." | tee -a "$chroot_log"
     chroot "$chroot_builder_folder" rm -rf /var/lib/rpm
     chroot "$chroot_builder_folder" mv "$TEMP_DB_PATH" /var/lib/rpm
-
-    echo "Importing CBL-Mariner GPG keys." | tee -a "$chroot_log"
-    for gpg_key in $(chroot "$chroot_builder_folder" rpm -q -l mariner-repos-shared | grep "rpm-gpg")
-    do
-        echo "Importing GPG key: $gpg_key" | tee -a "$chroot_log"
-        chroot "$chroot_builder_folder" rpm --import "$gpg_key"
-    done
 fi
+
+echo "Importing CBL-Mariner GPG keys." | tee -a "$chroot_log"
+for gpg_key in $(chroot "$chroot_builder_folder" rpm -q -l mariner-repos-shared | grep "rpm-gpg")
+do
+    echo "Importing GPG key: $gpg_key" | tee -a "$chroot_log"
+    chroot "$chroot_builder_folder" rpm --import "$gpg_key"
+done
 
 HOME=$ORIGINAL_HOME
 

--- a/toolkit/tools/pkggen/worker/create_worker_chroot.sh
+++ b/toolkit/tools/pkggen/worker/create_worker_chroot.sh
@@ -71,7 +71,7 @@ HOST_RPM_DB_BACKEND="$(rpm -E '%{_db_backend}')"
 GUEST_RPM_VERSION="$(chroot "$chroot_builder_folder" rpm --version)"
 GUEST_RPM_DB_BACKEND="$(chroot "$chroot_builder_folder" rpm -E '%{_db_backend}')"
 echo "Current host '$HOST_RPM_VERSION' with rpm db '$HOST_RPM_DB_BACKEND', guest has '$GUEST_RPM_VERSION' with rpm db '$GUEST_RPM_DB_BACKEND'" | tee -a "$chroot_log"
-#HOST_RPM_DB_BACKEND="hack"
+
 if [[ "$HOST_RPM_DB_BACKEND" == "$GUEST_RPM_DB_BACKEND" ]]; then
     echo "The host rpm db '$HOST_RPM_DB_BACKEND' matches the guest. Not rebuilding the database." | tee -a "$chroot_log"
 else

--- a/toolkit/tools/pkggen/worker/create_worker_chroot.sh
+++ b/toolkit/tools/pkggen/worker/create_worker_chroot.sh
@@ -71,7 +71,7 @@ HOST_RPM_DB_BACKEND="$(rpm -E '%{_db_backend}')"
 GUEST_RPM_VERSION="$(chroot "$chroot_builder_folder" rpm --version)"
 GUEST_RPM_DB_BACKEND="$(chroot "$chroot_builder_folder" rpm -E '%{_db_backend}')"
 echo "Current host '$HOST_RPM_VERSION' with rpm db '$HOST_RPM_DB_BACKEND', guest has '$GUEST_RPM_VERSION' with rpm db '$GUEST_RPM_DB_BACKEND'" | tee -a "$chroot_log"
-HOST_RPM_DB_BACKEND="hack"
+#HOST_RPM_DB_BACKEND="hack"
 if [[ "$HOST_RPM_DB_BACKEND" == "$GUEST_RPM_DB_BACKEND" ]]; then
     echo "The host rpm db '$HOST_RPM_DB_BACKEND' matches the guest. Not rebuilding the database." | tee -a "$chroot_log"
 else


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?

Fix two issues importing gpg keys in the worker chroot. The first change is to create the "/dev/null" node before installing packages in the worker chroot (so that "mariner-repos-shared" can import gpg keys). The second is to make sure the call to manually import gpg keys happens even when the rpm database is not rebuilt.

Fixes errors seen when building on Mariner 2.0 host such as:
```
ERRO[0015] Failed to clone 'libestr-0.1.11-1.cm2.x86_64' from RPM repo. Error: exit status 9 
ERRO[0017] Failed to clone 'postgresql-devel-14.5-1.cm2.x86_64' from RPM repo. Error: exit status 9 
ERRO[0020] Failed to clone 'autogen-5.18.16-8.cm2.x86_64' from RPM repo. Error: exit status 9

Cached_graph.dot.log
"stderr: Invalid input\nError processing package: filesystem-1.1-11.cm2.x86_64.rpm\nError(1033) : a downgrade is not allowed below the minimal version. Check 'minversions' in the configuration.\n"
```

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change create_worker_chroot.sh to create nodes before installing packages in chroot
- Change create_worker_chroot.sh to always import gpg keys even if not overwriting rpm database

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: 252503
