### PR TITLE
Bump Mariner Release version for off-cycle CVE fixes

### DIFF
--- a/SPECS/mariner-release/mariner-release.spec
+++ b/SPECS/mariner-release/mariner-release.spec
@@ -1,7 +1,7 @@
 Summary:        CBL-Mariner release files
 Name:           mariner-release
 Version:        2.0
-Release:        26%{?dist}
+Release:        27%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -62,6 +62,9 @@ EOF
 %config(noreplace) %{_sysconfdir}/issue.net
 
 %changelog
+* Mon Nov 21 2022 Mandeep Plaha <mandeepplaha@microsoft.com> - 2.0.27
+- Updating version for November update 2.
+
 * Wed Nov 09 2022 Jon Slobodzian <joslobo@microsoft.com> - 2.0-26
 - Updating version for November update.
 


### PR DESCRIPTION
Bump release version for November 2022 Update 2 Mariner Release.