### PR TITLE
libtiff: CVE 2023-0795

### DIFF
--- a/CVE-2023-0796.nopatch
+++ b/CVE-2023-0796.nopatch
@@ -1,0 +1,1 @@
+The CVE-2023-0795.patch also fixes CVE-2023-0796

--- a/CVE-2023-0797.nopatch
+++ b/CVE-2023-0797.nopatch
@@ -1,0 +1,1 @@
+The CVE-2023-0795.patch also fixes CVE-2023-0797

--- a/CVE-2023-0798.nopatch
+++ b/CVE-2023-0798.nopatch
@@ -1,0 +1,1 @@
+The CVE-2023-0795.patch also fixes CVE-2023-0798

--- a/CVE-2023-0799.nopatch
+++ b/CVE-2023-0799.nopatch
@@ -1,0 +1,1 @@
+The CVE-2023-0795.patch also fixes CVE-2023-0799

--- a/SPECS/libtiff/CVE-2023-0795.patch
+++ b/SPECS/libtiff/CVE-2023-0795.patch
@@ -1,64 +1,35 @@
+From 9c22495e5eeeae9e00a1596720c969656bb8d678 Mon Sep 17 00:00:00 2001
+From: Su_Laus <sulau@freenet.de>
+Date: Fri, 3 Feb 2023 15:31:31 +0100
+Subject: [PATCH] tiffcrop correctly update buffersize after rotateImage()
+ fix#520 rotateImage() set up a new buffer and calculates its size
+ individually. Therefore, seg_buffs[] size needs to be updated accordingly.
+ Before this fix, the seg_buffs buffer size was calculated with a different
+ formula than within rotateImage().
+
 diff --git a/tools/tiffcrop.c b/tools/tiffcrop.c
-index 2b8a8e9..efeb18d 100644
+index 2b8a8e9..603729f 100644
 --- a/tools/tiffcrop.c
 +++ b/tools/tiffcrop.c
