### PR TITLE
Nopatch kernel to address CVE-2022-36280, CVE-2022-41218, CVE-2022-4139, CVE-2022-42328, CVE-2022-42329, CVE-2022-4662, CVE-2023-23559

### DIFF
--- a/SPECS/kernel/CVE-2022-36280.nopatch
+++ b/SPECS/kernel/CVE-2022-36280.nopatch
@@ -1,0 +1,2 @@
+CVE-2022-36280 - patched in version 5.10.163
+upstream commit ID 4cf949c7fafe21e085a4ee386bb2dade9067316e -> stable commit ID 439cbbc1519547f9a7b483f0de33b556ebfec901 

--- a/SPECS/kernel/CVE-2022-41218.nopatch
+++ b/SPECS/kernel/CVE-2022-41218.nopatch
@@ -1,0 +1,2 @@
+CVE-2022-41218 - patched in version 5.10.163
+upstream commit ID fd3d91ab1c6ab0628fe642dd570b56302c30a792 -> stable commit ID 3df07728abde249e2d3f47cf22f134cb4d4f5fb1 

--- a/SPECS/kernel/CVE-2022-4139.nopatch
+++ b/SPECS/kernel/CVE-2022-4139.nopatch
@@ -1,0 +1,2 @@
+CVE-2022-4139 - patched in version 5.10.157
+upstream commit ID 04aa64375f48a5d430b5550d9271f8428883e550 -> stable commit ID 86f0082fb9470904b15546726417f28077088fee

--- a/SPECS/kernel/CVE-2022-42328.nopatch
+++ b/SPECS/kernel/CVE-2022-42328.nopatch
@@ -1,0 +1,2 @@
+CVE-2022-42328 - patched in version 5.10.159
+upstream commit ID 74e7e1efdad45580cc3839f2a155174cf158f9b5 -> stable commit ID 83632fc41449c480f2d0193683ec202caaa186c9

--- a/SPECS/kernel/CVE-2022-42329.nopatch
+++ b/SPECS/kernel/CVE-2022-42329.nopatch
@@ -1,0 +1,2 @@
+CVE-2022-42329 - patched in version 5.10.159
+upstream commit ID 74e7e1efdad45580cc3839f2a155174cf158f9b5 -> stable commit ID 83632fc41449c480f2d0193683ec202caaa186c9 

--- a/SPECS/kernel/CVE-2022-4662.nopatch
+++ b/SPECS/kernel/CVE-2022-4662.nopatch
@@ -1,0 +1,2 @@
+CVE-2022-4662 - patched in version 5.10.142
+upstream commit ID 9c6d778800b921bde3bff3cff5003d1650f942d1 -> stable commit ID abe3cfb7a7c8e907b312c7dbd7bf4d142b745aa8 

--- a/SPECS/kernel/CVE-2023-23559.nopatch
+++ b/SPECS/kernel/CVE-2023-23559.nopatch
@@ -1,0 +1,2 @@
+CVE-2023-23559  - patched in version 5.10.166
+upstream commit ID b870e73a56c4cccbec33224233eaf295839f228c -> stable commit ID 802fd7623e9ed19ee809b503e93fccc1e3f37bd6


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Address CVE-2022-36280, CVE-2022-41218, CVE-2022-4139, CVE-2022-42328, CVE-2022-42329, CVE-2022-4662, CVE-2023-23559

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Nopatch CVE-2022-36280, CVE-2022-41218, CVE-2022-4139, CVE-2022-42328, CVE-2022-42329, CVE-2022-4662, CVE-2023-23559

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2022-36280
- https://nvd.nist.gov/vuln/detail/CVE-2022-41218
- https://nvd.nist.gov/vuln/detail/CVE-2022-4139
- https://nvd.nist.gov/vuln/detail/CVE-2022-42328
- https://nvd.nist.gov/vuln/detail/CVE-2022-42329
- https://nvd.nist.gov/vuln/detail/CVE-2022-4662
- https://nvd.nist.gov/vuln/detail/CVE-2023-23559

