### PR TITLE
Add srpmdownloader to address DOWNLOAD_SRPMS 

### DIFF
--- a/toolkit/docs/building/building.md
+++ b/toolkit/docs/building/building.md
@@ -657,7 +657,7 @@ To reproduce an ISO build, run the same make invocation as before, but set:
 | UNATTENDED_INSTALLER          |                                                                                                        | Create unattended ISO installer if set. Overrides all other installer options.
 | PACKAGE_BUILD_LIST            |                                                                                                        | Additional packages to build. The package will be skipped if the build system thinks it is already up-to-date.
 | PACKAGE_REBUILD_LIST          |                                                                                                        | Always rebuild this package, even if it is up-to-date. Base package name, will match all virtual packages produced as well.
-| SRPM_PACK_LIST                |                                                                                                        | List of spec basenames to build into SRPMs. If empty, all specs under `$(SPECS_DIR)` will be packed.
+| SRPM_PACK_LIST                |                                                                                                        | List of spec basenames to download SRPMs for or build into SRPMs. If empty, all specs under `$(SPECS_DIR)` will be packed.
 | SSH_KEY_FILE                  |                                                                                                        | Use with `make meta-user-data` to add the ssh key from this file into `user-data`.
 
 ---

--- a/toolkit/scripts/srpm_pack.mk
+++ b/toolkit/scripts/srpm_pack.mk
@@ -51,23 +51,21 @@ $(BUILD_SRPMS_DIR): $(STATUS_FLAGS_DIR)/build_srpms.flag
 	@echo Finished updating $@
 
 ifeq ($(DOWNLOAD_SRPMS),y)
-$(STATUS_FLAGS_DIR)/build_srpms.flag: $(LOCAL_SPECS) $(LOCAL_SPEC_DIRS) $(SPECS_DIR)
-	for spec in $(LOCAL_SPECS); do \
-		spec_file=$${spec} && \
-		srpm_file=$$(rpmspec -q $${spec_file} --srpm --define='with_check 1' --define='dist $(DIST_TAG)' --queryformat %{NAME}-%{VERSION}-%{RELEASE}.src.rpm) && \
-		for url in $(SRPM_URL_LIST); do \
-			wget $${url}/$${srpm_file} \
-				-O $(BUILD_SRPMS_DIR)/$${srpm_file} \
-				--no-verbose \
-				$(if $(TLS_CERT),--certificate=$(TLS_CERT)) \
-				$(if $(TLS_KEY),--private-key=$(TLS_KEY)) \
-				&& \
-			touch $(BUILD_SRPMS_DIR)/$${srpm_file} && \
-			break; \
-		done || $(call print_error,Loop in $@ failed) ; \
-		{ [ -f $(BUILD_SRPMS_DIR)/$${srpm_file} ] || \
-			$(call print_error,Failed to download $${srpm_file});  } \
-	done || $(call print_error,Loop in $@ failed) ; \
+$(STATUS_FLAGS_DIR)/build_srpms.flag: $(chroot_worker) $(LOCAL_SPECS) $(LOCAL_SPEC_DIRS) $(SPECS_DIR) $(go-srpmdownloader) $(srpm_pack_list_file)
+	srpm_file=$$($(go-srpmdownloader) \
+		--dir=$(SPECS_DIR) \
+		--output-dir=$(BUILD_SRPMS_DIR) \
+		--dist-tag=$(DIST_TAG) \
+		--srpm-url-list="$(SRPM_URL_LIST)" \
+		--ca-cert=$(CA_CERT) \
+		--tls-cert=$(TLS_CERT) \
+		--tls-key=$(TLS_KEY) \
+		--build-dir=$(SRPM_BUILD_CHROOT_DIR) \
+		--worker-tar=$(chroot_worker)  \
+		$(if $(SRPM_PACK_LIST),--srpm-list=$(srpm_pack_list_file)) \
+		$(if $(filter y,$(RUN_CHECK)),--run-check) \
+		--log-file=$(SRPM_BUILD_LOGS_DIR)/srpmdownloader.log \
+		--log-level=$(LOG_LEVEL) )  && \
 	touch $@
 
 # Since all the SRPMs are being downloaded by the "input-srpms" target there is no need to differentiate toolchain srpms.

