### PR TITLE
Fix python-execnet test to use explicit pytest version

### DIFF
--- a/SPECS/python-execnet/python-execnet.spec
+++ b/SPECS/python-execnet/python-execnet.spec
@@ -6,7 +6,7 @@
 Summary:        Python execution distributor
 Name:           python-%{pkgname}
 Version:        1.7.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        MIT
 URL:            https://codespeak.net/execnet/
 Vendor:         Microsoft Corporation
@@ -56,6 +56,7 @@ python3 setup.py install --root=%{buildroot}
 %if %{with check}
 %check
 pip3 install tox
+sed -i "s/pytest$/pytest==7.1.3/" tox.ini
 LANG=en_US.UTF-8 tox -e py37
 %endif
 
@@ -65,6 +66,8 @@ LANG=en_US.UTF-8 tox -e py37
 %{python3_sitelib}/*
 
 %changelog
+* Mon Oct 31 2022 Jon Slobodzian <joslobo@microsoft.com> 1.7.1-3
+- Fix check tests to enforce the 7.1.3 version of pytest. 
 * Tue Jun 08 2021 Andrew Phelps <anphel@microsoft.com> 1.7.1-2
 - Fix check tests
 * Fri Aug 21 2020 Thomas Crain <thcrain@microsoft.com> 1.7.1-1


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Pytest recently updated to a new version.  The self-test for this package fails with the newer version.  This change patches the self-test to use an explicit version of pytest.

