### PR TITLE
Re-adding protobuf java subpackage and adding check section 

### DIFF
--- a/SPECS/mariner-rpm-macros/macros.python3
+++ b/SPECS/mariner-rpm-macros/macros.python3
@@ -50,6 +50,11 @@
   rm -rfv %{buildroot}%{_bindir}/__pycache__
 }
 
+%py3_check() %{expand:\\\
+  CFLAGS="${CFLAGS:-${RPM_OPT_FLAGS}}" LDFLAGS="${LDFLAGS:-${RPM_LD_FLAGS}}"\\\
+  %{__python3} %{py_setup} %{?py_setup_args} test --executable="%{__python3} %{py3_shbang_opts}" %{?*}
+}
+
 # This only supports Python 3.5+ and will never work with Python 2.
 # Hence, it has no Python version in the name.
 %pycached() %{lua:

--- a/SPECS/mariner-rpm-macros/mariner-rpm-macros.signatures.json
+++ b/SPECS/mariner-rpm-macros/mariner-rpm-macros.signatures.json
@@ -23,7 +23,7 @@
   "macros.pybytecompile": "4adea0fca2118af964997d0bf9932a28f3148ea72323fb161c1fb3bd6e2a8bdb",
   "macros.python": "791e0b9070d49790ef437d89e541287ce305d8e424afe42dafdab89f59106362",
   "macros.python-srpm": "34876cbf3bae90136bec7b36f75ed590d251c47c123faddf700a963aaa9a2c14",
-  "macros.python3": "b5a82a6bdfa40cd481c5139c957b95d0b126ff108cc964432d0b6b90972b743b",
+  "macros.python3": "556e35a8c46bac6719ff9516d579e232055e6a37aa89e5a60c03063384554907",
   "macros.rust-srpm": "ea69ab49a243c44ab75cfe506ba5d73046bf31e561698cc389ad5b4edb82f2b2",
   "macros.suse": "7cd64820e12a37fb22f3b09e4c5184b1f9eac94acbeea2783b1ec4940248e310",
   "pythondist.attr": "9162c91b09e01bc0c9c2e8b730424eda11ca4de35304434353dc3c8d9469419d",

--- a/SPECS/mariner-rpm-macros/mariner-rpm-macros.spec
+++ b/SPECS/mariner-rpm-macros/mariner-rpm-macros.spec
@@ -6,7 +6,7 @@
 Summary:        Mariner specific rpm macro files
 Name:           mariner-rpm-macros
 Version:        2.0
-Release:        20%{?dist}
+Release:        21%{?dist}
 License:        GPL+ AND MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner

--- a/SPECS/protobuf/generate_source_tarball.sh
+++ b/SPECS/protobuf/generate_source_tarball.sh
@@ -94,7 +94,9 @@ echo "Vendor m.2 modules..."
 cd $NAME_VER
 cd java
 
-# This will download sources and compile
+# Unfortunately it is not possible to just run mvn dependency:go-offline as it does not download things reqires for specific targets.
+# So you would need to run all targets used in this spec file such as: "mvn package", "mvn install", "maven test" to download all dependecies.
+# This will download sources and compile code.
 mvn package -DskipTests
 mvn install -DskipTests
 mvn test

--- a/SPECS/protobuf/generate_source_tarball.sh
+++ b/SPECS/protobuf/generate_source_tarball.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# Quit on failure
+set -e
+
+PKG_VERSION=""
+SRC_TARBALL=""
+OUT_FOLDER="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# parameters:
+#
+# --srcTarball  : src tarball file
+#                 this file contains the 'initial' source code of the component
+#                 and should be replaced with the new/modified src code
+# --outFolder   : folder where to copy the new tarball(s)
+# --pkgVersion  : package version
+#
+PARAMS=""
+while (( "$#" )); do
+    case "$1" in
+        --srcTarball)
+        if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
+            SRC_TARBALL=$2
+            shift 2
+        else
+            echo "Error: Argument for $1 is missing" >&2
+            exit 1
+        fi
+        ;;
+        --outFolder)
+        if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
+            OUT_FOLDER=$2
+            shift 2
+        else
+            echo "Error: Argument for $1 is missing" >&2
+            exit 1
+        fi
+        ;;
+        --pkgVersion)
+        if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
+            PKG_VERSION=$2
+            shift 2
+        else
+            echo "Error: Argument for $1 is missing" >&2
+            exit 1
+        fi
+        ;;
+        -*|--*=) # unsupported flags
+        echo "Error: Unsupported flag $1" >&2
+        exit 1
+        ;;
+        *) # preserve positional arguments
+        PARAMS="$PARAMS $1"
+        shift
+        ;;
+  esac
+done
+
+echo "--srcTarball   -> $SRC_TARBALL"
+echo "--outFolder    -> $OUT_FOLDER"
+echo "--pkgVersion   -> $PKG_VERSION"
+
+if [ -z "$PKG_VERSION" ]; then
+    echo "--pkgVersion parameter cannot be empty"
+    exit 1
+fi
+
+sudo apt install -y maven protobuf-devel
+
+echo "-- create temp folder"
+tmpdir=$(mktemp -d)
+function cleanup {
+    echo "+++ cleanup -> remove $tmpdir"
+    rm -rf $tmpdir
+}
+trap cleanup EXIT
+
+TARBALL_FOLDER="$tmpdir/tarballFolder"
+mkdir -p $TARBALL_FOLDER
+cp $SRC_TARBALL $tmpdir
+
+pushd $tmpdir > /dev/null
+
+PKG_NAME="protobuf"
+NAME_VER="$PKG_NAME-$PKG_VERSION"
+VENDOR_TARBALL="$OUT_FOLDER/$NAME_VER-m2.tar.gz"
+
+echo "Unpacking source tarball..."
+tar -xf $SRC_TARBALL
+
+echo "Vendor m.2 modules..."
+cd $NAME_VER
+cd java
+
+# This will download sources and compile
+mvn package -DskipTests
+mvn install -DskipTests
+mvn test
+
+echo ""
+echo "========================="
+echo "Tar vendored tarball"
+pushd /root/.m2
+
+tar  --sort=name \
+     --mtime="2021-04-26 00:00Z" \
+     --owner=0 --group=0 --numeric-owner \
+     --pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime \
+     -cf "$VENDOR_TARBALL" repository
+
+popd > /dev/null
+
+popd > /dev/null
+echo "$PKG_NAME vendored modules are available at $VENDOR_TARBALL"

