### PR TITLE
Revert "rust: update signatures to fix build break"

### DIFF
--- a/SPECS/rust/rust.signatures.json
+++ b/SPECS/rust/rust.signatures.json
@@ -2,7 +2,7 @@
  "Signatures": {
   "cargo-1.58.0-aarch64-unknown-linux-gnu.tar.gz": "68e2e7493af55c5792636c2b2b0b497b1e43b12eb2e91da71e92426701884c24",
   "cargo-1.58.0-x86_64-unknown-linux-gnu.tar.gz": "940aa91ad2de39c18749e8d789d88846de2debbcf6207247225b42c6c3bf731a",
-  "rust-1.59.0-cargo.tar.gz": "04a6b4637ae8b1b5470b2e36e990b54bc5a8978b1d0042db8c1cff5710474f04",
+  "rust-1.59.0-cargo.tar.gz": "8d2076b86d6cafe4181bf0738cc52e4490c5c0bcffffd86c087dfc710acae198",
   "rust-std-1.58.0-aarch64-unknown-linux-gnu.tar.gz": "3a1283a2dce7abf2816dc70d622215f5769c416abf3e94dd94dd6a5d1109f506",
   "rust-std-1.58.0-x86_64-unknown-linux-gnu.tar.gz": "0517b0cb57a311bbe1997e9b87fc6bae1f9e1eadec4f7d97374740f17f890842",
   "rustc-1.58.0-aarch64-unknown-linux-gnu.tar.gz": "34d8fdaec504efe6e9448ad5a118ac0e7ef3bd9a8f6c49ea68204f2f9a9dae4e",


### PR DESCRIPTION
Reverts microsoft/CBL-Mariner#5064

After talking with Jon, I was able to get the original cargo from the source RPM of the built package and uploaded it. The revert of PR and restoring original cargo file is needed so that it does not invalidate already built rust versions.

Original cargo tarball was restored in this pipeline https://dev.azure.com/mariner-org/mariner/_build/results?buildId=327188&view=results