### PR TITLE
Fixed cgmanifest validation's dependency on lua.

### DIFF
--- a/.github/workflows/validate-cg-manifest.sh
+++ b/.github/workflows/validate-cg-manifest.sh
@@ -59,17 +59,78 @@ ignore_known_issues=" \
 
 alt_source_tag="Source9999"
 
+function prepare_lua {
+  local lua_common_file_name
+  local lua_forge_file_name
+  local mariner_lua_dir
+  local mariner_srpm_lua_dir
+  local rpm_lua_dir
+  local rpm_macros_dir
+
+  rpm_macros_dir="$1"
+
+  lua_common_file_name="common.lua"
+  lua_forge_file_name="forge.lua"
+  rpm_lua_dir="/usr/lib/rpm/lua"
+  mariner_lua_dir="$rpm_lua_dir/mariner"
+  mariner_srpm_lua_dir="$mariner_lua_dir/srpm"
+
+  if [[ ! -d "$rpm_lua_dir" ]]
+  then
+    FILES_TO_CLEAN_UP+=("$rpm_lua_dir")
+  elif [[ ! -d "$mariner_lua_dir" ]]
+  then
+    FILES_TO_CLEAN_UP+=("$mariner_lua_dir")
+  elif [[ ! -d "$mariner_srpm_lua_dir" ]]
+  then
+    FILES_TO_CLEAN_UP+=("$mariner_srpm_lua_dir")
+  fi
+  mkdir -p "$mariner_srpm_lua_dir"
+
+  if [[ ! -f "$mariner_lua_dir/$lua_common_file_name" ]]
+  then
+    cp "$rpm_macros_dir/$lua_common_file_name" "$mariner_lua_dir/$lua_common_file_name"
+    FILES_TO_CLEAN_UP+=("$mariner_lua_dir/$lua_common_file_name")
+  fi
+
+  if [[ ! -f "$mariner_srpm_lua_dir/$lua_forge_file_name" ]]
+  then
+    cp "$rpm_macros_dir/$lua_forge_file_name" "$mariner_srpm_lua_dir/$lua_forge_file_name"
+    FILES_TO_CLEAN_UP+=("$mariner_srpm_lua_dir/$lua_forge_file_name")
+  fi
+}
+
+function specs_dir_from_spec_path {
+  # Assuming we always check specs inside CBL-Mariner's core GitHub repository.
+  # If that's the case, the spec paths will always have the following form:
+  #     [repo_directory_path]/[specs_directory]/[package_name]/[package_spec_files]
+  echo "$(realpath "$(dirname "$1")/../../SPECS")/mariner-rpm-macros"
+}
+
 rm -f bad_registrations.txt
 rm -rf ./cgmanifest_test_dir/
 