--- a/SPECS/protobuf/protobuf.signatures.json
+++ b/SPECS/protobuf/protobuf.signatures.json
@@ -1,5 +1,6 @@
 {
  "Signatures": {
-  "protobuf-all-3.17.3.tar.gz": "77ad26d3f65222fd96ccc18b055632b0bfedf295cb748b712a98ba1ac0b704b2"
+  "protobuf-all-3.17.3.tar.gz": "77ad26d3f65222fd96ccc18b055632b0bfedf295cb748b712a98ba1ac0b704b2",
+  "protobuf-3.17.3-m2.tar.gz": "cb8fb1b0f59fb96a0c19d8da624af452956bf8368108b6e79e446dbe36e2520a"
  }
 }

--- a/SPECS/protobuf/protobuf.spec
+++ b/SPECS/protobuf/protobuf.spec
@@ -11,20 +11,6 @@ Source0:        https://github.com/protocolbuffers/protobuf/releases/download/v%
 # Below is a manually created tarball, no download link.
 # We're using pre-populated maven modules and plugins from this tarball, since network is disabled during build time.
 # Use generate_source_tarbbal.sh to get this generated from a source code file.
-# Unfortunately it is not possible to just run mvn dependency:go-offline as it does not download things reqires for specific targets.
-# So you would need to run all targets used in this spec file such as: "mvn package", "mvn install", "maven test" to download all dependecies.
-# How to re-build this file:
-#   1. wget https://github.com/protocolbuffers/protobuf/releases/download/v%%{version}/%%{name}-all-%%{version}.tar.gz
-#   2. tar -xf %%{name}-%%{version}.tar.gz
-#   3. cd %%{name}-%%{version}
-#   4. mvm verify --fail-never
-#   5. cd /home/{user}/.m2
-#   5. tar  --sort=name \
-#           --mtime="2021-04-26 00:00Z" \
-#           --owner=0 --group=0 --numeric-owner \
-#           --pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime \
-#           -cf %%{name}-%%{version}-m2.tar.gz repository/
-#
 Source1:        %{name}-%{version}-m2.tar.gz
 BuildRequires:  curl
 BuildRequires:  libstdc++
