### PR TITLE
Updated toolkit's package resolution to accept installed packages.

### DIFF
--- a/toolkit/tools/internal/pkggraph/pkggraph.go
+++ b/toolkit/tools/internal/pkggraph/pkggraph.go
@@ -19,6 +19,7 @@ import (
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/file"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/logger"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/pkgjson"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/sliceutils"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/versioncompare"
 
 	"gonum.org/v1/gonum/graph"
@@ -1417,10 +1418,7 @@ func rpmsProvidedBySRPM(srpmPath string, pkgGraph *PkgGraph, graphMutex *sync.RW
 		rpmsMap[node.RpmPath] = true
 	}
 
-	rpmFiles = make([]string, 0, len(rpmsMap))
-	for rpm := range rpmsMap {
-		rpmFiles = append(rpmFiles, rpm)
-	}
+	rpmFiles = sliceutils.StringsSetToSlice(rpmsMap)
 
 	return
 }

--- a/toolkit/tools/internal/rpm/rpm.go
+++ b/toolkit/tools/internal/rpm/rpm.go
@@ -12,6 +12,7 @@ import (
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/file"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/logger"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/shell"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/sliceutils"
 )
 
 const (
@@ -53,15 +54,28 @@ const (
 )
 
 const (
+	installedRPMRegexRPMIndex = 1
+
 	rpmProgram      = "rpm"
 	rpmSpecProgram  = "rpmspec"
 	rpmBuildProgram = "rpmbuild"
 )
 
-var goArchToRpmArch = map[string]string{
-	"amd64": "x86_64",
-	"arm64": "aarch64",
-}
+var (
+	goArchToRpmArch = map[string]string{
+		"amd64": "x86_64",
+		"arm64": "aarch64",
+	}
+
+	// Output from 'rpm' prints installed RPMs in a line with the following format:
+	//
+	//	D: ========== +++ [name]-[version]-[release].[distribution] [architecture]-linux [hex_value]
+	//
+	// Example:
+	//
+	//	D: ========== +++ systemd-devel-239-42.cm2 x86_64-linux 0x0
+	installedRPMRegex = regexp.MustCompile(`^D: =+ \+{3} (\S+).*$`)
+)
 
 // GetRpmArch converts the GOARCH arch into an RPM arch
 func GetRpmArch(goArch string) (rpmArch string, err error) {
@@ -71,17 +85,6 @@ func GetRpmArch(goArch string) (rpmArch string, err error) {
 	}
 	return
 }
-
-var (
-	// Output from 'rpm' prints installed RPMs in a line with the following format:
-	//
-	//	D: ========== +++ [name]-[version]-[release].[distribution] [architecture]-linux [hex_value]
-	//
-	// Example:
-	//
-	//	D: ========== +++ systemd-devel-239-42.cm2 x86_64-linux 0x0
-	installedRPMLineRegex = regexp.MustCompile(`^D: =+ \+{3} (\S+).*$`)
-)
 
 // SetMacroDir adds RPM_CONFIGDIR=$(newMacroDir) into the shell's environment for the duration of a program.
 // To restore the environment the caller can use shell.SetEnvironment() with the returned origenv.
@@ -318,13 +321,13 @@ func QueryRPMProvides(rpmFile string) (provides []string, err error) {
 // end up being installed after resolving outdated, obsoleted, or conflicting packages.
 func ResolveCompetingPackages(rootDir string, rpmPaths ...string) (resolvedRPMs []string, err error) {
 	const (
-		queryFormat       = ""
-		installedRPMIndex = 1
-		squashErrors      = true
+		queryFormat  = ""
+		squashErrors = true
 	)
 
 	args := []string{
 		"-Uvvh",
+		"--replacepkgs",
 		"--nodeps",
 		"--root",
 		rootDir,
@@ -340,15 +343,15 @@ func ResolveCompetingPackages(rootDir string, rpmPaths ...string) (resolvedRPMs 
 	}
 
 	splitStdout := strings.Split(stderr, "\n")
+	uniqueResolvedRPMs := map[string]bool{}
 	for _, line := range splitStdout {
-		matches := installedRPMLineRegex.FindStringSubmatch(line)
-		if len(matches) == 0 {
-			continue
+		matches := installedRPMRegex.FindStringSubmatch(line)
+		if len(matches) != 0 {
+			uniqueResolvedRPMs[matches[installedRPMRegexRPMIndex]] = true
 		}
-
-		resolvedRPMs = append(resolvedRPMs, matches[installedRPMIndex])
 	}
 
+	resolvedRPMs = sliceutils.StringsSetToSlice(uniqueResolvedRPMs)
 	return
 }
 

--- a/toolkit/tools/internal/sliceutils/sliceutils.go
+++ b/toolkit/tools/internal/sliceutils/sliceutils.go
@@ -41,3 +41,17 @@ func FindMatches(slice []string, isMatch func(string) bool) []string {
 func StringMatch(expected, given interface{}) bool {
 	return expected.(string) == given.(string)
 }
+
+func StringsSetToSlice(inputSet map[string]bool) []string {
+	index := 0
+	outputSlice := make([]string, len(inputSet))
+
+	for element, elementInSet := range inputSet {
+		if elementInSet {
+			outputSlice[index] = element
+			index++
+		}
+	}
+
+	return outputSlice[:index]
+}

--- a/toolkit/tools/internal/sliceutils/sliceutils_test.go
+++ b/toolkit/tools/internal/sliceutils/sliceutils_test.go
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package sliceutils
+
+import (
+	"os"
+	"testing"
+
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/logger"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMain(m *testing.M) {
+	logger.InitStderrLog()
+	os.Exit(m.Run())
+}
+
+func TestShouldCreateEmptySliceFromNil(t *testing.T) {
+	outputSlice := StringsSetToSlice(nil)
+
+	assert.NotNil(t, outputSlice)
+	assert.Empty(t, outputSlice)
+}
+
+func TestShouldCreateEmptySliceFromEmptySet(t *testing.T) {
+	outputSlice := StringsSetToSlice(map[string]bool{})
+
+	assert.NotNil(t, outputSlice)
+	assert.Empty(t, outputSlice)
+}
+
+func TestShouldReturnValuesForAllTrueElementsInSet(t *testing.T) {
+	inputSet := map[string]bool{
+		"A": true,
+		"B": true,
+		"X": false,
+		"Y": false,
+	}
+	outputSlice := StringsSetToSlice(inputSet)
+
+	assert.NotNil(t, outputSlice)
+	assert.Len(t, outputSlice, 2)
+	assert.Contains(t, outputSlice, "A")
+	assert.Contains(t, outputSlice, "B")
+	assert.NotContains(t, outputSlice, "X")
+	assert.NotContains(t, outputSlice, "Y")
+}

--- a/toolkit/tools/scheduler/schedulerutils/buildworker.go
+++ b/toolkit/tools/scheduler/schedulerutils/buildworker.go
@@ -181,10 +181,7 @@ func getBuildDependencies(node *pkggraph.PkgNode, pkgGraph *pkggraph.PkgGraph, g
 		return
 	})
 
-	dependencies = make([]string, 0, len(dependencyLookup))
-	for depName := range dependencyLookup {
-		dependencies = append(dependencies, depName)
-	}
+	dependencies = sliceutils.StringsSetToSlice(dependencyLookup)
 
 	return
 }

--- a/toolkit/tools/scheduler/schedulerutils/graphbuildstate.go
+++ b/toolkit/tools/scheduler/schedulerutils/graphbuildstate.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/logger"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/pkggraph"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/sliceutils"
 )
 
 // nodeState represents the build state of a single node
@@ -90,26 +91,18 @@ func (g *GraphBuildState) BuildFailures() []*BuildResult {
 // ConflictingRPMs will return a list of *.rpm files which should not have been rebuilt.
 // This list is based on the manifest of pre-built toolchain rpms.
 func (g *GraphBuildState) ConflictingRPMs() (rpms []string) {
-	rpms = make([]string, len(g.conflictingRPMs))
-	i := 0
-	for f := range g.conflictingRPMs {
-		rpms[i] = f
-		i++
-	}
+	rpms = sliceutils.StringsSetToSlice(g.conflictingRPMs)
 	sort.Strings(rpms)
+
 	return rpms
 }
 
 // ConflictingSRPMs will return a list of *.src.rpm files which created rpms that should not have been rebuilt.
 // This list is based on the manifest of pre-built toolchain rpms.
 func (g *GraphBuildState) ConflictingSRPMs() (srpms []string) {
-	srpms = make([]string, len(g.conflictingSRPMs))
-	i := 0
-	for f := range g.conflictingSRPMs {
-		srpms[i] = f
-		i++
-	}
+	srpms = sliceutils.StringsSetToSlice(g.conflictingSRPMs)
 	sort.Strings(srpms)
+
 	return srpms
 }
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

Our RPM resolution mechanism is broken, when we have multiple candidates providing the same functionality and the best candidate is already installed in the build chroot. We never hit this case during full builds, but it happens for delta builds, where the set of available packages is the whole content of PMC (including package versions from previous releases) and not just the packages built during this run.

The fix adds the `--replacepkgs` argument to the RPM command we run during resolution, so that it doesn't error out if it finds an installed package. Other changes are just code refactoring.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Made RPM accept installed packages during packages resolution.
- Add a `sliceutils.StringsSetToSlice` helper function + tests.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local tests.
- Full pipeline build: 263626.
