### PR TITLE
Toolkit: Set CGO_ENABLED=0 when building go tools

### DIFF
--- a/toolkit/scripts/tools.mk
+++ b/toolkit/scripts/tools.mk
@@ -81,7 +81,7 @@ else
 $(TOOL_BINS_DIR)/%: $(go_common_files)
 	cd $(TOOLS_DIR)/$* && \
 		go test -covermode=atomic -coverprofile=$(BUILD_DIR)/tools/$*.test_coverage ./... && \
-		go build -o $(TOOL_BINS_DIR)
+		CGO_ENABLED=0 go build -o $(TOOL_BINS_DIR)
 endif
 
 # Runs tests for common components


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Disable CGO when building go-tools. This will statically compile the applications instead of dynamically linking them with glibc, which should make them more portable. When we updated build machines to Mariner 2.0, we started seeing the following error from the Mariner 1.0 ISO's liveinstaller application. (Mariner 2.0 has a newer glibc version than 1.0)
```
./liveinstaller: /lib/libc.so.6: version `GLIBC_2.32` not found (required by ./liveinstaller)
```

Our build machines (Mariner 2.0) appear to have CGO_ENABLED set to 1 by default.
```
$ docker run --rm -it mcr.microsoft.com/cbl-mariner/base/core:2.0 bash
# tdnf -y install "golang < 1.18"
# go env CGO_ENABLED
1
```

More info: https://go.googlesource.com/go/+/refs/heads/master/src/cmd/cgo/doc.go

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change toolkit/scripts/tools.mk to compile go tools with "CGO_ENABLED=0"

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: 259153
- Re-ran the AMD64 1.0 image build pipeline (build ID: 259153) using Mariner 2.0 host machine, downloaded the ISO, boot the ISO in a VM and install the Core packages with the terminal installer. System boots fine.
