### PR TITLE
Don't make go modules owned by root

### DIFF
--- a/toolkit/scripts/tools.mk
+++ b/toolkit/scripts/tools.mk
@@ -96,7 +96,7 @@ $(BUILD_DIR)/tools/internal.test_coverage: $(go_internal_files) $(go_imagegen_fi
 
 # Downloads all the go dependencies without using sudo, so we don't break other go use cases for the user.
 # We can check if $SUDO_USER is set (the user who invoked sudo), and if so, use that user to run go get via sudo -u.
-# We allow the command to fail with || true, since we don't want to fail the build if the user has already
+# We allow the command to fail with || echo ..., since we don't want to fail the build if the user has already
 # downloaded the dependencies as root. The go build command will download the dependencies if they are missing (but as root).
 $(STATUS_FLAGS_DIR)/got_go_deps.flag: $(go_common_files)
 	@cd $(TOOLS_DIR)/ && \


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
When we invoke our build commands it is usually of the form `sudo make ...` since we need permissions to create mount points, overlays, chroots, etc. 

`go build` will automatically pull any missing go modules during the build. This has a side-effect of polluting the `$GOPATH` (default is `~/go`) with modules owned by the root user when we build the go tools (since we are invoking `sudo make ...`). This can be fixed via an occasional invocation of `sudo chown -R $USER:$USER ~/go` but it would be better if we just never broke the files in the first place.

We can query the variable `$SUDO_USER` to see if the command is being invoked via a call to `sudo`, it will be empty otherwise. If it is set, we can use `sudo -u $SUDO_USER` to temporarily switch back to the calling user and run `go get ./...` to explicitly download all our dependencies. 

We allow this command to fail and fall back to the previous behavior. 

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Try to avoid pulling go modules as the root user so it doesn't mess up the user's dev environment.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local builds