### PR TITLE
msft-golang: bump version to 1.19.7 to address CVE-2022-41722, CVE-2022-41724, CVE-2022-41725, CVE-2022-41723, CVE-2023-24532

### DIFF
--- a/SPECS/msft-golang/msft-golang.signatures.json
+++ b/SPECS/msft-golang/msft-golang.signatures.json
@@ -1,6 +1,6 @@
 {
  "Signatures": {
-  "go.20220906.5.src.tar.gz": "6bc80048b70a618f9d0a8093d2926ceb407a0be6b48f2430d086e2bc1fa4f580",
+  "go.20230307.2.src.tar.gz": "7b9d1e37a3d47e82efaa16191ad5ccb3b68f1ab37246668ac76e7381ee912319",
   "go1.4-bootstrap-20171003.tar.gz": "f4ff5b5eb3a3cae1c993723f3eab519c5bae18866b5e5f96fe1102f0cb5c3e52"
  }
 }

--- a/SPECS/msft-golang/msft-golang.spec
+++ b/SPECS/msft-golang/msft-golang.spec
@@ -12,14 +12,14 @@
 %define __find_requires %{nil}
 Summary:        Go
 Name:           msft-golang
-Version:        1.19.1
-Release:        2%{?dist}
+Version:        1.19.7
+Release:        1%{?dist}
 License:        BSD
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Group:          System Environment/Security
 URL:            https://github.com/microsoft/go
-Source0:        https://github.com/microsoft/go/releases/download/v1.19.1-1/go.20220906.5.src.tar.gz
+Source0:        https://github.com/microsoft/go/releases/download/v1.19.7-1/go.20230307.2.src.tar.gz
 Source1:        https://dl.google.com/go/go1.4-bootstrap-20171003.tar.gz
 Patch0:         go14_bootstrap_aarch64.patch
 Conflicts:      go
@@ -115,6 +115,9 @@ fi
 %{_bindir}/*
 
 %changelog
+* Tue Mar 28 2023 Muhammad Falak <mwani@microsoft.com> - 1.19.7-1
+- Bump version to address CVE-2022-41722, CVE-2022-41724, CVE-2022-41725, CVE-2022-41723, CVE-2023-24532
+
 * Sat Sep 24 2022 Muhammad Falak <mwani@microsoft.com> - 1.19.1-2
 - Drop the explict VERSION in build
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -13383,8 +13383,8 @@
         "type": "other",
         "other": {
           "name": "msft-golang",
-          "version": "1.19.1",
-          "downloadUrl": "https://github.com/microsoft/go/releases/download/v1.19.1-1/go.20220906.5.src.tar.gz"
+          "version": "1.19.7",
+          "downloadUrl": "https://github.com/microsoft/go/releases/download/v1.19.7-1/go.20230307.2.src.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
- Bump version to 1.19.7 to address CVE-2022-41722, CVE-2022-41724, CVE-2022-41725, CVE-2022-41723, CVE-2023-24532

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Bump version to 1.19.7 to address CVE-2022-41722, CVE-2022-41724, CVE-2022-41725, CVE-2022-41723, CVE-2023-24532

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- NA

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2022-41722
- https://nvd.nist.gov/vuln/detail/CVE-2022-41723
- https://nvd.nist.gov/vuln/detail/CVE-2022-41724
- https://nvd.nist.gov/vuln/detail/CVE-2022-41725
- https://nvd.nist.gov/vuln/detail/CVE-2023-24532

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local Build

Buddy Build: [PR-5162](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=334336&view=results)