### PR TITLE
add boot order updating to gen2 iso installations

### DIFF
--- a/toolkit/resources/imageconfigs/additionalfiles/iso_initrd/root/runliveinstaller
+++ b/toolkit/resources/imageconfigs/additionalfiles/iso_initrd/root/runliveinstaller
@@ -96,6 +96,13 @@ if [[ ! -f "$UNATTENDED_CONFIG_FILE" ]]; then
     # Ensure the userspace speakup connector is up
     systemctl enable espeakup
     systemctl start espeakup
+else # if an unattended iso
+    # if boot type is 'efi'
+    if [[ $(jq ".SystemConfigs[0].BootType" $UNATTENDED_CONFIG_FILE | tr -d '"') == "efi" ]]; then
+        TARGET_DISK=$(jq ".Disks[0].TargetDisk.Value" $UNATTENDED_CONFIG_FILE | tr -d '"')
+        BOOT_PART_IDX=$(jq '.Disks[0].Partitions as $parts | $parts | index($parts[] | select(.Flags | index("boot")))' $UNATTENDED_CONFIG_FILE)
+        BOOT_PART_NO=$(($BOOT_PART_IDX+1)) 
+    fi
 fi
 
 cd /installer
@@ -116,6 +123,23 @@ done
 
 # Turn back on echoing input so the TTY session is usable for the user.
 stty echo
+
+
+# TODO: CHECK IF \EFI\BOOT\bootx64.efi is already first in boot order, if so, replace it?
+if [[ -f "./attendedconfig.json" ]]; then  #if iso is an attended install
+    if [[ $(jq ".SystemConfigs[0].BootType" ./attendedconfig.json -r) == "efi" ]]; then # if boot type is efi
+        TARGET_DISK=$(jq ".Disks[0].TargetDisk.Value" ./attendedconfig.json | tr -d '"')
+        BOOT_PART_IDX=$(jq '.Disks[0].Partitions as $parts | $parts | index($parts[] | select(.Flags | index("boot")))' ./attendedconfig.json) #finds the index of the partition with "boot" in it's Flags array
+        BOOT_PART_NO=$(($BOOT_PART_IDX+1)) 
+    fi
+fi
+
+#Update Boot Order
+efibootmgr -c                                                                              \
+    -d $TARGET_DISK                                                                        \
+    -p $BOOT_PART_NO                                                                       \
+    -l '\EFI\BOOT\bootx64.efi'                                                             \
+    -L Mariner
 
 if [ $installerExitCode -eq 0 ]; then
     reboot

--- a/toolkit/resources/imageconfigs/packagelists/iso-initrd-packages.json
+++ b/toolkit/resources/imageconfigs/packagelists/iso-initrd-packages.json
@@ -35,6 +35,7 @@
         "gzip",
         "haveged",
         "iputils",
+        "jq",
         "less",
         "libcap",
         "libgcc",


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

I've created this PR to update how Mariner installs itself during iso installation.

### Current Behavior:
Mariner installs itself onto Disk and reboots. Leaving boot order untouched, which causes seconds of failed booting into PXE after the post-install reboot and subsequent reboots.

### Desired Behavior:
When in an EFI boot type'd iso install, we have the ability to set our boot order via the EFI boot manager (i.e., efibootmgr). Using this tool's functionality, and the knowledge specified by our image config files (e.g., unattended.json configs, attendedconfig.json, etc) we can set the first target in the boot order to our shim 'bootx64.efi' which typically lives in /boot/efi

### Proposed solution:
There are a few approaches we can consider.

#### 1) runliveinstaller bash script
What I have done in this PR is a "low-touch" quick fix which leaves the go tools unaltered. This fix parses the config file used for installation using the jq (json query) tool to identify the disk and partition that the shim lives on. Then, after installation, runliveinstaller uses these values to instruct efibootmgr on the exact details of where bootx64.efi resides.

Note:  This fix assumes there are two possible sources for our config. In the unattended install setting, the config is the config file specified at build time and contained in the variable UNATTENDED_CONFIG_FILE in runliveinstaller. In the attended install setting, the current PR assumes this config is named and located at /installer/attendedconfig.json as is the current behavior with attended installs. This makes this fix highly coupled to the current conventions on where config files are named and placed.

#### 2) finding the end of the call stack
Next is a "medium-touch" approach. Journeying into the go tools, runliveinstaller calls liveinstaller.go. The logic within liveinstaller.go creates an imagerArguments object named `args` with an undefined configFile string. This `args` is passed into whichever type of installFunction is requested by the call to liveinstaller.go (as decided by it's function InstallerFactory()). Option 2 is to follow this logic along each install type's chain of function calls until the finished config is generated by the gotools. Then at the end of this chain of function calls make a call to a util function named updateBootOrder() that will perform the same call to efibootmgr to set the new boot target. 

The benefit of this fix is that it is an improved design over option 1, given that it does not rely on tight coupling between the discovery of config values and the config file's name and destination. One concern that has been risen is that this approach requires future devs to be aware of needing to add this call to updateBootOrder() at the end of any new installFuncs that may be created in the future.

#### 3) passing it back up the call stack
Next we have what I consider a "high-touch" approach. We can reverse the expectation of each of these installFunc call chains, and instead of adding the updateBootOrder() logic at the deepest point in their callstack, we can instead make it so that each installFunc must eventually pass back the location of the final config file. Then, inside of liveinstaller.go, after the installFunc has successfully returned up through its call chain, we can pass this config file path to the updateBootOrder function that lives solely within liveinstaller.go

#### 4) passing the pointer down the call stack
Finally we have one more "high-touch" approach. Currently the imagerArguments object, `args`, is passed by value to the installFunc. If we updated this to pass-by-pointer and we updated the configFile inside of imagerArguments to a pointer type. We could pass *args into the updateBootOrder() function that lives solely within liveinstaller.go.

Let this be an RFC for which direction we should take this boot-order change. I am still learning go and our tools, so if there are incorrect assumptions, or if I have missed a possible approach, please let me know!

Thank you,
Sean

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Updates the boot order via efibootmgr after iso installation by setting the first boot target to our shim ( \EFI\BOOT\bootx64.efi )

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Changes to runliveinstaller for boot order logic
- Adds the 'jq' tool to the list of iso-initrd-packages

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
NO


###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- local build and hyper-v to verify boot order changes 
