### PR TITLE
Mahuber/kata memfix

### DIFF
--- a/SPECS/gnupg2/gnupg2.spec
+++ b/SPECS/gnupg2/gnupg2.spec
@@ -1,7 +1,7 @@
 Summary:        OpenPGP standard implementation used for encrypted communication and data storage.
 Name:           gnupg2
 Version:        2.4.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        BSD and CC0 and GPLv2+ and LGPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -15,7 +15,7 @@ BuildRequires:  npth-devel >= 1.2
 BuildRequires:  libassuan-devel >= 2.5.0
 BuildRequires:  libksba-devel >= 1.3.4
 BuildRequires:  libgcrypt-devel > 1.9.1
-BuildRequires:  libgpg-error-devel >= 1.41
+BuildRequires:  libgpg-error-devel >= 1.46
 Requires:       libksba > 1.3.4
 Requires:       libgcrypt >= 1.9.1
 Requires:       libgpg-error >= 1.46
@@ -89,6 +89,9 @@ ln -s $(pwd)/bin/gpg $(pwd)/bin/gpg2
 %defattr(-,root,root)
 
 %changelog
+* Tue Mar 21 2023 Muhammad Falak <mwani@microsoft.com> - 2.4.0-2
+- Add correct version for libgpg-error-devel as a BR
+
 * Mon Jan 23 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 2.4.0-1
 - Auto-upgrade to 2.4.0 - to fix CVE-2022-3515
 - Update libgpg-error dependency to 1.46

--- a/SPECS/kata-containers/kata-containers.spec
+++ b/SPECS/kata-containers/kata-containers.spec
@@ -25,6 +25,8 @@
                                 DEFVIRTIOFSDAEMON=%{_libexecdir}/"virtiofsd" \\\
                                 DEFVIRTIOFSCACHESIZE=0 \\\
                                 DEFSANDBOXCGROUPONLY=false \\\
+                                DEFSTATICSANDBOXWORKLOADMEM=1984 \\\
+                                DEFMEMSZ=64 \\\
                                 SKIP_GO_VERSION_CHECK=y \\\
                                 MACHINETYPE=%{machinetype} \\\
                                 DESTDIR=%{buildroot} \\\
@@ -58,6 +60,7 @@ Patch5:         runtime-Support-for-AMD-SEV-SNP-VMs.patch
 Patch6:         runtime-clh-Use-the-new-API-to-boot-with-TDX-firmware-td-shim.patch
 Patch7:         versions-Update-Cloud-Hypervisor.patch
 Patch8:         runtime-Re-generate-the-client-code.patch
+Patch9:         runtime-reduce-uvm-high-mem-footprint.patch
 
 BuildRequires:  golang
 BuildRequires:  git-core
@@ -224,6 +227,9 @@ ln -sf %{_bindir}/kata-runtime %{buildroot}%{_prefix}/local/bin/kata-runtime
 %exclude %{kataosbuilderdir}/rootfs-builder/ubuntu
 
 %changelog
+* Wed Mar 22 2023 Manuel Huber <mahuber@microsoft.com> - 3.0.0-6
+- Integrate fix to reduce UVM memory consumption
+
 * Wed Mar 15 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 3.0.0-5
 - Bump release to rebuild with go 1.19.6
 

