### PR TITLE
Disable apparmor LSM at boot time

### DIFF
--- a/toolkit/imageconfigs/marketplace-gen1.json
+++ b/toolkit/imageconfigs/marketplace-gen1.json
@@ -68,7 +68,7 @@
                 "default": "kernel"
             },
             "KernelCommandLine": {
-                "ExtraCommandLine": "console=ttyS0"
+                "ExtraCommandLine": "console=ttyS0 apparmor=0"
             },
             "Hostname": "cbl-mariner"
         }

--- a/toolkit/imageconfigs/marketplace-gen2-aarch64.json
+++ b/toolkit/imageconfigs/marketplace-gen2-aarch64.json
@@ -70,7 +70,7 @@
                 "default": "kernel"
             },
             "KernelCommandLine": {
-                "ExtraCommandLine": "console=ttyS0"
+                "ExtraCommandLine": "console=ttyS0 apparmor=0"
             },
             "Hostname": "cbl-mariner"
         }

--- a/toolkit/imageconfigs/marketplace-gen2.json
+++ b/toolkit/imageconfigs/marketplace-gen2.json
@@ -70,7 +70,7 @@
                 "default": "kernel"
             },
             "KernelCommandLine": {
-                "ExtraCommandLine": "console=ttyS0"
+                "ExtraCommandLine": "console=ttyS0 apparmor=0"
             },
             "Hostname": "cbl-mariner"
         }


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
This PR addresses a behavior introduced to the Mariner 1.0 AKS Container Host by this PR https://github.com/microsoft/CBL-Mariner/pull/3261
https://github.com/microsoft/CBL-Mariner/pull/3261 introduced apparmor as a runtime requires for containerd, which unintentionally enabled very strict apparmor default policies in situations where containerd runtime is used. This enforcement is blocking customer container functionality that is expected to work.

So this change restores prior behavior by disabling AppArmor at the host/kernel level. We will be re-evaluating the default apparmor policies to ensure customer container functionality continues to work when we re-add AppArmor enforcement for containers.

Signed-off-by: Chris Co <chrco@microsoft.com>

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Set `apparmor=0` in the kernel command line on the Marketplace images

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://microsoft.visualstudio.com/OS/_workitems/edit/41597402

###### Links to CVEs  <!-- optional -->

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build of Marketplace images
- Confirm AppArmor is disabled in Azure VMs with this image
- 
![image](https://user-images.githubusercontent.com/35273088/198753323-184a5f59-d5ea-4eb7-832e-0a9dec653176.png)
