### PR TITLE
Updated `telegraf` to 1.26.0 to fix CVE-2022-23471

### DIFF
--- a/SPECS/telegraf/generate_source_tarball.sh
+++ b/SPECS/telegraf/generate_source_tarball.sh
@@ -4,31 +4,28 @@
 
 set -e
 
-PKG_VERSION=""
-SRC_TARBALL=""
-OUT_FOLDER="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
 get_param() {
     if [ -n "$2" ] && [ "${2:0:1}" != "-" ]; then
         echo "$2"
     else
-        echo "Error: Argument for ($1) is missing." >&2
+        echo "Error: argument for ($1) is missing." >&2
         return 1
     fi
 }
 
+PKG_VERSION=""
+SRC_TARBALL=""
+OUT_FOLDER="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
 # parameters:
 #
 # --srcTarball  : src tarball file
-#                 this file contains the 'initial' source code of the component
-#                 and should be replaced with the new/modified src code
 # --outFolder   : folder where to copy the new tarball(s)
 # --pkgVersion  : package version
 #
 while (( "$#" )); do
     case "$1" in
         --srcTarball)
-        # get_param
         SRC_TARBALL="$(get_param "$1" "$2")"
         shift 2
         ;;
@@ -40,8 +37,8 @@ while (( "$#" )); do
         PKG_VERSION="$(get_param "$1" "$2")"
         shift 2
         ;;
-        -*) # unsupported flags
-        echo "Error: Unsupported flag $1." >&2
+        -*)
+        echo "Error: unsupported flag $1." >&2
         exit 1
         ;;
   esac
@@ -64,7 +61,7 @@ fi
 SRC_TARBALL="$(realpath "$SRC_TARBALL")"
 OUT_FOLDER="$(realpath "$OUT_FOLDER")"
 
-echo "Creating tempdir."
+echo "Creating a tempdir."
 tmpdir=$(mktemp -d)
 function cleanup {
     echo "Clean-up: removing tempdir ($tmpdir)."
@@ -77,11 +74,11 @@ pushd "$tmpdir" > /dev/null
 NAME_VER="telegraf-$PKG_VERSION"
 VENDOR_TARBALL="$(realpath "$OUT_FOLDER/$NAME_VER-vendor.tar.gz")"
 
-echo "Unpacking source tarball."
+echo "Unpacking the source tarball."
 tar -xf "$SRC_TARBALL"
 
 cd "$NAME_VER"
-echo "Get vendored modules."
+echo "Getting the vendored modules."
 go mod vendor
 
 mkdir -p "$OUT_FOLDER"

--- a/SPECS/telegraf/generate_source_tarball.sh
+++ b/SPECS/telegraf/generate_source_tarball.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+set -e
+
+PKG_VERSION=""
+SRC_TARBALL=""
+OUT_FOLDER="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+get_param() {
+    if [ -n "$2" ] && [ "${2:0:1}" != "-" ]; then
+        echo "$2"
+    else
+        echo "Error: Argument for ($1) is missing." >&2
+        return 1
+    fi
+}
+
+# parameters:
+#
+# --srcTarball  : src tarball file
+#                 this file contains the 'initial' source code of the component
+#                 and should be replaced with the new/modified src code
+# --outFolder   : folder where to copy the new tarball(s)
+# --pkgVersion  : package version
+#
+while (( "$#" )); do
+    case "$1" in
+        --srcTarball)
+        # get_param
+        SRC_TARBALL="$(get_param "$1" "$2")"
+        shift 2
+        ;;
+        --outFolder)
+        OUT_FOLDER="$(get_param "$1" "$2")"
+        shift 2
+        ;;
+        --pkgVersion)
+        PKG_VERSION="$(get_param "$1" "$2")"
+        shift 2
+        ;;
+        -*) # unsupported flags
+        echo "Error: Unsupported flag $1." >&2
+        exit 1
+        ;;
+  esac
+done
+
+echo "--srcTarball   -> $SRC_TARBALL"
+echo "--outFolder    -> $OUT_FOLDER"
+echo "--pkgVersion   -> $PKG_VERSION"
+
+if [ -z "$PKG_VERSION" ]; then
+    echo "Error: --pkgVersion parameter cannot be empty." >&2
+    exit 1
+fi
+
+if [ ! -f "$SRC_TARBALL" ]; then
+    echo "Error: --srcTarball is not a file." >&2
+    exit 1
+fi
+
+SRC_TARBALL="$(realpath "$SRC_TARBALL")"
+OUT_FOLDER="$(realpath "$OUT_FOLDER")"
+
+echo "Creating tempdir."
+tmpdir=$(mktemp -d)
+function cleanup {
+    echo "Clean-up: removing tempdir ($tmpdir)."
+    rm -rf "$tmpdir"
+}
+trap cleanup EXIT
+
+pushd "$tmpdir" > /dev/null
+
+NAME_VER="telegraf-$PKG_VERSION"
+VENDOR_TARBALL="$(realpath "$OUT_FOLDER/$NAME_VER-vendor.tar.gz")"
+
+echo "Unpacking source tarball."
+tar -xf "$SRC_TARBALL"
+
+cd "$NAME_VER"
+echo "Get vendored modules."
+go mod vendor
+
+mkdir -p "$OUT_FOLDER"
+
+echo "Tar vendored modules."
+tar  --sort=name \
+     --mtime="2021-04-26 00:00Z" \
+     --owner=0 --group=0 --numeric-owner \
+     --pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime \
+     -cf "$VENDOR_TARBALL" vendor
+
+echo "Telegraf vendored modules are available at ($VENDOR_TARBALL)."
+echo "SHA256: $(sha256sum "$VENDOR_TARBALL")."

