### PR TITLE
Fix rsyslog.logrotate signature

### DIFF
--- a/SPECS/rsyslog/rsyslog.signatures.json
+++ b/SPECS/rsyslog/rsyslog.signatures.json
@@ -4,7 +4,7 @@
   "rsyslog-8.2204.1.tar.gz": "a6d731e46ad3d64f6ad4b19bbf1bf56ca4760a44a24bb96823189dc2e71f7028",
   "rsyslog-doc-8.2204.0.tar.gz": "e838ccdd74c146e5d3cd33e4602974f081b93a86b524c19a34f3eb8cbb5c2bfe",
   "rsyslog.conf": "3300e314e0df76f8049302ecceb8c0ee31d97f4ec62b10997eb34147b00d4af1",
-  "rsyslog.logrotate": "9829e881170a0e664fe1f3bb4d776744d4495f01e1374371f5e28700ad1608e3",
+  "rsyslog.logrotate": "546897eeb5caba4e2a403195d22c98312b6fea044213df95e9279f6b3a2279e6",
   "rsyslog.service": "df62c9fa758079016e3b73f39d3b5952dce1e0c14a063c7a776b86eeba405153"
  }
 }


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Fix for build break:
```
ERRO[0195] unable to hydrate file: rsyslog.logrotate    
ERRO[0195] Failed to pack (/specs/rsyslog/rsyslog.spec). Error: unable to hydrate file: rsyslog.logrotate 
```

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change ryslog.signatures.json with correct sha256sum for rsyslog.logrotate

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- sudo make input-srpms REBUILD_TOOLS=y SOURCE_URL=https://cblmarinerstorage.blob.core.windows.net/sources/core
