### PR TITLE
Changed toolkit, CONFIG_FILE input now overrides initrd_config_json

### DIFF
--- a/toolkit/scripts/imggen.mk
+++ b/toolkit/scripts/imggen.mk
@@ -11,7 +11,9 @@ assets_files             = $(shell find $(assets_dir))
 imggen_local_repo        = $(MANIFESTS_DIR)/image/local.repo
 imagefetcher_local_repo  = $(MANIFESTS_DIR)/package/local.repo
 imagefetcher_cloned_repo = $(MANIFESTS_DIR)/package/fetcher.repo
-ifeq ($(build_arch),aarch64)
+ifdef CONFIG_FILE
+initrd_config_json       = $(CONFIG_FILE)
+else ifeq ($(build_arch),aarch64)
 initrd_config_json       = $(RESOURCES_DIR)/imageconfigs/iso_initrd_arm64.json
 else
 initrd_config_json       = $(RESOURCES_DIR)/imageconfigs/iso_initrd.json


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
Needed for MarinerMOS build to configure initrd artifact.

###### Change Log  <!-- REQUIRED -->
- Changed toolkit, CONFIG_FILE input to imggen.mk, now overrides initrd_config_json

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO** only toolkit, not toolchain

###### Test Methodology
- Pipeline build id: 264992