--- a/SPECS/kata-containers/runtime-reduce-uvm-high-mem-footprint.patch
+++ b/SPECS/kata-containers/runtime-reduce-uvm-high-mem-footprint.patch
@@ -1,0 +1,279 @@
+From ff6c016a20f95580e7d1f06e3787c0675675807f Mon Sep 17 00:00:00 2001
+From: Manuel Huber <mahuber@microsoft.com>
+Date: Wed, 22 Mar 2023 17:12:09 +0000
+Subject: [PATCH] Merged PR 12983: Commit d5ed88f3: Fix 43668151: Resolve high
+ UVM memory footprint
+
+Bug: https://microsoft.visualstudio.com/OS/_workitems/edit/43668151
+
+Rationale: This is a temporary solution for optimizing memory usage for the
+current mechanism of requesting resources through pod Limit annotations:
+- if no Limits are specified and hence WorkloadMemMB is 0, set
+  a default value 'StaticWorkloadDefaultMem' to allocate a default amount
+  of memory for use for containers in the sandbox in addition to the base memory
+- if Limits are specified, the base memory and the sum of Limits are
+  allocated. The end user needs to be aware of the minimum memory
+  requirements for their pods, otherwise the pod will be stuck in the
+  ContainerCreating state
+
+Testing: Manual testing, creating pods with Limits and without limits, and with two containers where each container has a limit, tested with integration in a SPEC file where the config variables were set via environment variables via the make command
+---
+ src/runtime/Makefile                          |  8 ++++-
+ src/runtime/config/configuration-clh.toml.in  | 17 ++++++----
+ src/runtime/config/configuration-fc.toml.in   |  5 +++
+ src/runtime/config/configuration-qemu.toml.in |  7 +++-
+ src/runtime/pkg/katautils/config.go           | 32 ++++++++++---------
+ src/runtime/pkg/oci/utils.go                  | 11 +++++++
+ src/runtime/virtcontainers/hypervisor.go      |  2 +-
+ src/runtime/virtcontainers/sandbox.go         |  3 ++
+ 8 files changed, 61 insertions(+), 24 deletions(-)
+
+diff --git a/src/runtime/Makefile b/src/runtime/Makefile
+index b05106318..604e0ddae 100644
+--- a/src/runtime/Makefile
++++ b/src/runtime/Makefile
+@@ -150,7 +150,7 @@ DEFVCPUS := 1
+ # Default maximum number of vCPUs
+ DEFMAXVCPUS := 0
+ # Default memory size in MiB
+-DEFMEMSZ := 2048
++DEFMEMSZ ?= 2048
+ # Default memory slots
+ # Cases to consider :
+ # - nvdimm rootfs image
+@@ -211,6 +211,9 @@ DEFSANDBOXCGROUPONLY ?= false
+ 
+ DEFSTATICRESOURCEMGMT ?= false
+ 
++# Default memory for use for workloads within the sandbox if no specific workload memory value is requested
++DEFSTATICSANDBOXWORKLOADMEM ?= 2048
++
+ DEFBINDMOUNTS := []
+ 
+ SED = sed
+@@ -278,6 +281,7 @@ ifneq (,$(CLHCMD))
+     # CLH-specific options (all should be suffixed by "_CLH")
+     # currently, huge pages are required for virtiofsd support
+     DEFNETWORKMODEL_CLH := tcfilter
++    DEFSTATICRESOURCEMGMT_CLH = true
+     KERNELTYPE_CLH = uncompressed
+     KERNEL_NAME_CLH = $(call MAKE_KERNEL_NAME,$(KERNELTYPE_CLH))
+     KERNELPATH_CLH = $(KERNELDIR)/$(KERNEL_NAME_CLH)
+@@ -480,7 +484,9 @@ USER_VARS += DEFENTROPYSOURCE
+ USER_VARS += DEFVALIDENTROPYSOURCES
+ USER_VARS += DEFSANDBOXCGROUPONLY
+ USER_VARS += DEFSTATICRESOURCEMGMT
++USER_VARS += DEFSTATICRESOURCEMGMT_CLH
+ USER_VARS += DEFSTATICRESOURCEMGMT_FC
++USER_VARS += DEFSTATICSANDBOXWORKLOADMEM
+ USER_VARS += DEFBINDMOUNTS
+ USER_VARS += DEFVFIOMODE
+ USER_VARS += BUILDFLAGS
+diff --git a/src/runtime/config/configuration-clh.toml.in b/src/runtime/config/configuration-clh.toml.in
+index 59ddf43e1..4f05115b8 100644
+--- a/src/runtime/config/configuration-clh.toml.in
++++ b/src/runtime/config/configuration-clh.toml.in
+@@ -25,7 +25,7 @@ image = "@IMAGEPATH@"
+ #
+ # Known limitations:
+ # * Does not work by design:
+-#   - CPU Hotplug 
++#   - CPU Hotplug
+ #   - Memory Hotplug
+ #   - NVDIMM devices
+ #
+@@ -190,9 +190,9 @@ block_device_driver = "virtio-blk"
+ # and we strongly advise users to refer the Cloud Hypervisor official
+ # documentation for a better understanding of its internals:
+ # https://github.com/cloud-hypervisor/cloud-hypervisor/blob/main/docs/io_throttling.md
+-# 
++#
+ # Bandwidth rate limiter options
+-# 
++#
+ # net_rate_limiter_bw_max_rate controls network I/O bandwidth (size in bits/sec
+ # for SB/VM).
+ # The same value is used for inbound and outbound bandwidth.
+@@ -226,9 +226,9 @@ block_device_driver = "virtio-blk"
+ # and we strongly advise users to refer the Cloud Hypervisor official
+ # documentation for a better understanding of its internals:
+ # https://github.com/cloud-hypervisor/cloud-hypervisor/blob/main/docs/io_throttling.md
+-# 
++#
+ # Bandwidth rate limiter options
+-# 
++#
+ # disk_rate_limiter_bw_max_rate controls disk I/O bandwidth (size in bits/sec
+ # for SB/VM).
+ # The same value is used for inbound and outbound bandwidth.
+@@ -356,7 +356,12 @@ sandbox_cgroup_only=@DEFSANDBOXCGROUPONLY@
+ # - When running with pods, sandbox sizing information will only be available if using Kubernetes >= 1.23 and containerd >= 1.6. CRI-O
+ #   does not yet support sandbox sizing annotations.
+ # - When running single containers using a tool like ctr, container sizing information will be available.
+-static_sandbox_resource_mgmt=@DEFSTATICRESOURCEMGMT@
++static_sandbox_resource_mgmt=@DEFSTATICRESOURCEMGMT_CLH@
++
++# If set, the runtime will use the value as the default workload memory in MB for the sandbox when no workload memory request is passed
++# down to the shim via the OCI when static sandbox resource management is enabled. With this, we ensure that workloads have a proper
++# default amount of memory available within the sandbox.
++static_sandbox_default_workload_mem=@DEFSTATICSANDBOXWORKLOADMEM@
+ 
+ # If specified, sandbox_bind_mounts identifieds host paths to be mounted (ro) into the sandboxes shared path.
+ # This is only valid if filesystem sharing is utilized. The provided path(s) will be bindmounted into the shared fs directory.
+diff --git a/src/runtime/config/configuration-fc.toml.in b/src/runtime/config/configuration-fc.toml.in
+index b7f349c0d..e1a87762a 100644
+--- a/src/runtime/config/configuration-fc.toml.in
++++ b/src/runtime/config/configuration-fc.toml.in
+@@ -352,6 +352,11 @@ sandbox_cgroup_only=@DEFSANDBOXCGROUPONLY@
+ # - When running single containers using a tool like ctr, container sizing information will be available.
+ static_sandbox_resource_mgmt=@DEFSTATICRESOURCEMGMT_FC@
+ 
++# If set, the runtime will use the value as the default workload memory in MB for the sandbox when no workload memory request is passed
++# down to the shim via the OCI when static sandbox resource management is enabled. With this, we ensure that workloads have a proper
++# default amount of memory available within the sandbox.
++static_sandbox_default_workload_mem=@DEFSTATICSANDBOXWORKLOADMEM@
++
+ # If enabled, the runtime will not create Kubernetes emptyDir mounts on the guest filesystem. Instead, emptyDir mounts will
+ # be created on the host and shared via virtio-fs. This is potentially slower, but allows sharing of files from host to guest.
+ disable_guest_empty_dir=@DEFDISABLEGUESTEMPTYDIR@
+diff --git a/src/runtime/config/configuration-qemu.toml.in b/src/runtime/config/configuration-qemu.toml.in
+index d0a711dcf..7a5137247 100644
+--- a/src/runtime/config/configuration-qemu.toml.in
++++ b/src/runtime/config/configuration-qemu.toml.in
+@@ -26,7 +26,7 @@ machine_type = "@MACHINETYPE@"
+ #
+ # Known limitations:
+ # * Does not work by design:
+-#   - CPU Hotplug 
++#   - CPU Hotplug
+ #   - Memory Hotplug
+ #   - NVDIMM devices
+ #
+@@ -580,6 +580,11 @@ sandbox_cgroup_only=@DEFSANDBOXCGROUPONLY@
+ # - When running single containers using a tool like ctr, container sizing information will be available.
+ static_sandbox_resource_mgmt=@DEFSTATICRESOURCEMGMT@
+ 
++# If set, the runtime will use the value as the default workload memory in MB for the sandbox when no workload memory request is passed
++# down to the shim via the OCI when static sandbox resource management is enabled. With this, we ensure that workloads have a proper
++# default amount of memory available within the sandbox.
++static_sandbox_default_workload_mem=@DEFSTATICSANDBOXWORKLOADMEM@
++
+ # If specified, sandbox_bind_mounts identifieds host paths to be mounted (ro) into the sandboxes shared path.
+ # This is only valid if filesystem sharing is utilized. The provided path(s) will be bindmounted into the shared fs directory.
+ # If defaults are utilized, these mounts should be available in the guest at `/run/kata-containers/shared/containers/sandbox-mounts`
+diff --git a/src/runtime/pkg/katautils/config.go b/src/runtime/pkg/katautils/config.go
+index f3bc06bdf..b6220a44d 100644
+--- a/src/runtime/pkg/katautils/config.go
++++ b/src/runtime/pkg/katautils/config.go
+@@ -157,21 +157,22 @@ type hypervisor struct {
+ }
+ 
+ type runtime struct {
+-	InterNetworkModel         string   `toml:"internetworking_model"`
+-	JaegerEndpoint            string   `toml:"jaeger_endpoint"`
+-	JaegerUser                string   `toml:"jaeger_user"`
+-	JaegerPassword            string   `toml:"jaeger_password"`
+-	VfioMode                  string   `toml:"vfio_mode"`
+-	SandboxBindMounts         []string `toml:"sandbox_bind_mounts"`
+-	Experimental              []string `toml:"experimental"`
+-	Debug                     bool     `toml:"enable_debug"`
+-	Tracing                   bool     `toml:"enable_tracing"`
+-	DisableNewNetNs           bool     `toml:"disable_new_netns"`
+-	DisableGuestSeccomp       bool     `toml:"disable_guest_seccomp"`
+-	SandboxCgroupOnly         bool     `toml:"sandbox_cgroup_only"`
+-	StaticSandboxResourceMgmt bool     `toml:"static_sandbox_resource_mgmt"`
+-	EnablePprof               bool     `toml:"enable_pprof"`
+-	DisableGuestEmptyDir      bool     `toml:"disable_guest_empty_dir"`
++	InterNetworkModel               string   `toml:"internetworking_model"`
++	JaegerEndpoint                  string   `toml:"jaeger_endpoint"`
++	JaegerUser                      string   `toml:"jaeger_user"`
++	JaegerPassword                  string   `toml:"jaeger_password"`
++	VfioMode                        string   `toml:"vfio_mode"`
++	SandboxBindMounts               []string `toml:"sandbox_bind_mounts"`
++	Experimental                    []string `toml:"experimental"`
++	Debug                           bool     `toml:"enable_debug"`
++	Tracing                         bool     `toml:"enable_tracing"`
++	DisableNewNetNs                 bool     `toml:"disable_new_netns"`
++	DisableGuestSeccomp             bool     `toml:"disable_guest_seccomp"`
++	SandboxCgroupOnly               bool     `toml:"sandbox_cgroup_only"`
++	StaticSandboxResourceMgmt       bool     `toml:"static_sandbox_resource_mgmt"`
++	StaticSandboxWorkloadDefaultMem uint32   `toml:"static_sandbox_default_workload_mem"`
++	EnablePprof                     bool     `toml:"enable_pprof"`
++	DisableGuestEmptyDir            bool     `toml:"disable_guest_empty_dir"`
+ }
+ 
+ type agent struct {
+@@ -1313,6 +1314,7 @@ func LoadConfiguration(configPath string, ignoreLogging bool) (resolvedConfigPat
+ 	config.DisableGuestSeccomp = tomlConf.Runtime.DisableGuestSeccomp
+ 
+ 	config.StaticSandboxResourceMgmt = tomlConf.Runtime.StaticSandboxResourceMgmt
++	config.StaticSandboxWorkloadDefaultMem = tomlConf.Runtime.StaticSandboxWorkloadDefaultMem
+ 	config.SandboxCgroupOnly = tomlConf.Runtime.SandboxCgroupOnly
+ 	config.DisableNewNetNs = tomlConf.Runtime.DisableNewNetNs
+ 	config.EnablePprof = tomlConf.Runtime.EnablePprof
+diff --git a/src/runtime/pkg/oci/utils.go b/src/runtime/pkg/oci/utils.go
+index 95bfe2a33..59e55c47d 100644
+--- a/src/runtime/pkg/oci/utils.go
++++ b/src/runtime/pkg/oci/utils.go
+@@ -137,6 +137,9 @@ type RuntimeConfig struct {
+ 	// any later resource updates.
+ 	StaticSandboxResourceMgmt bool
+ 
++	// Memory to allocate for workloads within the sandbox when workload memory is unspecified
++	StaticSandboxWorkloadDefaultMem uint32
++
+ 	// Determines if create a netns for hypervisor process
+ 	DisableNewNetNs bool
+ 
+@@ -928,6 +931,8 @@ func SandboxConfig(ocispec specs.Spec, runtime RuntimeConfig, bundlePath, cid st
+ 
+ 		StaticResourceMgmt: runtime.StaticSandboxResourceMgmt,
+ 
++		StaticWorkloadDefaultMem: runtime.StaticSandboxWorkloadDefaultMem,
++
+ 		ShmSize: shmSize,
+ 
+ 		VfioMode: runtime.VfioMode,
+@@ -950,6 +955,12 @@ func SandboxConfig(ocispec specs.Spec, runtime RuntimeConfig, bundlePath, cid st
+ 	// with the base number of CPU/memory (which is equal to the default CPU/memory specified for the runtime
+ 	// configuration or annotations) as well as any specified workload resources.
+ 	if sandboxConfig.StaticResourceMgmt {
++		// If no Limits are set in pod config, use StaticWorkloadDefaultMem to ensure the containers generally
++		// have a reasonable amount of memory available
++		if sandboxConfig.SandboxResources.WorkloadMemMB == 0 {
++			sandboxConfig.SandboxResources.WorkloadMemMB = sandboxConfig.StaticWorkloadDefaultMem
++		}
++
+ 		sandboxConfig.SandboxResources.BaseCPUs = sandboxConfig.HypervisorConfig.NumVCPUs
+ 		sandboxConfig.SandboxResources.BaseMemMB = sandboxConfig.HypervisorConfig.MemorySize
+ 
+diff --git a/src/runtime/virtcontainers/hypervisor.go b/src/runtime/virtcontainers/hypervisor.go
+index c44c0bae7..60e2b99b3 100644
+--- a/src/runtime/virtcontainers/hypervisor.go
++++ b/src/runtime/virtcontainers/hypervisor.go
+@@ -71,7 +71,7 @@ const (
+ 	vSockLogsPort = 1025
+ 
+ 	// MinHypervisorMemory is the minimum memory required for a VM.
+-	MinHypervisorMemory = 256
++	MinHypervisorMemory = 64
+ 
+ 	defaultMsize9p = 8192
+ )
+diff --git a/src/runtime/virtcontainers/sandbox.go b/src/runtime/virtcontainers/sandbox.go
+index e4a16983e..24992111a 100644
+--- a/src/runtime/virtcontainers/sandbox.go
++++ b/src/runtime/virtcontainers/sandbox.go
+@@ -161,6 +161,9 @@ type SandboxConfig struct {
+ 	// StaticResourceMgmt indicates if the shim should rely on statically sizing the sandbox (VM)
+ 	StaticResourceMgmt bool
+ 
++	// Memory to allocate for workloads within the sandbox when workload memory is unspecified
++	StaticWorkloadDefaultMem uint32
++
+ 	ShmSize uint64
+ 
+ 	VfioMode config.VFIOModeType
+-- 
+2.33.6
+

--- a/toolkit/docs/building/prerequisites-mariner.md
+++ b/toolkit/docs/building/prerequisites-mariner.md
@@ -1,18 +1,35 @@
 
 # Build Requirements on `Mariner`
 
-## Requirements were validated on `Mariner 1.0`
+## Requirements were validated on `Mariner 2.0`
 
-This works regardless of installing `core` or `full` version of mariner.
-If you installed `full` version of mariner, some of these packages are already installed, so less packages will be downloaded.
-
-Requirements for building images with a toolkit:
+This page lists host machine requirements for building with the CBL-Mariner toolkit. They cover building the toolchain, packages, and images on a Mariner host.
 
 ```bash
 # Install required dependencies.
-sudo dnf -y install git make tar rpm-build gcc glibc-devel binutils \
-kernel-headers wget curl rpm qemu-img golang cdrkit python2 bison \
-gawk parted dosfstools pigz moby-engine moby-cli
+# Recommended but not required: `pigz` for faster compression operations.
+sudo tdnf -y install \
+    binutils \
+    cdrkit \
+    curl \
+    dosfstools \
+    gawk \
+    glibc-devel \
+    genisoimage \
+    git \
+    "golang < 1.18" \
+    kernel-headers \
+    make \
+    moby-cli \
+    moby-engine \
+    parted \
+    pigz \
+    qemu-img \
+    rpm \
+    rpm-build \
+    sudo \
+    tar \
+    wget
 
 # Enable Docker daemon at boot
 sudo systemctl enable --now docker.service

--- a/toolkit/docs/building/prerequisites-ubuntu.md
+++ b/toolkit/docs/building/prerequisites-ubuntu.md
@@ -3,7 +3,7 @@
 
 ## Requirements were validated on `Ubuntu 18.04`
 
-Requirements for building images with a toolkit:
+This page lists host machine requirements for building with the CBL-Mariner toolkit. They cover building the toolchain, packages, and images on an Ubuntu 18.04 host.
 
 ```bash
 # Add a backports repo in order to install the latest version of Go.
@@ -11,15 +11,25 @@ sudo add-apt-repository ppa:longsleep/golang-backports
 sudo apt-get update
 
 # Install required dependencies.
-sudo apt -y install git make tar wget curl rpm qemu-utils golang-1.17-go genisoimage python-minimal bison gawk parted
-
 # Recommended but not required: `pigz` for faster compression operations.
-sudo apt -y install pigz
+sudo apt -y install \
+    curl \
+    gawk \
+    genisoimage \
+    git \
+    golang-1.17-go \
+    make \
+    parted \
+    pigz \
+    qemu-utils \
+    rpm \
+    tar \
+    wget
 
 # Fix go 1.17 link
 sudo ln -vsf /usr/lib/go-1.17/bin/go /usr/bin/go
 
-# Install Docker.
+# Install and configure Docker.
 curl -fsSL https://get.docker.com -o get-docker.sh
 sudo sh get-docker.sh
 sudo usermod -aG docker $USER

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -218,8 +218,8 @@ libksba-1.6.3-1.cm2.aarch64.rpm
 libksba-devel-1.6.3-1.cm2.aarch64.rpm
 npth-1.6-4.cm2.aarch64.rpm
 pinentry-1.2.0-1.cm2.aarch64.rpm
-gnupg2-2.4.0-1.cm2.aarch64.rpm
-gnupg2-lang-2.4.0-1.cm2.aarch64.rpm
+gnupg2-2.4.0-2.cm2.aarch64.rpm
+gnupg2-lang-2.4.0-2.cm2.aarch64.rpm
 gpgme-1.16.0-1.cm2.aarch64.rpm
 mariner-repos-shared-2.0-8.cm2.noarch.rpm
 mariner-repos-2.0-8.cm2.noarch.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -218,8 +218,8 @@ libksba-1.6.3-1.cm2.x86_64.rpm
 libksba-devel-1.6.3-1.cm2.x86_64.rpm
 npth-1.6-4.cm2.x86_64.rpm
 pinentry-1.2.0-1.cm2.x86_64.rpm
-gnupg2-2.4.0-1.cm2.x86_64.rpm
-gnupg2-lang-2.4.0-1.cm2.x86_64.rpm
+gnupg2-2.4.0-2.cm2.x86_64.rpm
+gnupg2-lang-2.4.0-2.cm2.x86_64.rpm
 gpgme-1.16.0-1.cm2.x86_64.rpm
 mariner-repos-shared-2.0-8.cm2.noarch.rpm
 mariner-repos-2.0-8.cm2.noarch.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -117,9 +117,9 @@ glibc-tools-2.35-3.cm2.aarch64.rpm
 gmp-6.2.1-2.cm2.aarch64.rpm
 gmp-debuginfo-6.2.1-2.cm2.aarch64.rpm
 gmp-devel-6.2.1-2.cm2.aarch64.rpm
-gnupg2-2.4.0-1.cm2.aarch64.rpm
-gnupg2-debuginfo-2.4.0-1.cm2.aarch64.rpm
-gnupg2-lang-2.4.0-1.cm2.aarch64.rpm
+gnupg2-2.4.0-2.cm2.aarch64.rpm
+gnupg2-debuginfo-2.4.0-2.cm2.aarch64.rpm
+gnupg2-lang-2.4.0-2.cm2.aarch64.rpm
 gperf-3.1-4.cm2.aarch64.rpm
 gperf-debuginfo-3.1-4.cm2.aarch64.rpm
 gpgme-1.16.0-1.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -117,9 +117,9 @@ glibc-tools-2.35-3.cm2.x86_64.rpm
 gmp-6.2.1-2.cm2.x86_64.rpm
 gmp-debuginfo-6.2.1-2.cm2.x86_64.rpm
 gmp-devel-6.2.1-2.cm2.x86_64.rpm
-gnupg2-2.4.0-1.cm2.x86_64.rpm
-gnupg2-debuginfo-2.4.0-1.cm2.x86_64.rpm
-gnupg2-lang-2.4.0-1.cm2.x86_64.rpm
+gnupg2-2.4.0-2.cm2.x86_64.rpm
+gnupg2-debuginfo-2.4.0-2.cm2.x86_64.rpm
+gnupg2-lang-2.4.0-2.cm2.x86_64.rpm
 gperf-3.1-4.cm2.x86_64.rpm
 gperf-debuginfo-3.1-4.cm2.x86_64.rpm
 gpgme-1.16.0-1.cm2.x86_64.rpm

--- a/toolkit/tools/scheduler/schedulerutils/buildworker.go
+++ b/toolkit/tools/scheduler/schedulerutils/buildworker.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/file"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/logger"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/pkggraph"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/retry"
@@ -191,14 +192,14 @@ func getBuildDependencies(node *pkggraph.PkgNode, pkgGraph *pkggraph.PkgGraph, g
 
 // parseCheckSection reads the package build log file to determine if the %check section passed or not
 func parseCheckSection(logFile string) (err error) {
-	file, err := os.Open(logFile)
+	logFileObject, err := os.Open(logFile)
 	// If we can't open the log file, that's a build error.
 	if err != nil {
 		logger.Log.Errorf("Failed to open log file '%s' while checking package test results. Error: %v", logFile, err)
 		return
 	}
-	defer file.Close()
-	for scanner := bufio.NewScanner(file); scanner.Scan(); {
+	defer logFileObject.Close()
+	for scanner := bufio.NewScanner(logFileObject); scanner.Scan(); {
 		currLine := scanner.Text()
 		// Anything besides 0 is a failed test
 		if strings.Contains(currLine, "CHECK DONE") {
@@ -207,7 +208,7 @@ func parseCheckSection(logFile string) (err error) {
 			}
 			failedLogFile := strings.TrimSuffix(logFile, ".log")
 			failedLogFile = fmt.Sprintf("%s-FAILED_TEST-%d.log", failedLogFile, time.Now().UnixMilli())
-			err = os.Rename(logFile, failedLogFile)
+			err = file.Copy(logFile, failedLogFile)
 			if err != nil {
 				logger.Log.Errorf("Log file rename failed. Error: %v", err)
 				return


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x ] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x ] All package sources are available
- [x ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x ] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x ] All source files have up-to-date hashes in the `*.signatures.json` files
- [x ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ x] Documentation has been updated to match any changes to the build system
- [ x] Ready to merge

---

###### Summary <!-- REQUIRED -->
This PR improves UVM memory consumption behavior in kata-containers

###### Change Log  <!-- REQUIRED -->
The associated commit is the only change. It adds a patch file and introduce new variables for kata-containers make.

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Associated issues  <!-- optional -->
- Internal work item:¨https://microsoft.visualstudio.com/OS/_workitems/edit/43668151

###### Links to CVEs  <!-- optional -->

###### Test Methodology
- Internal builds of the SPEC file and application of the RPM