### PR TITLE
Fix chroot cleanup scripts

### DIFF
--- a/toolkit/scripts/pkggen.mk
+++ b/toolkit/scripts/pkggen.mk
@@ -43,7 +43,7 @@ $(call create_folder,$(rpmbuilding_logs_dir))
 graph-cache: $(cached_file)
 workplan: $(graph_file)
 clean: clean-workplan clean-cache
-clean-workplan:
+clean-workplan: clean-cache
 	rm -rf $(PKGBUILD_DIR)
 	rm -rf $(LOGS_DIR)/pkggen/workplan
 clean-cache:

--- a/toolkit/scripts/pkggen.mk
+++ b/toolkit/scripts/pkggen.mk
@@ -23,6 +23,7 @@ pkggen_rpms     = $(shell find $(RPMS_DIR)/*  2>/dev/null )
 
 # Pkggen workspace
 cache_working_dir      = $(PKGBUILD_DIR)/tdnf_cache_worker
+parse_working_dir      = $(BUILD_DIR)/spec_parsing
 rpmbuilding_logs_dir   = $(LOGS_DIR)/pkggen/rpmbuilding
 rpm_cache_files        = $(shell find $(CACHED_RPMS_DIR)/)
 validate-pkggen-config = $(STATUS_FLAGS_DIR)/validate-image-config-pkggen.flag
@@ -39,11 +40,11 @@ logging_command = --log-file=$(LOGS_DIR)/pkggen/workplan/$(notdir $@).log --log-
 $(call create_folder,$(LOGS_DIR)/pkggen/workplan)
 $(call create_folder,$(rpmbuilding_logs_dir))
 
-.PHONY: clean-workplan clean-cache graph-cache analyze-built-graph workplan
+.PHONY: clean-workplan clean-cache clean-spec-parse graph-cache analyze-built-graph workplan
 graph-cache: $(cached_file)
 workplan: $(graph_file)
-clean: clean-workplan clean-cache
-clean-workplan: clean-cache
+clean: clean-workplan clean-cache clean-spec-parse
+clean-workplan: clean-cache clean-spec-parse
 	rm -rf $(PKGBUILD_DIR)
 	rm -rf $(LOGS_DIR)/pkggen/workplan
 clean-cache:
@@ -52,6 +53,10 @@ clean-cache:
 	@echo Verifying no mountpoints present in $(cache_working_dir)
 	$(SCRIPTS_DIR)/safeunmount.sh "$(cache_working_dir)" && \
 	rm -rf $(cache_working_dir)
+clean-spec-parse:
+	@echo Verifying no mountpoints present in $(parse_working_dir)
+	$(SCRIPTS_DIR)/safeunmount.sh "$(parse_working_dir)" && \
+	rm -rf $(parse_working_dir)
 
 # Optionally generate a summary of any blocked packages after a build.
 analyze-built-graph: $(go-graphanalytics)
@@ -69,7 +74,7 @@ analyze-built-graph: $(go-graphanalytics)
 $(specs_file): $(chroot_worker) $(BUILD_SPECS_DIR) $(build_specs) $(build_spec_dirs) $(go-specreader)
 	$(go-specreader) \
 		--dir $(BUILD_SPECS_DIR) \
-		--build-dir $(BUILD_DIR)/spec_parsing \
+		--build-dir $(parse_working_dir) \
 		--srpm-dir $(BUILD_SRPMS_DIR) \
 		--rpm-dir $(RPMS_DIR) \
 		--dist-tag $(DIST_TAG) \

--- a/toolkit/scripts/toolkit.mk
+++ b/toolkit/scripts/toolkit.mk
@@ -55,6 +55,8 @@ clean-package-toolkit:
 
 clean-rpms-snapshot:
 	rm -f $(rpms_snapshot)
+	@echo Verifying no mountpoints present in $(rpms_snapshot_build_dir)
+	$(SCRIPTS_DIR)/safeunmount.sh "$(rpms_snapshot_build_dir)" && \
 	rm -rf $(rpms_snapshot_build_dir)
 	rm -f $(rpms_snapshot_logs_path)
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
In 2.0 we made the package fetchers use a chroot, we have a separate clean target for the pkg fetcher (`clean-cache`) which did not have an enforced ordering with the more general `clean-workplan`. If the package fetcher was killed halfway through it could leave behind a chroot which hasn't been cleaned up. Running `make clean` will generally run `clean-workplan` before running `clean-cache` which will try (and fail) to remove the chroot's `/proc/*` etc., and possibly put the host system into a bad state. This adds an explicit dependency so the chroot is cleaned up first.

We were also missing cleanups for the spec parsing chroot and snapshot chroots.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add a dependency on `clean-cache` to `clean-workplan`
- Add safeunmount.sh call for `$(rpms_snapshot_build_dir)`
- Add safeunmount.sh call for (new) `$(parse_working_dir)`

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local test
