### PR TITLE
Mitigate CVE-2020-35505 by disabling qemu emulation for am53c974 devi…

### DIFF
--- a/SPECS/qemu-kvm/CVE-2020-35505.patch
+++ b/SPECS/qemu-kvm/CVE-2020-35505.patch
@@ -1,0 +1,10 @@
+We are disabling the qemu support for am53c974 to prevent using it and
+exposing the CVE-2020-35505 vulnerability.
+--- a/hw/scsi/esp-pci.c	2022-11-15 15:30:07.808716734 -0800
++++ b/hw/scsi/esp-pci.c	2022-11-15 15:30:13.704819894 -0800
+@@ -532,4 +532,4 @@
+     type_register_static(&dc390_info);
+ }
+ 
+-type_init(esp_pci_register_types)
++// type_init(esp_pci_register_types)

--- a/SPECS/qemu-kvm/qemu-kvm.spec
+++ b/SPECS/qemu-kvm/qemu-kvm.spec
@@ -1,7 +1,7 @@
 Summary:        QEMU is a machine emulator and virtualizer
 Name:           qemu-kvm
 Version:        4.2.0
-Release:        45%{?dist}
+Release:        46%{?dist}
 License:        GPLv2 AND GPLv2+ AND CC-BY AND BSD
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -90,6 +90,7 @@ Patch1009:      CVE-2022-35414.patch
 Patch1010:      CVE-2022-0358.nopatch
 # CVE and provided patch not applicable to v4.2.0 hence adding nopatch.
 Patch1011:      CVE-2022-26354.nopatch
+Patch1012:      CVE-2020-35505.patch
 
 BuildRequires:  alsa-lib-devel
 BuildRequires:  glib-devel
@@ -216,6 +217,9 @@ fi
 %{_bindir}/qemu-nbd
 
 %changelog
+* Tue Nov 15 2022 George Mileka <gmileka@microsoft.com> - 4.2.0-46
+- Patch CVE-2020-35505.
+
 * Tue Oct 18 2022 Neha Agarwal <nehaagarwal@microsoft.com> - 4.2.0-45
 - Nopatch CVE-2022-26354.
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->

This fix mitigates the CVE-2020-35505 vulnerability in the qemu emulation of the am53c974 scsi device by disabling that device and making it unavailable to users.

###### Change Log  <!-- REQUIRED -->
- Packages Updated:
  - qemu-kvm
- CVEs fixed:
  - CVE-2020-35505

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2020-35505

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: [265187](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=265187&view=results).
- Install public Mariner iso.
- Validated qemu device am53c974 is present by running: `/usr/bin/qemu-system-x86_64 -device help | grep -i am53c974`
- Uninstalled both qemu-img and qemu-kvm using `rpm -e pkg-name`.
- Installed newly build qemu-img and qemu-kvm using `rpm -ivvh file-name`.
- Validated qemu device am53c974 is NOT present by running: `/usr/bin/qemu-system-x86_64 -device help | grep -i am53c974`