-@@ -271,7 +271,6 @@ struct  region {
-   uint32_t width;     /* width in pixels */
-   uint32_t length;    /* length in pixels */
-   uint32_t buffsize;  /* size of buffer needed to hold the cropped region */
--  unsigned char *buffptr; /* address of start of the region */
- };
- 
- /* Cropping parameters from command line and image data 
-@@ -526,7 +525,7 @@ static int rotateContigSamples24bits(uint16_t, uint16_t, uint16_t, uint32_t,
+@@ -526,7 +526,7 @@ static int rotateContigSamples24bits(uint16_t, uint16_t, uint16_t, uint32_t,
  static int rotateContigSamples32bits(uint16_t, uint16_t, uint16_t, uint32_t,
                                       uint32_t, uint32_t, uint8_t *, uint8_t *);
  static int rotateImage(uint16_t, struct image_data *, uint32_t *, uint32_t *,
 -                       unsigned char **);
-+                       unsigned char **, size_t *, int);
++                       unsigned char **, size_t *);
  static int mirrorImage(uint16_t, uint16_t, uint16_t, uint32_t, uint32_t,
                         unsigned char *);
  static int invertImage(uint16_t, uint16_t, uint16_t, uint32_t, uint32_t,
-@@ -5224,7 +5223,6 @@ initCropMasks (struct crop_mask *cps)
-      cps->regionlist[i].width = 0;
-      cps->regionlist[i].length = 0;
-      cps->regionlist[i].buffsize = 0;
--     cps->regionlist[i].buffptr = NULL;
-      cps->zonelist[i].position = 0;
-      cps->zonelist[i].total = 0;
-      }
-@@ -6557,7 +6555,13 @@ static int  correct_orientation(struct image_data *image, unsigned char **work_b
+@@ -6557,7 +6557,7 @@ static int  correct_orientation(struct image_data *image, unsigned char **work_b
        return (-1);
        }
   
 -    if (rotateImage(rotation, image, &image->width, &image->length, work_buff_ptr))
-+      /* Dummy variable in order not to switch two times the
-+      * image->width,->length within rotateImage(),
-+      * but switch xres, yres there. */
-+      uint32_t width = image->width;
-+      uint32_t length = image->length;
-+      if (rotateImage(rotation, image, &width, &length, work_buff_ptr, NULL,
-+                      TRUE))
++    if (rotateImage(rotation, image, &image->width, &image->length, work_buff_ptr, NULL))
        {
        TIFFError ("correct_orientation", "Unable to rotate image");
        return (-1);
-@@ -6665,7 +6669,6 @@ extractCompositeRegions(struct image_data *image,  struct crop_mask *crop,
-     /* These should not be needed for composite images */
-     crop->regionlist[i].width = crop_width;
-     crop->regionlist[i].length = crop_length;
--    crop->regionlist[i].buffptr = crop_buff;
- 
-     src_rowsize = ((img_width * bps * spp) + 7) / 8;
-     dst_rowsize = (((crop_width * bps * count) + 7) / 8);
-@@ -6904,7 +6907,6 @@ extractSeparateRegion(struct image_data *image,  struct crop_mask *crop,
- 
-   crop->regionlist[region].width = crop_width;
-   crop->regionlist[region].length = crop_length;
--  crop->regionlist[region].buffptr = crop_buff;
- 
-   src = read_buff;
-   dst = crop_buff;
-@@ -7781,16 +7783,20 @@ processCropSelections(struct image_data *image, struct crop_mask *crop,
+@@ -7781,16 +7781,19 @@ processCropSelections(struct image_data *image, struct crop_mask *crop,
  
      if (crop->crop_mode & CROP_ROTATE) /* rotate should be last as it can reallocate the buffer */
        {
@@ -68,8 +39,7 @@ index 2b8a8e9..efeb18d 100644
 +      size_t rot_buf_size = 0;
        if (rotateImage(crop->rotation, image, &crop->combined_width, 
 -                      &crop->combined_length, &crop_buff))
-+                      &crop->combined_length, &crop_buff, &rot_buf_size,
-+                      FALSE))
++                      &crop->combined_length, &crop_buff, &rot_buf_size))
          {
          TIFFError("processCropSelections", 
                    "Failed to rotate composite regions by %"PRIu32" degrees", crop->rotation);
@@ -82,25 +52,22 @@ index 2b8a8e9..efeb18d 100644
        }
      }
    else  /* Separated Images */
-@@ -7890,9 +7896,14 @@ processCropSelections(struct image_data *image, struct crop_mask *crop,
+@@ -7890,9 +7893,12 @@ processCropSelections(struct image_data *image, struct crop_mask *crop,
          {
            /* rotateImage() changes image->width, ->length, ->xres and ->yres, what it schouldn't do here, when more than one section is processed. 
             * ToDo: Therefore rotateImage() and its usage has to be reworked (e.g. like mirrorImage()) !!
 -           */
--	if (rotateImage(crop->rotation, image, &crop->regionlist[i].width, 
--			&crop->regionlist[i].length, &crop_buff))
 +            * Furthermore, rotateImage() set up a new buffer and calculates
 +            * its size individually. Therefore, seg_buffs size  needs to be
 +            * updated accordingly. */
 +  size_t rot_buf_size = 0;
-+  if (rotateImage(crop->rotation, image,
-+                  &crop->regionlist[i].width,
-+                  &crop->regionlist[i].length, &crop_buff,
-+                  &rot_buf_size, FALSE))
+ 	if (rotateImage(crop->rotation, image, &crop->regionlist[i].width, 
+-			&crop->regionlist[i].length, &crop_buff))
++			&crop->regionlist[i].length, &crop_buff, &rot_buf_size))
            {
            TIFFError("processCropSelections", 
                      "Failed to rotate crop region by %"PRIu16" degrees", crop->rotation);
-@@ -7903,8 +7914,7 @@ processCropSelections(struct image_data *image, struct crop_mask *crop,
+@@ -7903,8 +7909,7 @@ processCropSelections(struct image_data *image, struct crop_mask *crop,
          crop->combined_width = total_width;
          crop->combined_length = total_length;
          seg_buffs[i].buffer = crop_buff;
@@ -110,24 +77,45 @@ index 2b8a8e9..efeb18d 100644
          }
        }  /* for crop->selections loop */
      }  /* Separated Images (else case) */
-@@ -8024,7 +8034,7 @@ createCroppedImage(struct image_data *image, struct crop_mask *crop,
+@@ -8024,7 +8029,7 @@ createCroppedImage(struct image_data *image, struct crop_mask *crop,
    if (crop->crop_mode & CROP_ROTATE) /* rotate should be last as it can reallocate the buffer */
      {
      if (rotateImage(crop->rotation, image, &crop->combined_width, 
 -                    &crop->combined_length, crop_buff_ptr))
-+                    &crop->combined_length, crop_buff_ptr, NULL, TRUE))
++                    &crop->combined_length, crop_buff_ptr, NULL))
        {
        TIFFError("createCroppedImage", 
                  "Failed to rotate image or cropped selection by %"PRIu16" degrees", crop->rotation);
-@@ -8687,13 +8697,15 @@ rotateContigSamples32bits(uint16_t rotation, uint16_t spp, uint16_t bps, uint32_
+@@ -8687,7 +8692,7 @@ rotateContigSamples32bits(uint16_t rotation, uint16_t spp, uint16_t bps, uint32_
  /* Rotate an image by a multiple of 90 degrees clockwise */
  static int
  rotateImage(uint16_t rotation, struct image_data *image, uint32_t *img_width,
 -            uint32_t *img_length, unsigned char **ibuff_ptr)
-+            uint32_t *img_length, unsigned char **ibuff_ptr, size_t *rot_buf_size,
-+            int rot_image_params)
++            uint32_t *img_length, unsigned char **ibuff_ptr, size_t *rot_buf_size)
    {
    int      shift_width;
+   uint32_t   bytes_per_pixel, bytes_per_sample;
+@@ -8738,6 +8743,8 @@ rotateImage(uint16_t rotation, struct image_data *image, uint32_t *img_width,
+     return (-1);
+     }
+   _TIFFmemset(rbuff, '\0', buffsize + NUM_BUFF_OVERSIZE_BYTES);
++  if (rot_buf_size != NULL)
++      *rot_buf_size = buffsize;
+ 
+   ibuff = *ibuff_ptr;
+   switch (rotation)
+
+From 688012dca2c39033aa2dc7bcea9796787cfd1b44 Mon Sep 17 00:00:00 2001
+From: Su_Laus <sulau@freenet.de>
+Date: Sat, 4 Feb 2023 23:24:21 +0100
+Subject: [PATCH] tiffcrop correctly update buffersize after rotateImage()
+ fix#520  -- enlarge buffsize and check integer overflow within rotateImage().
+
+diff --git a/tools/tiffcrop.c b/tools/tiffcrop.c
+index 603729f..cf3ff8e 100644
+--- a/tools/tiffcrop.c
++++ b/tools/tiffcrop.c
+@@ -8698,7 +8698,8 @@ rotateImage(uint16_t rotation, struct image_data *image, uint32_t *img_width,
    uint32_t   bytes_per_pixel, bytes_per_sample;
    uint32_t   row, rowsize, src_offset, dst_offset;
    uint32_t   i, col, width, length;
@@ -137,7 +125,7 @@ index 2b8a8e9..efeb18d 100644
    unsigned char *ibuff;
    unsigned char *src;
    unsigned char *dst;
-@@ -8706,12 +8718,40 @@ rotateImage(uint16_t rotation, struct image_data *image, uint32_t *img_width,
+@@ -8711,12 +8712,40 @@ rotateImage(uint16_t rotation, struct image_data *image, uint32_t *img_width,
    spp = image->spp;
    bps = image->bps;
  
@@ -179,7 +167,7 @@ index 2b8a8e9..efeb18d 100644
  
    bytes_per_sample = (bps + 7) / 8;
    bytes_per_pixel  = ((bps * spp) + 7) / 8;
-@@ -8734,10 +8774,15 @@ rotateImage(uint16_t rotation, struct image_data *image, uint32_t *img_width,
+@@ -8739,7 +8768,10 @@ rotateImage(uint16_t rotation, struct image_data *image, uint32_t *img_width,
    /* Add 3 padding bytes for extractContigSamplesShifted32bits */
    if (!(rbuff = (unsigned char *)limitMalloc(buffsize + NUM_BUFF_OVERSIZE_BYTES)))
      {
@@ -191,12 +179,119 @@ index 2b8a8e9..efeb18d 100644
      return (-1);
      }
    _TIFFmemset(rbuff, '\0', buffsize + NUM_BUFF_OVERSIZE_BYTES);
-+  if (rot_buf_size != NULL)
-+      *rot_buf_size = buffsize;
+
+From 69818e2f2d246e6631ac2a2da692c3706b849c38 Mon Sep 17 00:00:00 2001
+From: Su_Laus <sulau@freenet.de>
+Date: Sun, 29 Jan 2023 11:09:26 +0100
+Subject: [PATCH] tiffcrop: Amend rotateImage() not to toggle the input (main)
+ image width and length parameters when only cropped image sections are
+ rotated. Remove buffptr from region structure because never used.
+
+Closes #492 #493 #494 #495 #499 #518 #519
+
+diff --git a/tools/tiffcrop.c b/tools/tiffcrop.c
+index cf3ff8e..6013b83 100644
+--- a/tools/tiffcrop.c
++++ b/tools/tiffcrop.c
+@@ -271,7 +271,6 @@ struct  region {
+   uint32_t width;     /* width in pixels */
+   uint32_t length;    /* length in pixels */
+   uint32_t buffsize;  /* size of buffer needed to hold the cropped region */
+-  unsigned char *buffptr; /* address of start of the region */
+ };
  
-   ibuff = *ibuff_ptr;
-   switch (rotation)
-@@ -8878,11 +8923,15 @@ rotateImage(uint16_t rotation, struct image_data *image, uint32_t *img_width,
+ /* Cropping parameters from command line and image data 
+@@ -526,7 +525,7 @@ static int rotateContigSamples24bits(uint16_t, uint16_t, uint16_t, uint32_t,
+ static int rotateContigSamples32bits(uint16_t, uint16_t, uint16_t, uint32_t,
+                                      uint32_t, uint32_t, uint8_t *, uint8_t *);
+ static int rotateImage(uint16_t, struct image_data *, uint32_t *, uint32_t *,
+-                       unsigned char **, size_t *);
++                       unsigned char **, size_t *, int);
+ static int mirrorImage(uint16_t, uint16_t, uint16_t, uint32_t, uint32_t,
+                        unsigned char *);
+ static int invertImage(uint16_t, uint16_t, uint16_t, uint32_t, uint32_t,
+@@ -5224,7 +5223,6 @@ initCropMasks (struct crop_mask *cps)
+      cps->regionlist[i].width = 0;
+      cps->regionlist[i].length = 0;
+      cps->regionlist[i].buffsize = 0;
+-     cps->regionlist[i].buffptr = NULL;
+      cps->zonelist[i].position = 0;
+      cps->zonelist[i].total = 0;
+      }
+@@ -6557,7 +6555,13 @@ static int  correct_orientation(struct image_data *image, unsigned char **work_b
+       return (-1);
+       }
+  
+-    if (rotateImage(rotation, image, &image->width, &image->length, work_buff_ptr, NULL))
++      /* Dummy variable in order not to switch two times the
++      * image->width,->length within rotateImage(),
++      * but switch xres, yres there. */
++      uint32_t width = image->width;
++      uint32_t length = image->length;
++      if (rotateImage(rotation, image, &width, &length, work_buff_ptr, NULL,
++                      TRUE))
+       {
+       TIFFError ("correct_orientation", "Unable to rotate image");
+       return (-1);
+@@ -6665,7 +6669,6 @@ extractCompositeRegions(struct image_data *image,  struct crop_mask *crop,
+     /* These should not be needed for composite images */
+     crop->regionlist[i].width = crop_width;
+     crop->regionlist[i].length = crop_length;
+-    crop->regionlist[i].buffptr = crop_buff;
+ 
+     src_rowsize = ((img_width * bps * spp) + 7) / 8;
+     dst_rowsize = (((crop_width * bps * count) + 7) / 8);
+@@ -6904,7 +6907,6 @@ extractSeparateRegion(struct image_data *image,  struct crop_mask *crop,
+ 
+   crop->regionlist[region].width = crop_width;
+   crop->regionlist[region].length = crop_length;
+-  crop->regionlist[region].buffptr = crop_buff;
+ 
+   src = read_buff;
+   dst = crop_buff;
+@@ -7786,7 +7788,8 @@ processCropSelections(struct image_data *image, struct crop_mask *crop,
+         * accordingly. */
+       size_t rot_buf_size = 0;
+       if (rotateImage(crop->rotation, image, &crop->combined_width, 
+-                      &crop->combined_length, &crop_buff, &rot_buf_size))
++                      &crop->combined_length, &crop_buff, &rot_buf_size,
++                      FALSE))
+         {
+         TIFFError("processCropSelections", 
+                   "Failed to rotate composite regions by %"PRIu32" degrees", crop->rotation);
+@@ -7897,8 +7900,10 @@ processCropSelections(struct image_data *image, struct crop_mask *crop,
+             * its size individually. Therefore, seg_buffs size  needs to be
+             * updated accordingly. */
+   size_t rot_buf_size = 0;
+-	if (rotateImage(crop->rotation, image, &crop->regionlist[i].width, 
+-			&crop->regionlist[i].length, &crop_buff, &rot_buf_size))
++  if (rotateImage(crop->rotation, image,
++                  &crop->regionlist[i].width,
++                  &crop->regionlist[i].length, &crop_buff,
++                  &rot_buf_size, FALSE))
+           {
+           TIFFError("processCropSelections", 
+                     "Failed to rotate crop region by %"PRIu16" degrees", crop->rotation);
+@@ -8029,7 +8034,7 @@ createCroppedImage(struct image_data *image, struct crop_mask *crop,
+   if (crop->crop_mode & CROP_ROTATE) /* rotate should be last as it can reallocate the buffer */
+     {
+     if (rotateImage(crop->rotation, image, &crop->combined_width, 
+-                    &crop->combined_length, crop_buff_ptr, NULL))
++                    &crop->combined_length, crop_buff_ptr, NULL, TRUE))
+       {
+       TIFFError("createCroppedImage", 
+                 "Failed to rotate image or cropped selection by %"PRIu16" degrees", crop->rotation);
+@@ -8692,7 +8697,8 @@ rotateContigSamples32bits(uint16_t rotation, uint16_t spp, uint16_t bps, uint32_
+ /* Rotate an image by a multiple of 90 degrees clockwise */
+ static int
+ rotateImage(uint16_t rotation, struct image_data *image, uint32_t *img_width,
+-            uint32_t *img_length, unsigned char **ibuff_ptr, size_t *rot_buf_size)
++            uint32_t *img_length, unsigned char **ibuff_ptr, size_t *rot_buf_size,
++            int rot_image_params)
+   {
+   int      shift_width;
+   uint32_t   bytes_per_pixel, bytes_per_sample;
+@@ -8917,11 +8923,15 @@ rotateImage(uint16_t rotation, struct image_data *image, uint32_t *img_width,
  
                *img_width = length;
                *img_length = width;
@@ -217,7 +312,7 @@ index 2b8a8e9..efeb18d 100644
  	      break;
  
      case 270: if ((bps % 8) == 0) /* byte aligned data */
-@@ -8955,11 +9004,15 @@ rotateImage(uint16_t rotation, struct image_data *image, uint32_t *img_width,
+@@ -8994,11 +9004,15 @@ rotateImage(uint16_t rotation, struct image_data *image, uint32_t *img_width,
  
                *img_width = length;
                *img_length = width;

--- a/SPECS/libtiff/CVE-2023-0795.patch
+++ b/SPECS/libtiff/CVE-2023-0795.patch
@@ -1,0 +1,240 @@
+diff --git a/tools/tiffcrop.c b/tools/tiffcrop.c
+index 2b8a8e9..6013b83 100644
+--- a/tools/tiffcrop.c
++++ b/tools/tiffcrop.c
+@@ -271,7 +271,6 @@ struct  region {
+   uint32_t width;     /* width in pixels */
+   uint32_t length;    /* length in pixels */
+   uint32_t buffsize;  /* size of buffer needed to hold the cropped region */
+-  unsigned char *buffptr; /* address of start of the region */
+ };
+ 
+ /* Cropping parameters from command line and image data 
+@@ -526,7 +525,7 @@ static int rotateContigSamples24bits(uint16_t, uint16_t, uint16_t, uint32_t,
+ static int rotateContigSamples32bits(uint16_t, uint16_t, uint16_t, uint32_t,
+                                      uint32_t, uint32_t, uint8_t *, uint8_t *);
+ static int rotateImage(uint16_t, struct image_data *, uint32_t *, uint32_t *,
+-                       unsigned char **);
++                       unsigned char **, size_t *, int);
+ static int mirrorImage(uint16_t, uint16_t, uint16_t, uint32_t, uint32_t,
+                        unsigned char *);
+ static int invertImage(uint16_t, uint16_t, uint16_t, uint32_t, uint32_t,
+@@ -5224,7 +5223,6 @@ initCropMasks (struct crop_mask *cps)
+      cps->regionlist[i].width = 0;
+      cps->regionlist[i].length = 0;
+      cps->regionlist[i].buffsize = 0;
+-     cps->regionlist[i].buffptr = NULL;
+      cps->zonelist[i].position = 0;
+      cps->zonelist[i].total = 0;
+      }
+@@ -6557,7 +6555,13 @@ static int  correct_orientation(struct image_data *image, unsigned char **work_b
+       return (-1);
+       }
+  
+-    if (rotateImage(rotation, image, &image->width, &image->length, work_buff_ptr))
++      /* Dummy variable in order not to switch two times the
++      * image->width,->length within rotateImage(),
++      * but switch xres, yres there. */
++      uint32_t width = image->width;
++      uint32_t length = image->length;
++      if (rotateImage(rotation, image, &width, &length, work_buff_ptr, NULL,
++                      TRUE))
+       {
+       TIFFError ("correct_orientation", "Unable to rotate image");
+       return (-1);
+@@ -6665,7 +6669,6 @@ extractCompositeRegions(struct image_data *image,  struct crop_mask *crop,
+     /* These should not be needed for composite images */
+     crop->regionlist[i].width = crop_width;
+     crop->regionlist[i].length = crop_length;
+-    crop->regionlist[i].buffptr = crop_buff;
+ 
+     src_rowsize = ((img_width * bps * spp) + 7) / 8;
+     dst_rowsize = (((crop_width * bps * count) + 7) / 8);
+@@ -6904,7 +6907,6 @@ extractSeparateRegion(struct image_data *image,  struct crop_mask *crop,
+ 
+   crop->regionlist[region].width = crop_width;
+   crop->regionlist[region].length = crop_length;
+-  crop->regionlist[region].buffptr = crop_buff;
+ 
+   src = read_buff;
+   dst = crop_buff;
+@@ -7781,16 +7783,20 @@ processCropSelections(struct image_data *image, struct crop_mask *crop,
+ 
+     if (crop->crop_mode & CROP_ROTATE) /* rotate should be last as it can reallocate the buffer */
+       {
++      /* rotateImage() set up a new buffer and calculates its size
++        * individually. Therefore, seg_buffs size  needs to be updated
++        * accordingly. */
++      size_t rot_buf_size = 0;
+       if (rotateImage(crop->rotation, image, &crop->combined_width, 
+-                      &crop->combined_length, &crop_buff))
++                      &crop->combined_length, &crop_buff, &rot_buf_size,
++                      FALSE))
+         {
+         TIFFError("processCropSelections", 
+                   "Failed to rotate composite regions by %"PRIu32" degrees", crop->rotation);
+         return (-1);
+         }
+       seg_buffs[0].buffer = crop_buff;
+-      seg_buffs[0].size = (((crop->combined_width * image->bps + 7 ) / 8)
+-                            * image->spp) * crop->combined_length; 
++      seg_buffs[0].size = rot_buf_size; 
+       }
+     }
+   else  /* Separated Images */
+@@ -7890,9 +7896,14 @@ processCropSelections(struct image_data *image, struct crop_mask *crop,
+         {
+           /* rotateImage() changes image->width, ->length, ->xres and ->yres, what it schouldn't do here, when more than one section is processed. 
+            * ToDo: Therefore rotateImage() and its usage has to be reworked (e.g. like mirrorImage()) !!
+-           */
+-	if (rotateImage(crop->rotation, image, &crop->regionlist[i].width, 
+-			&crop->regionlist[i].length, &crop_buff))
++            * Furthermore, rotateImage() set up a new buffer and calculates
++            * its size individually. Therefore, seg_buffs size  needs to be
++            * updated accordingly. */
++  size_t rot_buf_size = 0;
++  if (rotateImage(crop->rotation, image,
++                  &crop->regionlist[i].width,
++                  &crop->regionlist[i].length, &crop_buff,
++                  &rot_buf_size, FALSE))
+           {
+           TIFFError("processCropSelections", 
+                     "Failed to rotate crop region by %"PRIu16" degrees", crop->rotation);
+@@ -7903,8 +7914,7 @@ processCropSelections(struct image_data *image, struct crop_mask *crop,
+         crop->combined_width = total_width;
+         crop->combined_length = total_length;
+         seg_buffs[i].buffer = crop_buff;
+-        seg_buffs[i].size = (((crop->regionlist[i].width * image->bps + 7 ) / 8)
+-                               * image->spp) * crop->regionlist[i].length; 
++        seg_buffs[i].size = rot_buf_size;
+         }
+       }  /* for crop->selections loop */
+     }  /* Separated Images (else case) */
+@@ -8024,7 +8034,7 @@ createCroppedImage(struct image_data *image, struct crop_mask *crop,
+   if (crop->crop_mode & CROP_ROTATE) /* rotate should be last as it can reallocate the buffer */
+     {
+     if (rotateImage(crop->rotation, image, &crop->combined_width, 
+-                    &crop->combined_length, crop_buff_ptr))
++                    &crop->combined_length, crop_buff_ptr, NULL, TRUE))
+       {
+       TIFFError("createCroppedImage", 
+                 "Failed to rotate image or cropped selection by %"PRIu16" degrees", crop->rotation);
+@@ -8687,13 +8697,15 @@ rotateContigSamples32bits(uint16_t rotation, uint16_t spp, uint16_t bps, uint32_
+ /* Rotate an image by a multiple of 90 degrees clockwise */
+ static int
+ rotateImage(uint16_t rotation, struct image_data *image, uint32_t *img_width,
+-            uint32_t *img_length, unsigned char **ibuff_ptr)
++            uint32_t *img_length, unsigned char **ibuff_ptr, size_t *rot_buf_size,,
++            int rot_image_params)
+   {
+   int      shift_width;
+   uint32_t   bytes_per_pixel, bytes_per_sample;
+   uint32_t   row, rowsize, src_offset, dst_offset;
+   uint32_t   i, col, width, length;
+-  uint32_t   colsize, buffsize, col_offset, pix_offset;
++  uint32_t   colsize, col_offset, pix_offset;
++  tmsize_t buffsize;
+   unsigned char *ibuff;
+   unsigned char *src;
+   unsigned char *dst;
+@@ -8706,12 +8718,40 @@ rotateImage(uint16_t rotation, struct image_data *image, uint32_t *img_width,
+   spp = image->spp;
+   bps = image->bps;
+ 
++  if ((spp != 0 && bps != 0 &&
++        width > (uint32_t)((UINT32_MAX - 7) / spp / bps)) ||
++      (spp != 0 && bps != 0 &&
++        length > (uint32_t)((UINT32_MAX - 7) / spp / bps)))
++  {
++      TIFFError("rotateImage", "Integer overflow detected.");
++      return (-1);
++  }
+   rowsize = ((bps * spp * width) + 7) / 8;
+   colsize = ((bps * spp * length) + 7) / 8;
+   if ((colsize * width) > (rowsize * length))
+-    buffsize = (colsize + 1) * width;
++  {
++      if (((tmsize_t)colsize + 1) != 0 &&
++          (tmsize_t)width > ((TIFF_TMSIZE_T_MAX - NUM_BUFF_OVERSIZE_BYTES) /
++                              ((tmsize_t)colsize + 1)))
++      {
++          TIFFError("rotateImage",
++                    "Integer overflow when calculating buffer size.");
++          return (-1);
++      }
++      buffsize = ((tmsize_t)colsize + 1) * width;
++  }
+   else
++  {
++      if (((tmsize_t)rowsize + 1) != 0 &&
++          (tmsize_t)length > ((TIFF_TMSIZE_T_MAX - NUM_BUFF_OVERSIZE_BYTES) /
++                              ((tmsize_t)rowsize + 1)))
++      {
++          TIFFError("rotateImage",
++                    "Integer overflow when calculating buffer size.");
++          return (-1);
++      }
+     buffsize = (rowsize + 1) * length;
++  }
+ 
+   bytes_per_sample = (bps + 7) / 8;
+   bytes_per_pixel  = ((bps * spp) + 7) / 8;
+@@ -8734,10 +8774,15 @@ rotateImage(uint16_t rotation, struct image_data *image, uint32_t *img_width,
+   /* Add 3 padding bytes for extractContigSamplesShifted32bits */
+   if (!(rbuff = (unsigned char *)limitMalloc(buffsize + NUM_BUFF_OVERSIZE_BYTES)))
+     {
+-    TIFFError("rotateImage", "Unable to allocate rotation buffer of %1u bytes", buffsize + NUM_BUFF_OVERSIZE_BYTES);
++    TIFFError("rotateImage", 
++              "Unable to allocate rotation buffer of %" TIFF_SSIZE_FORMAT
++              " bytes ",
++              buffsize + NUM_BUFF_OVERSIZE_BYTES);
+     return (-1);
+     }
+   _TIFFmemset(rbuff, '\0', buffsize + NUM_BUFF_OVERSIZE_BYTES);
++  if (rot_buf_size != NULL)
++      *rot_buf_size = buffsize;
+ 
+   ibuff = *ibuff_ptr;
+   switch (rotation)
+@@ -8878,11 +8923,15 @@ rotateImage(uint16_t rotation, struct image_data *image, uint32_t *img_width,
+ 
+               *img_width = length;
+               *img_length = width;
+-              image->width = length;
+-              image->length = width;
+-              res_temp = image->xres;
+-              image->xres = image->yres;
+-              image->yres = res_temp;
++              /* Only toggle image parameters if whole input image is rotated. */
++              if (rot_image_params)
++              {
++                  image->width = length;
++                  image->length = width;
++                  res_temp = image->xres;
++                  image->xres = image->yres;
++                  image->yres = res_temp;
++              }
+ 	      break;
+ 
+     case 270: if ((bps % 8) == 0) /* byte aligned data */
+@@ -8955,11 +9004,15 @@ rotateImage(uint16_t rotation, struct image_data *image, uint32_t *img_width,
+ 
+               *img_width = length;
+               *img_length = width;
+-              image->width = length;
+-              image->length = width;
+-              res_temp = image->xres;
+-              image->xres = image->yres;
+-              image->yres = res_temp;
++              /* Only toggle image parameters if whole input image is rotated. */
++              if (rot_image_params)
++              {
++                  image->width = length;
++                  image->length = width;
++                  res_temp = image->xres;
++                  image->xres = image->yres;
++                  image->yres = res_temp;
++              }
+               break;
+     default:
+               break;

--- a/SPECS/libtiff/CVE-2023-0795.patch
+++ b/SPECS/libtiff/CVE-2023-0795.patch
@@ -1,5 +1,5 @@
 diff --git a/tools/tiffcrop.c b/tools/tiffcrop.c
-index 2b8a8e9..6013b83 100644
+index 2b8a8e9..efeb18d 100644
 --- a/tools/tiffcrop.c
 +++ b/tools/tiffcrop.c
 @@ -271,7 +271,6 @@ struct  region {
@@ -124,7 +124,7 @@ index 2b8a8e9..6013b83 100644
  static int
  rotateImage(uint16_t rotation, struct image_data *image, uint32_t *img_width,
 -            uint32_t *img_length, unsigned char **ibuff_ptr)
-+            uint32_t *img_length, unsigned char **ibuff_ptr, size_t *rot_buf_size,,
++            uint32_t *img_length, unsigned char **ibuff_ptr, size_t *rot_buf_size,
 +            int rot_image_params)
    {
    int      shift_width;

--- a/SPECS/libtiff/CVE-2023-0800.patch
+++ b/SPECS/libtiff/CVE-2023-0800.patch
@@ -1,0 +1,125 @@
+From 82a7fbb1fa7228499ffeb3a57a1d106a9626d57c Mon Sep 17 00:00:00 2001
+From: Su Laus <sulau@freenet.de>
+Date: Sun, 5 Feb 2023 15:53:15 +0000
+Subject: [PATCH] tiffcrop: added check for assumption on composite images
+ (fixes #496)
+
+tiffcrop: For composite images with more than one region, the combined_length or combined_width always needs to be equal, respectively. Otherwise, even the first section/region copy action might cause buffer overrun. This is now checked before the first copy action.
+
+Closes #496, #497, #498, #500, #501.
+---
+ tools/tiffcrop.c | 68 ++++++++++++++++++++++++++++++++++++++++++++++--
+ 1 file changed, 66 insertions(+), 2 deletions(-)
+
+diff --git a/tools/tiffcrop.c b/tools/tiffcrop.c
+index 5a067a4..2b8a8e9 100644
+--- a/tools/tiffcrop.c
++++ b/tools/tiffcrop.c
+@@ -5364,18 +5364,40 @@ computeInputPixelOffsets(struct crop_mask *crop, struct image_data *image,
+ 
+       crop->regionlist[i].buffsize = buffsize;
+       crop->bufftotal += buffsize;
++
++      /* For composite images with more than one region, the
++        * combined_length or combined_width always needs to be equal,
++        * respectively.
++        * Otherwise, even the first section/region copy
++        * action might cause buffer overrun. */
+       if (crop->img_mode == COMPOSITE_IMAGES)
+         {
+         switch (crop->edge_ref)
+           {
+           case EDGE_LEFT:
+           case EDGE_RIGHT:
++                if (i > 0 && zlength != crop->combined_length)
++                {
++                    TIFFError(
++                        "computeInputPixelOffsets",
++                        "Only equal length regions can be combined for "
++                        "-E left or right");
++                    return (-1);
++                }
+                crop->combined_length = zlength;
+                crop->combined_width += zwidth;
+                break;
+           case EDGE_BOTTOM:
+           case EDGE_TOP:  /* width from left, length from top */
+           default:
++                if (i > 0 && zwidth != crop->combined_width)
++                {
++                    TIFFError("computeInputPixelOffsets",
++                              "Only equal width regions can be "
++                              "combined for -E "
++                              "top or bottom");
++                    return (-1);
++                }
+                crop->combined_width = zwidth;
+                crop->combined_length += zlength;
+ 	       break;
+@@ -6589,6 +6611,46 @@ extractCompositeRegions(struct image_data *image,  struct crop_mask *crop,
+   crop->combined_width = 0;
+   crop->combined_length = 0;
+ 
++  /* If there is more than one region, check beforehand whether all the width
++    * and length values of the regions are the same, respectively. */
++  switch (crop->edge_ref)
++  {
++      default:
++      case EDGE_TOP:
++      case EDGE_BOTTOM:
++          for (i = 1; i < crop->selections; i++)
++          {
++              uint32_t crop_width0 =
++                  crop->regionlist[i - 1].x2 - crop->regionlist[i - 1].x1 + 1;
++              uint32_t crop_width1 =
++                  crop->regionlist[i].x2 - crop->regionlist[i].x1 + 1;
++              if (crop_width0 != crop_width1)
++              {
++                  TIFFError("extractCompositeRegions",
++                            "Only equal width regions can be combined for -E "
++                            "top or bottom");
++                  return (1);
++              }
++          }
++          break;
++      case EDGE_LEFT:
++      case EDGE_RIGHT:
++          for (i = 1; i < crop->selections; i++)
++          {
++              uint32_t crop_length0 =
++                  crop->regionlist[i - 1].y2 - crop->regionlist[i - 1].y1 + 1;
++              uint32_t crop_length1 =
++                  crop->regionlist[i].y2 - crop->regionlist[i].y1 + 1;
++              if (crop_length0 != crop_length1)
++              {
++                  TIFFError("extractCompositeRegions",
++                            "Only equal length regions can be combined for "
++                            "-E left or right");
++                  return (1);
++              }
++          }
++  }
++
+   for (i = 0; i < crop->selections; i++)
+     {
+     /* rows, columns, width, length are expressed in pixels */
+@@ -6613,7 +6675,8 @@ extractCompositeRegions(struct image_data *image,  struct crop_mask *crop,
+       default:
+       case EDGE_TOP:
+       case EDGE_BOTTOM:
+-	   if ((i > 0) && (crop_width != crop->regionlist[i - 1].width))
++        if ((crop->selections > i + 1) &&
++            (crop_width != crop->regionlist[i + 1].width))
+              {
+ 	     TIFFError ("extractCompositeRegions", 
+                           "Only equal width regions can be combined for -E top or bottom");
+@@ -6694,7 +6757,8 @@ extractCompositeRegions(struct image_data *image,  struct crop_mask *crop,
+ 	   break;
+       case EDGE_LEFT:  /* splice the pieces of each row together, side by side */
+       case EDGE_RIGHT:
+-	   if ((i > 0) && (crop_length != crop->regionlist[i - 1].length))
++        if ((crop->selections > i + 1) &&
++            (crop_length != crop->regionlist[i + 1].length))
+              {
+ 	     TIFFError ("extractCompositeRegions", 
+                           "Only equal length regions can be combined for -E left or right");

--- a/SPECS/libtiff/libtiff.spec
+++ b/SPECS/libtiff/libtiff.spec
@@ -1,7 +1,7 @@
 Summary:        TIFF libraries and associated utilities.
 Name:           libtiff
 Version:        4.4.0
-Release:        7%{?dist}
+Release:        8%{?dist}
 License:        libtiff
 URL:            https://gitlab.com/libtiff/libtiff
 Group:          System Environment/Libraries
@@ -78,6 +78,9 @@ make %{?_smp_mflags} -k check
 %{_datadir}/man/man3/*
 
 %changelog
+* Thu Feb 16 2023 Dallas Delaney <dadelan@microsoft.com> - 4.4.0-8
+- Patch CVE-2023-0800 CVE-2023-0801 CVE-2023-0802 CVE-2023-0803 CVE-2023-0804
+
 * Thu Feb 02 2023 Henry Li <lihl@microsoft.com> - 4.4.0-7
 - Patch CVE-2022-48281
 

--- a/SPECS/libtiff/libtiff.spec
+++ b/SPECS/libtiff/libtiff.spec
@@ -18,6 +18,7 @@ Patch4:         CVE-2022-3597.patch
 Patch5:         CVE-2022-3599.patch
 Patch6:         CVE-2022-3970.patch
 Patch7:         CVE-2022-48281.patch
+Patch8:         CVE-2023-0800.patch
 
 BuildRequires:  autoconf
 BuildRequires:  automake

--- a/SPECS/libtiff/libtiff.spec
+++ b/SPECS/libtiff/libtiff.spec
@@ -1,7 +1,7 @@
 Summary:        TIFF libraries and associated utilities.
 Name:           libtiff
 Version:        4.4.0
-Release:        8%{?dist}
+Release:        9%{?dist}
 License:        libtiff
 URL:            https://gitlab.com/libtiff/libtiff
 Group:          System Environment/Libraries
@@ -19,6 +19,7 @@ Patch5:         CVE-2022-3599.patch
 Patch6:         CVE-2022-3970.patch
 Patch7:         CVE-2022-48281.patch
 Patch8:         CVE-2023-0800.patch
+Patch9:         CVE-2023-0795.patch
 
 BuildRequires:  autoconf
 BuildRequires:  automake
@@ -78,6 +79,9 @@ make %{?_smp_mflags} -k check
 %{_datadir}/man/man3/*
 
 %changelog
+* Thu Feb 16 2023 Dallas Delaney <dadelan@microsoft.com> - 4.4.0-9
+- Patch CVE-2023-0795 CVE-2023-0796 CVE-2023-0797 CVE-2023-0798 CVE-2023-0799
+
 * Thu Feb 16 2023 Dallas Delaney <dadelan@microsoft.com> - 4.4.0-8
 - Patch CVE-2023-0800 CVE-2023-0801 CVE-2023-0802 CVE-2023-0803 CVE-2023-0804
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
CVE-2023-0795 CVE-2023-0796 CVE-2023-0797 CVE-2023-0798 CVE-2023-0799

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->


###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- Dependent on https://github.com/microsoft/CBL-Mariner/pull/4876
- combination of libtiff rotateImage() changes from https://gitlab.com/libtiff/libtiff/-/commits/master/tools/tiffcrop.c:  9c22495e5eeeae9e00a1596720c969656bb8d678, 688012dca2c39033aa2dc7bcea9796787cfd1b44, 69818e2f2d246e6631ac2a2da692c3706b849c38

###### Links to CVEs  <!-- optional -->
- CVE-2023-0795 CVE-2023-0796 CVE-2023-0797 CVE-2023-0798 CVE-2023-0799

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- [pipeline build](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=310670&view=results)
- local build