### PR TITLE
Disable systemd-oomd service & socket through 99-mariner.preset file

### DIFF
--- a/SPECS/systemd/99-mariner.preset
+++ b/SPECS/systemd/99-mariner.preset
@@ -1,0 +1,1 @@
+disable systemd-oomd.*

--- a/SPECS/systemd/99-mariner.preset
+++ b/SPECS/systemd/99-mariner.preset
@@ -1,1 +1,2 @@
-disable systemd-oomd.*
+disable systemd-oomd.socket
+disable systemd-oomd.service

--- a/SPECS/systemd/systemd-bootstrap.signatures.json
+++ b/SPECS/systemd/systemd-bootstrap.signatures.json
@@ -2,7 +2,7 @@
  "Signatures": {
   "50-security-hardening.conf": "c9fc6624a3178cc0980ec3495ac2d5f02a8a1f3a4cdadb8770628d7394b92e2c",
   "99-dhcp-en.network": "158c0003826cef9d780799c6edb2814800d4518f85f884710550f4c46d14be67",
-  "99-mariner.preset": "b8574df233a31480b3ba52d5b172ea0c26eefabc0a1f0cbe924a2f95df0a015a",
+  "99-mariner.preset": "84326fcef828f893827f3d5acdb7a6fe722a8c8e593b19dcc68b082a1c597c79",
   "systemd-250.3.tar.gz": "87b0eee7b6e5aaab2ab56d158f9536daa6bfd5de011f2a5fc6ccdd81ee1e7a24",
   "systemd.cfg": "1fd673c1da90560d9395a18df31f2ce6ef23972a6bf8c910ba6f3fb07818afa9"
  }

--- a/SPECS/systemd/systemd-bootstrap.signatures.json
+++ b/SPECS/systemd/systemd-bootstrap.signatures.json
@@ -2,6 +2,7 @@
  "Signatures": {
   "50-security-hardening.conf": "c9fc6624a3178cc0980ec3495ac2d5f02a8a1f3a4cdadb8770628d7394b92e2c",
   "99-dhcp-en.network": "158c0003826cef9d780799c6edb2814800d4518f85f884710550f4c46d14be67",
+  "99-mariner.preset": "b8574df233a31480b3ba52d5b172ea0c26eefabc0a1f0cbe924a2f95df0a015a",
   "systemd-250.3.tar.gz": "87b0eee7b6e5aaab2ab56d158f9536daa6bfd5de011f2a5fc6ccdd81ee1e7a24",
   "systemd.cfg": "1fd673c1da90560d9395a18df31f2ce6ef23972a6bf8c910ba6f3fb07818afa9"
  }

--- a/SPECS/systemd/systemd-bootstrap.spec
+++ b/SPECS/systemd/systemd-bootstrap.spec
@@ -1,7 +1,7 @@
 Summary:        Bootstrap version of systemd. Workaround for systemd circular dependency.
 Name:           systemd-bootstrap
 Version:        250.3
-Release:        10%{?dist}
+Release:        11%{?dist}
 License:        LGPLv2+ AND GPLv2+ AND MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -11,6 +11,7 @@ Source0:        https://github.com/systemd/systemd-stable/archive/v%{version}.ta
 Source1:        50-security-hardening.conf
 Source2:        systemd.cfg
 Source3:        99-dhcp-en.network
+Source4:        99-mariner.preset
 Patch0:         fix-journald-audit-logging.patch
 # Patch1 can be removed once we update systemd to a version containing the following commit:
 # https://github.com/systemd/systemd/commit/19193b489841a7bcccda7122ac0849cf6efe59fd
@@ -141,6 +142,7 @@ rm %{buildroot}%{_libdir}/systemd/system/default.target
 ln -sfv multi-user.target %{buildroot}%{_libdir}/systemd/system/default.target
 install -dm 0755 %{buildroot}/%{_sysconfdir}/systemd/network
 install -m 0644 %{SOURCE3} %{buildroot}/%{_sysconfdir}/systemd/network
+install -D -m 0644 %{SOURCE4} %{buildroot}%{_libdir}/systemd/system-preset/99-mariner.preset
 
 # Enable default systemd units.
 %post
