### PR TITLE
Revert "Disabling systemd-oomd by default in Mariner"

### DIFF
--- a/SPECS/systemd/systemd-bootstrap.spec
+++ b/SPECS/systemd/systemd-bootstrap.spec
@@ -1,7 +1,7 @@
 Summary:        Bootstrap version of systemd. Workaround for systemd circular dependency.
 Name:           systemd-bootstrap
 Version:        250.3
-Release:        11%{?dist}
+Release:        10%{?dist}
 License:        LGPLv2+ AND GPLv2+ AND MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -151,8 +151,6 @@ install -m 0644 %{SOURCE3} %{buildroot}/%{_sysconfdir}/systemd/network
 # to enable/disable services should succeed.
 if [ $1 -eq 1 ]; then
      systemctl preset-all
-     systemctl disable --now systemd-oomd
-     systemctl mask systemd-oomd
 fi
 
 %postun -p /sbin/ldconfig
@@ -243,9 +241,6 @@ fi
 %{_datadir}/pkgconfig/udev.pc
 
 %changelog
-* Tue Jan 10 2023 Adit Jha <aditjha@microsoft.com> - 250.3-11
-- Disabling systemd-oomd.service by default to keep systemctl status clean
-
 * Wed Dec 14 2022 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 250.3-10
 - Add patch for CVE-2022-45873
 

--- a/SPECS/systemd/systemd.spec
+++ b/SPECS/systemd/systemd.spec
@@ -1,7 +1,7 @@
 Summary:        Systemd-250
 Name:           systemd
 Version:        250.3
-Release:        13%{?dist}
+Release:        12%{?dist}
 License:        LGPLv2+ AND GPLv2+ AND MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -179,8 +179,6 @@ meson test -C build
 # to enable/disable services should succeed.
 if [ $1 -eq 1 ]; then
      systemctl preset-all
-     systemctl disable --now systemd-oomd
-     systemctl mask systemd-oomd
 fi
 
 %postun -p /sbin/ldconfig
@@ -273,9 +271,6 @@ fi
 %files lang -f %{name}.lang
 
 %changelog
-* Tue Jan 10 2023 Adit Jha <aditjha@microsoft.com> - 250.3-13
-- Disabling systemd-oomd.service by default to keep systemctl status clean
-
 * Wed Dec 14 2022 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 250.3-12
 - Add patch for CVE-2022-45873
 

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -548,10 +548,10 @@ sqlite-devel-3.39.2-2.cm2.aarch64.rpm
 sqlite-libs-3.39.2-2.cm2.aarch64.rpm
 swig-4.0.2-3.cm2.aarch64.rpm
 swig-debuginfo-4.0.2-3.cm2.aarch64.rpm
-systemd-bootstrap-250.3-11.cm2.aarch64.rpm
-systemd-bootstrap-debuginfo-250.3-11.cm2.aarch64.rpm
-systemd-bootstrap-devel-250.3-11.cm2.aarch64.rpm
-systemd-bootstrap-rpm-macros-250.3-11.cm2.noarch.rpm
+systemd-bootstrap-250.3-10.cm2.aarch64.rpm
+systemd-bootstrap-debuginfo-250.3-10.cm2.aarch64.rpm
+systemd-bootstrap-devel-250.3-10.cm2.aarch64.rpm
+systemd-bootstrap-rpm-macros-250.3-10.cm2.noarch.rpm
 tar-1.34-1.cm2.aarch64.rpm
 tar-debuginfo-1.34-1.cm2.aarch64.rpm
 tdnf-3.2.2-4.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -548,10 +548,10 @@ sqlite-devel-3.39.2-2.cm2.x86_64.rpm
 sqlite-libs-3.39.2-2.cm2.x86_64.rpm
 swig-4.0.2-3.cm2.x86_64.rpm
 swig-debuginfo-4.0.2-3.cm2.x86_64.rpm
-systemd-bootstrap-250.3-11.cm2.x86_64.rpm
-systemd-bootstrap-debuginfo-250.3-11.cm2.x86_64.rpm
-systemd-bootstrap-devel-250.3-11.cm2.x86_64.rpm
-systemd-bootstrap-rpm-macros-250.3-11.cm2.noarch.rpm
+systemd-bootstrap-250.3-10.cm2.x86_64.rpm
+systemd-bootstrap-debuginfo-250.3-10.cm2.x86_64.rpm
+systemd-bootstrap-devel-250.3-10.cm2.x86_64.rpm
+systemd-bootstrap-rpm-macros-250.3-10.cm2.noarch.rpm
 tar-1.34-1.cm2.x86_64.rpm
 tar-debuginfo-1.34-1.cm2.x86_64.rpm
 tdnf-3.2.2-4.cm2.x86_64.rpm


### PR DESCRIPTION
Reverts microsoft/CBL-Mariner#4580

Post-merge feedback: 
A better approach was advised.
it would be better to disable the service inside the preset file, and avoid masking the service.

@aditjha-msft will start next week on the revised improvement :)