### PR TITLE
Upgrade python-certifi to version 2022.12.07 to address CVE-2022-23491

### DIFF
--- a/SPECS/python-certifi/python-certifi.signatures.json
+++ b/SPECS/python-certifi/python-certifi.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "certifi-2021.10.08.tar.gz": "51c2cf76f7f2582d9c4eb5440bb311ef523ba0b319d0a973450ecebfb6802a3a"
+  "certifi-2022.12.07.tar.gz": "48d30258d28d0d04b9220492bca614cc596be8f14c94b96ea8298d9284a5e3dd"
  }
 }

--- a/SPECS/python-certifi/python-certifi.spec
+++ b/SPECS/python-certifi/python-certifi.spec
@@ -1,7 +1,7 @@
 Summary:        Python package for providing Mozilla's CA Bundle
 Name:           python-certifi
-Version:        2021.10.08
-Release:        2%{?dist}
+Version:        2022.12.07
+Release:        1%{?dist}
 License:        MPL-2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -46,6 +46,9 @@ pip3 install pytest
 %{python3_sitelib}/*
 
 %changelog
+* Tue Jan 24 2023 Muhammad Falak <mwani@microsoft.com> - 2022.12.07-1
+- Bump version to 2022.12.07 to address CVE-2022-23491
+
 * Sat Feb 12 2022 Muhammad Falak <mwani@microsoft.com> - 2021.10.08-2
 - Add an explict BR on pip
 - Drop un-needed dependencies

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -20794,8 +20794,8 @@
         "type": "other",
         "other": {
           "name": "python-certifi",
-          "version": "2021.10.08",
-          "downloadUrl": "https://github.com/certifi/python-certifi/archive/refs/tags/2021.10.08.tar.gz"
+          "version": "2022.12.07",
+          "downloadUrl": "https://github.com/certifi/python-certifi/archive/refs/tags/2022.12.07.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Upgrade python-certifi to version 2022.12.07 to address CVE-2022-23491

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Upgrade python-certifi to version 2022.12.07 to address CVE-2022-23491

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- NA

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2022-23491

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local Build

BuddyBuild:
- [AMD](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=297229&view=logs&j=ca395085-040a-526b-2ce8-bdc85f692774&t=d723e8ff-9fe0-5a1d-bed2-08b8dc44a520&l=18006)
- [ARM](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=297230&view=logs&j=ca395085-040a-526b-2ce8-bdc85f692774&t=d723e8ff-9fe0-5a1d-bed2-08b8dc44a520&l=17947)
