### PR TITLE
Split out 'doc' subpackage from Rust.

### DIFF
--- a/SPECS/rust/rust.spec
+++ b/SPECS/rust/rust.spec
@@ -9,8 +9,8 @@
 Summary:        Rust Programming Language
 Name:           rust
 Version:        1.62.1
-Release:        3%{?dist}
-License:        ASL 2.0 OR MIT
+Release:        4%{?dist}
+License:        (ASL 2.0 OR MIT) AND BSD AND CC-BY-3.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Group:          Applications/System
@@ -44,6 +44,13 @@ Provides:       cargo = %{version}-%{release}
 
 %description
 Rust Programming Language
+
+%package doc
+Summary:        Rust documentation.
+BuildArch:      noarch
+
+%description doc
+Documentation package for Rust.
 
 %prep
 # Setup .cargo directory
@@ -94,14 +101,14 @@ ln -s %{_prefix}/src/mariner/BUILD/rustc-%{version}-src/build/x86_64-unknown-lin
 
 %install
 USER=root SUDO_USER=root %make_install
+mv %{buildroot}%{_docdir}/%{name}/LICENSE-THIRD-PARTY .
 rm %{buildroot}%{_docdir}/%{name}/html/.lock
 rm %{buildroot}%{_docdir}/%{name}/*.old
 
 %ldconfig_scriptlets
 
 %files
-%license LICENSE-MIT LICENSE-APACHE COPYRIGHT
-%doc CONTRIBUTING.md README.md RELEASES.md
+%license LICENSE-APACHE LICENSE-MIT LICENSE-THIRD-PARTY COPYRIGHT
 %{_bindir}/rustc
 %{_bindir}/rustdoc
 %{_bindir}/rust-lldb
@@ -111,22 +118,26 @@ rm %{buildroot}%{_docdir}/%{name}/*.old
 %{_libexecdir}/cargo-credential-1password
 %{_bindir}/rust-gdb
 %{_bindir}/rust-gdbgui
-%doc %{_docdir}/%{name}/html/*
-%{_docdir}/%{name}/html/.stamp
-%doc %{_docdir}/%{name}/README.md
-%doc %{_docdir}/%{name}/COPYRIGHT
-%doc %{_docdir}/%{name}/LICENSE-APACHE
-%doc %{_docdir}/%{name}/LICENSE-MIT
-%doc src/tools/rustfmt/{README,CHANGELOG,Configurations}.md
-%doc src/tools/clippy/{README.md,CHANGELOG.md}
 %{_bindir}/cargo
 %{_bindir}/cargo-fmt
 %{_bindir}/rustfmt
 %{_datadir}/zsh/*
-%doc %{_docdir}/%{name}/LICENSE-THIRD-PARTY
 %{_sysconfdir}/bash_completion.d/cargo
 
+%files doc
+%license LICENSE-APACHE LICENSE-MIT LICENSE-THIRD-PARTY COPYRIGHT
+%doc %{_docdir}/%{name}/html/*
+%doc %{_docdir}/%{name}/README.md
+%doc CONTRIBUTING.md README.md RELEASES.md
+%doc src/tools/clippy/{README.md,CHANGELOG.md}
+%doc src/tools/rustfmt/{README,CHANGELOG,Configurations}.md
+%{_docdir}/%{name}/html/.stamp
+
 %changelog
+* Thu Nov 24 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.62.1-4
+- Split out separate 'doc' subpackage to reduce default package size.
+- Updated license information.
+
 * Tue Nov 01 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.62.1-3
 - Adding missing test dependency on "glibc-static".
 

--- a/SPECS/rust/rust.spec
+++ b/SPECS/rust/rust.spec
@@ -102,6 +102,7 @@ ln -s %{_prefix}/src/mariner/BUILD/rustc-%{version}-src/build/x86_64-unknown-lin
 %install
 USER=root SUDO_USER=root %make_install
 mv %{buildroot}%{_docdir}/%{name}/LICENSE-THIRD-PARTY .
+rm %{buildroot}%{_docdir}/%{name}/{COPYRIGHT,LICENSE-APACHE,LICENSE-MIT}
 rm %{buildroot}%{_docdir}/%{name}/html/.lock
 rm %{buildroot}%{_docdir}/%{name}/*.old
 
@@ -112,7 +113,6 @@ rm %{buildroot}%{_docdir}/%{name}/*.old
 %{_bindir}/rustc
 %{_bindir}/rustdoc
 %{_bindir}/rust-lldb
-%{_mandir}/man1/*
 %{_libdir}/lib*.so
 %{_libdir}/rustlib/*
 %{_libexecdir}/cargo-credential-1password
@@ -129,9 +129,10 @@ rm %{buildroot}%{_docdir}/%{name}/*.old
 %doc %{_docdir}/%{name}/html/*
 %doc %{_docdir}/%{name}/README.md
 %doc CONTRIBUTING.md README.md RELEASES.md
-%doc src/tools/clippy/{README.md,CHANGELOG.md}
-%doc src/tools/rustfmt/{README,CHANGELOG,Configurations}.md
+%doc src/tools/clippy/CHANGELOG.md
+%doc src/tools/rustfmt/Configurations.md
 %{_docdir}/%{name}/html/.stamp
+%{_mandir}/man1/*
 
 %changelog
 * Thu Nov 24 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.62.1-4


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

Following @eric-desrochers findings in #4282 we're splitting out Rust's documentation into a separate package to reduce the default one's size by ~600 MB. Great find, Eric!

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Moved Rust's documentation into a new `doc` subpackage.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #4282

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline buddy build: 269227.