-[[ $# -eq 0 ]] && echo "No specs passed to validate"
+if [[ $# -eq 0 ]]
+then
+  echo "No specs passed to validate."
+  exit
+fi
 
 WORK_DIR=$(mktemp -d -t)
+FILES_TO_CLEAN_UP=("$WORK_DIR")
 function clean_up {
     echo "Cleaning up..."
-    rm -rf "$WORK_DIR"
+    for file_path in "${FILES_TO_CLEAN_UP[@]}"
+    do
+      echo "   Removing ($file_path)."
+      rm -rf "$file_path"
+    done
 }
 trap clean_up EXIT SIGINT SIGTERM
+
+
+mariner_macros_dir="$(specs_dir_from_spec_path "$1")"
+prepare_lua "$mariner_macros_dir"
 
 echo "Checking $# specs."
 

--- a/.github/workflows/validate-cg-manifest.sh
+++ b/.github/workflows/validate-cg-manifest.sh
@@ -141,8 +141,11 @@ do
   echo "[$i/$#] Checking $original_spec"
 
   # Using a copy of the spec file, because parsing requires some pre-processing.
-  spec="$WORK_DIR/$(basename "$original_spec")"
-  cp "$original_spec" "$spec"
+  original_spec_dir_path="$(dirname "$original_spec")"
+  cp -r "$original_spec_dir_path" "$WORK_DIR"
+
+  original_spec_dir_name="$(basename "$original_spec_dir_path")"
+  spec="$WORK_DIR/$original_spec_dir_name/$(basename "$original_spec")"
 
   # Skipping specs for signed packages. Their unsigned versions should already be included in the manifest.
   if echo "$original_spec" | grep -q "SPECS-SIGNED"

--- a/.github/workflows/validate-cg-manifest.sh
+++ b/.github/workflows/validate-cg-manifest.sh
@@ -78,11 +78,11 @@ function prepare_lua {
 
   # We only want to clean-up directories, which were absent from the system.
   dirs_to_check=("$rpm_lua_dir" "$mariner_lua_dir" "$mariner_srpm_lua_dir")
-  for dir_to_check in "${dirs_to_check[@]}"
+  for dir_path in "${dirs_to_check[@]}"
   do
-    if [[ ! -d "$dir_to_check" ]]
+    if [[ ! -d "$dir_path" ]]
     then
-      FILES_TO_CLEAN_UP+=("$dir_to_check")
+      FILES_TO_CLEAN_UP+=("$dir_path")
     fi
   done
   mkdir -p "$mariner_srpm_lua_dir"

--- a/.github/workflows/validate-cg-manifest.sh
+++ b/.github/workflows/validate-cg-manifest.sh
@@ -60,6 +60,7 @@ ignore_known_issues=" \
 alt_source_tag="Source9999"
 
 function prepare_lua {
+  local -a dirs_to_check
   local lua_common_file_name
   local lua_forge_file_name
   local mariner_lua_dir
@@ -75,16 +76,15 @@ function prepare_lua {
   mariner_lua_dir="$rpm_lua_dir/mariner"
   mariner_srpm_lua_dir="$mariner_lua_dir/srpm"
 
-  if [[ ! -d "$rpm_lua_dir" ]]
-  then
-    FILES_TO_CLEAN_UP+=("$rpm_lua_dir")
-  elif [[ ! -d "$mariner_lua_dir" ]]
-  then
-    FILES_TO_CLEAN_UP+=("$mariner_lua_dir")
-  elif [[ ! -d "$mariner_srpm_lua_dir" ]]
-  then
-    FILES_TO_CLEAN_UP+=("$mariner_srpm_lua_dir")
-  fi
+  # We only want to clean-up directories, which were absent from the system.
+  dirs_to_check=("$rpm_lua_dir" "$mariner_lua_dir" "$mariner_srpm_lua_dir")
+  for dir_to_check in "${dirs_to_check[@]}"
+  do
+    if [[ ! -d "$dir_to_check" ]]
+    then
+      FILES_TO_CLEAN_UP+=("$dir_to_check")
+    fi
+  done
   mkdir -p "$mariner_srpm_lua_dir"
 
   if [[ ! -f "$mariner_lua_dir/$lua_common_file_name" ]]


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

Some of the spec macros like `%forgemeta` require the `mariner.common` and/or `marnier.srpm.forge` lua modules. These modules are correctly installed in the Mariner environment (like a worker chroot or a full image) but our PR checks run on Ubuntu, where these modules are not present. This PR conditionally installs these modules for the duration of the PR check, if they are not present, and makes sure they are removed afterwards, if such clean-up is needed.

**CALL FOR HELP**: I believe this fix could be more elegantly implemented by manipulating the [`LUA_PATH` env variable](https://community.exasol.com/t5/database-features/exasol-loves-lua-part-3-handling-modules/ta-p/2134). After multiple attempts I failed trying to do so, but if anyone has more experience with lua, please let me know.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Added lua modules required for spec parsing for the duration of the cgmanifest check.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #4163

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local validation runs.