--- a/toolkit/scripts/srpm_pack.mk
+++ b/toolkit/scripts/srpm_pack.mk
@@ -51,7 +51,7 @@ $(BUILD_SRPMS_DIR): $(STATUS_FLAGS_DIR)/build_srpms.flag
 	@echo Finished updating $@
 
 ifeq ($(DOWNLOAD_SRPMS),y)
-$(STATUS_FLAGS_DIR)/build_srpms.flag: $(chroot_worker) $(LOCAL_SPECS) $(LOCAL_SPEC_DIRS) $(SPECS_DIR) $(go-srpmdownloader) $(srpm_pack_list_file)
+$(STATUS_FLAGS_DIR)/build_srpms.flag: $(chroot_worker) $(LOCAL_SPECS) $(LOCAL_SPEC_DIRS) $(SPECS_DIR) $(depend_SPEC_DIRS) $(go-srpmdownloader) $(srpm_pack_list_file)
 	srpm_file=$$($(go-srpmdownloader) \
 		--dir=$(SPECS_DIR) \
 		--output-dir=$(BUILD_SRPMS_DIR) \

--- a/toolkit/scripts/tools.mk
+++ b/toolkit/scripts/tools.mk
@@ -30,6 +30,7 @@ go_tool_list = \
 	rpmssnapshot \
 	scheduler \
 	specreader \
+	srpmdownloader \
 	srpmpacker \
 	validatechroot \
 

--- a/toolkit/tools/internal/sliceutils/sliceutils.go
+++ b/toolkit/tools/internal/sliceutils/sliceutils.go
@@ -55,3 +55,21 @@ func StringsSetToSlice(inputSet map[string]bool) []string {
 
 	return outputSlice[:index]
 }
+
+// RemoveDuplicateStrings will remove duplicate entries from a string slice
+func RemoveDuplicateStrings(packList []string) (deduplicatedPackList []string) {
+	var (
+		packListSet = make(map[string]struct{})
+		exists      = struct{}{}
+	)
+
+	for _, entry := range packList {
+		packListSet[entry] = exists
+	}
+
+	for entry := range packListSet {
+		deduplicatedPackList = append(deduplicatedPackList, entry)
+	}
+
+	return
+}

--- a/toolkit/tools/internal/sliceutils/sliceutils.go
+++ b/toolkit/tools/internal/sliceutils/sliceutils.go
@@ -58,18 +58,9 @@ func StringsSetToSlice(inputSet map[string]bool) []string {
 
 // RemoveDuplicateStrings will remove duplicate entries from a string slice
 func RemoveDuplicateStrings(packList []string) (deduplicatedPackList []string) {
-	var (
-		packListSet = make(map[string]struct{})
-		exists      = struct{}{}
-	)
-
+	packListSet := map[string]bool{}
 	for _, entry := range packList {
-		packListSet[entry] = exists
+		packListSet[entry] = true
 	}
-
-	for entry := range packListSet {
-		deduplicatedPackList = append(deduplicatedPackList, entry)
-	}
-
-	return
+	return StringsSetToSlice(packListSet)
 }

--- a/toolkit/tools/internal/sliceutils/sliceutils_test.go
+++ b/toolkit/tools/internal/sliceutils/sliceutils_test.go
@@ -46,3 +46,22 @@ func TestShouldReturnValuesForAllTrueElementsInSet(t *testing.T) {
 	assert.NotContains(t, outputSlice, "X")
 	assert.NotContains(t, outputSlice, "Y")
 }
+
+func TestShouldReturnNoDuplicates(t *testing.T) {
+	inputSet := []string{
+		"A",
+		"A",
+		"B",
+		"A",
+		"C",
+		"B",
+		"B",
+	}
+	outputSlice := RemoveDuplicateStrings(inputSet)
+
+	assert.NotNil(t, outputSlice)
+	assert.Len(t, outputSlice, 3)
+	assert.Contains(t, outputSlice, "A")
+	assert.Contains(t, outputSlice, "B")
+	assert.Contains(t, outputSlice, "C")
+}

--- a/toolkit/tools/internal/srpm/srpm.go
+++ b/toolkit/tools/internal/srpm/srpm.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 package srpm
 
 import (

--- a/toolkit/tools/internal/srpm/srpm.go
+++ b/toolkit/tools/internal/srpm/srpm.go
@@ -1,0 +1,147 @@
+package srpm
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/buildpipeline"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/directory"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/logger"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/safechroot"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/sliceutils"
+)
+
+// ParsePackListFile will parse a list of packages to pack if one is specified.
+// Duplicate list entries in the file will be removed.
+func ParsePackListFile(packListFile string) (packList []string, err error) {
+	if packListFile == "" {
+		return
+	}
+
+	file, err := os.Open(packListFile)
+	if err != nil {
+		return
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line != "" {
+			packList = append(packList, line)
+		}
+	}
+
+	if len(packList) == 0 {
+		err = fmt.Errorf("cannot have empty pack list (%s)", packListFile)
+	}
+
+	packList = sliceutils.RemoveDuplicateStrings(packList)
+
+	return
+}
+
+// FindSPECFiles finds all SPEC files that should be considered for packing.
+// Takes into consideration a packList if provided.
+func FindSPECFiles(specsDir string, packList []string) (specFiles []string, err error) {
+	if len(packList) == 0 {
+		specSearch := filepath.Join(specsDir, "**/*.spec")
+		specFiles, err = filepath.Glob(specSearch)
+	} else {
+		for _, specName := range packList {
+			var specFile []string
+
+			specSearch := filepath.Join(specsDir, fmt.Sprintf("**/%s.spec", specName))
+			specFile, err = filepath.Glob(specSearch)
+
+			// If a SPEC is in the pack list, it must be packed.
+			if err != nil {
+				return
+			}
+			if len(specFile) != 1 {
+				if strings.HasPrefix(specName, "msopenjdk-11") {
+					logger.Log.Debugf("Ignoring missing match for '%s', which is externally-provided and thus doesn't have a local spec.", specName)
+					continue
+				} else {
+					err = fmt.Errorf("unexpected number of matches (%d) for spec file (%s)", len(specFile), specName)
+					return
+				}
+			}
+
+			specFiles = append(specFiles, specFile[0])
+		}
+	}
+
+	return
+}
+
+// createChroot creates a chroot to pack SRPMs inside of.
+func CreateChroot(workerTar, buildDir, outDir, specsDir string) (chroot *safechroot.Chroot, newBuildDir, newOutDir, newSpecsDir string, err error) {
+	const (
+		chrootName       = "srpmpacker_chroot"
+		existingDir      = false
+		leaveFilesOnDisk = false
+
+		outMountPoint    = "/output"
+		specsMountPoint  = "/specs"
+		buildDirInChroot = "/build"
+	)
+
+	extraMountPoints := []*safechroot.MountPoint{
+		safechroot.NewMountPoint(outDir, outMountPoint, "", safechroot.BindMountPointFlags, ""),
+		safechroot.NewMountPoint(specsDir, specsMountPoint, "", safechroot.BindMountPointFlags, ""),
+	}
+
+	extraDirectories := []string{
+		buildDirInChroot,
+	}
+
+	newBuildDir = buildDirInChroot
+	newOutDir = outMountPoint
+	newSpecsDir = specsMountPoint
+
+	chrootDir := filepath.Join(buildDir, chrootName)
+	chroot = safechroot.NewChroot(chrootDir, existingDir)
+
+	err = chroot.Initialize(workerTar, extraDirectories, extraMountPoints)
+	if err != nil {
+		return
+	}
+
+	defer func() {
+		if err != nil {
+			closeErr := chroot.Close(leaveFilesOnDisk)
+			if closeErr != nil {
+				logger.Log.Errorf("Failed to close chroot, err: %s", closeErr)
+			}
+		}
+	}()
+
+	// If this is container build then the bind mounts will not have been created.
+	if !buildpipeline.IsRegularBuild() {
+		// Copy in all of the SPECs so they can be packed.
+		specsInChroot := filepath.Join(chroot.RootDir(), newSpecsDir)
+		err = directory.CopyContents(specsDir, specsInChroot)
+		if err != nil {
+			return
+		}
+
+		// Copy any prepacked srpms so they will not be repacked.
+		srpmsInChroot := filepath.Join(chroot.RootDir(), newOutDir)
+		err = directory.CopyContents(outDir, srpmsInChroot)
+		if err != nil {
+			return
+		}
+	}
+
+	// Networking support is needed to download sources.
+	files := []safechroot.FileToCopy{
+		{Src: "/etc/resolv.conf", Dest: "/etc/resolv.conf"},
+	}
+
+	err = chroot.AddFiles(files...)
+	return
+}

--- a/toolkit/tools/internal/srpm/srpm.go
+++ b/toolkit/tools/internal/srpm/srpm.go
@@ -14,36 +14,6 @@ import (
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/sliceutils"
 )
 
-// ParsePackListFile will parse a list of packages to pack if one is specified.
-// Duplicate list entries in the file will be removed.
-func ParsePackListFile(packListFile string) (packList []string, err error) {
-	if packListFile == "" {
-		return
-	}
-
-	file, err := os.Open(packListFile)
-	if err != nil {
-		return
-	}
-	defer file.Close()
-
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if line != "" {
-			packList = append(packList, line)
-		}
-	}
-
-	if len(packList) == 0 {
-		err = fmt.Errorf("cannot have empty pack list (%s)", packListFile)
-	}
-
-	packList = sliceutils.RemoveDuplicateStrings(packList)
-
-	return
-}
-
 // FindSPECFiles finds all SPEC files that should be considered for packing.
 // Takes into consideration a packList if provided.
 func FindSPECFiles(specsDir string, packList []string) (specFiles []string, err error) {
@@ -78,8 +48,38 @@ func FindSPECFiles(specsDir string, packList []string) (specFiles []string, err 
 	return
 }
 
-// createChroot creates a chroot to pack SRPMs inside of.
-func CreateChroot(workerTar, buildDir, outDir, specsDir string) (chroot *safechroot.Chroot, newBuildDir, newOutDir, newSpecsDir string, err error) {
+// ParsePackListFile will parse a list of packages to pack if one is specified.
+// Duplicate list entries in the file will be removed.
+func ParsePackListFile(packListFile string) (packList []string, err error) {
+	if packListFile == "" {
+		return
+	}
+
+	file, err := os.Open(packListFile)
+	if err != nil {
+		return
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line != "" {
+			packList = append(packList, line)
+		}
+	}
+
+	if len(packList) == 0 {
+		err = fmt.Errorf("cannot have empty pack list (%s)", packListFile)
+	}
+
+	packList = sliceutils.RemoveDuplicateStrings(packList)
+
+	return
+}
+
+// createSRPMChroot creates a chroot to pack SRPMs inside of.
+func CreateSRPMChroot(workerTar, buildDir, outDir, specsDir string) (chroot *safechroot.Chroot, newBuildDir, newOutDir, newSpecsDir string, err error) {
 	const (
 		chrootName       = "srpmpacker_chroot"
 		existingDir      = false

--- a/toolkit/tools/internal/srpm/srpm_test.go
+++ b/toolkit/tools/internal/srpm/srpm_test.go
@@ -1,0 +1,117 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package srpm
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/logger"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMain(m *testing.M) {
+	logger.InitStderrLog()
+	os.Exit(m.Run())
+}
+
+func TestShouldReturnArrayOfSpecs(t *testing.T) {
+	inputSet := []string{
+		"test-a",
+	}
+	var emptyInputSet []string
+	specDir := "./testout"
+	fileA := "test-a.spec"
+	fileB := "test-b.spec"
+	filepathA := filepath.Join(specDir, fileA)
+	filepathB := filepath.Join(specDir, fileB)
+
+	os.Mkdir(specDir, 0777)
+	defer os.Remove(specDir)
+
+	fileAPtr, err := os.Create(filepathA)
+	assert.NoError(t, err)
+	defer os.Remove(filepathA)
+	defer fileAPtr.Close()
+
+	fileBPtr, err := os.Create(filepathB)
+	assert.NoError(t, err)
+	defer os.Remove(filepathB)
+	defer fileBPtr.Close()
+
+	outputSlice, err := FindSPECFiles("./", inputSet)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, outputSlice)
+	assert.Len(t, outputSlice, 1)
+	assert.Contains(t, outputSlice, filepathA)
+
+	outputSlice, err = FindSPECFiles("./", emptyInputSet)
+	assert.NoError(t, err)
+	assert.NotNil(t, outputSlice)
+	assert.Contains(t, outputSlice, filepathA)
+	assert.Contains(t, outputSlice, filepathB)
+
+}
+
+func TestShouldFailMissingSpec(t *testing.T) {
+	badInputSet := []string{
+		"test-a",
+	}
+	specDir := "./"
+	outputSlice, err := FindSPECFiles(specDir, badInputSet)
+	assert.Error(t, err)
+	assert.Equal(t, "unexpected number of matches (0) for spec file (test-a)", err.Error())
+	assert.Nil(t, outputSlice)
+}
+
+func TestShouldParseFileForSpecs(t *testing.T) {
+	d1 := []byte("test-a\ntest-b\ntest-a")
+	specDir := "./testout"
+	fileA := "packlist.txt"
+	filepathA := filepath.Join(specDir, fileA)
+
+	os.Mkdir(specDir, 0777)
+	defer os.Remove(specDir)
+
+	fileAPtr, err := os.Create(filepathA)
+	assert.NoError(t, err)
+	err = os.WriteFile(filepathA, d1, 0644)
+	assert.NoError(t, err)
+	defer os.Remove(filepathA)
+	defer fileAPtr.Close()
+
+	outputSlice, err := ParsePackListFile(filepathA)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, outputSlice)
+	assert.Len(t, outputSlice, 2)
+	assert.Contains(t, outputSlice, "test-a")
+	assert.Contains(t, outputSlice, "test-b")
+
+}
+
+func TestShouldFailEmptyPackList(t *testing.T) {
+	d1 := []byte("")
+	specDir := "./testout"
+	fileA := "packlist.txt"
+	filepathA := filepath.Join(specDir, fileA)
+
+	os.Mkdir(specDir, 0777)
+	defer os.Remove(specDir)
+
+	fileAPtr, err := os.Create(filepathA)
+	assert.NoError(t, err)
+	err = os.WriteFile(filepathA, d1, 0644)
+	assert.NoError(t, err)
+	defer os.Remove(filepathA)
+	defer fileAPtr.Close()
+
+	outputSlice, err := ParsePackListFile(filepathA)
+
+	assert.Error(t, err)
+	assert.Equal(t, "cannot have empty pack list (testout/packlist.txt)", err.Error())
+	assert.Nil(t, outputSlice)
+}

--- a/toolkit/tools/internal/srpm/srpm_test.go
+++ b/toolkit/tools/internal/srpm/srpm_test.go
@@ -113,5 +113,5 @@ func TestShouldFailEmptyPackList(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.Equal(t, "cannot have empty pack list (testout/packlist.txt)", err.Error())
-	assert.Nil(t, outputSlice)
+	assert.Equal(t, len(outputSlice), 0)
 }

--- a/toolkit/tools/srpmdownloader/srpmdownloader.go
+++ b/toolkit/tools/srpmdownloader/srpmdownloader.go
@@ -1,0 +1,233 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/buildpipeline"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/directory"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/exe"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/logger"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/network"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/retry"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/rpm"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/safechroot"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/srpm"
+
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+const (
+	defaultBuildDir    = "./build/SRPMS"
+	defaultWorkerCount = "10"
+)
+
+type sourceRetrievalConfiguration struct {
+	sourceURLs []string
+	caCerts    *x509.CertPool
+	tlsCerts   []tls.Certificate
+}
+
+var (
+	app = kingpin.New("srpmpacker", "A tool to package a SRPM.")
+
+	specsDir = exe.InputDirFlag(app, "Path to the SPEC directory to create SRPMs from.")
+	outDir   = exe.OutputDirFlag(app, "Directory to place the output SRPM.")
+	logFile  = exe.LogFileFlag(app)
+	logLevel = exe.LogLevelFlag(app)
+
+	buildDir = app.Flag("build-dir", "Directory to store temporary files while building.").Default(defaultBuildDir).String()
+	distTag  = app.Flag("dist-tag", "The distribution tag SRPMs will be built with.").Required().String()
+	runCheck = app.Flag("run-check", "Whether or not to run the spec file's check section during package build.").Bool()
+
+	workers = app.Flag("workers", "Number of concurrent goroutines to parse with.").Default(defaultWorkerCount).Int()
+
+	// Use String() and not ExistingFile() as the Makefile may pass an empty string if the user did not specify any of these options
+	srpmUrlList   = app.Flag("srpm-url-list", "urls for SRPM repo.").String()
+	srpmListFile  = app.Flag("srpm-list", "Path to a list of SPECs to pack. If empty will pack all SPECs.").ExistingFile()
+	caCertFile    = app.Flag("ca-cert", "Root certificate authority to use when downloading files.").String()
+	tlsClientCert = app.Flag("tls-cert", "TLS client certificate to use when downloading files.").String()
+	tlsClientKey  = app.Flag("tls-key", "TLS client key to use when downloading files.").String()
+
+	workerTar = app.Flag("worker-tar", "Full path to worker_chroot.tar.gz. If this argument is empty, SRPMs will be packed in the host environment.").ExistingFile()
+)
+
+func main() {
+	app.Version(exe.ToolkitVersion)
+	kingpin.MustParse(app.Parse(os.Args[1:]))
+	logger.InitBestEffort(*logFile, *logLevel)
+
+	if *workers <= 0 {
+		logger.Log.Fatalf("Value in --workers must be greater than zero. Found %d", *workers)
+	}
+
+	// Create a template configuration that all packed SRPM will be based on.
+	var templateSrcConfig sourceRetrievalConfiguration
+	// Setup remote source configuration
+	var err error
+	templateSrcConfig.caCerts, err = x509.SystemCertPool()
+	logger.PanicOnError(err, "Received error calling x509.SystemCertPool(). Error: %v", err)
+	if *caCertFile != "" {
+		newCACert, err := ioutil.ReadFile(*caCertFile)
+		if err != nil {
+			logger.Log.Panicf("Invalid CA certificate (%s), error: %s", *caCertFile, err)
+		}
+
+		templateSrcConfig.caCerts.AppendCertsFromPEM(newCACert)
+	}
+
+	if *tlsClientCert != "" && *tlsClientKey != "" {
+		cert, err := tls.LoadX509KeyPair(*tlsClientCert, *tlsClientKey)
+		if err != nil {
+			logger.Log.Panicf("Invalid TLS client key pair (%s) (%s), error: %s", *tlsClientCert, *tlsClientKey, err)
+		}
+
+		templateSrcConfig.tlsCerts = append(templateSrcConfig.tlsCerts, cert)
+
+	}
+	if *srpmUrlList != "" {
+		// Assumes that srpmUrlList come in as ',' seperated
+		urls := strings.Split(*srpmUrlList, " ")
+		templateSrcConfig.sourceURLs = urls
+	}
+
+	// A pack list may be provided, if so only pack this subset.
+	// If none is provided, pack all srpms.
+	srpmList, err := srpm.ParsePackListFile(*srpmListFile)
+	logger.PanicOnError(err)
+
+	logger.Log.Infof("SRPM list %s", srpmList)
+
+	err = getSRPMQueryWrapper(*specsDir, *distTag, *buildDir, *outDir, *workerTar, *workers, *runCheck, srpmList, templateSrcConfig)
+	logger.PanicOnError(err)
+
+}
+
+// getSRPMQueryWrapper wraps getSRPMQuery to conditionally run it inside a chroot.
+// If workerTar is non-empty, packing will occur inside a chroot, otherwise it will run on the host system.
+func getSRPMQueryWrapper(specsDir, distTag, buildDir, outDir, workerTar string, workers int, runCheck bool, srpmList []string, templateSrcConfig sourceRetrievalConfiguration) (err error) {
+	var chroot *safechroot.Chroot
+	originalOutDir := outDir
+	if workerTar != "" {
+		const leaveFilesOnDisk = false
+		chroot, buildDir, outDir, specsDir, err = srpm.CreateChroot(workerTar, buildDir, outDir, specsDir)
+		if err != nil {
+			return
+		}
+		defer chroot.Close(leaveFilesOnDisk)
+	}
+
+	doCreateAll := func() error {
+		err = getSRPMQuery(specsDir, distTag, buildDir, outDir, workers, runCheck, srpmList, templateSrcConfig)
+		return err
+	}
+
+	if chroot != nil {
+		logger.Log.Info("Grabbing SRPMs URL inside a chroot environment")
+		err = chroot.Run(doCreateAll)
+	} else {
+		logger.Log.Info("Grabbing SRPMs URL SRPMs in the host environment")
+		err = doCreateAll()
+	}
+
+	if err != nil {
+		return err
+	}
+
+	// If this is container build then the bind mounts will not have been created.
+	// Copy the chroot output to host output folder.
+	if !buildpipeline.IsRegularBuild() {
+		srpmsInChroot := filepath.Join(chroot.RootDir(), outDir)
+		err = directory.CopyContents(srpmsInChroot, originalOutDir)
+		if err != nil {
+			return err
+		}
+	}
+
+	return
+}
+
+// getSRPMQuery queries for the name, version and release of the SRPM
+func getSRPMQuery(specsDir, distTag, buildDir, outDir string, workers int, runCheck bool, srpmList []string, srcConfig sourceRetrievalConfiguration) (err error) {
+	const (
+		emptyQueryFormat = ``
+		querySrpm        = `%{NAME}-%{VERSION}-%{RELEASE}.src.rpm`
+	)
+	// Find the general SPEC query arguments
+	defines := rpm.DefaultDefines(runCheck)
+	defines[rpm.DistTagDefine] = distTag
+	arch, err := rpm.GetRpmArch(runtime.GOARCH)
+	if err != nil {
+		logger.Log.Warn(err)
+		return
+	}
+	specFiles, err := srpm.FindSPECFiles(specsDir, srpmList)
+	if err != nil {
+		return
+	}
+
+	// Parse each SPEC for name and version and hydrate SRPM
+	for _, specfile := range specFiles {
+		sourcedir := filepath.Dir(specfile)
+		logger.Log.Infof("specfile for %s", specfile)
+		var packageSRPMs []string
+		packageSRPMs, err = rpm.QuerySPEC(specfile, sourcedir, querySrpm, arch, defines, rpm.QueryHeaderArgument)
+		if err != nil {
+			logger.Log.Warn(err)
+			return err
+		}
+		packageSRPM := packageSRPMs[0]
+		downloadSRPM(packageSRPM, outDir, srcConfig)
+	}
+	return err
+}
+
+// downloadSRPM downloads SRPM trying each of srcConfig's urls
+func downloadSRPM(fileName string, newSourceDir string, srcConfig sourceRetrievalConfiguration) {
+	const (
+		downloadRetryAttempts = 3
+		downloadRetryDuration = time.Second
+	)
+	destinationFile := filepath.Join(newSourceDir, fileName)
+
+	var err error
+	var urlChosen string
+	srpmDownloaded := false
+	for _, urlSrc := range srcConfig.sourceURLs {
+		if srpmDownloaded {
+			break
+		}
+		logger.Log.Debugf("Trying (%s) from (%s)", fileName, urlSrc)
+		url := network.JoinURL(urlSrc, fileName)
+
+		err = retry.Run(func() error {
+			err := network.DownloadFile(url, destinationFile, srcConfig.caCerts, srcConfig.tlsCerts)
+			urlChosen = url
+			if err != nil {
+				logger.Log.Warnf("Failed to download (%s). Error: %s", url, err)
+				os.Remove(destinationFile)
+			} else {
+				srpmDownloaded = true
+			}
+
+			return err
+		}, downloadRetryAttempts, downloadRetryDuration)
+	}
+
+	if !srpmDownloaded {
+		logger.Log.Panicf("All attempts failed to download (%s). Error: %s", fileName, err)
+		return
+	}
+
+	logger.Log.Debugf("Hydrated (%s) from (%s)", fileName, urlChosen)
+
+}

--- a/toolkit/tools/srpmdownloader/srpmdownloader.go
+++ b/toolkit/tools/srpmdownloader/srpmdownloader.go
@@ -178,7 +178,6 @@ func getSRPMQuery(specsDir, distTag, buildDir, outDir string, workers int, runCh
 	// Parse each SPEC for name and version and hydrate SRPM
 	for _, specfile := range specFiles {
 		sourcedir := filepath.Dir(specfile)
-		logger.Log.Infof("specfile for %s", specfile)
 		var packageSRPMs []string
 		packageSRPMs, err = rpm.QuerySPEC(specfile, sourcedir, querySrpm, arch, defines, rpm.QueryHeaderArgument)
 		if err != nil {

--- a/toolkit/tools/srpmdownloader/srpmdownloader.go
+++ b/toolkit/tools/srpmdownloader/srpmdownloader.go
@@ -119,7 +119,7 @@ func getSRPMQueryWrapper(specsDir, distTag, buildDir, outDir, workerTar string, 
 	originalOutDir := outDir
 	if workerTar != "" {
 		const leaveFilesOnDisk = false
-		chroot, buildDir, outDir, specsDir, err = srpm.CreateChroot(workerTar, buildDir, outDir, specsDir)
+		chroot, buildDir, outDir, specsDir, err = srpm.CreateSRPMChroot(workerTar, buildDir, outDir, specsDir)
 		if err != nil {
 			return
 		}

--- a/toolkit/tools/srpmpacker/srpmpacker.go
+++ b/toolkit/tools/srpmpacker/srpmpacker.go
@@ -187,7 +187,7 @@ func createAllSRPMsWrapper(specsDir, distTag, buildDir, outDir, workerTar string
 	originalOutDir := outDir
 	if workerTar != "" {
 		const leaveFilesOnDisk = false
-		chroot, buildDir, outDir, specsDir, err = srpm.CreateChroot(workerTar, buildDir, outDir, specsDir)
+		chroot, buildDir, outDir, specsDir, err = srpm.CreateSRPMChroot(workerTar, buildDir, outDir, specsDir)
 		if err != nil {
 			return
 		}


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

Add `srpmdownloader` tool to fix the DOWNLOAD_SRPMS flag. 
This flag can be used with SRPM_URL_LIST and/or SRPM_PACK_LIST. 
`srpmdownloader` is needed so that the rpm query for the spec's
version is able to parse the macros within the spec file. In order to
successfully parse the macros, we need to be within a chroot that has
Mariner's macros installed.

In order to avoid code duplication between `srpmpacker` and `srpmdownloader`, 
create `srpm` and tests within `srpm_test`. 

`srpmpacker` functions that moved and were given tests
- removeDuplicateStrings -> sliceutils library function RemoveDuplicateStrings
- findSPECFiles -> srpm library function FindSPECFiles 
- parsePackListFile ->  srpm library function ParsePackListFile 
- createChroot ->  srpm library function CreateSRPMChroot

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add srpm library package and tests
- Add srpmdownloader.go

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://microsoft.visualstudio.com/OS/_workitems/edit/40942962/


###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- AMD: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=268205&view=results
- ARM: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=268240&view=results
- local tests
