### PR TITLE
curl: downgrade to 7.86 to fix perl-WWW-curl and patch CVE-2022-43551 

### DIFF
--- a/SPECS/curl/CVE-2022-43551.patch
+++ b/SPECS/curl/CVE-2022-43551.patch
@@ -1,0 +1,27 @@
+From b0a528fc66113cc495e42625df90ae75328a93f0 Mon Sep 17 00:00:00 2001
+From: Daniel Stenberg <daniel@haxx.se>
+Date: Mon, 19 Dec 2022 08:36:55 +0100
+Subject: [PATCH] http: use the IDN decoded name in HSTS checks
+
+Otherwise it stores the info HSTS into the persistent cache for the IDN
+name which will not match when the HSTS status is later checked for
+using the decoded name.
+
+Reported-by: Hiroki Kurosawa
+---
+ lib/http.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/http.c b/lib/http.c
+index 85528a2218eee..a784745a8d505 100644
+--- a/lib/http.c
++++ b/lib/http.c
+@@ -3646,7 +3646,7 @@ CURLcode Curl_http_header(struct Curl_easy *data, struct connectdata *conn,
+ #endif
+             )) {
+     CURLcode check =
+-      Curl_hsts_parse(data->hsts, data->state.up.hostname,
++      Curl_hsts_parse(data->hsts, conn->host.name,
+                       headp + strlen("Strict-Transport-Security:"));
+     if(check)
+       infof(data, "Illegal STS header skipped");

--- a/SPECS/curl/curl.signatures.json
+++ b/SPECS/curl/curl.signatures.json
@@ -1,5 +1,5 @@
 {
   "Signatures": {
-    "curl-7.87.0.tar.gz": "8a063d664d1c23d35526b87a2bf15514962ffdd8ef7fd40519191b3c23e39548"
+    "curl-7.86.0.tar.gz": "3dfdd39ba95e18847965cd3051ea6d22586609d9011d91df7bc5521288987a82"
   }
 }

--- a/SPECS/curl/curl.spec
+++ b/SPECS/curl/curl.spec
@@ -91,11 +91,7 @@ find %{buildroot} -type f -name "*.la" -delete -print
 
 %changelog
 * Thu Jan 12 2023 Aurélien Bombo <abombo@microsoft.com> - 7.86.0-2
-- Downgrade to 7.86.0 since 7.87.0 breaks perl-WWW-curl.
 - Apply patch to fix CVE-2022-43551.
-
-* Tue Jan 10 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 7.87.0-1
-- Auto-upgrade to 7.87.0 - CVE-2022-43551
 
 * Tue Nov 08 2022 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 7.86.0-1
 - Auto-upgrade to 7.86.0 - CVE-2022-42915

--- a/SPECS/curl/curl.spec
+++ b/SPECS/curl/curl.spec
@@ -1,6 +1,6 @@
 Summary:        An URL retrieval utility and library
 Name:           curl
-Version:        7.87.0
+Version:        7.86.0
 Release:        1%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
@@ -88,9 +88,6 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %{_libdir}/libcurl.so.4*
 
 %changelog
-* Tue Jan 10 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 7.87.0-1
-- Auto-upgrade to 7.87.0 - CVE-2022-43551
-
 * Tue Nov 08 2022 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 7.86.0-1
 - Auto-upgrade to 7.86.0 - CVE-2022-42915
 

--- a/SPECS/curl/curl.spec
+++ b/SPECS/curl/curl.spec
@@ -1,5 +1,6 @@
 Summary:        An URL retrieval utility and library
 Name:           curl
+# Heads up: 7.87 breaks perl-WWW-Curl (see #4588).
 Version:        7.86.0
 Release:        2%{?dist}
 License:        MIT

--- a/SPECS/curl/curl.spec
+++ b/SPECS/curl/curl.spec
@@ -1,13 +1,14 @@
 Summary:        An URL retrieval utility and library
 Name:           curl
 Version:        7.86.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Group:          System Environment/NetworkingLibraries
 URL:            https://curl.haxx.se
 Source0:        https://curl.haxx.se/download/%{name}-%{version}.tar.gz
+Patch0:         CVE-2022-43551.patch
 BuildRequires:  krb5-devel
 BuildRequires:  libssh2-devel
 BuildRequires:  openssl-devel
@@ -88,6 +89,13 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %{_libdir}/libcurl.so.4*
 
 %changelog
+* Thu Jan 12 2023 Aurélien Bombo <abombo@microsoft.com> - 7.86.0-2
+- Downgrade to 7.86.0 since 7.87.0 breaks perl-WWW-curl.
+- Apply patch to fix CVE-2022-43551.
+
+* Tue Jan 10 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 7.87.0-1
+- Auto-upgrade to 7.87.0 - CVE-2022-43551
+
 * Tue Nov 08 2022 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 7.86.0-1
 - Auto-upgrade to 7.86.0 - CVE-2022-42915
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -986,8 +986,8 @@
         "type": "other",
         "other": {
           "name": "curl",
-          "version": "7.87.0",
-          "downloadUrl": "https://curl.haxx.se/download/curl-7.87.0.tar.gz"
+          "version": "7.86.0",
+          "downloadUrl": "https://curl.haxx.se/download/curl-7.86.0.tar.gz"
         }
       }
     },

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -130,9 +130,9 @@ libsolv-0.7.20-1.cm1.aarch64.rpm
 libsolv-devel-0.7.20-1.cm1.aarch64.rpm
 libssh2-1.9.0-1.cm1.aarch64.rpm
 libssh2-devel-1.9.0-1.cm1.aarch64.rpm
