### PR TITLE
gRPC: add python binding for gRPC (python3-grpcio) for aarch64

### DIFF
--- a/SPECS/grpc/grpc.spec
+++ b/SPECS/grpc/grpc.spec
@@ -1,7 +1,7 @@
 Summary:        Open source remote procedure call (RPC) framework
 Name:           grpc
 Version:        1.42.0
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -26,7 +26,6 @@ Requires:       protobuf
 Requires:       zlib
 
 # Python
-%ifarch x86_64
 BuildRequires:      build-essential
 BuildRequires:      python3-devel
 BuildRequires:      python3-Cython
@@ -34,7 +33,7 @@ BuildRequires:      python3-six
 BuildRequires:      python3-wheel
 BuildRequires:      python3-setuptools
 BuildRequires:      python3-protobuf
-%endif
+
 
 %description
 gRPC is a modern, open source, high-performance remote procedure call (RPC) framework that can run anywhere. It enables client and server applications to communicate transparently, and simplifies the building of connected systems.
@@ -93,26 +92,23 @@ pushd cmake/build
    -DgRPC_ZLIB_PROVIDER:STRING='package'
 %cmake_build 
 popd
-#python
-%ifarch x86_64
-   export GRPC_PYTHON_BUILD_WITH_CYTHON=True
-   export GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=True
-   export GRPC_PYTHON_BUILD_SYSTEM_ZLIB=True
-   export GRPC_PYTHON_BUILD_SYSTEM_CARES=True
-   export GRPC_PYTHON_BUILD_SYSTEM_RE2=True
-   export GRPC_PYTHON_BUILD_SYSTEM_ABSL=True
-   %py3_build
-%endif
+
 
 %install
 pushd cmake/build
 %cmake_install
 find %{buildroot} -name '*.cmake' -delete
 popd
+
 #python
-%ifarch x86_64
-   %py3_install
-%endif
+export GRPC_PYTHON_BUILD_WITH_CYTHON=True
+export GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=True
+export GRPC_PYTHON_BUILD_SYSTEM_ZLIB=True
+export GRPC_PYTHON_BUILD_SYSTEM_CARES=True
+export GRPC_PYTHON_BUILD_SYSTEM_RE2=True
+export GRPC_PYTHON_BUILD_SYSTEM_ABSL=True
+%py3_install
+
 
 %files
 %license LICENSE
@@ -144,12 +140,14 @@ popd
 
 %files -n python3-grpcio
 %license LICENSE
-%ifarch x86_64
 %{python3_sitearch}/grpc
 %{python3_sitearch}/grpcio-%{version}-py%{python3_version}.egg-info
-%endif
+
 
 %changelog
+* Tue Feb 28 2023 Riken Maharjan <rmaharjan@microsoft.com> - 1.42.0-4
+- Add grpcio for aarch64.
+
 * Wed Nov 09 2022 Riken Maharjan <rmaharjan@microsoft.com> - 1.42.0-3
 - Add 'python3-grpcio' subpackage using Fedora 37 spec for guidance.
 

--- a/SPECS/grpc/grpc.spec
+++ b/SPECS/grpc/grpc.spec
@@ -92,7 +92,8 @@ pushd cmake/build
    -DgRPC_ZLIB_PROVIDER:STRING='package'
 %cmake_build 
 popd
-
+#uncommenting below line causes the whole build to get stuck in aarch64 machine 
+#%py3_build
 
 %install
 pushd cmake/build
@@ -107,13 +108,10 @@ export GRPC_PYTHON_BUILD_SYSTEM_ZLIB=True
 export GRPC_PYTHON_BUILD_SYSTEM_CARES=True
 export GRPC_PYTHON_BUILD_SYSTEM_RE2=True
 export GRPC_PYTHON_BUILD_SYSTEM_ABSL=True
+#uncommenting below line causes the whole build to get stuck in aarch64 machine 
+#%py3_install
+#using macros causes build to get stuck forever
 %{__python3} setup.py install -O1 --root %{buildroot}
-
-#hacky way to make the python3-grpcio to build 
-grpc_location=$(find  %{buildroot}%{python3_sitearch}/ -name "grpcio-*" | head -n 1)
-echo %{grpc_location}
-# install  %{grpc_location}/grpc                             %{grpc_location}/grpc
-# install  %{grpc_location}/EGG-INFO                         %{grpc_location}/grpc-%{version}-py%{python3_version}.egg-info
 
 %files
 %license LICENSE

