### PR TITLE
Add obsoletes between qemu-common, qemu-virtiofsd

### DIFF
--- a/SPECS/qemu/qemu.spec
+++ b/SPECS/qemu/qemu.spec
@@ -217,7 +217,7 @@ Obsoletes: %{name}-system-unicore32-core <= %{version}-%{release}
 Summary:        QEMU is a FAST! processor emulator
 Name:           qemu
 Version:        6.2.0
-Release:        9%{?dist}
+Release:        10%{?dist}
 License:        BSD AND CC-BY AND GPLv2+ AND LGPLv2+ AND MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -510,9 +510,12 @@ Summary:        qemu-pr-helper utility for %{name}
 This package provides the qemu-pr-helper utility that is required for certain
 SCSI features.
 
-%package -n qemu-virtiofsd
-Summary: QEMU virtio-fs shared file system daemon
-Provides: vhostuser-backend(fs)
+%package -n     qemu-virtiofsd
+Summary:        QEMU virtio-fs shared file system daemon
+Provides:       vhostuser-backend(fs)
+# qemu-common provided %%{_libexecdir}/virtiofsd prior to 6.2.0
+Obsoletes:      %{name}-common < 6.2.0
+
 %description -n qemu-virtiofsd
 This package provides virtiofsd daemon. This program is a vhost-user backend
 that implements the virtio-fs device that is used for sharing a host directory
@@ -2288,6 +2291,9 @@ useradd -r -u 107 -g qemu -G kvm -d / -s %{_sbindir}/nologin \
 
 
 %changelog
+* Wed Oct 26 2022 Olivia Crain <oliviacrain@microsoft.com> - 6.2.0-10
+- Have virtiofsd subpackage obsolete qemu-common from 6.1.0 releases
+
 * Tue Sep 28 2022 Saul Paredes <saulparedes@microsoft.com> - 6.2.0-9
 - Adress CVE-2022-2962
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
RPM has trouble choosing which package provides `/usr/libexec/virtiofsd`. For our series of `qemu-6.1.0` releases, this file resided in `qemu-common`. For our series of `qemu-6.2.0` releases, this file resides in `qemu-virtiofsd`. Since these packages have different names, RPM gives up on choosing a single provider for that file.

So, let's help RPM choose by explicitly stating that `qemu-virtiofsd` obsoletes all versions of `qemu-common` prior to 6.2.0. That way, RPM will always choose `qemu-virtiofsd` when querying for the latest owner of `/usr/libexec/virtiofsd`.

For more context, see the original bug report at the bottom of this description.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- `qemu-virtiofsd` now obsoletes `qemu-common < 6.2.0`

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Buddy build of `qemu` passes
- Downloading all 2.0 RPMs which provide `/usr/libexec/virtiofsd` and running `rpm -Uvvh --nodeps --test <rpms>` on them successfully returns `qemu-virtiofsd-6.2.0-10`
- The original `sudo make graph-cache` reproducer works now, if I put all of the `qemu*-6.2.0-10` RPMs in the output RPMs folder before running that command.

###### Original Bug

During a full build of core, with upstream repos enabled:

```bash
git checkout 2.0-stable
sudo make clean
sudo make toolchain REBUILD_TOOLS=y
sudo make copy-toolchain-rpms
sudo make graph-cache
```

We fail to find a valid package to download from upstream. We use rpm itself to try and determine a non-conflicting version of the package to select, so we may be seeing the results of a file changing location maybe?

