### PR TITLE
Documentation for CGroup toggle in toolkit/docs/formats/imageconfig.md to generate Mariner images with cgroupv2

### DIFF
--- a/toolkit/docs/formats/imageconfig.md
+++ b/toolkit/docs/formats/imageconfig.md
@@ -337,6 +337,11 @@ The Security Enhanced Linux (SELinux) feature is enabled by using the `SELinux` 
 This will instruct init (systemd) to set the configured mode on boot.  The `force_enforcing` option will set enforcing in the config and also add `enforcing=1` in the kernel command line,
 which is a higher precedent than the config file. This ensures SELinux boots in enforcing even if the /etc/selinux/config was altered.
 
+The version for CGroup in Mariner images can be enabled by using the `CGroup` key with value containing which version to use on boot. The value that can be chosen is either `version_one` or `version_two`. 
+The `version_two` value will set the cgroupv2 to be used in Mariner by setting the config value `systemd.unified_cgroup_hierarchy=1` in /boot/systemd.cfg. The value `version_one` or no value set will keep
+cgroupv1 (current default) to be enabled on boot. This KernelCommandLine option can be used to quickly generate Mariner images (including marketplace) with cgroupv2 enabled to fulfill customer needs.
+For more information about cgroups, see [About cgroupv2](https://kubernetes.io/docs/concepts/architecture/cgroups/).
+
 A sample KernelCommandLine enabling a basic IMA mode and passing two additional parameters:
 
 ``` json
@@ -351,6 +356,14 @@ A sample KernelCommandLine enabling SELinux and booting in enforcing mode:
 ``` json
 "KernelCommandLine": {
     "SELinux": "enforcing"
+},
+```
+
+A sample KernelCommandLine enabling CGroup and booting with cgroupv2 enabled:
+
+``` json
+"KernelCommandLine": {
+    "CGroup": "version_two"
 },
 ```
 

--- a/toolkit/docs/formats/imageconfig.md
+++ b/toolkit/docs/formats/imageconfig.md
@@ -338,9 +338,8 @@ This will instruct init (systemd) to set the configured mode on boot.  The `forc
 which is a higher precedent than the config file. This ensures SELinux boots in enforcing even if the /etc/selinux/config was altered.
 
 The version for CGroup in Mariner images can be enabled by using the `CGroup` key with value containing which version to use on boot. The value that can be chosen is either `version_one` or `version_two`. 
-The `version_two` value will set the cgroupv2 to be used in Mariner by setting the config value `systemd.unified_cgroup_hierarchy=1` in /boot/systemd.cfg. The value `version_one` or no value set will keep
-cgroupv1 (current default) to be enabled on boot. This KernelCommandLine option can be used to quickly generate Mariner images (including marketplace) with cgroupv2 enabled to fulfill customer needs.
-For more information about cgroups, see [About cgroupv2](https://kubernetes.io/docs/concepts/architecture/cgroups/).
+The `version_two` value will set the cgroupv2 to be used in Mariner by setting the config value `systemd.unified_cgroup_hierarchy=1` in the default kernel command line. The value `version_one` or no value set will keep cgroupv1 (current default) to be enabled on boot.
+For more information about cgroups with Kubernetes, see [About cgroupv2](https://kubernetes.io/docs/concepts/architecture/cgroups/).
 
 A sample KernelCommandLine enabling a basic IMA mode and passing two additional parameters:
 


### PR DESCRIPTION
This PR adds basic documentation related to using the `CGroup` key with its associated values to enable cgroupv2 in Mariner images on boot. The CGroup key is used in the KernelCommandLine options to enable either version one (default) or version two, which triggers the systemd.cfg file to use a config value of `systemd.unified_cgroup_hierarchy=1` on boot. 