### PR TITLE
Updated packages with a BR on `libtiff`.

### DIFF
--- a/SPECS-EXTENDED/libgxps/libgxps.spec
+++ b/SPECS-EXTENDED/libgxps/libgxps.spec
@@ -2,7 +2,7 @@ Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Name:           libgxps
 Version:        0.3.1
-Release:        7%{?dist}
+Release:        8%{?dist}
 Summary:        GObject based library for handling and rendering XPS documents
 
 License:        LGPLv2+
@@ -77,6 +77,9 @@ documents using the %{name} library.
 
 
 %changelog
+* Fri Mar 31 2023 Pawel Winogrodzki <pawelwi@microsoft.com> - 0.3.1-8
+- Bumping release to re-build with newer 'libtiff' libraries.
+
 * Mon Mar 21 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 0.3.1-7
 - Adding BR on '%%{_bindir}/xsltproc'.
 - Disabled gtk doc generation to remove network dependency during build-time.

--- a/SPECS-EXTENDED/netpbm/netpbm.spec
+++ b/SPECS-EXTENDED/netpbm/netpbm.spec
@@ -1,7 +1,7 @@
 Summary:         A library for handling different graphics file formats
 Name:            netpbm
 Version:         10.90.00
-Release:         4%{?dist}
+Release:         5%{?dist}
 # See copyright_summary for details
 License:         BSD and GPLv2 and IJG and MIT and Public Domain
 Vendor:         Microsoft Corporation
