### PR TITLE
kubevirt: Upgrade to 0.58.0

### DIFF
--- a/SPECS/kubevirt/disks-images-provider.yaml
+++ b/SPECS/kubevirt/disks-images-provider.yaml
@@ -16,10 +16,13 @@ spec:
         kubevirt.io: disks-images-provider
       name: disks-images-provider
     spec:
+      tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
       serviceAccountName: kubevirt-testing
       containers:
         - name: target
-          image: quay.io/kubevirt/disks-images-provider:v0.51.0
+          image: quay.io/kubevirt/disks-images-provider:v0.58.0
           imagePullPolicy: Always
           lifecycle:
             preStop:

--- a/SPECS/kubevirt/kubevirt.signatures.json
+++ b/SPECS/kubevirt/kubevirt.signatures.json
@@ -1,6 +1,6 @@
 {
   "Signatures": {
-    "disks-images-provider.yaml": "5aed2075600b4332812ebf39fd31053442578880b7686dfb6459b94624314dad",
-    "kubevirt-0.55.1.tar.gz": "f9a05eb480875cfb958b20706361bd9a58bd3cdd2e971d37d62d17454bb39160"
+    "disks-images-provider.yaml": "02beaa28c9d39e4d677569cc5e0fb9d0c1251a5749e2e93afb32d35e69def63c",
+    "kubevirt-0.55.1.tar.gz": "104bd0cb3d9ad62801434c093896c124c10b540dd2c2d01e657e1fbafeb250ac"
   }
 }

--- a/SPECS/kubevirt/kubevirt.signatures.json
+++ b/SPECS/kubevirt/kubevirt.signatures.json
@@ -1,6 +1,6 @@
 {
   "Signatures": {
     "disks-images-provider.yaml": "02beaa28c9d39e4d677569cc5e0fb9d0c1251a5749e2e93afb32d35e69def63c",
-    "kubevirt-0.55.1.tar.gz": "104bd0cb3d9ad62801434c093896c124c10b540dd2c2d01e657e1fbafeb250ac"
+    "kubevirt-0.58.0.tar.gz": "104bd0cb3d9ad62801434c093896c124c10b540dd2c2d01e657e1fbafeb250ac"
   }
 }

--- a/SPECS/kubevirt/kubevirt.signatures.json
+++ b/SPECS/kubevirt/kubevirt.signatures.json
@@ -1,6 +1,6 @@
 {
   "Signatures": {
     "disks-images-provider.yaml": "02beaa28c9d39e4d677569cc5e0fb9d0c1251a5749e2e93afb32d35e69def63c",
-    "kubevirt-0.58.0.tar.gz": "104bd0cb3d9ad62801434c093896c124c10b540dd2c2d01e657e1fbafeb250ac"
+    "kubevirt-0.58.0.tar.gz": "e54c74af63180e785e998630a73d4c85f56e3f74bca44c76318d12aacb8400e0"
   }
 }

--- a/SPECS/kubevirt/kubevirt.spec
+++ b/SPECS/kubevirt/kubevirt.spec
@@ -211,7 +211,7 @@ install -p -m 0644 cmd/virt-handler/ipv6-nat.nft %{buildroot}%{_datadir}/kube-vi
 %changelog
 * Mon Dec 26 2022 Kanika Nema <kanikanema@microsoft.com> - 0.58.0-1
 - Upgrade to 0.58.0
-  Build new component virt-launcher-monitor.
+- Build new component virt-launcher-monitor.
 
 * Fri Dec 16 2022 Daniel McIlvaney <damcilva@microsoft.com> - 0.55.1-4
 - Bump release to rebuild with go 1.18.8 with patch for CVE-2022-41717

--- a/SPECS/kubevirt/kubevirt.spec
+++ b/SPECS/kubevirt/kubevirt.spec
@@ -209,7 +209,7 @@ install -p -m 0644 cmd/virt-handler/ipv6-nat.nft %{buildroot}%{_datadir}/kube-vi
 %{_bindir}/virt-tests
 
 %changelog
