### PR TITLE
Upgrade gnupg2 to v2.4.0 to address CVE-2022-3515

### DIFF
--- a/SPECS/gnupg2/gnupg2.signatures.json
+++ b/SPECS/gnupg2/gnupg2.signatures.json
@@ -1,5 +1,5 @@
 {
-    "Signatures": {
-        "gnupg-2.3.7.tar.bz2": "ee163a5fb9ec99ffc1b18e65faef8d086800c5713d15a672ab57d3799da83669"
-    }
+  "Signatures": {
+    "gnupg-2.4.0.tar.bz2": "1d79158dd01d992431dd2e3facb89fdac97127f89784ea2cb610c600fb0c1483"
+  }
 }

--- a/SPECS/gnupg2/gnupg2.spec
+++ b/SPECS/gnupg2/gnupg2.spec
@@ -18,7 +18,7 @@ BuildRequires:  libgcrypt-devel > 1.9.1
 BuildRequires:  libgpg-error-devel >= 1.41
 Requires:       libksba > 1.3.4
 Requires:       libgcrypt >= 1.9.1
-Requires:       libgpg-error >= 1.41
+Requires:       libgpg-error >= 1.46
 Requires:       npth >= 1.2
 Requires:       libassuan >= 2.5.0
 Requires:       pinentry
@@ -91,6 +91,7 @@ ln -s $(pwd)/bin/gpg $(pwd)/bin/gpg2
 %changelog
 * Mon Jan 23 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 2.4.0-1
 - Auto-upgrade to 2.4.0 - to fix CVE-2022-3515
+- Update libgpg-error dependency to 1.46
 
 * Tue Aug 09 2022 Andrew Phelps <anphel@microsoft.com> - 2.3.7-1
 - Update to version 2.3.7 to resolve CVE-2022-34903

--- a/SPECS/gnupg2/gnupg2.spec
+++ b/SPECS/gnupg2/gnupg2.spec
@@ -1,6 +1,6 @@
 Summary:        OpenPGP standard implementation used for encrypted communication and data storage.
 Name:           gnupg2
-Version:        2.3.7
+Version:        2.4.0
 Release:        1%{?dist}
 License:        BSD and CC0 and GPLv2+ and LGPLv2+
 Vendor:         Microsoft Corporation
@@ -89,6 +89,9 @@ ln -s $(pwd)/bin/gpg $(pwd)/bin/gpg2
 %defattr(-,root,root)
 
 %changelog
+* Mon Jan 23 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 2.4.0-1
+- Auto-upgrade to 2.4.0 - to fix CVE-2022-3515
+
 * Tue Aug 09 2022 Andrew Phelps <anphel@microsoft.com> - 2.3.7-1
 - Update to version 2.3.7 to resolve CVE-2022-34903
 

--- a/SPECS/libgpg-error/libgpg-error.signatures.json
+++ b/SPECS/libgpg-error/libgpg-error.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "libgpg-error-1.43.tar.bz2": "a9ab83ca7acc442a5bd846a75b920285ff79bdb4e3d34aa382be88ed2c3aebaf"
+  "libgpg-error-1.46.tar.bz2": "b7e11a64246bbe5ef37748de43b245abd72cfcd53c9ae5e7fc5ca59f1c81268d"
  }
 }

--- a/SPECS/libgpg-error/libgpg-error.spec
+++ b/SPECS/libgpg-error/libgpg-error.spec
@@ -1,7 +1,7 @@
 Summary:        libgpg-error
 Name:           libgpg-error
-Version:        1.43
-Release:        2%{?dist}
+Version:        1.46
+Release:        1%{?dist}
 License:        GPLv2+
 URL:            https://gnupg.org/
 Group:          Development/Libraries
@@ -40,6 +40,8 @@ make DESTDIR=%{buildroot} install
 find %{buildroot} -type f -name "*.la" -delete -print
 rm -rf %{buildroot}/%{_infodir}
 %find_lang %{name}
+pwd
+install -m 755 %{_builddir}/%{name}-%{version}/src/gpg-error-config %{buildroot}/%{_bindir}/gpg-error-config
 
 %check
 make %{?_smp_mflags} check
@@ -56,7 +58,6 @@ make %{?_smp_mflags} check
 %{_bindir}/gpg-error
 %{_bindir}/yat2m
 %{_libdir}/libgpg-error.so.*
