### PR TITLE
update generation 2 boot order during iso installation

### DIFF
--- a/toolkit/resources/imageconfigs/additionalfiles/iso_initrd/root/runliveinstaller
+++ b/toolkit/resources/imageconfigs/additionalfiles/iso_initrd/root/runliveinstaller
@@ -118,7 +118,7 @@ done
 stty echo
 
 if [ $installerExitCode -eq 0 ]; then
-    /bin/bash
+    reboot
 else
     /bin/bash
 fi

--- a/toolkit/resources/imageconfigs/additionalfiles/iso_initrd/root/runliveinstaller
+++ b/toolkit/resources/imageconfigs/additionalfiles/iso_initrd/root/runliveinstaller
@@ -118,7 +118,7 @@ done
 stty echo
 
 if [ $installerExitCode -eq 0 ]; then
-    reboot
+    /bin/bash
 else
     /bin/bash
 fi

--- a/toolkit/tools/imagegen/attendedinstaller/attendedinstaller.go
+++ b/toolkit/tools/imagegen/attendedinstaller/attendedinstaller.go
@@ -145,7 +145,10 @@ func (ai *AttendedInstaller) Run() (config configuration.Config, installationQui
 		return
 	}
 
+	ai.finalConfig.SetDefaultConfig()
+
 	config = ai.finalConfig
+	
 	return
 }
 

--- a/toolkit/tools/imagegen/attendedinstaller/attendedinstaller.go
+++ b/toolkit/tools/imagegen/attendedinstaller/attendedinstaller.go
@@ -148,7 +148,7 @@ func (ai *AttendedInstaller) Run() (config configuration.Config, installationQui
 	ai.finalConfig.SetDefaultConfig()
 
 	config = ai.finalConfig
-	
+
 	return
 }
 

--- a/toolkit/tools/imagegen/configuration/configuration.go
+++ b/toolkit/tools/imagegen/configuration/configuration.go
@@ -304,7 +304,7 @@ func Load(configFilePath string) (config Config, err error) {
 		return
 	}
 
-	config.setDefaultConfig()
+	config.SetDefaultConfig()
 
 	return
 }
@@ -405,7 +405,7 @@ func resolveBaseDirPath(baseDirPath, configFilePath string) (absoluteBaseDirPath
 	return filepath.Abs(baseDirPath)
 }
 
