### PR TITLE
moby-runc: fix byte order while parsing cpuset range to bits

### DIFF
--- a/SPECS/moby-runc/0001-cgroups-cpuset-fix-byte-order-while-parsing-cpuset-r.patch
+++ b/SPECS/moby-runc/0001-cgroups-cpuset-fix-byte-order-while-parsing-cpuset-r.patch
@@ -1,0 +1,78 @@
+From 77cae9addc0c7c9ef52513b4e46b2e6485e4e469 Mon Sep 17 00:00:00 2001
+From: "Chengen, Du" <chengen.du@canonical.com>
+Date: Mon, 26 Sep 2022 14:28:18 +0800
+Subject: [PATCH] cgroups: cpuset: fix byte order while parsing cpuset range to
+ bits
+
+Runc parses cpuset range to bits in the case of cgroup v2 + systemd as cgroup driver.
+The byte order representation differs from systemd expectation, which will set
+different cpuset range in systemd transient unit if the length of parsed byte array exceeds one.
+
+	# cat config.json
+	...
+	"resources": {
+		...
+		"cpu": {
+			"cpus": "10-23"
+		}
+	},
+	...
+	# runc --systemd-cgroup run test
+	# cat /run/systemd/transient/runc-test.scope.d/50-AllowedCPUs.conf
+	# This is a drop-in unit file extension, created via "systemctl set-property"
+	# or an equivalent operation. Do not edit.
+	[Scope]
+	AllowedCPUs=0-7 10-15
+
+The cpuset.cpus in cgroup will also be set to wrong value after reloading systemd manager configuration.
+
+	# systemctl daemon-reload
+	# cat /sys/fs/cgroup/system.slice/runc-test.scope/cpuset.cpus
+	0-7,10-15
+
+Signed-off-by: seyeongkim <seyeong.kim@canonical.com>
+Signed-off-by: Chengen, Du <chengen.du@canonical.com>
+---
+ libcontainer/cgroups/systemd/cpuset.go      | 5 +++++
+ libcontainer/cgroups/systemd/cpuset_test.go | 6 +++---
+ 2 files changed, 8 insertions(+), 3 deletions(-)
+
+diff --git a/libcontainer/cgroups/systemd/cpuset.go b/libcontainer/cgroups/systemd/cpuset.go
+index 83d10dd7..dd474cf1 100644
+--- a/libcontainer/cgroups/systemd/cpuset.go
++++ b/libcontainer/cgroups/systemd/cpuset.go
+@@ -51,5 +51,10 @@ func RangeToBits(str string) ([]byte, error) {
+ 		// do not allow empty values
+ 		return nil, errors.New("empty value")
+ 	}
++
++	// fit cpuset parsing order in systemd
++	for l, r := 0, len(ret)-1; l < r; l, r = l+1, r-1 {
++		ret[l], ret[r] = ret[r], ret[l]
++	}
+ 	return ret, nil
+ }
+diff --git a/libcontainer/cgroups/systemd/cpuset_test.go b/libcontainer/cgroups/systemd/cpuset_test.go
+index 3030cba9..bda31a5b 100644
+--- a/libcontainer/cgroups/systemd/cpuset_test.go
++++ b/libcontainer/cgroups/systemd/cpuset_test.go
+@@ -22,13 +22,13 @@ func TestRangeToBits(t *testing.T) {
+ 		{in: "4-7", out: []byte{0xf0}},
+ 		{in: "0-7", out: []byte{0xff}},
+ 		{in: "0-15", out: []byte{0xff, 0xff}},
+-		{in: "16", out: []byte{1, 0, 0}},
+-		{in: "0-3,32-33", out: []byte{3, 0, 0, 0, 0x0f}},
++		{in: "16", out: []byte{0, 0, 1}},
++		{in: "0-3,32-33", out: []byte{0x0f, 0, 0, 0, 3}},
+ 		// extra spaces and tabs are ok
+ 		{in: "1, 2, 1-2", out: []byte{6}},
+ 		{in: "    , 1   , 3  ,  5-7,	", out: []byte{0xea}},
+ 		// somewhat large values
+-		{in: "128-130,1", out: []byte{7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2}},
++		{in: "128-130,1", out: []byte{2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7}},
+ 
+ 		{in: "-", isErr: true},
+ 		{in: "1-", isErr: true},
+-- 
+2.25.1
+

--- a/SPECS/moby-runc/moby-runc.spec
+++ b/SPECS/moby-runc/moby-runc.spec
@@ -5,7 +5,7 @@ Summary:        CLI tool for spawning and running containers per OCI spec.
 Name:           moby-%{upstream_name}
 # update "commit_hash" above when upgrading version
 Version:        1.1.2
-Release:        6%{?dist}
+Release:        7%{?dist}
 License:        ASL 2.0
 URL:            https://github.com/opencontainers/runc
 Group:          Virtualization/Libraries
@@ -13,6 +13,7 @@ Vendor:         Microsoft Corporation
 Distribution:   Mariner
 
 Source0:        https://github.com/opencontainers/runc/archive/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
+Patch0:         0001-cgroups-cpuset-fix-byte-order-while-parsing-cpuset-r.patch
 
 BuildRequires:  git
 BuildRequires:  golang => 1.16
@@ -36,6 +37,7 @@ runC is a CLI tool for spawning and running containers according to the OCI spec
 
 %prep
 %setup -q -n %{upstream_name}-%{version}
+%patch0 -p1
 
 %build
 export CGO_ENABLED=1
@@ -57,8 +59,8 @@ make install-man DESTDIR="%{buildroot}" PREFIX="%{_prefix}"
 %{_mandir}/*
 
 %changelog
-* Wed Jan 18 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 1.1.2-6
-- Bump release to rebuild with go 1.19.4
+* Wed Jan 25 2023 Vince Perri <viperri@microsoft.com> - 1.1.2-7
+- Add 0001-cgroups-cpuset-fix-byte-order-while-parsing-cpuset-r.patch
 
 * Fri Dec 16 2022 Daniel McIlvaney <damcilva@microsoft.com> - 1.1.2-5
 - Bump release to rebuild with go 1.18.8 with patch for CVE-2022-41717


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->

Fixes run cpuset range parsing when cgroups is being used. See https://github.com/opencontainers/runc/pull/3611. Required for HCI scenarios. This fix will be in the next minor release of moby-runc.

###### Change Log  <!-- REQUIRED -->
- Add 0001-cgroups-cpuset-fix-byte-order-while-parsing-cpuset-r.patch to moby-runc

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: xxxx
