### PR TITLE
Build curl with HTTP/2 support

### DIFF
--- a/SPECS/curl/curl.spec
+++ b/SPECS/curl/curl.spec
@@ -1,8 +1,8 @@
 Summary:        An URL retrieval utility and library
 Name:           curl
 Version:        7.86.0
-Release:        2%{?dist}
-License:        MIT
+Release:        3%{?dist}
+License:        curl
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Group:          System Environment/NetworkingLibraries
@@ -13,6 +13,7 @@ Patch0:         CVE-2022-43551.patch
 Patch1:         CVE-2022-43552.patch
 BuildRequires:  krb5-devel
 BuildRequires:  libssh2-devel
+BuildRequires:  nghttp2-devel
 BuildRequires:  openssl-devel
 Requires:       curl-libs = %{version}-%{release}
 Requires:       krb5
@@ -47,10 +48,6 @@ This package contains minimal set of shared curl libraries.
 %autosetup -p1
 
 %build
-# CVE-2021-22922 and CVE-2021-22923 are vulnerabilities when curl's metalink
-# feature. We do not build with "--with-libmetalink" option and are therefore
-# not affected by these CVEs, but I am placing this comment here as a reminder
-# to leave metalink disabled.
 %configure \
     CFLAGS="%{optflags}" \
     CXXFLAGS="%{optflags}" \
@@ -59,19 +56,18 @@ This package contains minimal set of shared curl libraries.
     --with-ssl \
     --with-gssapi \
     --with-libssh2 \
+    --with-nghttp2 \
     --with-ca-bundle=%{_sysconfdir}/pki/tls/certs/ca-bundle.trust.crt \
     --with-ca-path=%{_sysconfdir}/ssl/certs
-make %{?_smp_mflags}
+%make_build
 
 %install
