### PR TITLE
Patch util-linux to add patch to prevent cdrom probe on Azure VMs

### DIFF
--- a/SPECS/util-linux/libblkid-src-probe-check-for-ENOMEDIUM.patch
+++ b/SPECS/util-linux/libblkid-src-probe-check-for-ENOMEDIUM.patch
@@ -1,0 +1,34 @@
+From c80b3f3200486d8f11a56afa9bb2c27b9cc4ffe3 Mon Sep 17 00:00:00 2001
+From: Jeremi Piotrowski <jpiotrowski@linux.microsoft.com>
+Date: Wed, 8 Dec 2021 09:09:53 -0800
+Subject: [PATCH] libblkid/src/probe: check for ENOMEDIUM from
+ ioctl(CDROM_LAST_WRITTEN)
+
+The CD device on Azure VMs returns CDS_DISC_OK from CDROM_DRIVE_STATUS even
+when no disc is present. In that case an ENOMEDIUM from CDROM_LAST_WRITTEN
+follows. Catch that and return error to prevent probing which results in
+hundreds of "unaligned transfer" warnings in the kernel logbuffer.
+
+Signed-off-by: Jeremi Piotrowski <jpiotrowski@microsoft.com>
+---
+ libblkid/src/probe.c | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/libblkid/src/probe.c b/libblkid/src/probe.c
+index 3685ea5e13..513649916d 100644
+--- a/libblkid/src/probe.c
++++ b/libblkid/src/probe.c
+@@ -994,8 +994,12 @@ int blkid_probe_set_device(blkid_probe pr, int fd,
+ 		}
+ 
+ # ifdef CDROM_LAST_WRITTEN
+-		if (ioctl(fd, CDROM_LAST_WRITTEN, &last_written) == 0)
++		if (ioctl(fd, CDROM_LAST_WRITTEN, &last_written) == 0) {
+ 			pr->flags |= BLKID_FL_CDROM_DEV;
++		} else {
++			if (errno == ENOMEDIUM)
++				goto err;
++		}
+ # endif
+ 
+ 		if (pr->flags & BLKID_FL_CDROM_DEV) {

--- a/SPECS/util-linux/util-linux.spec
+++ b/SPECS/util-linux/util-linux.spec
@@ -1,7 +1,7 @@
 Summary:        Utilities for file systems, consoles, partitions, and messages
 Name:           util-linux
 Version:        2.37.4
-Release:        4%{?dist}
+Release:        5%{?dist}
 License:        GPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -11,6 +11,7 @@ Source0:        https://mirrors.edge.kernel.org/pub/linux/utils/%{name}/v2.37/%{
 Source1:        runuser
 Source2:        runuser-l
 Source3:        su
+Patch0:         libblkid-src-probe-check-for-ENOMEDIUM.patch
 BuildRequires:  audit-devel
 BuildRequires:  libcap-ng-devel
 BuildRequires:  libselinux-devel
@@ -19,8 +20,6 @@ BuildRequires:  pam-devel
 Requires:       %{name}-libs = %{version}-%{release}
 Requires:       audit-libs
 Conflicts:      toybox
-# util-linux contains su, which conflicts with shadow-utils < 4.9-10 that also contained su
-Conflicts:      shadow-utils < 4.9-10
 Provides:       %{name}-ng = %{version}-%{release}
 Provides:       hardlink = 1.3-9
 Provides:       uuidd = %{version}-%{release}
@@ -64,7 +63,7 @@ Group:          Development/Libraries
 These are library files of util-linux.
 
 %prep
-%setup -q
+%autosetup -p1
 sed -i -e 's@etc/adjtime@var/lib/hwclock/adjtime@g' $(grep -rl '%{_sysconfdir}/adjtime' .)
 
 %build
@@ -149,6 +148,9 @@ rm -rf %{buildroot}/lib/systemd/system
 %{_mandir}/man3/*
 
 %changelog
+* Mon Feb 06 2023 Mitch Zhu <mitchzhu@microsoft.com> - 2.37.4-5
+- Add patch to prevent cdrom probe on Azure VMs
+
 * Wed Jul 20 2022 Minghe Ren <mingheren@microsoft.com> - 2.37.4-4
 - Modify su to improve security
 - Change file permission on mount and umount to improve security

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -66,9 +66,9 @@ make-4.3-2.cm2.aarch64.rpm
 patch-2.7.6-7.cm2.aarch64.rpm
 libcap-ng-0.8.2-2.cm2.aarch64.rpm
 libcap-ng-devel-0.8.2-2.cm2.aarch64.rpm
-util-linux-2.37.4-4.cm2.aarch64.rpm
-util-linux-devel-2.37.4-4.cm2.aarch64.rpm
-util-linux-libs-2.37.4-4.cm2.aarch64.rpm
+util-linux-2.37.4-5.cm2.aarch64.rpm
+util-linux-devel-2.37.4-5.cm2.aarch64.rpm
+util-linux-libs-2.37.4-5.cm2.aarch64.rpm
 tar-1.34-1.cm2.aarch64.rpm
 xz-5.2.5-1.cm2.aarch64.rpm
 xz-devel-5.2.5-1.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -66,9 +66,9 @@ make-4.3-2.cm2.x86_64.rpm
 patch-2.7.6-7.cm2.x86_64.rpm
 libcap-ng-0.8.2-2.cm2.x86_64.rpm
 libcap-ng-devel-0.8.2-2.cm2.x86_64.rpm
-util-linux-2.37.4-4.cm2.x86_64.rpm
-util-linux-devel-2.37.4-4.cm2.x86_64.rpm
-util-linux-libs-2.37.4-4.cm2.x86_64.rpm
+util-linux-2.37.4-5.cm2.x86_64.rpm
+util-linux-devel-2.37.4-5.cm2.x86_64.rpm
+util-linux-libs-2.37.4-5.cm2.x86_64.rpm
 tar-1.34-1.cm2.x86_64.rpm
 xz-5.2.5-1.cm2.x86_64.rpm
 xz-devel-5.2.5-1.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -568,11 +568,11 @@ texinfo-6.8-1.cm2.aarch64.rpm
 texinfo-debuginfo-6.8-1.cm2.aarch64.rpm
 unzip-6.0-20.cm2.aarch64.rpm
 unzip-debuginfo-6.0-20.cm2.aarch64.rpm
-util-linux-2.37.4-4.cm2.aarch64.rpm
-util-linux-libs-2.37.4-4.cm2.aarch64.rpm
-util-linux-debuginfo-2.37.4-4.cm2.aarch64.rpm
-util-linux-devel-2.37.4-4.cm2.aarch64.rpm
-util-linux-lang-2.37.4-4.cm2.aarch64.rpm
+util-linux-2.37.4-5.cm2.aarch64.rpm
+util-linux-libs-2.37.4-5.cm2.aarch64.rpm
+util-linux-debuginfo-2.37.4-5.cm2.aarch64.rpm
+util-linux-devel-2.37.4-5.cm2.aarch64.rpm
+util-linux-lang-2.37.4-5.cm2.aarch64.rpm
 which-2.21-8.cm2.aarch64.rpm
 which-debuginfo-2.21-8.cm2.aarch64.rpm
 xz-5.2.5-1.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -568,11 +568,11 @@ texinfo-6.8-1.cm2.x86_64.rpm
 texinfo-debuginfo-6.8-1.cm2.x86_64.rpm
 unzip-6.0-20.cm2.x86_64.rpm
 unzip-debuginfo-6.0-20.cm2.x86_64.rpm
-util-linux-2.37.4-4.cm2.x86_64.rpm
-util-linux-libs-2.37.4-4.cm2.x86_64.rpm
-util-linux-debuginfo-2.37.4-4.cm2.x86_64.rpm
-util-linux-devel-2.37.4-4.cm2.x86_64.rpm
-util-linux-lang-2.37.4-4.cm2.x86_64.rpm
+util-linux-2.37.4-5.cm2.x86_64.rpm
+util-linux-libs-2.37.4-5.cm2.x86_64.rpm
+util-linux-debuginfo-2.37.4-5.cm2.x86_64.rpm
+util-linux-devel-2.37.4-5.cm2.x86_64.rpm
+util-linux-lang-2.37.4-5.cm2.x86_64.rpm
 which-2.21-8.cm2.x86_64.rpm
 which-debuginfo-2.21-8.cm2.x86_64.rpm
 xz-5.2.5-1.cm2.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Patch util-linux to add patch to prevent cdrom probe on Azure VMs

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Patch util-linux to add patch to prevent cdrom probe on Azure VMs

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- fixes #[41166398](https://microsoft.visualstudio.com/OS/_workitems/edit/41166398?src=WorkItemMention&src-action=artifact_link): many noise messages show up in dmesg

###### Links to CVEs  <!-- optional -->
- NA

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- [BuddyBuild](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=304077&view=results)
- Tested built RPM on an AKS cluster node
