### PR TITLE
Fixed `mariner_rpmspec` command.

### DIFF
--- a/toolkit/Makefile
+++ b/toolkit/Makefile
@@ -223,6 +223,7 @@ printvar-all-vars: ;
 printvar-verbose-all-vars: $(foreach var,$(interesting_variables),printvar-verbose-$(var))
 printvar-verbose-all-vars: ;
 
-# Leaving the body empty to avoid printing output during dry runs (-n flag).
 printvar-%: ; $(info $($(subst printvar-,,$@)))
+	@: # We want to supress 'make: Nothing to be done for ...' so execute a command so make thinks it has done something
 printvar-verbose-%: ; $(info $(subst printvar-verbose-,,$@): $($(subst printvar-verbose-,,$@)))
+	@: # We want to supress 'make: Nothing to be done for ...' so execute a command so make thinks it has done something

--- a/toolkit/Makefile
+++ b/toolkit/Makefile
@@ -223,7 +223,6 @@ printvar-all-vars: ;
 printvar-verbose-all-vars: $(foreach var,$(interesting_variables),printvar-verbose-$(var))
 printvar-verbose-all-vars: ;
 
+# Leaving the body empty to avoid printing output during dry runs (-n flag).
 printvar-%: ; $(info $($(subst printvar-,,$@)))
-	@: # We want to supress 'make: Nothing to be done for ...' so execute a command so make thinks it has done something
 printvar-verbose-%: ; $(info $(subst printvar-verbose-,,$@): $($(subst printvar-verbose-,,$@)))
-	@: # We want to supress 'make: Nothing to be done for ...' so execute a command so make thinks it has done something

--- a/toolkit/scripts/build_tag.mk
+++ b/toolkit/scripts/build_tag.mk
@@ -8,7 +8,7 @@
 
 DIST_TAG           ?= .cm2
 # Running 'git' as the owner of the repo, so it doesn't complain about the repo not belonging to root.
-BUILD_NUMBER       ?= $(call shell_real_build_only, runuser -u $$(stat -c "%U" $(PROJECT_ROOT)) -- git rev-parse --short HEAD)
+BUILD_NUMBER       ?= $(call shell_real_build_only, if [[ $UID == 0 ]]; then runuser -u $$(stat -c "%U" $(PROJECT_ROOT)) -- git rev-parse --short HEAD; else git rev-parse --short HEAD; fi)
 # an empty BUILD_NUMBER breaks the build later on
 ifeq ($(BUILD_NUMBER),)
    BUILD_NUMBER = non-git

--- a/toolkit/scripts/rpmops.sh
+++ b/toolkit/scripts/rpmops.sh
@@ -13,7 +13,7 @@ then
 fi
 
 # Additional macros required to parse spec files.
-DIST_TAG=$(make -sn -f $REPO_ROOT/toolkit/Makefile get-dist-tag)
+DIST_TAG=$(make -s -f $REPO_ROOT/toolkit/Makefile get-dist-tag)
 DEFINES=(-D "with_check 1" -D "dist $DIST_TAG")
 
 SPECS_DIR="$REPO_ROOT/SPECS"

--- a/toolkit/scripts/rpmops.sh
+++ b/toolkit/scripts/rpmops.sh
@@ -13,7 +13,7 @@ then
 fi
 
 # Additional macros required to parse spec files.
-DIST_TAG=$(make -qn -f $REPO_ROOT/toolkit/Makefile get-dist-tag)
+DIST_TAG=$(make -sn -f $REPO_ROOT/toolkit/Makefile get-dist-tag)
 DEFINES=(-D "with_check 1" -D "dist $DIST_TAG")
 
 SPECS_DIR="$REPO_ROOT/SPECS"


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

While working on #4181 we've introduced `make` commands to retrieve the distribution tag. Accidentally, we used the `-q` switch instead of `-s` to run `make` in silent mode, thus breaking the `mainrer_rpmspec` function, which relied on `make` to retrieve the distribution tag.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Used the correct switch for a silent `make` run.
- Fixed error when running as non-root.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #4181

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local script run.
