### PR TITLE
Update mlnx-ofa_kernel's BuildRequires to use kernel 5.15.87.1

### DIFF
--- a/SPECS/mlnx-ofa_kernel/mlnx-ofa_kernel.spec
+++ b/SPECS/mlnx-ofa_kernel/mlnx-ofa_kernel.spec
@@ -61,6 +61,7 @@
 %{!?KERNEL_SOURCES: %global KERNEL_SOURCES %K_SRC}
 
 %global MLNX_OFED_VERSION 5.6-1.0.3
+%global highest_supported_kernel 5.15.87.1
 
 %global utils_pname %{name}
 %global devel_pname %{name}-devel
@@ -77,7 +78,7 @@ Distribution:   Mariner
 Group:          System Environment/Base
 URL:            https://www.mellanox.com/
 Source:         https://www.mellanox.com/downloads/ofed/%{name}-%{MLNX_OFED_VERSION}.tgz#/%{name}-%{version}.tgz
-BuildRequires:  kernel-devel = 5.15.87.1
+BuildRequires:  kernel-devel <= %{highest_supported_kernel}
 BuildRequires:  kmod
 Obsoletes: kernel-ib
 Obsoletes: mlnx-en
@@ -90,13 +91,14 @@ Obsoletes: mlnx-en-kmp-trace
 Obsoletes: mlnx-en-doc
 Obsoletes: mlnx-en-debuginfo
 Obsoletes: mlnx-en-sources
-Requires: mlnx-tools >= 5.2.0
 Requires: coreutils
-Requires: pciutils
 Requires: grep
-Requires: procps
-Requires: module-init-tools
+Requires: kernel <= %{highest_supported_kernel}
 Requires: lsof
+Requires: mlnx-tools >= 5.2.0
+Requires: module-init-tools
+Requires: pciutils
+Requires: procps
 %description 
 InfiniBand "verbs", Access Layer  and ULPs.
 Utilities rpm with OFED release %MLNX_OFED_VERSION.
@@ -483,7 +485,9 @@ update-alternatives --remove \
 
 %changelog
 * Thu Mar 23 2023 Rachel Menge <rachelmenge@microsoft.com> - 5.6-2
-- BuildRequires kernel-devel=5.15.87.1
+- Add highest_supported_kernel macro = 5.15.87.1
+- Add BuildRequires for kernel-devel >= highest_supported_kernel
+- Add Requires for kernel >= highest_supported_kernel
 
 * Fri Jul 22 2022 Rachel Menge <rachelmenge@microsoft.com> - 5.6-1
 - Initial CBL-Mariner import from NVIDIA (license: GPLv2).

--- a/SPECS/mlnx-ofa_kernel/mlnx-ofa_kernel.spec
+++ b/SPECS/mlnx-ofa_kernel/mlnx-ofa_kernel.spec
@@ -70,14 +70,14 @@ Summary:        Infiniband HCA Driver
 Name:           mlnx-ofa_kernel
 # Update OFED version along with version updates
 Version:        5.6
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Group:          System Environment/Base
 URL:            https://www.mellanox.com/
 Source:         https://www.mellanox.com/downloads/ofed/%{name}-%{MLNX_OFED_VERSION}.tgz#/%{name}-%{version}.tgz
-BuildRequires:  kernel-devel
+BuildRequires:  kernel-devel = 5.15.87.1
 BuildRequires:  kmod
 Obsoletes: kernel-ib
 Obsoletes: mlnx-en
@@ -482,6 +482,9 @@ update-alternatives --remove \
 %{_prefix}/src/mlnx-ofa_kernel-%version
 
 %changelog
+* Thu Mar 23 2023 Rachel Menge <rachelmenge@microsoft.com> - 5.6-2
+- BuildRequires kernel-devel=5.15.87.1
+
 * Fri Jul 22 2022 Rachel Menge <rachelmenge@microsoft.com> - 5.6-1
 - Initial CBL-Mariner import from NVIDIA (license: GPLv2).
 - Lint spec to conform to Mariner

--- a/SPECS/mlnx-ofa_kernel/mlnx-ofa_kernel.spec
+++ b/SPECS/mlnx-ofa_kernel/mlnx-ofa_kernel.spec
@@ -486,8 +486,8 @@ update-alternatives --remove \
 %changelog
 * Thu Mar 23 2023 Rachel Menge <rachelmenge@microsoft.com> - 5.6-2
 - Add highest_supported_kernel macro = 5.15.87.1
-- Add BuildRequires for kernel-devel >= highest_supported_kernel
-- Add Requires for kernel >= highest_supported_kernel
+- Add BuildRequires for kernel-devel <= highest_supported_kernel
+- Add Requires for kernel <= highest_supported_kernel
 
 * Fri Jul 22 2022 Rachel Menge <rachelmenge@microsoft.com> - 5.6-1
 - Initial CBL-Mariner import from NVIDIA (license: GPLv2).


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Latest LTS `kernel` is no longer compatible with this version of the `mlnx-ofa_kernel`. Set BuildRequires on last known good kernel. This package should be upgraded to match the kernel package.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Update mlnx-ofa_kernel's BuildRequires to use kernel 5.15.87.1

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Buddy Build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=332043&view=results
- Delta build (shows 5.15.102.1 kernel built and new mlnx-ofa_kernel): https://dev.azure.com/mariner-org/mariner/_build/results?buildId=332063&view=logs&s=444ee1b5-8b3f-5598-a629-e88326f0c2f9
- Full build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=332309&view=results
