### PR TITLE
toolkit: Fix tar compression issue in update_manifest.sh

### DIFF
--- a/toolkit/resources/manifests/package/update_manifests.sh
+++ b/toolkit/resources/manifests/package/update_manifests.sh
@@ -34,7 +34,7 @@ echo Updating files...
 generate_toolchain () {
     # First generate toolchain_*.txt from TOOLCHAIN_ARCHIVE (toolchain_built_rpms_all.tar.gz)
     # This file is a sorted list of all toolchain packages in the tarball.
-    tar -ztf "$TOOLCHAIN_ARCHIVE" | sed 's+built_rpms_all/++g' | sed '/^$/d' > "$ToolchainManifest"
+    tar -tf "$TOOLCHAIN_ARCHIVE" | sed 's+built_rpms_all/++g' | sed '/^$/d' > "$ToolchainManifest"
     # Now sort the file in place
     LC_COLLATE=C sort -f -o "$ToolchainManifest" "$ToolchainManifest"
 }


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Modify the update_manifest.sh script to remove the "z" compression flag from the tar command. This script is used to update the toolchain manifest files based on a toolchain_built_rpms_all.tar.gz archive. The change is needed after the changes from #3683 
This will resolve the following error seen when using an uncompressed toolchain tarball:
```
$ ./resources/manifests/package/update_manifests.sh x86_64 ../toolchain_built_rpms_all.tar.gz
Updating files...

gzip: stdin: not in gzip format
tar: Child returned status 1
tar: Error is not recoverable: exiting no
```

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change tar command in update_manifest.sh

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**


###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Locally use the script with a recent toolchain archive.
```
$ ./resources/manifests/package/update_manifests.sh x86_64 ../toolchain_built_rpms_all.tar.gz
```
