### PR TITLE
Improved `ltp` package clean-up.

### DIFF
--- a/SPECS/ltp/ltp.spec
+++ b/SPECS/ltp/ltp.spec
@@ -80,7 +80,7 @@ make check
 
 %preun
 # Removing files with names not known until the tests are run.
-rm -rf %{ltp_prefix}/{output,results,testcases/bin/*}
+rm -rf %{ltp_prefix}/{output,results,testcases/bin/[0-9]*}
 
 %files
 %license COPYING

--- a/SPECS/ltp/ltp.spec
+++ b/SPECS/ltp/ltp.spec
@@ -10,7 +10,7 @@
 Summary:        Linux Test Project
 Name:           ltp
 Version:        20220930
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPL-2.0-only
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -38,6 +38,7 @@ BuildRequires:  make
 BuildRequires:  pkg-config
 
 Requires:  expect
+Requires:  gawk
 Requires:  glibc
 Requires:  libacl
 Requires:  libaio
@@ -77,6 +78,10 @@ make autotools
 sed -i "s/git submodule.*/@echo 'Skipping submodule init - already provided.'/" tools/sparse/Makefile
 make check
 
+%preun
+# Removing files with names not known until the tests are run.
+rm -rf %{ltp_prefix}/{output,results,testcases/bin/*}
+
 %files
 %license COPYING
 %{ltp_prefix}
@@ -85,6 +90,10 @@ make check
 %{_mandir}/*
 
 %changelog
+* Tue Dec 20 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 20220930-2
+- Fool-proofing LTP dependencies.
+- Cleaning up directories created during tests.
+
 * Wed Nov 30 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 20220930-1
 - Original version for CBL-Mariner.
 - License verified.


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

I've noticed that `ltp` was leaving behind files it generated while the tests were ran. Addressing this issue in this PR.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Made sure we clean-up files generated during test runs.
- Added explicit dependency on `gawk` to be on the safe side.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local package build.