--- a/SPECS/grpc/grpc.spec
+++ b/SPECS/grpc/grpc.spec
@@ -107,12 +107,13 @@ export GRPC_PYTHON_BUILD_SYSTEM_ZLIB=True
 export GRPC_PYTHON_BUILD_SYSTEM_CARES=True
 export GRPC_PYTHON_BUILD_SYSTEM_RE2=True
 export GRPC_PYTHON_BUILD_SYSTEM_ABSL=True
-%{__python3} setup.py install
+%{__python3} setup.py install -O1 --root %{buildroot}
 
 #hacky way to make the python3-grpcio to build 
 grpc_location=$(find  %{buildroot}%{python3_sitearch}/ -name "grpcio-*" | head -n 1)
-install  %{grpc_location}/grpc                             %{grpc_location}/grpc
-install  %{grpc_location}/EGG-INFO                         %{grpc_location}/grpc-%{version}-py%{python3_version}.egg-info
+echo %{grpc_location}
+# install  %{grpc_location}/grpc                             %{grpc_location}/grpc
+# install  %{grpc_location}/EGG-INFO                         %{grpc_location}/grpc-%{version}-py%{python3_version}.egg-info
 
 %files
 %license LICENSE

--- a/SPECS/grpc/grpc.spec
+++ b/SPECS/grpc/grpc.spec
@@ -109,6 +109,10 @@ export GRPC_PYTHON_BUILD_SYSTEM_RE2=True
 export GRPC_PYTHON_BUILD_SYSTEM_ABSL=True
 %py3_install
 
+#hacky way to make the python3-grpcio to build 
+grpc_location=$(find  %{buildroot}%{python3_sitearch}/ -name "grpcio-*" | head -n 1)
+install  %{grpc_location}/grpc                             %{grpc_location}/grpc
+install  %{grpc_location}/EGG-INFO                         %{grpc_location}/grpc-%{version}-py%{python3_version}.egg-info
 
 %files
 %license LICENSE

--- a/SPECS/grpc/grpc.spec
+++ b/SPECS/grpc/grpc.spec
@@ -93,7 +93,7 @@ pushd cmake/build
 %cmake_build 
 popd
 #uncommenting below line causes the whole build to get stuck in aarch64 machine 
-##%py3_build
+#py3_build
 
 %install
 pushd cmake/build
@@ -109,7 +109,7 @@ export GRPC_PYTHON_BUILD_SYSTEM_CARES=True
 export GRPC_PYTHON_BUILD_SYSTEM_RE2=True
 export GRPC_PYTHON_BUILD_SYSTEM_ABSL=True
 #uncommenting below line causes the whole build to get stuck in aarch64 machine 
-##%py3_install
+#py3_install
 #using macros causes build to get stuck forever
 %{__python3} setup.py install -O1 --root %{buildroot}
 

--- a/SPECS/grpc/grpc.spec
+++ b/SPECS/grpc/grpc.spec
@@ -107,7 +107,7 @@ export GRPC_PYTHON_BUILD_SYSTEM_ZLIB=True
 export GRPC_PYTHON_BUILD_SYSTEM_CARES=True
 export GRPC_PYTHON_BUILD_SYSTEM_RE2=True
 export GRPC_PYTHON_BUILD_SYSTEM_ABSL=True
-%py3_install
+%{__python3} setup.py install
 
 #hacky way to make the python3-grpcio to build 
 grpc_location=$(find  %{buildroot}%{python3_sitearch}/ -name "grpcio-*" | head -n 1)

--- a/SPECS/grpc/grpc.spec
+++ b/SPECS/grpc/grpc.spec
@@ -93,7 +93,7 @@ pushd cmake/build
 %cmake_build 
 popd
 #uncommenting below line causes the whole build to get stuck in aarch64 machine 
-#%py3_build
+##%py3_build
 
 %install
 pushd cmake/build
@@ -109,7 +109,7 @@ export GRPC_PYTHON_BUILD_SYSTEM_CARES=True
 export GRPC_PYTHON_BUILD_SYSTEM_RE2=True
 export GRPC_PYTHON_BUILD_SYSTEM_ABSL=True
 #uncommenting below line causes the whole build to get stuck in aarch64 machine 
-#%py3_install
+##%py3_install
 #using macros causes build to get stuck forever
 %{__python3} setup.py install -O1 --root %{buildroot}
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Add python3-grpcio (python binding for gRPC) for aarch64 machine. 

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change: Remove usages of python macros as it was causing the aarch64 build to get stuck.


###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES/NO**
NO

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- AMD Pipeline build id:  [319306](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=319306&view=results)
- ARM Pipeline build id:  [319302](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=319302&view=results)
