### PR TITLE
toolchain: Build coreutils and findutils after libselinux.

### DIFF
--- a/SPECS/coreutils/coreutils.spec
+++ b/SPECS/coreutils/coreutils.spec
@@ -1,7 +1,7 @@
 Summary:        Basic system utilities
 Name:           coreutils
 Version:        8.32
-Release:        5%{?dist}
+Release:        6%{?dist}
 License:        GPLv3
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -103,6 +103,9 @@ LANGUAGE=en_US.UTF-8 LC_ALL=en_US.UTF-8 make -k check
 %defattr(-,root,root)
 
 %changelog
+* Wed Nov 23 2022 Chris PeBenito <chpebeni@microsoft.com> 8.32-6
+- Force rebuild to address missing SELinux features.
+
 * Mon Jul 11 2022 Olivia Crain <oliviacrain@microsoft.com> - 8.32-5
 - Add upstream patch to fix race in env-signal-handler test
 - Ensure SRPMs built on any architecture include all patches

--- a/SPECS/coreutils/coreutils.spec
+++ b/SPECS/coreutils/coreutils.spec
@@ -103,7 +103,7 @@ LANGUAGE=en_US.UTF-8 LC_ALL=en_US.UTF-8 make -k check
 %defattr(-,root,root)
 
 %changelog
-* Wed Nov 23 2022 Chris PeBenito <chpebeni@microsoft.com> 8.32-6
+* Wed Nov 23 2022 Chris PeBenito <chpebeni@microsoft.com> - 8.32-6
 - Force rebuild to address missing SELinux features.
 
 * Mon Jul 11 2022 Olivia Crain <oliviacrain@microsoft.com> - 8.32-5

--- a/SPECS/findutils/findutils.spec
+++ b/SPECS/findutils/findutils.spec
@@ -1,7 +1,7 @@
 Summary:        This package contains programs to find files
 Name:           findutils
 Version:        4.8.0
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        GPLv3+
 URL:            http://www.gnu.org/software/findutils
 Group:          Applications/File
@@ -64,6 +64,8 @@ make %{?_smp_mflags} check
 %defattr(-,root,root)
 
 %changelog
+* Wed Nov 23 2022 Chris PeBenito <chpebeni@microsoft.com> 4.8.0-4
+- Force rebuild to address missing SELinux features.
 * Wed Mar 23 2022 Chris PeBenito <chpebeni@microsoft.com> 4.8.0-3
 - Add missing (Build)Requires needed to enable SELinux support.
 * Mon Feb 14 2022 Pawel Winogrodzki <pawelwi@microsoft.com> 4.8.0-2

--- a/SPECS/findutils/findutils.spec
+++ b/SPECS/findutils/findutils.spec
@@ -3,17 +3,16 @@ Name:           findutils
 Version:        4.8.0
 Release:        4%{?dist}
 License:        GPLv3+
-URL:            http://www.gnu.org/software/findutils
-Group:          Applications/File
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
+Group:          Applications/File
+URL:            https://www.gnu.org/software/findutils
 Source0:        https://ftp.gnu.org/gnu/findutils/%{name}-%{version}.tar.xz
-Requires:       libselinux
 BuildRequires:  libselinux-devel
+Requires:       libselinux
 Conflicts:      toybox
-
 # Required to unblock automatic BR resolution for some Python packages.
-Provides:       /usr/bin/find
+Provides:       %{_bindir}/find
 
 %description
 These programs are provided to recursively search through a
@@ -22,9 +21,10 @@ directory tree and to create, maintain, and search a database
 database has not been recently updated).
 
 %package lang
-Summary: Additional language files for findutils
-Group:   Applications/File
-Requires: %{name} = %{version}-%{release}
+Summary:        Additional language files for findutils
+Group:          Applications/File
+Requires:       %{name} = %{version}-%{release}
+
 %description lang
 These are the additional language files of findutils
 
@@ -64,28 +64,40 @@ make %{?_smp_mflags} check
 %defattr(-,root,root)
 
 %changelog
-* Wed Nov 23 2022 Chris PeBenito <chpebeni@microsoft.com> 4.8.0-4
+* Wed Nov 23 2022 Chris PeBenito <chpebeni@microsoft.com> - 4.8.0-4
 - Force rebuild to address missing SELinux features.
+- Fix spec lint issues.
+
 * Wed Mar 23 2022 Chris PeBenito <chpebeni@microsoft.com> 4.8.0-3
 - Add missing (Build)Requires needed to enable SELinux support.
+
 * Mon Feb 14 2022 Pawel Winogrodzki <pawelwi@microsoft.com> 4.8.0-2
 - Adding "Provides: /usr/bin/find".
+
 * Fri Oct 22 2021 Andrew Phelps <anphel@microsoft.com> 4.8.0-1
 - Update to version 4.8.0
 - License verified
