### PR TITLE
Fix package install error for buildah

### DIFF
--- a/SPECS-EXTENDED/buildah/buildah.spec
+++ b/SPECS-EXTENDED/buildah/buildah.spec
@@ -1,20 +1,11 @@
-Vendor:         Microsoft Corporation
-Distribution:   Mariner
 %global with_bundled 1
-
-
 %global with_debug 1
-
-
-
-
 %if 0%{?with_debug}
 %global _find_debuginfo_dwz_opts %{nil}
 %global _dwz_low_mem_die_limit 0
 %else
 %global debug_package   %{nil}
 %endif
-
 %global provider github
 %global provider_tld com
 %global project containers
@@ -22,53 +13,39 @@ Distribution:   Mariner
 # https://github.com/containers/buildah
 %global import_path %{provider}.%{provider_tld}/%{project}/%{repo}
 %global git0 https://%{import_path}
-
 # Used for comparing with latest upstream tag
 # to decide whether to autobuild (non-rawhide only)
 %define built_tag v1.18.0
 %define built_tag_strip %(b=%{built_tag}; echo ${b:1})
 %define download_url https://%{import_path}/archive/%{built_tag}.tar.gz
-
-Name: %{repo}
-Version: 1.18.0
-Release: 8%{?dist}
-Summary: A command line tool used for creating OCI Images
-License: ASL 2.0
-URL: https://%{name}.io
-Source: %{download_url}#/%{name}-%{version}.tar.gz
-BuildRequires: device-mapper-devel
-BuildRequires: golang
-BuildRequires: git
-BuildRequires: glib2-devel
-BuildRequires: glibc-static >= 2.35-3%{?dist}
-BuildRequires: go-md2man
-BuildRequires: go-rpm-macros
-BuildRequires: gpgme-devel
-BuildRequires: libassuan-devel
-BuildRequires: make
-Requires: containers-common
-# No ostree for centos 7
-
-BuildRequires: ostree-devel
-
-# No btrfs for centos 8
-
-BuildRequires: btrfs-progs-devel
-
-
-Requires: crun >= 0.10-1
-BuildRequires: libseccomp-static
-Recommends: container-selinux
-Requires: libseccomp >= 2.4.1-0
-Recommends: slirp4netns >= 0.3-0
-Recommends: fuse-overlayfs
-
-
-
-
-
-
-
+Summary:        A command line tool used for creating OCI Images
+Name:           %{repo}
+Version:        1.18.0
+Release:        9%{?dist}
+License:        ASL 2.0
+Vendor:         Microsoft Corporation
+Distribution:   Mariner
+URL:            https://%{name}.io
+Source:         %{download_url}#/%{name}-%{version}.tar.gz
+BuildRequires:  btrfs-progs-devel
+BuildRequires:  device-mapper-devel
+BuildRequires:  git
+BuildRequires:  glib2-devel
+BuildRequires:  glibc-static >= 2.35-3%{?dist}
+BuildRequires:  go-md2man
+BuildRequires:  go-rpm-macros
+BuildRequires:  golang
+BuildRequires:  gpgme-devel
+BuildRequires:  libassuan-devel
+BuildRequires:  libseccomp-static
+BuildRequires:  make
+BuildRequires:  ostree-devel
+Requires:       libcontainers-common
+Requires:       libseccomp >= 2.4.1-0
+Requires:       moby-runc
+Recommends:     container-selinux
+Recommends:     fuse-overlayfs
+Recommends:     slirp4netns >= 0.3-0
 
 %description
 The %{name} package provides a command line tool which can be used to
@@ -79,17 +56,16 @@ or
 * save container's root file system layer to create a new image
 * delete a working container or an image
 
-%package tests
-Summary: Tests for %{name}
-
-Requires: %{name} = %{version}-%{release}
-Requires: bats
-Requires: bzip2
-Requires: podman
-Requires: golang
-Requires: jq
-Requires: httpd-tools
-Requires: openssl
+%package  tests
+Summary:        Tests for %{name}
+Requires:       %{name} = %{version}-%{release}
+Requires:       bats
+Requires:       bzip2
+Requires:       golang
+Requires:       httpd-tools
+Requires:       jq
+Requires:       openssl
+Requires:       podman
 
 %description tests
 %{summary}
@@ -146,6 +122,9 @@ cp imgtype %{buildroot}/%{_bindir}/%{name}-imgtype
 %{_datadir}/%{name}/test
 
 %changelog
+* Tue Feb 28 2023 Sumedh Sharma <sumsharma@microsoft.com> - 1.18.0-9
+- Fix runtime requirements on libcontainers-common and moby-runc
+
 * Fri Feb 03 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 1.18.0-8
 - Bump release to rebuild with go 1.19.5
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
Fix buildah install error

###### Change Log  <!-- REQUIRED -->
- Change runtime dependency to libcontainers-common and moby-runc
- Lint spec

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Associated issues  <!-- optional -->
NA

###### Links to CVEs  <!-- optional -->
NA

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: Buddy Build
                              [AMD64](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=318252)
                              [ARM64](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=318253)
                               [NOTE: buildah srpm is built.
                                          The failure is due to "unresolved dependency" on runtime package podman.
                                          The reason is PMC has multiple podman versions. However, tdnf is unable to download
                                           version 2.2.1-5: "stderr: 1. nothing provides container-selinux needed by podman-2.2.1-5.cm2"]