### PR TITLE
Improve robustness of ISO initrd builds

### DIFF
--- a/toolkit/scripts/imggen.mk
+++ b/toolkit/scripts/imggen.mk
@@ -18,8 +18,8 @@ initrd_config_json       = $(RESOURCES_DIR)/imageconfigs/iso_initrd.json
 endif
 initrd_assets_dir        = $(RESOURCES_DIR)/imageconfigs/additionalfiles/iso_initrd/
 initrd_scripts_dir       = $(RESOURCES_DIR)/imageconfigs/postinstallscripts/iso_initrd/
-initrd_packages_dir      = $(RESOURCES_DIR)/imageconfigs/packagelists
-initrd_assets_files      = $(shell find $(initrd_assets_dir) $(initrd_scripts_dir) $(initrd_packages_dir))
+initrd_packages_json     = $(RESOURCES_DIR)/imageconfigs/packagelists/iso-initrd-packages.json
+initrd_assets_files      = $(initrd_packages_json) $(shell find $(initrd_assets_dir) $(initrd_scripts_dir))
 meta_user_data_files     = $(META_USER_DATA_DIR)/user-data $(META_USER_DATA_DIR)/meta-data
 ova_ovfinfo              = $(assets_dir)/ova/ovfinfo.txt
 ova_vmxtemplate          = $(assets_dir)/ova/vmx-template