-[ %{buildroot} != "/"] && rm -rf %{buildroot}/*
-make DESTDIR=%{buildroot} install
+%make_install
 install -v -d -m755 %{buildroot}/%{_docdir}/%{name}-%{version}
 find %{buildroot} -type f -name "*.la" -delete -print
 %{_fixperms} %{buildroot}/*
 
-%post   -p /sbin/ldconfig
-%postun -p /sbin/ldconfig
+%ldconfig_scriptlets libs
 
 %files
 %defattr(-,root,root)
@@ -92,6 +88,12 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %{_libdir}/libcurl.so.*
 
 %changelog
+* Tue Jan 10 2023 Olivia Crain <oliviacrain@microsoft.com> - 7.86.0-3
+- Build with HTTP/2 support
+- Remove comment about metalink- no longer supported
+- Use SPDX license expression, change license name (MIT -> curl)
+- License verified
+
 * Wed Dec 14 2022 Daniel McIlvaney <damcilva@microsoft.com> - 7.86.0-2
 - Patch CVE-2022-43551, CVE-2022-43552
 

--- a/SPECS/nghttp2/nghttp2.spec
+++ b/SPECS/nghttp2/nghttp2.spec
@@ -1,22 +1,18 @@
 Summary:        nghttp2 is an implementation of HTTP/2 and its header compression algorithm, HPACK.
 Name:           nghttp2
 Version:        1.46.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Group:          Applications/System
 URL:            https://nghttp2.org
 Source0:        https://github.com/nghttp2/nghttp2/releases/download/v%{version}/%{name}-%{version}.tar.xz
-
-BuildRequires:  c-ares-devel
-BuildRequires:  jansson-devel
-BuildRequires:  libevent-devel
-BuildRequires:  libxml2-devel
-BuildRequires:  openssl-devel
-BuildRequires:  systemd
-BuildRequires:  zlib-devel
-
+BuildRequires:  gcc
+BuildRequires:  make
+%if %{with_check}
+BuildRequires:  cunit
+%endif
 Provides:       libnghttp2 = %{version}-%{release}
 
 %description
@@ -24,28 +20,29 @@ Implementation of the Hypertext Transfer Protocol version 2 in C.
 
 %package devel
 Summary:        Header files for nghttp2
-
-Provides:       libnghttp2-devel = %{version}-%{release}
-
 Requires:       %{name} = %{version}-%{release}
+Provides:       libnghttp2-devel = %{version}-%{release}
 
 %description devel
 These are the header files of nghttp2.
 
 %prep
-%setup -q
+%autosetup
 
 %build
-./configure --prefix=%{_prefix}        \
-            --disable-static           \
-            --enable-lib-only          \
-            --disable-python-bindings
+%configure \
+    --disable-static           \
+    --enable-lib-only          \
+    --disable-python-bindings
 
-make %{?_smp_mflags}
+%make_build
 
 %install
-make DESTDIR=%{buildroot} install
-rm %{buildroot}/%{_libdir}/*.la
+%make_install
+find %{buildroot} -type f -name "*.la" -delete -print
+
+%check
+%make_build -k check
 
 %files
 %defattr(-,root,root)
@@ -62,6 +59,12 @@ rm %{buildroot}/%{_libdir}/*.la
 %{_libdir}/pkgconfig/*.pc
 
 %changelog
+* Tue Jan 10 2023 Olivia Crain <oliviacrain@microsoft.com> - 1.46.0-2
+- Remove dependencies not needed to build library
+- Add %%check sections with unit tests
+- License verified, no SPDX expression conversion necessary
+- Lint spec
+
 * Mon Jan 31 2022 Max Brodeur-Urbas <maxbr@microsoft.com> - 1.46.0-1
 - Upgrading to v1.46.0
 

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -189,9 +189,10 @@ libsolv-devel-0.7.20-1.cm2.aarch64.rpm
 libssh2-1.9.0-2.cm2.aarch64.rpm
 libssh2-devel-1.9.0-2.cm2.aarch64.rpm
 krb5-1.19.4-1.cm2.aarch64.rpm
-curl-7.86.0-2.cm2.aarch64.rpm
-curl-devel-7.86.0-2.cm2.aarch64.rpm
-curl-libs-7.86.0-2.cm2.aarch64.rpm
+nghttp2-1.46.0-2.cm2.aarch64.rpm
+curl-7.86.0-3.cm2.aarch64.rpm
+curl-devel-7.86.0-3.cm2.aarch64.rpm
+curl-libs-7.86.0-3.cm2.aarch64.rpm
 tdnf-3.2.2-4.cm2.aarch64.rpm
 tdnf-cli-libs-3.2.2-4.cm2.aarch64.rpm
 tdnf-devel-3.2.2-4.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -189,9 +189,10 @@ libsolv-devel-0.7.20-1.cm2.x86_64.rpm
 libssh2-1.9.0-2.cm2.x86_64.rpm
 libssh2-devel-1.9.0-2.cm2.x86_64.rpm
 krb5-1.19.4-1.cm2.x86_64.rpm
-curl-7.86.0-2.cm2.x86_64.rpm
-curl-devel-7.86.0-2.cm2.x86_64.rpm
-curl-libs-7.86.0-2.cm2.x86_64.rpm
+nghttp2-1.46.0-2.cm2.x86_64.rpm
+curl-7.86.0-3.cm2.x86_64.rpm
+curl-devel-7.86.0-3.cm2.x86_64.rpm
+curl-libs-7.86.0-3.cm2.x86_64.rpm
 tdnf-3.2.2-4.cm2.x86_64.rpm
 tdnf-cli-libs-3.2.2-4.cm2.x86_64.rpm
 tdnf-devel-3.2.2-4.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -46,10 +46,10 @@ cracklib-lang-2.9.7-5.cm2.aarch64.rpm
 createrepo_c-0.17.5-1.cm2.aarch64.rpm
 createrepo_c-debuginfo-0.17.5-1.cm2.aarch64.rpm
 createrepo_c-devel-0.17.5-1.cm2.aarch64.rpm
-curl-7.86.0-2.cm2.aarch64.rpm
-curl-debuginfo-7.86.0-2.cm2.aarch64.rpm
-curl-devel-7.86.0-2.cm2.aarch64.rpm
-curl-libs-7.86.0-2.cm2.aarch64.rpm
+curl-7.86.0-3.cm2.aarch64.rpm
+curl-debuginfo-7.86.0-3.cm2.aarch64.rpm
+curl-devel-7.86.0-3.cm2.aarch64.rpm
+curl-libs-7.86.0-3.cm2.aarch64.rpm
 Cython-debuginfo-0.29.32-1.cm2.aarch64.rpm
 debugedit-5.0-1.cm2.aarch64.rpm
 debugedit-debuginfo-5.0-1.cm2.aarch64.rpm
@@ -258,6 +258,9 @@ newt-0.52.21-4.cm2.aarch64.rpm
 newt-debuginfo-0.52.21-4.cm2.aarch64.rpm
 newt-devel-0.52.21-4.cm2.aarch64.rpm
 newt-lang-0.52.21-4.cm2.aarch64.rpm
+nghttp2-1.46.0-2.cm2.aarch64.rpm
+nghttp2-debuginfo-1.46.0-2.cm2.aarch64.rpm
+nghttp2-devel-1.46.0-2.cm2.aarch64.rpm
 ninja-build-1.10.2-2.cm2.aarch64.rpm
 ninja-build-debuginfo-1.10.2-2.cm2.aarch64.rpm
 npth-1.6-4.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -46,10 +46,10 @@ cracklib-lang-2.9.7-5.cm2.x86_64.rpm
 createrepo_c-0.17.5-1.cm2.x86_64.rpm
 createrepo_c-debuginfo-0.17.5-1.cm2.x86_64.rpm
 createrepo_c-devel-0.17.5-1.cm2.x86_64.rpm
-curl-7.86.0-2.cm2.x86_64.rpm
-curl-debuginfo-7.86.0-2.cm2.x86_64.rpm
-curl-devel-7.86.0-2.cm2.x86_64.rpm
-curl-libs-7.86.0-2.cm2.x86_64.rpm
+curl-7.86.0-3.cm2.x86_64.rpm
+curl-debuginfo-7.86.0-3.cm2.x86_64.rpm
+curl-devel-7.86.0-3.cm2.x86_64.rpm
+curl-libs-7.86.0-3.cm2.x86_64.rpm
 Cython-debuginfo-0.29.32-1.cm2.x86_64.rpm
 debugedit-5.0-1.cm2.x86_64.rpm
 debugedit-debuginfo-5.0-1.cm2.x86_64.rpm
@@ -258,6 +258,9 @@ newt-0.52.21-4.cm2.x86_64.rpm
 newt-debuginfo-0.52.21-4.cm2.x86_64.rpm
 newt-devel-0.52.21-4.cm2.x86_64.rpm
 newt-lang-0.52.21-4.cm2.x86_64.rpm
+nghttp2-1.46.0-2.cm2.x86_64.rpm
+nghttp2-debuginfo-1.46.0-2.cm2.x86_64.rpm
+nghttp2-devel-1.46.0-2.cm2.x86_64.rpm
 ninja-build-1.10.2-2.cm2.x86_64.rpm
 ninja-build-debuginfo-1.10.2-2.cm2.x86_64.rpm
 npth-1.6-4.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/update_manifests.sh
+++ b/toolkit/resources/manifests/package/update_manifests.sh
@@ -80,6 +80,7 @@ remove_packages_for_pkggen_core () {
     sed -i '/lua-rpm/d' $TmpPkgGen
     sed -i '/lua-srpm/d' $TmpPkgGen
     sed -ri '/mariner-repos-(debug|extended|extras|microsoft)/d' $TmpPkgGen
+    sed -i '/nghttp2-devel/d' $TmpPkgGen
     sed -i '/npth-[[:alpha:]]/d' $TmpPkgGen
     sed -i '/pcre-devel/d' $TmpPkgGen
     sed -i '/perl-5/d' $TmpPkgGen
@@ -266,6 +267,7 @@ generate_pkggen_core () {
         grep "^libsolv-" $TmpPkgGen
         grep "^libssh2-" $TmpPkgGen
         grep "^krb5-" $TmpPkgGen
+        grep "^nghttp2-" $TmpPkgGen
         grep "^curl-" $TmpPkgGen
         grep "^tdnf-" $TmpPkgGen
         grep "^createrepo_c-" $TmpPkgGen

--- a/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
+++ b/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
@@ -284,6 +284,7 @@ build_rpm_in_chroot_no_install procps-ng
 build_rpm_in_chroot_no_install sed
 build_rpm_in_chroot_no_install check
 build_rpm_in_chroot_no_install cpio
+build_rpm_in_chroot_no_install nghttp2
 
 # perl needs gdbm, bzip2, zlib
 chroot_and_install_rpms gdbm
@@ -393,9 +394,10 @@ build_rpm_in_chroot_no_install kbd
 chroot_and_install_rpms e2fsprogs
 build_rpm_in_chroot_no_install krb5
 
-# curl needs libssh2, krb5
+# curl needs libssh2, krb5, nghttp2
 chroot_and_install_rpms libssh2
 chroot_and_install_rpms krb5
+chroot_and_install_rpms nghttp2
 build_rpm_in_chroot_no_install curl
 
 # cracklib needs python3-setuptools (installed with python3)


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
This PR enables HTTP/2 support in `curl` as requested by internal customers.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Build `curl` with HTTP/2 support by adding `nghttp2` as a build requirement
- Move `nghttp2` to the toolchain to support above change

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Delta toolchain build succeeded
- Tested HTTP/2 functionality with new packages in a container
```console
$ curl -sI https://curl.se -o/dev/null -w '%{http_version}\n'
2
$ curl --version
curl 7.86.0 (x86_64-pc-linux-gnu) libcurl/7.86.0 OpenSSL/1.1.1k zlib/1.2.12 zstd/1.5.0 libssh2/1.9.0 nghttp2/1.46.0
Release-Date: 2022-10-26
Protocols: dict file ftp ftps gopher gophers http https imap imaps mqtt pop3 pop3s rtsp scp sftp smb smbs smtp smtps telnet tftp
Features: alt-svc AsynchDNS GSS-API HSTS HTTP2 HTTPS-proxy IPv6 Kerberos Largefile libz NTLM NTLM_WB SPNEGO SSL threadsafe TLS-SRP UnixSockets zstd
```

