### PR TITLE
Nopatch several CVEs for kernel

### DIFF
--- a/SPECS/kernel/CVE-2022-1204.nopatch
+++ b/SPECS/kernel/CVE-2022-1204.nopatch
@@ -1,0 +1,6 @@
+CVE-2022-1204 - Fix already backported to 5.15.35
+upstream commit ID 5352a761308397a0e6250fdc629bb3f615b94747 -> stable commit ID 1bf8946d5826788c82971977245bcd3313678eac
+upstream commit ID feef318c855a361a1eccd880f33e88c460eb63b4 -> stable commit ID b982492ec3a115e0a136856a1b2dbe32f2d21a0e
+upstream commit ID d01ffb9eee4af165d83b08dd73ebdf9fe94a519b -> stable commit ID 9af0fd5c4453a44c692be0cbb3724859b75d739b
+upstream commit ID 9fd75b66b8f68498454d685dc4ba13192ae069b0 -> stable commit ID 452ae92b99062d2f6a34324eaf705a3b7eac9f8b
+upstream commit ID 87563a043cef044fed5db7967a75741cc16ad2b1 -> stable commit ID bc706d89199b0d8ee5e2229e18fdb9c0720f6ba8

--- a/SPECS/kernel/CVE-2022-2785.nopatch
+++ b/SPECS/kernel/CVE-2022-2785.nopatch
@@ -1,0 +1,3 @@
+CVE-2022-2785 - Introducing commit is not in stable tree. No fix necessary at this time.
+Upstream introducing commit - b1d18a7574d0df5eb4117c14742baf8bc2b9bb74
+Upstream fix commit - 86f44fcec22ce2979507742bc53db8400e454f46

--- a/SPECS/kernel/CVE-2022-3344.nopatch
+++ b/SPECS/kernel/CVE-2022-3344.nopatch
@@ -1,0 +1,6 @@
+CVE-2022-3344 - Fix already backported 5.15.81.1
+Upstream: 16ae56d7e0528559bf8dc9070e3bfd8ba3de80df
+Stable: 3e87cb0caa25d667a9ca2fe15fef889e43ab8f95
+
+Upstream: ed129ec9057f89d615ba0c81a4984a90345a1684
+Stable: 6425c590d0cc6914658a630a40b7f8226aa028c3

--- a/SPECS/kernel/CVE-2022-3586.nopatch
+++ b/SPECS/kernel/CVE-2022-3586.nopatch
@@ -1,0 +1,3 @@
+CVE-2022-3586 - Fix already backported
+Upstream: 9efd23297cca530bb35e1848665805d3fcdd7889
+Stable: 1a889da60afc017050e1f517b3b976b462846668

--- a/SPECS/kernel/CVE-2022-3595.nopatch
+++ b/SPECS/kernel/CVE-2022-3595.nopatch
@@ -1,0 +1,3 @@
+CVE-2022-3595 - Introducing commit is not in stable tree. No fix necessary at this time.
+Upstream introducing commit - a4e430c8c8ba96be8c6ec4f2eb108bb8bcbee069
+Upstream fix commit - b854b4ee66437e6e1622fda90529c814978cb4ca

--- a/SPECS/kernel/CVE-2022-3910.nopatch
+++ b/SPECS/kernel/CVE-2022-3910.nopatch
@@ -1,0 +1,3 @@
+CVE-2022-3910 - Introducing commit is not in stable tree. No fix necessary at this time.
+Upstream introducing commit - aa184e8671f0f911fc2fb3f68cd506e4d7838faa
+Upstream fix commit - fc7222c3a9f56271fba02aabbfbae999042f1679

--- a/SPECS/kernel/CVE-2022-40768.nopatch
+++ b/SPECS/kernel/CVE-2022-40768.nopatch
@@ -1,0 +1,3 @@
+CVE-2022-40768 - Fix already backported
+Upstream: 6022f210461fef67e6e676fd8544ca02d1bcfa7a 
+Stable:	76efb4897bc38b2f16176bae27ae801037ebf49a

