### PR TITLE
Add support for qcow2 output images

### DIFF
--- a/toolkit/tools/roast/formats/qcow.go
+++ b/toolkit/tools/roast/formats/qcow.go
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package formats
+
+import (
+	"fmt"
+
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/shell"
+)
+
+const (
+	// QcowType represents the qcow2 virtual drive format
+	QcowType = "qcow2"
+)
+
+// Qcow implements Converter interface to convert a RAW image into a qcow2 file
+type Qcow struct {
+}
+
+// Convert converts the image in the qcow2 format
+func (v *Qcow) Convert(input, output string, isInputFile bool) (err error) {
+	const (
+		outputFormat = "qcow2"
+		squashErrors = false
+	)
+
+	if !isInputFile {
+		return fmt.Errorf("qcow2 conversion requires a RAW file as an input")
+	}
+
+	err = shell.ExecuteLive(squashErrors, "qemu-img", "convert", "-O", outputFormat, input, output)
+	return
+}
+
+// Extension returns the filetype extension produced by this converter.
+func (v *Qcow) Extension() string {
+	return QcowType
+}
+
+// NewQcow returns a new qcow format encoder
+func NewQcow() *Qcow {
+	return &Qcow{}
+}

--- a/toolkit/tools/roast/roast.go
+++ b/toolkit/tools/roast/roast.go
@@ -296,6 +296,8 @@ func converterFactory(formatType string) (converter formats.Converter, err error
 		converter = formats.NewInitrd()
 	case formats.OvaType:
 		converter = formats.NewOva()
+	case formats.QcowType:
+		converter = formats.NewQcow()
 	default:
 		err = fmt.Errorf("unsupported output format: %s", formatType)
 	}


### PR DESCRIPTION
Adds `qcow2` as an additional output image format, similar to `vhd` and `vhdx`. Intended primarily as a convenience facility for engineers testing VM images on Linux hosts (e.g., under KVM).

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
Adds `qcow2` as a supported output format from the `roast` tool. This is a minor convenience simplification for engineers who test by booting an output Mariner image under a Linux host (e.g., KVM).

###### Change Log  <!-- REQUIRED -->
Adds new `roast` implementation for `qcow2`; implementation looks very similar to other formats, using `qemu-img` to convert from the input raw image to the desired output type.

###### Does this affect the toolchain?
Affects image generation tools.

###### Test Methodology
Validated with a local build.
