### PR TITLE
Patch helm to fix CVE fix CVE-2022-23525 and CVE-2022-23526

### DIFF
--- a/SPECS/helm/CVE-2022-23525.patch
+++ b/SPECS/helm/CVE-2022-23525.patch
@@ -1,0 +1,94 @@
+From 256e976331db4b7335ef721e411e7b59c5317ccb Mon Sep 17 00:00:00 2001
+From: Martin Hickey <martin.hickey@ie.ibm.com>
+Date: Wed, 9 Nov 2022 16:11:43 +0000
+Subject: [PATCH] Update repo handling
+
+Signed-off-by: Martin Hickey <martin.hickey@ie.ibm.com>
+---
+ pkg/repo/index.go      |  8 ++++++++
+ pkg/repo/index_test.go | 33 +++++++++++++++++++++++++++++++++
+ pkg/repo/repo.go       |  3 +++
+ pkg/repo/repo_test.go  | 31 +++++++++++++++++++++++++++++++
+ 4 files changed, 75 insertions(+)
+
+diff --git a/pkg/repo/index.go b/pkg/repo/index.go
+index 1b65ac497c1..60cfe5801ff 100644
+--- a/pkg/repo/index.go
++++ b/pkg/repo/index.go
+@@ -118,6 +118,10 @@ func LoadIndexFile(path string) (*IndexFile, error) {
+ // MustAdd adds a file to the index
+ // This can leave the index in an unsorted state
+ func (i IndexFile) MustAdd(md *chart.Metadata, filename, baseURL, digest string) error {
++	if i.Entries == nil {
++		return errors.New("entries not initialized")
++	}
++
+ 	if md.APIVersion == "" {
+ 		md.APIVersion = chart.APIVersionV1
+ 	}
+@@ -339,6 +343,10 @@ func loadIndex(data []byte, source string) (*IndexFile, error) {
+ 
+ 	for name, cvs := range i.Entries {
+ 		for idx := len(cvs) - 1; idx >= 0; idx-- {
++			if cvs[idx] == nil {
++				log.Printf("skipping loading invalid entry for chart %q from %s: empty entry", name, source)
++				continue
++			}
+ 			if cvs[idx].APIVersion == "" {
+ 				cvs[idx].APIVersion = chart.APIVersionV1
+ 			}
+diff --git a/pkg/repo/index_test.go b/pkg/repo/index_test.go
+index a75a4177aef..2403e9a71ab 100644
+--- a/pkg/repo/index_test.go
++++ b/pkg/repo/index_test.go
+@@ -59,6 +59,15 @@ entries:
+       version: 1.0.0
+       home: https://github.com/something
+       digest: "sha256:1234567890abcdef"
++`
++	indexWithEmptyEntry = `
++apiVersion: v1
++entries:
++  grafana:
++  - apiVersion: v2
++    name: grafana
++  foo:
++  -
+ `
+ )
+ 
+@@@ -152,6 +152,12 @@ func TestLoadIndex_Duplicates(t *testing.T) {
+        }
+ }
++
++func TestLoadIndex_EmptyEntry(t *testing.T) {
++       if _, err := loadIndex([]byte(indexWithEmptyEntry), "indexWithEmptyEntry"); err != nil {
++               t.Errorf("unexpected error: %s", err)
++       }
++}
++
+ func TestLoadIndexFileAnnotations(t *testing.T) {
+        i, err := LoadIndexFile(annotationstestfile)
+        if err != nil {
+@@ -523,3 +529,21 @@ func TestIndexWrite(t *testing.T) {
+                t.Fatal("Index files doesn't contain expected content")
+        }
+ }
++
++func TestAddFileIndexEntriesNil(t *testing.T) {
++       i := NewIndexFile()
++       i.APIVersion = chart.APIVersionV1
++       i.Entries = nil
++       for _, x := range []struct {
++               md       *chart.Metadata
++               filename string
++               baseURL  string
++               digest   string
++       }{
++               {&chart.Metadata{APIVersion: "v2", Name: " ", Version: "8033-5.apinie+s.r"}, "setter-0.1.9+beta.tgz", "http://example.
++       } {
++               if err := i.MustAdd(x.md, x.filename, x.baseURL, x.digest); err == nil {
++                       t.Errorf("expected err to be non-nil when entries not initialized")
++               }
++       }
++}

--- a/SPECS/helm/CVE-2022-23526.patch
+++ b/SPECS/helm/CVE-2022-23526.patch
@@ -1,0 +1,74 @@
+From 775af2a0ceadef1bc8f627cdb70fadb3c69b8d86 Mon Sep 17 00:00:00 2001
+From: Martin Hickey <martin.hickey@ie.ibm.com>
+Date: Fri, 21 Oct 2022 18:04:05 +0100
+Subject: [PATCH] Update schema validation handling
+
+Signed-off-by: Martin Hickey <martin.hickey@ie.ibm.com>
+---
+ pkg/chartutil/jsonschema.go                   |  8 ++++++-
+ pkg/chartutil/jsonschema_test.go              | 24 +++++++++++++++++++
+ .../testdata/test-values-invalid.schema.json  |  1 +
+ 3 files changed, 32 insertions(+), 1 deletion(-)
+ create mode 100644 pkg/chartutil/testdata/test-values-invalid.schema.json
+
+diff --git a/pkg/chartutil/jsonschema.go b/pkg/chartutil/jsonschema.go
+index 753dc98c1eb..7b9768fd3cc 100644
+--- a/pkg/chartutil/jsonschema.go
++++ b/pkg/chartutil/jsonschema.go
+@@ -55,7 +55,13 @@ func ValidateAgainstSchema(chrt *chart.Chart, values map[string]interface{}) err
+ }
+ 
+ // ValidateAgainstSingleSchema checks that values does not violate the structure laid out in this schema
+-func ValidateAgainstSingleSchema(values Values, schemaJSON []byte) error {
++func ValidateAgainstSingleSchema(values Values, schemaJSON []byte) (reterr error) {
++	defer func() {
++		if r := recover(); r != nil {
++			reterr = fmt.Errorf("unable to validate schema: %s", r)
++		}
++	}()
++
+ 	valuesData, err := yaml.Marshal(values)
+ 	if err != nil {
+ 		return err
+diff --git a/pkg/chartutil/jsonschema_test.go b/pkg/chartutil/jsonschema_test.go
+index a0acd5a7f29..d71668ac888 100644
+--- a/pkg/chartutil/jsonschema_test.go
++++ b/pkg/chartutil/jsonschema_test.go
+@@ -38,6 +38,30 @@ func TestValidateAgainstSingleSchema(t *testing.T) {
+ 	}
+ }
+ 
++func TestValidateAgainstInvalidSingleSchema(t *testing.T) {
++	values, err := ReadValuesFile("./testdata/test-values.yaml")
++	if err != nil {
++		t.Fatalf("Error reading YAML file: %s", err)
++	}
++	schema, err := ioutil.ReadFile("./testdata/test-values-invalid.schema.json")
++	if err != nil {
++		t.Fatalf("Error reading YAML file: %s", err)
++	}
++
++	var errString string
++	if err := ValidateAgainstSingleSchema(values, schema); err == nil {
++		t.Fatalf("Expected an error, but got nil")
++	} else {
++		errString = err.Error()
++	}
++
++	expectedErrString := "unable to validate schema: runtime error: invalid " +
++		"memory address or nil pointer dereference"
++	if errString != expectedErrString {
++		t.Errorf("Error string :\n`%s`\ndoes not match expected\n`%s`", errString, expectedErrString)
++	}
++}
++
+ func TestValidateAgainstSingleSchemaNegative(t *testing.T) {
+ 	values, err := ReadValuesFile("./testdata/test-values-negative.yaml")
+ 	if err != nil {
+diff --git a/pkg/chartutil/testdata/test-values-invalid.schema.json b/pkg/chartutil/testdata/test-values-invalid.schema.json
+new file mode 100644
+index 00000000000..35a16a2c415
+--- /dev/null
++++ b/pkg/chartutil/testdata/test-values-invalid.schema.json
+@@ -0,0 +1 @@
++   1E1111111

--- a/SPECS/helm/helm.spec
+++ b/SPECS/helm/helm.spec
@@ -51,6 +51,17 @@ install -m 755 ./helm %{buildroot}%{_bindir}
 %doc ADOPTERS.md SECURITY.md code-of-conduct.md CONTRIBUTING.md README.md
 %{_bindir}/helm
 
+%if %{with check}
+%check
+# FAIL: TestValidateNoDeprecations
+#rm pkg/lint/rules/deprecations_test.go
+# FAIL: TestDeprecatedAPIFails
+#rm pkg/lint/rules/template_test.go
+# Needs Internet access
+#rm pkg/plugin/installer/vcs_installer_test.go
+%gocheck
+%endif
+
 %changelog
 * Wed Dec 21 2022 Jon Slobodzian <joslobo@microsoft.com> - 3.4.1-14
 - Patch CVE-2022-23525, CVE-2022-23526

--- a/SPECS/helm/helm.spec
+++ b/SPECS/helm/helm.spec
@@ -58,6 +58,7 @@ go test -v ./cmd/helm
 %changelog
 * Wed Dec 21 2022 Jon Slobodzian <joslobo@microsoft.com> - 3.4.1-14
 - Patch CVE-2022-23525, CVE-2022-23526
+- Added Check Section
 
 * Tue Dec 13 2022 Suresh Babu Chalamalasetty <schalam@microsoft.com> - 3.4.1-13
 - Bump release to rebuild with go 1.18.8-2

--- a/SPECS/helm/helm.spec
+++ b/SPECS/helm/helm.spec
@@ -51,16 +51,9 @@ install -m 755 ./helm %{buildroot}%{_bindir}
 %doc ADOPTERS.md SECURITY.md code-of-conduct.md CONTRIBUTING.md README.md
 %{_bindir}/helm
 
-%if %{with check}
+
 %check
-# FAIL: TestValidateNoDeprecations
-#rm pkg/lint/rules/deprecations_test.go
-# FAIL: TestDeprecatedAPIFails
-#rm pkg/lint/rules/template_test.go
-# Needs Internet access
-#rm pkg/plugin/installer/vcs_installer_test.go
-%gocheck
-%endif
+go test -v ./cmd/helm
 
 %changelog
 * Wed Dec 21 2022 Jon Slobodzian <joslobo@microsoft.com> - 3.4.1-14

--- a/SPECS/helm/helm.spec
+++ b/SPECS/helm/helm.spec
@@ -1,15 +1,13 @@
 %global debug_package %{nil}
-Summary:        The Kubernetes Package Manager
 Name:           helm
 Version:        3.4.1
-Release:        13%{?dist}
+Release:        14%{?dist}
+Summary:        The Kubernetes Package Manager
 License:        Apache 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
-Group:          Applications/Networking
 URL:            https://github.com/helm/helm
-#Source0:      https://github.com/%{name}/%{name}/archive/v%{version}.tar.gz
-Source0:        %{name}-%{version}.tar.gz
+Source0:        https://github.com/%{name}/%{name}/archive/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
 # Below is a manually created tarball, no download link.
 # We're using pre-populated Go modules from this tarball, since network is disabled during build time.
 # How to re-build this file:
@@ -26,6 +24,8 @@ Source0:        %{name}-%{version}.tar.gz
 Source1:        %{name}-%{version}-vendor.tar.gz
 Patch0:         CVE-2021-21303.patch
 Patch1:         CVE-2021-32690.patch
+Patch2:         CVE-2022-23525.patch
+Patch3:         CVE-2022-23526.patch
 BuildRequires:  golang >= 1.15.5
 
 %description
@@ -52,6 +52,9 @@ install -m 755 ./helm %{buildroot}%{_bindir}
 %{_bindir}/helm
 
 %changelog
+* Wed Dec 21 2022 Jon Slobodzian <joslobo@microsoft.com> - 3.4.1-14
+- Patch CVE-2022-23525, CVE-2022-23526
+
 * Tue Dec 13 2022 Suresh Babu Chalamalasetty <schalam@microsoft.com> - 3.4.1-13
 - Bump release to rebuild with go 1.18.8-2
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge


###### Summary <!-- REQUIRED -->
This change fixes CVE-2022-23525 and CVE-2022-23526.  This change was cherry-picked from main (2.0) and adapted for 1.0-dev.  It also introduces the helm self-tests.


##### How Tested
This we verified by adding the helm self-tests and running them
