### PR TITLE
Gate systemd's preset-all so it runs only on first install

### DIFF
--- a/SPECS/systemd/systemd-bootstrap.spec
+++ b/SPECS/systemd/systemd-bootstrap.spec
@@ -1,7 +1,7 @@
 Summary:        Bootstrap version of systemd. Workaround for systemd circular dependency.
 Name:           systemd-bootstrap
 Version:        250.3
-Release:        7%{?dist}
+Release:        8%{?dist}
 License:        LGPLv2+ AND GPLv2+ AND MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -141,7 +141,13 @@ install -m 0644 %{SOURCE3} %{buildroot}/%{_sysconfdir}/systemd/network
 # Enable default systemd units.
 %post
 /sbin/ldconfig
-systemctl preset-all
+# Only force the presets to default values when first installing systemd ($1 = # of currently installed pacakges,
+# $1 >= 2 for upgrades). This will resolve issues where systemd may be installed after a package that enables a service
+# during the same transaction, leaving the service disabled unexpectedly. Once systemd is installed all future attempts
+# to enable/disable services should succeed.
+if [ $1 -eq 1 ]; then
+     systemctl preset-all
+fi
 
 %postun -p /sbin/ldconfig
 
@@ -231,6 +237,9 @@ systemctl preset-all
 %{_datadir}/pkgconfig/udev.pc
 
 %changelog
+* Wed Nov 16 2022 Daniel McIlvaney <damcilva@microsoft.com> - 250.3-8
+- Conditionally run systemctl preset-all only when first installing systemd, not on upgrades
+
 * Tue Oct 04 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 250.3-7
 - Fixing default log location.
 

--- a/SPECS/systemd/systemd.spec
+++ b/SPECS/systemd/systemd.spec
@@ -1,7 +1,7 @@
 Summary:        Systemd-250
 Name:           systemd
 Version:        250.3
-Release:        9%{?dist}
+Release:        10%{?dist}
 License:        LGPLv2+ AND GPLv2+ AND MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -169,7 +169,13 @@ meson test -C build
 # Enable default systemd units.
 %post
 /sbin/ldconfig
-systemctl preset-all
+# Only force the presets to default values when first installing systemd ($1 = # of currently installed pacakges,
+# $1 >= 2 for upgrades). This will resolve issues where systemd may be installed after a package that enables a service
+# during the same transaction, leaving the service disabled unexpectedly. Once systemd is installed all future attempts
+# to enable/disable services should succeed.
+if [ $1 -eq 1 ]; then
+     systemctl preset-all
+fi
 
 %postun -p /sbin/ldconfig
 
@@ -261,6 +267,9 @@ systemctl preset-all
 %files lang -f %{name}.lang
 
 %changelog
+* Wed Nov 16 2022 Daniel McIlvaney <damcilva@microsoft.com> - 250.3-10
+- Conditionally run systemctl preset-all only when first installing systemd, not on upgrades
+
 * Tue Oct 04 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 250.3-9
 - Fixing default log location.
 

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -545,10 +545,10 @@ sqlite-devel-3.39.2-1.cm2.aarch64.rpm
 sqlite-libs-3.39.2-1.cm2.aarch64.rpm
 swig-4.0.2-3.cm2.aarch64.rpm
 swig-debuginfo-4.0.2-3.cm2.aarch64.rpm
-systemd-bootstrap-250.3-7.cm2.aarch64.rpm
-systemd-bootstrap-debuginfo-250.3-7.cm2.aarch64.rpm
-systemd-bootstrap-devel-250.3-7.cm2.aarch64.rpm
-systemd-bootstrap-rpm-macros-250.3-7.cm2.noarch.rpm
+systemd-bootstrap-250.3-8.cm2.aarch64.rpm
+systemd-bootstrap-debuginfo-250.3-8.cm2.aarch64.rpm
+systemd-bootstrap-devel-250.3-8.cm2.aarch64.rpm
+systemd-bootstrap-rpm-macros-250.3-8.cm2.noarch.rpm
 tar-1.34-1.cm2.aarch64.rpm
 tar-debuginfo-1.34-1.cm2.aarch64.rpm
 tdnf-3.2.2-4.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -545,10 +545,10 @@ sqlite-devel-3.39.2-1.cm2.x86_64.rpm
 sqlite-libs-3.39.2-1.cm2.x86_64.rpm
 swig-4.0.2-3.cm2.x86_64.rpm
 swig-debuginfo-4.0.2-3.cm2.x86_64.rpm
-systemd-bootstrap-250.3-7.cm2.x86_64.rpm
-systemd-bootstrap-debuginfo-250.3-7.cm2.x86_64.rpm
-systemd-bootstrap-devel-250.3-7.cm2.x86_64.rpm
-systemd-bootstrap-rpm-macros-250.3-7.cm2.noarch.rpm
+systemd-bootstrap-250.3-8.cm2.x86_64.rpm
+systemd-bootstrap-debuginfo-250.3-8.cm2.x86_64.rpm
+systemd-bootstrap-devel-250.3-8.cm2.x86_64.rpm
+systemd-bootstrap-rpm-macros-250.3-8.cm2.noarch.rpm
 tar-1.34-1.cm2.x86_64.rpm
 tar-debuginfo-1.34-1.cm2.x86_64.rpm
 tdnf-3.2.2-4.cm2.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
When upgrading systemd, sometimes user customized services would be enabled/disabled unexpectedly. Our systemd package was calling `systemctl preset-all` during upgrade, which would clear any user customizations and reset all services back to their default enabled/disabled state.

We should only run this during the first install of systemd to guard against transaction ordering issues (say a transaction requires both a service and systemd, but rpm may occasionally choose a poor ordering even if the service has `Requires(post): systemd` if the transactions are complex). Once systemd is installed all future attempts to configure services during install should function normally.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Gate `systemd`'s `%post: systemctl preset-all` behind a conditional that only runs on first install.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Testing to follow