-curl-7.86.0-1.cm1.aarch64.rpm
-curl-devel-7.86.0-1.cm1.aarch64.rpm
-curl-libs-7.86.0-1.cm1.aarch64.rpm
+curl-7.86.0-2.cm1.aarch64.rpm
+curl-devel-7.86.0-2.cm1.aarch64.rpm
+curl-libs-7.86.0-2.cm1.aarch64.rpm
 tdnf-2.1.0-7.cm1.aarch64.rpm
 tdnf-cli-libs-2.1.0-7.cm1.aarch64.rpm
 tdnf-devel-2.1.0-7.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -130,9 +130,9 @@ libsolv-0.7.20-1.cm1.aarch64.rpm
 libsolv-devel-0.7.20-1.cm1.aarch64.rpm
 libssh2-1.9.0-1.cm1.aarch64.rpm
 libssh2-devel-1.9.0-1.cm1.aarch64.rpm
-curl-7.87.0-1.cm1.aarch64.rpm
-curl-devel-7.87.0-1.cm1.aarch64.rpm
-curl-libs-7.87.0-1.cm1.aarch64.rpm
+curl-7.86.0-1.cm1.aarch64.rpm
+curl-devel-7.86.0-1.cm1.aarch64.rpm
+curl-libs-7.86.0-1.cm1.aarch64.rpm
 tdnf-2.1.0-7.cm1.aarch64.rpm
 tdnf-cli-libs-2.1.0-7.cm1.aarch64.rpm
 tdnf-devel-2.1.0-7.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -130,9 +130,9 @@ libsolv-0.7.20-1.cm1.x86_64.rpm
 libsolv-devel-0.7.20-1.cm1.x86_64.rpm
 libssh2-1.9.0-1.cm1.x86_64.rpm
 libssh2-devel-1.9.0-1.cm1.x86_64.rpm
-curl-7.87.0-1.cm1.x86_64.rpm
-curl-devel-7.87.0-1.cm1.x86_64.rpm
-curl-libs-7.87.0-1.cm1.x86_64.rpm
+curl-7.86.0-1.cm1.x86_64.rpm
+curl-devel-7.86.0-1.cm1.x86_64.rpm
+curl-libs-7.86.0-1.cm1.x86_64.rpm
 tdnf-2.1.0-7.cm1.x86_64.rpm
 tdnf-cli-libs-2.1.0-7.cm1.x86_64.rpm
 tdnf-devel-2.1.0-7.cm1.x86_64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -130,9 +130,9 @@ libsolv-0.7.20-1.cm1.x86_64.rpm
 libsolv-devel-0.7.20-1.cm1.x86_64.rpm
 libssh2-1.9.0-1.cm1.x86_64.rpm
 libssh2-devel-1.9.0-1.cm1.x86_64.rpm
-curl-7.86.0-1.cm1.x86_64.rpm
-curl-devel-7.86.0-1.cm1.x86_64.rpm
-curl-libs-7.86.0-1.cm1.x86_64.rpm
+curl-7.86.0-2.cm1.x86_64.rpm
+curl-devel-7.86.0-2.cm1.x86_64.rpm
+curl-libs-7.86.0-2.cm1.x86_64.rpm
 tdnf-2.1.0-7.cm1.x86_64.rpm
 tdnf-cli-libs-2.1.0-7.cm1.x86_64.rpm
 tdnf-devel-2.1.0-7.cm1.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -51,10 +51,10 @@ cryptsetup-debuginfo-2.3.7-1.cm1.aarch64.rpm
 cryptsetup-devel-2.3.7-1.cm1.aarch64.rpm
 cryptsetup-libs-2.3.7-1.cm1.aarch64.rpm
 cryptsetup-reencrypt-2.3.7-1.cm1.aarch64.rpm
