### PR TITLE
Revert "[AUTOPATCHER-CORE] nodejs upgrade to version 16.17.1 - CVE-2022-32213 - "

### DIFF
--- a/SPECS/nodejs/nodejs.signatures.json
+++ b/SPECS/nodejs/nodejs.signatures.json
@@ -1,5 +1,5 @@
 {
-  "Signatures": {
-    "node-v16.17.1.tar.xz": "def33a26ed76ad308c9fdf04028cbbd4ace7c5de2fa8c866be79836c12f3251d"
-  }
+ "Signatures": {
+  "node-v16.16.0.tar.xz": "327688a0d6dafbf7b32324069f16e3d893dcb6654c889c24240e976441c20ffe"
+ }
 }

--- a/SPECS/nodejs/nodejs.spec
+++ b/SPECS/nodejs/nodejs.spec
@@ -5,8 +5,8 @@ Summary:        A JavaScript runtime built on Chrome's V8 JavaScript engine.
 Name:           nodejs
 # WARNINGS: MUST check and update the 'npm_version' macro for every version update of this package.
 #           The version of NPM can be found inside the sources under 'deps/npm/package.json'.
-Version:        16.17.1
-Release:        1%{?dist}
+Version:        16.16.0
+Release:        2%{?dist}
 License:        BSD and MIT and Public Domain and naist-2003
 Group:          Applications/System
 Vendor:         Microsoft Corporation
@@ -114,9 +114,6 @@ make cctest
 %{_datadir}/systemtap/tapset/node.stp
 
 %changelog
-* Mon Oct 24 2022 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 16.17.1-1
-- Upgrade to 16.17.1
-
 * Thu Aug 18 2022 Cameron Baird <cameronbaird@microsoft.com> - 16.16.0-2
 - Change npm_version to 8.11.0 to reflect the actual version of npm bundled with v16.16.0
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -12913,8 +12913,8 @@
         "type": "other",
         "other": {
           "name": "nodejs",
-          "version": "16.17.1",
-          "downloadUrl": "https://nodejs.org/download/release/v16.17.1/node-v16.17.1.tar.xz"
+          "version": "16.16.0",
+          "downloadUrl": "https://nodejs.org/download/release/v16.16.0/node-v16.16.0.tar.xz"
         }
       }
     },


### PR DESCRIPTION
Reverts microsoft/CBL-Mariner#4071

missed Jon's comment about the version jump