@@ -224,6 +224,9 @@ popd
 %doc userguide/*
 
 %changelog
+* Fri Mar 31 2023 Pawel Winogrodzki <pawelwi@microsoft.com> - 10.90.00-5
+- Bumping release to re-build with newer 'libtiff' libraries.
+
 * Fri Apr 15 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 10.90.00-4
 - Updating source URL.
 
@@ -1317,4 +1320,3 @@ popd
 
 * Thu Jul 10 1997 Erik Troan <ewt@redhat.com>
 - built against glibc
-

--- a/SPECS-EXTENDED/openjpeg2/openjpeg2.spec
+++ b/SPECS-EXTENDED/openjpeg2/openjpeg2.spec
@@ -10,7 +10,7 @@ Distribution:   Mariner
 
 Name:           openjpeg2
 Version:        2.3.1
-Release:        11%{?dist}
+Release:        12%{?dist}
 Summary:        C-Library for JPEG 2000
 
 # windirent.h is MIT, the rest is BSD
@@ -353,6 +353,9 @@ chmod +x %{buildroot}%{_bindir}/opj2_jpip_viewer
 
 
 %changelog
+* Fri Mar 31 2023 Pawel Winogrodzki <pawelwi@microsoft.com> - 2.3.1-12
+- Bumping release to re-build with newer 'libtiff' libraries.
+
 * Fri Oct 15 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 2.3.1-11
 - Initial CBL-Mariner import from Fedora 33 (license: MIT).
 

--- a/SPECS-EXTENDED/openjpeg2/openjpeg2.spec
+++ b/SPECS-EXTENDED/openjpeg2/openjpeg2.spec
@@ -355,6 +355,7 @@ chmod +x %{buildroot}%{_bindir}/opj2_jpip_viewer
 %changelog
 * Fri Mar 31 2023 Pawel Winogrodzki <pawelwi@microsoft.com> - 2.3.1-12
 - Bumping release to re-build with newer 'libtiff' libraries.
+- License verified.
 
 * Fri Oct 15 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 2.3.1-11
 - Initial CBL-Mariner import from Fedora 33 (license: MIT).

--- a/SPECS/gd/gd.spec
+++ b/SPECS/gd/gd.spec
@@ -20,7 +20,7 @@
 %define lname libgd3
 Name:           gd
 Version:        2.3.3
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        A Drawing Library for Programs That Use PNG and JPEG Output
 License:        MIT
 Vendor:         Microsoft Corporation
@@ -157,6 +157,9 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %{_libdir}/pkgconfig/gdlib.pc
 
 %changelog
+* Fri Mar 31 2023 Pawel Winogrodzki <pawelwi@microsoft.com> - 2.3.3-3
+- Bumping release to re-build with newer 'libtiff' libraries.
+
 * Tue Jun 28 2022 Nicolas Guibourge <nicolasg@microsoft.com> - 2.3.3-2
 - Added temporary directory variable to check section to fix failing tests
 - See https://github.com/libgd/libgd/issues/763 for details

--- a/SPECS/gdk-pixbuf2/gdk-pixbuf2.spec
+++ b/SPECS/gdk-pixbuf2/gdk-pixbuf2.spec
@@ -2,7 +2,7 @@
 Summary:        An image loading library
 Name:           gdk-pixbuf2
 Version:        2.40.0
-Release:        4%{?dist}
+Release:        5%{?dist}
 License:        LGPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -116,6 +116,9 @@ gdk-pixbuf-query-loaders-%{__isa_bits} --update-cache
 %{_datadir}/installed-tests
 
 %changelog
+* Fri Mar 31 2023 Pawel Winogrodzki <pawelwi@microsoft.com> - 2.40.0-5
+- Bumping release to re-build with newer 'libtiff' libraries.
+
 * Wed Dec 08 2021 Thomas Crain <thcrain@microsoft.com> - 2.40.0-4
 - License verified
 - Lint spec

--- a/SPECS/lcms2/lcms2.spec
+++ b/SPECS/lcms2/lcms2.spec
@@ -1,7 +1,7 @@
 Summary:        Color Management Engine
 Name:           lcms2
 Version:        2.13.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -71,6 +71,9 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %{_libdir}/pkgconfig/lcms2.pc
 
 %changelog
+* Fri Mar 31 2023 Pawel Winogrodzki <pawelwi@microsoft.com> - 2.13.1-2
+- Bumping release to re-build with newer 'libtiff' libraries.
+
 * Wed Apr 27 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 2.13.1-1
 - Updating to 2.13.1.
 - Fixing source URL.

--- a/SPECS/libgdiplus/libgdiplus.spec
+++ b/SPECS/libgdiplus/libgdiplus.spec
@@ -1,7 +1,7 @@
 Summary:        C-based implementation of the GDI+ API
 Name:           libgdiplus
 Version:        6.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -61,6 +61,9 @@ find %{buildroot} -type f -name '*.a' -delete -print
 %{_libdir}/pkgconfig/%{name}.pc
 
 %changelog
+* Fri Mar 31 2023 Pawel Winogrodzki <pawelwi@microsoft.com> - 6.1-2
+- Bumping release to re-build with newer 'libtiff' libraries.
+
 * Mon Jul 11 2022 Olivia Crain <oliviacrain@microsoft.com> - 6.1-1
 - Original version for CBL-Mariner (license: MIT)
 - License verified

--- a/SPECS/libtiff/libtiff.spec
+++ b/SPECS/libtiff/libtiff.spec
@@ -54,7 +54,7 @@ make %{?_smp_mflags} -k check
 %defattr(-,root,root)
 %license LICENSE.md
 %{_bindir}/*
-%{_libdir}/*.so.*
+%{_libdir}/*.so.6*
 
 %files devel
 %defattr(-,root,root)

--- a/SPECS/libwebp/libwebp.spec
+++ b/SPECS/libwebp/libwebp.spec
@@ -1,7 +1,7 @@
 Summary:        Library to encode and decode webP format images
 Name:           libwebp
 Version:        1.2.2
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        BSD
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -63,6 +63,9 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %{_libdir}/pkgconfig/*.pc
 
 %changelog
+* Fri Mar 31 2023 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.2.2-2
+- Bumping release to re-build with newer 'libtiff' libraries.
+
 * Tue Jan 25 2022 Henry Li <lihl@microsoft.com> - 1.2.2-1
 - Upgrade to version 1.2.2
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

Recent version bump for `libtiff` (#5154) introduced a bump in the version of its shared library. I missed that during build validation and I'm fixing this here.

**NOTE**: skipping the release bump in `libtiff.spec` itself despite the change, since we haven't had a successful build in our pipelines, yet.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Forced rebuild of packages with a BR on `libtiff`.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #5154

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
Buddy builds:
- [Buddy builds](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=336641&view=results).
- ^Failing ptest runs due to unrelated issues with test runs for `gtk2` and `gdk-pixbuf2`.
- ^Failing `lcms2` build related to our tooling not being smart enough to wait for updated `libwebp`. Local build fine.