### PR TITLE
Add an upstream patch to kubevirt to fix an SELinux issue

### DIFF
--- a/SPECS/kubevirt/fgetxattr-for-relabel.patch
+++ b/SPECS/kubevirt/fgetxattr-for-relabel.patch
@@ -1,0 +1,117 @@
+commit 28d947c6c487166c8d41b785a8a96a814ce1af81
+Author: Roman Mohr <rmohr@google.com>
+Date:   Tue Aug 23 19:31:36 2022 +0200
+
+    Use fgetxattr to get selinux labels
+    
+    Instead of using lgetxattr on a fd path (/proc/self/fd/<num>), directly
+    use `fgetxattr`.
+    
+    It turns out that `lgetxattr` does not return a consistent result on all
+    kernel version when used on a filedescriptor path.
+    
+    This is often not an issue. It would just mean that virt-handler would
+    label a few devices in its namespces on every start, even if it would
+    not have to. But on some operating systems (e.g. Centos8, but not
+    Centos8 stream) we then fail on the not needed relabeling attempt.
+    
+    Before:
+    
+    lgetxattr sometimes returns weird resources on a file descroptor path:
+    
+    ```
+    Error: error relabeling file /proc/self/fd/7 from label system_u:system_r:spc_t:s0 to label system_u:object_r:container_file_t:s0. Reason: operation not supported
+    [...]
+    error relabeling file /proc/self/fd/7 from label system_u:system_r:spc_t:s0 to label system_u:object_r:container_file_t:s0. Reason: operation not supported
+    ```
+    
+    After:
+    
+    Successful detection of matching labels results in no action:
+    
+    ```
+    root@virt-handler-gk5vb:~# ./virt-chroot selinux relabel system_u:object_r:container_file_t:s0 /dev/net/tun
+    ```
+    
+    Mismatches are still detected as expected:
+    
+    ```
+    root@virt-handler-gk5vb:~# ./virt-chroot selinux relabel system_u:object_r:container_file_t:s1 /dev/net/tun
+    Error: error relabeling file /proc/self/fd/7 from label system_u:object_r:container_file_t:s0 to label system_u:object_r:container_file_t:s1. Reason: operation not supported
+    
+    [...]
+    error relabeling file /proc/self/fd/7 from label system_u:object_r:container_file_t:s0 to label system_u:object_r:container_file_t:s1. Reason: operation not supported
+    ```
+    
+    Signed-off-by: Roman Mohr <rmohr@google.com>
+
+diff --git a/cmd/virt-chroot/BUILD.bazel b/cmd/virt-chroot/BUILD.bazel
+index fd26041a0..250a25bf2 100644
+--- a/cmd/virt-chroot/BUILD.bazel
++++ b/cmd/virt-chroot/BUILD.bazel
+@@ -17,7 +17,6 @@ go_library(
+         "//vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs:go_default_library",
+         "//vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs2:go_default_library",
+         "//vendor/github.com/opencontainers/runc/libcontainer/configs:go_default_library",
+-        "//vendor/github.com/opencontainers/selinux/go-selinux:go_default_library",
+         "//vendor/github.com/spf13/cobra:go_default_library",
+         "//vendor/github.com/vishvananda/netlink:go_default_library",
+         "//vendor/golang.org/x/sys/unix:go_default_library",
+diff --git a/cmd/virt-chroot/selinux.go b/cmd/virt-chroot/selinux.go
+index 29cc03712..c75962017 100644
+--- a/cmd/virt-chroot/selinux.go
++++ b/cmd/virt-chroot/selinux.go
+@@ -7,7 +7,6 @@ import (
+ 	"os"
+ 	"path/filepath"
+ 
+-	"github.com/opencontainers/selinux/go-selinux"
+ 	"github.com/spf13/cobra"
+ 	"golang.org/x/sys/unix"
+ 
+@@ -67,10 +66,6 @@ func RelabelCommand() *cobra.Command {
+ 
+ 			defer fd.Close()
+ 			filePath := fd.SafePath()
+-			currentFileLabel, err := selinux.FileLabel(filePath)
+-			if err != nil {
+-				return fmt.Errorf("could not retrieve label of file %s. Reason: %v", filePath, err)
+-			}
+ 
+ 			writeableFD, err := os.OpenFile(filePath, os.O_APPEND|unix.S_IWRITE, os.ModePerm)
+ 			if err != nil {
+@@ -78,6 +73,11 @@ func RelabelCommand() *cobra.Command {
+ 			}
+ 			defer writeableFD.Close()
+ 
++			currentFileLabel, err := getLabel(writeableFD)
++			if err != nil {
++				return fmt.Errorf("faild to get selinux label for file %v: %v", filePath, err)
++			}
++
+ 			if currentFileLabel != label {
+ 				if err := unix.Fsetxattr(int(writeableFD.Fd()), xattrNameSelinux, []byte(label), 0); err != nil {
+ 					return fmt.Errorf("error relabeling file %s with label %s. Reason: %v", filePath, label, err)
+@@ -90,3 +90,22 @@ func RelabelCommand() *cobra.Command {
+ 	relabelCommad.Flags().StringVar(&root, "root", "/", "safe root path which will be prepended to passed in files")
+ 	return relabelCommad
+ }
++
++func getLabel(file *os.File) (string, error) {
++	// let's first find out the actual buffer size
++	var buffer []byte
++	labelLength, err := unix.Fgetxattr(int(file.Fd()), xattrNameSelinux, buffer)
++	if err != nil {
++		return "", fmt.Errorf("error reading fgetxattr: %v", err)
++	}
++	// now ask with the needed size
++	buffer = make([]byte, labelLength)
++	labelLength, err = unix.Fgetxattr(int(file.Fd()), xattrNameSelinux, buffer)
++	if err != nil {
++		return "", fmt.Errorf("error reading fgetxattr: %v", err)
++	}
++	if labelLength > 0 && buffer[labelLength-1] == '\x00' {
++		labelLength = labelLength - 1
++	}
++	return string(buffer[:labelLength]), nil
++}

--- a/SPECS/kubevirt/kubevirt.spec
+++ b/SPECS/kubevirt/kubevirt.spec
@@ -211,7 +211,7 @@ install -p -m 0644 cmd/virt-handler/ipv6-nat.nft %{buildroot}%{_datadir}/kube-vi
 %{_bindir}/virt-tests
 
 %changelog
-* Wed Feb 4 2023 Kanika Nema <kanikanema@microsoft.com> - 0.58.0-4
+* Wed Feb 04 2023 Kanika Nema <kanikanema@microsoft.com> - 0.58.0-4
 - Add a upstream patch (from v0.59.0-alpha2) without which virt-handler
   containers don't start.
 

--- a/SPECS/kubevirt/kubevirt.spec
+++ b/SPECS/kubevirt/kubevirt.spec
@@ -20,7 +20,7 @@
 Summary:        Container native virtualization
 Name:           kubevirt
 Version:        0.58.0
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -28,6 +28,8 @@ Group:          System/Management
 URL:            https://github.com/kubevirt/kubevirt
 Source0:        https://github.com/kubevirt/kubevirt/archive/refs/tags/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
 Source1:        disks-images-provider.yaml
+# Upstream patch to fix issue #8544, PR #8594
+Patch:          fgetxattr-for-relabel.patch
 BuildRequires:  glibc-devel
 BuildRequires:  glibc-static >= 2.35-3%{?dist}
 BuildRequires:  golang
@@ -209,6 +211,10 @@ install -p -m 0644 cmd/virt-handler/ipv6-nat.nft %{buildroot}%{_datadir}/kube-vi
 %{_bindir}/virt-tests
 
 %changelog
+* Wed Feb 4 2023 Kanika Nema <kanikanema@microsoft.com> - 0.58.0-4
+- Add a upstream patch (from v0.59.0-alpha2) without which virt-handler
+  containers don't start.
+
 * Fri Feb 03 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 0.58.0-3
 - Bump release to rebuild with go 1.19.5
 

--- a/SPECS/kubevirt/kubevirt.spec
+++ b/SPECS/kubevirt/kubevirt.spec
@@ -29,7 +29,7 @@ URL:            https://github.com/kubevirt/kubevirt
 Source0:        https://github.com/kubevirt/kubevirt/archive/refs/tags/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
 Source1:        disks-images-provider.yaml
 # Upstream patch to fix issue #8544, PR #8594
-Patch0:          fgetxattr-for-relabel.patch
+Patch0:         fgetxattr-for-relabel.patch
 BuildRequires:  glibc-devel
 BuildRequires:  glibc-static >= 2.35-3%{?dist}
 BuildRequires:  golang
@@ -211,8 +211,8 @@ install -p -m 0644 cmd/virt-handler/ipv6-nat.nft %{buildroot}%{_datadir}/kube-vi
 %{_bindir}/virt-tests
 
 %changelog
-* Wed Feb 04 2023 Kanika Nema <kanikanema@microsoft.com> - 0.58.0-4
-- Add a upstream patch (from v0.59.0-alpha2) without which virt-handler
+* Mon Feb 13 2023 Kanika Nema <kanikanema@microsoft.com> - 0.58.0-4
+- Add an upstream patch (from v0.59.0-alpha2) without which virt-handler
   containers don't start.
 
 * Fri Feb 03 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 0.58.0-3

--- a/SPECS/kubevirt/kubevirt.spec
+++ b/SPECS/kubevirt/kubevirt.spec
@@ -29,7 +29,7 @@ URL:            https://github.com/kubevirt/kubevirt
 Source0:        https://github.com/kubevirt/kubevirt/archive/refs/tags/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
 Source1:        disks-images-provider.yaml
 # Upstream patch to fix issue #8544, PR #8594
-Patch:          fgetxattr-for-relabel.patch
+Patch0:          fgetxattr-for-relabel.patch
 BuildRequires:  glibc-devel
 BuildRequires:  glibc-static >= 2.35-3%{?dist}
 BuildRequires:  golang


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Add an upstream patch to fix kubevirt issue #8544, PR #8594. This bug has been fixed only in the latest version v0.59.0 which is still at alpha2 release. Without this fix, virt-handler containers do not start on a system with selinux set to enforced. 
To unblock mariner HCI and AODS testing on v0.58.0 the required patch has been pulled in v0.58.0. Once version 0.59.0 is released, the rpms will be upgraded, and this patch can be removed.


###### Change Log  <!-- REQUIRED -->
Added an upstream patch to fix kubevirt issue #8544, PR #8594

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->


###### Links to CVEs  <!-- optional -->


###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: Full pipeline build 304370
The golden containers consuming the new rpms have been tested to confirm kubevirt is deployed as expected.