### PR TITLE
Fix missing dependency tracking for spec sources, refactor Makefile to skip shell commands during dry-run

### DIFF
--- a/toolkit/Makefile
+++ b/toolkit/Makefile
@@ -221,6 +221,5 @@ printvar-all-vars: ;
 printvar-verbose-all-vars: $(foreach var,$(interesting_variables),printvar-verbose-$(var))
 printvar-verbose-all-vars: ;
 
-#$(print_targets): ; $(info $($(subst print-,,$@)))
 printvar-%: ; $(info $($(subst printvar-,,$@)))
 printvar-verbose-%: ; $(info $(subst printvar-verbose-,,$@): $($(subst printvar-verbose-,,$@)))

--- a/toolkit/Makefile
+++ b/toolkit/Makefile
@@ -192,6 +192,35 @@ clean:
 	rm -rf $(BUILD_DIR)
 	rm -rf $(toolkit_root)/out
 
-# output version number
-get-version:
-	@echo $(RELEASE_VERSION)
+######## VARIABLE PRINTING ########
+
+# Some common version information that is useful to gather. Generally should be run with the Make flag --quiet
+get-version: printvar-RELEASE_VERSION
+get-dist-tag: printvar-DIST_TAG
+get-release-major: printvar-RELEASE_MAJOR_ID
+
+# Make an easy way to print out the build variables. These must be the last entries in the makefile so that all other
+# files have their variables inluded
+
+# Print out all variables to stdout, either or of the form "<VALUE>" or the verbose form "varname: <VALUE>"
+#   printvar-all-vars
+#   printvar-verbose-all-vars
+
+# Print a specific variable to stdout, using the same format as above
+#   printvar-*
+#   printvar-verbose-*
+
+# Use these targets like so:  `my-var=$(make printvar-MY_VAR --quiet)`
+# The --quiet flag is important to avoid printing extra output
+.PHONY: printvar-all-vars printvar-verbose-all-vars
+
+# Gather the variables we want to print out, removing any automatic .* variables, and the self reference
+interesting_variables = $(filter-out .% interesting_variables, $(sort $(.VARIABLES)))
+printvar-all-vars: $(foreach var,$(interesting_variables),printvar-$(var))
+printvar-all-vars: ;
+printvar-verbose-all-vars: $(foreach var,$(interesting_variables),printvar-verbose-$(var))
+printvar-verbose-all-vars: ;
+
+#$(print_targets): ; $(info $($(subst print-,,$@)))
+printvar-%: ; $(info $($(subst printvar-,,$@)))
+printvar-verbose-%: ; $(info $(subst printvar-verbose-,,$@): $($(subst printvar-verbose-,,$@)))

--- a/toolkit/Makefile
+++ b/toolkit/Makefile
@@ -124,38 +124,9 @@ ifeq ($(USE_PREVIEW_REPO),y)
    endif
 endif
 
