### PR TITLE
Fixed package capabilities resolution

### DIFF
--- a/SPECS/libkcapi/libkcapi.spec
+++ b/SPECS/libkcapi/libkcapi.spec
@@ -45,8 +45,8 @@ done                                                             \
 ln -s libkcapi.so.%{version}.hmac                            \\\
   "$lib_path"/fipscheck/libkcapi.so.%{vmajor}.hmac               \
 %{nil}
-%global fipscheck_evr     1.5.0-9
-%global hmaccalc_evr      0.9.14-10%{?dist}
+%global fipscheck_next_evr     1.5.0-10%{?dist}
+%global hmaccalc_next_evr      0.9.14-11%{?dist}
 %if %{with_sysctl_tweak}
 # Priority for the sysctl.d preset.
 %global sysctl_prio       50
@@ -58,7 +58,7 @@ ln -s libkcapi.so.%{version}.hmac                            \\\
 Summary:        User space interface to the Linux Kernel Crypto API
 Name:           libkcapi
 Version:        %{vmajor}.%{vminor}.%{vpatch}
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        BSD OR GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -105,9 +105,9 @@ Header files for applications that use %{name}.
 %package        fipscheck
 Summary:        Drop-in replacements for fipscheck/fipshmac provided by the %{name} package
 Requires:       %{name}%{?_isa} = %{version}-%{release}
-Obsoletes:      fipscheck <= %{fipscheck_evr}
-Provides:       fipscheck = %{fipscheck_evr}.1
-Provides:       fipscheck%{?_isa} = %{fipscheck_evr}.1
+Obsoletes:      fipscheck < %{fipscheck_next_evr}
+Provides:       fipscheck = %{fipscheck_next_evr}
+Provides:       fipscheck%{?_isa} = %{fipscheck_next_evr}
 
 %description    fipscheck
 Provides drop-in replacements for fipscheck and fipshmac tools (from
@@ -116,9 +116,9 @@ package fipscheck) using %{name}.
 %package        hmaccalc
 Summary:        Drop-in replacements for hmaccalc provided by the %{name} package
 Requires:       %{name}%{?_isa} = %{version}-%{release}
