### PR TITLE
Fixed printing built RPMs from spec.

### DIFF
--- a/toolkit/tools/internal/rpm/rpm.go
+++ b/toolkit/tools/internal/rpm/rpm.go
@@ -211,12 +211,9 @@ func QuerySPEC(specFile, sourceDir, queryFormat, arch string, defines map[string
 
 // QuerySPECForBuiltRPMs queries a SPEC file with queryFormat. Returns only the subpackages, which generate a .rpm file.
 func QuerySPECForBuiltRPMs(specFile, sourceDir, arch string, defines map[string]string) (result []string, err error) {
-	const (
-		builtRPMsSwitch = "--builtrpms"
-		queryFormat     = ""
-	)
+	const queryFormat = "%{nvra}\n"
 
-	return QuerySPEC(specFile, sourceDir, queryFormat, arch, defines, builtRPMsSwitch)
+	return QuerySPEC(specFile, sourceDir, queryFormat, arch, defines, QueryBuiltRPMHeadersArgument)
 }
 
 // QueryPackage queries an RPM or SRPM file with queryFormat. Returns the output split by line and trimmed.

--- a/toolkit/tools/internal/rpm/rpm_test.go
+++ b/toolkit/tools/internal/rpm/rpm_test.go
@@ -104,7 +104,7 @@ func TestArchShouldFailForExcludedArchitectures(t *testing.T) {
 	assert.False(t, matches)
 }
 
-func TestShouldNotListDefaultPackageInRPMsList(t *testing.T) {
+func TestShouldListOnlySubpackageWithArchitectureInRPMsList(t *testing.T) {
 	expectedRPMs := []string{
 		fmt.Sprintf("subpackage_name-1.0.0-1%s.%s", defines[definesDistKey], buildArch),
 	}

--- a/toolkit/tools/internal/rpm/rpm_test.go
+++ b/toolkit/tools/internal/rpm/rpm_test.go
@@ -4,6 +4,7 @@
 package rpm
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -13,13 +14,17 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const specsDir = "testdata"
+const (
+	definesDistKey      = "dist"
+	definesWithCheckKey = "with_check"
+	specsDir            = "testdata"
+)
 
 var buildArch = goArchToRpmArch[runtime.GOARCH]
 
 var defines = map[string]string{
-	"dist":       ".cmX",
-	"with_check": "1",
+	definesDistKey:      ".cmX",
+	definesWithCheckKey: "1",
 }
 
 func TestMain(m *testing.M) {
@@ -97,4 +102,15 @@ func TestArchShouldFailForExcludedArchitectures(t *testing.T) {
 	matches, err := SpecArchIsCompatible(specFilePath, specsDir, buildArch, defines)
 	assert.NoError(t, err)
 	assert.False(t, matches)
+}
+
+func TestShouldNotListDefaultPackageInRPMsList(t *testing.T) {
+	expectedRPMs := []string{
+		fmt.Sprintf("subpackage_name-1.0.0-1%s.%s", defines[definesDistKey], buildArch),
+	}
+	specFilePath := filepath.Join(specsDir, "no_default_package.spec")
+
+	builtRPMs, err := QuerySPECForBuiltRPMs(specFilePath, specsDir, buildArch, defines)
+	assert.NoError(t, err)
+	assert.EqualValues(t, expectedRPMs, builtRPMs)
 }

--- a/toolkit/tools/internal/rpm/testdata/no_default_package.spec
+++ b/toolkit/tools/internal/rpm/testdata/no_default_package.spec
@@ -29,5 +29,3 @@ Test subpackage, which should be generate when this spec is built.
 %changelog
 * Mon Nov 07 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.0.0-1
 - Initial creation.
-
-

--- a/toolkit/tools/internal/rpm/testdata/no_default_package.spec
+++ b/toolkit/tools/internal/rpm/testdata/no_default_package.spec
@@ -1,0 +1,33 @@
+Summary:        Test spec file with with no default package
+Name:           no_default_package
+Version:        1.0.0
+Release:        1%{?dist}
+License:        MIT
+URL:            https://test.com
+Group:          Test
+Vendor:         Microsoft
+Distribution:   Mariner
+
+%description
+Test spec. Make sure the default package is not built!
+
+%package -n subpackage_name
+Summary:        Actually built subpackage
+
+%description -n subpackage_name
+Test subpackage, which should be generate when this spec is built.
+
+%prep
+
+%build
+
+%install
+
+%files -n subpackage_name
+%defattr(-,root,root)
+
+%changelog
+* Mon Nov 07 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.0.0-1
+- Initial creation.
+
+


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

After a recent `rpm` package update to version 4.18.0 the results for `rpmspec --builtrpms [spec_path]` print "src" instead of the architecture as the last component.

Before:
```bash
root [ / ]# rpmspec --builtrpms -q --target x86_64 -D "dist .cm2" mariner-repos.spec 
mariner-repos-2.0-8.cm2.noarch
mariner-repos-debug-2.0-8.cm2.noarch
mariner-repos-debug-preview-2.0-8.cm2.noarch
mariner-repos-extended-2.0-8.cm2.noarch
mariner-repos-extended-debug-2.0-8.cm2.noarch
mariner-repos-extended-preview-2.0-8.cm2.noarch
mariner-repos-extended-debug-preview-2.0-8.cm2.noarch
mariner-repos-extras-2.0-8.cm2.noarch
mariner-repos-extras-preview-2.0-8.cm2.noarch
mariner-repos-microsoft-2.0-8.cm2.noarch
mariner-repos-microsoft-preview-2.0-8.cm2.noarch
mariner-repos-preview-2.0-8.cm2.noarch
mariner-repos-shared-2.0-8.cm2.noarch
```

After:
```bash
root [ / ]# rpmspec --builtrpms -q --target x86_64 -D "dist .cm2" mariner-repos.spec 
mariner-repos-2.0-8.cm2.src
mariner-repos-debug-2.0-8.cm2.src
mariner-repos-debug-preview-2.0-8.cm2.src
mariner-repos-extended-2.0-8.cm2.src
mariner-repos-extended-debug-2.0-8.cm2.src
mariner-repos-extended-preview-2.0-8.cm2.src
mariner-repos-extended-debug-preview-2.0-8.cm2.src
mariner-repos-extras-2.0-8.cm2.src
mariner-repos-extras-preview-2.0-8.cm2.src
mariner-repos-microsoft-2.0-8.cm2.src
mariner-repos-microsoft-preview-2.0-8.cm2.src
mariner-repos-preview-2.0-8.cm2.src
mariner-repos-shared-2.0-8.cm2.src
```

This is not what our code and tooling expects when parsing the output, so I've modified the query to use the `%{nvra}` macro explicitly and thus print the results the way they were printed for <4.18.0 versions of `rpm`.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Switched to using the `%{nvra}\n` query format with the `--builtrpms` switch.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local snapshot builds.
