### PR TITLE
kata-containers: integrate fix to reduce UVM memory consumption

### DIFF
--- a/SPECS/kata-containers/kata-containers.spec
+++ b/SPECS/kata-containers/kata-containers.spec
@@ -41,7 +41,7 @@
 Summary:        Kata Containers version 2.x repository
 Name:           kata-containers
 Version:        3.0.0
-Release:        5%{?dist}
+Release:        6%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 URL:            https://github.com/%{name}/%{name}

--- a/SPECS/kata-containers/kata-containers.spec
+++ b/SPECS/kata-containers/kata-containers.spec
@@ -25,6 +25,8 @@
                                 DEFVIRTIOFSDAEMON=%{_libexecdir}/"virtiofsd" \\\
                                 DEFVIRTIOFSCACHESIZE=0 \\\
                                 DEFSANDBOXCGROUPONLY=false \\\
+                                DEFSTATICSANDBOXWORKLOADMEM=1984 \\\
+                                DEFMEMSZ=64 \\\
                                 SKIP_GO_VERSION_CHECK=y \\\
                                 MACHINETYPE=%{machinetype} \\\
                                 DESTDIR=%{buildroot} \\\
@@ -58,6 +60,7 @@ Patch5:         runtime-Support-for-AMD-SEV-SNP-VMs.patch
 Patch6:         runtime-clh-Use-the-new-API-to-boot-with-TDX-firmware-td-shim.patch
 Patch7:         versions-Update-Cloud-Hypervisor.patch
 Patch8:         runtime-Re-generate-the-client-code.patch
+Patch9:         runtime-reduce-uvm-high-mem-footprint.patch
 
 BuildRequires:  golang
 BuildRequires:  git-core
@@ -224,6 +227,9 @@ ln -sf %{_bindir}/kata-runtime %{buildroot}%{_prefix}/local/bin/kata-runtime
 %exclude %{kataosbuilderdir}/rootfs-builder/ubuntu
 
 %changelog
+* Wed Mar 22 2023 Manuel Huber <mahuber@microsoft.com> - 3.0.0-6
+- Integrate fix to reduce UVM memory consumption
+
 * Wed Mar 15 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 3.0.0-5
 - Bump release to rebuild with go 1.19.6
 

