### PR TITLE
Add nopatch for qt5-qtbase cve CVE-2023-25193

### DIFF
--- a/SPECS/qt5-qtbase/CVE-2023-25193.nopatch
+++ b/SPECS/qt5-qtbase/CVE-2023-25193.nopatch
@@ -1,0 +1,23 @@
+The CVE-2023-25193 vulnerability is in package 'harfbuzz'
+Reference: https://nvd.nist.gov/vuln/detail/CVE-2023-25193
+
+The qt5-qtbase sources have vendored code of harfbuzz under 'src/3rdparty'
+(a) src/3rdparty/harfbuzz-ng - Version 1.7.4
+    qt configuration option "-qt-harfbuzz" is used to link statically to the harfbuzz library
+    which is bundled in your QT version. Sources are present under harfbuzz-ng
+    ( Source: https://doc.qt.io/qt-5/qtgui-attribution-harfbuzz-ng.html )
+   
+(b) src/3rdparty/harfbuzz
+    This compiled sources correspond to harfbuzz-old.
+    ( Source: https://github.com/harfbuzz/harfbuzz-old )
+
+The current build configuration links againt system harfbuzz library (-system-harfbuzz).
+The system harfbuzz sources have been patched for this CVE.
+
+Also, the vendored harfbuzz versions are very old. The system harfbuzz version has had lot of
+file restructuring and code refactoring. Hence, applying or creating a patch to fix CVE-2023-25193
+is not feasible in the vendored sources.
+
+Additional links:
+Regarding harfbuzz-ng and harfbuzz-old
+( https://harfbuzz.github.io/ )

--- a/SPECS/qt5-qtbase/qt5-qtbase.spec
+++ b/SPECS/qt5-qtbase/qt5-qtbase.spec
@@ -33,7 +33,7 @@
 Name:         qt5-qtbase
 Summary:      Qt5 - QtBase components
 Version:      5.12.11
-Release:      4%{?dist}
+Release:      5%{?dist}
 # See LICENSE.GPL3-EXCEPT.txt, for exception details
 License:      GFDL AND LGPLv3 AND GPLv2 AND GPLv3 with exceptions AND QT License Agreement 4.0
 Vendor:       Microsoft Corporation
@@ -737,6 +737,9 @@ fi
 %{_qt5_libdir}/cmake/Qt5Gui/Qt5Gui_QXdgDesktopPortalThemePlugin.cmake
 
 %changelog
+* Fri Feb 24 2023 Sumedh Sharma <sumsharma@microsoft.com> - 5.12.11-5
+- Patch CVE-2023-25193
+
 * Mon Nov 28 2022 Suresh Babu Chalamalasetty <schalam@microsoft.com> - 5.12.11-4
 - Update source download path and remove recommends mesa-dri-drivers for gui sub package.
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
Add nopatch for CVE-2023-25193 since the vendored harfbuzz code in package sources are very old for a patch to be applied or created from the system harfbuzz source version.

###### Change Log  <!-- REQUIRED -->
- Add nopatch for CVE-2023-25193

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Associated issues  <!-- optional -->
NA

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2023-25193

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: Buddy Build
                              [AMD64](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=315809)
                              [ARM64](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=315810)
