### PR TITLE
Patch `libarchive` for CVE-2022-36227

### DIFF
--- a/SPECS/libarchive/CVE-2022-36227.patch
+++ b/SPECS/libarchive/CVE-2022-36227.patch
@@ -1,0 +1,35 @@
+From bff38efe8c110469c5080d387bec62a6ca15b1a5 Mon Sep 17 00:00:00 2001
+From: obiwac <obiwac@gmail.com>
+Date: Fri, 22 Jul 2022 22:41:10 +0200
+Subject: [PATCH] libarchive: Handle a `calloc` returning NULL (fixes #1754)
+
+---
+ libarchive/archive_write.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/libarchive/archive_write.c b/libarchive/archive_write.c
+index 66592e826..27626b541 100644
+--- a/libarchive/archive_write.c
++++ b/libarchive/archive_write.c
+@@ -201,6 +201,10 @@ __archive_write_allocate_filter(struct archive *_a)
+ 	struct archive_write_filter *f;
+ 
+ 	f = calloc(1, sizeof(*f));
++
++	if (f == NULL)
++		return (NULL);
++
+ 	f->archive = _a;
+ 	f->state = ARCHIVE_WRITE_FILTER_STATE_NEW;
+ 	if (a->filter_first == NULL)
+@@ -548,6 +552,10 @@ archive_write_open2(struct archive *_a, void *client_data,
+ 	a->client_data = client_data;
+ 
+ 	client_filter = __archive_write_allocate_filter(_a);
++
++	if (client_filter == NULL)
++		return (ARCHIVE_FATAL);
++
+ 	client_filter->open = archive_write_client_open;
+ 	client_filter->write = archive_write_client_write;
+ 	client_filter->close = archive_write_client_close;

--- a/SPECS/libarchive/libarchive.spec
+++ b/SPECS/libarchive/libarchive.spec
@@ -1,7 +1,7 @@
 Summary:        Multi-format archive and compression library
 Name:           libarchive
 Version:        3.6.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 # Certain files have individual licenses. For more details see contents of "COPYING".
 License:        BSD AND Public Domain AND (ASL 2.0 OR CC0 1.0 OR OpenSSL)
 Vendor:         Microsoft Corporation
@@ -9,6 +9,8 @@ Distribution:   Mariner
 Group:          System Environment/Development
 URL:            https://www.libarchive.org/
 Source0:        https://github.com/libarchive/libarchive/releases/download/v%{version}/%{name}-%{version}.tar.gz
+Patch0:         CVE-2022-36227.patch
+
 BuildRequires:  xz-devel
 BuildRequires:  xz-libs
 Requires:       xz-libs
@@ -58,6 +60,9 @@ make %{?_smp_mflags} check
 %{_libdir}/pkgconfig/*.pc
 
 %changelog
+* Thu Dec 01 2022 Muhammad Falak <mwani@microsoft.com> - 3.6.1-2
+- Patch CVE-2022-36227
+
 * Fri Aug 12 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 3.6.1-1
 - Updating to version 3.6.1 to fix CVE-2021-36976.
 

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -163,9 +163,9 @@ krb5-lang-1.18.4-2.cm1.aarch64.rpm
 libaio-0.3.112-3.cm1.aarch64.rpm
 libaio-debuginfo-0.3.112-3.cm1.aarch64.rpm
 libaio-devel-0.3.112-3.cm1.aarch64.rpm
-libarchive-3.6.1-1.cm1.aarch64.rpm
-libarchive-debuginfo-3.6.1-1.cm1.aarch64.rpm
-libarchive-devel-3.6.1-1.cm1.aarch64.rpm
+libarchive-3.6.1-2.cm1.aarch64.rpm
+libarchive-debuginfo-3.6.1-2.cm1.aarch64.rpm
+libarchive-devel-3.6.1-2.cm1.aarch64.rpm
 libassuan-2.5.1-3.cm1.aarch64.rpm
 libassuan-debuginfo-2.5.1-3.cm1.aarch64.rpm
 libcap-2.26-2.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -163,9 +163,9 @@ krb5-lang-1.18.4-2.cm1.x86_64.rpm
 libaio-0.3.112-3.cm1.x86_64.rpm
 libaio-debuginfo-0.3.112-3.cm1.x86_64.rpm
 libaio-devel-0.3.112-3.cm1.x86_64.rpm
-libarchive-3.6.1-1.cm1.x86_64.rpm
-libarchive-debuginfo-3.6.1-1.cm1.x86_64.rpm
-libarchive-devel-3.6.1-1.cm1.x86_64.rpm
+libarchive-3.6.1-2.cm1.x86_64.rpm
+libarchive-debuginfo-3.6.1-2.cm1.x86_64.rpm
+libarchive-devel-3.6.1-2.cm1.x86_64.rpm
 libassuan-2.5.1-3.cm1.x86_64.rpm
 libassuan-debuginfo-2.5.1-3.cm1.x86_64.rpm
 libcap-2.26-2.cm1.x86_64.rpm


### PR DESCRIPTION
* Patch `libarchive` for CVE-2022-36227
* libarchive: manifests: update entry

Signed-off-by: Muhammad Falak R Wani <falakreyaz@gmail.com>

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---
Fix for CVE-2022-36227