--- a/SPECS/kata-containers/runtime-reduce-uvm-high-mem-footprint.patch
+++ b/SPECS/kata-containers/runtime-reduce-uvm-high-mem-footprint.patch
@@ -1,0 +1,279 @@
+From ff6c016a20f95580e7d1f06e3787c0675675807f Mon Sep 17 00:00:00 2001
+From: Manuel Huber <mahuber@microsoft.com>
+Date: Wed, 22 Mar 2023 17:12:09 +0000
+Subject: [PATCH] Merged PR 12983: Commit d5ed88f3: Fix 43668151: Resolve high
+ UVM memory footprint
+
+Bug: https://microsoft.visualstudio.com/OS/_workitems/edit/43668151
+
+Rationale: This is a temporary solution for optimizing memory usage for the
+current mechanism of requesting resources through pod Limit annotations:
+- if no Limits are specified and hence WorkloadMemMB is 0, set
+  a default value 'StaticWorkloadDefaultMem' to allocate a default amount
+  of memory for use for containers in the sandbox in addition to the base memory
+- if Limits are specified, the base memory and the sum of Limits are
+  allocated. The end user needs to be aware of the minimum memory
+  requirements for their pods, otherwise the pod will be stuck in the
+  ContainerCreating state
+
+Testing: Manual testing, creating pods with Limits and without limits, and with two containers where each container has a limit, tested with integration in a SPEC file where the config variables were set via environment variables via the make command
+---
+ src/runtime/Makefile                          |  8 ++++-
+ src/runtime/config/configuration-clh.toml.in  | 17 ++++++----
+ src/runtime/config/configuration-fc.toml.in   |  5 +++
+ src/runtime/config/configuration-qemu.toml.in |  7 +++-
+ src/runtime/pkg/katautils/config.go           | 32 ++++++++++---------
+ src/runtime/pkg/oci/utils.go                  | 11 +++++++
+ src/runtime/virtcontainers/hypervisor.go      |  2 +-
+ src/runtime/virtcontainers/sandbox.go         |  3 ++
+ 8 files changed, 61 insertions(+), 24 deletions(-)
+
+diff --git a/src/runtime/Makefile b/src/runtime/Makefile
+index b05106318..604e0ddae 100644
+--- a/src/runtime/Makefile
++++ b/src/runtime/Makefile
+@@ -150,7 +150,7 @@ DEFVCPUS := 1
+ # Default maximum number of vCPUs
+ DEFMAXVCPUS := 0
+ # Default memory size in MiB
+-DEFMEMSZ := 2048
++DEFMEMSZ ?= 2048
+ # Default memory slots
+ # Cases to consider :
+ # - nvdimm rootfs image
+@@ -211,6 +211,9 @@ DEFSANDBOXCGROUPONLY ?= false
+ 
+ DEFSTATICRESOURCEMGMT ?= false
+ 
++# Default memory for use for workloads within the sandbox if no specific workload memory value is requested
++DEFSTATICSANDBOXWORKLOADMEM ?= 2048
++
+ DEFBINDMOUNTS := []
+ 
+ SED = sed
+@@ -278,6 +281,7 @@ ifneq (,$(CLHCMD))
+     # CLH-specific options (all should be suffixed by "_CLH")
+     # currently, huge pages are required for virtiofsd support
+     DEFNETWORKMODEL_CLH := tcfilter
++    DEFSTATICRESOURCEMGMT_CLH = true
+     KERNELTYPE_CLH = uncompressed
+     KERNEL_NAME_CLH = $(call MAKE_KERNEL_NAME,$(KERNELTYPE_CLH))
+     KERNELPATH_CLH = $(KERNELDIR)/$(KERNEL_NAME_CLH)
+@@ -480,7 +484,9 @@ USER_VARS += DEFENTROPYSOURCE
+ USER_VARS += DEFVALIDENTROPYSOURCES
+ USER_VARS += DEFSANDBOXCGROUPONLY
+ USER_VARS += DEFSTATICRESOURCEMGMT
++USER_VARS += DEFSTATICRESOURCEMGMT_CLH
+ USER_VARS += DEFSTATICRESOURCEMGMT_FC
++USER_VARS += DEFSTATICSANDBOXWORKLOADMEM
+ USER_VARS += DEFBINDMOUNTS
+ USER_VARS += DEFVFIOMODE
+ USER_VARS += BUILDFLAGS
+diff --git a/src/runtime/config/configuration-clh.toml.in b/src/runtime/config/configuration-clh.toml.in
+index 59ddf43e1..4f05115b8 100644
+--- a/src/runtime/config/configuration-clh.toml.in
++++ b/src/runtime/config/configuration-clh.toml.in
+@@ -25,7 +25,7 @@ image = "@IMAGEPATH@"
+ #
+ # Known limitations:
+ # * Does not work by design:
+-#   - CPU Hotplug 
++#   - CPU Hotplug
+ #   - Memory Hotplug
+ #   - NVDIMM devices
+ #
+@@ -190,9 +190,9 @@ block_device_driver = "virtio-blk"
+ # and we strongly advise users to refer the Cloud Hypervisor official
+ # documentation for a better understanding of its internals:
+ # https://github.com/cloud-hypervisor/cloud-hypervisor/blob/main/docs/io_throttling.md
+-# 
++#
+ # Bandwidth rate limiter options
+-# 
++#
+ # net_rate_limiter_bw_max_rate controls network I/O bandwidth (size in bits/sec
+ # for SB/VM).
+ # The same value is used for inbound and outbound bandwidth.
+@@ -226,9 +226,9 @@ block_device_driver = "virtio-blk"
+ # and we strongly advise users to refer the Cloud Hypervisor official
+ # documentation for a better understanding of its internals:
+ # https://github.com/cloud-hypervisor/cloud-hypervisor/blob/main/docs/io_throttling.md
+-# 
++#
+ # Bandwidth rate limiter options
+-# 
++#
+ # disk_rate_limiter_bw_max_rate controls disk I/O bandwidth (size in bits/sec
+ # for SB/VM).
+ # The same value is used for inbound and outbound bandwidth.
+@@ -356,7 +356,12 @@ sandbox_cgroup_only=@DEFSANDBOXCGROUPONLY@
+ # - When running with pods, sandbox sizing information will only be available if using Kubernetes >= 1.23 and containerd >= 1.6. CRI-O
+ #   does not yet support sandbox sizing annotations.
+ # - When running single containers using a tool like ctr, container sizing information will be available.
+-static_sandbox_resource_mgmt=@DEFSTATICRESOURCEMGMT@
++static_sandbox_resource_mgmt=@DEFSTATICRESOURCEMGMT_CLH@
++
++# If set, the runtime will use the value as the default workload memory in MB for the sandbox when no workload memory request is passed
++# down to the shim via the OCI when static sandbox resource management is enabled. With this, we ensure that workloads have a proper
++# default amount of memory available within the sandbox.
++static_sandbox_default_workload_mem=@DEFSTATICSANDBOXWORKLOADMEM@
+ 
+ # If specified, sandbox_bind_mounts identifieds host paths to be mounted (ro) into the sandboxes shared path.
+ # This is only valid if filesystem sharing is utilized. The provided path(s) will be bindmounted into the shared fs directory.
+diff --git a/src/runtime/config/configuration-fc.toml.in b/src/runtime/config/configuration-fc.toml.in
+index b7f349c0d..e1a87762a 100644
+--- a/src/runtime/config/configuration-fc.toml.in
++++ b/src/runtime/config/configuration-fc.toml.in
+@@ -352,6 +352,11 @@ sandbox_cgroup_only=@DEFSANDBOXCGROUPONLY@
+ # - When running single containers using a tool like ctr, container sizing information will be available.
+ static_sandbox_resource_mgmt=@DEFSTATICRESOURCEMGMT_FC@
+ 
++# If set, the runtime will use the value as the default workload memory in MB for the sandbox when no workload memory request is passed
++# down to the shim via the OCI when static sandbox resource management is enabled. With this, we ensure that workloads have a proper
++# default amount of memory available within the sandbox.
++static_sandbox_default_workload_mem=@DEFSTATICSANDBOXWORKLOADMEM@
++
+ # If enabled, the runtime will not create Kubernetes emptyDir mounts on the guest filesystem. Instead, emptyDir mounts will
+ # be created on the host and shared via virtio-fs. This is potentially slower, but allows sharing of files from host to guest.
+ disable_guest_empty_dir=@DEFDISABLEGUESTEMPTYDIR@
+diff --git a/src/runtime/config/configuration-qemu.toml.in b/src/runtime/config/configuration-qemu.toml.in
+index d0a711dcf..7a5137247 100644
+--- a/src/runtime/config/configuration-qemu.toml.in
++++ b/src/runtime/config/configuration-qemu.toml.in
+@@ -26,7 +26,7 @@ machine_type = "@MACHINETYPE@"
+ #
+ # Known limitations:
+ # * Does not work by design:
+-#   - CPU Hotplug 
++#   - CPU Hotplug
+ #   - Memory Hotplug
+ #   - NVDIMM devices
+ #
+@@ -580,6 +580,11 @@ sandbox_cgroup_only=@DEFSANDBOXCGROUPONLY@
+ # - When running single containers using a tool like ctr, container sizing information will be available.
+ static_sandbox_resource_mgmt=@DEFSTATICRESOURCEMGMT@
+ 
++# If set, the runtime will use the value as the default workload memory in MB for the sandbox when no workload memory request is passed
++# down to the shim via the OCI when static sandbox resource management is enabled. With this, we ensure that workloads have a proper
++# default amount of memory available within the sandbox.
++static_sandbox_default_workload_mem=@DEFSTATICSANDBOXWORKLOADMEM@
++
+ # If specified, sandbox_bind_mounts identifieds host paths to be mounted (ro) into the sandboxes shared path.
+ # This is only valid if filesystem sharing is utilized. The provided path(s) will be bindmounted into the shared fs directory.
+ # If defaults are utilized, these mounts should be available in the guest at `/run/kata-containers/shared/containers/sandbox-mounts`
+diff --git a/src/runtime/pkg/katautils/config.go b/src/runtime/pkg/katautils/config.go
+index f3bc06bdf..b6220a44d 100644
+--- a/src/runtime/pkg/katautils/config.go
++++ b/src/runtime/pkg/katautils/config.go
+@@ -157,21 +157,22 @@ type hypervisor struct {
+ }
+ 
+ type runtime struct {
+-	InterNetworkModel         string   `toml:"internetworking_model"`
+-	JaegerEndpoint            string   `toml:"jaeger_endpoint"`
+-	JaegerUser                string   `toml:"jaeger_user"`
+-	JaegerPassword            string   `toml:"jaeger_password"`
+-	VfioMode                  string   `toml:"vfio_mode"`
+-	SandboxBindMounts         []string `toml:"sandbox_bind_mounts"`
+-	Experimental              []string `toml:"experimental"`
+-	Debug                     bool     `toml:"enable_debug"`
+-	Tracing                   bool     `toml:"enable_tracing"`
+-	DisableNewNetNs           bool     `toml:"disable_new_netns"`
+-	DisableGuestSeccomp       bool     `toml:"disable_guest_seccomp"`
+-	SandboxCgroupOnly         bool     `toml:"sandbox_cgroup_only"`
+-	StaticSandboxResourceMgmt bool     `toml:"static_sandbox_resource_mgmt"`
+-	EnablePprof               bool     `toml:"enable_pprof"`
+-	DisableGuestEmptyDir      bool     `toml:"disable_guest_empty_dir"`
++	InterNetworkModel               string   `toml:"internetworking_model"`
++	JaegerEndpoint                  string   `toml:"jaeger_endpoint"`
++	JaegerUser                      string   `toml:"jaeger_user"`
++	JaegerPassword                  string   `toml:"jaeger_password"`
++	VfioMode                        string   `toml:"vfio_mode"`
++	SandboxBindMounts               []string `toml:"sandbox_bind_mounts"`
++	Experimental                    []string `toml:"experimental"`
++	Debug                           bool     `toml:"enable_debug"`
++	Tracing                         bool     `toml:"enable_tracing"`
++	DisableNewNetNs                 bool     `toml:"disable_new_netns"`
++	DisableGuestSeccomp             bool     `toml:"disable_guest_seccomp"`
++	SandboxCgroupOnly               bool     `toml:"sandbox_cgroup_only"`
++	StaticSandboxResourceMgmt       bool     `toml:"static_sandbox_resource_mgmt"`
++	StaticSandboxWorkloadDefaultMem uint32   `toml:"static_sandbox_default_workload_mem"`
++	EnablePprof                     bool     `toml:"enable_pprof"`
++	DisableGuestEmptyDir            bool     `toml:"disable_guest_empty_dir"`
+ }
+ 
+ type agent struct {
+@@ -1313,6 +1314,7 @@ func LoadConfiguration(configPath string, ignoreLogging bool) (resolvedConfigPat
+ 	config.DisableGuestSeccomp = tomlConf.Runtime.DisableGuestSeccomp
+ 
+ 	config.StaticSandboxResourceMgmt = tomlConf.Runtime.StaticSandboxResourceMgmt
++	config.StaticSandboxWorkloadDefaultMem = tomlConf.Runtime.StaticSandboxWorkloadDefaultMem
+ 	config.SandboxCgroupOnly = tomlConf.Runtime.SandboxCgroupOnly
+ 	config.DisableNewNetNs = tomlConf.Runtime.DisableNewNetNs
+ 	config.EnablePprof = tomlConf.Runtime.EnablePprof
+diff --git a/src/runtime/pkg/oci/utils.go b/src/runtime/pkg/oci/utils.go
+index 95bfe2a33..59e55c47d 100644
+--- a/src/runtime/pkg/oci/utils.go
++++ b/src/runtime/pkg/oci/utils.go
+@@ -137,6 +137,9 @@ type RuntimeConfig struct {
+ 	// any later resource updates.
+ 	StaticSandboxResourceMgmt bool
+ 
++	// Memory to allocate for workloads within the sandbox when workload memory is unspecified
++	StaticSandboxWorkloadDefaultMem uint32
++
+ 	// Determines if create a netns for hypervisor process
+ 	DisableNewNetNs bool
+ 
+@@ -928,6 +931,8 @@ func SandboxConfig(ocispec specs.Spec, runtime RuntimeConfig, bundlePath, cid st
+ 
+ 		StaticResourceMgmt: runtime.StaticSandboxResourceMgmt,
+ 
++		StaticWorkloadDefaultMem: runtime.StaticSandboxWorkloadDefaultMem,
++
+ 		ShmSize: shmSize,
+ 
+ 		VfioMode: runtime.VfioMode,
+@@ -950,6 +955,12 @@ func SandboxConfig(ocispec specs.Spec, runtime RuntimeConfig, bundlePath, cid st
+ 	// with the base number of CPU/memory (which is equal to the default CPU/memory specified for the runtime
+ 	// configuration or annotations) as well as any specified workload resources.
+ 	if sandboxConfig.StaticResourceMgmt {
++		// If no Limits are set in pod config, use StaticWorkloadDefaultMem to ensure the containers generally
++		// have a reasonable amount of memory available
++		if sandboxConfig.SandboxResources.WorkloadMemMB == 0 {
++			sandboxConfig.SandboxResources.WorkloadMemMB = sandboxConfig.StaticWorkloadDefaultMem
++		}
++
+ 		sandboxConfig.SandboxResources.BaseCPUs = sandboxConfig.HypervisorConfig.NumVCPUs
+ 		sandboxConfig.SandboxResources.BaseMemMB = sandboxConfig.HypervisorConfig.MemorySize
+ 
+diff --git a/src/runtime/virtcontainers/hypervisor.go b/src/runtime/virtcontainers/hypervisor.go
+index c44c0bae7..60e2b99b3 100644
+--- a/src/runtime/virtcontainers/hypervisor.go
++++ b/src/runtime/virtcontainers/hypervisor.go
+@@ -71,7 +71,7 @@ const (
+ 	vSockLogsPort = 1025
+ 
+ 	// MinHypervisorMemory is the minimum memory required for a VM.
+-	MinHypervisorMemory = 256
++	MinHypervisorMemory = 64
+ 
+ 	defaultMsize9p = 8192
+ )
+diff --git a/src/runtime/virtcontainers/sandbox.go b/src/runtime/virtcontainers/sandbox.go
+index e4a16983e..24992111a 100644
+--- a/src/runtime/virtcontainers/sandbox.go
++++ b/src/runtime/virtcontainers/sandbox.go
+@@ -161,6 +161,9 @@ type SandboxConfig struct {
+ 	// StaticResourceMgmt indicates if the shim should rely on statically sizing the sandbox (VM)
+ 	StaticResourceMgmt bool
+ 
++	// Memory to allocate for workloads within the sandbox when workload memory is unspecified
++	StaticWorkloadDefaultMem uint32
++
+ 	ShmSize uint64
+ 
+ 	VfioMode config.VFIOModeType
+-- 
+2.33.6
+


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
This PR improves UVM memory consumption behavior in kata-containers

###### Change Log  <!-- REQUIRED -->
The associated commit is the only change. It adds a patch file and introduce new variables for kata-containers make.

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Associated issues  <!-- optional -->
- Internal work item:¨https://microsoft.visualstudio.com/OS/_workitems/edit/43668151

###### Links to CVEs  <!-- optional -->

###### Test Methodology
- Buddy build: https://github.com/microsoft/CBL-Mariner/pull/5134
  - verified RPM was patched and that CLH config contains proper variables/values
- Application of the patched RPM in AKS clusters, testing various pod deployments with different memory limits and without memory limits