@@ -79,7 +65,6 @@ BuildRequires:  maven
 BuildRequires:  msopenjdk-11
 Requires:       %{name} = %{version}-%{release}
 Requires:       msopenjdk-11
-Provides:       %{name}-java = %{version}-%{release}
 
 %description    java
 This contains protobuf java libraries.

--- a/SPECS/protobuf/protobuf.spec
+++ b/SPECS/protobuf/protobuf.spec
@@ -50,6 +50,9 @@ Requires:       python3
 Requires:       python3-libs
 Provides:       %{name}-python3 = %{version}-%{release}
 
+%description -n python3-%{name}
+This contains protobuf python3 libraries.
+
 %package -n     java-%{name}
 Summary:        protobuf java lib
 Group:          Development/Libraries
@@ -62,9 +65,6 @@ Provides:       %{name}-java = %{version}-%{release}
 
 %description    java
 This contains protobuf java package.
-
-%description -n python3-%{name}
-This contains protobuf python3 libraries.
 
 %prep
 %autosetup

--- a/SPECS/protobuf/protobuf.spec
+++ b/SPECS/protobuf/protobuf.spec
@@ -61,6 +61,7 @@ This contains protobuf python3 libraries.
 Summary:        protobuf java lib
 Group:          Development/Libraries
 BuildRequires:  chkconfig
+BuildRequires:  javapackages-local-bootstrap
 BuildRequires:  maven
 BuildRequires:  msopenjdk-11
 Requires:       %{name} = %{version}-%{release}
@@ -79,7 +80,7 @@ popd
 
 %build
 %configure --disable-silent-rules
-export JAVA_HOME=$(find %{_lib}/jvm -name "openjdk*")
+export JAVA_HOME=%{java_home}
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$(find $JAVA_HOME/lib -name "jli")
 %make_build
 
@@ -113,16 +114,18 @@ popd
 
 %check
 # run C++ unit tests
-%make_build check
+%make_build check || test_succeeded=false
 
 # run python subpackage tests
 cd python
-%py3_check
+%py3_check || test_succeeded=false
 cd ..
 
 # run java subpackage tests
 cd java
-mvn -o test
+mvn -o test || test_succeeded=false
+
+${test_succeeded:-true}
 
 %files
 %defattr(-,root,root)

--- a/SPECS/protobuf/protobuf.spec
+++ b/SPECS/protobuf/protobuf.spec
@@ -58,9 +58,9 @@ Summary:        protobuf java lib
 Group:          Development/Libraries
 Requires:       %{name} = %{version}-%{release}
 BuildRequires:  chkconfig
-BuildRequires:  temurin-8-jdk >= 8.0.362
+BuildRequires:  temurin-8-jdk >= 8.0.362.0.0.9
 BuildRequires:  maven >= 3.8.6
-Requires:       temurin-8-jdk >= 8.0.362
+Requires:       temurin-8-jdk >= 8.0.362.0.0.9
 Provides:       %{name}-java = %{version}-%{release}
 
 %description -n java-%{name}

--- a/SPECS/protobuf/protobuf.spec
+++ b/SPECS/protobuf/protobuf.spec
@@ -74,11 +74,11 @@ This contains protobuf python3 libraries.
 %package -n     java-%{name}
 Summary:        protobuf java lib
 Group:          Development/Libraries
-Requires:       %{name} = %{version}-%{release}
 BuildRequires:  chkconfig
-BuildRequires:  msopenjdk-11
 BuildRequires:  maven
 BuildRequires:  msopenjdk-11
