### PR TITLE
Removed explicit `initrd` target from the toolkit.

### DIFF
--- a/toolkit/scripts/imggen.mk
+++ b/toolkit/scripts/imggen.mk
@@ -51,7 +51,7 @@ $(call create_folder,$(imager_disk_output_dir))
 $(call create_folder,$(artifact_dir))
 $(call create_folder,$(meta_user_data_tmp_dir))
 
-.PHONY: fetch-image-packages fetch-external-image-packages make-raw-image image iso initrd validate-image-config clean-imagegen
+.PHONY: fetch-image-packages fetch-external-image-packages make-raw-image image iso validate-image-config clean-imagegen
 
 clean: clean-imagegen
 clean-imagegen:
@@ -163,16 +163,12 @@ $(image_external_package_cache_summary): $(cached_file) $(go-imagepkgfetcher) $(
 		--output-summary-file=$@ \
 		--output-dir=$(external_rpm_cache)
 
-# Stand alone target to build just the initrd, should not be used in conjunction with other targets. Use the 'iso' target instead.
-initrd: $(go-liveinstaller) $(go-imager)
+$(initrd_img): $(go-liveinstaller) $(go-imager) $(initrd_config_json) $(INITRD_CACHE_SUMMARY)
 	# Recursive make call to build the initrd image $(artifact_dir)/iso-initrd.img
-	$(MAKE) image CONFIG_FILE=$(initrd_config_json) IMAGE_CACHE_SUMMARY=$(INITRD_CACHE_SUMMARY) IMAGE_TAG=
+	$(MAKE) image MAKEOVERRIDES= CONFIG_FILE=$(initrd_config_json) IMAGE_CACHE_SUMMARY=$(INITRD_CACHE_SUMMARY) IMAGE_TAG=
 
-iso: $(go-isomaker) $(go-liveinstaller) $(go-imager) $(depend_CONFIG_FILE) $(CONFIG_FILE) $(initrd_config_json) $(validate-config) $(image_package_cache_summary)
+iso: $(go-isomaker) $(go-imager) $(depend_CONFIG_FILE) $(CONFIG_FILE) $(initrd_img) $(validate-config) $(image_package_cache_summary)
 	$(if $(CONFIG_FILE),,$(error Must set CONFIG_FILE=))
-	# Recursive make call to build the initrd image iso_initrd/iso-initrd.img
-	# Called here instead of as a traditional dependency to make sure package builds are done sequentially for each config.
-	$(MAKE) image CONFIG_FILE=$(initrd_config_json) IMAGE_CACHE_SUMMARY=$(INITRD_CACHE_SUMMARY) IMAGE_TAG= && \
 	$(go-isomaker) \
 		--base-dir $(CONFIG_BASE_DIR) \
 		--build-dir $(workspace_dir) \


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

Conversation with one of our partners made me realize that the explicit `initrd` target makes it seem like this is part of Mariner's toolkit public interface and can/should be used when building initrds. I'm modifying the toolkit to make it clearer that the official image building interfaces are only `image` and `iso`.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Replaced the `initrd` target with the initrd's file path.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline buddy build: 266631
