### PR TITLE
vim: Upgrade vim to 9.0.1402 Fix CVE-2023-1264

### DIFF
--- a/SPECS/vim/vim.signatures.json
+++ b/SPECS/vim/vim.signatures.json
@@ -1,5 +1,5 @@
 {
   "Signatures": {
-    "vim-9.0.1378.tar.gz": "2f7089042fa4abe4e978d285d00ad5dbd8bc53fab1d5d4264c7fa203eb7c3a6b"
+    "vim-9.0.1402.tar.gz": "607c9a8b771be2e2826f618f72c2215418332644210c999d708778a57ab5a5fa"
   }
 }

--- a/SPECS/vim/vim.spec
+++ b/SPECS/vim/vim.spec
@@ -106,6 +106,7 @@ fi
 %{_datarootdir}/vim/vim*/ftplugof.vim
 %{_datarootdir}/vim/vim*/gvimrc_example.vim
 %{_datarootdir}/vim/vim*/import/dist/vimhelp.vim
+%{_datarootdir}/vim/vim*/import/dist/vimhighlight.vim
 %{_datarootdir}/vim/vim*/indent.vim
 %{_datarootdir}/vim/vim*/indent/*
 %{_datarootdir}/vim/vim*/indoff.vim

--- a/SPECS/vim/vim.spec
+++ b/SPECS/vim/vim.spec
@@ -1,6 +1,6 @@
 Summary:        Text editor
 Name:           vim
-Version:        9.0.1378
+Version:        9.0.1402
 Release:        1%{?dist}
 License:        Vim
 Vendor:         Microsoft Corporation
@@ -191,6 +191,9 @@ fi
 %{_bindir}/vimdiff
 
 %changelog
+* Thu Mar 16 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 9.0.1402-1
+- Auto-upgrade to 9.0.1402 - Fix CVE-2023-1264
+
 * Fri Mar 10 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 9.0.1378-1
 - Auto-upgrade to 9.0.1378 - patch CVE-2023-1175
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -8636,8 +8636,8 @@
         "type": "other",
         "other": {
           "name": "vim",
-          "version": "9.0.1378",
-          "downloadUrl": "https://github.com/vim/vim/archive/v9.0.1378.tar.gz"
+          "version": "9.0.1402",
+          "downloadUrl": "https://github.com/vim/vim/archive/v9.0.1402.tar.gz"
         }
       }
     },


### PR DESCRIPTION
Upgrade vim to v9.0.1402 Fix CVE-2023-1264
Auto upgrade pipeline run -> https://dev.azure.com/mariner-org/mariner/_build/results?buildId=328371&view=results

AMD64 build -> https://dev.azure.com/mariner-org/mariner/_build/results?buildId=328405&view=results
ARM64 build -> https://dev.azure.com/mariner-org/mariner/_build/results?buildId=328406&view=results

CVE link: https://nvd.nist.gov/vuln/detail/CVE-2023-1264