### PR TITLE
Clear SRPM pack list file when SRPM_PACK_LIST argument is empty

### DIFF
--- a/toolkit/scripts/srpm_pack.mk
+++ b/toolkit/scripts/srpm_pack.mk
@@ -24,7 +24,7 @@ $(srpm_pack_list_file): $(depend_SRPM_PACK_LIST)
 	@echo $(strip $(SRPM_PACK_LIST)) | tr " " "\n" > $(srpm_pack_list_file)
 else # Empty pack list, build all under $(SPECS_DIR)
 $(srpm_pack_list_file): $(depend_SRPM_PACK_LIST)
-	@touch $@
+	@truncate -s 0 $@
 endif
 
 $(call create_folder,$(BUILD_DIR))


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Subsequent calls to make targets with different `SRPM_PACK_LIST` arguments can result in an SRPM pack list file that doesn't match the contents of the `SRPM_PACK_LIST` make variable.

More specifically, we don't clear the pack list file if `SRPM_PACK_LIST` goes from non-empty to empty. This results in a limited set of SRPMs being built when the user expects all SRPMs to be built.

###### Change Log  <!-- REQUIRED -->
- Use `truncate -s 0` on the SRPM pack list when `SRPM_PACK_LIST` is empty. This (a) creates the file with zero size if not present, (b) truncates the file to zero size if present, and (c) updates the mtime of the file in all cases.

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Associated issues  <!-- optional -->
- Fixes ADO/OS/42357379

###### Test Methodology
Following sequence succeeds and builds the expected SRPMs for each command:
```sh
sudo make input-srpms SRPM_PACK_LIST="iptables" -j8 REBUILD_TOOLS=y
sudo make input-srpms SRPM_PACK_LIST="" -j8 REBUILD_TOOLS=y
```
