### PR TITLE
Patch moby-containerd to add ptrace readby and tracedby to default AppArmor profile

### DIFF
--- a/SPECS/moby-containerd/add_ptrace_readby_tracedby_to_apparmor.patch
+++ b/SPECS/moby-containerd/add_ptrace_readby_tracedby_to_apparmor.patch
@@ -1,0 +1,28 @@
+From 8d868dadb746aabfd3583d834510109afe9b1919 Mon Sep 17 00:00:00 2001
+From: Juan Hoyos <juan.s.hoyos@outlook.com>
+Date: Wed, 23 Nov 2022 15:01:32 -0500
+Subject: [PATCH] Add ptrace readby and tracedby to default AppArmor profile
+
+Fixes https://github.com/containerd/containerd/issues/7695. The default profile allows processes within the container to trace others, but blocks reads/traces. This means that diagnostic facilities in processes can't easily collect crash/hang dumps. A usual workflow used by solutions like crashpad and similar projects is that the process that's unresponsive will spawn a process to collect diagnostic data using ptrace. seccomp-bpf, yama ptrace settings, and CAP_SYS_PTRACE already provide security mechanisms to reduce the scopes in which the API can be used. This enables reading from /proc/* files provided the tracer process passes all other checks.
+
+Signed-off-by: Juan Hoyos <juan.s.hoyos@outlook.com>
+---
+ contrib/apparmor/template.go | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/contrib/apparmor/template.go b/contrib/apparmor/template.go
+index 7544db749e7..c0b0e542e1c 100644
+--- a/contrib/apparmor/template.go
++++ b/contrib/apparmor/template.go
+@@ -84,7 +84,9 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
+   deny /sys/kernel/security/** rwklx,
+ 
+ {{if ge .Version 208095}}
+-  ptrace (trace,read) peer={{.Name}},
++  # allow processes within the container to trace each other,
++  # provided all other LSM and yama setting allow it.
++  ptrace (trace,tracedby,read,readby) peer={{.Name}},
+ {{end}}
+ }
+ `
+ 

--- a/SPECS/moby-containerd/moby-containerd.spec
+++ b/SPECS/moby-containerd/moby-containerd.spec
@@ -5,7 +5,7 @@
 Summary: Industry-standard container runtime
 Name: moby-%{upstream_name}
 Version: 1.6.12
-Release: 2%{?dist}
+Release: 3%{?dist}
 License: ASL 2.0
 Group: Tools/Container
 URL: https://www.containerd.io
@@ -16,6 +16,7 @@ Source0: https://github.com/containerd/containerd/archive/v%{version}.tar.gz#/%{
 Source1: containerd.service
 Source2: containerd.toml
 Patch0:  Makefile.patch
+Patch1:  add_ptrace_readby_tracedby_to_apparmor.patch
 
 %{?systemd_requires}
 
@@ -85,6 +86,9 @@ fi
 %config(noreplace) %{_sysconfdir}/containerd/config.toml
 
 %changelog
+* Mon Dec 19 2022 Aadhar Agarwal <aadagarwal@microsoft.com> - 1.6.12-3
+- Backport upstream fix in containerd to add ptrace readby and tracedby to default AppArmor profile (add_ptrace_readby_tracedby_to_apparmor.patch)
+
 * Fri Dec 16 2022 Daniel McIlvaney <damcilva@microsoft.com> - 1.6.12-2
 - Bump release to rebuild with go 1.18.8 with patch for CVE-2022-41717
 


### PR DESCRIPTION

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
- This PR backports an [upstream fix](https://github.com/containerd/containerd/commit/8d868dadb746aabfd3583d834510109afe9b1919) in containerd to add ptrace readby and tracedby to default AppArmor profile
- It is needed because dotnet-dump fails on Mariner and this is the root cause

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add the upstream containerd fix through a patch - `add_ptrace_readby_tracedby_to_apparmor.patch`
- Update `moby-containerd.spec` file accordingly

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- [Overall dotnet-dump bug](https://microsoft.visualstudio.com/OS/_sprints/taskboard/Mariner%20Platform/OS/2212?workitem=41597402)
- [Backport containerd fix task on Mariner 2.0](https://microsoft.visualstudio.com/OS/_sprints/taskboard/Mariner%20Platform/OS/2212?workitem=42592404)

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->

How the build was validated?
- Local build
- AMD-64 [Buddy Build](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=280069&view=results)
- ARM-64 [Buddy Build](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=280070&view=results)

How the task was validated?
- Created a Mariner AKS cluster
- Created an Ubuntu pod
- Copied [ptrace.c](https://gist.github.com/hoyosjs/4ba78cb3993284bae786f3a84d8c87cb) into the Ubuntu pod
- Ran `gcc ptrace.c -o a.out` and got the expected passing result:
<img width="370" alt="image" src="https://user-images.githubusercontent.com/108542189/208557842-6263728f-4bce-49e3-9adc-d77867964cb1.png">


