### PR TITLE
change binaries location

### DIFF
--- a/SPECS/coreutils/coreutils.spec
+++ b/SPECS/coreutils/coreutils.spec
@@ -1,7 +1,7 @@
 Summary:        Basic system utilities
 Name:           coreutils
 Version:        8.32
-Release:        6%{?dist}
+Release:        7%{?dist}
 License:        GPLv3
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -60,20 +60,16 @@ make %{?_smp_mflags}
 
 %install
 make DESTDIR=%{buildroot} install
-install -vdm 755 %{buildroot}/bin
 install -vdm 755 %{buildroot}%{_sbindir}
 install -vdm 755 %{buildroot}%{_mandir}/man8
-mv -v %{buildroot}%{_bindir}/{arch,cat,chgrp,chmod,chown,cp,date,dd,df,echo} %{buildroot}/bin
-mv -v %{buildroot}%{_bindir}/{false,ln,ls,mkdir,mknod,mv,pwd,rm} %{buildroot}/bin
-mv -v %{buildroot}%{_bindir}/{rmdir,stty,sync,true,uname,test,[} %{buildroot}/bin
 mv -v %{buildroot}%{_bindir}/chroot %{buildroot}%{_sbindir}
 mv -v %{buildroot}%{_mandir}/man1/chroot.1 %{buildroot}%{_mandir}/man8/chroot.8
 sed -i s/\"1\"/\"8\"/1 %{buildroot}%{_mandir}/man8/chroot.8
-mv -v %{buildroot}%{_bindir}/{head,sleep,nice} %{buildroot}/bin
 rm -rf %{buildroot}%{_infodir}
 install -vdm755 %{buildroot}%{_sysconfdir}/profile.d
 install -m 0644 %{SOURCE1} %{buildroot}%{_sysconfdir}/profile.d/
 %find_lang %{name}
+ln -s %{buildroot}%{_bindir} %{buildroot}/
 
 %check
 sed -i '/tests\/misc\/sort.pl/d' Makefile
@@ -92,6 +88,7 @@ LANGUAGE=en_US.UTF-8 LC_ALL=en_US.UTF-8 make -k check
 %files
 %defattr(-,root,root)
 %license COPYING
+%exclude /bin
 /bin/*
 %{_sysconfdir}/profile.d/serial-console.sh
 %{_libexecdir}/*
@@ -103,6 +100,10 @@ LANGUAGE=en_US.UTF-8 LC_ALL=en_US.UTF-8 make -k check
 %defattr(-,root,root)
 
 %changelog
+* Wed Nov 30 2022 Minghe Ren <mingheren@microsoft.com> - 8.32-7
+- Keep binaries installed in the default location at /usr/bin
+- Add soft link /bin to /usr/bin
+
 * Wed Nov 23 2022 Chris PeBenito <chpebeni@microsoft.com> - 8.32-6
 - Force rebuild to address missing SELinux features.
 

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -40,8 +40,8 @@ ncurses-libs-6.3-2.cm2.aarch64.rpm
 ncurses-term-6.3-2.cm2.aarch64.rpm
 readline-8.1-1.cm2.aarch64.rpm
 readline-devel-8.1-1.cm2.aarch64.rpm
-coreutils-8.32-6.cm2.aarch64.rpm
-coreutils-lang-8.32-6.cm2.aarch64.rpm
+coreutils-8.32-7.cm2.aarch64.rpm
+coreutils-lang-8.32-7.cm2.aarch64.rpm
 bash-5.1.8-1.cm2.aarch64.rpm
 bash-devel-5.1.8-1.cm2.aarch64.rpm
 bash-lang-5.1.8-1.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -40,8 +40,8 @@ ncurses-libs-6.3-2.cm2.x86_64.rpm
 ncurses-term-6.3-2.cm2.x86_64.rpm
 readline-8.1-1.cm2.x86_64.rpm
 readline-devel-8.1-1.cm2.x86_64.rpm
-coreutils-8.32-6.cm2.x86_64.rpm
-coreutils-lang-8.32-6.cm2.x86_64.rpm
+coreutils-8.32-7.cm2.x86_64.rpm
+coreutils-lang-8.32-7.cm2.x86_64.rpm
 bash-5.1.8-1.cm2.x86_64.rpm
 bash-devel-5.1.8-1.cm2.x86_64.rpm
 bash-lang-5.1.8-1.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -30,9 +30,9 @@ chkconfig-debuginfo-1.20-3.cm2.aarch64.rpm
 chkconfig-lang-1.20-3.cm2.aarch64.rpm
 cmake-3.21.4-2.cm2.aarch64.rpm
 cmake-debuginfo-3.21.4-2.cm2.aarch64.rpm
-coreutils-8.32-6.cm2.aarch64.rpm
-coreutils-debuginfo-8.32-6.cm2.aarch64.rpm
-coreutils-lang-8.32-6.cm2.aarch64.rpm
+coreutils-8.32-7.cm2.aarch64.rpm
+coreutils-debuginfo-8.32-7.cm2.aarch64.rpm
+coreutils-lang-8.32-7.cm2.aarch64.rpm
 cpio-2.13-4.cm2.aarch64.rpm
 cpio-debuginfo-2.13-4.cm2.aarch64.rpm
 cpio-lang-2.13-4.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -30,9 +30,9 @@ chkconfig-debuginfo-1.20-3.cm2.x86_64.rpm
 chkconfig-lang-1.20-3.cm2.x86_64.rpm
 cmake-3.21.4-2.cm2.x86_64.rpm
 cmake-debuginfo-3.21.4-2.cm2.x86_64.rpm
-coreutils-8.32-6.cm2.x86_64.rpm
-coreutils-debuginfo-8.32-6.cm2.x86_64.rpm
-coreutils-lang-8.32-6.cm2.x86_64.rpm
+coreutils-8.32-7.cm2.x86_64.rpm
+coreutils-debuginfo-8.32-7.cm2.x86_64.rpm
+coreutils-lang-8.32-7.cm2.x86_64.rpm
 cpio-2.13-4.cm2.x86_64.rpm
 cpio-debuginfo-2.13-4.cm2.x86_64.rpm
 cpio-lang-2.13-4.cm2.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
- Move binaries installed by coreutils package into default install location at /usr/bin instead of /bin
- We moved all the binaries to /bin at frist place as we followed Centos coreutils.spec but later they moved all the binaries into /usr/bin/ [upstream PR](https://github.com/vmware/photon/commit/3a7b668080aefefa61f30f42d165d51b7283a5f0#diff-2c1479545d88b270d5949996da652f11dc9feae915beba7eaef20c2efc2970af)

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Remove the code that move binaries into /bin
- For 2.0 to reduce the risk of this change (closed [PR](https://github.com/microsoft/CBL-Mariner/pull/4272)) , add soft link /bin --> /usr/bin as there are many other packages that still arbitrary use binaries in /bin.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
YES

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
[Bug 41031409](https://microsoft.visualstudio.com/OS/_workitems/edit/41031409): tdnf coreutils package dependency resolution

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: [272214](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=272214&view=results)
- local toolchain and package build