### PR TITLE
Upgrade golang to 1.18.8 to fix CVE-2022-2879, CVE-2022-2880, CVE-2022-41715, CVE-2022-27664, CVE-2022-32190

### DIFF
--- a/SPECS-EXTENDED/buildah/buildah.spec
+++ b/SPECS-EXTENDED/buildah/buildah.spec
@@ -31,7 +31,7 @@ Distribution:   Mariner
 
 Name: %{repo}
 Version: 1.18.0
-Release: 5%{?dist}
+Release: 6%{?dist}
 Summary: A command line tool used for creating OCI Images
 License: ASL 2.0
 URL: https://%{name}.io
@@ -146,6 +146,9 @@ cp imgtype %{buildroot}/%{_bindir}/%{name}-imgtype
 %{_datadir}/%{name}/test
 
 %changelog
+* Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 1.18.0-6
+- Bump release to rebuild with go 1.18.8
+
 * Tue Sep 13 2022 Andy Caldwell <andycaldwell@microsoft.com> - 1.18.0-5
 - Rebuilt for glibc-static 2.35-3
 

--- a/SPECS-EXTENDED/containernetworking-plugins/containernetworking-plugins.spec
+++ b/SPECS-EXTENDED/containernetworking-plugins/containernetworking-plugins.spec
@@ -24,7 +24,7 @@
 
 Name:          %{project}-%{repo}
 Version:       1.1.1
-Release:       2%{?dist}
+Release:       3%{?dist}
 Summary:       Libraries for writing CNI plugin
 License:       ASL 2.0 and BSD and MIT
 Vendor:        Microsoft Corporation
@@ -129,6 +129,9 @@ install -p plugins/ipam/dhcp/systemd/cni-dhcp.socket %{buildroot}%{_unitdir}
 %{_unitdir}/cni-dhcp.socket
 
 %changelog
+* Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 1.1.1-3
+- Bump release to rebuild with go 1.18.8
+
 * Mon Aug 22 2022 Olivia Crain <oliviacrain@microsoft.com> - 1.1.1-2
 - Bump release to rebuild against Go 1.18.5
 
@@ -270,4 +273,3 @@ install -p plugins/ipam/dhcp/systemd/cni-dhcp.socket %{buildroot}%{_unitdir}
 
 * Sun May 07 2017 Timothy St. Clair <tstclair@heptio.com> - 0.5.1-1
 - Initial package
-

--- a/SPECS-EXTENDED/delve/delve.spec
+++ b/SPECS-EXTENDED/delve/delve.spec
@@ -2,7 +2,7 @@ Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Name:                   delve
 Version:                1.5.0
-Release:                5%{?dist}
+Release:                6%{?dist}
 Summary:                A debugger for the Go programming language
 
 License:                MIT
@@ -72,6 +72,9 @@ done
 
 
 %changelog
+* Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 1.5.0-6
+- Bump release to rebuild with go 1.18.8
+
 * Tue Aug 23 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.5.0-5
 - License verified.
 

--- a/SPECS-EXTENDED/podman/podman.spec
+++ b/SPECS-EXTENDED/podman/podman.spec
@@ -36,7 +36,7 @@
 
 Name:           podman
 Version:        4.1.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        ASL 2.0 and BSD and ISC and MIT and MPLv2.0
 Summary:        Manage Pods, Containers and Container Images
 Vendor:         Microsoft Corporation
@@ -386,6 +386,9 @@ cp -pav test/system %{buildroot}/%{_datadir}/%{name}/test/
 
 # rhcontainerbot account currently managed by lsm5
 %changelog
+* Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 4.1.1-4
+- Bump release to rebuild with go 1.18.8
+
 * Tue Sep 13 2022 Andy Caldwell <andycaldwell@microsoft.com> - 4.1.1-3
 - Rebuilt for glibc-static 2.35-3
 

--- a/SPECS-EXTENDED/toolbox/toolbox.spec
+++ b/SPECS-EXTENDED/toolbox/toolbox.spec
@@ -2,7 +2,7 @@ Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Name:          toolbox
 Version:       0.0.18
-Release:       3%{?dist}
+Release:       4%{?dist}
 Summary:       Unprivileged development environment
 
 License:       ASL 2.0
@@ -131,6 +131,9 @@ Dockerfile if the image isn't based on the fedora-toolbox image.
 
 
 %changelog
+* Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 0.0.18-4
+- Bump release to rebuild with go 1.18.8
+
 * Thu Oct 14 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 0.0.18-3
 - Initial CBL-Mariner import from Fedora 32 (license: MIT).
 - Removing 'Requires' for 'podman' as we don't want to provide it with the 'toolbox'.

--- a/SPECS-EXTENDED/toolbox/toolbox.spec
+++ b/SPECS-EXTENDED/toolbox/toolbox.spec
@@ -5,7 +5,7 @@ Version:       0.0.18
 Release:       4%{?dist}
 Summary:       Unprivileged development environment
 
-License:       ASL 2.0
+License:       Apache-2.0
 URL:           https://github.com/containers/toolbox
 Source0:       https://github.com/containers/%{name}/releases/download/%{version}/%{name}-%{version}.tar.xz
 
@@ -133,6 +133,7 @@ Dockerfile if the image isn't based on the fedora-toolbox image.
 %changelog
 * Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 0.0.18-4
 - Bump release to rebuild with go 1.18.8
+- License verified
 
 * Thu Oct 14 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 0.0.18-3
 - Initial CBL-Mariner import from Fedora 32 (license: MIT).

--- a/SPECS-EXTENDED/umoci/umoci.spec
+++ b/SPECS-EXTENDED/umoci/umoci.spec
@@ -1,7 +1,7 @@
 Summary:        Open Container Image manipulation tool
 Name:           umoci
 Version:        0.4.7
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        Apache-2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -39,6 +39,9 @@ go test -mod=vendor
 %{_bindir}/umoci
 
 %changelog
+* Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 0.4.7-3
+- Bump release to rebuild with go 1.18.8
+
 * Mon Aug 22 2022 Olivia Crain <oliviacrain@microsoft.com> - 0.4.7-2
 - Bump release to rebuild against Go 1.18.5
 

--- a/SPECS/KeysInUse-OpenSSL/KeysInUse-OpenSSL.spec
+++ b/SPECS/KeysInUse-OpenSSL/KeysInUse-OpenSSL.spec
@@ -1,7 +1,7 @@
 Summary:        The KeysInUse Engine for OpenSSL allows the logging of private key usage through OpenSSL
 Name:           KeysInUse-OpenSSL
 Version:        0.3.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -67,6 +67,9 @@ if [ -x %{_bindir}/keysinuseutil ]; then
 fi
 
 %changelog
+* Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 0.3.1-4
+- Bump release to rebuild with go 1.18.8
+
 * Thu Sep 01 2022 Maxwell Moyer-McKee <mamckee@microsoft.com> - 0.3.1-3
 - Fix bad permissions on engine library during package install
 - Simplify package installation strategy

--- a/SPECS/application-gateway-kubernetes-ingress/application-gateway-kubernetes-ingress.spec
+++ b/SPECS/application-gateway-kubernetes-ingress/application-gateway-kubernetes-ingress.spec
@@ -2,7 +2,7 @@
 Summary:        Application Gateway Ingress Controller
 Name:           application-gateway-kubernetes-ingress
 Version:        1.4.0
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -54,6 +54,9 @@ cp appgw-ingress %{buildroot}%{_bindir}/
 %{_bindir}/appgw-ingress
 
 %changelog
+* Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 1.4.0-4
+- Bump release to rebuild with go 1.18.8
+
 * Mon Aug 22 2022 Olivia Crain <oliviacrain@microsoft.com> - 1.4.0-3
 - Bump release to rebuild against Go 1.18.5
 

--- a/SPECS/azcopy/azcopy.spec
+++ b/SPECS/azcopy/azcopy.spec
@@ -1,7 +1,7 @@
 Summary:        The new Azure Storage data transfer utility - AzCopy v10
 Name:           azcopy
 Version:        10.15.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -61,6 +61,9 @@ go test -mod=vendor
 %{_bindir}/azcopy
 
 %changelog
+* Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 10.15.0-3
+- Bump release to rebuild with go 1.18.8
+
 * Mon Aug 22 2022 Olivia Crain <oliviacrain@microsoft.com> - 10.15.0-2
 - Bump release to rebuild against Go 1.18.5
 

--- a/SPECS/blobfuse/blobfuse.spec
+++ b/SPECS/blobfuse/blobfuse.spec
@@ -1,7 +1,7 @@
 Summary:        FUSE adapter - Azure Storage Blobs
 Name:           blobfuse
 Version:        1.4.5
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -46,6 +46,9 @@ install -p -m 755 build/blobfuse %{buildroot}%{_bindir}/
 %{_bindir}/blobfuse
 
 %changelog
+* Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 1.4.5-2
+- Bump release to rebuild with go 1.18.8
+
 * Sat Sep 17 2022 Muhammad Falak <mwani@microsoft.com> - 1.4.5-1
 - Bump version to 1.4.5
 

--- a/SPECS/blobfuse2/blobfuse2.spec
+++ b/SPECS/blobfuse2/blobfuse2.spec
@@ -8,7 +8,7 @@
 Summary:        FUSE adapter - Azure Storage
 Name:           blobfuse2
 Version:        %{blobfuse2_version}.%{preview_suffix}
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -81,6 +81,9 @@ install -D -m 0644 ./setup/blobfuse2-logrotate %{buildroot}%{_sysconfdir}/logrot
 %{_sysconfdir}/logrotate.d/blobfuse2
 
 %changelog
+* Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 2.0.0.preview.3-2
+- Bump release to rebuild with go 1.18.8
+
 * Mon Oct 03 2022 Gauri Prasad <gapra@microsoft.com> - 2.0.0.preview.3-1
 - Add blobfuse2 spec
 - License verified

--- a/SPECS/cert-manager/cert-manager.spec
+++ b/SPECS/cert-manager/cert-manager.spec
@@ -1,7 +1,7 @@
 Summary:        Automatically provision and manage TLS certificates in Kubernetes
 Name:           cert-manager
 Version:        1.7.3
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -111,6 +111,9 @@ install -D -m0755 bin/webhook %{buildroot}%{_bindir}/
 %{_bindir}/webhook
 
 %changelog
+* Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 1.7.3-3
+- Bump release to rebuild with go 1.18.8
+
 * Mon Aug 22 2022 Olivia Crain <oliviacrain@microsoft.com> - 1.7.3-2
 - Bump release to rebuild against Go 1.18.5
 

--- a/SPECS/cf-cli/cf-cli.spec
+++ b/SPECS/cf-cli/cf-cli.spec
@@ -1,7 +1,7 @@
 Summary:        The official command line client for Cloud Foundry.
 Name:           cf-cli
 Version:        8.4.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        Apache-2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -59,6 +59,9 @@ install -p -m 755 -t %{buildroot}%{_bindir} ./out/cf
 %{_bindir}/cf
 
 %changelog
+* Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 8.4.0-3
+- Bump release to rebuild with go 1.18.8
+
 * Mon Aug 22 2022 Olivia Crain <oliviacrain@microsoft.com> - 8.4.0-2
 - Bump release to rebuild against Go 1.18.5
 

