### PR TITLE
Pull build and CVE fixes to 2.0 - cyrus-sasl, haproxy, python-werkzeug, telegraf

### DIFF
--- a/SPECS/cyrus-sasl-bootstrap/cyrus-sasl-bootstrap.spec
+++ b/SPECS/cyrus-sasl-bootstrap/cyrus-sasl-bootstrap.spec
@@ -5,7 +5,7 @@
 Summary:        Cyrus Simple Authentication Service Layer (SASL) library
 Name:           %{_base_name}-bootstrap
 Version:        2.1.28
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        BSD with advertising
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -25,7 +25,6 @@ Requires:       openssl
 Requires:       pam
 Requires:       systemd
 Requires:       libdb
-AutoProv:       no
 
 %description
 The Cyrus SASL package contains a Simple Authentication and Security
@@ -42,7 +41,6 @@ Summary:        Files needed for developing applications with Cyrus SASL
 Requires:       %{name} = %{version}-%{release}
 Requires:       %{name}-lib = %{version}-%{release}
 Requires:       pkg-config
-AutoProv:       no
 
 %description devel
 The %{name}-devel package contains files needed for developing and
@@ -50,7 +48,6 @@ compiling applications which use the Cyrus SASL library.
 
 %package lib
 Summary:        Shared libraries needed by applications which use Cyrus SASL
-AutoProv:       no
 
 %description lib
 The %{name}-lib package contains shared libraries which are needed by
@@ -195,6 +192,9 @@ make %{?_smp_mflags} check
 %exclude %{_plugindir2}/libsql.so.%{_soversion}*
 
 %changelog
+* Mon Feb 27 2023 Cameron Baird <cameronbaird@microsoft.com> - 2.1.28-4
+- Remove AutoProv no to address build issues in openldap
+
 * Thu Feb 23 2023 Saul Paredes <saulparedes@microsoft.com> - 2.1.28-3
 - Bump release to solve dependency issue
 

--- a/SPECS/cyrus-sasl/cyrus-sasl.spec
+++ b/SPECS/cyrus-sasl/cyrus-sasl.spec
@@ -4,7 +4,7 @@
 Summary:        Cyrus Simple Authentication Service Layer (SASL) library
 Name:           cyrus-sasl
 Version:        2.1.28
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        BSD with advertising
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -30,7 +30,7 @@ Requires:       pam
 Requires:       systemd
 Requires:       libdb
 
-Obsoletes:      %{name}-bootstrap
+Obsoletes:      %{name}-bootstrap <= %{version}-%{release}
 
 %description
 The Cyrus SASL package contains a Simple Authentication and Security
@@ -47,7 +47,7 @@ Summary:        Files needed for developing applications with Cyrus SASL
 Requires:       %{name} = %{version}-%{release}
 Requires:       %{name}-lib = %{version}-%{release}
 Requires:       pkg-config
-Obsoletes:      %{name}-bootstrap-devel
+Obsoletes:      %{name}-bootstrap-devel <= %{version}-%{release}
 
 %description devel
 The %{name}-devel package contains files needed for developing and
@@ -83,6 +83,7 @@ a directory server, accessed using LDAP, for storing shared secrets.
 
 %package lib
 Summary:        Shared libraries needed by applications which use Cyrus SASL
+Obsoletes:      %{name}-bootstrap-lib <= %{version}-%{release}
 
 %description lib
 The %{name}-lib package contains shared libraries which are needed by
@@ -92,7 +93,6 @@ applications which use the Cyrus SASL library.
 Summary:        CRAM-MD5 and DIGEST-MD5 authentication support for Cyrus SASL
 
 Requires:       %{name}-lib = %{version}-%{release}
-Obsoletes:      %{name}-bootstrap-lib
 
 %description md5
 The %{name}-md5 package contains the Cyrus SASL plugins which support
@@ -310,6 +310,10 @@ make %{?_smp_mflags} check
 %{_plugindir2}/libsql.so.%{_soversion}*
 
 %changelog
+* Mon Feb 27 2023 Cameron Baird <cameronbaird@microsoft.com> - 2.1.28-4
+- Fix Obsoletes happening in md5 subpackage when it should be lib.
+- Gate cyrus-sasl obsoletes by pkg version/rel
+
 * Thu Feb 23 2023 Saul Paredes <saulparedes@microsoft.com> - 2.1.28-3
 - Bump release to solve dependency issue
 

