### PR TITLE
[1.0] Resolve dbus CVE-2022-42010, CVE-2022-42011, CVE-2022-42012

### DIFF
--- a/SPECS/dbus/CVE-2022-42010.patch
+++ b/SPECS/dbus/CVE-2022-42010.patch
@@ -1,0 +1,112 @@
+From 9d07424e9011e3bbe535e83043d335f3093d2916 Mon Sep 17 00:00:00 2001
+From: Simon McVittie <smcv@collabora.com>
+Date: Tue, 13 Sep 2022 15:10:22 +0100
+Subject: [PATCH] dbus-marshal-validate: Check brackets in signature nest
+ correctly
+
+In debug builds with assertions enabled, a signature with incorrectly
+nested `()` and `{}`, for example `a{i(u}` or `(a{ii)}`, could result
+in an assertion failure.
+
+In production builds without assertions enabled, a signature with
+incorrectly nested `()` and `{}` could potentially result in a crash
+or incorrect message parsing, although we do not have a concrete example
+of either of these failure modes.
+
+Thanks: Evgeny Vereshchagin
+Resolves: https://gitlab.freedesktop.org/dbus/dbus/-/issues/418
+Resolves: CVE-2022-42010
+Signed-off-by: Simon McVittie <smcv@collabora.com>
+---
+ dbus/dbus-marshal-validate.c | 38 +++++++++++++++++++++++++++++++++++-
+ 1 file changed, 37 insertions(+), 1 deletion(-)
+
+diff --git a/dbus/dbus-marshal-validate.c b/dbus/dbus-marshal-validate.c
+index 4d492f3f3..ae68414dd 100644
+--- a/dbus/dbus-marshal-validate.c
++++ b/dbus/dbus-marshal-validate.c
+@@ -62,6 +62,8 @@ _dbus_validate_signature_with_reason (const DBusString *type_str,
+ 
+   int element_count;
+   DBusList *element_count_stack;
++  char opened_brackets[DBUS_MAXIMUM_TYPE_RECURSION_DEPTH * 2 + 1] = { '\0' };
++  char last_bracket;
+ 
+   result = DBUS_VALID;
+   element_count_stack = NULL;
+@@ -93,6 +95,10 @@ _dbus_validate_signature_with_reason (const DBusString *type_str,
+ 
+   while (p != end)
+     {
++      _dbus_assert (struct_depth + dict_entry_depth >= 0);
++      _dbus_assert (struct_depth + dict_entry_depth < _DBUS_N_ELEMENTS (opened_brackets));
++      _dbus_assert (opened_brackets[struct_depth + dict_entry_depth] == '\0');
++
+       switch (*p)
+         {
+         case DBUS_TYPE_BYTE:
+@@ -136,6 +142,10 @@ _dbus_validate_signature_with_reason (const DBusString *type_str,
+               goto out;
+             }
+ 
++          _dbus_assert (struct_depth + dict_entry_depth >= 1);
++          _dbus_assert (struct_depth + dict_entry_depth < _DBUS_N_ELEMENTS (opened_brackets));
++          _dbus_assert (opened_brackets[struct_depth + dict_entry_depth - 1] == '\0');
++          opened_brackets[struct_depth + dict_entry_depth - 1] = DBUS_STRUCT_BEGIN_CHAR;
+           break;
+ 
+         case DBUS_STRUCT_END_CHAR:
+@@ -151,9 +161,20 @@ _dbus_validate_signature_with_reason (const DBusString *type_str,
+               goto out;
+             }
+ 
++          _dbus_assert (struct_depth + dict_entry_depth >= 1);
++          _dbus_assert (struct_depth + dict_entry_depth < _DBUS_N_ELEMENTS (opened_brackets));
++          last_bracket = opened_brackets[struct_depth + dict_entry_depth - 1];
++
++          if (last_bracket != DBUS_STRUCT_BEGIN_CHAR)
++            {
++              result = DBUS_INVALID_STRUCT_ENDED_BUT_NOT_STARTED;
++              goto out;
++            }
++
+           _dbus_list_pop_last (&element_count_stack);
+ 
+           struct_depth -= 1;
++          opened_brackets[struct_depth + dict_entry_depth] = '\0';
+           break;
+ 
+         case DBUS_DICT_ENTRY_BEGIN_CHAR:
+@@ -178,6 +199,10 @@ _dbus_validate_signature_with_reason (const DBusString *type_str,
+               goto out;
+             }
+ 
++          _dbus_assert (struct_depth + dict_entry_depth >= 1);
++          _dbus_assert (struct_depth + dict_entry_depth < _DBUS_N_ELEMENTS (opened_brackets));
++          _dbus_assert (opened_brackets[struct_depth + dict_entry_depth - 1] == '\0');
++          opened_brackets[struct_depth + dict_entry_depth - 1] = DBUS_DICT_ENTRY_BEGIN_CHAR;
+           break;
+ 
+         case DBUS_DICT_ENTRY_END_CHAR:
+@@ -186,8 +211,19 @@ _dbus_validate_signature_with_reason (const DBusString *type_str,
+               result = DBUS_INVALID_DICT_ENTRY_ENDED_BUT_NOT_STARTED;
+               goto out;
+             }
+-            
++
++          _dbus_assert (struct_depth + dict_entry_depth >= 1);
++          _dbus_assert (struct_depth + dict_entry_depth < _DBUS_N_ELEMENTS (opened_brackets));
++          last_bracket = opened_brackets[struct_depth + dict_entry_depth - 1];
++
++          if (last_bracket != DBUS_DICT_ENTRY_BEGIN_CHAR)
++            {
++              result = DBUS_INVALID_DICT_ENTRY_ENDED_BUT_NOT_STARTED;
++              goto out;
++            }
++
+           dict_entry_depth -= 1;
++          opened_brackets[struct_depth + dict_entry_depth] = '\0';
+ 
+           element_count = 
+             _DBUS_POINTER_TO_INT (_dbus_list_pop_last (&element_count_stack));
+             

--- a/SPECS/dbus/CVE-2022-42011.patch
+++ b/SPECS/dbus/CVE-2022-42011.patch
@@ -1,0 +1,53 @@
+From 079bbf16186e87fb0157adf8951f19864bc2ed69 Mon Sep 17 00:00:00 2001
+From: Simon McVittie <smcv@collabora.com>
+Date: Mon, 12 Sep 2022 13:14:18 +0100
+Subject: [PATCH] dbus-marshal-validate: Validate length of arrays of
+ fixed-length items
+
+This fast-path previously did not check that the array was made up
+of an integer number of items. This could lead to assertion failures
+and out-of-bounds accesses during subsequent message processing (which
+assumes that the message has already been validated), particularly after
+the addition of _dbus_header_remove_unknown_fields(), which makes it
+more likely that dbus-daemon will apply non-trivial edits to messages.
+
+Thanks: Evgeny Vereshchagin
+Fixes: e61f13cf "Bug 18064 - more efficient validation for fixed-size type arrays"
+Resolves: https://gitlab.freedesktop.org/dbus/dbus/-/issues/413
+Resolves: CVE-2022-42011
+Signed-off-by: Simon McVittie <smcv@collabora.com>
+---
+ dbus/dbus-marshal-validate.c | 13 ++++++++++++-
+ 1 file changed, 12 insertions(+), 1 deletion(-)
+
+diff --git a/dbus/dbus-marshal-validate.c b/dbus/dbus-marshal-validate.c
+index ae68414dd..7d0d6cf72 100644
+--- a/dbus/dbus-marshal-validate.c
++++ b/dbus/dbus-marshal-validate.c
+@@ -503,13 +503,24 @@ validate_body_helper (DBusTypeReader       *reader,
+                  */ 
+                 if (dbus_type_is_fixed (array_elem_type))
+                   {
++                    /* Note that fixed-size types all have sizes equal to
++                     * their alignments, so this is really the item size. */
++                    alignment = _dbus_type_get_alignment (array_elem_type);
++                    _dbus_assert (alignment == 1 || alignment == 2 ||
++                                  alignment == 4 || alignment == 8);
++
++                    /* Because the alignment is a power of 2, this is
++                     * equivalent to: (claimed_len % alignment) != 0,
++                     * but avoids slower integer division */
++                    if ((claimed_len & (alignment - 1)) != 0)
++                      return DBUS_INVALID_ARRAY_LENGTH_INCORRECT;
++
+                     /* bools need to be handled differently, because they can
+                      * have an invalid value
+                      */
+                     if (array_elem_type == DBUS_TYPE_BOOLEAN)
+                       {
+                         dbus_uint32_t v;
+-                        alignment = _dbus_type_get_alignment (array_elem_type);
+ 
+                         while (p < array_end)
+                           {
+

--- a/SPECS/dbus/CVE-2022-42012.patch
+++ b/SPECS/dbus/CVE-2022-42012.patch
@@ -42,10 +42,10 @@ Signed-off-by: Simon McVittie <smcv@collabora.com>
  dbus/dbus-marshal-byteswap.c | 6 +-----
  1 file changed, 1 insertion(+), 5 deletions(-)
 
-diff --git a/./dbus/dbus-marshal-byteswap.c b/../dbus-new/dbus/dbus-marshal-byteswap.c
+diff --git a/dbus/dbus-marshal-byteswap.c b/dbus/dbus-marshal-byteswap.c
 index 27695aa..7104e9c 100644
---- a/./dbus/dbus-marshal-byteswap.c
-+++ b/../dbus-new/dbus/dbus-marshal-byteswap.c
+--- a/dbus/dbus-marshal-byteswap.c
++++ b/dbus/dbus-marshal-byteswap.c
 @@ -61,6 +61,7 @@ byteswap_body_helper (DBusTypeReader       *reader,
          case DBUS_TYPE_BOOLEAN:
          case DBUS_TYPE_INT32:

--- a/SPECS/dbus/CVE-2022-42012.patch
+++ b/SPECS/dbus/CVE-2022-42012.patch
@@ -1,0 +1,68 @@
+From 236f16e444e88a984cf12b09225e0f8efa6c5b44 Mon Sep 17 00:00:00 2001
+From: Simon McVittie <smcv@collabora.com>
+Date: Fri, 30 Sep 2022 13:46:31 +0100
+Subject: [PATCH] dbus-marshal-byteswap: Byte-swap Unix fd indexes if needed
+
+When a D-Bus message includes attached file descriptors, the body of the
+message contains unsigned 32-bit indexes pointing into an out-of-band
+array of file descriptors. Some D-Bus APIs like GLib's GDBus refer to
+these indexes as "handles" for the associated fds (not to be confused
+with a Windows HANDLE, which is a kernel object).
+
+The assertion message removed by this commit is arguably correct up to
+a point: fd-passing is only reasonable on a local machine, and no known
+operating system allows processes of differing endianness even on a
+multi-endian ARM or PowerPC CPU, so it makes little sense for the sender
+to specify a byte-order that differs from the byte-order of the recipient.
+
+However, this doesn't account for the fact that a malicious sender
+doesn't have to restrict itself to only doing things that make sense.
+On a system with untrusted local users, a message sender could crash
+the system dbus-daemon (a denial of service) by sending a message in
+the opposite endianness that contains handles to file descriptors.
+
+Before this commit, if assertions are enabled, attempting to byteswap
+a fd index would cleanly crash the message recipient with an assertion
+failure. If assertions are disabled, attempting to byteswap a fd index
+would silently do nothing without advancing the pointer p, causing the
+message's type and the pointer into its contents to go out of sync, which
+can result in a subsequent crash (the crash demonstrated by fuzzing was
+a use-after-free, but other failure modes might be possible).
+
+In principle we could resolve this by rejecting wrong-endianness messages
+from a local sender, but it's actually simpler and less code to treat
+wrong-endianness messages as valid and byteswap them.
+
+Thanks: Evgeny Vereshchagin
+Fixes: ba7daa60 "unix-fd: add basic marshalling code for unix fds"
+Resolves: https://gitlab.freedesktop.org/dbus/dbus/-/issues/417
+Resolves: CVE-2022-42012
+Signed-off-by: Simon McVittie <smcv@collabora.com>
+---
+ dbus/dbus-marshal-byteswap.c | 6 +-----
+ 1 file changed, 1 insertion(+), 5 deletions(-)
+
+diff --git a/./dbus/dbus-marshal-byteswap.c b/../dbus-new/dbus/dbus-marshal-byteswap.c
+index 27695aa..7104e9c 100644
+--- a/./dbus/dbus-marshal-byteswap.c
++++ b/../dbus-new/dbus/dbus-marshal-byteswap.c
+@@ -61,6 +61,7 @@ byteswap_body_helper (DBusTypeReader       *reader,
+         case DBUS_TYPE_BOOLEAN:
+         case DBUS_TYPE_INT32:
+         case DBUS_TYPE_UINT32:
++        case DBUS_TYPE_UNIX_FD:
+           {
+             p = _DBUS_ALIGN_ADDRESS (p, 4);
+             *((dbus_uint32_t*)p) = DBUS_UINT32_SWAP_LE_BE (*((dbus_uint32_t*)p));
+@@ -188,11 +189,6 @@ byteswap_body_helper (DBusTypeReader       *reader,
+           }
+           break;
+ 
+-        case DBUS_TYPE_UNIX_FD:
+-          /* fds can only be passed on a local machine, so byte order must always match */
+-          _dbus_assert_not_reached("attempted to byteswap unix fds which makes no sense");
+-          break;
+-
+         default:
+           _dbus_assert_not_reached ("invalid typecode in supposedly-validated signature");
+           break;

--- a/SPECS/dbus/dbus.spec
+++ b/SPECS/dbus/dbus.spec
@@ -2,7 +2,7 @@
 Summary:        DBus for systemd
 Name:           dbus
 Version:        1.13.6
-Release:        5%{?dist}
+Release:        6%{?dist}
 License:        GPLv2+ OR AFL
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -10,6 +10,9 @@ Group:          Applications/File
 URL:            https://www.freedesktop.org/wiki/Software/dbus
 Source0:        https://%{name}.freedesktop.org/releases/%{name}/%{name}-%{version}.tar.gz
 Patch0:         CVE-2019-12749.patch
+Patch1:         CVE-2022-42010.patch
+Patch2:         CVE-2022-42011.patch
+Patch3:         CVE-2022-42012.patch
 BuildRequires:  expat-devel
 BuildRequires:  systemd-devel
 BuildRequires:  xz-devel
@@ -79,6 +82,9 @@ make %{?_smp_mflags} check
 %{_libdir}/*.so
 
 %changelog
+* Fri Feb 03 2023 Henry Li <lihl@microsoft.com> - 1.13.6-6
+- Resolve CVE-2022-42010, CVE-2022-42011 and CVE-2022-42012
+
 * Tue Feb 16 2021 Daniel Burgener <daburgen@microsoft.com> - 1.13.6-5
 - Enable SELinux support
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
- Resolve CVE-2022-42010, CVE-2022-42011 and CVE-2022-42012

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Resolve CVE-2022-42010, CVE-2022-42011 and CVE-2022-42012

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
NO

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2022-42010
- https://nvd.nist.gov/vuln/detail/CVE-2022-42011
- https://nvd.nist.gov/vuln/detail/CVE-2022-42012

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local Build
