### PR TITLE
Bump toolkit/tools' cgmanifest.json's listing for ulikunitz/xz to v0.5.10

### DIFF
--- a/toolkit/tools/cgmanifest.json
+++ b/toolkit/tools/cgmanifest.json
@@ -113,7 +113,7 @@
                 "Type": "Go",
                 "Go": {
                     "Name": "github.com/ulikunitz/xz",
-                    "Version": "v0.5.7"
+                    "Version": "v0.5.10"
                 }
             }
         },


### PR DESCRIPTION
Bump toolkit/tools' cgmanifest.json's listing for ulikunitz/xz to v0.5.10

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Component governance scanners that check for security vulnerabilities in out-of-date libraries were detecting ulikunitz/xz as out of date because the cgmanifest.json file wasn't updated to v0.5.10 when the go.mod file was updated. See this [PR](https://github.com/microsoft/CBL-Mariner/commit/0fccb369d0649fe4ea5ab2124af5c7dcddb24d95) that updated the go.mod file without touching the cgmanifest.json file.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Update toolkit/tools' cgmanifest.json's entry for ulikunitz/xz to match its corresponding go.mod, which lists v0.5.10.

###### Does this affect the toolchain?
No.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- This is adding what should be a missed change from a prior PR - specifically the "cgmanifest files are up-to-date" checkbox - this shouldn't be a functional change.