-%{_mandir}/man1/*
 
 %files devel
 %defattr(-,root,root)
@@ -73,6 +74,9 @@ make %{?_smp_mflags} check
 %defattr(-,root,root)
 
 %changelog
+* Fri Mar 03 2023 Bala <balakumaran.kannan@microsoft.com> - 1.46-1
+- Upgrade to version 1.46 to support gnupg2
+
 * Tue Feb 08 2022 Thomas Crain <thcrain@microsoft.com> - 1.43-2
 - Remove manual pkgconfig(*) provides in toolchain specs
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -4430,8 +4430,8 @@
         "type": "other",
         "other": {
           "name": "gnupg2",
-          "version": "2.3.7",
-          "downloadUrl": "https://gnupg.org/ftp/gcrypt/gnupg/gnupg-2.3.7.tar.bz2"
+          "version": "2.4.0",
+          "downloadUrl": "https://gnupg.org/ftp/gcrypt/gnupg/gnupg-2.4.0.tar.bz2"
         }
       }
     },

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -9271,8 +9271,8 @@
         "type": "other",
         "other": {
           "name": "libgpg-error",
-          "version": "1.43",
-          "downloadUrl": "https://gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-1.43.tar.bz2"
+          "version": "1.46",
+          "downloadUrl": "https://gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-1.46.tar.bz2"
         }
       }
     },

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -212,7 +212,7 @@ mariner-rpm-macros-2.0-20.cm2.noarch.rpm
 mariner-check-macros-2.0-20.cm2.noarch.rpm
 libassuan-2.5.5-2.cm2.aarch64.rpm
 libassuan-devel-2.5.5-2.cm2.aarch64.rpm
-libgpg-error-1.43-2.cm2.aarch64.rpm
+libgpg-error-1.46-1.cm2.aarch64.rpm
 libgcrypt-1.9.4-1.cm2.aarch64.rpm
 libksba-1.6.3-1.cm2.aarch64.rpm
 libksba-devel-1.6.3-1.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -218,8 +218,8 @@ libksba-1.6.3-1.cm2.aarch64.rpm
 libksba-devel-1.6.3-1.cm2.aarch64.rpm
 npth-1.6-4.cm2.aarch64.rpm
 pinentry-1.2.0-1.cm2.aarch64.rpm
-gnupg2-2.3.7-1.cm2.aarch64.rpm
-gnupg2-lang-2.3.7-1.cm2.aarch64.rpm
+gnupg2-2.4.0-1.cm2.aarch64.rpm
+gnupg2-lang-2.4.0-1.cm2.aarch64.rpm
 gpgme-1.16.0-1.cm2.aarch64.rpm
 mariner-repos-shared-2.0-8.cm2.noarch.rpm
 mariner-repos-2.0-8.cm2.noarch.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -218,8 +218,8 @@ libksba-1.6.3-1.cm2.x86_64.rpm
 libksba-devel-1.6.3-1.cm2.x86_64.rpm
 npth-1.6-4.cm2.x86_64.rpm
 pinentry-1.2.0-1.cm2.x86_64.rpm
-gnupg2-2.3.7-1.cm2.x86_64.rpm
-gnupg2-lang-2.3.7-1.cm2.x86_64.rpm
+gnupg2-2.4.0-1.cm2.x86_64.rpm
+gnupg2-lang-2.4.0-1.cm2.x86_64.rpm
 gpgme-1.16.0-1.cm2.x86_64.rpm
 mariner-repos-shared-2.0-8.cm2.noarch.rpm
 mariner-repos-2.0-8.cm2.noarch.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -212,14 +212,14 @@ mariner-rpm-macros-2.0-20.cm2.noarch.rpm
 mariner-check-macros-2.0-20.cm2.noarch.rpm
 libassuan-2.5.5-2.cm2.x86_64.rpm
 libassuan-devel-2.5.5-2.cm2.x86_64.rpm
-libgpg-error-1.43-2.cm2.x86_64.rpm
+libgpg-error-1.46-1.cm2.x86_64.rpm
 libgcrypt-1.9.4-1.cm2.x86_64.rpm
 libksba-1.6.3-1.cm2.x86_64.rpm
 libksba-devel-1.6.3-1.cm2.x86_64.rpm
 npth-1.6-4.cm2.x86_64.rpm
 pinentry-1.2.0-1.cm2.x86_64.rpm
-gnupg2-2.4.0-1.cm2.x86_64.rpm
-gnupg2-lang-2.4.0-1.cm2.x86_64.rpm
+gnupg2-2.3.7-1.cm2.x86_64.rpm
+gnupg2-lang-2.3.7-1.cm2.x86_64.rpm
 gpgme-1.16.0-1.cm2.x86_64.rpm
 mariner-repos-shared-2.0-8.cm2.noarch.rpm
 mariner-repos-2.0-8.cm2.noarch.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -167,10 +167,10 @@ libgcrypt-debuginfo-1.9.4-1.cm2.aarch64.rpm
 libgcrypt-devel-1.9.4-1.cm2.aarch64.rpm
 libgomp-11.2.0-4.cm2.aarch64.rpm
 libgomp-devel-11.2.0-4.cm2.aarch64.rpm
-libgpg-error-1.43-2.cm2.aarch64.rpm
-libgpg-error-debuginfo-1.43-2.cm2.aarch64.rpm
-libgpg-error-devel-1.43-2.cm2.aarch64.rpm
-libgpg-error-lang-1.43-2.cm2.aarch64.rpm
+libgpg-error-1.46-1.cm2.aarch64.rpm
+libgpg-error-debuginfo-1.46-1.cm2.aarch64.rpm
+libgpg-error-devel-1.46-1.cm2.aarch64.rpm
+libgpg-error-lang-1.46-1.cm2.aarch64.rpm
 libksba-1.6.3-1.cm2.aarch64.rpm
 libksba-debuginfo-1.6.3-1.cm2.aarch64.rpm
 libksba-devel-1.6.3-1.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -117,9 +117,9 @@ glibc-tools-2.35-3.cm2.aarch64.rpm
 gmp-6.2.1-2.cm2.aarch64.rpm
 gmp-debuginfo-6.2.1-2.cm2.aarch64.rpm
 gmp-devel-6.2.1-2.cm2.aarch64.rpm
-gnupg2-2.3.7-1.cm2.aarch64.rpm
-gnupg2-debuginfo-2.3.7-1.cm2.aarch64.rpm
-gnupg2-lang-2.3.7-1.cm2.aarch64.rpm
+gnupg2-2.4.0-1.cm2.aarch64.rpm
+gnupg2-debuginfo-2.4.0-1.cm2.aarch64.rpm
+gnupg2-lang-2.4.0-1.cm2.aarch64.rpm
 gperf-3.1-4.cm2.aarch64.rpm
 gperf-debuginfo-3.1-4.cm2.aarch64.rpm
 gpgme-1.16.0-1.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -117,9 +117,9 @@ glibc-tools-2.35-3.cm2.x86_64.rpm
 gmp-6.2.1-2.cm2.x86_64.rpm
 gmp-debuginfo-6.2.1-2.cm2.x86_64.rpm
 gmp-devel-6.2.1-2.cm2.x86_64.rpm
-gnupg2-2.4.0-1.cm2.x86_64.rpm
-gnupg2-debuginfo-2.4.0-1.cm2.x86_64.rpm
-gnupg2-lang-2.4.0-1.cm2.x86_64.rpm
+gnupg2-2.3.7-1.cm2.x86_64.rpm
+gnupg2-debuginfo-2.3.7-1.cm2.x86_64.rpm
+gnupg2-lang-2.3.7-1.cm2.x86_64.rpm
 gperf-3.1-4.cm2.x86_64.rpm
 gperf-debuginfo-3.1-4.cm2.x86_64.rpm
 gpgme-1.16.0-1.cm2.x86_64.rpm
@@ -167,10 +167,10 @@ libgcrypt-debuginfo-1.9.4-1.cm2.x86_64.rpm
 libgcrypt-devel-1.9.4-1.cm2.x86_64.rpm
 libgomp-11.2.0-4.cm2.x86_64.rpm
 libgomp-devel-11.2.0-4.cm2.x86_64.rpm
-libgpg-error-1.43-2.cm2.x86_64.rpm
-libgpg-error-debuginfo-1.43-2.cm2.x86_64.rpm
-libgpg-error-devel-1.43-2.cm2.x86_64.rpm
-libgpg-error-lang-1.43-2.cm2.x86_64.rpm
+libgpg-error-1.46-1.cm2.x86_64.rpm
+libgpg-error-debuginfo-1.46-1.cm2.x86_64.rpm
+libgpg-error-devel-1.46-1.cm2.x86_64.rpm
+libgpg-error-lang-1.46-1.cm2.x86_64.rpm
 libksba-1.6.3-1.cm2.x86_64.rpm
 libksba-debuginfo-1.6.3-1.cm2.x86_64.rpm
 libksba-devel-1.6.3-1.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -117,9 +117,9 @@ glibc-tools-2.35-3.cm2.x86_64.rpm
 gmp-6.2.1-2.cm2.x86_64.rpm
 gmp-debuginfo-6.2.1-2.cm2.x86_64.rpm
 gmp-devel-6.2.1-2.cm2.x86_64.rpm
-gnupg2-2.3.7-1.cm2.x86_64.rpm
-gnupg2-debuginfo-2.3.7-1.cm2.x86_64.rpm
-gnupg2-lang-2.3.7-1.cm2.x86_64.rpm
+gnupg2-2.4.0-1.cm2.x86_64.rpm
+gnupg2-debuginfo-2.4.0-1.cm2.x86_64.rpm
+gnupg2-lang-2.4.0-1.cm2.x86_64.rpm
 gperf-3.1-4.cm2.x86_64.rpm
 gperf-debuginfo-3.1-4.cm2.x86_64.rpm
 gpgme-1.16.0-1.cm2.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it) - Triggered full build with build-id 320621
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
 - Upgrade gnupg2 to 2.4.0
 - Upgrade libgpg-error to 1.46 to support gnupg2-2.4.0

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- https://nvd.nist.gov/vuln/detail/CVE-2022-3515

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
Build started under buildId - 320624

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2022-3515

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: 320624
