### PR TITLE
Worked around RPM package resolution bug.

### DIFF
--- a/SPECS/libkcapi/libkcapi.spec
+++ b/SPECS/libkcapi/libkcapi.spec
@@ -45,8 +45,8 @@ done                                                             \
 ln -s libkcapi.so.%{version}.hmac                            \\\
   "$lib_path"/fipscheck/libkcapi.so.%{vmajor}.hmac               \
 %{nil}
-%global fipscheck_evr     1.5.0-9
-%global hmaccalc_evr      0.9.14-10%{?dist}
+%global fipscheck_next_evr     1.5.0-10%{?dist}
+%global hmaccalc_next_evr      0.9.14-11%{?dist}
 %if %{with_sysctl_tweak}
 # Priority for the sysctl.d preset.
 %global sysctl_prio       50
@@ -58,7 +58,7 @@ ln -s libkcapi.so.%{version}.hmac                            \\\
 Summary:        User space interface to the Linux Kernel Crypto API
 Name:           libkcapi
 Version:        %{vmajor}.%{vminor}.%{vpatch}
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        BSD OR GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -105,9 +105,9 @@ Header files for applications that use %{name}.
 %package        fipscheck
 Summary:        Drop-in replacements for fipscheck/fipshmac provided by the %{name} package
 Requires:       %{name}%{?_isa} = %{version}-%{release}
-Obsoletes:      fipscheck <= %{fipscheck_evr}
-Provides:       fipscheck = %{fipscheck_evr}.1
-Provides:       fipscheck%{?_isa} = %{fipscheck_evr}.1
+Obsoletes:      fipscheck < %{fipscheck_next_evr}
+Provides:       fipscheck = %{fipscheck_next_evr}
+Provides:       fipscheck%{?_isa} = %{fipscheck_next_evr}
 
 %description    fipscheck
 Provides drop-in replacements for fipscheck and fipshmac tools (from
@@ -116,9 +116,9 @@ package fipscheck) using %{name}.
 %package        hmaccalc
 Summary:        Drop-in replacements for hmaccalc provided by the %{name} package
 Requires:       %{name}%{?_isa} = %{version}-%{release}
-Obsoletes:      hmaccalc <= %{hmaccalc_evr}
-Provides:       hmaccalc = %{hmaccalc_evr}.1
-Provides:       hmaccalc%{?_isa} = %{hmaccalc_evr}.1
+Obsoletes:      hmaccalc < %{hmaccalc_next_evr}
+Provides:       hmaccalc = %{hmaccalc_next_evr}
+Provides:       hmaccalc%{?_isa} = %{hmaccalc_next_evr}
 
 %description    hmaccalc
 Provides drop-in replacements for sha*hmac tools (from package
@@ -256,6 +256,9 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %{_libexecdir}/%{name}/*
 
 %changelog
+* Thu Jan 19 2023 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.3.1-2
+- Fixing 'Obsoletes' and 'Provides' for 'fipscheck' and 'hmaccalc' subpackages.
+
 * Mon Jan 10 2022 Henry Li <lihl@microsoft.com> - 1.3.1-1
 - Upgrade to version 1.3.1
 

--- a/toolkit/tools/internal/packagerepo/repocloner/rpmrepocloner/rpmrepocloner.go
+++ b/toolkit/tools/internal/packagerepo/repocloner/rpmrepocloner/rpmrepocloner.go
@@ -323,7 +323,6 @@ func (r *RpmRepoCloner) WhatProvides(pkgVer *pkgjson.PackageVer) (packageNames [
 		releaseverCliArg,
 	}
 
-	foundPackages := make(map[string]bool)
 	// Consider the built (local) RPMs first, then the already cached (e.g. tooolchain), and finally all remote packages.
 	repoOrderList := []string{builtRepoID, cacheRepoID, allRepoIDs}
 	for _, repoID := range repoOrderList {
@@ -344,12 +343,13 @@ func (r *RpmRepoCloner) WhatProvides(pkgVer *pkgjson.PackageVer) (packageNames [
 				return
 			}
 
+			// MUST keep order of packages printed by TDNF.
+			// TDNF will print the packages starting from the highest version, which allows us to work around an RPM bug:
+			// https://github.com/rpm-software-management/rpm/issues/2359
 			for _, matches := range packageLookupNameMatchRegex.FindAllStringSubmatch(stdout, -1) {
 				packageName := matches[packageNameIndex]
-				if _, found := foundPackages[packageName]; !found {
-					foundPackages[packageName] = true
-					logger.Log.Debugf("'%s' is available from package '%s'", pkgVer.Name, packageName)
-				}
+				packageNames = append(packageNames, packageName)
+				logger.Log.Debugf("'%s' is available from package '%s'", pkgVer.Name, packageName)
 			}
 
 			return
@@ -358,19 +358,15 @@ func (r *RpmRepoCloner) WhatProvides(pkgVer *pkgjson.PackageVer) (packageNames [
 			return
 		}
 
-		if len(foundPackages) > 0 {
+		if len(packageNames) > 0 {
 			logger.Log.Debug("Found required package(s), skipping further search in other repos.")
 			break
 		}
 	}
 
-	if len(foundPackages) == 0 {
+	if len(packageNames) == 0 {
 		err = fmt.Errorf("could not resolve %s", pkgVer.Name)
 		return
-	}
-
-	for packageName := range foundPackages {
-		packageNames = append(packageNames, packageName)
 	}
 
 	logger.Log.Debugf("Translated '%s' to package(s): %s", pkgVer.Name, strings.Join(packageNames, " "))


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

Package builds may fail randomly while resolving the best package to provide a `BuildRequires`. This is due to an [RPM bug](https://github.com/rpm-software-management/rpm/issues/2359), where it may choose multiple conflicting packages to provide the same capability, thus causing a build break,

This change replaces makes use of the order, in which TDNF lists packages after running `tdnf provides`. Since it starts with the latest version of each package, RPM should resolve the packages correctly, when handed in this order.

This is an alternative solution to #4492 and #4645.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Made sure we analyze packages in order printed by `tdnf provides`.
- Updated `libkcapi` to fix its `Provides` and `Obsoletes`.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #4492
- #4645

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- [Official pipeline build](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=296748&view=results).
