### PR TITLE
rpm-ostree: introduce patch to workaround a breaking lint

### DIFF
--- a/SPECS/rpm-ostree/rpm-ostree-drop-lint-which-treats-warning-as-error.patch
+++ b/SPECS/rpm-ostree/rpm-ostree-drop-lint-which-treats-warning-as-error.patch
@@ -1,0 +1,26 @@
+From 5c16e156d420258c327243172cccb8817a264688 Mon Sep 17 00:00:00 2001
+From: Muhammad Falak R Wani <falakreyaz@gmail.com>
+Date: Mon, 20 Mar 2023 10:47:21 +0530
+Subject: [PATCH] rust: lib: modify lint for `unused_must_use` to enable build
+
+Signed-off-by: Muhammad Falak R Wani <falakreyaz@gmail.com>
+---
+ rust/src/lib.rs | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/rust/src/lib.rs b/rust/src/lib.rs
+index 25ac0881..735cdaa7 100644
+--- a/rust/src/lib.rs
++++ b/rust/src/lib.rs
+@@ -10,7 +10,7 @@
+ // See https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html
+ #![deny(missing_debug_implementations)]
+ #![deny(unsafe_op_in_unsafe_fn)]
+-#![forbid(unused_must_use)]
++#![warn(unused_must_use)]
+ #![allow(clippy::ptr_arg)]
+ 
+ // pub(crate) utilities
+-- 
+2.40.0
+

--- a/SPECS/rpm-ostree/rpm-ostree.spec
+++ b/SPECS/rpm-ostree/rpm-ostree.spec
@@ -1,7 +1,7 @@
 Summary:        Commit RPMs to an OSTree repository
 Name:           rpm-ostree
 Version:        2022.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        LGPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -10,6 +10,7 @@ Source0:        %{url}/releases/download/v%{version}/%{name}-%{version}.tar.xz
 Patch0:         rpm-ostree-libdnf-build.patch
 Patch1:         rpm-ostree-disable-selinux.patch
 Patch2:         CVE-2022-31394.patch
+Patch3:         rpm-ostree-drop-lint-which-treats-warning-as-error.patch
 BuildRequires:  attr-devel
 BuildRequires:  autoconf
 BuildRequires:  autogen
@@ -155,6 +156,9 @@ make check
 %{_datadir}/gir-1.0/*-1.0.gir
 
 %changelog
+* Mon Mar 20 2023 Muhammad Falak <mwani@microsoft.com> - 2022.1-4
+- Drop a lint which treats a warning as error to enable build with rust 1.68.0
+
 * Thu Mar 09 2023 Nan Liu <liunan@microsoft.com> - 2022.1-3
 - Apply patch for CVE-2022-31394
 


### PR DESCRIPTION
Signed-off-by: Muhammad Falak R Wani <falakreyaz@gmail.com>

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
With the recent bump of rust to 1.62.0 -> 1.68.0 some of lints break the build.
Modify the lint `#![forbid(unused_must_use)]` -> `#![warn(unused_must_use)]`
This change does not change anything semantically and enables the build with
the recent compiler (1.68.0).

This is a workaround till, we upgrade `rpm-ostree` to a more recent version.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Modify a lint to enable build

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://github.com/microsoft/CBL-Mariner/pull/5091

###### Links to CVEs  <!-- optional -->
- NA

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Buddy Build (both ARM & AMD): [PR-5122](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=329695&view=results)
- Full Delta Build: [link](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=329650&view=results)

While at it, I rebuilt all direct rust dependents.
