### PR TITLE
Nopatch kernel to address CVE-2022-41218, CVE-2022-42328, CVE-2022-42329, CVE-2022-4662, CVE-2023-0266, CVE-2023-0468, CVE-2023-23559 

### DIFF
--- a/SPECS/kernel/CVE-2022-41218.nopatch
+++ b/SPECS/kernel/CVE-2022-41218.nopatch
@@ -1,0 +1,3 @@
+CVE-2022-41218 - patched in 5.15.87.1
+Upstream: fd3d91ab1c6ab0628fe642dd570b56302c30a792
+Stable: 8b45a3b19a2e909e830d09a90a7e1ec8601927d9

--- a/SPECS/kernel/CVE-2022-42328.nopatch
+++ b/SPECS/kernel/CVE-2022-42328.nopatch
@@ -1,0 +1,3 @@
+CVE-2022-42328 - patched in 5.15.83.1
+Upstream: 74e7e1efdad45580cc3839f2a155174cf158f9b5
+Stable: 5d0fa6fc8899fe842329c0109f8ddd01144b1ed8

--- a/SPECS/kernel/CVE-2022-42329.nopatch
+++ b/SPECS/kernel/CVE-2022-42329.nopatch
@@ -1,0 +1,3 @@
+CVE-2022-42329 - patched in 5.15.83.1
+Upstream: 74e7e1efdad45580cc3839f2a155174cf158f9b5 
+Stable: 5d0fa6fc8899fe842329c0109f8ddd01144b1ed8 

--- a/SPECS/kernel/CVE-2022-4662.nopatch
+++ b/SPECS/kernel/CVE-2022-4662.nopatch
@@ -1,0 +1,3 @@
+CVE-2022-4662 - patched in 5.15.66.1
+Upstream: 9c6d778800b921bde3bff3cff5003d1650f942d1 
+Stable: c548b99e1c37db6f7df86ecfe9a1f895d6c5966e

--- a/SPECS/kernel/CVE-2023-0266.nopatch
+++ b/SPECS/kernel/CVE-2023-0266.nopatch
@@ -1,0 +1,3 @@
+CVE-2023-0266 - patched in 5.15.88.1
+Upstream: 56b88b50565cd8b946a2d00b0c83927b7ebb055e 
+Stable: 26350c21bc5e97a805af878e092eb8125843fe2c 

--- a/SPECS/kernel/CVE-2023-0468.nopatch
+++ b/SPECS/kernel/CVE-2023-0468.nopatch
@@ -1,0 +1,6 @@
+CVE-2023-0468 - patched in 5.15.82.1
+Upstream: 12ad3d2d6c5b0131a6052de91360849e3e154846 
+Stable: df4b177b48516da64b988722a22d93d257dcda9a 
+
+Upstream: a26a35e9019fd70bf3cf647dcfdae87abc7bacea 
+Stable: 4b702b7d11ce1b9d26fc6d7c5a7ef4ac1d455048 

--- a/SPECS/kernel/CVE-2023-23559.nopatch
+++ b/SPECS/kernel/CVE-2023-23559.nopatch
@@ -1,0 +1,3 @@
+CVE-2023-23559 - patched in 5.15.91.1
+Upstream: b870e73a56c4cccbec33224233eaf295839f228c 
+Stable: 8cbf932c5c40b0c20597fa623c308d5bde0848b5 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Nopatch CVE-2022-41218, CVE-2022-42328, CVE-2022-42329, CVE-2022-4662, CVE-2023-0266, CVE-2023-0468, CVE-2023-23559 

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Address CVE-2022-41218, CVE-2022-42328, CVE-2022-42329, CVE-2022-4662, CVE-2023-0266, CVE-2023-0468, CVE-2023-23559 

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
 - https://nvd.nist.gov/vuln/detail/CVE-2022-41218 
 - https://nvd.nist.gov/vuln/detail/CVE-2022-42328 
 - https://nvd.nist.gov/vuln/detail/CVE-2022-42329 
 - https://nvd.nist.gov/vuln/detail/CVE-2022-4662 
 - https://nvd.nist.gov/vuln/detail/CVE-2023-0266 
 - https://nvd.nist.gov/vuln/detail/CVE-2023-0468 
 - https://nvd.nist.gov/vuln/detail/CVE-2023-23559 

