### PR TITLE
Bump haproxy version to 2.4.22 for CVE-2023-25725

### DIFF
--- a/SPECS/haproxy/CVE-2023-25725.nopatch
+++ b/SPECS/haproxy/CVE-2023-25725.nopatch
@@ -1,0 +1,5 @@
+CVE-2023-25725 - Patched in haproxy stable release 2.4.22
+
+Upstream: https://github.com/haproxy/haproxy/commit/a8598a2eb11b6c989e81f0dbf10be361782e8d32
+
+Stable Release Notes: https://git.haproxy.org/?p=haproxy-2.4.git;a=log;h=refs/tags/v2.4.22 

--- a/SPECS/haproxy/CVE-2023-25725.nopatch
+++ b/SPECS/haproxy/CVE-2023-25725.nopatch
@@ -1,5 +1,0 @@
-CVE-2023-25725 - Patched in haproxy stable release 2.4.22
-
-Upstream: https://github.com/haproxy/haproxy/commit/a8598a2eb11b6c989e81f0dbf10be361782e8d32
-
-Stable Release Notes: https://git.haproxy.org/?p=haproxy-2.4.git;a=log;h=refs/tags/v2.4.22 

--- a/SPECS/haproxy/haproxy.signatures.json
+++ b/SPECS/haproxy/haproxy.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "haproxy-2.4.13.tar.gz": "4788fe975fe7e521746f826c25e80bc95cd15983e2bafa33e43bff23a3fe5ba1"
+  "haproxy-2.4.22.tar.gz": "0895340b36b704a1dbb25fea3bbaee5ff606399d6943486ebd7f256fee846d3a"
  }
 }

--- a/SPECS/haproxy/haproxy.spec
+++ b/SPECS/haproxy/haproxy.spec
@@ -1,19 +1,19 @@
 Summary:        A fast, reliable HA, load balancing, and proxy solution.
 Name:           haproxy
-Version:        2.4.13
+Version:        2.4.22
 Release:        1%{?dist}
 License:        GPLv2+
-URL:            http://www.haproxy.org
-Group:          Applications/System
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
+Group:          Applications/System
+URL:            https://www.haproxy.org
 Source0:        http://www.haproxy.org/download/2.4/src/%{name}-%{version}.tar.gz
+BuildRequires:  lua-devel
 BuildRequires:  openssl-devel
 BuildRequires:  pcre-devel
-BuildRequires:  lua-devel
 BuildRequires:  pkg-config
-BuildRequires:  zlib-devel
 BuildRequires:  systemd-devel
+BuildRequires:  zlib-devel
 Requires:       systemd
 
 %description
@@ -23,6 +23,7 @@ for very high traffic web-sites.
 
 %package        doc
 Summary:        Documentation for haproxy
+
 %description    doc
 It contains the documentation and manpages for haproxy package.
 Requires:       %{name} = %{version}-%{release}