-* Mon Dec 26 2022 Kanika Nema <kanikanema@microsoft.com> - 0.58.0
+* Mon Dec 26 2022 Kanika Nema <kanikanema@microsoft.com> - 0.58.0-1
 - Upgrade to 0.58.0
   Build new component virt-launcher-monitor.
 

--- a/SPECS/kubevirt/kubevirt.spec
+++ b/SPECS/kubevirt/kubevirt.spec
@@ -19,8 +19,8 @@
 %global debug_package %{nil}
 Summary:        Container native virtualization
 Name:           kubevirt
-Version:        0.55.1
-Release:        4%{?dist}
+Version:        0.58.0
+Release:        1%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -115,6 +115,7 @@ build_tests="true" \
     cmd/virt-freezer \
     cmd/virt-handler \
     cmd/virt-launcher \
+    cmd/virt-launcher-monitor \
     cmd/virt-operator \
     cmd/virt-probe \
     cmd/virtctl \
@@ -130,6 +131,7 @@ install -p -m 0755 _out/cmd/virt-controller/virt-controller %{buildroot}%{_bindi
 install -p -m 0755 _out/cmd/virt-chroot/virt-chroot %{buildroot}%{_bindir}/
 install -p -m 0755 _out/cmd/virt-handler/virt-handler %{buildroot}%{_bindir}/
 install -p -m 0555 _out/cmd/virt-launcher/virt-launcher %{buildroot}%{_bindir}/
+install -p -m 0555 _out/cmd/virt-launcher-monitor/virt-launcher-monitor %{buildroot}%{_bindir}/
 install -p -m 0755 _out/cmd/virt-freezer/virt-freezer %{buildroot}%{_bindir}/
 install -p -m 0755 _out/cmd/virt-probe/virt-probe %{buildroot}%{_bindir}/
 install -p -m 0755 _out/cmd/virt-operator/virt-operator %{buildroot}%{_bindir}/
@@ -189,6 +191,7 @@ install -p -m 0644 cmd/virt-handler/ipv6-nat.nft %{buildroot}%{_datadir}/kube-vi
 %dir %{_datadir}/kube-virt
 %dir %{_datadir}/kube-virt/virt-launcher
 %{_bindir}/virt-launcher
+%{_bindir}/virt-launcher-monitor
 %{_bindir}/virt-freezer
 %{_bindir}/virt-probe
 %{_bindir}/node-labeller.sh
@@ -206,6 +209,10 @@ install -p -m 0644 cmd/virt-handler/ipv6-nat.nft %{buildroot}%{_datadir}/kube-vi
 %{_bindir}/virt-tests
 
 %changelog
+* Mon Dec 26 2022 Kanika Nema <kanikanema@microsoft.com> - 0.58.0
+- Upgrade to 0.58.0
+  Build new component virt-launcher-monitor.
+
 * Fri Dec 16 2022 Daniel McIlvaney <damcilva@microsoft.com> - 0.55.1-4
 - Bump release to rebuild with go 1.18.8 with patch for CVE-2022-41717
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -7701,8 +7701,8 @@
         "type": "other",
         "other": {
           "name": "kubevirt",
-          "version": "0.55.1",
-          "downloadUrl": "https://github.com/kubevirt/kubevirt/archive/refs/tags/v0.55.1.tar.gz"
+          "version": "0.58.0",
+          "downloadUrl": "https://github.com/kubevirt/kubevirt/archive/refs/tags/v0.58.0.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Mariner HCI (AODS) needs a newer version of kubevirt. This change upgrades the package to the current latest version 0.58.0

###### Change Log  <!-- REQUIRED -->
Package upgraded to 0.58.0

###### Does this affect the toolchain?  <!-- REQUIRED -->
No

###### Associated issues  <!-- optional -->
https://dev.azure.com/mariner-org/ECF/_workitems/edit/3092/
###### Links to CVEs  <!-- optional -->

###### Test Methodology
- Buddy build id: 282644