-ifneq ($(strip $(SRPM_PACK_LIST)),)
-LOCAL_SPECS = $(wildcard $(addprefix $(SPECS_DIR)/*/,$(addsuffix .spec,$(strip SRPM_PACK_LIST))))
-else # Empty pack list, build all under $(SPECS_DIR)
-LOCAL_SPECS = $(shell find $(SPECS_DIR)/ -type f -name '*.spec')
-endif
-
-LOCAL_SPEC_DIRS = $(foreach spec,$(LOCAL_SPECS),$(dir $(spec)))
-
 CA_CERT     ?=
 TLS_CERT    ?=
 TLS_KEY     ?=
-
-# Build defines
-DIST_TAG           ?= .cm2
-# Running 'git' as the owner of the repo, so it doesn't complain about the repo not belonging to root.
-BUILD_NUMBER       ?= $(shell runuser -u $$(stat -c "%U" $(PROJECT_ROOT)) -- git rev-parse --short HEAD)
-# an empty BUILD_NUMBER breaks the build later on
-ifeq ($(BUILD_NUMBER),)
-   BUILD_NUMBER = non-git
-endif
-RELEASE_MAJOR_ID   ?= 2.0
-# use minor ID defined in file (if exist) otherwise define it
-# note this file must be single line
-ifneq ($(wildcard $(OUT_DIR)/version-minor-id.config),)
-   RELEASE_MINOR_ID ?= .$(shell cat $(OUT_DIR)/version-minor-id.config)
-else
-   RELEASE_MINOR_ID ?= .$(shell date +'%Y%m%d.%H%M')
-endif
-RELEASE_VERSION    ?= $(RELEASE_MAJOR_ID)$(RELEASE_MINOR_ID)
-
-# Image tag - empty by default. Does not apply to the initrd.
-IMAGE_TAG          ?=
 
 # panic,fatal,error,warn,info,debug,trace
 LOG_LEVEL          ?= info
@@ -173,6 +144,9 @@ all: toolchain go-tools chroot-tools
 # Misc function defines
 # Variable prerequisite tracking
 include $(SCRIPTS_DIR)/utils.mk
+
+# Set the variables for build number, distro tag, etc
+include $(SCRIPTS_DIR)/build_tag.mk
 
 # Bootstrap the toolchain's compilers and other tools with:
 #   toolchain, raw-toolchain, clean-toolchain, check-manifests, check-x86_64-manifests, check-aarch64-manifests

--- a/toolkit/Makefile
+++ b/toolkit/Makefile
@@ -214,9 +214,12 @@ get-release-major: printvar-RELEASE_MAJOR_ID
 # The --quiet flag is important to avoid printing extra output
 .PHONY: printvar-all-vars printvar-verbose-all-vars
 
-# Gather the variables we want to print out, removing any automatic .* variables, and the self reference
-interesting_variables = $(filter-out .% interesting_variables, $(sort $(.VARIABLES)))
+# Gather the variables we want to print out, removing any automatic .* variables, and the self reference, along with special characters that may interfere with Make
+sanitize_variables = $(subst ',,$(subst ",,$(subst `,,$(subst \#,,$(subst $$,,$(subst :,,$1))))))
+interesting_variables  = $(filter-out .% interesting_variables, $(sort $(call sanitize_variables,$(.VARIABLES))))
 
+$(warning $(shell env))
+$(warning $(.VARIABLES))
 $(warning DEBUG: printvar-all-vars: $(foreach var,$(interesting_variables),printvar-$(var)))
 
 printvar-all-vars: $(foreach var,$(interesting_variables),printvar-$(var))

--- a/toolkit/Makefile
+++ b/toolkit/Makefile
@@ -216,6 +216,9 @@ get-release-major: printvar-RELEASE_MAJOR_ID
 
 # Gather the variables we want to print out, removing any automatic .* variables, and the self reference
 interesting_variables = $(filter-out .% interesting_variables, $(sort $(.VARIABLES)))
+
+$(warning DEBUG: printvar-all-vars: $(foreach var,$(interesting_variables),printvar-$(var)))
+
 printvar-all-vars: $(foreach var,$(interesting_variables),printvar-$(var))
 printvar-all-vars: ;
 printvar-verbose-all-vars: $(foreach var,$(interesting_variables),printvar-verbose-$(var))

--- a/toolkit/Makefile
+++ b/toolkit/Makefile
@@ -218,10 +218,6 @@ get-release-major: printvar-RELEASE_MAJOR_ID
 sanitize_variables = $(subst ',,$(subst ",,$(subst `,,$(subst \#,,$(subst $$,,$(subst :,,$1))))))
 interesting_variables  = $(filter-out .% interesting_variables, $(sort $(call sanitize_variables,$(.VARIABLES))))
 
-$(warning $(shell env))
-$(warning $(.VARIABLES))
-$(warning DEBUG: printvar-all-vars: $(foreach var,$(interesting_variables),printvar-$(var)))
-
 printvar-all-vars: $(foreach var,$(interesting_variables),printvar-$(var))
 printvar-all-vars: ;
 printvar-verbose-all-vars: $(foreach var,$(interesting_variables),printvar-verbose-$(var))

--- a/toolkit/Makefile
+++ b/toolkit/Makefile
@@ -222,4 +222,6 @@ printvar-verbose-all-vars: $(foreach var,$(interesting_variables),printvar-verbo
 printvar-verbose-all-vars: ;
 
 printvar-%: ; $(info $($(subst printvar-,,$@)))
+	@: # We want to supress 'make: Nothing to be done for ...' so execute a command so make thinks it has done something
 printvar-verbose-%: ; $(info $(subst printvar-verbose-,,$@): $($(subst printvar-verbose-,,$@)))
+	@: # We want to supress 'make: Nothing to be done for ...' so execute a command so make thinks it has done something

--- a/toolkit/docs/coding_guide/makefiles.md
+++ b/toolkit/docs/coding_guide/makefiles.md
@@ -54,3 +54,12 @@ endef
 my_out_folder.txt:  $(depend_MY_OUT_FOLDER)
         @echo $(MY_OUT_FOLDER) changed value! > $@
 ```
+When using `$(shell ...)` consider how long the shell command will run for. When tab completing Make will run with `-n|--dry-run` which will parse the makefiles, and generate a list of possible targets. If the shell command is very slow it will freeze the tab completion until complete. Instead we have an alternate function `$(call shell_real_build_only, ...)` which will only run the command during an actual build.
+
+Consider this especially for complex calls to `find` etc.
+```make
+# Consider replacing this:
+local_specs = $(shell find $(SPECS_DIR)/ -type f -name '*.spec')
+# With this:
+local_specs = $(call shell_real_build_only, find $(SPECS_DIR)/ -type f -name '*.spec')
+```

--- a/toolkit/docs/how_it_works/5_misc.md
+++ b/toolkit/docs/how_it_works/5_misc.md
@@ -6,6 +6,7 @@ Miscellaneous Topics
     - [Config Tracking](#Config-Tracking)
     - [Folder Dependencies](#Folder-Dependencies)
     - [Go Tools Compiling](#Go-Tools-Compiling)
+    - [Disabling shell commands during dry-run](#Disabling-shell-commands-during-dry-run)
 - [Distroless Images](#distroless-images)
 
 ## Chroot
@@ -142,6 +143,11 @@ Each go tool will run a self test when it is built, if test files are available.
 
 ##### `$(go_common_files)`
 This variable tracks all shared files which may be used by any go tool. Shared packages are found in `./tools/internal/` while the `./tools/go.mod` and `./tools/go.sum` files track external dependencies for the go tools. If any of these files change all the go tools will rebuild.
+
+### Disabling shell commands during dry-run
+The `shell_real_build_only` function is offered which will invoke `$(shell ...)` only if the makefile is actually being built. When tab competing, or doing other non-build operations (`-n|--dry-run`) make will still evaluate `$(shell ...)` commands. This can be very costly time-wise for things like `$(shell find $(some_dir)/ -type f)` which may contain large numbers of file. Instead invoking `$(call shell_real_build_only, find $(some_dir)/ -type f)` will only run the command for non-dry-run flows.
+
+When Make is running with `--dry-run` or `-n` it will add the short-form flag `-n` to the automatic variable `$(MAKEFLAGS)`. If the `-n` flag is present the call to `shell_real_build_only` is a no-op, otherwise it pass the shell command through to `$(shell $1)`
 
 ## Distroless images
 

--- a/toolkit/scripts/build_tag.mk
+++ b/toolkit/scripts/build_tag.mk
@@ -1,0 +1,27 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# Contains:
+#	- Tags which define the current build
+
+######## BUILD DEFINES ########
+
+DIST_TAG           ?= .cm2
+# Running 'git' as the owner of the repo, so it doesn't complain about the repo not belonging to root.
+BUILD_NUMBER       ?= $(call shell_real_build_only, runuser -u $$(stat -c "%U" $(PROJECT_ROOT)) -- git rev-parse --short HEAD)
+# an empty BUILD_NUMBER breaks the build later on
+ifeq ($(BUILD_NUMBER),)
+   BUILD_NUMBER = non-git
+endif
+RELEASE_MAJOR_ID   ?= 2.0
+# use minor ID defined in file (if exist) otherwise define it
+# note this file must be single line
+ifneq ($(wildcard $(OUT_DIR)/version-minor-id.config),)
+   RELEASE_MINOR_ID ?= .$(shell cat $(OUT_DIR)/version-minor-id.config)
+else
+   RELEASE_MINOR_ID ?= .$(shell date +'%Y%m%d.%H%M')
+endif
+RELEASE_VERSION    ?= $(RELEASE_MAJOR_ID)$(RELEASE_MINOR_ID)
+
+# Image tag - empty by default. Does not apply to the initrd.
+IMAGE_TAG          ?=

--- a/toolkit/scripts/imggen.mk
+++ b/toolkit/scripts/imggen.mk
@@ -24,7 +24,7 @@ else
 initrd_packages_json     = $(RESOURCES_DIR)/imageconfigs/packagelists/iso-initrd-packages.json
 endif
 initrd_packages_json    += $(RESOURCES_DIR)/imageconfigs/packagelists/accessibility-packages.json
-initrd_assets_files      = $(initrd_packages_json) $(shell find $(initrd_assets_dir) $(initrd_scripts_dir))
+initrd_assets_files      = $(initrd_packages_json) $(call shell_real_build_only, find $(initrd_assets_dir) $(initrd_scripts_dir))
 meta_user_data_files     = $(META_USER_DATA_DIR)/user-data $(META_USER_DATA_DIR)/meta-data
 ova_ovfinfo              = $(assets_dir)/ova/ovfinfo.txt
 ova_vmxtemplate          = $(assets_dir)/ova/vmx-template

--- a/toolkit/scripts/imggen.mk
+++ b/toolkit/scripts/imggen.mk
@@ -53,7 +53,7 @@ initrd_img               = $(IMAGES_DIR)/iso_initrd_arm64/iso-initrd.img
 else
 initrd_img               = $(IMAGES_DIR)/iso_initrd/iso-initrd.img
 endif
-meta_user_data_iso       = ${IMAGES_DIR)/meta-user-data.iso
+meta_user_data_iso       = $(IMAGES_DIR)/meta-user-data.iso
 
 $(call create_folder,$(workspace_dir))
 $(call create_folder,$(imager_disk_output_dir))
@@ -205,4 +205,4 @@ meta-user-data: $(meta_user_data_files)
 	if [ -n "$(TLS_CERT)" ] && [ -n "$(TLS_KEY)" ] && [ -n "$(CA_CERT)" ]; then \
 		$(SCRIPTS_DIR)/addcerts.sh $(meta_user_data_tmp_dir)/user-data $(TLS_CERT) $(TLS_KEY) $(CA_CERT); \
 	fi
-	genisoimage -output $(IMAGES_DIR)/meta-user-data.iso -volid cidata -joliet -rock $(meta_user_data_tmp_dir)/*
+	genisoimage -output $(meta_user_data_iso) -volid cidata -joliet -rock $(meta_user_data_tmp_dir)/*

--- a/toolkit/scripts/imggen.mk
+++ b/toolkit/scripts/imggen.mk
@@ -5,9 +5,9 @@ $(call create_folder,$(IMAGEGEN_DIR))
 
 # Resources
 config_name              = $(notdir $(CONFIG_FILE:%.json=%))
-config_other_files       = $(if $(CONFIG_FILE),$(shell find $(CONFIG_BASE_DIR)))
+config_other_files       = $(if $(CONFIG_FILE),$(call shell_real_build_only, find $(CONFIG_BASE_DIR)))
 assets_dir               = $(RESOURCES_DIR)/assets/
-assets_files             = $(shell find $(assets_dir))
+assets_files             = $(call shell_real_build_only, find $(assets_dir))
 imggen_local_repo        = $(MANIFESTS_DIR)/image/local.repo
 imagefetcher_local_repo  = $(MANIFESTS_DIR)/package/local.repo
 imagefetcher_cloned_repo = $(MANIFESTS_DIR)/package/fetcher.repo
@@ -30,7 +30,7 @@ ova_ovfinfo              = $(assets_dir)/ova/ovfinfo.txt
 ova_vmxtemplate          = $(assets_dir)/ova/vmx-template
 
 # Built RPMs
-imggen_rpms = $(shell find $(RPMS_DIR) -type f -name '*.rpm')
+imggen_rpms = $(call shell_real_build_only, find $(RPMS_DIR) -type f -name '*.rpm')
 
 # Imagegen workspace and cache
 imggen_config_dir                    = $(IMAGEGEN_DIR)/$(config_name)
@@ -47,7 +47,7 @@ image_external_package_cache_summary = $(imggen_config_dir)/image_external_deps.
 # Outputs
 artifact_dir             = $(IMAGES_DIR)/$(config_name)
 imager_disk_output_dir   = $(imggen_config_dir)/imager_output
-imager_disk_output_files = $(shell find $(imager_disk_output_dir) -not -name '*:*' -not -name '* *')
+imager_disk_output_files = $(call shell_real_build_only, find $(imager_disk_output_dir) -not -name '*:*' -not -name '* *')
 ifeq ($(build_arch),aarch64)
 initrd_img               = $(IMAGES_DIR)/iso_initrd_arm64/iso-initrd.img
 else

--- a/toolkit/scripts/pkggen.mk
+++ b/toolkit/scripts/pkggen.mk
@@ -18,15 +18,15 @@ pkggen_local_repo           = $(MANIFESTS_DIR)/package/local.repo
 graphpkgfetcher_cloned_repo = $(MANIFESTS_DIR)/package/fetcher.repo
 
 # SPECs and Built RPMs
-build_specs     = $(shell find $(BUILD_SPECS_DIR)/ -type f -name '*.spec')
+build_specs     = $(call shell_real_build_only, find $(BUILD_SPECS_DIR)/ -type f -name '*.spec')
 build_spec_dirs = $(foreach spec,$(build_specs),$(dir $(spec)))
-pkggen_rpms     = $(shell find $(RPMS_DIR)/*  2>/dev/null )
+pkggen_rpms     = $(call shell_real_build_only, find $(RPMS_DIR)/*  2>/dev/null )
 
 # Pkggen workspace
 cache_working_dir      = $(PKGBUILD_DIR)/tdnf_cache_worker
 parse_working_dir      = $(BUILD_DIR)/spec_parsing
 rpmbuilding_logs_dir   = $(LOGS_DIR)/pkggen/rpmbuilding
-rpm_cache_files        = $(shell find $(CACHED_RPMS_DIR)/)
+rpm_cache_files        = $(call shell_real_build_only, find $(CACHED_RPMS_DIR)/)
 validate-pkggen-config = $(STATUS_FLAGS_DIR)/validate-image-config-pkggen.flag
 
 # Outputs

--- a/toolkit/scripts/pkggen.mk
+++ b/toolkit/scripts/pkggen.mk
@@ -125,7 +125,7 @@ ifeq ($(STOP_ON_FETCH_FAIL),y)
 graphpkgfetcher_extra_flags += --stop-on-failure
 endif
 
-$(cached_file): $(graph_file) $(go-graphpkgfetcher) $(chroot_worker) $(pkggen_local_repo) $(depend_REPO_LIST) $(REPO_LIST) $(shell find $(CACHED_RPMS_DIR)/) $(pkggen_rpms) $(TOOLCHAIN_MANIFEST)
+$(cached_file): $(graph_file) $(go-graphpkgfetcher) $(chroot_worker) $(pkggen_local_repo) $(depend_REPO_LIST) $(REPO_LIST) $(call shell_real_build_only, find $(CACHED_RPMS_DIR)/) $(pkggen_rpms) $(TOOLCHAIN_MANIFEST)
 	mkdir -p $(CACHED_RPMS_DIR)/cache && \
 	$(go-graphpkgfetcher) \
 		--input=$(graph_file) \

--- a/toolkit/scripts/rpmops.sh
+++ b/toolkit/scripts/rpmops.sh
@@ -13,7 +13,8 @@ then
 fi
 
 # Additional macros required to parse spec files.
-DEFINES=(-D "with_check 1" -D "dist $(grep -P "DIST_TAG" "$REPO_ROOT"/toolkit/Makefile | grep -oP "\.cm\d+")")
+DIST_TAG=$(make -qn -f $REPO_ROOT/toolkit/Makefile get-dist-tag)
+DEFINES=(-D "with_check 1" -D "dist $DIST_TAG")
 
 SPECS_DIR="$REPO_ROOT/SPECS"
 

--- a/toolkit/scripts/srpm_expand.mk
+++ b/toolkit/scripts/srpm_expand.mk
@@ -8,7 +8,7 @@ $(call create_folder,$(BUILD_SPECS_DIR))
 
 ######## SRPM EXPANDING ########
 
-srpms = $(shell find $(BUILD_SRPMS_DIR)/ -type f -name '*.src.rpm')
+srpms = $(call shell_real_build_only, find $(BUILD_SRPMS_DIR)/ -type f -name '*.src.rpm')
 srpms_basename = $(foreach srpm,$(srpms),$(notdir $(srpm)))
 srpm_expand_logs_dir = $(LOGS_DIR)/srpm_expand
 srpm_expand_log = $(srpm_expand_logs_dir)/srpm_expand.log

--- a/toolkit/scripts/srpm_pack.mk
+++ b/toolkit/scripts/srpm_pack.mk
@@ -20,11 +20,13 @@ toolchain_spec_list = $(toolchain_build_dir)/toolchain_specs.txt
 srpm_pack_list_file = $(BUILD_SRPMS_DIR)/pack_list.txt
 
 # Configure the list of packages we want to process into SRPMs
-custom_srpm_pack_list = $(strip $(SRPM_PACK_LIST))
-ifneq ($(custom_srpm_pack_list),) # Pack list has user entries in it, only build selected .spec files
-local_specs = $(wildcard $(addprefix $(SPECS_DIR)/*/,$(addsuffix .spec,$(custom_srpm_pack_list))))
+# Strip any whitespace from user input and reasign using override so we can compare it with the empty string
+override SRPM_PACK_LIST := $(strip $(SRPM_PACK_LIST))
+
+ifneq ($(SRPM_PACK_LIST),) # Pack list has user entries in it, only build selected .spec files
+local_specs = $(wildcard $(addprefix $(SPECS_DIR)/*/,$(addsuffix .spec,$(SRPM_PACK_LIST))))
 $(srpm_pack_list_file): $(depend_SRPM_PACK_LIST)
-	@echo $(custom_srpm_pack_list) | tr " " "\n" > $(srpm_pack_list_file)
+	@echo $(SRPM_PACK_LIST) | tr " " "\n" > $(srpm_pack_list_file)
 else # Empty pack list, build all under $(SPECS_DIR)
 local_specs = $(call shell_real_build_only, find $(SPECS_DIR)/ -type f -name '*.spec')
 $(srpm_pack_list_file): $(depend_SRPM_PACK_LIST)
@@ -93,7 +95,7 @@ $(STATUS_FLAGS_DIR)/build_srpms.flag: $(chroot_worker) $(local_specs) $(local_sp
 		--signature-handling=$(SRPM_FILE_SIGNATURE_HANDLING) \
 		--worker-tar=$(chroot_worker) \
 		$(if $(filter y,$(RUN_CHECK)),--run-check) \
-		$(if $(custom_srpm_pack_list),--pack-list=$(srpm_pack_list_file)) \
+		$(if $(SRPM_PACK_LIST),--pack-list=$(srpm_pack_list_file)) \
 		--log-file=$(SRPM_BUILD_LOGS_DIR)/srpmpacker.log \
 		--log-level=$(LOG_LEVEL) && \
 	touch $@

--- a/toolkit/scripts/toolchain.mk
+++ b/toolkit/scripts/toolchain.mk
@@ -26,7 +26,7 @@ toolchain_expected_contents = $(toolchain_build_dir)/expected_archive_contents.t
 raw_toolchain = $(toolchain_build_dir)/toolchain_from_container.tar.gz
 final_toolchain = $(toolchain_build_dir)/toolchain_built_rpms_all.tar.gz
 toolchain_files = \
-	$(shell find $(SCRIPTS_DIR)/toolchain -name *.sh) \
+	$(call shell_real_build_only, find $(SCRIPTS_DIR)/toolchain -name *.sh) \
 	$(SCRIPTS_DIR)/toolchain/container/Dockerfile
 
 TOOLCHAIN_MANIFEST ?= $(TOOLCHAIN_MANIFESTS_DIR)/toolchain_$(build_arch).txt
@@ -249,7 +249,7 @@ $(toolchain_local_temp)%: ;
 #	that all of the toolchain .rpms are correct. The different toolchain sources may have identical files but with
 #	different contents, so always redo the bulk rpm extraction. The $(toolchain_rpms): target will take 
 #	responsibility for updating the .rpms in the final destination if needed.
-$(STATUS_FLAGS_DIR)/toolchain_local_temp.flag: $(selected_toolchain_archive) $(toolchain_local_temp) $(shell find $(toolchain_local_temp)/* 2>/dev/null) $(STATUS_FLAGS_DIR)/toolchain_verify.flag  $(depend_TOOLCHAIN_ARCHIVE) $(depend_REBUILD_TOOLCHAIN)
+$(STATUS_FLAGS_DIR)/toolchain_local_temp.flag: $(selected_toolchain_archive) $(toolchain_local_temp) $(call shell_real_build_only, find $(toolchain_local_temp)/* 2>/dev/null) $(STATUS_FLAGS_DIR)/toolchain_verify.flag  $(depend_TOOLCHAIN_ARCHIVE) $(depend_REBUILD_TOOLCHAIN)
 	mkdir -p $(toolchain_local_temp) && \
 	rm -f $(toolchain_local_temp)/* && \
 	tar -xf $(selected_toolchain_archive) -C $(toolchain_local_temp) --strip-components 1 && \

--- a/toolkit/scripts/toolkit.mk
+++ b/toolkit/scripts/toolkit.mk
@@ -88,7 +88,7 @@ rpms-snapshot: $(rpms_snapshot)
 $(rpms_snapshot): $(rpms_snapshot_per_specs) $(depend_SPECS_DIR)
 	cp $(rpms_snapshot_per_specs) $(rpms_snapshot)
 
-$(rpms_snapshot_per_specs): $(go-rpmssnapshot) $(chroot_worker) $(LOCAL_SPECS) $(LOCAL_SPEC_DIRS) $(SPECS_DIR)
+$(rpms_snapshot_per_specs): $(go-rpmssnapshot) $(chroot_worker) $(local_specs) $(local_spec_dirs) $(SPECS_DIR)
 	@mkdir -p "$(rpms_snapshot_build_dir)"
 	$(go-rpmssnapshot) \
 		--input="$(SPECS_DIR)" \

--- a/toolkit/scripts/tools.mk
+++ b/toolkit/scripts/tools.mk
@@ -54,7 +54,7 @@ define go_util_rule
 go-$(notdir $(tool))=$(tool)
 .PHONY: go-$(notdir $(tool))
 go-$(notdir $(tool)): $(tool)
-$(tool): $(shell find $(TOOLS_DIR)/$(notdir $(tool))/ -type f -name '*.go')
+$(tool): $(call shell_real_build_only, find $(TOOLS_DIR)/$(notdir $(tool))/ -type f -name '*.go')
 endef
 $(foreach tool,$(go_tool_targets),$(eval $(go_util_rule)))
 
@@ -107,7 +107,7 @@ go-fmt-all:
 
 # Formats the test coverage for the tools
 .PHONY: $(BUILD_DIR)/tools/all_tools.coverage
-$(BUILD_DIR)/tools/all_tools.coverage: $(shell find $(TOOLS_DIR)/ -type f -name '*.go')
+$(BUILD_DIR)/tools/all_tools.coverage: $(call shell_real_build_only, find $(TOOLS_DIR)/ -type f -name '*.go')
 	cd $(TOOLS_DIR) && go test -coverpkg=./... -covermode=atomic -coverprofile=$@ ./...
 $(test_coverage_report): $(BUILD_DIR)/tools/all_tools.coverage
 	cd $(TOOLS_DIR) && go tool cover -html=$(BUILD_DIR)/tools/all_tools.coverage -o $@

--- a/toolkit/scripts/utils.mk
+++ b/toolkit/scripts/utils.mk
@@ -37,8 +37,6 @@ $(shell $1)
 endef
 endif # ifeq (n,$(findstring...
 
-myvar = $(call shell_real_build_only, ls)
-
 # Echos a message to console, then calls "exit 1"
 # Of the form: { echo "MSG" ; exit 1 ; }
 #

--- a/toolkit/scripts/utils.mk
+++ b/toolkit/scripts/utils.mk
@@ -20,8 +20,24 @@ build_arch := $(shell uname -m)
 #
 # $1 - Folder path
 define create_folder
-$(shell if [ ! -d $1 ]; then mkdir -p $1 && touch -d @0 $1 ; fi )
+$(call shell_real_build_only, if [ ! -d $1 ]; then mkdir -p $1 && touch -d @0 $1 ; fi )
 endef
+
+# Runs a shell commannd only if we are actually doing a build rather than parsing the makefile for tab-completion etc
+# Make will automatically create the MAKEFLAGS variable which contains each of the flags, non-build commmands will include -n
+# which is the short form of --dry-run.
+#
+# $1 - The full command to run, if we are not doing --dry-run
+ifeq (n,$(findstring n,$(firstword $(MAKEFLAGS))))
+define shell_real_build_only
+endef
+else # ifeq (n,$(findstring...
+define shell_real_build_only
+$(shell $1)
+endef
+endif # ifeq (n,$(findstring...
+
+myvar = $(call shell_real_build_only, ls)
 
 # Echos a message to console, then calls "exit 1"
 # Of the form: { echo "MSG" ; exit 1 ; }

--- a/toolkit/scripts/utils.mk
+++ b/toolkit/scripts/utils.mk
@@ -29,12 +29,9 @@ endef
 #
 # $1 - The full command to run, if we are not doing --dry-run
 ifeq (n,$(findstring n,$(firstword $(MAKEFLAGS))))
-define shell_real_build_only
-endef
+shell_real_build_only =
 else # ifeq (n,$(findstring...
-define shell_real_build_only
-$(shell $1)
-endef
+shell_real_build_only = $(shell $1)
 endif # ifeq (n,$(findstring...
 
 # Echos a message to console, then calls "exit 1"


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
The `input-srpms` build target has not been tracking changes to miscellaneous source files in the `./SPECS/pkg/*` directories. In Mariner 1.0 we tracked these files with https://github.com/microsoft/CBL-Mariner/blob/e72e08fdf005802a4dec67c5fc9906df954b5e36/toolkit/scripts/srpm_pack.mk#L18 which was used as a dependency of srpm packing; however, this was lost in the refactor for 2.0.

Unfortunately adding this dependency tracking back has the unintended side effect of breaking Make's `--dry-run` behavior. This is used when tab completing on the command line among other things. The call to `$(shell find $(local_spec_dirs) -type f -name '*')` takes a long time to complete and is re-run every time the tab-completion runs. 

To avoid this a new function `shell_real_build_only` was added which will only call through to `$(shell ...)` when Make is not running with `--dry-run`. 

```make
# Consider replacing this:
local_specs = $(shell find $(SPECS_DIR)/ -type f -name '*.spec')
# With this:
local_specs = $(call shell_real_build_only, find $(SPECS_DIR)/ -type f -name '*.spec')
```

To make this function available to the build-tag and specs makefile components the code was refactored so it would be parsed after `util.mk`.

Since the version variables have moved a set of variable printing functions has been added.
```bash
var=$(make -qn printvar-MY_VAR)
var=$(make -qn get-dist-tag)
```

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Restore dependency tracking of `$(local_spec_sources)` for `input-srpms` target
- Add `shell_real_build_only` function to conditionally disable calls to `$(shell ...)` during dry-runs.
- Add variable printing support to the makefile

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local builds
