### PR TITLE
Enable adb-generic-tools in mstflint build config

### DIFF
--- a/SPECS/mstflint/mstflint.spec
+++ b/SPECS/mstflint/mstflint.spec
@@ -59,7 +59,7 @@ find %{buildroot} -type f -name '*.a' -delete
 
 %changelog
 * Thu Feb 23 2023 Elaheh Dehghani <edehghani@microsoft.com> - 4.21.0-3
-- Enabled 'adb-generic-tools' in build config (license: MIT)
+- Enabled 'adb-generic-tools' in build config.
 
 * Tue Aug 30 2022 Zhichun Wan <zhichunwan@microsoft.com> - 4.21.0-2
 - Initial CBL-Mariner import from Fedora 37 (license: MIT)

--- a/SPECS/mstflint/mstflint.spec
+++ b/SPECS/mstflint/mstflint.spec
@@ -1,7 +1,7 @@
 Summary:        Mellanox firmware burning tool
 Name:           mstflint
 Version:        4.21.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        GPLv2 OR BSD
 Vendor:         Microsoft Corporation
 Distribution:   Mariner

--- a/SPECS/mstflint/mstflint.spec
+++ b/SPECS/mstflint/mstflint.spec
@@ -37,7 +37,7 @@ find . -type f -iname '*.cpp' -exec chmod a-x '{}' ';'
 
 %build
 ./autogen.sh
-%configure --enable-fw-mgr
+%configure --enable-fw-mgr --enable-adb-generic-tools
 %make_build
 
 %install
@@ -58,6 +58,9 @@ find %{buildroot} -type f -name '*.a' -delete
 %{_mandir}/man1/*
 
 %changelog
+* Thu Feb 23 2023 Elaheh Dehghani <edehghani@microsoft.com> - 4.21.0-3
+- Enabled 'adb-generic-tools' in build config (license: MIT)
+
 * Tue Aug 30 2022 Zhichun Wan <zhichunwan@microsoft.com> - 4.21.0-2
 - Initial CBL-Mariner import from Fedora 37 (license: MIT)
 - Removed Obsoletes


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
This PR enables adb-generic-tools for mstflint's build config which results into compiling the following tools: mstreg and mstlink. This config flag was requested by Nvidia.


###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Built with RUN_CHECK=y
- Installed the mstflint rpm package using tdnf on Mariner2.0 successfully