+
 * Sat May 09 2020 Nick Samson <nisamson@microsoft.com> 4.6.0-7
 - Added %%license line automatically
+
 * Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 4.6.0-6
 - Initial CBL-Mariner import from Photon (license: Apache2).
+
 * Sun Sep 09 2018 Alexey Makhalov <amakhalov@vmware.com> 4.6.0-5
 - Fix compilation issue against glibc-2.28
+
 * Mon Oct 02 2017 Alexey Makhalov <amakhalov@vmware.com> 4.6.0-4
 - Added conflicts toybox
+
 * Tue May 02 2017 Anish Swaminathan <anishs@vmware.com> 4.6.0-3
 - Add lang package.
+
 * Tue May 24 2016 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 4.6.0-2
 - GA - Bump release of all rpms
+
 * Tue Apr 26 2016 Anish Swaminathan <anishs@vmware.com> 4.6.0-1
 - Updated to version 4.6.0
+
 * Wed Nov 5 2014 Divya Thaluru <dthaluru@vmware.com> 4.4.2-1
 - Initial build. First version

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -40,8 +40,8 @@ ncurses-libs-6.3-2.cm2.aarch64.rpm
 ncurses-term-6.3-2.cm2.aarch64.rpm
 readline-8.1-1.cm2.aarch64.rpm
 readline-devel-8.1-1.cm2.aarch64.rpm
-coreutils-8.32-5.cm2.aarch64.rpm
-coreutils-lang-8.32-5.cm2.aarch64.rpm
+coreutils-8.32-6.cm2.aarch64.rpm
+coreutils-lang-8.32-6.cm2.aarch64.rpm
 bash-5.1.8-1.cm2.aarch64.rpm
 bash-devel-5.1.8-1.cm2.aarch64.rpm
 bash-lang-5.1.8-1.cm2.aarch64.rpm
@@ -58,8 +58,8 @@ grep-3.7-2.cm2.aarch64.rpm
 grep-lang-3.7-2.cm2.aarch64.rpm
 diffutils-3.8-1.cm2.aarch64.rpm
 gawk-5.1.0-2.cm2.aarch64.rpm
-findutils-4.8.0-3.cm2.aarch64.rpm
-findutils-lang-4.8.0-3.cm2.aarch64.rpm
+findutils-4.8.0-4.cm2.aarch64.rpm
+findutils-lang-4.8.0-4.cm2.aarch64.rpm
 gettext-0.21-2.cm2.aarch64.rpm
 gzip-1.12-1.cm2.aarch64.rpm
 make-4.3-2.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -40,8 +40,8 @@ ncurses-libs-6.3-2.cm2.x86_64.rpm
 ncurses-term-6.3-2.cm2.x86_64.rpm
 readline-8.1-1.cm2.x86_64.rpm
 readline-devel-8.1-1.cm2.x86_64.rpm
-coreutils-8.32-5.cm2.x86_64.rpm
-coreutils-lang-8.32-5.cm2.x86_64.rpm
+coreutils-8.32-6.cm2.x86_64.rpm
+coreutils-lang-8.32-6.cm2.x86_64.rpm
 bash-5.1.8-1.cm2.x86_64.rpm
 bash-devel-5.1.8-1.cm2.x86_64.rpm
 bash-lang-5.1.8-1.cm2.x86_64.rpm
@@ -58,8 +58,8 @@ grep-3.7-2.cm2.x86_64.rpm
 grep-lang-3.7-2.cm2.x86_64.rpm
 diffutils-3.8-1.cm2.x86_64.rpm
 gawk-5.1.0-2.cm2.x86_64.rpm
-findutils-4.8.0-3.cm2.x86_64.rpm
-findutils-lang-4.8.0-3.cm2.x86_64.rpm
+findutils-4.8.0-4.cm2.x86_64.rpm
+findutils-lang-4.8.0-4.cm2.x86_64.rpm
 gettext-0.21-2.cm2.x86_64.rpm
 gzip-1.12-1.cm2.x86_64.rpm
 make-4.3-2.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -30,9 +30,9 @@ chkconfig-debuginfo-1.20-3.cm2.aarch64.rpm
 chkconfig-lang-1.20-3.cm2.aarch64.rpm
 cmake-3.21.4-2.cm2.aarch64.rpm
 cmake-debuginfo-3.21.4-2.cm2.aarch64.rpm
-coreutils-8.32-5.cm2.aarch64.rpm
-coreutils-debuginfo-8.32-5.cm2.aarch64.rpm
-coreutils-lang-8.32-5.cm2.aarch64.rpm
+coreutils-8.32-6.cm2.aarch64.rpm
+coreutils-debuginfo-8.32-6.cm2.aarch64.rpm
+coreutils-lang-8.32-6.cm2.aarch64.rpm
 cpio-2.13-4.cm2.aarch64.rpm
 cpio-debuginfo-2.13-4.cm2.aarch64.rpm
 cpio-lang-2.13-4.cm2.aarch64.rpm
