### PR TITLE
Update strongswan for CVE-2022-40617

### DIFF
--- a/SPECS/strongswan/strongswan.signatures.json
+++ b/SPECS/strongswan/strongswan.signatures.json
@@ -1,5 +1,5 @@
 {
- "Signatures": {
-  "strongswan-5.9.5.tar.bz2": "983e4ef4a4c6c9d69f5fe6707c7fe0b2b9a9291943bbf4e008faab6bf91c0bdd"
- }
+  "Signatures": {
+    "strongswan-5.9.8.tar.bz2": "d3303a43c0bd7b75a12b64855e8edcb53696f06190364f26d1533bde1f2e453c"
+  }
 }

--- a/SPECS/strongswan/strongswan.spec
+++ b/SPECS/strongswan/strongswan.spec
@@ -1,6 +1,6 @@
 Summary:        The OpenSource IPsec-based VPN Solution
 Name:           strongswan
-Version:        5.9.5
+Version:        5.9.8
 Release:        1%{?dist}
 License:        GPLv2+
 Vendor:         Microsoft Corporation
@@ -20,6 +20,9 @@ strongSwan is a complete IPsec implementation for Linux 2.6, 3.x, and 4.x kernel
 %autosetup -p1
 
 %build
+# Disabling "format-security" warning, not compatible with strongswan custom printf specifiers
+export CCFLAGS="%{optflags}"
+export CFLAGS="$CFLAGS -Wno-format-security"
 %configure
 sed -i '/stdlib.h/a #include <stdint.h>' src/libstrongswan/utils/utils.h &&
 make %{?_smp_mflags}
@@ -48,6 +51,9 @@ make check
 %{_datadir}/strongswan/*
 
 %changelog
+* Thu Dec 08 2022 Henry Beberman <henry.beberman@microsoft.com> - 5.9.8-1
+- Updated to version 5.9.8 to fix CVE-2022-40617
+
 * Tue Apr 12 2022 Nicolas Guibourge <nicolasg@microsoft.com> - 5.9.5-1
 - Updated to version 5.9.5 to fix CVE-2021-45079.
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -25877,8 +25877,8 @@
         "type": "other",
         "other": {
           "name": "strongswan",
-          "version": "5.9.5",
-          "downloadUrl": "https://download.strongswan.org/strongswan-5.9.5.tar.bz2"
+          "version": "5.9.8",
+          "downloadUrl": "https://download.strongswan.org/strongswan-5.9.8.tar.bz2"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Upgrade strongswan to 5.9.8 to fix CVE-2022-40617

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Upgrade strongswan to 5.9.8 to fix CVE-2022-40617
- Set -Wno-format-security because strongswan enabled -Werror and is [explicitly incompatible](https://github.com/strongswan/strongswan/commit/1f242e772b7076b32136d86d403e77874a8f83e4#diff-49473dca262eeab3b4a43002adb08b4db31020d190caaad1594b47f1d5daa810R1457) with -Wformat-security.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2022-40617

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build succeeded
- %check section tests show same results as previous version.
- Buddy build 275418 succeeded
