### PR TITLE
Nopatch hyperv-daemons for CVE-2023-0266, CVE-2022-0742, CVE-2022-27666

### DIFF
--- a/SPECS/hyperv-daemons/CVE-2022-0742.nopatch
+++ b/SPECS/hyperv-daemons/CVE-2022-0742.nopatch
@@ -1,0 +1,3 @@
+CVE-2023-0742 - Introducing commit not present (5.10.167.1)
+Introducing commit: f185de28d9ae6c978135993769352e523ee8df06
+Upstream fix commit: 2d3916f3189172d5c69d33065c3c21119fe539fc

--- a/SPECS/hyperv-daemons/CVE-2022-27666.nopatch
+++ b/SPECS/hyperv-daemons/CVE-2022-27666.nopatch
@@ -1,0 +1,3 @@
+CVE-2022-27666 - fix present in 5.10.109 kernel
+Upstream: ebe48d368e97d007bfeb76fcb065d6cfc4c96645
+Stable: 9248694dac20eda06e22d8503364dc9d03df4e2f

--- a/SPECS/hyperv-daemons/CVE-2023-0266.nopatch
+++ b/SPECS/hyperv-daemons/CVE-2023-0266.nopatch
@@ -1,0 +1,4 @@
+CVE-2023-0266 - patched in 5.10.167.1
+Upstream: 56b88b50565cd8b946a2d00b0c83927b7ebb055e
+Upstream: 1fa4445f9adf19a3028ce0e8f375bac75214fc10
+Stable (combination of above): df02234e6b87d2a9a82acd3198e44bdeff8488c6


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Nopatch hyperv-daemons for CVE-2023-0266, CVE-2022-0742, CVE-2022-27666

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Nopatch hyperv-daemons for CVE-2023-0266, CVE-2022-0742, CVE-2022-27666

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2022-27666
- https://nvd.nist.gov/vuln/detail/CVE-2022-0742
- https://nvd.nist.gov/vuln/detail/CVE-2023-0266

