### PR TITLE
add ephemeral disk warning

### DIFF
--- a/SPECS/WALinuxAgent/WALinuxAgent.signatures.json
+++ b/SPECS/WALinuxAgent/WALinuxAgent.signatures.json
@@ -1,5 +1,8 @@
 {
  "Signatures": {
-  "WALinuxAgent-2.2.54.2.tar.gz": "2c047d262ca55718268a0921c7bd04b6c1ab1032bd885e3e0949107f493e7b7c"
+  "WALinuxAgent-2.2.54.2.tar.gz": "2c047d262ca55718268a0921c7bd04b6c1ab1032bd885e3e0949107f493e7b7c",
+  "ephemeral-disk-warning": "5f3a42706ef6058cc82ff32d3f3f636d99c0b8e0007eb60376182ab9cb288b7f",
+  "ephemeral-disk-warning.conf": "128e531c029e04afdab591f44d2b0a69d5a4eb9dec8867282d0acb1ebded76d0",
+  "ephemeral-disk-warning.service": "627b06ab9692aafd20b8c2af4cc779675329426d2ad0c82ddc787d762027d0e9"
  }
 }

--- a/SPECS/WALinuxAgent/WALinuxAgent.spec
+++ b/SPECS/WALinuxAgent/WALinuxAgent.spec
@@ -1,7 +1,7 @@
 Summary:        The Windows Azure Linux Agent
 Name:           WALinuxAgent
 Version:        2.2.54.2
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -9,6 +9,9 @@ Group:          System/Daemons
 URL:            https://github.com/Azure/WALinuxAgent
 #Source0:       https://github.com/Azure/WALinuxAgent/archive/refs/tags/v%{version}.tar.gz
 Source0:        %{name}-%{version}.tar.gz
+Source1:        ephemeral-disk-warning.service
+Source2:        ephemeral-disk-warning.conf
+Source3:        ephemeral-disk-warning
 BuildRequires:  python3
 BuildRequires:  python3-distro
 BuildRequires:  python3-libs
@@ -55,12 +58,16 @@ install -m 644 config/66-azure-storage.rules %{buildroot}/%{_sysconfdir}/udev/ru
 sed -i 's,#!/usr/bin/env python,#!/usr/bin/python3,' %{buildroot}%{_bindir}/waagent
 sed -i 's,#!/usr/bin/env python,#!/usr/bin/python3,' %{buildroot}%{_bindir}/waagent2.0
 sed -i 's,/usr/bin/python ,/usr/bin/python3 ,' %{buildroot}%{_lib}/systemd/system/waagent.service
+install -m 644 %{SOURCE1} %{buildroot}%{_libdir}/systemd/system/ephemeral-disk-warning.service
+install -m 644 %{SOURCE2} %{buildroot}%{_sysconfdir}/ephemeral-disk-warning.conf
+install -m 644 %{SOURCE3} %{buildroot}%{_bindir}/ephemeral-disk-warning
 
 %check
 python3 setup.py check && python3 setup.py test
 
 %post
 %systemd_post waagent.service
+%systemd_post ephemeral-disk-warning.service
 
 %preun
 %systemd_preun waagent.service
@@ -75,12 +82,17 @@ python3 setup.py check && python3 setup.py test
 %license LICENSE.txt
 %attr(0755,root,root) %{_bindir}/waagent
 %attr(0755,root,root) %{_bindir}/waagent2.0
+%attr(0755,root,root) %{_bindir}/ephemeral-disk-warning
 %config %{_sysconfdir}/waagent.conf
