### PR TITLE
Updated 4 `rubygem-*` packages to obsolete older versions of `ruby`.

### DIFF
--- a/SPECS/rubygem-minitest/rubygem-minitest.spec
+++ b/SPECS/rubygem-minitest/rubygem-minitest.spec
@@ -20,7 +20,9 @@ BuildRequires:  ruby
 
 Requires:       ruby(release)
 
+# This package used to be bundled with older versions of Ruby.
 Obsoletes:      ruby <= 3.1.2-2%{?dist}
+
 Provides:       rubygem(minitest) = %{version}-%{release}
 
 %description

--- a/SPECS/rubygem-minitest/rubygem-minitest.spec
+++ b/SPECS/rubygem-minitest/rubygem-minitest.spec
@@ -3,7 +3,7 @@
 Summary:        Minitest provides a complete suite of testing facilities
 Name:           rubygem-%{gem_name}
 Version:        5.15.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 # minitest source is licensed under MIT and minitest.gemspec is taken from ruby source, licensed under the rest
 License:        MIT AND (Ruby OR BSD) AND Public Domain AND MIT AND CC0 AND zlib AND UCD
 Vendor:         Microsoft Corporation
@@ -13,11 +13,15 @@ URL:            https://github.com/seattlerb/minitest
 Source0:        https://github.com/minitest/minitest/archive/refs/tags/v%{version}.tar.gz#/%{gem_name}-%{version}.tar.gz
 # When updating the version, please make necessary changes in this .gemspec, e.g. update version, dependencies (use https://rubygems.org/gems/minitest)
 Source1:        minitest.gemspec
+BuildArch:      noarch
+
 BuildRequires:  git
 BuildRequires:  ruby
+
 Requires:       ruby(release)
+
+Obsoletes:      ruby <= 3.1.2-2%{?dist}
 Provides:       rubygem(minitest) = %{version}-%{release}
-BuildArch:      noarch
 
 %description
 minitest/unit is a small and incredibly fast unit testing framework.
@@ -47,6 +51,9 @@ cp README.rdoc %{buildroot}%{gem_instdir}/
 %{gemdir}
 
 %changelog
+* Mon Oct 24 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 5.15.0-2
+- Adding 'Obsoletes: ruby <= 3.1.2-2'.
+
 * Tue May 24 2022 Neha Agarwal <nehaagarwal@microsoft.com> - 5.15.0-1
 - Update to v5.15.0
 - Get source.tar.gz from upstream, get initial .gemspec from ruby2.7.4 source (license (Ruby OR BSD) AND Public Domain AND MIT AND CC0 AND zlib AND UCD)

--- a/SPECS/rubygem-power_assert/rubygem-power_assert.spec
+++ b/SPECS/rubygem-power_assert/rubygem-power_assert.spec
@@ -15,7 +15,9 @@ BuildArch:      noarch
 BuildRequires:  git
 BuildRequires:  ruby
 
+# This package used to be bundled with older versions of Ruby.
 Obsoletes:      ruby <= 3.1.2-2%{?dist}
+
 Provides:       rubygem(power_assert) = %{version}-%{release}
 
 %description

--- a/SPECS/rubygem-power_assert/rubygem-power_assert.spec
+++ b/SPECS/rubygem-power_assert/rubygem-power_assert.spec
@@ -2,7 +2,7 @@
 Summary:        Power Assert for Ruby
 Name:           rubygem-%{gem_name}
 Version:        2.0.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        BSD
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -10,10 +10,13 @@ Group:          Development/Languages
 URL:            https://github.com/ruby/power_assert/
 Source0:        https://github.com/ruby/power_assert/archive/refs/tags/v%{version}.tar.gz#/%{gem_name}-%{version}.tar.gz
 Patch0:         fix-file_list.patch
+BuildArch:      noarch
+
 BuildRequires:  git
 BuildRequires:  ruby
+
+Obsoletes:      ruby <= 3.1.2-2%{?dist}
 Provides:       rubygem(power_assert) = %{version}-%{release}
-BuildArch:      noarch
 
 %description
 Power Assert shows each value of variables and method calls in the expression.
@@ -36,6 +39,9 @@ gem install -V --local --force --install-dir %{buildroot}/%{gemdir} %{gem_name}-
 %{gemdir}
 
 %changelog
+* Mon Oct 24 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 2.0.1-4
+- Adding 'Obsoletes: ruby <= 3.1.2-2'.
+
 * Wed Jul 06 2022 Neha Agarwal <nehaagarwal@microsoft.com> - 2.0.1-3
 - Added missing lib files
 