--- a/SPECS/cni-plugins/cni-plugins.spec
+++ b/SPECS/cni-plugins/cni-plugins.spec
@@ -2,7 +2,7 @@
 Summary:        Container Network Interface (CNI) plugins
 Name:           cni-plugins
 Version:        0.9.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -38,6 +38,9 @@ make -k check |& tee %{_specdir}/%{name}-check-log || %{nocheck}
 %{_default_cni_plugins_dir}/*
 
 %changelog
+* Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 0.9.1-4
+- Bump release to rebuild with go 1.18.8
+
 * Mon Aug 22 2022 Olivia Crain <oliviacrain@microsoft.com> - 0.9.1-3
 - Bump release to rebuild against Go 1.18.5
 

--- a/SPECS/cni/cni.spec
+++ b/SPECS/cni/cni.spec
@@ -24,7 +24,7 @@
 Summary:        Container Network Interface - networking for Linux containers
 Name:           cni
 Version:        1.0.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        Apache-2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -113,6 +113,9 @@ install -m 755 -d "%{buildroot}%{cni_doc_dir}"
 %{_sbindir}/cnitool
 
 %changelog
+* Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 1.0.1-4
+- Bump release to rebuild with go 1.18.8
+
 * Mon Aug 22 2022 Olivia Crain <oliviacrain@microsoft.com> - 1.0.1-3
 - Bump release to rebuild against Go 1.18.5
 
@@ -189,7 +192,7 @@ install -m 755 -d "%{buildroot}%{cni_doc_dir}"
     + Update cnitool documentation for spec v0.4.0
     + Add cni-route-override to CNI plugin list
   * Build and test changes:
-    + Release: bump go to v1.12
+    + Release: 4%{?dist}
 
 * Fri May 17 2019 John Paul Adrian Glaubitz <adrian.glaubitz@suse.com>
 - Update to version 0.7.0:

--- a/SPECS/containerized-data-importer/containerized-data-importer.spec
+++ b/SPECS/containerized-data-importer/containerized-data-importer.spec
@@ -18,7 +18,7 @@
 Summary:        Container native virtualization
 Name:           containerized-data-importer
 Version:        1.51.0
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -198,6 +198,9 @@ install -m 0644 _out/manifests/release/cdi-cr.yaml %{buildroot}%{_datadir}/cdi/m
 
 
 %changelog
+* Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 1.51.0-4
+- Bump release to rebuild with go 1.18.8
+
 * Mon Aug 22 2022 Ameya Usgaonkar <ausgaonkar@microsoft.com> - 1.51.0-3
 - Shorthand nomenclature for containerized-data-importer (cdi)
 - Provide api as apiserver

--- a/SPECS/coredns/coredns-1.8.0.spec
+++ b/SPECS/coredns/coredns-1.8.0.spec
@@ -3,7 +3,7 @@
 Summary:        Fast and flexible DNS server
 Name:           coredns
 Version:        1.8.0
-Release:        8%{?dist}
+Release:        9%{?dist}
 License:        Apache License 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -58,6 +58,9 @@ install -p -m 755 -t %{buildroot}%{_bindir} %{name}
 %{_bindir}/%{name}
 
 %changelog
+* Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 1.8.0-9
+- Bump release to rebuild with go 1.18.8
+
 * Mon Aug 22 2022 Olivia Crain <oliviacrain@microsoft.com> - 1.8.0-8
 - Bump release to rebuild against Go 1.18.5
 

--- a/SPECS/coredns/coredns-1.8.4.spec
+++ b/SPECS/coredns/coredns-1.8.4.spec
@@ -3,7 +3,7 @@
 Summary:        Fast and flexible DNS server
 Name:           coredns
 Version:        1.8.4
-Release:        7%{?dist}
+Release:        8%{?dist}
 License:        Apache License 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -58,6 +58,9 @@ install -p -m 755 -t %{buildroot}%{_bindir} %{name}
 %{_bindir}/%{name}
 
 %changelog
+* Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 1.8.4-8
+- Bump release to rebuild with go 1.18.8
+
 * Mon Aug 22 2022 Olivia Crain <oliviacrain@microsoft.com> - 1.8.4-7
 - Bump release to rebuild against Go 1.18.5
 

--- a/SPECS/coredns/coredns-1.8.6.spec
+++ b/SPECS/coredns/coredns-1.8.6.spec
@@ -3,7 +3,7 @@
 Summary:        Fast and flexible DNS server
 Name:           coredns
 Version:        1.8.6
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        Apache License 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -58,6 +58,9 @@ install -p -m 755 -t %{buildroot}%{_bindir} %{name}
 %{_bindir}/%{name}
 
 %changelog
+* Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 1.8.6-4
+- Bump release to rebuild with go 1.18.8
+
 * Mon Aug 22 2022 Olivia Crain <oliviacrain@microsoft.com> - 1.8.6-3
 - Bump release to rebuild against Go 1.18.5
 

--- a/SPECS/cri-o/cri-o.spec
+++ b/SPECS/cri-o/cri-o.spec
@@ -26,7 +26,7 @@ Summary:        OCI-based implementation of Kubernetes Container Runtime Interfa
 # Define macros for further referenced sources
 Name:           cri-o
 Version:        1.21.2
-Release:        6%{?dist}
+Release:        7%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -203,6 +203,9 @@ mkdir -p /opt/cni/bin
 %{_fillupdir}/sysconfig.kubelet
 
 %changelog
+* Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 1.21.2-7
+- Bump release to rebuild with go 1.18.8
+
 * Mon Aug 22 2022 Olivia Crain <oliviacrain@microsoft.com> - 1.21.2-6
 - Bump release to rebuild against Go 1.18.5
 

--- a/SPECS/cri-tools/cri-tools.spec
+++ b/SPECS/cri-tools/cri-tools.spec
@@ -1,7 +1,7 @@
 Summary:        CRI tools
 Name:           cri-tools
 Version:        1.23.0
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -50,6 +50,9 @@ install -p -m 644 -t %{buildroot}%{_docdir}/%{name} ./docs/crictl.md
 %{_docdir}/%{name}
 
 %changelog
+* Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 1.23.0-4
+- Bump release to rebuild with go 1.18.8
+
 * Mon Aug 22 2022 Olivia Crain <oliviacrain@microsoft.com> - 1.23.0-3
 - Bump release to rebuild against Go 1.18.5
 

--- a/SPECS/csi-driver-lvm/csi-driver-lvm.spec
+++ b/SPECS/csi-driver-lvm/csi-driver-lvm.spec
@@ -1,7 +1,7 @@
 Summary:        Container storage interface for logical volume management
 Name:           csi-driver-lvm
 Version:        0.4.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -63,6 +63,9 @@ install -D -m0755 bin/lvmplugin %{buildroot}%{_bindir}/
 %{_bindir}/lvmplugin
 
 %changelog
+* Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 0.4.1-3
+- Bump release to rebuild with go 1.18.8
+
 * Tue Sep 27 2022 Lanze Liu <lanzeliu@microsoft.com> - 0.4.1-2
 - Split binaries into separate packages
 

--- a/SPECS/dcos-cli/dcos-cli.spec
+++ b/SPECS/dcos-cli/dcos-cli.spec
@@ -1,7 +1,7 @@
 Summary:        The command line for DC/OS
 Name:           dcos-cli
 Version:        1.2.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        Apache-2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -45,6 +45,9 @@ go test -mod=vendor
 %{_bindir}/dcos
 
 %changelog
+* Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 1.2.0-3
+- Bump release to rebuild with go 1.18.8
+
 * Mon Aug 22 2022 Olivia Crain <oliviacrain@microsoft.com> - 1.2.0-2
 - Bump release to rebuild against Go 1.18.5
 

--- a/SPECS/etcd/etcd-3.5.0.spec
+++ b/SPECS/etcd/etcd-3.5.0.spec
@@ -1,7 +1,7 @@
 Summary:        A highly-available key value store for shared configuration
 Name:           etcd
 Version:        3.5.0
-Release:        5%{?dist}
+Release:        6%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -138,6 +138,9 @@ install -vdm755 %{buildroot}%{_sharedstatedir}/etcd
 /%{_docdir}/%{name}-%{version}-tools/*
 
 %changelog
+* Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 3.5.0-6
+- Bump release to rebuild with go 1.18.8
+
 * Mon Aug 22 2022 Olivia Crain <oliviacrain@microsoft.com> - 3.5.0-5
 - Bump release to rebuild against Go 1.18.5
 

--- a/SPECS/etcd/etcd-3.5.1.spec
+++ b/SPECS/etcd/etcd-3.5.1.spec
@@ -1,7 +1,7 @@
 Summary:        A highly-available key value store for shared configuration
 Name:           etcd
 Version:        3.5.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -143,6 +143,9 @@ install -vdm755 %{buildroot}%{_sharedstatedir}/etcd
 /%{_docdir}/%{name}-%{version}-tools/*
 
 %changelog
+*   Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 3.5.1-4
+-   Bump release to rebuild with go 1.18.8
+
 *   Mon Aug 22 2022 Olivia Crain <oliviacrain@microsoft.com> - 3.5.1-3
 -   Bump release to rebuild against Go 1.18.5
 

--- a/SPECS/flannel/flannel.spec
+++ b/SPECS/flannel/flannel.spec
@@ -4,7 +4,7 @@
 Summary:        Simple and easy way to configure a layer 3 network fabric designed for Kubernetes
 Name:           flannel
 Version:        0.14.0
-Release:        5%{?dist}
+Release:        6%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -48,6 +48,9 @@ install -p -m 755 -t %{buildroot}%{_bindir} ./dist/flanneld
 %{_bindir}/flanneld
 
 %changelog
+* Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 0.14.0-6
+- Bump release to rebuild with go 1.18.8
+
 * Wed Oct 05 2022 Andy Caldwell <andycaldwell@microsoft.com> - 0.14.0-5
 - Bump release to rebuild against glibc 2.35-3
 

--- a/SPECS/gh/gh.spec
+++ b/SPECS/gh/gh.spec
@@ -1,7 +1,7 @@
 Summary:        GitHub official command line tool
 Name:           gh
 Version:        2.13.0
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -75,6 +75,9 @@ make test
 %{_datadir}/zsh/site-functions/_gh
 
 %changelog
+* Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 2.13.0-4
+- Bump release to rebuild with go 1.18.8
+
 * Mon Aug 22 2022 Olivia Crain <oliviacrain@microsoft.com> - 2.13.0-3
 - Bump release to rebuild against Go 1.18.5
 

--- a/SPECS/git-lfs/git-lfs.spec
+++ b/SPECS/git-lfs/git-lfs.spec
@@ -2,7 +2,7 @@
 Summary:       Git extension for versioning large files
 Name:          git-lfs
 Version:       3.1.4
-Release:       3%{?dist}
+Release:       4%{?dist}
 Group:         System Environment/Programming
 Vendor:        Microsoft Corporation
 Distribution:  Mariner
@@ -77,6 +77,9 @@ git lfs uninstall
 %{_mandir}/man5/*
 
 %changelog
+*   Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 3.1.4-4
+-   Bump release to rebuild with go 1.18.8
+
 *   Wed Sep 28 2022 Suresh Babu Chalamalasetty <schalam@microsoft.com> 3.1.4-3
 -   Initial CBL-Mariner import from Photon (license: Apache2)
 -   License verified

--- a/SPECS/glide/glide.spec
+++ b/SPECS/glide/glide.spec
@@ -1,7 +1,7 @@
 Summary:        Vendor Package Management for Golang
 Name:           glide
 Version:        0.13.3
-Release:        12%{?dist}
+Release:        13%{?dist}
 License:        MIT
 URL:            https://github.com/Masterminds/glide
 # Source0:      https://github.com/Masterminds/%{name}/archive/v%{version}.tar.gz
@@ -53,6 +53,9 @@ popd
 %{_bindir}/glide
 
 %changelog
+*   Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 0.13.3-13
+-   Bump release to rebuild with go 1.18.8
+
 *   Mon Aug 22 2022 Olivia Crain <oliviacrain@microsoft.com> - 0.13.3-12
 -   Bump release to rebuild against Go 1.18.5
 

--- a/SPECS/go-md2man/go-md2man.spec
+++ b/SPECS/go-md2man/go-md2man.spec
@@ -1,7 +1,7 @@
 Summary:        Converts markdown into roff (man pages)
 Name:           go-md2man
 Version:        2.0.1
-Release:        9%{?dist}
+Release:        10%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -48,6 +48,9 @@ cp go-md2man-%{version}/LICENSE.md %{buildroot}%{_docdir}/%{name}-%{version}/LIC
 %{_bindir}/go-md2man
 
 %changelog
+* Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 2.0.1-10
+- Bump release to rebuild with go 1.18.8
+
 * Mon Aug 22 2022 Olivia Crain <oliviacrain@microsoft.com> - 2.0.1-9
 - Bump release to rebuild against Go 1.18.5
 

--- a/SPECS/gobject-introspection/gobject-introspection.spec
+++ b/SPECS/gobject-introspection/gobject-introspection.spec
@@ -2,7 +2,7 @@
 Summary:        Introspection system for GObject-based libraries
 Name:           gobject-introspection
 Version:        %{BaseVersion}.0
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        GPLv2+ AND LGPLv2+ AND MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -98,6 +98,9 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %{_mandir}/man1/*.gz
 
 %changelog
+* Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 1.71.0-4
+- Bump release to rebuild with go 1.18.8
+
 * Mon Aug 22 2022 Olivia Crain <oliviacrain@microsoft.com> - 1.71.0-3
 - Bump release to rebuild against Go 1.18.5
 

--- a/SPECS/golang/golang.signatures.json
+++ b/SPECS/golang/golang.signatures.json
@@ -1,6 +1,6 @@
 {
  "Signatures": {
-  "go1.18.5.src.tar.gz": "9920d3306a1ac536cdd2c796d6cb3c54bc559c226fc3cc39c32f1e0bd7f50d2a",
+  "go1.18.8.src.tar.gz": "1f79802305015479e77d8c641530bc54ec994657d5c5271e0172eb7118346a12",
   "go1.4-bootstrap-20171003.tar.gz": "f4ff5b5eb3a3cae1c993723f3eab519c5bae18866b5e5f96fe1102f0cb5c3e52"
  }
 }

--- a/SPECS/golang/golang.spec
+++ b/SPECS/golang/golang.spec
@@ -12,9 +12,9 @@
 %define __find_requires %{nil}
 Summary:        Go
 Name:           golang
-Version:        1.18.5
+Version:        1.18.8
 Release:        1%{?dist}
-License:        BSD
+License:        BSD-3-Clause
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Group:          System Environment/Security
@@ -116,6 +116,12 @@ fi
 %{_bindir}/*
 
 %changelog
+* Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 1.18.8-1
+- Upgrade to version 1.18.8 (fixes CVE-2022-41716, which only applies to Windows environments)
+- Also fixes CVE-2022-2879, CVE-2022-2880, CVE-2022-41715 (fixed in 1.18.7)
+- Also fixes CVE-2022-27664, CVE-2022-32190 (fixed in 1.18.6)
+- Use SPDX short identifier for license tag
+
 * Fri Aug 19 2022 Olivia Crain <oliviacrain@microsoft.com> - 1.18.5-1
 - Upgrade to version to fix CVE-2022-1705, CVE-2022-1962, CVE-2022-28131,
   CVE-2022-30630, CVE-2022-30631, CVE-2022-30632, CVE-2022-30633, CVE-2022-30635,

--- a/SPECS/helm/helm.spec
+++ b/SPECS/helm/helm.spec
@@ -2,7 +2,7 @@
 
 Name:          helm
 Version:       3.9.4
-Release:       1%{?dist}
+Release:       2%{?dist}
 Summary:       The Kubernetes Package Manager
 Group:         Applications/Networking
 License:       Apache 2.0
@@ -52,6 +52,9 @@ install -m 755 ./helm %{buildroot}%{_bindir}
 
 
 %changelog
+* Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 3.9.4-2
+- Bump release to rebuild with go 1.18.8
+
 * Mon Oct 24 2022 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 3.9.4-1
 - Upgrade to 3.9.4
 

--- a/SPECS/jx/jx.spec
+++ b/SPECS/jx/jx.spec
@@ -1,7 +1,7 @@
 Summary:        Command line tool for working with Jenkins X.
 Name:           jx
 Version:        3.2.236
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        Apache-2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -60,6 +60,9 @@ install -p -m 755 -t %{buildroot}%{_bindir} ./build/jx
 %{_bindir}/jx
 
 %changelog
+* Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 3.2.236-3
+- Bump release to rebuild with go 1.18.8
+
 * Mon Aug 22 2022 Olivia Crain <oliviacrain@microsoft.com> - 3.2.236-2
 - Bump release to rebuild against Go 1.18.5
 

--- a/SPECS/k3s/k3s-1.23.8.spec
+++ b/SPECS/k3s/k3s-1.23.8.spec
@@ -1,7 +1,7 @@
 Summary:        Lightweight Kubernetes
 Name:           k3s
 Version:        1.23.8
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        ASL 2.0
 Group:          System Environment/Base
 URL:            http://k3s.io
@@ -79,6 +79,9 @@ exit 0
 %{install_sh}
 
 %changelog
+* Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 1.23.8-2
+- Bump release to rebuild with go 1.18.8
+
 * Fri Jul 29 2022 Lior Lustgarten <lilustga@microsoft.com> - 1.23.8-1
 - Update to 1.23.8
 

--- a/SPECS/k3s/k3s-1.24.3.spec
+++ b/SPECS/k3s/k3s-1.24.3.spec
@@ -1,7 +1,7 @@
 Summary:        Lightweight Kubernetes
 Name:           k3s
 Version:        1.24.3
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        ASL 2.0
 Group:          System Environment/Base
 URL:            http://k3s.io
@@ -79,6 +79,9 @@ exit 0
 %{install_sh}
 
 %changelog
+* Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 1.24.3-2
+- Bump release to rebuild with go 1.18.8
+
 * Tue Aug 30 2022 Animesh Garg <animeshgarg@microsoft.com> - 1.24.3-1
 - Updated k3s to 1.24.3
 
@@ -105,4 +108,3 @@ exit 0
 
 * Mon Mar 2 2020 Erik Wilson <erik@rancher.com> 0.1-1
 - Initial version
-

--- a/SPECS/k3s/k3s.spec
+++ b/SPECS/k3s/k3s.spec
@@ -1,7 +1,7 @@
 Summary:        Lightweight Kubernetes
 Name:           k3s
 Version:        1.25.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        ASL 2.0
 Group:          System Environment/Base
 URL:            http://k3s.io
@@ -79,6 +79,9 @@ exit 0
 %{install_sh}
 
 %changelog
+* Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 1.25.0-2
+- Bump release to rebuild with go 1.18.8
+
 * Tue Sep 20 2022 Animesh Garg <animeshgarg@microsoft.com> - 1.25.0-1
 - Updated k3s to 1.25.0
 
@@ -108,4 +111,3 @@ exit 0
 
 * Mon Mar 2 2020 Erik Wilson <erik@rancher.com> 0.1-1
 - Initial version
-

--- a/SPECS/kata-containers/kata-containers.spec
+++ b/SPECS/kata-containers/kata-containers.spec
@@ -39,7 +39,7 @@
 Summary:        Kata Containers version 2.x repository
 Name:           kata-containers
 Version:        2.5.0
-Release:        6%{?dist}
+Release:        7%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 URL:            https://github.com/%{name}/%{name}
@@ -220,6 +220,9 @@ ln -sf %{_bindir}/kata-runtime %{buildroot}%{_prefix}/local/bin/kata-runtime
 %exclude %{kataosbuilderdir}/rootfs-builder/ubuntu
 
 %changelog
+* Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 2.5.0-7
+- Bump release to rebuild with go 1.18.8
+
 * Thu Sep 15 2022 Neha Agarwal <nehaagarwal@microsoft.com> - 2.5.0-6
 - Add patch to avoid memory hotplug timeout, add libseccomp.
 

--- a/SPECS/keda/keda.spec
+++ b/SPECS/keda/keda.spec
@@ -1,7 +1,7 @@
 Summary:        Kubernetes-based Event Driven Autoscaling
 Name:           keda
 Version:        2.4.0
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -55,6 +55,9 @@ cp ./bin/keda-adapter %{buildroot}%{_bindir}
 %{_bindir}/%{name}-adapter
 
 %changelog
+* Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 2.4.0-4
+- Bump release to rebuild with go 1.18.8
+
 * Mon Aug 22 2022 Olivia Crain <oliviacrain@microsoft.com> - 2.4.0-3
 - Bump release to rebuild against Go 1.18.5
 

--- a/SPECS/kube-vip-cloud-provider/kube-vip-cloud-provider.spec
+++ b/SPECS/kube-vip-cloud-provider/kube-vip-cloud-provider.spec
@@ -1,7 +1,7 @@
 Summary:        The Kube-Vip cloud provider functions as a general-purpose cloud provider for on-premises bare-metal or virtualized setups
 Name:           kube-vip-cloud-provider
 Version:        0.0.2
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        ASL 2.0
 URL:            https://github.com/kube-vip/kube-vip-cloud-provider
 Group:          Applications/Text
@@ -42,6 +42,9 @@ install kube-vip-cloud-provider %{buildroot}%{_bindir}/kube-vip-cloud-provider
 %{_bindir}/kube-vip-cloud-provider
 
 %changelog
+* Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 0.0.2-2
+- Bump release to rebuild with go 1.18.8
+
 * Tue Sep 06 2022 Vinayak Gupta <guptavinayak@microsoft.com> - 0.0.2-1
 - Original version for CBL-Mariner
 - License Verified

--- a/SPECS/kubevirt/kubevirt.spec
+++ b/SPECS/kubevirt/kubevirt.spec
@@ -20,7 +20,7 @@
 Summary:        Container native virtualization
 Name:           kubevirt
 Version:        0.55.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -206,6 +206,9 @@ install -p -m 0644 cmd/virt-handler/ipv6-nat.nft %{buildroot}%{_datadir}/kube-vi
 %{_bindir}/virt-tests
 
 %changelog
+* Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 0.55.1-2
+- Bump release to rebuild with go 1.18.8
+
 * Thu Sep 22 2022 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 0.55.1-1
 - Upgrade to 0.55.1
 

--- a/SPECS/kured/kured.spec
+++ b/SPECS/kured/kured.spec
@@ -25,7 +25,7 @@
 Summary:        Kubernetes daemonset to perform safe automatic node reboots
 Name:           kured
 Version:        1.9.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        Apache-2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -122,6 +122,9 @@ sed -i -e 's|image: .*|image: registry.opensuse.org/kubic/kured:%{version}|g' %{
 %{_datarootdir}/k8s-yaml/kured/kured.yaml
 
 %changelog
+* Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 1.9.1-4
+- Bump release to rebuild with go 1.18.8
+
 * Mon Aug 22 2022 Olivia Crain <oliviacrain@microsoft.com> - 1.9.1-3
 - Bump release to rebuild against Go 1.18.5
 

--- a/SPECS/libguestfs/libguestfs.spec
+++ b/SPECS/libguestfs/libguestfs.spec
@@ -25,7 +25,7 @@
 Summary:        Access and modify virtual machine disk images
 Name:           libguestfs
 Version:        1.44.0
-Release:        9%{?dist}
+Release:        10%{?dist}
 License:        LGPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -1234,6 +1234,9 @@ rm ocaml/html/.gitignore
 %endif
 
 %changelog
+* Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 1.44.0-10
+- Bump release to rebuild with go 1.18.8
+
 * Tue Sep 13 2022 Andy Caldwell <andycaldwell@microsoft.com> - 1.44.0-9
 - Rebuilt for glibc-static 2.35-3
 

--- a/SPECS/libnvidia-container/libnvidia-container.spec
+++ b/SPECS/libnvidia-container/libnvidia-container.spec
@@ -4,7 +4,7 @@
 Summary:        NVIDIA container runtime library
 Name:           libnvidia-container
 Version:        1.11.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        BSD AND ASL2.0 AND GPLv3+ AND LGPLv3+ AND MIT AND GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -132,6 +132,9 @@ This package contains command-line tools that facilitate using the library.
 %{_bindir}/*
 
 %changelog
+* Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 1.11.0-2
+- Bump release to rebuild with go 1.18.8
+
 * Wed Sep 21 2022 Henry Li <lihl@microsoft.com> - 1.11.0-1
 - Upgrade to version 1.11.0
 

--- a/SPECS/local-path-provisioner/local-path-provisioner.spec
+++ b/SPECS/local-path-provisioner/local-path-provisioner.spec
@@ -1,7 +1,7 @@
 Summary:        Provides a way for the Kubernetes users to utilize the local storage in each node
 Name:           local-path-provisioner
 Version:        0.0.21
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        ASL 2.0
 URL:            https://github.com/rancher/local-path-provisioner
 Group:          Applications/Text
@@ -30,7 +30,9 @@ install local-path-provisioner %{buildroot}%{_bindir}/local-path-provisioner
 %{_bindir}/local-path-provisioner
 
 %changelog
+* Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 0.0.21-2
+- Bump release to rebuild with go 1.18.8
+
 * Thu Jun 23 2022 Lior Lustgarten <lilustga@microsoft.com> 0.0.21-1
 - Original version for CBL-Mariner
 - License Verified
-

--- a/SPECS/moby-buildx/moby-buildx.spec
+++ b/SPECS/moby-buildx/moby-buildx.spec
@@ -5,7 +5,7 @@ Summary:        A Docker CLI plugin for extended build capabilities with BuildKi
 Name:           moby-%{upstream_name}
 # update "commit_hash" above when upgrading version
 Version:        0.7.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        ASL 2.0
 Group:          Tools/Container
 Vendor:         Microsoft Corporation
@@ -42,6 +42,9 @@ cp -aT buildx "%{buildroot}/%{_libexecdir}/docker/cli-plugins/docker-buildx"
 %{_libexecdir}/docker/cli-plugins/docker-buildx
 
 %changelog
+* Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 0.7.1-4
+- Bump release to rebuild with go 1.18.8
+
 * Mon Aug 22 2022 Olivia Crain <oliviacrain@microsoft.com> - 0.7.1-3
 - Bump release to rebuild against Go 1.18.5
 

--- a/SPECS/moby-cli/moby-cli.spec
+++ b/SPECS/moby-cli/moby-cli.spec
@@ -4,7 +4,7 @@
 Summary: The open-source application container engine client.
 Name: moby-%{upstream_name}
 Version: 20.10.12
-Release: 3%{?dist}
+Release: 4%{?dist}
 License: ASL 2.0
 Group: Tools/Container
 URL: https://github.com/docker/cli
@@ -80,6 +80,9 @@ install -p -m 644 contrib/completion/fish/docker.fish %{buildroot}%{_datadir}/fi
 %{_datadir}/fish/vendor_completions.d/docker.fish
 
 %changelog
+* Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 20.10.12-4
+- Bump release to rebuild with go 1.18.8
+
 * Mon Aug 22 2022 Olivia Crain <oliviacrain@microsoft.com> - 20.10.12-3
 - Bump release to rebuild against Go 1.18.5
 

--- a/SPECS/moby-containerd/moby-containerd.spec
+++ b/SPECS/moby-containerd/moby-containerd.spec
@@ -5,7 +5,7 @@
 Summary: Industry-standard container runtime
 Name: moby-%{upstream_name}
 Version: 1.6.6
-Release: 2%{?dist}
+Release: 3%{?dist}
 License: ASL 2.0
 Group: Tools/Container
 URL: https://www.containerd.io
@@ -85,6 +85,9 @@ fi
 %config(noreplace) %{_sysconfdir}/containerd/config.toml
 
 %changelog
+* Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 1.6.6-3
+- Bump release to rebuild with go 1.18.8
+
 * Mon Aug 22 2022 Olivia Crain <oliviacrain@microsoft.com> - 1.6.6-2
 - Bump release to rebuild against Go 1.18.5
 

--- a/SPECS/moby-engine/moby-engine.spec
+++ b/SPECS/moby-engine/moby-engine.spec
@@ -4,7 +4,7 @@
 Summary: The open-source application container engine
 Name:    %{upstream_name}-engine
 Version: 20.10.14
-Release: 1%{?dist}
+Release: 2%{?dist}
 License: ASL 2.0
 Group:   Tools/Container
 URL: https://mobyproject.org
@@ -125,6 +125,9 @@ fi
 %{_unitdir}/*
 
 %changelog
+* Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 20.10.14-2
+- Bump release to rebuild with go 1.18.8
+
 * Fri Sep 30 2022 Adit Jha <aditjha@microsoft.com> - 20.10.14-1
 - Upgrade to 20.10.14 to fix CVE-2022-24769
 

--- a/SPECS/moby-runc/moby-runc.spec
+++ b/SPECS/moby-runc/moby-runc.spec
@@ -5,7 +5,7 @@ Summary:        CLI tool for spawning and running containers per OCI spec.
 Name:           moby-%{upstream_name}
 # update "commit_hash" above when upgrading version
 Version:        1.1.2
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        ASL 2.0
 URL:            https://github.com/opencontainers/runc
 Group:          Virtualization/Libraries
@@ -57,6 +57,9 @@ make install-man DESTDIR="%{buildroot}" PREFIX="%{_prefix}"
 %{_mandir}/*
 
 %changelog
+* Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 1.1.2-4
+- Bump release to rebuild with go 1.18.8
+
 * Mon Aug 22 2022 Olivia Crain <oliviacrain@microsoft.com> - 1.1.2-3
 - Bump release to rebuild against Go 1.18.5
 

--- a/SPECS/msft-golang/msft-golang.signatures.json
+++ b/SPECS/msft-golang/msft-golang.signatures.json
@@ -1,6 +1,6 @@
 {
  "Signatures": {
-  "go.20220906.5.src.tar.gz": "6bc80048b70a618f9d0a8093d2926ceb407a0be6b48f2430d086e2bc1fa4f580",
+  "go.20221101.1.src.tar.gz": "6bc80048b70a618f9d0a8093d2926ceb407a0be6b48f2430d086e2bc1fa4f580",
   "go1.4-bootstrap-20171003.tar.gz": "f4ff5b5eb3a3cae1c993723f3eab519c5bae18866b5e5f96fe1102f0cb5c3e52"
  }
 }

--- a/SPECS/msft-golang/msft-golang.signatures.json
+++ b/SPECS/msft-golang/msft-golang.signatures.json
@@ -1,6 +1,6 @@
 {
  "Signatures": {
-  "go.20221101.1.src.tar.gz": "6bc80048b70a618f9d0a8093d2926ceb407a0be6b48f2430d086e2bc1fa4f580",
+  "go.20220906.5.src.tar.gz": "6bc80048b70a618f9d0a8093d2926ceb407a0be6b48f2430d086e2bc1fa4f580",
   "go1.4-bootstrap-20171003.tar.gz": "f4ff5b5eb3a3cae1c993723f3eab519c5bae18866b5e5f96fe1102f0cb5c3e52"
  }
 }

--- a/SPECS/msft-golang/msft-golang.spec
+++ b/SPECS/msft-golang/msft-golang.spec
@@ -10,18 +10,16 @@
 # rpmbuild magic to keep from having meta dependency on libc.so.6
 %define _use_internal_dependency_generator 0
 %define __find_requires %{nil}
-%global msft_golang_release_number 1
-%global msft_golang_release_date 20221101.1
 Summary:        Go
 Name:           msft-golang
-Version:        1.19.3
-Release:        1%{?dist}
-License:        BSD-3-Clause
+Version:        1.19.1
+Release:        2%{?dist}
+License:        BSD
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Group:          System Environment/Security
 URL:            https://github.com/microsoft/go
-Source0:        https://github.com/microsoft/go/releases/download/v%{version}-%{msft_golang_release_number}/go.%{msft_golang_release_date}.src.tar.gz
+Source0:        https://github.com/microsoft/go/releases/download/v1.19.1-1/go.20220906.5.src.tar.gz
 Source1:        https://dl.google.com/go/go1.4-bootstrap-20171003.tar.gz
 Patch0:         go14_bootstrap_aarch64.patch
 Conflicts:      go
@@ -117,11 +115,6 @@ fi
 %{_bindir}/*
 
 %changelog
-* Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 1.19.3-1
-- Upgrade to version 1.19.3 (fixes CVE-2022-41716, which only applies to Windows environments)
-- Also fixes CVE-2022-2879, CVE-2022-2880, CVE-2022-41715 (fixed in 1.19.2)
-- Use SPDX short identifier for license tag
-
 * Sat Sep 24 2022 Muhammad Falak <mwani@microsoft.com> - 1.19.1-2
 - Drop the explict VERSION in build
 

--- a/SPECS/msft-golang/msft-golang.spec
+++ b/SPECS/msft-golang/msft-golang.spec
@@ -10,16 +10,18 @@
 # rpmbuild magic to keep from having meta dependency on libc.so.6
 %define _use_internal_dependency_generator 0
 %define __find_requires %{nil}
+%global msft_golang_release_number 1
+%global msft_golang_release_date 20221101.1
 Summary:        Go
 Name:           msft-golang
-Version:        1.19.1
-Release:        2%{?dist}
-License:        BSD
+Version:        1.19.3
+Release:        1%{?dist}
+License:        BSD-3-Clause
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Group:          System Environment/Security
 URL:            https://github.com/microsoft/go
-Source0:        https://github.com/microsoft/go/releases/download/v1.19.1-1/go.20220906.5.src.tar.gz
+Source0:        https://github.com/microsoft/go/releases/download/v%{version}-%{msft_golang_release_number}/go.%{msft_golang_release_date}.src.tar.gz
 Source1:        https://dl.google.com/go/go1.4-bootstrap-20171003.tar.gz
 Patch0:         go14_bootstrap_aarch64.patch
 Conflicts:      go
@@ -115,6 +117,11 @@ fi
 %{_bindir}/*
 
 %changelog
+* Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 1.19.3-1
+- Upgrade to version 1.19.3 (fixes CVE-2022-41716, which only applies to Windows environments)
+- Also fixes CVE-2022-2879, CVE-2022-2880, CVE-2022-41715 (fixed in 1.19.2)
+- Use SPDX short identifier for license tag
+
 * Sat Sep 24 2022 Muhammad Falak <mwani@microsoft.com> - 1.19.1-2
 - Drop the explict VERSION in build
 

--- a/SPECS/multus/multus.spec
+++ b/SPECS/multus/multus.spec
@@ -19,7 +19,7 @@
 Summary:        CNI plugin providing multiple interfaces in containers
 Name:           multus
 Version:        3.8
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -70,6 +70,9 @@ install -D -m0644 images/multus-daemonset-crio.yml %{buildroot}%{_datadir}/k8s-y
 %{_datarootdir}/k8s-yaml/multus/multus.yaml
 
 %changelog
+* Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 3.8-2
+- Bump release to rebuild with go 1.18.8
+
 * Wed Sep 07 2022 Yash Panchal <yashpanchal@microsoft.com> - 3.8-1
 - License verified
 - Initial changes to build for Mariner

--- a/SPECS/nmi/nmi.spec
+++ b/SPECS/nmi/nmi.spec
@@ -2,7 +2,7 @@
 Summary:        Node Managed Identity
 Name:           nmi
 Version:        1.8.7
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -63,6 +63,9 @@ popd
 %{_bindir}/%{name}
 
 %changelog
+* Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 1.8.7-4
+- Bump release to rebuild with go 1.18.8
+
 * Mon Aug 22 2022 Olivia Crain <oliviacrain@microsoft.com> - 1.8.7-3
 - Bump release to rebuild against Go 1.18.5
 

--- a/SPECS/node-problem-detector/node-problem-detector.spec
+++ b/SPECS/node-problem-detector/node-problem-detector.spec
@@ -1,7 +1,7 @@
 Summary:        Kubernetes daemon to detect and report node issues
 Name:           node-problem-detector
 Version:        0.8.10
-Release:        5%{?dist}
+Release:        6%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -64,6 +64,9 @@ make test
 %config(noreplace) %{_sysconfdir}/node-problem-detector.d/*
 
 %changelog
+* Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 0.8.10-6
+- Bump release to rebuild with go 1.18.8
+
 * Mon Aug 29 2022 Sean Dougherty <sdougherty@microsoft.com> - 0.8.10-5
 - Removed arch-specific logic in Makefile with 001-remove_arch_specific_makefile_logic.patch.
 

--- a/SPECS/nvidia-container-toolkit/nvidia-container-toolkit.spec
+++ b/SPECS/nvidia-container-toolkit/nvidia-container-toolkit.spec
@@ -2,7 +2,7 @@
 Summary:        NVIDIA container runtime hook
 Name:           nvidia-container-toolkit
 Version:        1.11.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        ALS2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -94,6 +94,9 @@ rm -f %{_bindir}/nvidia-container-toolkit
 %{_bindir}/nvidia-ctk
 
 %changelog
+* Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 1.11.0-2
+- Bump release to rebuild with go 1.18.8
+
 * Wed Sep 21 2022 Henry Li <lihl@microsoft.com> - 1.11.0-1
 - Upgrade to version 1.11.0
 - Remove patch that no longer applies to v1.11.0

--- a/SPECS/opa/opa.spec
+++ b/SPECS/opa/opa.spec
@@ -5,7 +5,7 @@
 Summary:        Open source, general-purpose policy engine
 Name:           opa
 Version:        0.31.0
-Release:        3%{?dist}
+Release:        4%{?dist}
 # Upstream license specification: MIT and Apache-2.0
 # Main package:    ASL 2.0
 # internal/jwx:    MIT
@@ -63,6 +63,9 @@ install -D -p -m 0644 _man/*         %{buildroot}%{_mandir}/man1/
 %{_bindir}/*
 
 %changelog
+* Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 0.31.0-4
+- Bump release to rebuild with go 1.18.8
+
 * Mon Aug 22 2022 Olivia Crain <oliviacrain@microsoft.com> - 0.31.0-3
 - Bump release to rebuild against Go 1.18.5
 

--- a/SPECS/packer/packer.spec
+++ b/SPECS/packer/packer.spec
@@ -1,7 +1,7 @@
 Summary:        Tool for creating identical machine images for multiple platforms from a single source configuration.
 Name:           packer
 Version:        1.8.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        MPLv2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -60,6 +60,9 @@ go test -mod=vendor
 %{_bindir}/packer
 
 %changelog
+* Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 1.8.1-4
+- Bump release to rebuild with go 1.18.8
+
 * Mon Aug 22 2022 Olivia Crain <oliviacrain@microsoft.com> - 1.8.1-3
 - Bump release to rebuild against Go 1.18.5
 

--- a/SPECS/prometheus-node-exporter/prometheus-node-exporter.spec
+++ b/SPECS/prometheus-node-exporter/prometheus-node-exporter.spec
@@ -5,7 +5,7 @@
 Summary:        Exporter for machine metrics
 Name:           prometheus-node-exporter
 Version:        1.3.1
-Release:        9%{?dist}
+Release:        10%{?dist}
 # Upstream license specification: Apache-2.0
 License:        ASL 2.0 AND MIT
 Vendor:         Microsoft Corporation
@@ -107,6 +107,9 @@ getent passwd 'prometheus' >/dev/null || useradd -r -g 'prometheus' -d '%{_share
 %dir %attr(0755,prometheus,prometheus) %{_sharedstatedir}/prometheus/node-exporter
 
 %changelog
+* Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 1.3.1-10
+- Bump release to rebuild with go 1.18.8
+
 * Mon Aug 22 2022 Olivia Crain <oliviacrain@microsoft.com> - 1.3.1-9
 - Bump release to rebuild against Go 1.18.5
 

--- a/SPECS/prometheus-process-exporter/prometheus-process-exporter.spec
+++ b/SPECS/prometheus-process-exporter/prometheus-process-exporter.spec
@@ -5,7 +5,7 @@
 Summary:        Prometheus exporter exposing process metrics from procfs
 Name:           prometheus-process-exporter
 Version:        0.7.10
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -97,6 +97,9 @@ getent passwd 'prometheus' >/dev/null || useradd -r -g 'prometheus' -d '%{_share
 %dir %attr(0755,prometheus,prometheus) %{_sharedstatedir}/prometheus
 
 %changelog
+* Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 0.7.10-4
+- Bump release to rebuild with go 1.18.8
+
 * Mon Aug 22 2022 Olivia Crain <oliviacrain@microsoft.com> - 0.7.10-3
 - Bump release to rebuild against Go 1.18.5
 

--- a/SPECS/prometheus/prometheus.spec
+++ b/SPECS/prometheus/prometheus.spec
@@ -3,7 +3,7 @@
 
 Name:           prometheus
 Version:        2.36.0
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Prometheus monitoring system and time series database
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -142,6 +142,9 @@ fi
 %attr(0755,prometheus,prometheus) %{_sharedstatedir}/prometheus
 
 %changelog
+* Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 2.36.0-4
+- Bump release to rebuild with go 1.18.8
+
 * Mon Aug 22 2022 Olivia Crain <oliviacrain@microsoft.com> - 2.36.0-3
 - Bump release to rebuild against Go 1.18.5
 

--- a/SPECS/rook/rook.spec
+++ b/SPECS/rook/rook.spec
@@ -19,7 +19,7 @@
 Summary:        Orchestrator for distributed storage systems in cloud-native environments
 Name:           rook
 Version:        1.6.2
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        Apache-2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -248,6 +248,9 @@ sed -i -e "s|\(.*tag: \)VERSION|\1%{helm_appVersion}|" %{values_yaml}
 # bother adding docs or changelog or anything
 
 %changelog
+* Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 1.6.2-4
+- Bump release to rebuild with go 1.18.8
+
 * Mon Aug 22 2022 Olivia Crain <oliviacrain@microsoft.com> - 1.6.2-3
 - Bump release to rebuild against Go 1.18.5
 

--- a/SPECS/skopeo/skopeo.spec
+++ b/SPECS/skopeo/skopeo.spec
@@ -1,7 +1,7 @@
 Summary:        Inspect container images and repositories on registries
 Name:           skopeo
 Version:        1.9.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        Apache-2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -46,6 +46,9 @@ make test-unit-local
 %{_mandir}/man1/%%{name}*
 
 %changelog
+* Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 1.9.1-3
+- Bump release to rebuild with go 1.18.8
+
 * Mon Aug 22 2022 Olivia Crain <oliviacrain@microsoft.com> - 1.9.1-2
 - Bump release to rebuild against Go 1.18.5
 

--- a/SPECS/sriov-network-device-plugin/sriov-network-device-plugin.spec
+++ b/SPECS/sriov-network-device-plugin/sriov-network-device-plugin.spec
@@ -1,7 +1,7 @@
 Summary:        Plugin for discovering and advertising networking resources
 Name:           sriov-network-device-plugin
 Version:        3.4.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -32,6 +32,9 @@ install -D -m0755 images/ddptool-1.0.1.12.tar.gz %{buildroot}/usr/share/%{name}/
 /usr/share/%{name}/ddptool-1.0.1.12.tar.gz
 
 %changelog
+* Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 3.4.0-2
+- Bump release to rebuild with go 1.18.8
+
 * Fri Sep 23 2022 Aditya Dubey <adityadubey@microsoft.com> - 3.4.0-1
 - Original version for CBL-Mariner
 - License Verified

--- a/SPECS/telegraf/telegraf.spec
+++ b/SPECS/telegraf/telegraf.spec
@@ -1,7 +1,7 @@
 Summary:        agent for collecting, processing, aggregating, and writing metrics.
 Name:           telegraf
 Version:        1.23.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -90,6 +90,9 @@ fi
 %dir %{_sysconfdir}/%{name}/telegraf.d
 
 %changelog
+* Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 1.23.0-3
+- Bump release to rebuild with go 1.18.8
+
 * Mon Aug 22 2022 Olivia Crain <oliviacrain@microsoft.com> - 1.23.0-2
 - Bump release to rebuild against Go 1.18.5
 

--- a/SPECS/terraform/terraform.spec
+++ b/SPECS/terraform/terraform.spec
@@ -1,7 +1,7 @@
 Summary:        Infrastructure as code deployment management tool
 Name:           terraform
 Version:        1.3.2
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        MPLv2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -57,6 +57,9 @@ install -p -m 755 -t %{buildroot}%{_bindir} ./terraform
 %{_bindir}/terraform
 
 %changelog
+* Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 1.3.2-2
+- Bump release to rebuild with go 1.18.8
+
 * Mon Oct 10 2022 Henry Li <lihl@microsoft.com> - 1.3.2-1
 - Upgrade to version 1.3.2 to resolve CVE-2021-36230
 

--- a/SPECS/vitess/vitess.spec
+++ b/SPECS/vitess/vitess.spec
@@ -3,7 +3,7 @@
 
 Name:           vitess
 Version:        8.0.0
-Release:        5%{?dist}
+Release:        6%{?dist}
 Summary:        Database clustering system for horizontal scaling of MySQL
 # Upstream license specification: MIT and Apache-2.0
 License:        MIT and ASL 2.0
@@ -107,6 +107,9 @@ go check -t go/cmd \
 %{_bindir}/*
 
 %changelog
+* Tue Nov 01 2022 Olivia Crain <oliviacrain@microsoft.com> - 8.0.0-6
+- Bump release to rebuild with go 1.18.8
+
 * Mon Aug 22 2022 Olivia Crain <oliviacrain@microsoft.com> - 8.0.0-5
 - Bump release to rebuild against Go 1.18.5
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -12233,8 +12233,8 @@
         "type": "other",
         "other": {
           "name": "msft-golang",
-          "version": "1.19.3",
-          "downloadUrl": "https://github.com/microsoft/go/releases/download/v1.19.3-1/go.20221101.1.src.tar.gz"
+          "version": "1.19.1",
+          "downloadUrl": "https://github.com/microsoft/go/releases/download/v1.19.1-1/go.20220906.5.src.tar.gz"
         }
       }
     },

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -4100,8 +4100,8 @@
         "type": "other",
         "other": {
           "name": "golang",
-          "version": "1.18.5",
-          "downloadUrl": "https://golang.org/dl/go1.18.5.src.tar.gz"
+          "version": "1.18.8",
+          "downloadUrl": "https://golang.org/dl/go1.18.8.src.tar.gz"
         }
       }
     },
@@ -12233,8 +12233,8 @@
         "type": "other",
         "other": {
           "name": "msft-golang",
-          "version": "1.19.1",
-          "downloadUrl": "https://github.com/microsoft/go/releases/download/v1.19.1-1/go.20220906.5.src.tar.gz"
+          "version": "1.19.3",
+          "downloadUrl": "https://github.com/microsoft/go/releases/download/v1.19.3-1/go.20221101.1.src.tar.gz"
         }
       }
     },


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Happy Go 1.18.8 release day! We're upgrading `golang` to the latest version to get the security fixes from the 1.18.6, 1.18.7 releases.

A bump for `msft-golang` will come in a separate PR.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- `golang`: Upgrade from 1.18.5 to 1.18.8
- No change to Go 1.17- we need these for k8s, but that branch no longer receives security updates
- Bump release of packages that depend on `golang` to force rebuild

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2022-2879
- https://nvd.nist.gov/vuln/detail/CVE-2022-2880
- https://nvd.nist.gov/vuln/detail/CVE-2022-41715
- https://nvd.nist.gov/vuln/detail/CVE-2022-27664
- https://nvd.nist.gov/vuln/detail/CVE-2022-32190

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
[AMD64 BB](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=259230&view=results) (failed due to known issue with qemu that has since been fixed, but otherwise looks good)
[ARM64 BB](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=259229&view=results) (failed due to known issue with qemu that has since been fixed, but otherwise looks good)
