### PR TITLE
Patch libtiff for CVE-2023-0795(to 0799) and CVE-2023-0800(to 0804)

### DIFF
--- a/SPECS/libtiff/CVE-2023-0795.patch
+++ b/SPECS/libtiff/CVE-2023-0795.patch
@@ -1,0 +1,418 @@
+From 73e2e0c70332b9bc54bb38b8cffb7ed223b4e0ef Mon Sep 17 00:00:00 2001
+From: Su_Laus <sulau@freenet.de>
+Date: Fri, 3 Feb 2023 15:31:31 +0100
+Subject: [PATCH 1/4] tiffcrop correctly update buffersize after rotateImage()
+ fix#520 rotateImage() set up a new buffer and calculates its size
+ individually. Therefore, seg_buffs[] size needs to be updated accordingly.
+ Before this fix, the seg_buffs buffer size was calculated with a different
+ formula than within rotateImage().
+
+Closes #520.
+---
+ tools/tiffcrop.c | 35 ++++++++++++++++++++++-------------
+ 1 file changed, 22 insertions(+), 13 deletions(-)
+
+diff --git a/tools/tiffcrop.c b/tools/tiffcrop.c
+index 5a067a4..ba07bc3 100644
+--- a/tools/tiffcrop.c
++++ b/tools/tiffcrop.c
+@@ -526,7 +526,7 @@ static int rotateContigSamples24bits(uint16_t, uint16_t, uint16_t, uint32_t,
+ static int rotateContigSamples32bits(uint16_t, uint16_t, uint16_t, uint32_t,
+                                      uint32_t, uint32_t, uint8_t *, uint8_t *);
+ static int rotateImage(uint16_t, struct image_data *, uint32_t *, uint32_t *,
+-                       unsigned char **);
++                       unsigned char **, size_t *);
+ static int mirrorImage(uint16_t, uint16_t, uint16_t, uint32_t, uint32_t,
+                        unsigned char *);
+ static int invertImage(uint16_t, uint16_t, uint16_t, uint32_t, uint32_t,
+@@ -6535,7 +6535,7 @@ static int  correct_orientation(struct image_data *image, unsigned char **work_b
+       return (-1);
+       }
+  
+-    if (rotateImage(rotation, image, &image->width, &image->length, work_buff_ptr))
++    if (rotateImage(rotation, image, &image->width, &image->length, work_buff_ptr, NULL))
+       {
+       TIFFError ("correct_orientation", "Unable to rotate image");
+       return (-1);
+@@ -7717,16 +7717,20 @@ processCropSelections(struct image_data *image, struct crop_mask *crop,
+ 
+     if (crop->crop_mode & CROP_ROTATE) /* rotate should be last as it can reallocate the buffer */
+       {
++
++      /* rotateImage() set up a new buffer and calculates its size
++       * individually. Therefore, seg_buffs size  needs to be updated
++       * accordingly. */
++      size_t rot_buf_size = 0;
+       if (rotateImage(crop->rotation, image, &crop->combined_width, 
+-                      &crop->combined_length, &crop_buff))
++                      &crop->combined_length, &crop_buff, &rot_buf_size))
+         {
+         TIFFError("processCropSelections", 
+                   "Failed to rotate composite regions by %"PRIu32" degrees", crop->rotation);
+         return (-1);
+         }
+       seg_buffs[0].buffer = crop_buff;
+-      seg_buffs[0].size = (((crop->combined_width * image->bps + 7 ) / 8)
+-                            * image->spp) * crop->combined_length; 
++      seg_buffs[0].size = rot_buf_size;
+       }
+     }
+   else  /* Separated Images */
+@@ -7826,9 +7830,13 @@ processCropSelections(struct image_data *image, struct crop_mask *crop,
+         {
+           /* rotateImage() changes image->width, ->length, ->xres and ->yres, what it schouldn't do here, when more than one section is processed. 
+            * ToDo: Therefore rotateImage() and its usage has to be reworked (e.g. like mirrorImage()) !!
+-           */
+-	if (rotateImage(crop->rotation, image, &crop->regionlist[i].width, 
+-			&crop->regionlist[i].length, &crop_buff))
++           * Furthermore, rotateImage() set up a new buffer and calculates
++           * its size individually. Therefore, seg_buffs size  needs to be
++           * updated accordingly. */
++          size_t rot_buf_size = 0;
++          if (rotateImage(
++                  crop->rotation, image, &crop->regionlist[i].width,
++                  &crop->regionlist[i].length, &crop_buff, &rot_buf_size))
+           {
+           TIFFError("processCropSelections", 
+                     "Failed to rotate crop region by %"PRIu16" degrees", crop->rotation);
+@@ -7839,8 +7847,7 @@ processCropSelections(struct image_data *image, struct crop_mask *crop,
+         crop->combined_width = total_width;
+         crop->combined_length = total_length;
+         seg_buffs[i].buffer = crop_buff;
+-        seg_buffs[i].size = (((crop->regionlist[i].width * image->bps + 7 ) / 8)
+-                               * image->spp) * crop->regionlist[i].length; 
++        seg_buffs[i].size = rot_buf_size;
+         }
+       }  /* for crop->selections loop */
+     }  /* Separated Images (else case) */
+@@ -7960,7 +7967,7 @@ createCroppedImage(struct image_data *image, struct crop_mask *crop,
+   if (crop->crop_mode & CROP_ROTATE) /* rotate should be last as it can reallocate the buffer */
+     {
+     if (rotateImage(crop->rotation, image, &crop->combined_width, 
+-                    &crop->combined_length, crop_buff_ptr))
++                    &crop->combined_length, crop_buff_ptr, NULL))
+       {
+       TIFFError("createCroppedImage", 
+                 "Failed to rotate image or cropped selection by %"PRIu16" degrees", crop->rotation);
+@@ -8623,7 +8630,7 @@ rotateContigSamples32bits(uint16_t rotation, uint16_t spp, uint16_t bps, uint32_
+ /* Rotate an image by a multiple of 90 degrees clockwise */
+ static int
+ rotateImage(uint16_t rotation, struct image_data *image, uint32_t *img_width,
+-            uint32_t *img_length, unsigned char **ibuff_ptr)
++            uint32_t *img_length, unsigned char **ibuff_ptr, size_t *rot_buf_size)
+   {
+   int      shift_width;
+   uint32_t   bytes_per_pixel, bytes_per_sample;
+@@ -8674,7 +8681,9 @@ rotateImage(uint16_t rotation, struct image_data *image, uint32_t *img_width,
+     return (-1);
+     }
+   _TIFFmemset(rbuff, '\0', buffsize + NUM_BUFF_OVERSIZE_BYTES);
+-
++  if (rot_buf_size != NULL)
++      *rot_buf_size = buffsize;
++ 
+   ibuff = *ibuff_ptr;
+   switch (rotation)
+     {
+-- 
+2.25.1
+
+
+From 3966d1a996816aa7841ba0e089962297558c689c Mon Sep 17 00:00:00 2001
+From: Su_Laus <sulau@freenet.de>
+Date: Fri, 3 Feb 2023 17:38:55 +0100
+Subject: [PATCH 2/4] TIFFClose() avoid NULL pointer dereferencing. fix#515
+
+Closes #515
+---
+ libtiff/tif_close.c | 13 ++++++++-----
+ tools/tiffcrop.c    |  6 ++++--
+ 2 files changed, 12 insertions(+), 7 deletions(-)
+
+diff --git a/libtiff/tif_close.c b/libtiff/tif_close.c
+index 04977bc..34162b6 100644
+--- a/libtiff/tif_close.c
++++ b/libtiff/tif_close.c
+@@ -125,11 +125,14 @@ TIFFCleanup(TIFF* tif)
+ void
+ TIFFClose(TIFF* tif)
+ {
+-	TIFFCloseProc closeproc = tif->tif_closeproc;
+-	thandle_t fd = tif->tif_clientdata;
+-
+-	TIFFCleanup(tif);
+-	(void) (*closeproc)(fd);
++    if (tif != NULL)
++    {
++        TIFFCloseProc closeproc = tif->tif_closeproc;
++        thandle_t fd = tif->tif_clientdata;
++
++        TIFFCleanup(tif);
++        (void)(*closeproc)(fd);
++    }
+ }
+ 
+ /* vim: set ts=8 sts=8 sw=8 noet: */
+diff --git a/tools/tiffcrop.c b/tools/tiffcrop.c
+index ba07bc3..ccd5549 100644
+--- a/tools/tiffcrop.c
++++ b/tools/tiffcrop.c
+@@ -2554,8 +2554,10 @@ main(int argc, char* argv[])
+       }
+     }
+ 
+-  TIFFClose(out);
+-
++  if (out != NULL)
++  {
++      TIFFClose(out);
++  }
+   return (0);
+   } /* end main */
+ 
+-- 
+2.25.1
+
+
+From 46b817001a978badbf96cfa3e5277369a7c5d26e Mon Sep 17 00:00:00 2001
+From: Su_Laus <sulau@freenet.de>
+Date: Sat, 4 Feb 2023 23:24:21 +0100
+Subject: [PATCH 3/4] tiffcrop correctly update buffersize after rotateImage()
+ fix#520 -- enlarge buffsize and check integer overflow within rotateImage().
+
+---
+ tools/tiffcrop.c | 40 ++++++++++++++++++++++++++++++++++++----
+ 1 file changed, 36 insertions(+), 4 deletions(-)
+
+diff --git a/tools/tiffcrop.c b/tools/tiffcrop.c
+index ccd5549..b59caf8 100644
+--- a/tools/tiffcrop.c
++++ b/tools/tiffcrop.c
+@@ -8638,7 +8638,8 @@ rotateImage(uint16_t rotation, struct image_data *image, uint32_t *img_width,
+   uint32_t   bytes_per_pixel, bytes_per_sample;
+   uint32_t   row, rowsize, src_offset, dst_offset;
+   uint32_t   i, col, width, length;
+-  uint32_t   colsize, buffsize, col_offset, pix_offset;
++  uint32_t colsize, col_offset, pix_offset;
++  tmsize_t buffsize;
+   unsigned char *ibuff;
+   unsigned char *src;
+   unsigned char *dst;
+@@ -8651,12 +8652,40 @@ rotateImage(uint16_t rotation, struct image_data *image, uint32_t *img_width,
+   spp = image->spp;
+   bps = image->bps;
+ 
++  if ((spp != 0 && bps != 0 &&
++       width > (uint32_t)((UINT32_MAX - 7) / spp / bps)) ||
++      (spp != 0 && bps != 0 &&
++       length > (uint32_t)((UINT32_MAX - 7) / spp / bps)))
++  {
++      TIFFError("rotateImage", "Integer overflow detected.");
++      return (-1);
++  }
+   rowsize = ((bps * spp * width) + 7) / 8;
+   colsize = ((bps * spp * length) + 7) / 8;
+   if ((colsize * width) > (rowsize * length))
+-    buffsize = (colsize + 1) * width;
++  {
++      if (((tmsize_t)colsize + 1) != 0 &&
++          (tmsize_t)width > ((TIFF_TMSIZE_T_MAX - NUM_BUFF_OVERSIZE_BYTES) /
++                             ((tmsize_t)colsize + 1)))
++      {
++          TIFFError("rotateImage",
++                    "Integer overflow when calculating buffer size.");
++          return (-1);
++      }
++      buffsize = ((tmsize_t)colsize + 1) * width;
++  }
+   else
+-    buffsize = (rowsize + 1) * length;
++  {
++     if (((tmsize_t)rowsize + 1) != 0 &&
++         (tmsize_t)length > ((TIFF_TMSIZE_T_MAX - NUM_BUFF_OVERSIZE_BYTES) /
++                             ((tmsize_t)rowsize + 1)))
++     {
++         TIFFError("rotateImage",
++                   "Integer overflow when calculating buffer size.");
++         return (-1);
++     }
++     buffsize = (rowsize + 1) * length;
++  }
+ 
+   bytes_per_sample = (bps + 7) / 8;
+   bytes_per_pixel  = ((bps * spp) + 7) / 8;
+@@ -8679,7 +8708,10 @@ rotateImage(uint16_t rotation, struct image_data *image, uint32_t *img_width,
+   /* Add 3 padding bytes for extractContigSamplesShifted32bits */
+   if (!(rbuff = (unsigned char *)limitMalloc(buffsize + NUM_BUFF_OVERSIZE_BYTES)))
+     {
+-    TIFFError("rotateImage", "Unable to allocate rotation buffer of %1u bytes", buffsize + NUM_BUFF_OVERSIZE_BYTES);
++    TIFFError("rotateImage",
++              "Unable to allocate rotation buffer of %" TIFF_SSIZE_FORMAT
++              " bytes ",
++              buffsize + NUM_BUFF_OVERSIZE_BYTES);
+     return (-1);
+     }
+   _TIFFmemset(rbuff, '\0', buffsize + NUM_BUFF_OVERSIZE_BYTES);
+-- 
+2.25.1
+
+
+From 8427a4c110ff1570e9546701274ef21564e6aa8a Mon Sep 17 00:00:00 2001
+From: Su_Laus <sulau@freenet.de>
+Date: Sun, 29 Jan 2023 11:09:26 +0100
+Subject: [PATCH 4/4] tiffcrop: Amend rotateImage() not to toggle the input
+ (main) image width and length parameters when only cropped image sections are
+ rotated. Remove buffptr from region structure because never used.
+
+Closes #492 #493 #494 #495 #499 #518 #519
+---
+ tools/tiffcrop.c | 56 +++++++++++++++++++++++++++++-------------------
+ 1 file changed, 34 insertions(+), 22 deletions(-)
+
+diff --git a/tools/tiffcrop.c b/tools/tiffcrop.c
+index b59caf8..1f183df 100644
+--- a/tools/tiffcrop.c
++++ b/tools/tiffcrop.c
+@@ -271,7 +271,6 @@ struct  region {
+   uint32_t width;     /* width in pixels */
+   uint32_t length;    /* length in pixels */
+   uint32_t buffsize;  /* size of buffer needed to hold the cropped region */
+-  unsigned char *buffptr; /* address of start of the region */
+ };
+ 
+ /* Cropping parameters from command line and image data 
+@@ -526,7 +525,7 @@ static int rotateContigSamples24bits(uint16_t, uint16_t, uint16_t, uint32_t,
+ static int rotateContigSamples32bits(uint16_t, uint16_t, uint16_t, uint32_t,
+                                      uint32_t, uint32_t, uint8_t *, uint8_t *);
+ static int rotateImage(uint16_t, struct image_data *, uint32_t *, uint32_t *,
+-                       unsigned char **, size_t *);
++                       unsigned char **, size_t *, int);
+ static int mirrorImage(uint16_t, uint16_t, uint16_t, uint32_t, uint32_t,
+                        unsigned char *);
+ static int invertImage(uint16_t, uint16_t, uint16_t, uint32_t, uint32_t,
+@@ -5226,7 +5225,6 @@ initCropMasks (struct crop_mask *cps)
+      cps->regionlist[i].width = 0;
+      cps->regionlist[i].length = 0;
+      cps->regionlist[i].buffsize = 0;
+-     cps->regionlist[i].buffptr = NULL;
+      cps->zonelist[i].position = 0;
+      cps->zonelist[i].total = 0;
+      }
+@@ -6537,7 +6535,13 @@ static int  correct_orientation(struct image_data *image, unsigned char **work_b
+       return (-1);
+       }
+  
+-    if (rotateImage(rotation, image, &image->width, &image->length, work_buff_ptr, NULL))
++     /* Dummy variable in order not to switch two times the
++       * image->width,->length within rotateImage(),
++       * but switch xres, yres there. */
++      uint32_t width = image->width;
++      uint32_t length = image->length;
++      if (rotateImage(rotation, image, &width, &length, work_buff_ptr, NULL,
++                        TRUE))
+       {
+       TIFFError ("correct_orientation", "Unable to rotate image");
+       return (-1);
+@@ -6605,7 +6609,6 @@ extractCompositeRegions(struct image_data *image,  struct crop_mask *crop,
+     /* These should not be needed for composite images */
+     crop->regionlist[i].width = crop_width;
+     crop->regionlist[i].length = crop_length;
+-    crop->regionlist[i].buffptr = crop_buff;
+ 
+     src_rowsize = ((img_width * bps * spp) + 7) / 8;
+     dst_rowsize = (((crop_width * bps * count) + 7) / 8);
+@@ -6842,7 +6845,6 @@ extractSeparateRegion(struct image_data *image,  struct crop_mask *crop,
+ 
+   crop->regionlist[region].width = crop_width;
+   crop->regionlist[region].length = crop_length;
+-  crop->regionlist[region].buffptr = crop_buff;
+ 
+   src = read_buff;
+   dst = crop_buff;
+@@ -7725,7 +7727,7 @@ processCropSelections(struct image_data *image, struct crop_mask *crop,
+        * accordingly. */
+       size_t rot_buf_size = 0;
+       if (rotateImage(crop->rotation, image, &crop->combined_width, 
+-                      &crop->combined_length, &crop_buff, &rot_buf_size))
++                      &crop->combined_length, &crop_buff, &rot_buf_size, FALSE))
+         {
+         TIFFError("processCropSelections", 
+                   "Failed to rotate composite regions by %"PRIu32" degrees", crop->rotation);
+@@ -7836,9 +7838,10 @@ processCropSelections(struct image_data *image, struct crop_mask *crop,
+            * its size individually. Therefore, seg_buffs size  needs to be
+            * updated accordingly. */
+           size_t rot_buf_size = 0;
+-          if (rotateImage(
+-                  crop->rotation, image, &crop->regionlist[i].width,
+-                  &crop->regionlist[i].length, &crop_buff, &rot_buf_size))
++          if (rotateImage(crop->rotation, image,
++                          &crop->regionlist[i].width,
++                          &crop->regionlist[i].length, &crop_buff,
++                          &rot_buf_size, FALSE))
+           {
+           TIFFError("processCropSelections", 
+                     "Failed to rotate crop region by %"PRIu16" degrees", crop->rotation);
+@@ -7969,7 +7972,7 @@ createCroppedImage(struct image_data *image, struct crop_mask *crop,
+   if (crop->crop_mode & CROP_ROTATE) /* rotate should be last as it can reallocate the buffer */
+     {
+     if (rotateImage(crop->rotation, image, &crop->combined_width, 
+-                    &crop->combined_length, crop_buff_ptr, NULL))
++                    &crop->combined_length, crop_buff_ptr, NULL, TRUE))
+       {
+       TIFFError("createCroppedImage", 
+                 "Failed to rotate image or cropped selection by %"PRIu16" degrees", crop->rotation);
+@@ -8632,7 +8635,8 @@ rotateContigSamples32bits(uint16_t rotation, uint16_t spp, uint16_t bps, uint32_
+ /* Rotate an image by a multiple of 90 degrees clockwise */
+ static int
+ rotateImage(uint16_t rotation, struct image_data *image, uint32_t *img_width,
+-            uint32_t *img_length, unsigned char **ibuff_ptr, size_t *rot_buf_size)
++            uint32_t *img_length, unsigned char **ibuff_ptr, size_t *rot_buf_size,
++	    int rot_image_params)
+   {
+   int      shift_width;
+   uint32_t   bytes_per_pixel, bytes_per_sample;
+@@ -8857,11 +8861,15 @@ rotateImage(uint16_t rotation, struct image_data *image, uint32_t *img_width,
+ 
+               *img_width = length;
+               *img_length = width;
+-              image->width = length;
+-              image->length = width;
+-              res_temp = image->xres;
+-              image->xres = image->yres;
+-              image->yres = res_temp;
++              /* Only toggle image parameters if whole input image is rotated. */
++              if (rot_image_params)
++              {
++                  image->width = length;
++                  image->length = width;
++                  res_temp = image->xres;
++                  image->xres = image->yres;
++                  image->yres = res_temp;
++              }
+ 	      break;
+ 
+     case 270: if ((bps % 8) == 0) /* byte aligned data */
+@@ -8934,11 +8942,15 @@ rotateImage(uint16_t rotation, struct image_data *image, uint32_t *img_width,
+ 
+               *img_width = length;
+               *img_length = width;
+-              image->width = length;
+-              image->length = width;
+-              res_temp = image->xres;
+-              image->xres = image->yres;
+-              image->yres = res_temp;
++              /* Only toggle image parameters if whole input image is rotated. */
++              if (rot_image_params)
++              {
++                  image->width = length;
++                  image->length = width;
++                  res_temp = image->xres;
++                  image->xres = image->yres;
++                  image->yres = res_temp;
++              }
+               break;
+     default:
+               break;
+-- 
+2.25.1
+

--- a/SPECS/libtiff/CVE-2023-0796.nopatch
+++ b/SPECS/libtiff/CVE-2023-0796.nopatch
@@ -1,0 +1,1 @@
+The CVE-2023-0795.patch also fixes CVE-2023-0796

--- a/SPECS/libtiff/CVE-2023-0797.nopatch
+++ b/SPECS/libtiff/CVE-2023-0797.nopatch
@@ -1,0 +1,1 @@
+The CVE-2023-0795.patch also fixes CVE-2023-0797

--- a/SPECS/libtiff/CVE-2023-0798.nopatch
+++ b/SPECS/libtiff/CVE-2023-0798.nopatch
@@ -1,0 +1,1 @@
+The CVE-2023-0795.patch also fixes CVE-2023-0798

--- a/SPECS/libtiff/CVE-2023-0799.nopatch
+++ b/SPECS/libtiff/CVE-2023-0799.nopatch
@@ -1,0 +1,1 @@
+The CVE-2023-0795.patch also fixes CVE-2023-0799

--- a/SPECS/libtiff/CVE-2023-0800.patch
+++ b/SPECS/libtiff/CVE-2023-0800.patch
@@ -1,0 +1,137 @@
+From 8982fa43d1f2dfcd980ff6c335698d41b3401b16 Mon Sep 17 00:00:00 2001
+From: Su Laus <sulau@freenet.de>
+Date: Sun, 5 Feb 2023 15:53:15 +0000
+Subject: [PATCH] tiffcrop: added check for assumption on composite images
+ (fixes #496)
+
+tiffcrop: For composite images with more than one region, the combined_length or combined_width always needs to be equal, respectively. Otherwise, even the first section/region copy action might cause buffer overrun. This is now checked before the first copy action.
+
+Closes #496, #497, #498, #500, #501.
+---
+ tools/tiffcrop.c | 74 ++++++++++++++++++++++++++++++++++++++++++++----
+ 1 file changed, 69 insertions(+), 5 deletions(-)
+
+diff --git a/tools/tiffcrop.c b/tools/tiffcrop.c
+index 1f183df..8c9141a 100644
+--- a/tools/tiffcrop.c
++++ b/tools/tiffcrop.c
+@@ -5364,18 +5364,40 @@ computeInputPixelOffsets(struct crop_mask *crop, struct image_data *image,
+ 
+       crop->regionlist[i].buffsize = buffsize;
+       crop->bufftotal += buffsize;
++
++      /* For composite images with more than one region, the
++       * combined_length or combined_width always needs to be equal,
++       * respectively.
++       * Otherwise, even the first section/region copy
++       * action might cause buffer overrun. */
+       if (crop->img_mode == COMPOSITE_IMAGES)
+         {
+         switch (crop->edge_ref)
+           {
+           case EDGE_LEFT:
+           case EDGE_RIGHT:
++               if (i > 0 && zlength != crop->combined_length)
++              {
++                  TIFFError(
++                      "computeInputPixelOffsets",
++                      "Only equal length regions can be combined for "
++                      "-E left or right");
++                  return (-1);
++               }
+                crop->combined_length = zlength;
+                crop->combined_width += zwidth;
+                break;
+           case EDGE_BOTTOM:
+           case EDGE_TOP:  /* width from left, length from top */
+           default:
++              if (i > 0 && zwidth != crop->combined_width)
++              {
++                  TIFFError("computeInputPixelOffsets",
++                            "Only equal width regions can be "
++                            "combined for -E "
++                            "top or bottom");
++                  return (-1);
++               }
+                crop->combined_width = zwidth;
+                crop->combined_length += zlength;
+ 	       break;
+@@ -6595,6 +6617,46 @@ extractCompositeRegions(struct image_data *image,  struct crop_mask *crop,
+   crop->combined_width = 0;
+   crop->combined_length = 0;
+ 
++  /* If there is more than one region, check beforehand whether all the width
++   * and length values of the regions are the same, respectively. */
++  switch (crop->edge_ref)
++  {
++      default:
++      case EDGE_TOP:
++      case EDGE_BOTTOM:
++          for (i = 1; i < crop->selections; i++)
++          {
++              uint32_t crop_width0 =
++                  crop->regionlist[i - 1].x2 - crop->regionlist[i - 1].x1 + 1;
++              uint32_t crop_width1 =
++                  crop->regionlist[i].x2 - crop->regionlist[i].x1 + 1;
++              if (crop_width0 != crop_width1)
++              {
++                  TIFFError("extractCompositeRegions",
++                            "Only equal width regions can be combined for -E "
++                            "top or bottom");
++                  return (1);
++              }
++          }
++          break;
++      case EDGE_LEFT:
++      case EDGE_RIGHT:
++          for (i = 1; i < crop->selections; i++)
++          {
++              uint32_t crop_length0 =
++                  crop->regionlist[i - 1].y2 - crop->regionlist[i - 1].y1 + 1;
++              uint32_t crop_length1 =
++                  crop->regionlist[i].y2 - crop->regionlist[i].y1 + 1;
++              if (crop_length0 != crop_length1)
++              {
++                  TIFFError("extractCompositeRegions",
++                            "Only equal length regions can be combined for "
++                            "-E left or right");
++                  return (1);
++              }
++          }
++  }
++
+   for (i = 0; i < crop->selections; i++)
+     {
+     /* rows, columns, width, length are expressed in pixels */
+@@ -6618,8 +6680,9 @@ extractCompositeRegions(struct image_data *image,  struct crop_mask *crop,
+       default:
+       case EDGE_TOP:
+       case EDGE_BOTTOM:
+-	   if ((i > 0) && (crop_width != crop->regionlist[i - 1].width))
+-             {
++            if ((crop->selections > i + 1) &&
++                (crop_width != crop->regionlist[i + 1].width))
++            {
+ 	     TIFFError ("extractCompositeRegions", 
+                           "Only equal width regions can be combined for -E top or bottom");
+ 	     return (1);
+@@ -6699,12 +6762,13 @@ extractCompositeRegions(struct image_data *image,  struct crop_mask *crop,
+ 	   break;
+       case EDGE_LEFT:  /* splice the pieces of each row together, side by side */
+       case EDGE_RIGHT:
+-	   if ((i > 0) && (crop_length != crop->regionlist[i - 1].length))
+-             {
++            if ((crop->selections > i + 1) &&
++                (crop_length != crop->regionlist[i + 1].length))
++            {
+ 	     TIFFError ("extractCompositeRegions", 
+                           "Only equal length regions can be combined for -E left or right");
+ 	     return (1);
+-             }
++            }
+            crop->combined_width += crop_width;
+            crop->combined_length = crop_length;
+            dst_rowsize = (((composite_width * bps * count) + 7) / 8);
+-- 
+2.25.1
+

--- a/SPECS/libtiff/CVE-2023-0801.nopatch
+++ b/SPECS/libtiff/CVE-2023-0801.nopatch
@@ -1,0 +1,1 @@
+The CVE-2023-0800.patch also fixes CVE-2023-0801

--- a/SPECS/libtiff/CVE-2023-0802.nopatch
+++ b/SPECS/libtiff/CVE-2023-0802.nopatch
@@ -1,0 +1,1 @@
+The CVE-2023-0800.patch also fixes CVE-2023-0802

--- a/SPECS/libtiff/CVE-2023-0803.nopatch
+++ b/SPECS/libtiff/CVE-2023-0803.nopatch
@@ -1,0 +1,1 @@
+The CVE-2023-0800.patch also fixes CVE-2023-0803

--- a/SPECS/libtiff/CVE-2023-0804.nopatch
+++ b/SPECS/libtiff/CVE-2023-0804.nopatch
@@ -1,0 +1,1 @@
+The CVE-2023-0800.patch also fixes CVE-2023-0804

--- a/SPECS/libtiff/libtiff.spec
+++ b/SPECS/libtiff/libtiff.spec
@@ -23,12 +23,10 @@ Patch7:         CVE-2022-48281.patch
 Patch8:         CVE-2023-0795.patch
 #Also fixes CVE-2023-0801/0802/0803/0804
 Patch9:         CVE-2023-0800.patch
-
 BuildRequires:  autoconf
 BuildRequires:  automake
 BuildRequires:  libjpeg-turbo-devel
 BuildRequires:  libtool
-
 Requires:       libjpeg-turbo
 Provides:       %{name}-tools = %{version}-%{release}
 
@@ -37,7 +35,6 @@ The LibTIFF package contains the TIFF libraries and associated utilities. The li
 
 %package        devel
 Summary:        Header and development files
-
 Requires:       %{name} = %{version}-%{release}
 Requires:       libjpeg-turbo-devel
 
@@ -82,9 +79,8 @@ make %{?_smp_mflags} -k check
 %changelog
 * Wed Feb 22 2023 Sumedh Sharma <sumsharma@microsoft.com> - 4.4.0-8
 - Add patch for CVE-2023-0795,CVE-2023-0796,CVE-2023-0797,CVE-2023-0798 & CVE-2023-0799
-  Also includes fixes for
-  . tiffcrop correctly update buffersize after rotateImage(). fix#520
-  . TIFFClose() avoid NULL pointer dereferencing. fix#515
+- Add fix for: tiffcrop correctly update buffersize after rotateImage(). fix#520
+- Add fix for: TIFFClose() avoid NULL pointer dereferencing. fix#515
 - Add patch for CVE-2023-0800,CVE-2023-0801,CVE-2023-0802,CVE-2023-0803 & CVE-2023-0804
 
 * Wed Feb 08 2023 Rachel Menge <rachelmenge@microsoft.com> - 4.4.0-7

--- a/SPECS/libtiff/libtiff.spec
+++ b/SPECS/libtiff/libtiff.spec
@@ -1,7 +1,7 @@
 Summary:        TIFF libraries and associated utilities.
 Name:           libtiff
 Version:        4.4.0
-Release:        7%{?dist}
+Release:        8%{?dist}
 License:        libtiff
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -16,9 +16,13 @@ Patch2:         CVE-2022-2953.patch
 Patch3:         CVE-2022-3570.patch
 # Also fixes CVE-2022-3626 and CVE-2022-3627
 Patch4:         CVE-2022-3597.patch
-Patch5:	        CVE-2022-3599.patch
+Patch5:         CVE-2022-3599.patch
 Patch6:         CVE-2022-3970.patch
 Patch7:         CVE-2022-48281.patch
+# Also fixes CVE-2023-0796/0797/0798/0799
+Patch8:         CVE-2023-0795.patch
+#Also fixes CVE-2023-0801/0802/0803/0804
+Patch9:         CVE-2023-0800.patch
 
 BuildRequires:  autoconf
 BuildRequires:  automake
@@ -76,6 +80,13 @@ make %{?_smp_mflags} -k check
 %{_mandir}/man3/*
 
 %changelog
+* Wed Feb 22 2023 Sumedh Sharma <sumsharma@microsoft.com> - 4.4.0-8
+- Add patch for CVE-2023-0795,CVE-2023-0796,CVE-2023-0797,CVE-2023-0798 & CVE-2023-0799
+  Also includes fixes for
+  . tiffcrop correctly update buffersize after rotateImage(). fix#520
+  . TIFFClose() avoid NULL pointer dereferencing. fix#515
+- Add patch for CVE-2023-0800,CVE-2023-0801,CVE-2023-0802,CVE-2023-0803 & CVE-2023-0804
+
 * Wed Feb 08 2023 Rachel Menge <rachelmenge@microsoft.com> - 4.4.0-7
 - Add patch for CVE-2022-48281
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
Add patches to fix below CVE's:
CVE-2023-0795
CVE-2023-0796
CVE-2023-0797
CVE-2023-0798
CVE-2023-0799
CVE-2023-0800
CVE-2023-0801
CVE-2023-0802
CVE-2023-0803
CVE-2023-0804

###### Change Log  <!-- REQUIRED -->
- Add patch for CVE-2023-0795,CVE-2023-0796,CVE-2023-0797,CVE-2023-0798 & CVE-2023-0799
  Also includes fixes for
  . tiffcrop correctly update buffersize after rotateImage(). fix#520
  . TIFFClose() avoid NULL pointer dereferencing. fix#515
- Add patch for CVE-2023-0800,CVE-2023-0801,CVE-2023-0802,CVE-2023-0803 & CVE-2023-0804

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Associated issues  <!-- optional -->
NA

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2023-0795
- https://nvd.nist.gov/vuln/detail/CVE-2023-0796
- https://nvd.nist.gov/vuln/detail/CVE-2023-0797
- https://nvd.nist.gov/vuln/detail/CVE-2023-0798
- https://nvd.nist.gov/vuln/detail/CVE-2023-0799
- https://nvd.nist.gov/vuln/detail/CVE-2023-0800
- https://nvd.nist.gov/vuln/detail/CVE-2023-0801
- https://nvd.nist.gov/vuln/detail/CVE-2023-0802
- https://nvd.nist.gov/vuln/detail/CVE-2023-0803
- https://nvd.nist.gov/vuln/detail/CVE-2023-0804

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: BuddyBuild
                              [AMD64](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=314303)
                              [ARM64](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=314209)