### PR TITLE
Fixing CHECK_BUILD_RETRIES issues

### DIFF
--- a/toolkit/tools/scheduler/schedulerutils/buildworker.go
+++ b/toolkit/tools/scheduler/schedulerutils/buildworker.go
@@ -243,7 +243,7 @@ func buildSRPMFile(agent buildagents.BuildAgent, buildAttempts int, checkAttempt
 		}
 
 		if agent.Config().RunCheck {
-			buildErr := parseCheckSection(logFile)
+			buildErr = parseCheckSection(logFile)
 			checkFailed = (buildErr != nil)
 		}
 		return
@@ -251,7 +251,7 @@ func buildSRPMFile(agent buildagents.BuildAgent, buildAttempts int, checkAttempt
 
 	// temporary solution; potential fix: once stable, fail builds if %check section fails?
 	if err != nil && checkFailed {
-		logger.Log.Debugf("Tests failed for '%s'. Ignoring since the package built correctly. Error: %v", srpmFile, err)
+		logger.Log.Warnf("Tests failed for '%s'. Ignoring since the package built correctly. Error: %v", srpmFile, err)
 		err = nil
 	}
 	return


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Fix a bug in parseCheckSection of the go tooling & upgrade test failures to warning.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Removed a colon from buildworker.go
- Upgraded a log statement from debug to warning.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
NO

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: 320300
