### PR TITLE
R: fix build with curl >= 8.0.0

### DIFF
--- a/SPECS/R/0001-configure-fix-compilation-with-curl-8.0.0.patch
+++ b/SPECS/R/0001-configure-fix-compilation-with-curl-8.0.0.patch
@@ -1,0 +1,26 @@
+From 7749a2feb5287073419dd5294e9d412d28a4bbda Mon Sep 17 00:00:00 2001
+From: Muhammad Falak R Wani <falakreyaz@gmail.com>
+Date: Fri, 31 Mar 2023 10:40:22 +0530
+Subject: [PATCH] configure: fix compilation with curl >= 8.0.0
+
+Signed-off-by: Muhammad Falak R Wani <falakreyaz@gmail.com>
+---
+ configure | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/configure b/configure
+index 1227d92..e6b72d3 100755
+--- a/configure
++++ b/configure
+@@ -46052,8 +46052,6 @@ int main()
+ {
+ #ifdef LIBCURL_VERSION_MAJOR
+ #if LIBCURL_VERSION_MAJOR > 7
+-  exit(1);
+-#elif LIBCURL_VERSION_MAJOR == 7 && LIBCURL_VERSION_MINOR >= 28
+   exit(0);
+ #else
+   exit(1);
+-- 
+2.40.0
+

--- a/SPECS/R/R.spec
+++ b/SPECS/R/R.spec
@@ -10,7 +10,7 @@ Group:          System Environment/Daemons
 URL:            https://www.r-project.org
 Source0:        https://cran.r-project.org/src/base/R-4/R-%{version}.tar.gz
 # This change is a best hunch fix as the limitation on curl version 7 was set
-# on 2018. Given curl 8.0.0 is not an actual breaking change, this patch should be fine.
+# in 2018. Given curl 8.0.0 is not an actual breaking change, this patch should be fine.
 # We should drop this when R eventually gets official support for build with curl >= 8.0.0
 Patch0:         0001-configure-fix-compilation-with-curl-8.0.0.patch
 BuildRequires:  build-essential

--- a/SPECS/R/R.spec
+++ b/SPECS/R/R.spec
@@ -9,6 +9,9 @@ Distribution:   Mariner
 Group:          System Environment/Daemons
 URL:            https://www.r-project.org
 Source0:        https://cran.r-project.org/src/base/R-4/R-%{version}.tar.gz
+# This change is a best hunch fix as the limitation on curl version 7 was set
+# on 2018. Given curl 8.0.0 is not an actual breaking change, this patch should be fine.
+# We should drop this when R eventually gets official support for build with curl >= 8.0.0
 Patch0:         0001-configure-fix-compilation-with-curl-8.0.0.patch
 BuildRequires:  build-essential
 BuildRequires:  bzip2-devel

--- a/SPECS/R/R.spec
+++ b/SPECS/R/R.spec
@@ -2,13 +2,14 @@
 Summary:        A language for data analysis and graphics
 Name:           R
 Version:        4.1.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Group:          System Environment/Daemons
 URL:            https://www.r-project.org
 Source0:        https://cran.r-project.org/src/base/R-4/R-%{version}.tar.gz
+Patch0:         0001-configure-fix-compilation-with-curl-8.0.0.patch
 BuildRequires:  build-essential
 BuildRequires:  bzip2-devel
 BuildRequires:  curl-devel
@@ -117,6 +118,9 @@ TZ="Europe/Paris" make check -k -i
 %endif
 
 %changelog
+* Fri Mar 31 2023 Muhammad Falak <mwani@microsoft.com> - 4.1.0-3
+- Patch to fix build with curl >= 8.0.0
+
 * Thu Dec 02 2021 Andrew Phelps <anphel@microsoft.com> - 4.1.0-2
 - Build with JDK 11
 * Wed Jun 16 2021 Rachel Menge <rachelmenge@microsoft.com> - 4.1.0-1


### PR DESCRIPTION
Signed-off-by: Muhammad Falak R Wani <falakreyaz@gmail.com>

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Fix Build break with bump of curl to 8.0.1

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Introduce patch to resolve build break with curl >= 8.0.0

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://github.com/microsoft/CBL-Mariner/pull/5172

###### Links to CVEs  <!-- optional -->
- NA

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local Build

- Full Build [PR-5194](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=336378&view=results)

NOTE: The bump to curl 8.0.0 is not a real breaking change from 7.x as per [this](https://daniel.haxx.se/blog/2023/03/20/curl-8-0-0-is-here/)