### PR TITLE
Create kernel specific subpackages for specialized kernels

### DIFF
--- a/SPECS-EXTENDED/kernel-rt/kernel-rt.spec
+++ b/SPECS-EXTENDED/kernel-rt/kernel-rt.spec
@@ -60,6 +60,11 @@ ExclusiveArch:  x86_64
 %ifarch x86_64
 BuildRequires:  pciutils-devel
 %endif
+Conflicts:      kernel
+Conflicts:      kernel-azure
+Conflicts:      kernel-hci
+Conflicts:      kernel-mshv
+Conflicts:      kernel-uvm
 # When updating the config files it is important to sanitize them.
 # Steps for updating a config file:
 #  1. Extract the linux sources into a folder
@@ -124,9 +129,7 @@ This package contains the 'perf' performance analysis tools for Linux kernel.
 %package -n     python3-perf-rt
 Summary:        Python 3 extension for perf tools
 Requires:       python3
-Conflicts:      python3-perf
-Conflicts:      python3-perf-azure
-Conflicts:      python3-perf-hci
+Requires:       %{name} = %{version}-%{release}
 
 %description -n python3-perf-rt
 This package contains the Python 3 extension for the 'perf' performance analysis tools for Linux kernel.
@@ -140,9 +143,7 @@ This package contains common device tree blobs (dtb)
 
 %package -n     bpftool-rt
 Summary:        Inspection and simple manipulation of eBPF programs and maps
-Conflicts:      bpftool
-Conflicts:      bpftool-azure
-Conflicts:      bpftool-hci
+Requires:       %{name} = %{version}-%{release}
 
 %description -n  bpftool-rt
 This package contains the bpftool, which allows inspection and simple

--- a/SPECS-EXTENDED/kernel-rt/kernel-rt.spec
+++ b/SPECS-EXTENDED/kernel-rt/kernel-rt.spec
@@ -121,12 +121,13 @@ Requires:       audit
 %description tools
 This package contains the 'perf' performance analysis tools for Linux kernel.
 
-%package        python3-perf
+%package -n     python3-perf-rt
 Summary:        Python 3 extension for perf tools
 Requires:       python3
-Conflicts:      python3-perf
+Obsoletes:      python3-perf
+Provides:       python3-perf
 
-%description python3-perf
+%description -n python3-perf-rt
 This package contains the Python 3 extension for the 'perf' performance analysis tools for Linux kernel.
 
 %package dtb
@@ -136,11 +137,12 @@ Group:          System Environment/Kernel
 %description dtb
 This package contains common device tree blobs (dtb)
 
-%package        bpftool
+%package -n     bpftool-rt
 Summary:        Inspection and simple manipulation of eBPF programs and maps
-Conflicts:      bpftool
+Obsoletes:      bpftool
+Provides:       bpftool
 
-%description    bpftool
+%description -n bpftool-rt
 This package contains the bpftool, which allows inspection and simple
 manipulation of eBPF programs and maps.
 
