### PR TITLE
remove manpages from the container image

### DIFF
--- a/toolkit/imageconfigs/postinstallscripts/core-container/cleanup.sh
+++ b/toolkit/imageconfigs/postinstallscripts/core-container/cleanup.sh
@@ -2,5 +2,6 @@
 # cleanup
 rm -rf /boot/*
 rm -rf /usr/src/
+rm -rf /usr/share/man
 rm -rf /home/*
 rm -rf /var/log/*


### PR DESCRIPTION
Removes the (openssl) man pages from the distroless container images. This saves an additional 552K.