-func (c *Config) setDefaultConfig() {
+func (c *Config) SetDefaultConfig() {
 	c.DefaultSystemConfig = &c.SystemConfigs[0]
 	for i, systemConfig := range c.SystemConfigs {
 		if systemConfig.IsDefault {

--- a/toolkit/tools/imagegen/configuration/configuration.go
+++ b/toolkit/tools/imagegen/configuration/configuration.go
@@ -99,7 +99,7 @@ func (c *Config) GetBootPartition() (partitionIndex int, partition *Partition) {
 	for i, d := range c.Disks {
 		for j, p := range d.Partitions {
 			if p.HasFlag(PartitionFlagBoot) {
-				return j, &c.Disks[i].Partitions[j] 
+				return j, &c.Disks[i].Partitions[j]
 			}
 		}
 	}

--- a/toolkit/tools/imagegen/configuration/configuration.go
+++ b/toolkit/tools/imagegen/configuration/configuration.go
@@ -95,6 +95,17 @@ func (c *Config) GetDiskContainingPartition(partition *Partition) (disk *Disk) {
 	return nil
 }
 
+func (c *Config) GetBootPartition() (partitionIndex int, partition *Partition) {
+	for i, d := range c.Disks {
+		for j, p := range d.Partitions {
+			if p.HasFlag(PartitionFlagBoot) {
+				return j, &c.Disks[i].Partitions[j] 
+			}
+		}
+	}
+	return
+}
+
 // GetKernelCmdLineValue returns the output of a specific option setting in /proc/cmdline
 func GetKernelCmdLineValue(option string) (cmdlineValue string, err error) {
 	const cmdlineFile = "/proc/cmdline"

--- a/toolkit/tools/imagegen/configuration/configuration_test.go
+++ b/toolkit/tools/imagegen/configuration/configuration_test.go
@@ -270,6 +270,14 @@ func TestShouldFailPartLabelWithNoName(t *testing.T) {
 	assert.Equal(t, "failed to parse [Config]: invalid [Config]: [SystemConfig] 'SmallerDisk' mounts a [Partition] 'MyBoot' via PARTLABEL, but it has no [Name]", err.Error())
 }
 
+func TestShouldSucceedReturnPartitionIndexAndObjectForBootPartition(t *testing.T) {
+	actualConfiguration, err := Load("testdata/test_configuration.json")
+	assert.NoError(t, err)
+	bootIndex, bootPartition := actualConfiguration.GetBootPartition()
+	assert.ObjectsAreEqualValues(expectedConfiguration.Disks[0].Partitions[0], bootPartition)
+	assert.Equal(t, 0, bootIndex)
+}
+
 var expectedConfiguration Config = Config{
 	Disks: []Disk{
 		{

--- a/toolkit/tools/imagegen/configuration/systemconfig.go
+++ b/toolkit/tools/imagegen/configuration/systemconfig.go
@@ -70,6 +70,9 @@ func (s *SystemConfig) IsValid() (err error) {
 	// IsDefault must be validated by a parent struct
 
 	// Validate BootType
+	// if (s.BootType != "efi" && s.BootType != "legacy") {
+	// 	return fmt.Errorf("invalid [BootType]: %s. Expecting values of either 'efi' or 'legacy'.", s.Hostname)
+	// }
 
 	// Validate HostName
 	if (!govalidator.IsDNSName(s.Hostname) || strings.Contains(s.Hostname, "_")) && s.Hostname != "" {

--- a/toolkit/tools/imagegen/configuration/systemconfig.go
+++ b/toolkit/tools/imagegen/configuration/systemconfig.go
@@ -69,11 +69,6 @@ func (s *SystemConfig) GetMountpointPartitionSetting(mountPoint string) (partiti
 func (s *SystemConfig) IsValid() (err error) {
 	// IsDefault must be validated by a parent struct
 
-	// Validate BootType
-	// if (s.BootType != "efi" && s.BootType != "legacy") {
-	// 	return fmt.Errorf("invalid [BootType]: %s. Expecting values of either 'efi' or 'legacy'.", s.Hostname)
-	// }
-
 	// Validate HostName
 	if (!govalidator.IsDNSName(s.Hostname) || strings.Contains(s.Hostname, "_")) && s.Hostname != "" {
 		return fmt.Errorf("invalid [Hostname]: %s", s.Hostname)
@@ -81,6 +76,11 @@ func (s *SystemConfig) IsValid() (err error) {
 
 	if strings.TrimSpace(s.Name) == "" {
 		return fmt.Errorf("missing [Name] field")
+	}
+
+	// Validate BootType
+	if s.BootType != "efi" && s.BootType != "legacy" && s.BootType != "none" && s.BootType != "" {
+		return fmt.Errorf("invalid [BootType]: %s. Expecting values of either 'efi', 'legacy', 'none' or empty string.", s.BootType)
 	}
 
 	if len(s.PackageLists) == 0 && len(s.Packages) == 0 {

--- a/toolkit/tools/imagegen/configuration/systemconfig_test.go
+++ b/toolkit/tools/imagegen/configuration/systemconfig_test.go
@@ -140,17 +140,17 @@ func TestShouldSucceedParsingMissingDefaultKernelForRootfs_SystemConfig(t *testi
 func TestShouldFailParsingInvalidKernelForRootfs_SystemConfig(t *testing.T) {
 	var checkedSystemConfig SystemConfig
 
-	rootfsInvalidKernelConfig := validSystemConfig
-	rootfsInvalidKernelConfig.KernelOptions = map[string]string{"_comment": "trick the check", "extra": ""}
-	rootfsInvalidKernelConfig.PartitionSettings = []PartitionSetting{}
+	invalidBootTypeConfig := validSystemConfig
+	invalidBootTypeConfig.KernelOptions = map[string]string{"_comment": "trick the check", "extra": ""}
+	invalidBootTypeConfig.PartitionSettings = []PartitionSetting{}
 
-	rootfsInvalidKernelConfig.Encryption = RootEncryption{}
+	invalidBootTypeConfig.Encryption = RootEncryption{}
 
-	err := rootfsInvalidKernelConfig.IsValid()
+	err := invalidBootTypeConfig.IsValid()
 	assert.Error(t, err)
 	assert.Equal(t, "empty kernel entry found in the [KernelOptions] field (extra); remember that kernels are FORBIDDEN from appearing in any of the [PackageLists] or [Packages]", err.Error())
 
-	err = remarshalJSON(rootfsInvalidKernelConfig, &checkedSystemConfig)
+	err = remarshalJSON(invalidBootTypeConfig, &checkedSystemConfig)
 	assert.Error(t, err)
 	assert.Equal(t, "failed to parse [SystemConfig]: empty kernel entry found in the [KernelOptions] field (extra); remember that kernels are FORBIDDEN from appearing in any of the [PackageLists] or [Packages]", err.Error())
 }
@@ -364,4 +364,13 @@ func TestShouldFailToParseInvalidJSON_SystemConfig(t *testing.T) {
 
 func TestShouldSetRemoveRpmDbToFalse(t *testing.T) {
 	assert.Equal(t, validSystemConfig.RemoveRpmDb, false)
+}
+
+func TestShouldFailParsingUnexpectedBootType_SystemConfig(t *testing.T) {
+	invalidBootTypeConfig := validSystemConfig
+	invalidBootTypeConfig.BootType = "uefi"
+
+	err := invalidBootTypeConfig.IsValid()
+	assert.Error(t, err)
+	assert.Equal(t, "invalid [BootType]: uefi. Expecting values of either 'efi', 'legacy', 'none' or empty string.", err.Error())
 }

--- a/toolkit/tools/liveinstaller/liveinstaller.go
+++ b/toolkit/tools/liveinstaller/liveinstaller.go
@@ -56,7 +56,7 @@ type imagerArguments struct {
 
 type installationDetails struct {
 	installationQuit bool
-	finalConfig configuration.Config
+	finalConfig      configuration.Config
 }
 
 func handleCtrlC(signals chan os.Signal) {
@@ -138,13 +138,13 @@ func installerFactory(forceAttended bool, configFile, templateConfigFile string)
 }
 
 func updateBootOrder(installDetails installationDetails) (err error) {
-	if (installDetails.finalConfig.DefaultSystemConfig.BootType != "efi") {
+	if installDetails.finalConfig.DefaultSystemConfig.BootType != "efi" {
 		logger.Log.Info("No BootType of 'efi' detected. Not attempting to set EFI boot order.")
 		return
 	}
 
 	err = removeOldMarinerBootTargets()
-	if (err != nil) {
+	if err != nil {
 		return
 	}
 
@@ -158,17 +158,17 @@ func updateBootOrder(installDetails installationDetails) (err error) {
 
 func formatBootEntryCreationCommand(installDetails installationDetails) (program string, commandArgs []string) {
 	program = "efibootmgr"
-	
+
 	cfg := installDetails.finalConfig
 	bootPartIdx, bootPart := cfg.GetBootPartition()
 	bootDisk := cfg.GetDiskContainingPartition(bootPart)
 	commandArgs = []string{
-		"-c",                                       // Create a new bootnum and place it in the beginning of the boot order
-		"-d", bootDisk.TargetDisk.Value,            // Specify which disk the boot file is on
-		"-p", fmt.Sprintf("%d", bootPartIdx+1),     // Specify which partition the boot file is on
-		"-l", "'\\EFI\\BOOT\\bootx64.efi'",         // Specify the path for where the boot file is located on the partition
-		"-L", "Mariner",                            // Specify what label you would like to give this boot entry
-		"-v",                                       // Be verbose
+		"-c",                            // Create a new bootnum and place it in the beginning of the boot order
+		"-d", bootDisk.TargetDisk.Value, // Specify which disk the boot file is on
+		"-p", fmt.Sprintf("%d", bootPartIdx+1), // Specify which partition the boot file is on
+		"-l", "'\\EFI\\BOOT\\bootx64.efi'", // Specify the path for where the boot file is located on the partition
+		"-L", "Mariner", // Specify what label you would like to give this boot entry
+		"-v", // Be verbose
 	}
 	return
 }
@@ -176,12 +176,12 @@ func formatBootEntryCreationCommand(installDetails installationDetails) (program
 func removeOldMarinerBootTargets() (err error) {
 	logger.Log.Info("Removing pre-existing 'Mariner' boot targets from efibootmgr")
 	const squashErrors = false
-	program := "efibootmgr"                                            // Default behavior when piped or called without options is to print current boot order in a human-readable format
+	program := "efibootmgr" // Default behavior when piped or called without options is to print current boot order in a human-readable format
 	commandArgs := []string{
-		"|", "grep", "\"Mariner\"",                                    // Filter boot order for Mariner boot targets
-		"|", "sed", "'s/* Mariner//g'",                                // Pruning for just the bootnum 
-		"|", "sed", "'s/Boot*//g'",                                    // Pruning for just the bootnum
-		"|", "xargs", "-t", "-i", "efibootmgr", "-b", "{}", "-B",      // Calling efibootmgr --delete-bootnum (aka `-B`) on each pre-existing bootnum with a Mariner label
+		"|", "grep", "\"Mariner\"", // Filter boot order for Mariner boot targets
+		"|", "sed", "'s/* Mariner//g'", // Pruning for just the bootnum
+		"|", "sed", "'s/Boot*//g'", // Pruning for just the bootnum
+		"|", "xargs", "-t", "-i", "efibootmgr", "-b", "{}", "-B", // Calling efibootmgr --delete-bootnum (aka `-B`) on each pre-existing bootnum with a Mariner label
 	}
 	err = shell.ExecuteLive(squashErrors, program, commandArgs...)
 	return


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Current behavior:
Mariner installs itself onto Disk and reboots. Leaving boot order untouched, which causes seconds of failed booting into PXE after the post-install reboot and subsequent reboots.

Introduced behavior:
When in an EFI boot type'd iso install, we have the ability to set our boot order via the EFI boot manager (i.e., efibootmgr). Using this tool's functionality, and the knowledge specified by our image config files (e.g., unattended.json configs, attendedconfig.json, etc) we can set the first target in the boot order to our shim 'bootx64.efi' which typically lives in /boot/efi

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
Primary:
 - When installing a gen2 image via ISO, set the newly installed shim (bootx64.efi) as the first target in the EFI boot order
 - All 'installFunc' implementations must now pass back a new InstallationDetails object 

Supporting Changes:
 - Change configuration.setDefaultConfig to an exported function, so that config objects not generated by configuration.Load() (i.e., attended installers) can have their default config properly set.
 - Added a new utility function to configuration.go to find the first partition that has the Boot flag set.
 - Split updateBootOrder() into multiple functions, ejectDisk() and updateBootOrder()
 - Added a new function, removeOldMarinerBootTargets(), that removes older entries of the Mariner shim from the efi boot order when attempting to install.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- [(Work Item)/(Bug) 34925438](https://microsoft.visualstudio.com/OS/_sprints/taskboard/Mariner%20Platform/OS/2211?workitem=34925438)


###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Multiple local builds of ISOs (attended and unattended)
- Pipeline build: ([ARM64 - PASSED](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=274138&view=results)) ([AMD64 - PASSED](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=274222&view=results))