--- a/SPECS/rubygem-rake/rubygem-rake.spec
+++ b/SPECS/rubygem-rake/rubygem-rake.spec
@@ -17,7 +17,9 @@ BuildRequires:  rubygems-devel
 BuildRequires:  rubygem(minitest) >= 5
 %endif
 
+# This package used to be bundled with older versions of Ruby.
 Obsoletes:      ruby <= 3.1.2-2%{?dist}
+
 Provides:       rubygem(%{gem_name}) = %{version}-%{release}
 
 %description

--- a/SPECS/rubygem-rake/rubygem-rake.spec
+++ b/SPECS/rubygem-rake/rubygem-rake.spec
@@ -2,14 +2,13 @@
 Summary:        Rake is a Make-like program implemented in Ruby
 Name:           rubygem-%{gem_name}
 Version:        13.0.6
-Release:        5%{?dist}
+Release:        6%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 URL:            https://ruby.github.io/rake/
 Source0:        https://github.com/ruby/rake/archive/refs/tags/v%{version}.tar.gz#/%{gem_name}-%{version}.tar.gz
 BuildArch:      noarch
-Provides:       rubygem(%{gem_name}) = %{version}-%{release}
 
 BuildRequires:  ruby
 BuildRequires:  ruby(release)
@@ -17,6 +16,9 @@ BuildRequires:  rubygems-devel
 %if %{with_check}
 BuildRequires:  rubygem(minitest) >= 5
 %endif
+
+Obsoletes:      ruby <= 3.1.2-2%{?dist}
+Provides:       rubygem(%{gem_name}) = %{version}-%{release}
 
 %description
 Rake is a Make-like program implemented in Ruby. Tasks and dependencies are
@@ -75,6 +77,9 @@ popd
 %doc %{gem_instdir}/*.rdoc
 
 %changelog
+* Mon Oct 24 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 13.0.6-6
+- Adding 'Obsoletes: ruby <= 3.1.2-2'.
+
 * Wed Jun 22 2022 Neha Agarwal <nehaagarwal@microsoft.com> - 13.0.6-5
 - Add provides.
 

--- a/SPECS/rubygem-test-unit/rubygem-test-unit.spec
+++ b/SPECS/rubygem-test-unit/rubygem-test-unit.spec
@@ -16,7 +16,9 @@ BuildRequires:  ruby
 
 Requires:       rubygem-power_assert
 
+# This package used to be bundled with older versions of Ruby.
 Obsoletes:      ruby <= 3.1.2-2%{?dist}
+
 Provides:       rubygem(test-unit) = %{version}-%{release}
 
 %description

--- a/SPECS/rubygem-test-unit/rubygem-test-unit.spec
+++ b/SPECS/rubygem-test-unit/rubygem-test-unit.spec
@@ -2,18 +2,22 @@
 Summary:        An xUnit family unit testing framework for Ruby
 Name:           rubygem-%{gem_name}
 Version:        3.5.3
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        PSF AND BSD
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Group:          Development/Languages
 URL:            https://test-unit.github.io/
 Source0:        https://github.com/test-unit/test-unit/archive/refs/tags/%{version}.tar.gz#/%{gem_name}-%{version}.tar.gz
+BuildArch:      noarch
+
 BuildRequires:  git
 BuildRequires:  ruby
+
 Requires:       rubygem-power_assert
+
+Obsoletes:      ruby <= 3.1.2-2%{?dist}
 Provides:       rubygem(test-unit) = %{version}-%{release}
-BuildArch:      noarch
 
 %description
 Test::Unit (test-unit) is unit testing framework for Ruby, based on xUnit
@@ -42,6 +46,9 @@ cp PSFL %{buildroot}%{gem_instdir}/
 %{gemdir}
 
 %changelog
+* Mon Oct 24 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 3.5.3-3
+- Adding 'Obsoletes: ruby <= 3.1.2-2'.
+
 * Wed Apr 20 2022 Neha Agarwal <nehaagarwal@microsoft.com> - 3.5.3-2
 - Add provides
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

A while ago we removed bundled Ruby gems from the `ruby` package and moved them to separate packages (#3035). Since now both the new packages and the older version of `ruby` provide the same files, we can hit package installation conflicts in some corner cases. To alleviate that, I'm adding an `Obsoletes: ruby <= [old_ruby_version]` to make RPM or the package managers choose the right combination of packages.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Added `Obsoletes` to `rubygem-minitest`, `rubygem-power_asser`, `rubygem-rake`, and `rubygem-test-unit`.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #3035

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local package build.