@@ -373,10 +375,10 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %{_libdir}/perf/include/bpf/*
 %{_includedir}/perf/perf_dlfilter.h
 
-%files python3-perf
+%files -n python3-perf-rt
 %{python3_sitearch}/*
 
-%files bpftool
+%files -n bpftool-rt
 %{_sbindir}/bpftool
 %{_sysconfdir}/bash_completion.d/bpftool
 

--- a/SPECS-EXTENDED/kernel-rt/kernel-rt.spec
+++ b/SPECS-EXTENDED/kernel-rt/kernel-rt.spec
@@ -383,7 +383,7 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %{_sysconfdir}/bash_completion.d/bpftool
 
 %changelog
-* Mon Mar 20 2023 Rachel Menge <rachelmenge@microsoft.com> - 5.15.55.1-3
+* Fri Mar 31 2023 Rachel Menge <rachelmenge@microsoft.com> - 5.15.55.1-3
 - Rename bpftool and python3-perf to be kernel specific
 
 * Tue Sep 13 2022 Saul Paredes <saulparedes@microsoft.com> - 5.15.55.1-2

--- a/SPECS-EXTENDED/kernel-rt/kernel-rt.spec
+++ b/SPECS-EXTENDED/kernel-rt/kernel-rt.spec
@@ -13,7 +13,7 @@
 Summary:        Realtime Linux Kernel
 Name:           kernel-rt
 Version:        5.15.55.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -121,11 +121,12 @@ Requires:       audit
 %description tools
 This package contains the 'perf' performance analysis tools for Linux kernel.
 
-%package -n     python3-perf
+%package        python3-perf
 Summary:        Python 3 extension for perf tools
 Requires:       python3
+Conflicts:      python3-perf
 
-%description -n python3-perf
+%description python3-perf
 This package contains the Python 3 extension for the 'perf' performance analysis tools for Linux kernel.
 
 %package dtb
@@ -135,10 +136,11 @@ Group:          System Environment/Kernel
 %description dtb
 This package contains common device tree blobs (dtb)
 
-%package -n     bpftool
+%package        bpftool
 Summary:        Inspection and simple manipulation of eBPF programs and maps
+Conflicts:      bpftool
 
-%description -n bpftool
+%description    bpftool
 This package contains the bpftool, which allows inspection and simple
 manipulation of eBPF programs and maps.
 
@@ -371,14 +373,17 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %{_libdir}/perf/include/bpf/*
 %{_includedir}/perf/perf_dlfilter.h
 
-%files -n python3-perf
+%files python3-perf
 %{python3_sitearch}/*
 
-%files -n bpftool
+%files bpftool
 %{_sbindir}/bpftool
 %{_sysconfdir}/bash_completion.d/bpftool
 
 %changelog
+* Mon Mar 20 2023 Rachel Menge <rachelmenge@microsoft.com> - 5.15.55.1-3
+- Rename bpftool and python3-perf to be kernel specific
+
 * Tue Sep 13 2022 Saul Paredes <saulparedes@microsoft.com> - 5.15.55.1-2
 - Adjust crashkernel param to crash, dump memory to a file, and recover correctly
 

--- a/SPECS-EXTENDED/kernel-rt/kernel-rt.spec
+++ b/SPECS-EXTENDED/kernel-rt/kernel-rt.spec
@@ -121,13 +121,12 @@ Requires:       audit
 %description tools
 This package contains the 'perf' performance analysis tools for Linux kernel.
 
-%package -n     python3-perf-rt
+%package        python3-perf
 Summary:        Python 3 extension for perf tools
 Requires:       python3
-Obsoletes:      python3-perf
-Provides:       python3-perf
+Conflicts:      python3-perf
 
-%description -n python3-perf-rt
+%description python3-perf
 This package contains the Python 3 extension for the 'perf' performance analysis tools for Linux kernel.
 
 %package dtb
@@ -137,12 +136,11 @@ Group:          System Environment/Kernel
 %description dtb
 This package contains common device tree blobs (dtb)
 
-%package -n     bpftool-rt
+%package        bpftool
 Summary:        Inspection and simple manipulation of eBPF programs and maps
-Obsoletes:      bpftool
-Provides:       bpftool
+Conflicts:      bpftool
 
-%description -n bpftool-rt
+%description    bpftool
 This package contains the bpftool, which allows inspection and simple
 manipulation of eBPF programs and maps.
 
@@ -375,10 +373,10 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %{_libdir}/perf/include/bpf/*
 %{_includedir}/perf/perf_dlfilter.h
 
-%files -n python3-perf-rt
+%files python3-perf
 %{python3_sitearch}/*
 
-%files -n bpftool-rt
+%files bpftool
 %{_sbindir}/bpftool
 %{_sysconfdir}/bash_completion.d/bpftool
 

--- a/SPECS-EXTENDED/kernel-rt/kernel-rt.spec
+++ b/SPECS-EXTENDED/kernel-rt/kernel-rt.spec
@@ -381,7 +381,7 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %{_sysconfdir}/bash_completion.d/bpftool
 
 %changelog
-* Fri Mar 31 2023 Rachel Menge <rachelmenge@microsoft.com> - 5.15.55.1-3
+* Mon Mar 20 2023 Rachel Menge <rachelmenge@microsoft.com> - 5.15.55.1-3
 - Rename bpftool and python3-perf to be kernel specific
 
 * Tue Sep 13 2022 Saul Paredes <saulparedes@microsoft.com> - 5.15.55.1-2

--- a/SPECS-EXTENDED/kernel-rt/kernel-rt.spec
+++ b/SPECS-EXTENDED/kernel-rt/kernel-rt.spec
@@ -121,12 +121,14 @@ Requires:       audit
 %description tools
 This package contains the 'perf' performance analysis tools for Linux kernel.
 
-%package        python3-perf
+%package -n     python3-perf-rt
 Summary:        Python 3 extension for perf tools
 Requires:       python3
 Conflicts:      python3-perf
+Conflicts:      python3-perf-azure
+Conflicts:      python3-perf-hci
 
-%description python3-perf
+%description -n python3-perf-rt
 This package contains the Python 3 extension for the 'perf' performance analysis tools for Linux kernel.
 
 %package dtb
@@ -136,11 +138,13 @@ Group:          System Environment/Kernel
 %description dtb
 This package contains common device tree blobs (dtb)
 
-%package        bpftool
+%package -n     bpftool-rt
 Summary:        Inspection and simple manipulation of eBPF programs and maps
 Conflicts:      bpftool
+Conflicts:      bpftool-azure
+Conflicts:      bpftool-hci
 
-%description    bpftool
+%description -n  bpftool-rt
 This package contains the bpftool, which allows inspection and simple
 manipulation of eBPF programs and maps.
 
@@ -373,10 +377,10 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %{_libdir}/perf/include/bpf/*
 %{_includedir}/perf/perf_dlfilter.h
 
-%files python3-perf
+%files -n python3-perf-rt
 %{python3_sitearch}/*
 
-%files bpftool
+%files -n bpftool-rt
 %{_sbindir}/bpftool
 %{_sysconfdir}/bash_completion.d/bpftool
 

--- a/SPECS-SIGNED/kernel-azure-signed/kernel-azure-signed.spec
+++ b/SPECS-SIGNED/kernel-azure-signed/kernel-azure-signed.spec
@@ -10,7 +10,7 @@
 Summary:        Signed Linux Kernel for Azure
 Name:           kernel-azure-signed-%{buildarch}
 Version:        5.15.102.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -153,6 +153,9 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %exclude /module_info.ld
 
 %changelog
+* Mon Mar 20 2023 Rachel Menge <rachelmenge@microsoft.com> - 5.15.102.1-2
+- Bump release to match kernel-azure
+
 * Tue Mar 14 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 5.15.102.1-1
 - Auto-upgrade to 5.15.102.1
 

--- a/SPECS-SIGNED/kernel-hci-signed/kernel-hci-signed.spec
+++ b/SPECS-SIGNED/kernel-hci-signed/kernel-hci-signed.spec
@@ -5,7 +5,7 @@
 Summary:        Signed Linux Kernel for HCI
 Name:           kernel-hci-signed-%{buildarch}
 Version:        5.15.102.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -149,6 +149,9 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %exclude /module_info.ld
 
 %changelog
+* Mon Mar 20 2023 Rachel Menge <rachelmenge@microsoft.com> - 5.15.102.1-2
+- Bump release to match kernel-hci
+
 * Tue Mar 14 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 5.15.102.1-1
 - Auto-upgrade to 5.15.102.1
 

--- a/SPECS-SIGNED/kernel-signed/kernel-signed.spec
+++ b/SPECS-SIGNED/kernel-signed/kernel-signed.spec
@@ -10,7 +10,7 @@
 Summary:        Signed Linux Kernel for %{buildarch} systems
 Name:           kernel-signed-%{buildarch}
 Version:        5.15.102.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -153,6 +153,9 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %exclude /module_info.ld
 
 %changelog
+* Fri Mar 31 2023 Rachel Menge <rachelmenge@microsoft.com> - 5.15.102.1-4
+- Bump release to match kernel
+
 * Wed Mar 29 2023 Rachel Menge <rachelmenge@microsoft.com> - 5.15.102.1-3
 - Bump release to match kernel
 

--- a/SPECS-SIGNED/kernel-signed/kernel-signed.spec
+++ b/SPECS-SIGNED/kernel-signed/kernel-signed.spec
@@ -10,7 +10,7 @@
 Summary:        Signed Linux Kernel for %{buildarch} systems
 Name:           kernel-signed-%{buildarch}
 Version:        5.15.102.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -153,6 +153,9 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %exclude /module_info.ld
 
 %changelog
+* Thu Apr 06 2023 Rachel Menge <rachelmenge@microsoft.com> - 5.15.102.1-4
+- Bump release to match kernel
+
 * Wed Mar 29 2023 Rachel Menge <rachelmenge@microsoft.com> - 5.15.102.1-3
 - Bump release to match kernel
 

--- a/SPECS-SIGNED/kernel-signed/kernel-signed.spec
+++ b/SPECS-SIGNED/kernel-signed/kernel-signed.spec
@@ -10,7 +10,7 @@
 Summary:        Signed Linux Kernel for %{buildarch} systems
 Name:           kernel-signed-%{buildarch}
 Version:        5.15.102.1
-Release:        4%{?dist}
+Release:        3%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -153,9 +153,6 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %exclude /module_info.ld
 
 %changelog
-* Fri Mar 31 2023 Rachel Menge <rachelmenge@microsoft.com> - 5.15.102.1-4
-- Bump release to match kernel
-
 * Wed Mar 29 2023 Rachel Menge <rachelmenge@microsoft.com> - 5.15.102.1-3
 - Bump release to match kernel
 

--- a/SPECS/kernel-azure/kernel-azure.spec
+++ b/SPECS/kernel-azure/kernel-azure.spec
@@ -18,7 +18,7 @@
 Summary:        Linux Kernel
 Name:           kernel-azure
 Version:        5.15.102.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -122,11 +122,12 @@ Requires:       audit
 %description tools
 This package contains the 'perf' performance analysis tools for Linux kernel.
 
-%package -n     python3-perf
+%package        python3-perf
 Summary:        Python 3 extension for perf tools
 Requires:       python3
+Conflicts:      python3-perf
 
-%description -n python3-perf
+%description    python3-perf
 This package contains the Python 3 extension for the 'perf' performance analysis tools for Linux kernel.
 
 %package dtb
@@ -136,10 +137,11 @@ Group:          System Environment/Kernel
 %description dtb
 This package contains common device tree blobs (dtb)
 
-%package -n     bpftool
+%package        bpftool
 Summary:        Inspection and simple manipulation of eBPF programs and maps
+Conflicts:      bpftool
 
-%description -n bpftool
+%description bpftool
 This package contains the bpftool, which allows inspection and simple
 manipulation of eBPF programs and maps.
 
@@ -393,7 +395,7 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %{_libdir}/perf/include/bpf/*
 %{_includedir}/perf/perf_dlfilter.h
 
-%files -n python3-perf
+%files python3-perf
 %{python3_sitearch}/*
 
 %ifarch aarch64
@@ -401,11 +403,14 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 /boot/dtb/fsl-imx8mq-evk.dtb
 %endif
 
-%files -n bpftool
+%files bpftool
 %{_sbindir}/bpftool
 %{_sysconfdir}/bash_completion.d/bpftool
 
 %changelog
+* Mon Mar 20 2023 Rachel Menge <rachelmenge@microsoft.com> - 5.15.102.1-2
+- Rename bpftool and python3-perf to be kernel specific
+
 * Tue Mar 14 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 5.15.102.1-1
 - Auto-upgrade to 5.15.102.1
 

--- a/SPECS/kernel-azure/kernel-azure.spec
+++ b/SPECS/kernel-azure/kernel-azure.spec
@@ -410,7 +410,7 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %{_sysconfdir}/bash_completion.d/bpftool
 
 %changelog
-* Mon Mar 20 2023 Rachel Menge <rachelmenge@microsoft.com> - 5.15.102.1-2
+* Fri Mar 31 2023 Rachel Menge <rachelmenge@microsoft.com> - 5.15.102.1-2
 - Rename bpftool and python3-perf to be kernel specific
 
 * Tue Mar 14 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 5.15.102.1-1

--- a/SPECS/kernel-azure/kernel-azure.spec
+++ b/SPECS/kernel-azure/kernel-azure.spec
@@ -122,12 +122,13 @@ Requires:       audit
 %description tools
 This package contains the 'perf' performance analysis tools for Linux kernel.
 
-%package        python3-perf
+%package -n     python3-perf-azure
 Summary:        Python 3 extension for perf tools
 Requires:       python3
-Conflicts:      python3-perf
+Obsoletes:      python3-perf
+Provides:       python3-perf
 
-%description    python3-perf
+%description -n   python3-perf-azure
 This package contains the Python 3 extension for the 'perf' performance analysis tools for Linux kernel.
 
 %package dtb
@@ -137,11 +138,12 @@ Group:          System Environment/Kernel
 %description dtb
 This package contains common device tree blobs (dtb)
 
-%package        bpftool
+%package -n     bpftool-azure
 Summary:        Inspection and simple manipulation of eBPF programs and maps
-Conflicts:      bpftool
+Obsoletes:      bpftool
+Provides:       bpftool
 
-%description bpftool
+%description -n bpftool-azure
 This package contains the bpftool, which allows inspection and simple
 manipulation of eBPF programs and maps.
 
@@ -395,7 +397,7 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %{_libdir}/perf/include/bpf/*
 %{_includedir}/perf/perf_dlfilter.h
 
-%files python3-perf
+%files -n python3-perf-azure
 %{python3_sitearch}/*
 
 %ifarch aarch64
@@ -403,7 +405,7 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 /boot/dtb/fsl-imx8mq-evk.dtb
 %endif
 
-%files bpftool
+%files -n bpftool-azure
 %{_sbindir}/bpftool
 %{_sysconfdir}/bash_completion.d/bpftool
 

--- a/SPECS/kernel-azure/kernel-azure.spec
+++ b/SPECS/kernel-azure/kernel-azure.spec
@@ -122,12 +122,14 @@ Requires:       audit
 %description tools
 This package contains the 'perf' performance analysis tools for Linux kernel.
 
-%package        python3-perf
+%package -n     python3-perf-azure
 Summary:        Python 3 extension for perf tools
 Requires:       python3
 Conflicts:      python3-perf
+Conflicts:      python3-perf-hci
+Conflicts:      python3-perf-rt
 
-%description    python3-perf
+%description -n python3-perf-azure
 This package contains the Python 3 extension for the 'perf' performance analysis tools for Linux kernel.
 
 %package dtb
@@ -137,11 +139,13 @@ Group:          System Environment/Kernel
 %description dtb
 This package contains common device tree blobs (dtb)
 
-%package        bpftool
+%package -n     bpftool-azure
 Summary:        Inspection and simple manipulation of eBPF programs and maps
 Conflicts:      bpftool
+Conflicts:      bpftool-hci
+Conflicts:      bpftool-rt
 
-%description bpftool
+%description -n bpftool-azure
 This package contains the bpftool, which allows inspection and simple
 manipulation of eBPF programs and maps.
 
@@ -395,7 +399,7 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %{_libdir}/perf/include/bpf/*
 %{_includedir}/perf/perf_dlfilter.h
 
-%files python3-perf
+%files -n python3-perf-azure
 %{python3_sitearch}/*
 
 %ifarch aarch64
@@ -403,7 +407,7 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 /boot/dtb/fsl-imx8mq-evk.dtb
 %endif
 
-%files bpftool
+%files -n bpftool-azure
 %{_sbindir}/bpftool
 %{_sysconfdir}/bash_completion.d/bpftool
 

--- a/SPECS/kernel-azure/kernel-azure.spec
+++ b/SPECS/kernel-azure/kernel-azure.spec
@@ -408,7 +408,7 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %{_sysconfdir}/bash_completion.d/bpftool
 
 %changelog
-* Fri Mar 31 2023 Rachel Menge <rachelmenge@microsoft.com> - 5.15.102.1-2
+* Mon Mar 20 2023 Rachel Menge <rachelmenge@microsoft.com> - 5.15.102.1-2
 - Rename bpftool and python3-perf to be kernel specific
 
 * Tue Mar 14 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 5.15.102.1-1

--- a/SPECS/kernel-azure/kernel-azure.spec
+++ b/SPECS/kernel-azure/kernel-azure.spec
@@ -53,6 +53,11 @@ Requires:       filesystem
 Requires:       kmod
 Requires(post): coreutils
 Requires(postun): coreutils
+Conflicts:      kernel
+Conflicts:      kernel-hci
+Conflicts:      kernel-rt
+Conflicts:      kernel-mshv
+Conflicts:      kernel-uvm
 # When updating the config files it is important to sanitize them.
 # Steps for updating a config file:
 #  1. Extract the linux sources into a folder
@@ -125,9 +130,7 @@ This package contains the 'perf' performance analysis tools for Linux kernel.
 %package -n     python3-perf-azure
 Summary:        Python 3 extension for perf tools
 Requires:       python3
-Conflicts:      python3-perf
-Conflicts:      python3-perf-hci
-Conflicts:      python3-perf-rt
+Requires:       %{name} = %{version}-%{release}
 
 %description -n python3-perf-azure
 This package contains the Python 3 extension for the 'perf' performance analysis tools for Linux kernel.
@@ -141,9 +144,7 @@ This package contains common device tree blobs (dtb)
 
 %package -n     bpftool-azure
 Summary:        Inspection and simple manipulation of eBPF programs and maps
-Conflicts:      bpftool
-Conflicts:      bpftool-hci
-Conflicts:      bpftool-rt
+Requires:       %{name} = %{version}-%{release}
 
 %description -n bpftool-azure
 This package contains the bpftool, which allows inspection and simple

--- a/SPECS/kernel-azure/kernel-azure.spec
+++ b/SPECS/kernel-azure/kernel-azure.spec
@@ -122,13 +122,12 @@ Requires:       audit
 %description tools
 This package contains the 'perf' performance analysis tools for Linux kernel.
 
-%package -n     python3-perf-azure
+%package        python3-perf
 Summary:        Python 3 extension for perf tools
 Requires:       python3
-Obsoletes:      python3-perf
-Provides:       python3-perf
+Conflicts:      python3-perf
 
-%description -n   python3-perf-azure
+%description    python3-perf
 This package contains the Python 3 extension for the 'perf' performance analysis tools for Linux kernel.
 
 %package dtb
@@ -138,12 +137,11 @@ Group:          System Environment/Kernel
 %description dtb
 This package contains common device tree blobs (dtb)
 
-%package -n     bpftool-azure
+%package        bpftool
 Summary:        Inspection and simple manipulation of eBPF programs and maps
-Obsoletes:      bpftool
-Provides:       bpftool
+Conflicts:      bpftool
 
-%description -n bpftool-azure
+%description bpftool
 This package contains the bpftool, which allows inspection and simple
 manipulation of eBPF programs and maps.
 
@@ -397,7 +395,7 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %{_libdir}/perf/include/bpf/*
 %{_includedir}/perf/perf_dlfilter.h
 
-%files -n python3-perf-azure
+%files python3-perf
 %{python3_sitearch}/*
 
 %ifarch aarch64
@@ -405,7 +403,7 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 /boot/dtb/fsl-imx8mq-evk.dtb
 %endif
 
-%files -n bpftool-azure
+%files bpftool
 %{_sbindir}/bpftool
 %{_sysconfdir}/bash_completion.d/bpftool
 

--- a/SPECS/kernel-hci/kernel-hci.spec
+++ b/SPECS/kernel-hci/kernel-hci.spec
@@ -66,6 +66,11 @@ Requires:       filesystem
 Requires:       kmod
 Requires(post): coreutils
 Requires(postun): coreutils
+Conflicts:      kernel
+Conflicts:      kernel-azure
+Conflicts:      kernel-mshv
+Conflicts:      kernel-rt
+Conflicts:      kernel-uvm
 ExclusiveArch:  x86_64
 # When updating the config files it is important to sanitize them.
 # Steps for updating a config file:
@@ -139,9 +144,7 @@ This package contains the 'perf' performance analysis tools for Linux kernel.
 %package -n     python3-perf-hci
 Summary:        Python 3 extension for perf tools
 Requires:       python3
-Conflicts:      python3-perf
-Conflicts:      python3-perf-azure
-Conflicts:      python3-perf-rt
+Requires:       %{name} = %{version}-%{release}
 
 %description -n python3-perf-hci
 This package contains the Python 3 extension for the 'perf' performance analysis tools for Linux kernel.
@@ -155,9 +158,7 @@ This package contains common device tree blobs (dtb)
 
 %package -n     bpftool-hci
 Summary:        Inspection and simple manipulation of eBPF programs and maps
-Conflicts:      bpftool
-Conflicts:      bpftool-azure
-Conflicts:      bpftool-rt
+Requires:       %{name} = %{version}-%{release}
 
 %description -n bpftool-hci
 This package contains the bpftool, which allows inspection and simple

--- a/SPECS/kernel-hci/kernel-hci.spec
+++ b/SPECS/kernel-hci/kernel-hci.spec
@@ -422,7 +422,7 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %{_sysconfdir}/bash_completion.d/bpftool
 
 %changelog
-* Mon Mar 20 2023 Rachel Menge <rachelmenge@microsoft.com> - 5.15.102.1-2
+* Fri Mar 31 2023 Rachel Menge <rachelmenge@microsoft.com> - 5.15.102.1-2
 - Rename bpftool and python3-perf to be kernel specific
 
 * Tue Mar 14 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 5.15.102.1-1

--- a/SPECS/kernel-hci/kernel-hci.spec
+++ b/SPECS/kernel-hci/kernel-hci.spec
@@ -9,7 +9,7 @@
 Summary:        Linux Kernel for HCI
 Name:           kernel-hci
 Version:        5.15.102.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -136,11 +136,12 @@ Requires:       audit
 %description tools
 This package contains the 'perf' performance analysis tools for Linux kernel.
 
-%package -n     python3-perf
+%package        python3-perf
 Summary:        Python 3 extension for perf tools
 Requires:       python3
+Conflicts:      python3-perf
 
-%description -n python3-perf
+%description python3-perf
 This package contains the Python 3 extension for the 'perf' performance analysis tools for Linux kernel.
 
 %package dtb
@@ -150,10 +151,11 @@ Group:          System Environment/Kernel
 %description dtb
 This package contains common device tree blobs (dtb)
 
-%package -n     bpftool
+%package        bpftool
 Summary:        Inspection and simple manipulation of eBPF programs and maps
+Conflicts:      bpftool
 
-%description -n bpftool
+%description bpftool
 This package contains the bpftool, which allows inspection and simple
 manipulation of eBPF programs and maps.
 
@@ -410,14 +412,17 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %{_libdir}/perf/include/bpf/*
 %{_includedir}/perf/perf_dlfilter.h
 
-%files -n python3-perf
+%files python3-perf
 %{python3_sitearch}/*
 
-%files -n bpftool
+%files bpftool
 %{_sbindir}/bpftool
 %{_sysconfdir}/bash_completion.d/bpftool
 
 %changelog
+* Mon Mar 20 2023 Rachel Menge <rachelmenge@microsoft.com> - 5.15.102.1-2
+- Rename bpftool and python3-perf to be kernel specific
+
 * Tue Mar 14 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 5.15.102.1-1
 - Auto-upgrade to 5.15.102.1
 

--- a/SPECS/kernel-hci/kernel-hci.spec
+++ b/SPECS/kernel-hci/kernel-hci.spec
@@ -136,12 +136,13 @@ Requires:       audit
 %description tools
 This package contains the 'perf' performance analysis tools for Linux kernel.
 
-%package        python3-perf
+%package -n     python3-perf-hci
 Summary:        Python 3 extension for perf tools
 Requires:       python3
-Conflicts:      python3-perf
+Obsoletes:      python3-perf
+Provides:       python3-perf
 
-%description python3-perf
+%description -n python3-perf-hci
 This package contains the Python 3 extension for the 'perf' performance analysis tools for Linux kernel.
 
 %package dtb
@@ -151,11 +152,12 @@ Group:          System Environment/Kernel
 %description dtb
 This package contains common device tree blobs (dtb)
 
-%package        bpftool
+%package -n     bpftool-hci
 Summary:        Inspection and simple manipulation of eBPF programs and maps
-Conflicts:      bpftool
+Obsoletes:      bpftool
+Provides:       bpftool
 
-%description bpftool
+%description -n bpftool-hci
 This package contains the bpftool, which allows inspection and simple
 manipulation of eBPF programs and maps.
 
@@ -412,10 +414,10 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %{_libdir}/perf/include/bpf/*
 %{_includedir}/perf/perf_dlfilter.h
 
-%files python3-perf
+%files -n python3-perf-hci
 %{python3_sitearch}/*
 
-%files bpftool
+%files -n bpftool-hci
 %{_sbindir}/bpftool
 %{_sysconfdir}/bash_completion.d/bpftool
 

--- a/SPECS/kernel-hci/kernel-hci.spec
+++ b/SPECS/kernel-hci/kernel-hci.spec
@@ -136,12 +136,14 @@ Requires:       audit
 %description tools
 This package contains the 'perf' performance analysis tools for Linux kernel.
 
-%package        python3-perf
+%package -n     python3-perf-hci
 Summary:        Python 3 extension for perf tools
 Requires:       python3
 Conflicts:      python3-perf
+Conflicts:      python3-perf-azure
+Conflicts:      python3-perf-rt
 
-%description python3-perf
+%description -n python3-perf-hci
 This package contains the Python 3 extension for the 'perf' performance analysis tools for Linux kernel.
 
 %package dtb
@@ -151,11 +153,13 @@ Group:          System Environment/Kernel
 %description dtb
 This package contains common device tree blobs (dtb)
 
-%package        bpftool
+%package -n     bpftool-hci
 Summary:        Inspection and simple manipulation of eBPF programs and maps
 Conflicts:      bpftool
+Conflicts:      bpftool-azure
+Conflicts:      bpftool-rt
 
-%description bpftool
+%description -n bpftool-hci
 This package contains the bpftool, which allows inspection and simple
 manipulation of eBPF programs and maps.
 
@@ -412,10 +416,10 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %{_libdir}/perf/include/bpf/*
 %{_includedir}/perf/perf_dlfilter.h
 
-%files python3-perf
+%files -n python3-perf-hci
 %{python3_sitearch}/*
 
-%files bpftool
+%files -n bpftool-hci
 %{_sbindir}/bpftool
 %{_sysconfdir}/bash_completion.d/bpftool
 

--- a/SPECS/kernel-hci/kernel-hci.spec
+++ b/SPECS/kernel-hci/kernel-hci.spec
@@ -420,7 +420,7 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %{_sysconfdir}/bash_completion.d/bpftool
 
 %changelog
-* Fri Mar 31 2023 Rachel Menge <rachelmenge@microsoft.com> - 5.15.102.1-2
+* Mon Mar 20 2023 Rachel Menge <rachelmenge@microsoft.com> - 5.15.102.1-2
 - Rename bpftool and python3-perf to be kernel specific
 
 * Tue Mar 14 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 5.15.102.1-1

--- a/SPECS/kernel-hci/kernel-hci.spec
+++ b/SPECS/kernel-hci/kernel-hci.spec
@@ -136,13 +136,12 @@ Requires:       audit
 %description tools
 This package contains the 'perf' performance analysis tools for Linux kernel.
 
-%package -n     python3-perf-hci
+%package        python3-perf
 Summary:        Python 3 extension for perf tools
 Requires:       python3
-Obsoletes:      python3-perf
-Provides:       python3-perf
+Conflicts:      python3-perf
 
-%description -n python3-perf-hci
+%description python3-perf
 This package contains the Python 3 extension for the 'perf' performance analysis tools for Linux kernel.
 
 %package dtb
@@ -152,12 +151,11 @@ Group:          System Environment/Kernel
 %description dtb
 This package contains common device tree blobs (dtb)
 
-%package -n     bpftool-hci
+%package        bpftool
 Summary:        Inspection and simple manipulation of eBPF programs and maps
-Obsoletes:      bpftool
-Provides:       bpftool
+Conflicts:      bpftool
 
-%description -n bpftool-hci
+%description bpftool
 This package contains the bpftool, which allows inspection and simple
 manipulation of eBPF programs and maps.
 
@@ -414,10 +412,10 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %{_libdir}/perf/include/bpf/*
 %{_includedir}/perf/perf_dlfilter.h
 
-%files -n python3-perf-hci
+%files python3-perf
 %{python3_sitearch}/*
 
-%files -n bpftool-hci
+%files bpftool
 %{_sbindir}/bpftool
 %{_sysconfdir}/bash_completion.d/bpftool
 

--- a/SPECS/kernel-headers/kernel-headers.spec
+++ b/SPECS/kernel-headers/kernel-headers.spec
@@ -1,7 +1,7 @@
 Summary:        Linux API header files
 Name:           kernel-headers
 Version:        5.15.102.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -36,6 +36,9 @@ cp -rv usr/include/* /%{buildroot}%{_includedir}
 %{_includedir}/*
 
 %changelog
+* Fri Mar 31 2023 Rachel Menge <rachelmenge@microsoft.com> - 5.15.102.1-4
+- Bump release to match kernel
+
 * Wed Mar 29 2023 Rachel Menge <rachelmenge@microsoft.com> - 5.15.102.1-3
 - Bump release to match kernel
 

--- a/SPECS/kernel-headers/kernel-headers.spec
+++ b/SPECS/kernel-headers/kernel-headers.spec
@@ -1,7 +1,7 @@
 Summary:        Linux API header files
 Name:           kernel-headers
 Version:        5.15.102.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -36,6 +36,9 @@ cp -rv usr/include/* /%{buildroot}%{_includedir}
 %{_includedir}/*
 
 %changelog
+* Thu Apr 06 2023 Rachel Menge <rachelmenge@microsoft.com> - 5.15.102.1-4
+- Bump release to match kernel
+
 * Wed Mar 29 2023 Rachel Menge <rachelmenge@microsoft.com> - 5.15.102.1-3
 - Bump release to match kernel
 

--- a/SPECS/kernel-headers/kernel-headers.spec
+++ b/SPECS/kernel-headers/kernel-headers.spec
@@ -1,7 +1,7 @@
 Summary:        Linux API header files
 Name:           kernel-headers
 Version:        5.15.102.1
-Release:        4%{?dist}
+Release:        3%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -36,9 +36,6 @@ cp -rv usr/include/* /%{buildroot}%{_includedir}
 %{_includedir}/*
 
 %changelog
-* Fri Mar 31 2023 Rachel Menge <rachelmenge@microsoft.com> - 5.15.102.1-4
-- Bump release to match kernel
-
 * Wed Mar 29 2023 Rachel Menge <rachelmenge@microsoft.com> - 5.15.102.1-3
 - Bump release to match kernel
 

--- a/SPECS/kernel/kernel.spec
+++ b/SPECS/kernel/kernel.spec
@@ -57,6 +57,11 @@ Requires:       filesystem
 Requires:       kmod
 Requires(post): coreutils
 Requires(postun): coreutils
+Conflicts:      kernel-azure
+Conflicts:      kernel-hci
+Conflicts:      kernel-mshv
+Conflicts:      kernel-rt
+Conflicts:      kernel-uvm
 # When updating the config files it is important to sanitize them.
 # Steps for updating a config file:
 #  1. Extract the linux sources into a folder
@@ -129,9 +134,7 @@ This package contains the 'perf' performance analysis tools for Linux kernel.
 %package -n     python3-perf
 Summary:        Python 3 extension for perf tools
 Requires:       python3
-Conflicts:      python3-perf-azure
-Conflicts:      python3-perf-hci
-Conflicts:      python3-perf-rt
+Requires:       %{name} = %{version}-%{release}
 
 %description -n python3-perf
 This package contains the Python 3 extension for the 'perf' performance analysis tools for Linux kernel.
@@ -145,9 +148,7 @@ This package contains common device tree blobs (dtb)
 
 %package -n     bpftool
 Summary:        Inspection and simple manipulation of eBPF programs and maps
-Conflicts:      bpftool-azure
-Conflicts:      bpftool-hci
-Conflicts:      bpftool-rt
+Requires:       %{name} = %{version}-%{release}
 
 %description -n bpftool
 This package contains the bpftool, which allows inspection and simple

--- a/SPECS/kernel/kernel.spec
+++ b/SPECS/kernel/kernel.spec
@@ -129,6 +129,8 @@ This package contains the 'perf' performance analysis tools for Linux kernel.
 %package -n     python3-perf
 Summary:        Python 3 extension for perf tools
 Requires:       python3
+Obsoletes:      python3-perf
+Provides:       python3-perf
 
 %description -n python3-perf
 This package contains the Python 3 extension for the 'perf' performance analysis tools for Linux kernel.
@@ -142,6 +144,8 @@ This package contains common device tree blobs (dtb)
 
 %package -n     bpftool
 Summary:        Inspection and simple manipulation of eBPF programs and maps
+Obsoletes:      bpftool
+Provides:       bpftool
 
 %description -n bpftool
 This package contains the bpftool, which allows inspection and simple

--- a/SPECS/kernel/kernel.spec
+++ b/SPECS/kernel/kernel.spec
@@ -414,6 +414,9 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %{_sysconfdir}/bash_completion.d/bpftool
 
 %changelog
+* Fri Mar 31 2023 Rachel Menge <rachelmenge@microsoft.com> - 5.15.102.1-4
+- Create Obsoletes and Provides for kernel subpackages bpftool, python3-perf
+
 * Wed Mar 29 2023 Rachel Menge <rachelmenge@microsoft.com> - 5.15.102.1-3
 - Enable CONFIG_NET_CLS_FLOWER module
 

--- a/SPECS/kernel/kernel.spec
+++ b/SPECS/kernel/kernel.spec
@@ -410,9 +410,6 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %{_sysconfdir}/bash_completion.d/bpftool
 
 %changelog
-* Fri Mar 31 2023 Rachel Menge <rachelmenge@microsoft.com> - 5.15.102.1-4
-- Create Obsoletes and Provides for kernel subpackages bpftool, python3-perf
-
 * Wed Mar 29 2023 Rachel Menge <rachelmenge@microsoft.com> - 5.15.102.1-3
 - Enable CONFIG_NET_CLS_FLOWER module
 

--- a/SPECS/kernel/kernel.spec
+++ b/SPECS/kernel/kernel.spec
@@ -129,8 +129,6 @@ This package contains the 'perf' performance analysis tools for Linux kernel.
 %package -n     python3-perf
 Summary:        Python 3 extension for perf tools
 Requires:       python3
-Obsoletes:      python3-perf
-Provides:       python3-perf
 
 %description -n python3-perf
 This package contains the Python 3 extension for the 'perf' performance analysis tools for Linux kernel.
@@ -144,8 +142,6 @@ This package contains common device tree blobs (dtb)
 
 %package -n     bpftool
 Summary:        Inspection and simple manipulation of eBPF programs and maps
-Obsoletes:      bpftool
-Provides:       bpftool
 
 %description -n bpftool
 This package contains the bpftool, which allows inspection and simple

--- a/SPECS/kernel/kernel.spec
+++ b/SPECS/kernel/kernel.spec
@@ -18,7 +18,7 @@
 Summary:        Linux Kernel
 Name:           kernel
 Version:        5.15.102.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -129,6 +129,9 @@ This package contains the 'perf' performance analysis tools for Linux kernel.
 %package -n     python3-perf
 Summary:        Python 3 extension for perf tools
 Requires:       python3
+Conflicts:      python3-perf-azure
+Conflicts:      python3-perf-hci
+Conflicts:      python3-perf-rt
 
 %description -n python3-perf
 This package contains the Python 3 extension for the 'perf' performance analysis tools for Linux kernel.
@@ -142,6 +145,9 @@ This package contains common device tree blobs (dtb)
 
 %package -n     bpftool
 Summary:        Inspection and simple manipulation of eBPF programs and maps
+Conflicts:      bpftool-azure
+Conflicts:      bpftool-hci
+Conflicts:      bpftool-rt
 
 %description -n bpftool
 This package contains the bpftool, which allows inspection and simple
@@ -410,6 +416,9 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %{_sysconfdir}/bash_completion.d/bpftool
 
 %changelog
+* Thu Apr 06 2023 Rachel Menge <rachelmenge@microsoft.com> - 5.15.102.1-4
+- Add additional conflicts to bpftool and python3-perf subpackages
+
 * Wed Mar 29 2023 Rachel Menge <rachelmenge@microsoft.com> - 5.15.102.1-3
 - Enable CONFIG_NET_CLS_FLOWER module
 

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -1,5 +1,5 @@
 filesystem-1.1-12.cm2.aarch64.rpm
-kernel-headers-5.15.102.1-3.cm2.noarch.rpm
+kernel-headers-5.15.102.1-4.cm2.noarch.rpm
 glibc-2.35-3.cm2.aarch64.rpm
 glibc-devel-2.35-3.cm2.aarch64.rpm
 glibc-i18n-2.35-3.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -1,5 +1,5 @@
 filesystem-1.1-12.cm2.aarch64.rpm
-kernel-headers-5.15.102.1-4.cm2.noarch.rpm
+kernel-headers-5.15.102.1-3.cm2.noarch.rpm
 glibc-2.35-3.cm2.aarch64.rpm
 glibc-devel-2.35-3.cm2.aarch64.rpm
 glibc-i18n-2.35-3.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -1,5 +1,5 @@
 filesystem-1.1-12.cm2.x86_64.rpm
-kernel-headers-5.15.102.1-3.cm2.noarch.rpm
+kernel-headers-5.15.102.1-4.cm2.noarch.rpm
 glibc-2.35-3.cm2.x86_64.rpm
 glibc-devel-2.35-3.cm2.x86_64.rpm
 glibc-i18n-2.35-3.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -1,5 +1,5 @@
 filesystem-1.1-12.cm2.x86_64.rpm
-kernel-headers-5.15.102.1-4.cm2.noarch.rpm
+kernel-headers-5.15.102.1-3.cm2.noarch.rpm
 glibc-2.35-3.cm2.x86_64.rpm
 glibc-devel-2.35-3.cm2.x86_64.rpm
 glibc-i18n-2.35-3.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -135,7 +135,7 @@ intltool-0.51.0-7.cm2.noarch.rpm
 itstool-2.0.6-4.cm2.noarch.rpm
 kbd-2.2.0-1.cm2.aarch64.rpm
 kbd-debuginfo-2.2.0-1.cm2.aarch64.rpm
-kernel-headers-5.15.102.1-3.cm2.noarch.rpm
+kernel-headers-5.15.102.1-4.cm2.noarch.rpm
 kmod-29-1.cm2.aarch64.rpm
 kmod-debuginfo-29-1.cm2.aarch64.rpm
 kmod-devel-29-1.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -135,7 +135,7 @@ intltool-0.51.0-7.cm2.noarch.rpm
 itstool-2.0.6-4.cm2.noarch.rpm
 kbd-2.2.0-1.cm2.aarch64.rpm
 kbd-debuginfo-2.2.0-1.cm2.aarch64.rpm
-kernel-headers-5.15.102.1-4.cm2.noarch.rpm
+kernel-headers-5.15.102.1-3.cm2.noarch.rpm
 kmod-29-1.cm2.aarch64.rpm
 kmod-debuginfo-29-1.cm2.aarch64.rpm
 kmod-devel-29-1.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -135,7 +135,7 @@ intltool-0.51.0-7.cm2.noarch.rpm
 itstool-2.0.6-4.cm2.noarch.rpm
 kbd-2.2.0-1.cm2.x86_64.rpm
 kbd-debuginfo-2.2.0-1.cm2.x86_64.rpm
-kernel-headers-5.15.102.1-3.cm2.noarch.rpm
+kernel-headers-5.15.102.1-4.cm2.noarch.rpm
 kmod-29-1.cm2.x86_64.rpm
 kmod-debuginfo-29-1.cm2.x86_64.rpm
 kmod-devel-29-1.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -135,7 +135,7 @@ intltool-0.51.0-7.cm2.noarch.rpm
 itstool-2.0.6-4.cm2.noarch.rpm
 kbd-2.2.0-1.cm2.x86_64.rpm
 kbd-debuginfo-2.2.0-1.cm2.x86_64.rpm
-kernel-headers-5.15.102.1-4.cm2.noarch.rpm
+kernel-headers-5.15.102.1-3.cm2.noarch.rpm
 kmod-29-1.cm2.x86_64.rpm
 kmod-debuginfo-29-1.cm2.x86_64.rpm
 kmod-devel-29-1.cm2.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
There was a bug where certain specialized kernels (`kernel-azure`, `kernel-hci`, `kernel-rt`) would create subpackages of the same name (`bpftool`, `python3-perf`) as the generic kernel. This will cause packages to be published and overwritten. **For now,** create specialized version names (ex. `kernel-azure-bpftool`) of the subpackages from specialized kernels. Explicitly call out the conflict with the generic kernel's subpackages. This should be investigated further for a less involved solution.

Subpackage changes from kernel-azure
`bpftool` -> `bpftool-azure` which conflicts with `bpftool` and variants
`python3-perf `-> `python3-perf-azure` which conflicts with `python3-perf` and variants

Subpackage changes from kernel-hci 
`bpftool` -> `bpftool-hci` which conflicts with `bpftool` and variants
`python3-perf` ->python3-perf-hci` which conflicts with `python3-perf` and variants

Subpackage changes from kernel-rt
`bpftool` -> `bpftool-rt` which conflicts with `bpftool` and variants
`python3-perf` ->python3-perf-rt` which conflicts with `python3-perf` and variants


###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Rename bpftool and python3-perf to be kernel specific
- Add conflicts with the other subpackages

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://microsoft.visualstudio.com/OS/_workitems/edit/43814917/

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- (in progress) https://dev.azure.com/mariner-org/mariner/_build/results?buildId=330766&view=results
- Buddy Build Pipeline https://dev.azure.com/mariner-org/mariner/_build/results?buildId=330010&view=results
- Tested
![image](https://user-images.githubusercontent.com/10325590/226734749-7fd7506a-46b6-4963-a6ac-85ed8f6f4e6a.png)

