### PR TITLE
Disabling systemd-oomd by default in Mariner

### DIFF
--- a/SPECS/systemd/systemd-bootstrap.spec
+++ b/SPECS/systemd/systemd-bootstrap.spec
@@ -1,7 +1,7 @@
 Summary:        Bootstrap version of systemd. Workaround for systemd circular dependency.
 Name:           systemd-bootstrap
 Version:        250.3
-Release:        10%{?dist}
+Release:        11%{?dist}
 License:        LGPLv2+ AND GPLv2+ AND MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -152,6 +152,7 @@ install -m 0644 %{SOURCE3} %{buildroot}/%{_sysconfdir}/systemd/network
 if [ $1 -eq 1 ]; then
      systemctl preset-all
 fi
+systemctl disable systemd-oomd.service
 
 %postun -p /sbin/ldconfig
 
@@ -241,6 +242,9 @@ fi
 %{_datadir}/pkgconfig/udev.pc
 
 %changelog
+* Tue Jan 10 2023 Adit Jha <aditjha@microsoft.com> - 250.3-11
+- Disabling systemd-oomd.service by default to keep systemctl status clean
+
 * Wed Dec 14 2022 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 250.3-10
 - Add patch for CVE-2022-45873
 

--- a/SPECS/systemd/systemd-bootstrap.spec
+++ b/SPECS/systemd/systemd-bootstrap.spec
@@ -151,8 +151,9 @@ install -m 0644 %{SOURCE3} %{buildroot}/%{_sysconfdir}/systemd/network
 # to enable/disable services should succeed.
 if [ $1 -eq 1 ]; then
      systemctl preset-all
+     systemctl disable systemd-oomd.service
+
 fi
-systemctl disable systemd-oomd.service
 
 %postun -p /sbin/ldconfig
 

--- a/SPECS/systemd/systemd-bootstrap.spec
+++ b/SPECS/systemd/systemd-bootstrap.spec
@@ -151,8 +151,8 @@ install -m 0644 %{SOURCE3} %{buildroot}/%{_sysconfdir}/systemd/network
 # to enable/disable services should succeed.
 if [ $1 -eq 1 ]; then
      systemctl preset-all
-     systemctl disable systemd-oomd.service
-
+     systemctl disable --now systemd-oomd
+     systemctl mask systemd-oomd
 fi
 
 %postun -p /sbin/ldconfig

--- a/SPECS/systemd/systemd.spec
+++ b/SPECS/systemd/systemd.spec
@@ -179,8 +179,8 @@ meson test -C build
 # to enable/disable services should succeed.
 if [ $1 -eq 1 ]; then
      systemctl preset-all
-     systemctl disable systemd-oomd.service
-
+     systemctl disable --now systemd-oomd
+     systemctl mask systemd-oomd
 fi
 
 %postun -p /sbin/ldconfig

--- a/SPECS/systemd/systemd.spec
+++ b/SPECS/systemd/systemd.spec
@@ -179,6 +179,7 @@ meson test -C build
 # to enable/disable services should succeed.
 if [ $1 -eq 1 ]; then
      systemctl preset-all
+     systemctl disable systemd-oomd.service
 fi
 
 %postun -p /sbin/ldconfig

--- a/SPECS/systemd/systemd.spec
+++ b/SPECS/systemd/systemd.spec
@@ -1,7 +1,7 @@
 Summary:        Systemd-250
 Name:           systemd
 Version:        250.3
-Release:        12%{?dist}
+Release:        13%{?dist}
 License:        LGPLv2+ AND GPLv2+ AND MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -179,8 +179,8 @@ meson test -C build
 # to enable/disable services should succeed.
 if [ $1 -eq 1 ]; then
      systemctl preset-all
-     systemctl disable systemd-oomd.service
 fi
+systemctl disable systemd-oomd.service
 
 %postun -p /sbin/ldconfig
 
@@ -272,6 +272,9 @@ fi
 %files lang -f %{name}.lang
 
 %changelog