--- a/SPECS/haproxy/haproxy.signatures.json
+++ b/SPECS/haproxy/haproxy.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "haproxy-2.4.13.tar.gz": "4788fe975fe7e521746f826c25e80bc95cd15983e2bafa33e43bff23a3fe5ba1"
+  "haproxy-2.4.22.tar.gz": "0895340b36b704a1dbb25fea3bbaee5ff606399d6943486ebd7f256fee846d3a"
  }
 }

--- a/SPECS/haproxy/haproxy.spec
+++ b/SPECS/haproxy/haproxy.spec
@@ -1,19 +1,19 @@
 Summary:        A fast, reliable HA, load balancing, and proxy solution.
 Name:           haproxy
-Version:        2.4.13
+Version:        2.4.22
 Release:        1%{?dist}
 License:        GPLv2+
-URL:            http://www.haproxy.org
-Group:          Applications/System
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
+Group:          Applications/System
+URL:            https://www.haproxy.org
 Source0:        http://www.haproxy.org/download/2.4/src/%{name}-%{version}.tar.gz
+BuildRequires:  lua-devel
 BuildRequires:  openssl-devel
 BuildRequires:  pcre-devel
-BuildRequires:  lua-devel
 BuildRequires:  pkg-config
-BuildRequires:  zlib-devel
 BuildRequires:  systemd-devel
+BuildRequires:  zlib-devel
 Requires:       systemd
 
 %description
@@ -23,6 +23,7 @@ for very high traffic web-sites.
 
 %package        doc
 Summary:        Documentation for haproxy
+
 %description    doc
 It contains the documentation and manpages for haproxy package.
 Requires:       %{name} = %{version}-%{release}
