### PR TITLE
kernel-azure: Install vmlinux with root executable permissions

### DIFF
--- a/SPECS-SIGNED/kernel-azure-signed/kernel-azure-signed.spec
+++ b/SPECS-SIGNED/kernel-azure-signed/kernel-azure-signed.spec
@@ -10,7 +10,7 @@
 Summary:        Signed Linux Kernel for Azure
 Name:           kernel-azure-signed-%{buildarch}
 Version:        5.15.92.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -153,6 +153,9 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %exclude /module_info.ld
 
 %changelog
+* Wed Feb 15 2023 Rachel Menge <rachelmenge@microsoft.com> - 5.15.92.1-2
+- Bump to match kernel-azure release
+
 * Mon Feb 06 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 5.15.92.1-1
 - Auto-upgrade to 5.15.92.1
 

--- a/SPECS/kernel-azure/kernel-azure.spec
+++ b/SPECS/kernel-azure/kernel-azure.spec
@@ -18,7 +18,7 @@
 Summary:        Linux Kernel
 Name:           kernel-azure
 Version:        5.15.92.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -224,7 +224,7 @@ install -D -m 640 arch/arm64/boot/dts/freescale/imx8mq-evk.dtb %{buildroot}/boot
 install -vm 400 System.map %{buildroot}/boot/System.map-%{uname_r}
 install -vm 600 .config %{buildroot}/boot/config-%{uname_r}
 cp -r Documentation/*        %{buildroot}%{_defaultdocdir}/linux-%{uname_r}
-install -vm 644 vmlinux %{buildroot}%{_libdir}/debug/lib/modules/%{uname_r}/vmlinux-%{uname_r}
+install -vm 744 vmlinux %{buildroot}%{_libdir}/debug/lib/modules/%{uname_r}/vmlinux-%{uname_r}
 # `perf test vmlinux` needs it
 ln -s vmlinux-%{uname_r} %{buildroot}%{_libdir}/debug/lib/modules/%{uname_r}/vmlinux
 
@@ -406,6 +406,9 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %{_sysconfdir}/bash_completion.d/bpftool
 
 %changelog
+* Wed Feb 15 2023 Rachel Menge <rachelmenge@microsoft.com> - 5.15.92.1-2
+- Install vmlinux as root executable for debuginfo
+
 * Mon Feb 06 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 5.15.92.1-1
 - Auto-upgrade to 5.15.92.1
 


### PR DESCRIPTION
Cherry-pick of abe001946ec6e9889b03dc8fe8d2ff0a89cd7660

There was a bug where debug sources were missing from sources that were built into vmlinux. This is because find_debuginfo, the script which extracts debug sources, looks only at files which are executable. Because we were installing vmlinux as 644, it was being skipped. Therefore, change to install with permissions 744.

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Cherry-pick of abe001946ec6e9889b03dc8fe8d2ff0a89cd7660

debuginfo packages are generated via find-debuginfo script. This script is packaged in the [debugedit rpm](https://github.com/microsoft/CBL-Mariner/blob/main/SPECS/debugedit/debugedit.spec). The script is run after the %install phase of an rpm. It looks at the BUILDROOT for its sources. Specifically it will look for all the executables in this [line](https://sourceware.org/git/?p=debugedit.git;a=blob;f=scripts/find-debuginfo.in;h=7dec3c3bfdc59a5b3cd53838f9cf748c0b1a932c;hb=HEAD#l422).  Because we were initally installing vmlinux with 644 permissions, it was not seen as an executable and not analyzed by find-debuginfo. Thus, only the modules had their debuginfo extracted leading to missing debug sources such as tcp.c.

Fix by giving vmlinux root executable permissions.
This increases the kernel-debuginfo package from about 828MB to 847MB (19MB difference)

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Install vmlinux with root executable permissions 

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://microsoft.visualstudio.com/OS/_workitems/edit/41078627/

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=313775&view=results