+* Tue Jan 10 2023 Adit Jha <aditjha@microsoft.com> - 250.3-13
+- Disabling systemd-oomd.service by default to keep systemctl status clean
+
 * Wed Dec 14 2022 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 250.3-12
 - Add patch for CVE-2022-45873
 

--- a/SPECS/systemd/systemd.spec
+++ b/SPECS/systemd/systemd.spec
@@ -179,8 +179,9 @@ meson test -C build
 # to enable/disable services should succeed.
 if [ $1 -eq 1 ]; then
      systemctl preset-all
+     systemctl disable systemd-oomd.service
+
 fi
-systemctl disable systemd-oomd.service
 
 %postun -p /sbin/ldconfig
 

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -548,10 +548,10 @@ sqlite-devel-3.39.2-2.cm2.aarch64.rpm
 sqlite-libs-3.39.2-2.cm2.aarch64.rpm
 swig-4.0.2-3.cm2.aarch64.rpm
 swig-debuginfo-4.0.2-3.cm2.aarch64.rpm
-systemd-bootstrap-250.3-10.cm2.aarch64.rpm
-systemd-bootstrap-debuginfo-250.3-10.cm2.aarch64.rpm
-systemd-bootstrap-devel-250.3-10.cm2.aarch64.rpm
-systemd-bootstrap-rpm-macros-250.3-10.cm2.noarch.rpm
+systemd-bootstrap-250.3-11.cm2.aarch64.rpm
+systemd-bootstrap-debuginfo-250.3-11.cm2.aarch64.rpm
+systemd-bootstrap-devel-250.3-11.cm2.aarch64.rpm
+systemd-bootstrap-rpm-macros-250.3-11.cm2.noarch.rpm
 tar-1.34-1.cm2.aarch64.rpm
 tar-debuginfo-1.34-1.cm2.aarch64.rpm
 tdnf-3.2.2-4.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -548,10 +548,10 @@ sqlite-devel-3.39.2-2.cm2.x86_64.rpm
 sqlite-libs-3.39.2-2.cm2.x86_64.rpm
 swig-4.0.2-3.cm2.x86_64.rpm
 swig-debuginfo-4.0.2-3.cm2.x86_64.rpm
-systemd-bootstrap-250.3-10.cm2.x86_64.rpm
-systemd-bootstrap-debuginfo-250.3-10.cm2.x86_64.rpm
-systemd-bootstrap-devel-250.3-10.cm2.x86_64.rpm
-systemd-bootstrap-rpm-macros-250.3-10.cm2.noarch.rpm
+systemd-bootstrap-250.3-11.cm2.x86_64.rpm
+systemd-bootstrap-debuginfo-250.3-11.cm2.x86_64.rpm
+systemd-bootstrap-devel-250.3-11.cm2.x86_64.rpm
+systemd-bootstrap-rpm-macros-250.3-11.cm2.noarch.rpm
 tar-1.34-1.cm2.x86_64.rpm
 tar-debuginfo-1.34-1.cm2.x86_64.rpm
 tdnf-3.2.2-4.cm2.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x ] The toolchain/worker package manifests are up-to-date
- [x ] Any updated packages successfully build (or no packages were changed)
- [x ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x ] All package sources are available
- [ x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ x] Documentation has been updated to match any changes to the build system
- [ x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
The systemd oomd service relies on cgroupv2 to be enabled otherwise it causes the systemctl status to be _degraded_. After discussion with Chris and Dan Streetman, the consensus was that this service is not required and should be loaded but disabled by default in our Mariner images. This PR accomplishes that by disabling the systemd-oomd module in the spec files for systemd, and lets the systemctl status be _running_

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- systemd spec files have commands in the %post section that disable systemd-oomd module 
- toolchain text files were updated to systemd release bump
- 
###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
YES

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- (https://dev.azure.com/microsoft/OS/_workitems/edit/41521816)

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: 291859
- Local build with RPM testing and validating pipeline build image artifacts that systemd-oomd is disabled and masked by default and systemctl status is _running_