-curl-7.86.0-1.cm1.aarch64.rpm
-curl-debuginfo-7.86.0-1.cm1.aarch64.rpm
-curl-devel-7.86.0-1.cm1.aarch64.rpm
-curl-libs-7.86.0-1.cm1.aarch64.rpm
+curl-7.86.0-2.cm1.aarch64.rpm
+curl-debuginfo-7.86.0-2.cm1.aarch64.rpm
+curl-devel-7.86.0-2.cm1.aarch64.rpm
+curl-libs-7.86.0-2.cm1.aarch64.rpm
 cyrus-sasl-2.1.28-1.cm1.aarch64.rpm
 cyrus-sasl-debuginfo-2.1.28-1.cm1.aarch64.rpm
 device-mapper-2.03.05-6.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -51,10 +51,10 @@ cryptsetup-debuginfo-2.3.7-1.cm1.aarch64.rpm
 cryptsetup-devel-2.3.7-1.cm1.aarch64.rpm
 cryptsetup-libs-2.3.7-1.cm1.aarch64.rpm
 cryptsetup-reencrypt-2.3.7-1.cm1.aarch64.rpm
-curl-7.87.0-1.cm1.aarch64.rpm
-curl-debuginfo-7.87.0-1.cm1.aarch64.rpm
-curl-devel-7.87.0-1.cm1.aarch64.rpm
-curl-libs-7.87.0-1.cm1.aarch64.rpm
+curl-7.86.0-1.cm1.aarch64.rpm
+curl-debuginfo-7.86.0-1.cm1.aarch64.rpm
+curl-devel-7.86.0-1.cm1.aarch64.rpm
+curl-libs-7.86.0-1.cm1.aarch64.rpm
 cyrus-sasl-2.1.28-1.cm1.aarch64.rpm
 cyrus-sasl-debuginfo-2.1.28-1.cm1.aarch64.rpm
 device-mapper-2.03.05-6.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -51,10 +51,10 @@ cryptsetup-debuginfo-2.3.7-1.cm1.x86_64.rpm
 cryptsetup-devel-2.3.7-1.cm1.x86_64.rpm
 cryptsetup-libs-2.3.7-1.cm1.x86_64.rpm
 cryptsetup-reencrypt-2.3.7-1.cm1.x86_64.rpm
-curl-7.86.0-1.cm1.x86_64.rpm
-curl-debuginfo-7.86.0-1.cm1.x86_64.rpm
-curl-devel-7.86.0-1.cm1.x86_64.rpm
-curl-libs-7.86.0-1.cm1.x86_64.rpm
+curl-7.86.0-2.cm1.x86_64.rpm
+curl-debuginfo-7.86.0-2.cm1.x86_64.rpm
+curl-devel-7.86.0-2.cm1.x86_64.rpm
+curl-libs-7.86.0-2.cm1.x86_64.rpm
 cyrus-sasl-2.1.28-1.cm1.x86_64.rpm
 cyrus-sasl-debuginfo-2.1.28-1.cm1.x86_64.rpm
 device-mapper-2.03.05-6.cm1.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -51,10 +51,10 @@ cryptsetup-debuginfo-2.3.7-1.cm1.x86_64.rpm
 cryptsetup-devel-2.3.7-1.cm1.x86_64.rpm
 cryptsetup-libs-2.3.7-1.cm1.x86_64.rpm
 cryptsetup-reencrypt-2.3.7-1.cm1.x86_64.rpm
-curl-7.87.0-1.cm1.x86_64.rpm
-curl-debuginfo-7.87.0-1.cm1.x86_64.rpm
-curl-devel-7.87.0-1.cm1.x86_64.rpm
-curl-libs-7.87.0-1.cm1.x86_64.rpm
+curl-7.86.0-1.cm1.x86_64.rpm
+curl-debuginfo-7.86.0-1.cm1.x86_64.rpm
+curl-devel-7.86.0-1.cm1.x86_64.rpm
+curl-libs-7.86.0-1.cm1.x86_64.rpm
 cyrus-sasl-2.1.28-1.cm1.x86_64.rpm
 cyrus-sasl-debuginfo-2.1.28-1.cm1.x86_64.rpm
 device-mapper-2.03.05-6.cm1.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
This reverts #4577 because curl 7.87 breaks perl-WWW-Curl (also [tracked by Debian](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1027632)) and instead applies the upstream patch to fix CVE-2022-43551.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline builds: [AMD64](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=291803&view=results) [ARM64](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=291812&view=results) (both curl & perl-WWW-Curl)
