### PR TITLE
Move -lib obsoletes to correct subpackage and remove AutoProv: No in cyrus-sasl-bootstrap to address build break

### DIFF
--- a/SPECS/cyrus-sasl-bootstrap/cyrus-sasl-bootstrap.spec
+++ b/SPECS/cyrus-sasl-bootstrap/cyrus-sasl-bootstrap.spec
@@ -5,7 +5,7 @@
 Summary:        Cyrus Simple Authentication Service Layer (SASL) library
 Name:           %{_base_name}-bootstrap
 Version:        2.1.28
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        BSD with advertising
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -25,7 +25,6 @@ Requires:       openssl
 Requires:       pam
 Requires:       systemd
 Requires:       libdb
-AutoProv:       no
 
 %description
 The Cyrus SASL package contains a Simple Authentication and Security
@@ -42,7 +41,6 @@ Summary:        Files needed for developing applications with Cyrus SASL
 Requires:       %{name} = %{version}-%{release}
 Requires:       %{name}-lib = %{version}-%{release}
 Requires:       pkg-config
-AutoProv:       no
 
 %description devel
 The %{name}-devel package contains files needed for developing and
@@ -50,7 +48,6 @@ compiling applications which use the Cyrus SASL library.
 
 %package lib
 Summary:        Shared libraries needed by applications which use Cyrus SASL
-AutoProv:       no
 
 %description lib
 The %{name}-lib package contains shared libraries which are needed by
@@ -195,6 +192,9 @@ make %{?_smp_mflags} check
 %exclude %{_plugindir2}/libsql.so.%{_soversion}*
 
 %changelog
+* Mon Feb 27 2023 Cameron Baird <cameronbaird@microsoft.com> - 2.1.28-4
+- Remove AutoProv no to address build issues in openldap
+
 * Thu Feb 23 2023 Saul Paredes <saulparedes@microsoft.com> - 2.1.28-3
 - Bump release to solve dependency issue
 

--- a/SPECS/cyrus-sasl/cyrus-sasl.spec
+++ b/SPECS/cyrus-sasl/cyrus-sasl.spec
@@ -4,7 +4,7 @@
 Summary:        Cyrus Simple Authentication Service Layer (SASL) library
 Name:           cyrus-sasl
 Version:        2.1.28
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        BSD with advertising
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -30,7 +30,7 @@ Requires:       pam
 Requires:       systemd
 Requires:       libdb
 
-Obsoletes:      %{name}-bootstrap
+Obsoletes:      %{name}-bootstrap <= %{version}-%{release}
 
 %description
 The Cyrus SASL package contains a Simple Authentication and Security
@@ -47,7 +47,7 @@ Summary:        Files needed for developing applications with Cyrus SASL
 Requires:       %{name} = %{version}-%{release}
 Requires:       %{name}-lib = %{version}-%{release}
 Requires:       pkg-config
-Obsoletes:      %{name}-bootstrap-devel
+Obsoletes:      %{name}-bootstrap-devel <= %{version}-%{release}
 
 %description devel
 The %{name}-devel package contains files needed for developing and
@@ -83,6 +83,7 @@ a directory server, accessed using LDAP, for storing shared secrets.
 
 %package lib
 Summary:        Shared libraries needed by applications which use Cyrus SASL
+Obsoletes:      %{name}-bootstrap-lib <= %{version}-%{release}
 
 %description lib
 The %{name}-lib package contains shared libraries which are needed by
@@ -92,7 +93,6 @@ applications which use the Cyrus SASL library.
 Summary:        CRAM-MD5 and DIGEST-MD5 authentication support for Cyrus SASL
 
 Requires:       %{name}-lib = %{version}-%{release}
-Obsoletes:      %{name}-bootstrap-lib
 
 %description md5
 The %{name}-md5 package contains the Cyrus SASL plugins which support
@@ -310,6 +310,10 @@ make %{?_smp_mflags} check
 %{_plugindir2}/libsql.so.%{_soversion}*
 
 %changelog
+* Mon Feb 27 2023 Cameron Baird <cameronbaird@microsoft.com> - 2.1.28-4
+- Fix Obsoletes happening in md5 subpackage when it should be lib.
+- Gate cyrus-sasl obsoletes by pkg version/rel
+
 * Thu Feb 23 2023 Saul Paredes <saulparedes@microsoft.com> - 2.1.28-3
 - Bump release to solve dependency issue
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Fixes several issues with the cyrus-sasl and bootstrap packages to address a build break. 

Found 5 problems
file /usr/lib/libsasl2.so.3.0.0 conflicts between attempted installs of cyrus-sasl-bootstrap-lib-2.1.28-3.cm2.x86_64 and cyrus-sasl-lib-2.1.28-2.cm2.x86_64
file /usr/lib/sasl2/libanonymous.so.3.0.0 conflicts between attempted installs of cyrus-sasl-bootstrap-lib-2.1.28-3.cm2.x86_64 and cyrus-sasl-lib-2.1.28-2.cm2.x86_64
file /usr/lib/sasl2/libsasldb.so.3.0.0 conflicts between attempted installs of cyrus-sasl-bootstrap-lib-2.1.28-3.cm2.x86_64 and cyrus-sasl-lib-2.1.28-2.cm2.x86_64
file /usr/sbin/sasldblistusers2 conflicts between attempted installs of cyrus-sasl-bootstrap-lib-2.1.28-3.cm2.x86_64 and cyrus-sasl-lib-2.1.28-2.cm2.x86_64
file /usr/sbin/saslpasswd2 conflicts between attempted installs of cyrus-sasl-bootstrap-lib-2.1.28-3.cm2.x86_64 and cyrus-sasl-lib-2.1.28-2.cm2.x86_64"

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- gate cyrus-sasl obsoletes by pkg version/rel
- Remove AutoProv: No in cyrus-sasl-bootstrap
- Move Obsoletes: lib line to cyrus-sasl-lib subpackage, was in md5 by mistake.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**


###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- https://dev.azure.com/mariner-org/mariner/_build/results?buildId=318109&view=results (failure unrelated to issue, openldap and cyrus-sasl both built)