+%config %{_sysconfdir}/ephemeral-disk-warning.conf
 %ghost %{_localstatedir}/log/waagent.log
 %dir %attr(0700, root, root) %{_sharedstatedir}/waagent
 %{_lib}/python3.7/site-packages/*
 
 %changelog
+* Tue Nov 29 2022 Nan Liu <liunan@microsoft.com> - 2.2.54.2-4
+- Add ephemeral-disk-warning.service
+
 * Tue Dec 14 2021 Neha Agarwal <nehaagarwal@microsoft.com> - 2.2.54.2-3
 - Include the 66-azure-storage udev rule.
 

--- a/SPECS/WALinuxAgent/ephemeral-disk-warning
+++ b/SPECS/WALinuxAgent/ephemeral-disk-warning
@@ -1,0 +1,31 @@
+#!/bin/sh
+dev_resource=$(readlink -f /dev/disk/azure/resource-part1)
+dev_resource_mp=$(awk '$1==R {print$2}' "R=${dev_resource}" /proc/mounts)
+warn_file="${dev_resource_mp}/DATALOSS_WARNING_README.txt"
+
+if [ ! -f "${warn_file}" ]; then
+    cat > ${warn_file} <<EOM
+WARNING: THIS IS A TEMPORARY DISK.
+
+Any data stored on this drive is SUBJECT TO LOSS and THERE IS NO WAY TO
+RECOVER IT.
+
+Please do not use this disk for storing any personal or application data.
+
+For additional details to please refer to the MSDN documentation at:
+http://msdn.microsoft.com/en-us/library/windowsazure/jj672979.aspx
+
+To remove this warning run:
+    sudo chattr -i $warn_file
+    sudo rm $warn_file
+
+This warning is written each boot; to disable it:
+    echo "manual" | sudo tee /etc/ephemeral-disk-warning.override
+    sudo systemctl disable ephemeral-disk-warning.service
+
+EOM
+
+    chmod 0444 ${warn_file}
+    chattr +i ${warn_file}
+    logger "Added ephemeral disk warning to ${warn_file}"
+fi

--- a/SPECS/WALinuxAgent/ephemeral-disk-warning.conf
+++ b/SPECS/WALinuxAgent/ephemeral-disk-warning.conf
@@ -1,0 +1,55 @@
+# ephemeral-disk-warning - warns user that the disk is really, really ephemeral
+#
+# On Azure, the ephemeral disk is extremely ephemeral; the ephemeral disk is
+# unsafe between boots. This places a file on /mnt that warns the user
+# that the disk is a dangerous place for storing data of any importance.
+
+env RESOURCE_DISK=/dev/disk/azure/resource-part1
+
+start on (stopped rc RUNLEVEL=[2345] and stopped cloud-config)
+task
+script
+    if [ ! -e $RESOURCE_DISK ]; then
+            logger "Disk $RESOURCE_DISK does not exist, skipping ephemeral warning"
+            exit 0
+    fi
+
+    ephemeral_kdev=$(readlink -f $RESOURCE_DISK)
+    ephemeral_mp=$(awk '$1==kd {print$2}' "kd=$ephemeral_kdev" /proc/mounts)
+    warn_file="$ephemeral_mp/DATALOSS_WARNING_README.txt"
+
+    if [ -z "$ephemeral_mp" ]; then
+            logger "Unable to discover mount point of $ephemeral_kdev. Ephemeral warning will not be written"
+            exit 0
+    else
+            logger "Ephemeral disk $ephemeral_kdev located at $ephemeral_mp"
+    fi
+
+    if [ ! -e "$warn_file" ]; then
+        cat >> $warn_file <<EOF
+WARNING: THIS IS A TEMPORARY DISK.
+
+Any data stored on this drive is SUBJECT TO LOSS and THERE IS NO WAY TO
+RECOVER IT.
+
+Please do not use this disk for storing any personal or application data.
+
+For additional details to please refer to the MSDN documentation at:
+http://msdn.microsoft.com/en-us/library/windowsazure/jj672979.aspx
+
+To remove this warning run:
+    sudo chattr -i $warn_file
+    sudo rm $warn_file
+
+This warning is written each boot; to disable it:
+    echo "manual" | sudo tee /etc/ephemeral-disk-warning.override
+    sudo systemctl disable ephemeral-disk-warning.service
+
+EOF
+        chmod 0444 $warn_file
+        chattr +i $warn_file
+        logger "Added ephemeral disk warning to $warn_file"
+    fi
+    logger "WARNING: $ephemeral_mp is an ephemeral disk. See $warn_file for more information"
+
+end script

--- a/SPECS/WALinuxAgent/ephemeral-disk-warning.service
+++ b/SPECS/WALinuxAgent/ephemeral-disk-warning.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Write warning to Azure ephemeral disk
+After=cloud-config.service
+ConditionVirtualization=microsoft
+ConditionPathIsMountPoint=/mnt
+ConditionPathExists=/dev/disk/azure/resource-part1
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/ephemeral-disk-warning
+RemainAfterExit=yes
+StandardOutput=journal+console
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Mariner doesn't place the dataloss warning on its ephemeral resource disk for the VMs with temporary storage, which caused test failures in BVT and Hotpatch. In Ubuntu there's a systemd service ([ephemeral-disk-warning.service](https://git.launchpad.net/ubuntu/+source/walinuxagent/tree/debian)) that writes the dataloss warning file. So this PR adds ephemeral-disk-warning configuration and service files into WALinuxAgent package to write the dataloss warning on each boot.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add ephemeral-disk-warning.service

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://microsoft.visualstudio.com/OS/_workitems/edit/41968484/

###### Links to CVEs  <!-- optional -->

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build
- Tested by building custom Gen1 and Gen2 images and booting Azure VMs:
For the VM sizes with temporary storage, DATALOSS_WARNING_README file is written into /mnt:
![MicrosoftTeams-image (2)](https://user-images.githubusercontent.com/108544011/204633936-ed0b0bac-995a-45f1-9013-ddb323dfd4cd.png)
For the VM sizes without temporary storage, there is no dataloss warning file under /mnt:
![MicrosoftTeams-image (3)](https://user-images.githubusercontent.com/108544011/204634021-c2c6faff-1094-428e-9774-25469a02a4bc.png)
