### PR TITLE
Fix manifest checks with RPM 4.18

### DIFF
--- a/toolkit/scripts/toolchain/check_manifests.sh
+++ b/toolkit/scripts/toolchain/check_manifests.sh
@@ -18,7 +18,7 @@ write_rpms_from_spec () {
     fi
 
     version=$(rpmspec -q $1 --define="with_check 0" --define="dist $DIST_TAG" --qf="%{VERSION}" --srpm 2>/dev/null)
-    rpmWithoutExtension=$(rpmspec -q $1 --define="with_check 0" --define="dist $DIST_TAG" --target=$ARCH 2>/dev/null)
+    rpmWithoutExtension=$(rpmspec -q $1 --define="with_check 0" --define="dist $DIST_TAG" --target=$ARCH --qf="%{nvra}\n" 2>/dev/null)
 
     for rpm in $rpmWithoutExtension
     do


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
[RPM 4.18.0 changed the default query](https://github.com/rpm-software-management/rpm/commit/82dafa39a2dfd3e24858681ca75f467c1e1b3635) used by `rpmspec -q` when no query format string is specified. The old behavior uses the `%{nvra}` format string, which uses the final architecture of a package (through the `%{arch}` tag) regardless of whether we're querying a source package or not. RPM 4.18.0 introduces a new tag, `%{archsuffix}` which is the same as `%{arch}` except that it returns `src` or `nosrc` when querying a source package. The new default query format string was changed to `%{nvr}.%{archsuffix}`.

This broke our manifest checking script, which expects the default query to be `%{nvra}`. We query source RPMs to check whether a set of built RPMs matches the expected output. When faced with the choice of keeping the old behavior or adapting to new behavior, we definitely want the old behavior. We want the manifest to reflect the names of the final built toolchain RPMs, complete with the architecture tag.

So, let's fix the manifest check when host RPM is 4.18.0 or later by explicitly querying the built packages with the `%{nvra}` format string.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- `check_manifests.sh`: Use `%{nvra}` query format string when querying packages built by toolchain SRPMs.
 
###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Manifest check test passes on hosts with RPM 4.17.0 and 4.18.0.