--- a/SPECS/telegraf/telegraf.signatures.json
+++ b/SPECS/telegraf/telegraf.signatures.json
@@ -1,6 +1,6 @@
 {
  "Signatures": {
-  "telegraf-1.25.2.tar.gz": "e7038dc5be123a7e8906100d48f145d806030dafbcdb4dbd52f0343b6d1837e0",
-  "telegraf-1.25.2-vendor.tar.gz": "1ed2944aa65471e7ce539bc30c23d4aaeef05e73ffb6eab6a266f788fe8444b8"
+  "telegraf-1.26.0.tar.gz": "ee6933a16930dfd8b32832f0ed9e0393bb14cdb973abc1a773bfb58976470ea8",
+  "telegraf-1.26.0-vendor.tar.gz": "fc29d1b8b635b7cf71aba435b5d16041846bb4604d6e75f6f4b64b8868ffed18"
  }
 }

--- a/SPECS/telegraf/telegraf.spec
+++ b/SPECS/telegraf/telegraf.spec
@@ -8,25 +8,8 @@ Distribution:   Mariner
 Group:          Development/Tools
 URL:            https://github.com/influxdata/telegraf
 Source0:        %{url}/archive/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
+# Use the generate_source_tarbbal.sh script to get the vendored sources.
 Source1:        %{name}-%{version}-vendor.tar.gz
-# Below is a manually created tarball, no download link.
-# We're using pre-populated Go modules from this tarball, since network is disabled during build time.
-# How to re-build this file:
-#   1. wget %{url}/archive/v%{version}.tar.gz -O %%{name}-%%{version}.tar.gz
-#   2. tar -xf %%{name}-%%{version}.tar.gz
-#   3. cd %%{name}-%%{version}
-#   4. go mod vendor
-#   5. tar  --sort=name \
-#           --mtime="2021-04-26 00:00Z" \
-#           --owner=0 --group=0 --numeric-owner \
-#           --pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime \
-#           -cf %%{name}-%%{version}-vendor.tar.gz vendor
-#
-#   NOTES:
-#       - You require GNU tar version 1.28+.
-#       - The additional options enable generation of a tarball with the same hash every time regardless of the environment.
-#         See: https://reproducible-builds.org/docs/archives/
-#       - For the value of "--mtime" use the date "2021-04-26 00:00Z" to simplify future updates.
 Patch0:         add-extra-metrics.patch
 BuildRequires:  golang
 BuildRequires:  systemd-devel

--- a/SPECS/telegraf/telegraf.spec
+++ b/SPECS/telegraf/telegraf.spec
@@ -1,14 +1,13 @@
 Summary:        agent for collecting, processing, aggregating, and writing metrics.
 Name:           telegraf
-Version:        1.25.2
-Release:        3%{?dist}
+Version:        1.26.0
+Release:        1%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Group:          Development/Tools
 URL:            https://github.com/influxdata/telegraf
-#Source0:       %{url}/archive/v%{version}.tar.gz
-Source0:        %{name}-%{version}.tar.gz
+Source0:        %{url}/archive/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
 Source1:        %{name}-%{version}-vendor.tar.gz
 # Below is a manually created tarball, no download link.
 # We're using pre-populated Go modules from this tarball, since network is disabled during build time.
@@ -90,6 +89,9 @@ fi
 %dir %{_sysconfdir}/%{name}/telegraf.d
 
 %changelog
+* Wed Mar 29 2023 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.26.0-1
+- Updating to version 1.26.0 to address CVEs in vendored sources for "containerd".
+
 * Tue Mar 28 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 1.25.2-3
 - Bump release to rebuild with go 1.19.7
 

--- a/SPECS/telegraf/telegraf.spec
+++ b/SPECS/telegraf/telegraf.spec
@@ -58,7 +58,10 @@ mkdir -pv %{buildroot}%{_sysconfdir}/%{name}/%{name}.d
 install -m 755 -D %{name} %{buildroot}%{_bindir}/%{name}
 install -m 755 -D scripts/%{name}.service %{buildroot}%{_unitdir}/%{name}.service
 install -m 755 -D etc/logrotate.d/%{name} %{buildroot}%{_sysconfdir}/logrotate.d/%{name}
-install -m 755 -D etc/telegraf.conf %{buildroot}%{_sysconfdir}/%{name}/telegraf.conf
+
+# Provide empty config file.
+./%{name} config > telegraf.conf
+install -m 755 -D telegraf.conf %{buildroot}%{_sysconfdir}/%{name}/telegraf.conf
 
 %pre
 getent group telegraf >/dev/null || groupadd -r telegraf

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -28087,8 +28087,8 @@
         "type": "other",
         "other": {
           "name": "telegraf",
-          "version": "1.25.2",
-          "downloadUrl": "https://github.com/influxdata/telegraf/archive/v1.25.2.tar.gz"
+          "version": "1.26.0",
+          "downloadUrl": "https://github.com/influxdata/telegraf/archive/v1.26.0.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

Updating `telegraf` to fix a CVE in its vendored sources for `containerd`.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Updated `telegraf` to version 1.26.0.
- Added the `generate_source_tarball.sh` script to enable auto-upgrades.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://github.com/influxdata/telegraf/pull/12693

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2022-23471

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local package build.