@@ -42,7 +43,7 @@ sed -i "s/192.168.1.22/127.0.0.0/g" examples/transparent_proxy.cfg
 [ %{buildroot} != "/"] && rm -rf %{buildroot}/*
 make DESTDIR=%{buildroot} PREFIX=%{_prefix} DOCDIR=%{_docdir}/haproxy TARGET=linux2628 install
 install -vDm755 admin/systemd/haproxy.service \
-       %{buildroot}/usr/lib/systemd/system/haproxy.service
+       %{buildroot}%{_libdir}/systemd/system/haproxy.service
 install -vDm644 examples/transparent_proxy.cfg  %{buildroot}/%{_sysconfdir}/haproxy/haproxy.cfg
 
 %files
@@ -58,42 +59,61 @@ install -vDm644 examples/transparent_proxy.cfg  %{buildroot}/%{_sysconfdir}/hapr
 %{_mandir}/*
 
 %changelog
-*   Thu Feb 24 2022 Minghe Ren <mingheren@microsoft.com> 2.4.13-1
--   Update to 2.4.13
--   License verified
--   Add nopatch for CVE-2022-0711
-*   Thu Jun 04 2020 Ruying Chen <v-ruyche@microsoft.com> 2.1.5-1
--   Update to 2.1.5
-*   Tue May 19 2020 Nicolas Ontiveros <niontive@microsoft.com> 1.9.6-5
--   Fix CVE-2019-14241.
--   Fix CVE-2020-11100.
-*   Sat May 09 2020 Nick Samson <nisamson@microsoft.com> 1.9.6-4
--   Added %%license line automatically
-*   Tue Apr 21 2020 Nicolas Ontiveros <niontive@microsoft.com> 1.9.6-3
--   Fix CVE-2019-19330.
--   Remove sha1 macro.
-*   Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 1.9.6-2
--   Initial CBL-Mariner import from Photon (license: Apache2).
-*   Tue Apr 2 2019 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 1.9.6-1
--   Update to 1.9.6
-*   Thu Feb 28 2019 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 1.8.14-2
--   Patch for CVE_2018_20102
--   Patch for CVE_2018_20103
-*   Tue Dec 04 2018 Ajay Kaher <akaher@vmware.com> 1.8.14-1
--   Update to version 1.8.14
-*   Thu Oct 25 2018 Srivatsa S. Bhat (VMware) <srivatsa@csail.mit.edu> 1.8.13-2
--   Build with USE_SYSTEMD=1 to fix service startup.
-*   Wed Sep 12 2018 Anish Swaminathan <anishs@vmware.com> 1.8.13-1
--   Update to version 1.8.13
-*   Tue Apr 04 2017 Dheeraj Shetty <dheerajs@vmware.com> 1.6.12-1
--   Updated to version 1.6.12
-*   Sun Nov 27 2016 Vinay Kulkarni <kulkarniv@vmware.com> 1.6.10-1
--   Upgrade to 1.6.10 to address CVE-2016-5360
-*   Tue May 24 2016 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 1.6.3-3
--   GA - Bump release of all rpms
-*   Fri May 20 2016 Xiaolin Li <xiaolinl@vmware.com> 1.6.3-2
--   Add haproxy-systemd-wrapper to package, add a default configuration file.
-*   Mon Feb 22 2016 Xiaolin Li <xiaolinl@vmware.com> 1.6.3-1
--   Updated to version 1.6.3
-*   Thu Oct 01 2015 Vinay Kulkarni <kulkarniv@vmware.com> 1.5.14-1
--   Add haproxy v1.5 package.
+* Wed Feb 22 2023 Sumedh Sharma <sumsharma@microsoft.com> - 2.4.22-1
+- Update to patch version 2.4.22 to fix CVE-2023-25725
+
+* Thu Feb 24 2022 Minghe Ren <mingheren@microsoft.com> - 2.4.13-1
+- Update to 2.4.13
+- License verified
+- Add nopatch for CVE-2022-0711
+
+* Thu Jun 04 2020 Ruying Chen <v-ruyche@microsoft.com> - 2.1.5-1
+- Update to 2.1.5
+
+* Tue May 19 2020 Nicolas Ontiveros <niontive@microsoft.com> - 1.9.6-5
+- Fix CVE-2019-14241.
+- Fix CVE-2020-11100.
+
+* Sat May 09 2020 Nick Samson <nisamson@microsoft.com> - 1.9.6-4
+- Added %%license line automatically
+
+* Tue Apr 21 2020 Nicolas Ontiveros <niontive@microsoft.com> - 1.9.6-3
+- Fix CVE-2019-19330.
+- Remove sha1 macro.
+
+* Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> - 1.9.6-2
+- Initial CBL-Mariner import from Photon (license: Apache2).
+
+* Tue Apr 2 2019 Priyesh Padmavilasom <ppadmavilasom@vmware.com> - 1.9.6-1
+- Update to 1.9.6
+
+* Thu Feb 28 2019 Priyesh Padmavilasom <ppadmavilasom@vmware.com> - 1.8.14-2
+- Patch for CVE_2018_20102
+- Patch for CVE_2018_20103
+
+* Tue Dec 04 2018 Ajay Kaher <akaher@vmware.com> - 1.8.14-1
+- Update to version 1.8.14
+
+* Thu Oct 25 2018 Srivatsa S. Bhat (VMware) <srivatsa@csail.mit.edu> - 1.8.13-2
+- Build with USE_SYSTEMD=1 to fix service startup.
+
+* Wed Sep 12 2018 Anish Swaminathan <anishs@vmware.com> - 1.8.13-1
+- Update to version 1.8.13
+
+* Tue Apr 04 2017 Dheeraj Shetty <dheerajs@vmware.com> - 1.6.12-1
+- Updated to version 1.6.12
+
+* Sun Nov 27 2016 Vinay Kulkarni <kulkarniv@vmware.com> - 1.6.10-1
+- Upgrade to 1.6.10 to address CVE-2016-5360
+
+* Tue May 24 2016 Priyesh Padmavilasom <ppadmavilasom@vmware.com> - 1.6.3-3
+- GA - Bump release of all rpms
+
+* Fri May 20 2016 Xiaolin Li <xiaolinl@vmware.com> - 1.6.3-2
+- Add haproxy-systemd-wrapper to package, add a default configuration file.
+
+* Mon Feb 22 2016 Xiaolin Li <xiaolinl@vmware.com> - 1.6.3-1
+- Updated to version 1.6.3
+
+* Thu Oct 01 2015 Vinay Kulkarni <kulkarniv@vmware.com> - 1.5.14-1
+- Add haproxy v1.5 package.

--- a/SPECS/haproxy/haproxy.spec
+++ b/SPECS/haproxy/haproxy.spec
@@ -60,7 +60,7 @@ install -vDm644 examples/transparent_proxy.cfg  %{buildroot}/%{_sysconfdir}/hapr
 
 %changelog
 * Wed Feb 22 2023 Sumedh Sharma <sumsharma@microsoft.com> - 2.4.22-1
-- Update to patch version 2.4.22 to fix CVE-2023-25725
+- Update to 2.4.22 to fix CVE-2023-25725
 
 * Thu Feb 24 2022 Minghe Ren <mingheren@microsoft.com> - 2.4.13-1
 - Update to 2.4.13

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -4890,8 +4890,8 @@
         "type": "other",
         "other": {
           "name": "haproxy",
-          "version": "2.4.13",
-          "downloadUrl": "http://www.haproxy.org/download/2.4/src/haproxy-2.4.13.tar.gz"
+          "version": "2.4.22",
+          "downloadUrl": "http://www.haproxy.org/download/2.4/src/haproxy-2.4.22.tar.gz"
         }
       }
     },


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
Bump package version to 2.4.22 to patch CVE-2023-25725

Reference:
Upstream: https://github.com/haproxy/haproxy/commit/a8598a2eb11b6c989e81f0dbf10be361782e8d32
Release Note: https://git.haproxy.org/?p=haproxy-2.4.git;a=log;h=refs/tags/v2.4.22

###### Change Log  <!-- REQUIRED -->
- Bump version to 2.4.22
- Lint spec

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Associated issues  <!-- optional -->
NA

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2023-25725

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: Buddy Build
                              [AMD64](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=314554)
                              [ARM64](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=314555)
