### PR TITLE
Fix python-six test to use explicit version 7.1.3

### DIFF
--- a/SPECS/python-six/python-six.spec
+++ b/SPECS/python-six/python-six.spec
@@ -3,7 +3,7 @@
 
 Name:           python-six
 Version:        1.11.0
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        Python 2 and 3 compatibility utilities
 License:        MIT
 Group:          Development/Languages/Python
@@ -53,11 +53,8 @@ python2 setup.py install --prefix=%{_prefix} --root=%{buildroot}
 python3 setup.py install --prefix=%{_prefix} --root=%{buildroot}
 
 %check
-easy_install_2=$(ls /usr/bin |grep easy_install |grep 2)
-$easy_install_2 pytest
-python2 test_six.py
 easy_install_3=$(ls /usr/bin |grep easy_install |grep 3)
-$easy_install_3 pytest
+$easy_install_3 pytest==7.1.3
 python3 test_six.py
 
 

--- a/SPECS/python-six/python-six.spec
+++ b/SPECS/python-six/python-six.spec
@@ -68,6 +68,8 @@ python3 test_six.py
 %{python3_sitelib}/*
 
 %changelog
+*   Wed Nov 09 2022 Jon Slobodzian <joslobo@microsoft.com> 1.11.0-5
+-   Fix python-six test to use explicit version of pytest. Latest version is incompatible
 *   Sat May 09 2020 Nick Samson <nisamson@microsoft.com> 1.11.0-4
 -   Added %%license line automatically
 *   Tue Apr 07 2020 Paul Monson <paulmon@microsoft.com> 1.11.0-3


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Pytest recently updated to a version that causes the self-test to fail.  This change forces the self-test to use python version 7.1.3.  This change also removes the pytest2 test.  It was previously failing and the result was overridden by the py3 test.  Since python2 is only supported for build reasons, it was decided to remove the test.  