### PR TITLE
cglib: Fix package install failure due to missing runtime dependency

### DIFF
--- a/SPECS-EXTENDED/cglib/cglib.spec
+++ b/SPECS-EXTENDED/cglib/cglib.spec
@@ -22,7 +22,7 @@ Distribution:   Mariner
 %global tarball_name RELEASE_3_2_4
 Name:           cglib
 Version:        3.2.4
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Code Generation Library
 License:        Apache-2.0
 Group:          Development/Libraries/Java
@@ -36,7 +36,7 @@ BuildRequires:  javapackages-local-bootstrap
 BuildRequires:  objectweb-asm >= 5
 Provides:       %{name}-nohook = %{version}-%{release}
 Obsoletes:      %{name}-nohook < %{version}-%{release}
-Requires:       mvn(org.ow2.asm:asm)
+Requires:       objectweb-asm >= 5
 BuildArch:      noarch
 %if %{with tests}
 BuildConflicts: java-devel >= 9
@@ -123,6 +123,10 @@ cp -r %{name}/target/site/apidocs/* %{buildroot}%{_javadocdir}/%{name}/
 %{_javadocdir}/%{name}
 
 %changelog
+* Wed Nov 09 2022 Sumedh Sharma <sumsharma@microsoft.com> - 3.2.4-3
+- Fix runtime requirements on objectweb-asm instead of mvn(org.ow2.asm:asm)
+- License verified
+
 * Thu Oct 14 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 3.2.4-2
 - Converting the 'Release' tag to the '[number].[distribution]' format.
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Update Requires section of package to fix install failure

###### Change Log  <!-- REQUIRED -->
- change runtime requirement to objectweb-asm instead of mvn(org.ow2.asm:asm)

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Associated issues  <!-- optional -->

###### Links to CVEs  <!-- optional -->

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: Buddy Build https://dev.azure.com/mariner-org/mariner/_build/results?buildId=270268&view=results