### PR TITLE
Bump Mariner Release version for off-cycle CVE fixes

### DIFF
--- a/SPECS/mariner-release/mariner-release.spec
+++ b/SPECS/mariner-release/mariner-release.spec
@@ -1,7 +1,7 @@
 Summary:        CBL-Mariner release files
 Name:           mariner-release
 Version:        2.0
-Release:        25%{?dist}
+Release:        26%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -62,6 +62,9 @@ EOF
 %config(noreplace) %{_sysconfdir}/issue.net
 
 %changelog
+* Wed Nov 09 2022 Jon Slobodzian <joslobo@microsoft.com> - 2.0-26
+- Updating version for November update.
+
 * Sat Oct 29 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 2.0-25
 - Updating version for a full October release.
 


### PR DESCRIPTION
Bump release version for November 2022 Mariner Release.