Note the following output:
```
time="2022-10-18T02:19:44Z" level=debug msg="Fetched 'qemu-virtiofsd-6.2.0-8.cm2.x86_64' as potential candidate (is pre-built: false)."
time="2022-10-18T02:19:44Z" level=debug msg="Found 7 candidates. Resolving."
time="2022-10-18T02:19:44Z" level=debug msg="Executing: [rpm -Uvvh --nodeps --root /tmp/mariner/build/pkg_artifacts/tdnf_cache_worker --test /tmp/mariner/build/rpm_cache/cache/qemu-virtiofsd-6.2.0-7.cm2.x86_64.rpm /tmp/mariner/build/rpm_cache/cache/qemu-virtiofsd-6.2.0-5.cm2.x86_64.rpm /tmp/mariner/build/rpm_cache/cache/qemu-virtiofsd-6.2.0-4.cm2.x86_64.rpm /tmp/mariner/build/rpm_cache/cache/qemu-virtiofsd-6.2.0-3.cm2.x86_64.rpm /tmp/mariner/build/rpm_cache/cache/qemu-common-6.1.0-14.cm2.x86_64.rpm /tmp/mariner/build/rpm_cache/cache/qemu-virtiofsd-6.2.0-9.cm2.x86_64.rpm /tmp/mariner/build/rpm_cache/cache/qemu-virtiofsd-6.2.0-8.cm2.x86_64.rpm]"
time="2022-10-18T02:19:44Z" level=warning msg="ufdio:       1 reads,    17154 total bytes in 0.000013 secs
    rpm: RPM should not be used directly install RPM packages, use Alien instead!
    rpm: However assuming you know what you are doing...
    D: ============== /tmp/mariner/build/rpm_cache/cache/qemu-virtiofsd-6.2.0-7.cm2.x86_64.rpm
    D: loading keyring from pubkeys in /tmp/mariner/build/pkg_artifacts/tdnf_cache_worker/root/.rpmdb/pubkeys/*.key
    D: couldn't find any keys in /tmp/mariner/build/pkg_artifacts/tdnf_cache_worker/root/.rpmdb/pubkeys/*.key
    D: loading keyring from rpmdb
    D: opening  db environment /tmp/mariner/build/pkg_artifacts/tdnf_cache_worker/root/.rpmdb cdb:0x401
    D: opening  db index       /tmp/mariner/build/pkg_artifacts/tdnf_cache_worker/root/.rpmdb/Packages 0x400 mode=0x0
    D: locked   db index       /tmp/mariner/build/pkg_artifacts/tdnf_cache_worker/root/.rpmdb/Packages
    D: opening  db index       /tmp/mariner/build/pkg_artifacts/tdnf_cache_worker/root/.rpmdb/Name 0x400 mode=0x0
    warning: /tmp/mariner/build/rpm_cache/cache/qemu-virtiofsd-6.2.0-7.cm2.x86_64.rpm: Header V4 RSA/SHA256 Signature, key ID 3135ce90: NOKEY
    D: /tmp/mariner/build/rpm_cache/cache/qemu-virtiofsd-6.2.0-7.cm2.x86_64.rpm: Header SHA1 digest: OK
    D: /tmp/mariner/build/rpm_cache/cache/qemu-virtiofsd-6.2.0-7.cm2.x86_64.rpm: Header SHA256 digest: OK
    ufdio:       6 reads,    18537 total bytes in 0.000019 secs
    D: \tadded binary package [0]
    D: ============== /tmp/mariner/build/rpm_cache/cache/qemu-virtiofsd-6.2.0-5.cm2.x86_64.rpm
    D: /tmp/mariner/build/rpm_cache/cache/qemu-virtiofsd-6.2.0-5.cm2.x86_64.rpm: Header V4 RSA/SHA256 Signature, key ID 3135ce90: NOKEY
    D: /tmp/mariner/build/rpm_cache/cache/qemu-virtiofsd-6.2.0-5.cm2.x86_64.rpm: Header SHA1 digest: OK
    D: /tmp/mariner/build/rpm_cache/cache/qemu-virtiofsd-6.2.0-5.cm2.x86_64.rpm: Header SHA256 digest: OK
    ufdio:       6 reads,    18377 total bytes in 0.000021 secs
    D: Obsoletes: qemu-virtiofsd > 6.2.0-5.cm2                  YES (added provide)
    warning: package qemu-virtiofsd-6.2.0-7.cm2.x86_64 was already added, skipping qemu-virtiofsd-6.2.0-5.cm2.x86_64
    D: \tadded binary package [1]
    D: ============== /tmp/mariner/build/rpm_cache/cache/qemu-virtiofsd-6.2.0-4.cm2.x86_64.rpm
    D: /tmp/mariner/build/rpm_cache/cache/qemu-virtiofsd-6.2.0-4.cm2.x86_64.rpm: Header V4 RSA/SHA256 Signature, key ID 3135ce90: NOKEY
    D: /tmp/mariner/build/rpm_cache/cache/qemu-virtiofsd-6.2.0-4.cm2.x86_64.rpm: Header SHA1 digest: OK
    D: /tmp/mariner/build/rpm_cache/cache/qemu-virtiofsd-6.2.0-4.cm2.x86_64.rpm: Header SHA256 digest: OK
    ufdio:       6 reads,    18293 total bytes in 0.000014 secs
    D: Obsoletes: qemu-virtiofsd > 6.2.0-4.cm2                  YES (added provide)
    warning: package qemu-virtiofsd-6.2.0-7.cm2.x86_64 was already added, skipping qemu-virtiofsd-6.2.0-4.cm2.x86_64
    D: \tadded binary package [2]
    D: ============== /tmp/mariner/build/rpm_cache/cache/qemu-virtiofsd-6.2.0-3.cm2.x86_64.rpm
    D: /tmp/mariner/build/rpm_cache/cache/qemu-virtiofsd-6.2.0-3.cm2.x86_64.rpm: Header V4 RSA/SHA256 Signature, key ID 3135ce90: NOKEY
    D: /tmp/mariner/build/rpm_cache/cache/qemu-virtiofsd-6.2.0-3.cm2.x86_64.rpm: Header SHA1 digest: OK
    D: /tmp/mariner/build/rpm_cache/cache/qemu-virtiofsd-6.2.0-3.cm2.x86_64.rpm: Header SHA256 digest: OK
    ufdio:       6 reads,    18217 total bytes in 0.000010 secs
    D: Obsoletes: qemu-virtiofsd > 6.2.0-3.cm2                  YES (added provide)
    warning: package qemu-virtiofsd-6.2.0-7.cm2.x86_64 was already added, skipping qemu-virtiofsd-6.2.0-3.cm2.x86_64
    D: \tadded binary package [3]
    D: ============== /tmp/mariner/build/rpm_cache/cache/qemu-common-6.1.0-14.cm2.x86_64.rpm
    D: /tmp/mariner/build/rpm_cache/cache/qemu-common-6.1.0-14.cm2.x86_64.rpm: Header V4 RSA/SHA256 Signature, key ID 3135ce90: NOKEY
    D: /tmp/mariner/build/rpm_cache/cache/qemu-common-6.1.0-14.cm2.x86_64.rpm: Header SHA1 digest: OK
    D: /tmp/mariner/build/rpm_cache/cache/qemu-common-6.1.0-14.cm2.x86_64.rpm: Header SHA256 digest: OK
    ufdio:       6 reads,    31749 total bytes in 0.000016 secs
    D: \tadded binary package [4]
    D: ============== /tmp/mariner/build/rpm_cache/cache/qemu-virtiofsd-6.2.0-9.cm2.x86_64.rpm
    D: /tmp/mariner/build/rpm_cache/cache/qemu-virtiofsd-6.2.0-9.cm2.x86_64.rpm: Header V4 RSA/SHA256 Signature, key ID 3135ce90: NOKEY
    D: /tmp/mariner/build/rpm_cache/cache/qemu-virtiofsd-6.2.0-9.cm2.x86_64.rpm: Header SHA1 digest: OK
    D: /tmp/mariner/build/rpm_cache/cache/qemu-virtiofsd-6.2.0-9.cm2.x86_64.rpm: Header SHA256 digest: OK
    ufdio:       6 reads,    18729 total bytes in 0.000011 secs
    D: Obsoletes: qemu-virtiofsd < 6.2.0-9.cm2                  YES (added provide)
    warning: package qemu-virtiofsd-6.2.0-7.cm2.x86_64 was already added, replacing with qemu-virtiofsd-6.2.0-9.cm2.x86_64
    D: \tadded binary package [5]
    D: ============== /tmp/mariner/build/rpm_cache/cache/qemu-virtiofsd-6.2.0-8.cm2.x86_64.rpm
    D: /tmp/mariner/build/rpm_cache/cache/qemu-virtiofsd-6.2.0-8.cm2.x86_64.rpm: Header V4 RSA/SHA256 Signature, key ID 3135ce90: NOKEY
    D: /tmp/mariner/build/rpm_cache/cache/qemu-virtiofsd-6.2.0-8.cm2.x86_64.rpm: Header SHA1 digest: OK
    D: /tmp/mariner/build/rpm_cache/cache/qemu-virtiofsd-6.2.0-8.cm2.x86_64.rpm: Header SHA256 digest: OK
    ufdio:       6 reads,    18653 total bytes in 0.000011 secs
    D: Obsoletes: qemu-virtiofsd > 6.2.0-8.cm2                  YES (added provide)
    warning: package qemu-virtiofsd-6.2.0-9.cm2.x86_64 was already added, skipping qemu-virtiofsd-6.2.0-8.cm2.x86_64
    D: \tadded binary package [6]
    D: found 0 source and 7 binary packages
    D: ========== recording tsort relations
    D: ========== tsorting packages (order, #predecessors, #succesors, depth)
    D:     0    0    0    1   +qemu-common-6.1.0-14.cm2.x86_64
    D:     1    0    0    1   +qemu-virtiofsd-6.2.0-9.cm2.x86_64
    D: installing binary packages
    D: sanity checking 2 elements
    D: computing 98 file fingerprints
    D: opening  db index       /tmp/mariner/build/pkg_artifacts/tdnf_cache_worker/root/.rpmdb/Basenames 0x400 mode=0x0
    D: opening  db index       /tmp/mariner/build/pkg_artifacts/tdnf_cache_worker/root/.rpmdb/Group 0x400 mode=0x0
    D: opening  db index       /tmp/mariner/build/pkg_artifacts/tdnf_cache_worker/root/.rpmdb/Requirename 0x400 mode=0x0
    D: opening  db index       /tmp/mariner/build/pkg_artifacts/tdnf_cache_worker/root/.rpmdb/Providename 0x400 mode=0x0
    D: opening  db index       /tmp/mariner/build/pkg_artifacts/tdnf_cache_worker/root/.rpmdb/Conflictname 0x400 mode=0x0
    D: opening  db index       /tmp/mariner/build/pkg_artifacts/tdnf_cache_worker/root/.rpmdb/Obsoletename 0x400 mode=0x0
    D: opening  db index       /tmp/mariner/build/pkg_artifacts/tdnf_cache_worker/root/.rpmdb/Triggername 0x400 mode=0x0
    D: opening  db index       /tmp/mariner/build/pkg_artifacts/tdnf_cache_worker/root/.rpmdb/Dirnames 0x400 mode=0x0
    D: opening  db index       /tmp/mariner/build/pkg_artifacts/tdnf_cache_worker/root/.rpmdb/Installtid 0x400 mode=0x0
    D: opening  db index       /tmp/mariner/build/pkg_artifacts/tdnf_cache_worker/root/.rpmdb/Sigmd5 0x400 mode=0x0
    D: opening  db index       /tmp/mariner/build/pkg_artifacts/tdnf_cache_worker/root/.rpmdb/Sha1header 0x400 mode=0x0
    D: opening  db index       /tmp/mariner/build/pkg_artifacts/tdnf_cache_worker/root/.rpmdb/Filetriggername 0x400 mode=0x0
    D: opening  db index       /tmp/mariner/build/pkg_artifacts/tdnf_cache_worker/root/.rpmdb/Transfiletriggername 0x400 mode=0x0
    D: opening  db index       /tmp/mariner/build/pkg_artifacts/tdnf_cache_worker/root/.rpmdb/Recommendname 0x400 mode=0x0
    D: opening  db index       /tmp/mariner/build/pkg_artifacts/tdnf_cache_worker/root/.rpmdb/Suggestname 0x400 mode=0x0
    D: opening  db index       /tmp/mariner/build/pkg_artifacts/tdnf_cache_worker/root/.rpmdb/Supplementname 0x400 mode=0x0
    D: opening  db index       /tmp/mariner/build/pkg_artifacts/tdnf_cache_worker/root/.rpmdb/Enhancename 0x400 mode=0x0
    D: computing file dispositions
    D: 0x00000801     4096     22366780      8310354 /
    \tfile /usr/libexec/virtiofsd conflicts between attempted installs of qemu-virtiofsd-6.2.0-9.cm2.x86_64 and qemu-common-6.1.0-14.cm2.x86_64
    \tfile /usr/share/man/man1/virtiofsd.1.gz conflicts between attempted installs of qemu-virtiofsd-6.2.0-9.cm2.x86_64 and qemu-common-6.1.0-14.cm2.x86_64
    D: closed   db index       /tmp/mariner/build/pkg_artifacts/tdnf_cache_worker/root/.rpmdb/Packages
    D: closed   db index       /tmp/mariner/build/pkg_artifacts/tdnf_cache_worker/root/.rpmdb/Enhancename
    D: closed   db index       /tmp/mariner/build/pkg_artifacts/tdnf_cache_worker/root/.rpmdb/Supplementname
    D: closed   db index       /tmp/mariner/build/pkg_artifacts/tdnf_cache_worker/root/.rpmdb/Suggestname
    D: closed   db index       /tmp/mariner/build/pkg_artifacts/tdnf_cache_worker/root/.rpmdb/Recommendname
    D: closed   db index       /tmp/mariner/build/pkg_artifacts/tdnf_cache_worker/root/.rpmdb/Transfiletriggername
    D: closed   db index       /tmp/mariner/build/pkg_artifacts/tdnf_cache_worker/root/.rpmdb/Filetriggername
    D: closed   db index       /tmp/mariner/build/pkg_artifacts/tdnf_cache_worker/root/.rpmdb/Sha1header
    D: closed   db index       /tmp/mariner/build/pkg_artifacts/tdnf_cache_worker/root/.rpmdb/Sigmd5
    D: closed   db index       /tmp/mariner/build/pkg_artifacts/tdnf_cache_worker/root/.rpmdb/Installtid
    D: closed   db index       /tmp/mariner/build/pkg_artifacts/tdnf_cache_worker/root/.rpmdb/Dirnames
    D: closed   db index       /tmp/mariner/build/pkg_artifacts/tdnf_cache_worker/root/.rpmdb/Triggername
    D: closed   db index       /tmp/mariner/build/pkg_artifacts/tdnf_cache_worker/root/.rpmdb/Obsoletename
    D: closed   db index       /tmp/mariner/build/pkg_artifacts/tdnf_cache_worker/root/.rpmdb/Conflictname
    D: closed   db index       /tmp/mariner/build/pkg_artifacts/tdnf_cache_worker/root/.rpmdb/Providename
    D: closed   db index       /tmp/mariner/build/pkg_artifacts/tdnf_cache_worker/root/.rpmdb/Requirename
    D: closed   db index       /tmp/mariner/build/pkg_artifacts/tdnf_cache_worker/root/.rpmdb/Group
    D: closed   db index       /tmp/mariner/build/pkg_artifacts/tdnf_cache_worker/root/.rpmdb/Basenames
    D: closed   db index       /tmp/mariner/build/pkg_artifacts/tdnf_cache_worker/root/.rpmdb/Name
    D: closed   db environment /tmp/mariner/build/pkg_artifacts/tdnf_cache_worker/root/.rpmdb
    D: removed  db environment /tmp/mariner/build/pkg_artifacts/tdnf_cache_worker/root/.rpmdb
    D: Exit status: 2"
time="2022-10-18T02:19:44Z" level=error msg="Failed while trying to pick an RPM providing '/usr/libexec/virtiofsd' from the following RPMs: [/tmp/mariner/build/rpm_cache/cache/qemu-virtiofsd-6.2.0-7.cm2.x86_64.rpm /tmp/mariner/build/rpm_cache/cache/qemu-virtiofsd-6.2.0-5.cm2.x86_64.rpm /tmp/mariner/build/rpm_cache/cache/qemu-virtiofsd-6.2.0-4.cm2.x86_64.rpm /tmp/mariner/build/rpm_cache/cache/qemu-virtiofsd-6.2.0-3.cm2.x86_64.rpm /tmp/mariner/build/rpm_cache/cache/qemu-common-6.1.0-14.cm2.x86_64.rpm /tmp/mariner/build/rpm_cache/cache/qemu-virtiofsd-6.2.0-9.cm2.x86_64.rpm /tmp/mariner/build/rpm_cache/cache/qemu-virtiofsd-6.2.0-8.cm2.x86_64.rpm]"
time="2022-10-18T02:19:44Z" level=error msg="Failed to find an RPM to provide '/usr/libexec/virtiofsd'. Error: exit status 2"
time="2022-10-18T02:19:44Z" level=debug msg="Failed to resolve all nodes in the graph while resolving '/usr/libexec/virtiofsd(,):<ID:18778 Type:Remote State:Unresolved Rpm:/tmp/mariner/build/rpm_cache/cache/qemu-virtiofsd-6.2.0-7.cm2.x86_64.rpm> from '<NO_SRPM_PATH>' in '<NO_REPO>''
    Nodes which have this as a dependency:
    \t'kata-containers(x86-64)(=2.5.0-6.cm2,):<ID:4806 Type:Run State:Meta Rpm:/tmp/mariner/out/RPMS/x86_64/kata-containers-2.5.0-6.cm2.x86_64.rpm> from '/tmp/mariner/build/INTERMEDIATE_SRPMS/kata-containers-2.5.0-6.cm2.src.rpm' in '<LOCAL>'' depends on '/usr/libexec/virtiofsd(,):<ID:18778 Type:Remote State:Unresolved Rpm:/tmp/mariner/build/rpm_cache/cache/qemu-virtiofsd-6.2.0-7.cm2.x86_64.rpm> from '<NO_SRPM_PATH>' in '<NO_REPO>''
    \t'kata-containers(=2.5.0-6.cm2,):<ID:4808 Type:Run State:Meta Rpm:/tmp/mariner/out/RPMS/x86_64/kata-containers-2.5.0-6.cm2.x86_64.rpm> from '/tmp/mariner/build/INTERMEDIATE_SRPMS/kata-containers-2.5.0-6.cm2.src.rpm' in '<LOCAL>'' depends on '/usr/libexec/virtiofsd(,):<ID:18778 Type:Remote State:Unresolved Rpm:/tmp/mariner/build/rpm_cache/cache/qemu-virtiofsd-6.2.0-7.cm2.x86_64.rpm> from '<NO_SRPM_PATH>' in '<NO_REPO>''
    \t'ALL():<ID:18923 Type:Goal State:Meta Rpm:<NO_RPM_PATH>> from '<NO_SRPM_PATH>' in '<NO_REPO>'' depends on '/usr/libexec/virtiofsd(,):<ID:18778 Type:Remote State:Unresolved Rpm:/tmp/mariner/build/rpm_cache/cache/qemu-virtiofsd-6.2.0-7.cm2.x86_64.rpm> from '<NO_SRPM_PATH>' in '<NO_REPO>''
    "
```