@@ -81,9 +81,9 @@ file-devel-5.40-2.cm2.aarch64.rpm
 file-libs-5.40-2.cm2.aarch64.rpm
 filesystem-1.1-12.cm2.aarch64.rpm
 filesystem-asc-1.1-12.cm2.aarch64.rpm
-findutils-4.8.0-3.cm2.aarch64.rpm
-findutils-debuginfo-4.8.0-3.cm2.aarch64.rpm
-findutils-lang-4.8.0-3.cm2.aarch64.rpm
+findutils-4.8.0-4.cm2.aarch64.rpm
+findutils-debuginfo-4.8.0-4.cm2.aarch64.rpm
+findutils-lang-4.8.0-4.cm2.aarch64.rpm
 flex-2.6.4-7.cm2.aarch64.rpm
 flex-debuginfo-2.6.4-7.cm2.aarch64.rpm
 flex-devel-2.6.4-7.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -30,9 +30,9 @@ chkconfig-debuginfo-1.20-3.cm2.x86_64.rpm
 chkconfig-lang-1.20-3.cm2.x86_64.rpm
 cmake-3.21.4-2.cm2.x86_64.rpm
 cmake-debuginfo-3.21.4-2.cm2.x86_64.rpm
-coreutils-8.32-5.cm2.x86_64.rpm
-coreutils-debuginfo-8.32-5.cm2.x86_64.rpm
-coreutils-lang-8.32-5.cm2.x86_64.rpm
+coreutils-8.32-6.cm2.x86_64.rpm
+coreutils-debuginfo-8.32-6.cm2.x86_64.rpm
+coreutils-lang-8.32-6.cm2.x86_64.rpm
 cpio-2.13-4.cm2.x86_64.rpm
 cpio-debuginfo-2.13-4.cm2.x86_64.rpm
 cpio-lang-2.13-4.cm2.x86_64.rpm
@@ -81,9 +81,9 @@ file-devel-5.40-2.cm2.x86_64.rpm
 file-libs-5.40-2.cm2.x86_64.rpm
 filesystem-1.1-12.cm2.x86_64.rpm
 filesystem-asc-1.1-12.cm2.x86_64.rpm
-findutils-4.8.0-3.cm2.x86_64.rpm
-findutils-debuginfo-4.8.0-3.cm2.x86_64.rpm
-findutils-lang-4.8.0-3.cm2.x86_64.rpm
+findutils-4.8.0-4.cm2.x86_64.rpm
+findutils-debuginfo-4.8.0-4.cm2.x86_64.rpm
+findutils-lang-4.8.0-4.cm2.x86_64.rpm
 flex-2.6.4-7.cm2.x86_64.rpm
 flex-debuginfo-2.6.4-7.cm2.x86_64.rpm
 flex-devel-2.6.4-7.cm2.x86_64.rpm

--- a/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
+++ b/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
@@ -263,7 +263,6 @@ build_rpm_in_chroot_no_install readline
 build_rpm_in_chroot_no_install bash
 build_rpm_in_chroot_no_install bzip2
 build_rpm_in_chroot_no_install gdbm
-build_rpm_in_chroot_no_install coreutils
 build_rpm_in_chroot_no_install gettext
 build_rpm_in_chroot_no_install sqlite
 build_rpm_in_chroot_no_install expat
@@ -274,7 +273,6 @@ build_rpm_in_chroot_no_install lz4
 build_rpm_in_chroot_no_install m4
 build_rpm_in_chroot_no_install libcap
 build_rpm_in_chroot_no_install popt
-build_rpm_in_chroot_no_install findutils
 build_rpm_in_chroot_no_install tar
 build_rpm_in_chroot_no_install gawk
 build_rpm_in_chroot_no_install gzip
@@ -466,6 +464,11 @@ chroot_and_install_rpms swig
 build_rpm_in_chroot_no_install libselinux
 
 chroot_and_install_rpms libselinux
+
+# coreutils and findutils require libselinux
+# for SELinux support.
+build_rpm_in_chroot_no_install coreutils
+build_rpm_in_chroot_no_install findutils
 
 build_rpm_in_chroot_no_install glib
 build_rpm_in_chroot_no_install libassuan


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Build coreutils and findutils after libselinux so that SELinux features are enabled in these packages.

###### Change Log  <!-- REQUIRED -->
- Build coreutils and findutils after libselinux.
- Fix findutils spec lint issues.

###### Does this affect the toolchain?  <!-- REQUIRED -->
**YES**

###### Test Methodology
- Pipeline build id: 268640