+Requires:       msopenjdk-11
+Requires:       %{name} = %{version}-%{release}
 Provides:       %{name}-java = %{version}-%{release}
 
 %description -n java-%{name}
@@ -94,7 +94,7 @@ popd
 
 %build
 %configure --disable-silent-rules
-export JAVA_HOME=$(find /usr/lib/jvm -name "OpenJDK*")
+export JAVA_HOME=$(find %{_lib}/jvm -name "openjdk*")
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$(find $JAVA_HOME/lib -name "jli")
 %make_build
 

--- a/SPECS/protobuf/protobuf.spec
+++ b/SPECS/protobuf/protobuf.spec
@@ -77,8 +77,8 @@ Group:          Development/Libraries
 BuildRequires:  chkconfig
 BuildRequires:  maven
 BuildRequires:  msopenjdk-11
-Requires:       msopenjdk-11
 Requires:       %{name} = %{version}-%{release}
+Requires:       msopenjdk-11
 Provides:       %{name}-java = %{version}-%{release}
 
 %description -n java-%{name}

--- a/SPECS/protobuf/protobuf.spec
+++ b/SPECS/protobuf/protobuf.spec
@@ -58,9 +58,9 @@ Summary:        protobuf java lib
 Group:          Development/Libraries
 Requires:       %{name} = %{version}-%{release}
 BuildRequires:  chkconfig
-BuildRequires:  temurin-8-jdk >= 1.8.0.45
-BuildRequires:  maven >= 3.3.3
-Requires:       temurin-8-jdk >= 1.8.0.45
+BuildRequires:  temurin-8-jdk >= 8.0.362
+BuildRequires:  maven >= 3.8.6
+Requires:       temurin-8-jdk >= 8.0.362
 Provides:       %{name}-java = %{version}-%{release}
 
 %description    java

--- a/SPECS/protobuf/protobuf.spec
+++ b/SPECS/protobuf/protobuf.spec
@@ -71,7 +71,7 @@ Provides:       %{name}-python3 = %{version}-%{release}
 %description -n python3-%{name}
 This contains protobuf python3 libraries.
 
-%package -n     java-%{name}
+%package        java
 Summary:        protobuf java lib
 Group:          Development/Libraries
 BuildRequires:  chkconfig
@@ -162,7 +162,7 @@ mvn -o test
 %files -n python3-%{name}
 %{python3_sitelib}/*
 
-%files -n java-%{name}
+%files java
 %{_libdir}/java/protobuf/*.jar
 
 %changelog

--- a/SPECS/protobuf/protobuf.spec
+++ b/SPECS/protobuf/protobuf.spec
@@ -115,6 +115,11 @@ popd
 # run C++ unit tests
 %make_build check
 
+# run python subpackage tests
+cd python
+%py3_check
+cd ..
+
 # run java subpackage tests
 cd java
 mvn -o test

--- a/SPECS/protobuf/protobuf.spec
+++ b/SPECS/protobuf/protobuf.spec
@@ -81,8 +81,8 @@ Requires:       %{name} = %{version}-%{release}
 Requires:       msopenjdk-11
 Provides:       %{name}-java = %{version}-%{release}
 
-%description -n java-%{name}
-This contains protobuf java package.
+%description    java
+This contains protobuf java libraries.
 
 %prep
 %autosetup

--- a/SPECS/protobuf/protobuf.spec
+++ b/SPECS/protobuf/protobuf.spec
@@ -63,7 +63,7 @@ BuildRequires:  maven >= 3.8.6
 Requires:       temurin-8-jdk >= 8.0.362
 Provides:       %{name}-java = %{version}-%{release}
 
-%description    java
+%description -n java-%{name}
 This contains protobuf java package.
 
 %prep


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Adds back protobuf java subpackage, as it will be required for future packages such as Hadoop. As well as adds check section that runs built-in unit tests for the protobuf make and java subpackage.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Re-added back protobuf java subpackage. As it will be required for future packages such as Hadoop
- Added check sections that runs main make tests and also java subpackage tests

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local
- Pipeline build id: [Official pipeline build](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=318117&view=results)
