### PR TITLE
Updated rpmops.sh: added a '/bin/sh' check.

### DIFF
--- a/toolkit/scripts/livepatching/generate_livepatch_spec.sh
+++ b/toolkit/scripts/livepatching/generate_livepatch_spec.sh
@@ -88,7 +88,7 @@ LIVEPATCH_SPEC_PATH="$LIVEPATCH_SPECS_DIR/$LIVEPATCH_NAME.spec"
 
 if [[ -f "$LIVEPATCH_SPEC_PATH" ]]
 then
-    echo "Livepatch spec ($LIVEPATCH_SPEC_PATH) alread exists. Exiting."
+    echo "Livepatch spec ($LIVEPATCH_SPEC_PATH) already exists. Exiting."
     exit 0
 fi
 

--- a/toolkit/scripts/rpmops.sh
+++ b/toolkit/scripts/rpmops.sh
@@ -6,6 +6,12 @@
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 
+RPM_SHELL="$(readlink /bin/sh)"
+if [[ "$RPM_SHELL" != "bash" ]]
+then
+    echo "WARNING: host system's '/bin/sh' links to '$RPM_SHELL'. Mariner specs require 'bash'. Parsing specs may fail or generate unpredictable results." >&2
+fi
+
 # Additional macros required to parse spec files.
 DEFINES=(-D "with_check 1" -D "dist $(grep -P "DIST_TAG" "$REPO_ROOT"/toolkit/Makefile | grep -oP "\.cm\d+")")
 
@@ -21,6 +27,7 @@ done
 function mariner_rpmspec {
     # Looking for spec path in the argument list to extract its directory.
     local sourcedir
+
     for arg in "$@"
     do
         if [[ "$arg" == *.spec && -f "$arg" ]]
@@ -32,9 +39,9 @@ function mariner_rpmspec {
 
     if [[ -z $sourcedir ]]
     then        
-        echo "Must pass valid spec path to 'mariner_rpmspec'!"
+        echo "Must pass valid spec path to 'mariner_rpmspec'!" >&2
         return 1
     fi
 
-    rpmspec "${DEFINES[@]}" -D "_sourcedir $sourcedir" "${MACROS[@]}" "$@"
+    rpmspec "${MACROS[@]}" "${DEFINES[@]}" -D "_sourcedir $sourcedir" "$@"
 }


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

Mariner specs require the `/bin/sh` link to point to `bash` in order to correctly parse the spec. For other shells the script macros might fail due to unsupported commands. For example, 'dash' doesn't support the `[[` built-in command. So far I couldn't find a way to override RPM's default interpreter, so at least we're going to print a warning in an effort to ease debugging.

Sample issue: when #4048 was created, the host system where parsing was performed used 'dash', which caused `livepatch.spec` macros to evaluate `[[` incorrectly and overwrite the signed livepatch spec as consequence.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Added an RPM shell check to `rpmops.sh`.
- Changed order of `rpmspec` arguments, so our defines overwrite any default values from the macro files.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #4048

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local script run.
