### PR TITLE
Cherry-pick 'Pass pkgver to tar in mariabd src tar generation script (#4724)'

### DIFF
--- a/SPECS/mariadb/generate_source_tarball.sh
+++ b/SPECS/mariadb/generate_source_tarball.sh
@@ -78,7 +78,7 @@ git clone --depth 1 https://github.com/MariaDB/server.git -b mariadb-$PKG_VERSIO
 pushd server
 git submodule update --depth 1 --init --recursive 
 popd
-mv server mariadb-$1
+mv server mariadb-$PKG_VERSION
 
 if [[ -n $SRC_TARBALL ]]; then
     TARBALL_NAME="$(basename $SRC_TARBALL)"
@@ -95,6 +95,6 @@ NEW_TARBALL="$OUT_FOLDER/$TARBALL_NAME"
 tar --sort=name --mtime="2021-11-10 00:00Z" \
     --owner=0 --group=0 --numeric-owner \
     --pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime \
-    -zcf $NEW_TARBALL mariadb-$1
+    -zcf $NEW_TARBALL mariadb-$PKG_VERSION
 
 echo "Source tarball $NEW_TARBALL successfully created!"


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Cherry-pick of commit 271aac9fe62f7c5893bc2152ec9d4bd484347782 (#4724) into 1.0-dev