--- a/toolkit/scripts/imggen.mk
+++ b/toolkit/scripts/imggen.mk
@@ -168,7 +168,7 @@ $(image_external_package_cache_summary): $(cached_file) $(go-imagepkgfetcher) $(
 		--output-dir=$(external_rpm_cache)
 
 # We need to ensure that initrd_img recursive build will never run concurrently with another build component, so add all ISO prereqs as 
-#	order-only-prerequisites to initrd_img
+# order-only-prerequisites to initrd_img
 iso_deps = $(go-isomaker) $(go-imager) $(depend_CONFIG_FILE) $(CONFIG_FILE) $(validate-config) $(image_package_cache_summary)
 # The initrd bundles these files into the image, we should rebuild it if they change
 initrd_bundled_files = $(go-liveinstaller) $(go-imager) $(assets_files) $(initrd_assets_files) $(imggen_local_repo)

--- a/toolkit/scripts/imggen.mk
+++ b/toolkit/scripts/imggen.mk
@@ -16,6 +16,9 @@ initrd_config_json       = $(RESOURCES_DIR)/imageconfigs/iso_initrd_arm64.json
 else
 initrd_config_json       = $(RESOURCES_DIR)/imageconfigs/iso_initrd.json
 endif
+initrd_assets_dir        = $(RESOURCES_DIR)/imageconfigs/additionalfiles/iso_initrd/
+initrd_scripts_dir       = $(RESOURCES_DIR)/imageconfigs/postinstallscripts/iso_initrd/
+initrd_assets_files      = $(shell find $(initrd_assets_dir) $(initrd_scripts_dir))
 meta_user_data_files     = $(META_USER_DATA_DIR)/user-data $(META_USER_DATA_DIR)/meta-data
 ova_ovfinfo              = $(assets_dir)/ova/ovfinfo.txt
 ova_vmxtemplate          = $(assets_dir)/ova/vmx-template
@@ -163,11 +166,17 @@ $(image_external_package_cache_summary): $(cached_file) $(go-imagepkgfetcher) $(
 		--output-summary-file=$@ \
 		--output-dir=$(external_rpm_cache)
 
-$(initrd_img): $(go-liveinstaller) $(go-imager) $(initrd_config_json) $(INITRD_CACHE_SUMMARY)
+# We need to ensure that initrd_img recursive build will never run concurrently with another build component, so add all ISO prereqs as 
+#	order-only-prerequisites to initrd_img
+iso_deps = $(go-isomaker) $(go-imager) $(depend_CONFIG_FILE) $(CONFIG_FILE) $(validate-config) $(image_package_cache_summary)
+# The initrd bundles these files into the image, we should rebuild it if they change
+initrd_bundled_files = $(go-liveinstaller) $(go-imager) $(assets_files) $(initrd_assets_files) $(imggen_local_repo)
+
+$(initrd_img): $(initrd_bundled_files) $(initrd_config_json) $(INITRD_CACHE_SUMMARY) | $(iso_deps)
 	# Recursive make call to build the initrd image $(artifact_dir)/iso-initrd.img
 	$(MAKE) image MAKEOVERRIDES= CONFIG_FILE=$(initrd_config_json) IMAGE_CACHE_SUMMARY=$(INITRD_CACHE_SUMMARY) IMAGE_TAG=
 
-iso: $(go-isomaker) $(go-imager) $(depend_CONFIG_FILE) $(CONFIG_FILE) $(initrd_img) $(validate-config) $(image_package_cache_summary)
+iso: $(initrd_img) $(iso_deps)
 	$(if $(CONFIG_FILE),,$(error Must set CONFIG_FILE=))
 	$(go-isomaker) \
 		--base-dir $(CONFIG_BASE_DIR) \

--- a/toolkit/scripts/imggen.mk
+++ b/toolkit/scripts/imggen.mk
@@ -18,7 +18,8 @@ initrd_config_json       = $(RESOURCES_DIR)/imageconfigs/iso_initrd.json
 endif
 initrd_assets_dir        = $(RESOURCES_DIR)/imageconfigs/additionalfiles/iso_initrd/
 initrd_scripts_dir       = $(RESOURCES_DIR)/imageconfigs/postinstallscripts/iso_initrd/
-initrd_assets_files      = $(shell find $(initrd_assets_dir) $(initrd_scripts_dir))
+initrd_packages_dir      = $(RESOURCES_DIR)/imageconfigs/packagelists
+initrd_assets_files      = $(shell find $(initrd_assets_dir) $(initrd_scripts_dir) $(initrd_packages_dir))
 meta_user_data_files     = $(META_USER_DATA_DIR)/user-data $(META_USER_DATA_DIR)/meta-data
 ova_ovfinfo              = $(assets_dir)/ova/ovfinfo.txt
 ova_vmxtemplate          = $(assets_dir)/ova/vmx-template

--- a/toolkit/scripts/imggen.mk
+++ b/toolkit/scripts/imggen.mk
@@ -18,7 +18,12 @@ initrd_config_json       = $(RESOURCES_DIR)/imageconfigs/iso_initrd.json
 endif
 initrd_assets_dir        = $(RESOURCES_DIR)/imageconfigs/additionalfiles/iso_initrd/
 initrd_scripts_dir       = $(RESOURCES_DIR)/imageconfigs/postinstallscripts/iso_initrd/
+ifeq ($(build_arch),aarch64)
+initrd_packages_json     = $(RESOURCES_DIR)/imageconfigs/packagelists/iso-initrd-packages-arm64.json
+else
 initrd_packages_json     = $(RESOURCES_DIR)/imageconfigs/packagelists/iso-initrd-packages.json
+endif
+initrd_packages_json    += $(RESOURCES_DIR)/imageconfigs/packagelists/accessibility-packages.json
 initrd_assets_files      = $(initrd_packages_json) $(shell find $(initrd_assets_dir) $(initrd_scripts_dir))
 meta_user_data_files     = $(META_USER_DATA_DIR)/user-data $(META_USER_DATA_DIR)/meta-data
 ova_ovfinfo              = $(assets_dir)/ova/ovfinfo.txt


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
The ISO target (`make iso ...`) can be fragile, both to changes in the files included in the ISO's initrd, and to parallel builds. We can harden this by tracking the files included with the ISO in the makefile, as well as defining some order-only prerequisites for the initrd target.

Order-only prerequisites mean that a given target will allways be built after another target, but changing the prerequisite won't actually case a follow-on rebuild of the target. (ie `a: b | c`, `c` will always be completed before `a` starts, but changing `c` won't cause `a` to rebuild during future builds). By making all of the `iso:` target's prerequisites also order-only prerequisites for the `$(initrd_img)` target, we can guarantee that all the build actions needed to prep for `iso:` will be completed before we make the recursive call to build the initrd. (The makefile was trying to build the worker chroot twice in parallel in the same directory, this did not end well)

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Make `iso:`'s prerequisites order-only prerequisites for `$(initrd_img)` as well to avoid parallel builds during the recursive call
- Track all the assets we include in `$(initrd_img)` so that changes to those files will always cause a rebuild of the initrd.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://microsoft.visualstudio.com/OS/_workitems/edit/42963350
- https://microsoft.visualstudio.com/OS/_workitems/edit/42951530/

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local ISO & image builds