@@ -202,6 +204,7 @@ fi
 %config(noreplace) /boot/systemd.cfg
 %{_libdir}/udev/*
 %{_libdir}/systemd/*
+%{_libdir}/systemd/system-preset/99-mariner.preset
 %{_libdir}/environment.d/99-environment.conf
 %exclude %{_libdir}/debug
 %exclude %{_datadir}/locale
@@ -241,6 +244,9 @@ fi
 %{_datadir}/pkgconfig/udev.pc
 
 %changelog
+* Wed Jan 25 2023 Adit Jha <aditjha@microsoft.com> - 250.3-11
+- Add 99-mariner.preset to disable systemd-oomd by default
+
 * Wed Dec 14 2022 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 250.3-10
 - Add patch for CVE-2022-45873
 

--- a/SPECS/systemd/systemd.signatures.json
+++ b/SPECS/systemd/systemd.signatures.json
@@ -2,7 +2,7 @@
  "Signatures": {
   "50-security-hardening.conf": "c9fc6624a3178cc0980ec3495ac2d5f02a8a1f3a4cdadb8770628d7394b92e2c",
   "99-dhcp-en.network": "158c0003826cef9d780799c6edb2814800d4518f85f884710550f4c46d14be67",
-  "99-mariner.preset": "b8574df233a31480b3ba52d5b172ea0c26eefabc0a1f0cbe924a2f95df0a015a",
+  "99-mariner.preset": "84326fcef828f893827f3d5acdb7a6fe722a8c8e593b19dcc68b082a1c597c79",
   "systemd-250.3.tar.gz": "87b0eee7b6e5aaab2ab56d158f9536daa6bfd5de011f2a5fc6ccdd81ee1e7a24",
   "systemd.cfg": "1fd673c1da90560d9395a18df31f2ce6ef23972a6bf8c910ba6f3fb07818afa9"
  }

--- a/SPECS/systemd/systemd.signatures.json
+++ b/SPECS/systemd/systemd.signatures.json
@@ -2,6 +2,7 @@
  "Signatures": {
   "50-security-hardening.conf": "c9fc6624a3178cc0980ec3495ac2d5f02a8a1f3a4cdadb8770628d7394b92e2c",
   "99-dhcp-en.network": "158c0003826cef9d780799c6edb2814800d4518f85f884710550f4c46d14be67",
+  "99-mariner.preset": "b8574df233a31480b3ba52d5b172ea0c26eefabc0a1f0cbe924a2f95df0a015a",
   "systemd-250.3.tar.gz": "87b0eee7b6e5aaab2ab56d158f9536daa6bfd5de011f2a5fc6ccdd81ee1e7a24",
   "systemd.cfg": "1fd673c1da90560d9395a18df31f2ce6ef23972a6bf8c910ba6f3fb07818afa9"
  }

--- a/SPECS/systemd/systemd.spec
+++ b/SPECS/systemd/systemd.spec
@@ -1,7 +1,7 @@
 Summary:        Systemd-250
 Name:           systemd
 Version:        250.3
-Release:        13%{?dist}
+Release:        14%{?dist}
 License:        LGPLv2+ AND GPLv2+ AND MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -11,6 +11,7 @@ Source0:        https://github.com/%{name}/%{name}-stable/archive/v%{version}.ta
 Source1:        50-security-hardening.conf
 Source2:        systemd.cfg
 Source3:        99-dhcp-en.network
+Source4:        99-mariner.preset
 Patch0:         fix-journald-audit-logging.patch
 # Patch1 can be removed once we update systemd to a version containing the following commit:
 # https://github.com/systemd/systemd/commit/19193b489841a7bcccda7122ac0849cf6efe59fd
@@ -167,6 +168,8 @@ rm %{buildroot}%{_libdir}/systemd/system/default.target
 ln -sfv multi-user.target %{buildroot}%{_libdir}/systemd/system/default.target
 install -dm 0755 %{buildroot}/%{_sysconfdir}/systemd/network
 install -m 0644 %{SOURCE3} %{buildroot}/%{_sysconfdir}/systemd/network
+install -D -m 0644 %{SOURCE4} %{buildroot}%{_libdir}/systemd/system-preset/99-mariner.preset
+
 %find_lang %{name} ../%{name}.lang
 
 %check
@@ -232,6 +235,7 @@ fi
 %config(noreplace) /boot/systemd.cfg
 %{_libdir}/udev/*
 %{_libdir}/systemd/*
+%{_libdir}/systemd/system-preset/99-mariner.preset
 %{_libdir}/environment.d/99-environment.conf
 %exclude %{_libdir}/debug
 %exclude %{_datadir}/locale
@@ -273,6 +277,9 @@ fi
 %files lang -f %{name}.lang
 
 %changelog
+* Wed Jan 25 2023 Adit Jha <aditjha@microsoft.com> - 250.3-14
+- Add 99-mariner.preset to disable systemd-oomd by default
+
 * Mon Jan 23 2023 Cameron Baird <cameronbaird@microsoft.com> - 250.3-13
 - Add patch for CVE-2022-4415
 - Add patch backport-helper-util-macros.patch to backport needed macros for CVE-2022-4415.patch

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -551,10 +551,10 @@ sqlite-devel-3.39.2-2.cm2.aarch64.rpm
 sqlite-libs-3.39.2-2.cm2.aarch64.rpm
 swig-4.0.2-3.cm2.aarch64.rpm
 swig-debuginfo-4.0.2-3.cm2.aarch64.rpm
-systemd-bootstrap-250.3-10.cm2.aarch64.rpm
-systemd-bootstrap-debuginfo-250.3-10.cm2.aarch64.rpm
-systemd-bootstrap-devel-250.3-10.cm2.aarch64.rpm
-systemd-bootstrap-rpm-macros-250.3-10.cm2.noarch.rpm
+systemd-bootstrap-250.3-11.cm2.aarch64.rpm
+systemd-bootstrap-debuginfo-250.3-11.cm2.aarch64.rpm
+systemd-bootstrap-devel-250.3-11.cm2.aarch64.rpm
+systemd-bootstrap-rpm-macros-250.3-11.cm2.noarch.rpm
 tar-1.34-1.cm2.aarch64.rpm
 tar-debuginfo-1.34-1.cm2.aarch64.rpm
 tdnf-3.2.2-4.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -551,10 +551,10 @@ sqlite-devel-3.39.2-2.cm2.x86_64.rpm
 sqlite-libs-3.39.2-2.cm2.x86_64.rpm
 swig-4.0.2-3.cm2.x86_64.rpm
 swig-debuginfo-4.0.2-3.cm2.x86_64.rpm
-systemd-bootstrap-250.3-10.cm2.x86_64.rpm
-systemd-bootstrap-debuginfo-250.3-10.cm2.x86_64.rpm
-systemd-bootstrap-devel-250.3-10.cm2.x86_64.rpm
-systemd-bootstrap-rpm-macros-250.3-10.cm2.noarch.rpm
+systemd-bootstrap-250.3-11.cm2.x86_64.rpm
+systemd-bootstrap-debuginfo-250.3-11.cm2.x86_64.rpm
+systemd-bootstrap-devel-250.3-11.cm2.x86_64.rpm
+systemd-bootstrap-rpm-macros-250.3-11.cm2.noarch.rpm
 tar-1.34-1.cm2.x86_64.rpm
 tar-debuginfo-1.34-1.cm2.x86_64.rpm
 tdnf-3.2.2-4.cm2.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
This PR creates a mariner specific preset file and uses this to disable the systemd-oomd service and socket because these are dependent on cgroupv2 being enabled and that is not currently the case with Mariner by default. This was originally causing Mariner's state to be degraded, and we will be disabling systemd-oomd by default, and allow someone to enable if needed.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Created 99-mariner.preset file to store any future mariner specific preset decisions
- Added logic in spec files for systemd to apply preset file in respective locations

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
NO

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://dev.azure.com/microsoft/OS/_workitems/edit/41521816



###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: 299675
