### PR TITLE
Upgrade telegraf to 1.25.2 to fix several vendored CVEs

### DIFF
--- a/SPECS/telegraf/telegraf.signatures.json
+++ b/SPECS/telegraf/telegraf.signatures.json
@@ -1,6 +1,6 @@
 {
  "Signatures": {
   "telegraf-1.25.2.tar.gz": "e7038dc5be123a7e8906100d48f145d806030dafbcdb4dbd52f0343b6d1837e0",
-  "telegraf-vendor-1.25.2.tar.gz": "1ed2944aa65471e7ce539bc30c23d4aaeef05e73ffb6eab6a266f788fe8444b8"
+  "telegraf-1.25.2-vendor.tar.gz": "1ed2944aa65471e7ce539bc30c23d4aaeef05e73ffb6eab6a266f788fe8444b8"
  }
 }

--- a/SPECS/telegraf/telegraf.signatures.json
+++ b/SPECS/telegraf/telegraf.signatures.json
@@ -1,6 +1,6 @@
 {
  "Signatures": {
-  "telegraf-1.23.0.tar.gz": "097f0ae89332dd55c121dbb6b5f81b151a0f0418c11d26b430b33be31ca90d0b",
-  "telegraf-vendor-1.23.0.tar.gz": "f872b6b6c0ae1d6617ce3e1b4055afe07c5fa8a55a0bf3e55d6ba63a05837503"
+  "telegraf-1.25.2.tar.gz": "e7038dc5be123a7e8906100d48f145d806030dafbcdb4dbd52f0343b6d1837e0",
+  "telegraf-vendor-1.25.2.tar.gz": "1ed2944aa65471e7ce539bc30c23d4aaeef05e73ffb6eab6a266f788fe8444b8"
  }
 }

--- a/SPECS/telegraf/telegraf.spec
+++ b/SPECS/telegraf/telegraf.spec
@@ -1,7 +1,7 @@
 Summary:        agent for collecting, processing, aggregating, and writing metrics.
 Name:           telegraf
-Version:        1.23.0
-Release:        6%{?dist}
+Version:        1.25.2
+Release:        1%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -9,7 +9,7 @@ Group:          Development/Tools
 URL:            https://github.com/influxdata/telegraf
 #Source0:       %{url}/archive/v%{version}.tar.gz
 Source0:        %{name}-%{version}.tar.gz
-Source1:        %{name}-vendor-%{version}.tar.gz
+Source1:        %{name}-%{version}-vendor.tar.gz
 # Below is a manually created tarball, no download link.
 # We're using pre-populated Go modules from this tarball, since network is disabled during build time.
 # How to re-build this file:
@@ -90,6 +90,11 @@ fi
 %dir %{_sysconfdir}/%{name}/telegraf.d
 
 %changelog
+* Fri Feb 24 2023 Olivia Crain <oliviacrain@microsoft.com> - 1.25.2-1
+- Upgrade to latest upstream version to fix the following CVEs in vendored packages:
+  CVE-2019-3826, CVE-2022-1996, CVE-2022-29190, CVE-2022-29222, CVE-2022-29189, 
+  CVE-2022-32149, CVE-2022-23471
+
 * Fri Feb 03 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 1.23.0-6
 - Bump release to rebuild with go 1.19.5
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -27267,8 +27267,8 @@
         "type": "other",
         "other": {
           "name": "telegraf",
-          "version": "1.23.0",
-          "downloadUrl": "https://github.com/influxdata/telegraf/archive/v1.23.0.tar.gz"
+          "version": "1.25.2",
+          "downloadUrl": "https://github.com/influxdata/telegraf/archive/v1.25.2.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Upgrade telegraf to 1.25.2 to fix several CVEs in vendored components and support customer requirements.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Upgrade to latest upstream version to fix the following CVEs in vendored packages:
    CVE-2019-3826, CVE-2022-1996, CVE-2022-29190, CVE-2022-29222, CVE-2022-29189, 
    CVE-2022-32149, CVE-2022-23471

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
https://nvd.nist.gov/vuln/detail/CVE-2019-3826
https://nvd.nist.gov/vuln/detail/CVE-2022-1996
https://nvd.nist.gov/vuln/detail/CVE-2022-29190
https://nvd.nist.gov/vuln/detail/CVE-2022-29222
https://nvd.nist.gov/vuln/detail/CVE-2022-29189
https://nvd.nist.gov/vuln/detail/CVE-2022-32149
https://nvd.nist.gov/vuln/detail/CVE-2022-23471

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- [Test build for amd64, arm64](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=316276&view=logs&j=5efef3f1-f455-5449-a69c-2b662ccf0c63)
