### PR TITLE
Patch libconfuse for CVE-2022-40320

### DIFF
--- a/SPECS/libconfuse/CVE-2022-40320.patch
+++ b/SPECS/libconfuse/CVE-2022-40320.patch
@@ -1,0 +1,39 @@
+From d73777c2c3566fb2647727bb56d9a2295b81669b Mon Sep 17 00:00:00 2001
+From: Joachim Wiberg <troglobit@gmail.com>
+Date: Fri, 2 Sep 2022 16:12:46 +0200
+Subject: [PATCH] Fix #163: unterminated username used with getpwnam()
+
+Signed-off-by: Joachim Wiberg <troglobit@gmail.com>
+Signed-off-by: Henry Beberman <henry.beberman@microsoft.com>
+---
+ src/confuse.c | 10 ++++++----
+ 1 file changed, 6 insertions(+), 4 deletions(-)
+
+diff -Naur a/src/confuse.c b/src/confuse.c
+--- a/src/confuse.c	2020-06-21 20:53:26.000000000 +0000
++++ b/src/confuse.c	2022-12-09 00:55:50.887811234 +0000
+@@ -1863,18 +1863,20 @@
+ 			passwd = getpwuid(geteuid());
+ 			file = filename + 1;
+ 		} else {
+-			/* ~user or ~user/path */
+-			char *user;
++			char *user; /* ~user or ~user/path */
++			size_t len;
+ 
+ 			file = strchr(filename, '/');
+ 			if (file == 0)
+ 				file = filename + strlen(filename);
+ 
+-			user = malloc(file - filename);
++			len = file - filename - 1;
++			user = malloc(len + 1);
+ 			if (!user)
+ 				return NULL;
+ 
+-			strncpy(user, filename + 1, file - filename - 1);
++			strncpy(user, &filename[1], len);
++			user[len] = 0;
+ 			passwd = getpwnam(user);
+ 			free(user);
+ 		}

--- a/SPECS/libconfuse/libconfuse.spec
+++ b/SPECS/libconfuse/libconfuse.spec
@@ -1,13 +1,14 @@
 Summary:        Configuration file parser library
 Name:           libconfuse
 Version:        3.3
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        ISC
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Group:          Development/Libraries
 URL:            https://github.com/libconfuse/libconfuse
 Source0:        https://github.com/libconfuse/libconfuse/releases/download/v%{version}/confuse-%{version}.tar.gz
+Patch0:         CVE-2022-40320.patch
 BuildRequires:  gcc
 BuildRequires:  make
 
@@ -33,6 +34,9 @@ Requires:       %{name} = %{version}-%{release}
 %configure
 %make_build
 
+%check
+make check
+
 %install
 %make_install
 find %{buildroot} -type f -name "*.la" -delete -print
@@ -55,6 +59,10 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %{_libdir}/pkgconfig/libconfuse.pc
 
 %changelog
+* Thu Dec 08 2022 Henry Beberman <henry.beberman@microsoft.com> 3.3-2
+- Apply upstream patch for CVE-2022-40320
+- Add check section
+
 * Mon Feb 08 2021 Henry Beberman <henry.beberman@microsoft.com> 3.3-1
 - Add libconfuse spec
 - License verified


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Apply libconfuse upstream patch for CVE-2022-40320

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Apply libconfuse upstream patch for CVE-2022-40320

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2022-40320

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build succeeded
- Added check section tests all pass
- Pipeline build id: 275555
