### PR TITLE
Patch CVE-2022-40897 in python-setuptools

### DIFF
--- a/SPECS/python-setuptools/CVE-2022-40897.patch
+++ b/SPECS/python-setuptools/CVE-2022-40897.patch
@@ -1,0 +1,12 @@
+diff -ru setuptools-40.2.0/setuptools/package_index.py setuptools-40.2.0-mod/setuptools/package_index.py
+--- setuptools-40.2.0/setuptools/package_index.py	2018-08-21 13:04:36.000000000 -0700
++++ setuptools-40.2.0-mod/setuptools/package_index.py	2023-01-03 15:00:04.313117605 -0800
+@@ -213,7 +213,7 @@
+     return wrapper
+ 
+ 
+-REL = re.compile(r"""<([^>]*\srel\s*=\s*['"]?([^'">]+)[^>]*)>""", re.I)
++REL = re.compile(r"""<([^>]*\srel\s{0,10}=\s{0,10}['"]?([^'" >]+)[^>]*)>""", re.I)
+ # this line is here to fix emacs' cruddy broken syntax highlighting
+ 
+ 

--- a/SPECS/python-setuptools/python-setuptools.spec
+++ b/SPECS/python-setuptools/python-setuptools.spec
@@ -28,8 +28,7 @@ you to more easily build and distribute Python packages, especially ones that
 have dependencies on other packages.
 
 %prep
-%setup -n setuptools-%{version}
-%patch0 -p1
+%autosetup -p1 -n setuptools-%{version}
 
 %build
 python2 bootstrap.py

--- a/SPECS/python-setuptools/python-setuptools.spec
+++ b/SPECS/python-setuptools/python-setuptools.spec
@@ -3,13 +3,14 @@
 Summary:        Download, build, install, upgrade, and uninstall Python packages
 Name:           python-setuptools
 Version:        40.2.0
-Release:        6%{?dist}
+Release:        7%{?dist}
 License:        MIT
 Group:          Development/Languages
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 URL:            https://pypi.python.org/pypi/setuptools
 Source0:        https://files.pythonhosted.org/packages/ef/1d/201c13e353956a1c840f5d0fbf0461bd45bbd678ea4843ebf25924e8984c/setuptools-%{version}.zip
+Patch0:         CVE-2022-40897.patch
 
 BuildArch: noarch
 
@@ -28,6 +29,7 @@ have dependencies on other packages.
 
 %prep
 %setup -n setuptools-%{version}
+%patch0 -p1
 
 %build
 python2 bootstrap.py
@@ -55,6 +57,9 @@ python2 setup.py test
 %{python2_sitelib}/*
 
 %changelog
+* Tue Jan 3 2023 Aadhar Agarwal <aadagarwal@microsoft.com> - 40.2.0-7
+- Add patch for CVE-2022-40897
+
 * Mon Nov 16 2020 Pawel Winogrodzki <pawelwi@microsoft.com> - 40.2.0-6
 - Adding explicit runtime dependency on 'python-xml'.
 

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -364,7 +364,7 @@ python3-rpm-4.14.2-15.cm1.aarch64.rpm
 python-curses-2.7.18-11.cm1.aarch64.rpm
 python-gpg-1.13.1-6.cm1.aarch64.rpm
 python-rpm-4.14.2-15.cm1.aarch64.rpm
-python-setuptools-40.2.0-6.cm1.noarch.rpm
+python-setuptools-40.2.0-7.cm1.noarch.rpm
 python-xml-2.7.18-11.cm1.aarch64.rpm
 readline-7.0-4.cm1.aarch64.rpm
 readline-debuginfo-7.0-4.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -364,7 +364,7 @@ python3-rpm-4.14.2-15.cm1.x86_64.rpm
 python-curses-2.7.18-11.cm1.x86_64.rpm
 python-gpg-1.13.1-6.cm1.x86_64.rpm
 python-rpm-4.14.2-15.cm1.x86_64.rpm
-python-setuptools-40.2.0-6.cm1.noarch.rpm
+python-setuptools-40.2.0-7.cm1.noarch.rpm
 python-xml-2.7.18-11.cm1.x86_64.rpm
 readline-7.0-4.cm1.x86_64.rpm
 readline-debuginfo-7.0-4.cm1.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
- Addresses CVE-2022-49897

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Backport patch from [this](https://github.com/pypa/setuptools/commit/43a9c9bfa6aa626ec2a22540bea28d2ca77964be) commit
- However, the change to `setuptools/tests/test_packageindex.py` that is in the commit does not apply here since the line that is being removed is not present in setuptools version 40.2.0


###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2022-40897

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Tested locally
- AMD64 [buddy build](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=286257&view=results)
- ARM64 [buddy build](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=286258&view=results)
- Pipeline build id: 285952 (running)