--- a/SPECS/kernel/CVE-2022-4127.nopatch
+++ b/SPECS/kernel/CVE-2022-4127.nopatch
@@ -1,0 +1,3 @@
+CVE-2022-4127 - Introducing commit is not in stable tree. No fix necessary at this time.
+Upstream introducing commit - a7c41b4687f5902af70cd559806990930c8a307b
+Upstream fix commit - d785a773bed966a75ca1f11d108ae1897189975b

--- a/SPECS/kernel/CVE-2022-41849.nopatch
+++ b/SPECS/kernel/CVE-2022-41849.nopatch
@@ -1,0 +1,2 @@
+CVE-2022-41849 - Fix already backported 5.15.75
+upstream commit ID 5610bcfe8693c02e2e4c8b31427f1bdbdecc839c -> stable commit ID 2b0897e33682a332167b7d355eec28693b62119e

--- a/SPECS/kernel/CVE-2022-41850.nopatch
+++ b/SPECS/kernel/CVE-2022-41850.nopatch
@@ -1,0 +1,2 @@
+CVE-2022-41850 - Fix already backported 5.15.75
+upstream commit ID cacdb14b1c8d3804a3a7d31773bc7569837b71a4 -> stable commit ID c61786dc727d1850336d12c85a032c9a36ae396d

--- a/SPECS/kernel/CVE-2022-43945.nopatch
+++ b/SPECS/kernel/CVE-2022-43945.nopatch
@@ -1,0 +1,7 @@
+CVE-2022-43945 - Fix already backported
+upstream commit ID 90bfc37b5ab91c1a6165e3e5cfc49bf04571b762 -> stable commit ID 6b55707ff8b296243a9cf6636d6d8459b6a4a7f8
+upstream commit ID 1242a87da0d8cd2a428e96ca68e7ea899b0f4624 -> stable commit ID cedaf73c8bdaa666cd125257861155f273464a6f
+upstream commit ID 00b4492686e0497fdb924a9d4c8f6f99377e176c -> stable commit ID dc7f225090c29a5f3b9419b1af32846a201555e7
+upstream commit ID 640f87c190e0d1b2a0fcb2ecf6d2cd53b1c41991 -> stable commit ID 071a076fd1b763aa6fe478efa047e0a549ba9c22
+upstream commit ID 401bc1f90874280a80b93f23be33a0e7e2d1f912 -> stable commit ID 2be9331ca6061bc6ea32247266f45b8b21030244
+upstream commit ID fa6be9cc6e80ec79892ddf08a8c10cabab9baf38 -> stable commit ID 75d9de25a6f833dd0701ca546ac926cabff2b5af


### PR DESCRIPTION
CVE-2022-1204, CVE-2022-2785, CVE-2022-3586, CVE-2022-3595, CVE-2022-3910, CVE-2022-40768, CVE-2022-4127, CVE-2022-41849, CVE-2022-41850, CVE-2022-43945, CVE-2022-3344 for kernel

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Nopatch CVE-2022-1204, CVE-2022-2785, CVE-2022-3586, CVE-2022-3595, CVE-2022-3910, CVE-2022-40768, CVE-2022-4127, CVE-2022-41849, CVE-2022-41850, CVE-2022-43945, CVE-2022-3344 for kernel

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES/NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
 - https://nvd.nist.gov/vuln/detail/CVE-2022-1204
 - https://nvd.nist.gov/vuln/detail/CVE-2022-2785
 - https://nvd.nist.gov/vuln/detail/CVE-2022-3586
 - https://nvd.nist.gov/vuln/detail/CVE-2022-3595
 - https://nvd.nist.gov/vuln/detail/CVE-2022-3910
 - https://nvd.nist.gov/vuln/detail/CVE-2022-40768
 - https://nvd.nist.gov/vuln/detail/CVE-2022-4127
 - https://nvd.nist.gov/vuln/detail/CVE-2022-41849
 - https://nvd.nist.gov/vuln/detail/CVE-2022-41850
 - https://nvd.nist.gov/vuln/detail/CVE-2022-43945
 - https://nvd.nist.gov/vuln/detail/CVE-2022-3344

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- N/A