@@ -42,7 +43,7 @@ sed -i "s/192.168.1.22/127.0.0.0/g" examples/transparent_proxy.cfg
 [ %{buildroot} != "/"] && rm -rf %{buildroot}/*
 make DESTDIR=%{buildroot} PREFIX=%{_prefix} DOCDIR=%{_docdir}/haproxy TARGET=linux2628 install
 install -vDm755 admin/systemd/haproxy.service \
-       %{buildroot}/usr/lib/systemd/system/haproxy.service
+       %{buildroot}%{_libdir}/systemd/system/haproxy.service
 install -vDm644 examples/transparent_proxy.cfg  %{buildroot}/%{_sysconfdir}/haproxy/haproxy.cfg
 
 %files
@@ -58,42 +59,61 @@ install -vDm644 examples/transparent_proxy.cfg  %{buildroot}/%{_sysconfdir}/hapr
 %{_mandir}/*
 
 %changelog
-*   Thu Feb 24 2022 Minghe Ren <mingheren@microsoft.com> 2.4.13-1
--   Update to 2.4.13
--   License verified
--   Add nopatch for CVE-2022-0711
-*   Thu Jun 04 2020 Ruying Chen <v-ruyche@microsoft.com> 2.1.5-1
--   Update to 2.1.5
-*   Tue May 19 2020 Nicolas Ontiveros <niontive@microsoft.com> 1.9.6-5
--   Fix CVE-2019-14241.
--   Fix CVE-2020-11100.
-*   Sat May 09 2020 Nick Samson <nisamson@microsoft.com> 1.9.6-4
--   Added %%license line automatically
-*   Tue Apr 21 2020 Nicolas Ontiveros <niontive@microsoft.com> 1.9.6-3
--   Fix CVE-2019-19330.
--   Remove sha1 macro.
-*   Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 1.9.6-2
--   Initial CBL-Mariner import from Photon (license: Apache2).
-*   Tue Apr 2 2019 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 1.9.6-1
--   Update to 1.9.6
-*   Thu Feb 28 2019 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 1.8.14-2
--   Patch for CVE_2018_20102
--   Patch for CVE_2018_20103
-*   Tue Dec 04 2018 Ajay Kaher <akaher@vmware.com> 1.8.14-1
--   Update to version 1.8.14
-*   Thu Oct 25 2018 Srivatsa S. Bhat (VMware) <srivatsa@csail.mit.edu> 1.8.13-2
--   Build with USE_SYSTEMD=1 to fix service startup.
-*   Wed Sep 12 2018 Anish Swaminathan <anishs@vmware.com> 1.8.13-1
--   Update to version 1.8.13
-*   Tue Apr 04 2017 Dheeraj Shetty <dheerajs@vmware.com> 1.6.12-1
--   Updated to version 1.6.12
-*   Sun Nov 27 2016 Vinay Kulkarni <kulkarniv@vmware.com> 1.6.10-1
--   Upgrade to 1.6.10 to address CVE-2016-5360
-*   Tue May 24 2016 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 1.6.3-3
--   GA - Bump release of all rpms
-*   Fri May 20 2016 Xiaolin Li <xiaolinl@vmware.com> 1.6.3-2
--   Add haproxy-systemd-wrapper to package, add a default configuration file.
-*   Mon Feb 22 2016 Xiaolin Li <xiaolinl@vmware.com> 1.6.3-1
--   Updated to version 1.6.3
-*   Thu Oct 01 2015 Vinay Kulkarni <kulkarniv@vmware.com> 1.5.14-1
--   Add haproxy v1.5 package.
+* Wed Feb 22 2023 Sumedh Sharma <sumsharma@microsoft.com> - 2.4.22-1
+- Update to 2.4.22 to fix CVE-2023-25725
+
+* Thu Feb 24 2022 Minghe Ren <mingheren@microsoft.com> - 2.4.13-1
+- Update to 2.4.13
+- License verified
+- Add nopatch for CVE-2022-0711
+
+* Thu Jun 04 2020 Ruying Chen <v-ruyche@microsoft.com> - 2.1.5-1
+- Update to 2.1.5
+
+* Tue May 19 2020 Nicolas Ontiveros <niontive@microsoft.com> - 1.9.6-5
+- Fix CVE-2019-14241.
+- Fix CVE-2020-11100.
+
+* Sat May 09 2020 Nick Samson <nisamson@microsoft.com> - 1.9.6-4
+- Added %%license line automatically
+
+* Tue Apr 21 2020 Nicolas Ontiveros <niontive@microsoft.com> - 1.9.6-3
+- Fix CVE-2019-19330.
+- Remove sha1 macro.
+
+* Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> - 1.9.6-2
+- Initial CBL-Mariner import from Photon (license: Apache2).
+
+* Tue Apr 2 2019 Priyesh Padmavilasom <ppadmavilasom@vmware.com> - 1.9.6-1
+- Update to 1.9.6
+
+* Thu Feb 28 2019 Priyesh Padmavilasom <ppadmavilasom@vmware.com> - 1.8.14-2
+- Patch for CVE_2018_20102
+- Patch for CVE_2018_20103
+
+* Tue Dec 04 2018 Ajay Kaher <akaher@vmware.com> - 1.8.14-1
+- Update to version 1.8.14
+
+* Thu Oct 25 2018 Srivatsa S. Bhat (VMware) <srivatsa@csail.mit.edu> - 1.8.13-2
+- Build with USE_SYSTEMD=1 to fix service startup.
+
+* Wed Sep 12 2018 Anish Swaminathan <anishs@vmware.com> - 1.8.13-1
+- Update to version 1.8.13
+
+* Tue Apr 04 2017 Dheeraj Shetty <dheerajs@vmware.com> - 1.6.12-1
+- Updated to version 1.6.12
+
+* Sun Nov 27 2016 Vinay Kulkarni <kulkarniv@vmware.com> - 1.6.10-1
+- Upgrade to 1.6.10 to address CVE-2016-5360
+
+* Tue May 24 2016 Priyesh Padmavilasom <ppadmavilasom@vmware.com> - 1.6.3-3
+- GA - Bump release of all rpms
+
+* Fri May 20 2016 Xiaolin Li <xiaolinl@vmware.com> - 1.6.3-2
+- Add haproxy-systemd-wrapper to package, add a default configuration file.
+
+* Mon Feb 22 2016 Xiaolin Li <xiaolinl@vmware.com> - 1.6.3-1
+- Updated to version 1.6.3
+
+* Thu Oct 01 2015 Vinay Kulkarni <kulkarniv@vmware.com> - 1.5.14-1
+- Add haproxy v1.5 package.

--- a/SPECS/python-werkzeug/python-werkzeug.spec
+++ b/SPECS/python-werkzeug/python-werkzeug.spec
@@ -31,7 +31,7 @@ Requires:       python3
 Werkzeug started as simple collection of various utilities for WSGI applications and has become one of the most advanced WSGI utility modules. It includes a powerful debugger, full featured request and response objects, HTTP utilities to handle entity tags, cache control headers, HTTP dates, cookie handling, file uploads, a powerful URL routing system and a bunch of community contributed addon modules.
 
 %prep
-%autosetup -n werkzeug-%{version}
+%autosetup -n werkzeug-%{version} -p1
 
 %build
 %py3_build

--- a/SPECS/telegraf/telegraf.signatures.json
+++ b/SPECS/telegraf/telegraf.signatures.json
@@ -1,6 +1,6 @@
 {
  "Signatures": {
-  "telegraf-1.23.0.tar.gz": "097f0ae89332dd55c121dbb6b5f81b151a0f0418c11d26b430b33be31ca90d0b",
-  "telegraf-vendor-1.23.0.tar.gz": "f872b6b6c0ae1d6617ce3e1b4055afe07c5fa8a55a0bf3e55d6ba63a05837503"
+  "telegraf-1.25.2.tar.gz": "e7038dc5be123a7e8906100d48f145d806030dafbcdb4dbd52f0343b6d1837e0",
+  "telegraf-1.25.2-vendor.tar.gz": "1ed2944aa65471e7ce539bc30c23d4aaeef05e73ffb6eab6a266f788fe8444b8"
  }
 }

--- a/SPECS/telegraf/telegraf.spec
+++ b/SPECS/telegraf/telegraf.spec
@@ -1,7 +1,7 @@
 Summary:        agent for collecting, processing, aggregating, and writing metrics.
 Name:           telegraf
-Version:        1.23.0
-Release:        6%{?dist}
+Version:        1.25.2
+Release:        1%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -9,7 +9,7 @@ Group:          Development/Tools
 URL:            https://github.com/influxdata/telegraf
 #Source0:       %{url}/archive/v%{version}.tar.gz
 Source0:        %{name}-%{version}.tar.gz
-Source1:        %{name}-vendor-%{version}.tar.gz
+Source1:        %{name}-%{version}-vendor.tar.gz
 # Below is a manually created tarball, no download link.
 # We're using pre-populated Go modules from this tarball, since network is disabled during build time.
 # How to re-build this file:
@@ -90,6 +90,11 @@ fi
 %dir %{_sysconfdir}/%{name}/telegraf.d
 
 %changelog
+* Fri Feb 24 2023 Olivia Crain <oliviacrain@microsoft.com> - 1.25.2-1
+- Upgrade to latest upstream version to fix the following CVEs in vendored packages:
+  CVE-2019-3826, CVE-2022-1996, CVE-2022-29190, CVE-2022-29222, CVE-2022-29189, 
+  CVE-2022-32149, CVE-2022-23471
+
 * Fri Feb 03 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 1.23.0-6
 - Bump release to rebuild with go 1.19.5
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -27197,8 +27197,8 @@
         "type": "other",
         "other": {
           "name": "telegraf",
-          "version": "1.23.0",
-          "downloadUrl": "https://github.com/influxdata/telegraf/archive/v1.23.0.tar.gz"
+          "version": "1.25.2",
+          "downloadUrl": "https://github.com/influxdata/telegraf/archive/v1.25.2.tar.gz"
         }
       }
     },

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -4870,8 +4870,8 @@
         "type": "other",
         "other": {
           "name": "haproxy",
-          "version": "2.4.13",
-          "downloadUrl": "http://www.haproxy.org/download/2.4/src/haproxy-2.4.13.tar.gz"
+          "version": "2.4.22",
+          "downloadUrl": "http://www.haproxy.org/download/2.4/src/haproxy-2.4.22.tar.gz"
         }
       }
     },


### PR DESCRIPTION
Pull fixes to 2.0:

Upgrade telegraf to 1.25.2 to fix several vendored CVEs (#4921)
fix python-werkzeug CVE build failure (#4961)
Move -lib obsoletes to correct subpackage and remove AutoProv: No in cyrus-sasl-bootstrap to address build break (#4957)
Bump haproxy version to 2.4.22 for CVE-2023-25725 (#4905)