-Obsoletes:      hmaccalc <= %{hmaccalc_evr}
-Provides:       hmaccalc = %{hmaccalc_evr}.1
-Provides:       hmaccalc%{?_isa} = %{hmaccalc_evr}.1
+Obsoletes:      hmaccalc < %{hmaccalc_next_evr}
+Provides:       hmaccalc = %{hmaccalc_next_evr}
+Provides:       hmaccalc%{?_isa} = %{hmaccalc_next_evr}
 
 %description    hmaccalc
 Provides drop-in replacements for sha*hmac tools (from package
@@ -256,6 +256,9 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %{_libexecdir}/%{name}/*
 
 %changelog
+* Thu Jan 19 2023 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.3.1-2
+- Fixing 'Obsoletes' and 'Provides' for 'fipscheck' and 'hmaccalc' subpackages.
+
 * Mon Jan 10 2022 Henry Li <lihl@microsoft.com> - 1.3.1-1
 - Upgrade to version 1.3.1
 

--- a/toolkit/tools/graphpkgfetcher/graphpkgfetcher.go
+++ b/toolkit/tools/graphpkgfetcher/graphpkgfetcher.go
@@ -15,7 +15,6 @@ import (
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/packagerepo/repoutils"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/pkggraph"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/pkgjson"
-	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/rpm"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/scheduler/schedulerutils"
 
 	"gonum.org/v1/gonum/graph"
@@ -217,39 +216,6 @@ func resolveSingleNode(cloner *rpmrepocloner.RpmRepoCloner, node *pkggraph.PkgNo
 	}
 
 	logger.Log.Infof("Choosing '%s' to provide '%s'.", filepath.Base(node.RpmPath), node.VersionedPkg.Name)
-
-	return
-}
-
-func assignRPMPath(node *pkggraph.PkgNode, outDir string, resolvedPackages []string) (err error) {
-	rpmPaths := []string{}
-	for _, resolvedPackage := range resolvedPackages {
-		rpmPaths = append(rpmPaths, rpmPackageToRPMPath(resolvedPackage, outDir))
-	}
-
-	node.RpmPath = rpmPaths[0]
-	if len(rpmPaths) > 1 {
-		var resolvedRPMs []string
-		logger.Log.Debugf("Found %d candidates. Resolving.", len(rpmPaths))
-
-		resolvedRPMs, err = rpm.ResolveCompetingPackages(*tmpDir, rpmPaths...)
-		if err != nil {
-			logger.Log.Errorf("Failed while trying to pick an RPM providing '%s' from the following RPMs: %v", node.VersionedPkg.Name, rpmPaths)
-			return
-		}
-
-		resolvedRPMsCount := len(resolvedRPMs)
-		if resolvedRPMsCount == 0 {
-			logger.Log.Errorf("Failed while trying to pick an RPM providing '%s'. No RPM can be installed from the following: %v", node.VersionedPkg.Name, rpmPaths)
-			return
-		}
-
-		if resolvedRPMsCount > 1 {
-			logger.Log.Warnf("Found %d candidates to provide '%s'. Picking the first one.", resolvedRPMsCount, node.VersionedPkg.Name)
-		}
-
-		node.RpmPath = rpmPackageToRPMPath(resolvedRPMs[0], outDir)
-	}
 
 	return
 }

--- a/toolkit/tools/internal/packagerepo/repocloner/repocloner.go
+++ b/toolkit/tools/internal/packagerepo/repocloner/repocloner.go
@@ -25,6 +25,7 @@ type RepoCloner interface {
 	Initialize(destinationDir, tmpDir, workerTar, existingRpmsDir string, usePreviewRepo bool, repoDefinitions []string) error
 	AddNetworkFiles(tlsClientCert, tlsClientKey string) error
 	Clone(cloneDeps bool, packagesToClone ...*pkgjson.PackageVer) (prebuiltPackage bool, err error)
+	BestProvidesCandidate(pkgVer *pkgjson.PackageVer) (packageName string, err error)
 	WhatProvides(pkgVer *pkgjson.PackageVer) (packageNames []string, err error)
 	ConvertDownloadedPackagesIntoRepo() error
 	ClonedRepoContents() (repoContents *RepoContents, err error)

--- a/toolkit/tools/internal/packagerepo/repocloner/repocloner.go
+++ b/toolkit/tools/internal/packagerepo/repocloner/repocloner.go
@@ -22,13 +22,12 @@ type RepoPackage struct {
 // It is capable of generate a local repository consisting of a set of request packages
 // and their dependencies.
 type RepoCloner interface {
-	Initialize(destinationDir, tmpDir, workerTar, existingRpmsDir string, usePreviewRepo bool, repoDefinitions []string) error
 	AddNetworkFiles(tlsClientCert, tlsClientKey string) error
-	Clone(cloneDeps bool, packagesToClone ...*pkgjson.PackageVer) (prebuiltPackage bool, err error)
 	BestProvidesCandidate(pkgVer *pkgjson.PackageVer) (packageName string, err error)
-	WhatProvides(pkgVer *pkgjson.PackageVer) (packageNames []string, err error)
-	ConvertDownloadedPackagesIntoRepo() error
-	ClonedRepoContents() (repoContents *RepoContents, err error)
+	Clone(cloneDeps bool, packagesToClone ...*pkgjson.PackageVer) (prebuiltPackage bool, err error)
 	CloneDirectory() string
+	ClonedRepoContents() (repoContents *RepoContents, err error)
 	Close() error
+	ConvertDownloadedPackagesIntoRepo() error
+	Initialize(destinationDir, tmpDir, workerTar, existingRpmsDir string, usePreviewRepo bool, repoDefinitions []string) error
 }

--- a/toolkit/tools/internal/packagerepo/repocloner/rpmrepocloner/rpmrepocloner.go
+++ b/toolkit/tools/internal/packagerepo/repocloner/rpmrepocloner/rpmrepocloner.go
@@ -353,13 +353,25 @@ func (r *RpmRepoCloner) BestProvidesCandidate(pkgVer *pkgjson.PackageVer) (packa
 
 			completeArgs := append([]string{"install"}, baseAndRepoArgs...)
 
-			stdout, stderr, exitCode := shell.ExecuteWithExitCode("tdnf", completeArgs...)
+			stdout, stderr, err := shell.Execute("tdnf", completeArgs...)
+
+			exitCode, err := shell.ErrToExitCode(err)
+			if err != nil {
+				return
+			}
+
 			logger.Log.Debugf("TDNF search for provide '%s' with 'install':\n%s", pkgVer.Name, stdout)
+
 			if exitCode == tdnf.ExitCodeOK {
 				logger.Log.Debugf("Package providing '%s' already installed. Attempting reinstallation.", pkgVer.Name)
 
 				completeArgs = append([]string{"reinstall"}, baseAndRepoArgs...)
-				stdout, stderr, exitCode = shell.ExecuteWithExitCode("tdnf", completeArgs...)
+				stdout, stderr, err = shell.Execute("tdnf", completeArgs...)
+
+				exitCode, err = shell.ErrToExitCode(err)
+				if err != nil {
+					return
+				}
 
 				logger.Log.Debugf("TDNF search for provide '%s' with 'reinstall':\n%s", pkgVer.Name, stdout)
 			}

--- a/toolkit/tools/internal/packagerepo/repocloner/rpmrepocloner/rpmrepocloner.go
+++ b/toolkit/tools/internal/packagerepo/repocloner/rpmrepocloner/rpmrepocloner.go
@@ -353,30 +353,19 @@ func (r *RpmRepoCloner) BestProvidesCandidate(pkgVer *pkgjson.PackageVer) (packa
 
 			completeArgs := append([]string{"install"}, baseAndRepoArgs...)
 
-			stdout, stderr, err := shell.Execute("tdnf", completeArgs...)
-
-			exitCode, err := shell.ErrToExitCode(err)
-			if err != nil {
-				return
-			}
-
+			stdout, stderr, exitCode, err := shell.ExecuteWithExitCode("tdnf", completeArgs...)
 			logger.Log.Debugf("TDNF search for provide '%s' with 'install':\n%s", pkgVer.Name, stdout)
-
 			if exitCode == tdnf.ExitCodeOK {
 				logger.Log.Debugf("Package providing '%s' already installed. Attempting reinstallation.", pkgVer.Name)
 
 				completeArgs = append([]string{"reinstall"}, baseAndRepoArgs...)
-				stdout, stderr, err = shell.Execute("tdnf", completeArgs...)
-
-				exitCode, err = shell.ErrToExitCode(err)
-				if err != nil {
-					return
-				}
+				stdout, stderr, exitCode, err = shell.ExecuteWithExitCode("tdnf", completeArgs...)
 
 				logger.Log.Debugf("TDNF search for provide '%s' with 'reinstall':\n%s", pkgVer.Name, stdout)
 			}
+
 			if exitCode != tdnf.ExitCodeOperationAborted {
-				logger.Log.Debugf("Failed to lookup provide '%s', TDNF error: '%s'", pkgVer.Name, stderr)
+				logger.Log.Debugf("Failed to lookup provide '%s'. Error: %v. Exit code: %d. TDNF error:\n'%s'", pkgVer.Name, err, exitCode, stderr)
 				return
 			}
 
@@ -393,7 +382,7 @@ func (r *RpmRepoCloner) BestProvidesCandidate(pkgVer *pkgjson.PackageVer) (packa
 				bestCandidateLine[installPackageVersionReleaseIndex],
 				bestCandidateLine[installPackageArchIndex])
 
-			return
+			return nil
 		})
 		if err != nil {
 			return

--- a/toolkit/tools/internal/packagerepo/repocloner/rpmrepocloner/rpmrepocloner.go
+++ b/toolkit/tools/internal/packagerepo/repocloner/rpmrepocloner/rpmrepocloner.go
@@ -59,7 +59,7 @@ var (
 	//   - repo:         		fetcher-cloned-repo
 	//   - size human-readable:	1.4M
 	//   - size in bytes:		1468006
-	installPackageRegex = regexp.MustCompile(`\n\s*(\S+)\s+(\S+)\s+(\S+\.cm\d+)\s+(\S+)\s+(\d+\.\d+[[:alpha:]])\s+(\d+)`)
+	installPackageRegex = regexp.MustCompile(`\n\s*(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\d+\.\d+[[:alpha:]])\s+(\d+)`)
 )
 
 const (

--- a/toolkit/tools/internal/rpm/rpm.go
+++ b/toolkit/tools/internal/rpm/rpm.go
@@ -320,6 +320,21 @@ func QueryRPMProvides(rpmFile string) (provides []string, err error) {
 	return
 }
 
+// QueryRPMWhatProvides returns the packages providing a given file path.
+func QueryRPMWhatProvides(filePath string) (packageName string, err error) {
+	const queryWhatProvidesOption = "-qf"
+
+	logger.Log.Debugf("Querying RPM file package providing file (%s)", filePath)
+	stdout, stderr, err := shell.Execute(rpmProgram, queryWhatProvidesOption, filePath)
+	if err != nil {
+		logger.Log.Warnf("RPM query failed.\nStdout: %s.\nStderr: %s", stdout, stderr)
+		return
+	}
+
+	packageName = strings.TrimSpace(stdout)
+	return
+}
+
 // ResolveCompetingPackages takes in a list of RPMs and returns only the ones, which would
 // end up being installed after resolving outdated, obsoleted, or conflicting packages.
 func ResolveCompetingPackages(rootDir string, rpmPaths ...string) (resolvedRPMs []string, err error) {

--- a/toolkit/tools/internal/shell/shell.go
+++ b/toolkit/tools/internal/shell/shell.go
@@ -70,23 +70,15 @@ func PermanentlyStopAllProcesses(signal unix.Signal) {
 	}
 }
 
-// ErrToExitCode converts shell errors to exit codes.
-func ErrToExitCode(shellErr error) (exitCode int, err error) {
-	exitCode = 0
-
-	if shellErr != nil {
-		if exitError, ok := err.(*exec.ExitError); ok {
-			exitCode = exitError.ExitCode()
-		} else {
-			err = fmt.Errorf("unable to convert error '%v' to exit code", shellErr)
-		}
-	}
+// Execute runs the provided command.
+func Execute(program string, args ...string) (stdout, stderr string, err error) {
+	stdout, stderr, _, err = ExecuteWithExitCode(program, args...)
 
 	return
 }
 
 // Execute runs the provided command.
-func Execute(program string, args ...string) (stdout, stderr string, err error) {
+func ExecuteWithExitCode(program string, args ...string) (stdout, stderr string, exitCode int, err error) {
 	var (
 		outBuf bytes.Buffer
 		errBuf bytes.Buffer
@@ -104,7 +96,7 @@ func Execute(program string, args ...string) (stdout, stderr string, err error) 
 	defer untrackProcess(cmd)
 
 	err = cmd.Wait()
-	return outBuf.String(), errBuf.String(), err
+	return outBuf.String(), errBuf.String(), cmd.ProcessState.ExitCode(), err
 }
 
 // ExecuteWithStdin - Run the command and use Stdin to pass input during execution

--- a/toolkit/tools/internal/shell/shell.go
+++ b/toolkit/tools/internal/shell/shell.go
@@ -92,6 +92,20 @@ func Execute(program string, args ...string) (stdout, stderr string, err error) 
 	return outBuf.String(), errBuf.String(), err
 }
 
+// ExecuteWithExitCode runs the provided command and converts Go errors to command's exit code.
+func ExecuteWithExitCode(program string, args ...string) (stdout, stderr string, exitCode int) {
+	exitCode = 0
+
+	stdout, stderr, err := Execute(program, args...)
+	if err != nil {
+		if exitError, ok := err.(*exec.ExitError); ok {
+			exitCode = exitError.ExitCode()
+		}
+	}
+
+	return
+}
+
 // ExecuteWithStdin - Run the command and use Stdin to pass input during execution
 func ExecuteWithStdin(input, program string, args ...string) (stdout, stderr string, err error) {
 	var (

--- a/toolkit/tools/internal/shell/shell.go
+++ b/toolkit/tools/internal/shell/shell.go
@@ -70,6 +70,21 @@ func PermanentlyStopAllProcesses(signal unix.Signal) {
 	}
 }
 
+// ErrToExitCode converts shell errors to exit codes.
+func ErrToExitCode(shellErr error) (exitCode int, err error) {
+	exitCode = 0
+
+	if shellErr != nil {
+		if exitError, ok := err.(*exec.ExitError); ok {
+			exitCode = exitError.ExitCode()
+		} else {
+			err = fmt.Errorf("unable to convert error '%v' to exit code", shellErr)
+		}
+	}
+
+	return
+}
+
 // Execute runs the provided command.
 func Execute(program string, args ...string) (stdout, stderr string, err error) {
 	var (
@@ -90,20 +105,6 @@ func Execute(program string, args ...string) (stdout, stderr string, err error) 
 
 	err = cmd.Wait()
 	return outBuf.String(), errBuf.String(), err
-}
-
-// ExecuteWithExitCode runs the provided command and converts Go errors to command's exit code.
-func ExecuteWithExitCode(program string, args ...string) (stdout, stderr string, exitCode int) {
-	exitCode = 0
-
-	stdout, stderr, err := Execute(program, args...)
-	if err != nil {
-		if exitError, ok := err.(*exec.ExitError); ok {
-			exitCode = exitError.ExitCode()
-		}
-	}
-
-	return
 }
 
 // ExecuteWithStdin - Run the command and use Stdin to pass input during execution

--- a/toolkit/tools/internal/tdnf/tdnf.go
+++ b/toolkit/tools/internal/tdnf/tdnf.go
@@ -12,8 +12,9 @@ import (
 )
 
 const (
-	ExitCodeOK               = 0
-	ExitCodeOperationAborted = 8
+	ExitCodeOK                 = 0
+	ExitCodeOperationAborted   = 8
+	ExitCodeNoMatchingPackages = 243
 )
 
 const (

--- a/toolkit/tools/internal/tdnf/tdnf.go
+++ b/toolkit/tools/internal/tdnf/tdnf.go
@@ -12,6 +12,11 @@ import (
 )
 
 const (
+	ExitCodeOK               = 0
+	ExitCodeOperationAborted = 8
+)
+
+const (
 	// ReleaseverArgument specifies the release version argument to be used with tdnf
 	releaseverArgument = "--releasever"
 )


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

Package builds may fail randomly while resolving the best package to provide a `BuildRequires`. This is due to an [RPM bug](https://github.com/rpm-software-management/rpm/issues/2359), where it may choose multiple conflicting packages to provide the same capability, thus causing a build break,

This change replaces our reliance on RPM with asking TDNF to simulate an (re-)installation of a package. We parse TDNF's output and choose the last package it would attempt to install, as that is the one providing the required capability (other listed packages are dependencies for that last package).

This is an alternative solution to #4492.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Replaced calls to `rpm.ResolveCompetingPackages` with `RepoCloner.BestProvidesCandidate`.
- Removed (now) unused `RepoCloner.WhatProvides` and `graphpkgfetcher.assignRPMPath`.
- Fixed versioning of `Obsoletes` and `Provides` in `libkcapi.spec`.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Full pipeline build from ID 295603.