### PR TITLE
cloud-hypervisor: patch vendored versionize crate to fix CVE-2023-28448

### DIFF
--- a/SPECS/cloud-hypervisor/CVE-2023-28448.patch
+++ b/SPECS/cloud-hypervisor/CVE-2023-28448.patch
@@ -1,0 +1,113 @@
+From a57a051ba006cfa3b41a0532f484df759e008d47 Mon Sep 17 00:00:00 2001
+From: Patrick Roy <roypat@amazon.co.uk>
+Date: Mon, 13 Mar 2023 11:01:19 +0000
+Subject: [PATCH] Add missing bounds check to FamStructWrapper::deserialize
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+An issue was discovered in the `Versionize::deserialize`
+implementation provided by the `versionize` crate for
+`vmm_sys_utils::fam::FamStructWrapper`, which can lead to out of
+bounds memory accesses. Objects of this type are used to model
+structures containing C-style flexible array members [1]. These
+structures contain a memory allocation that is prefixed by a header
+containing the size of the allocation.
+
+Due to treating the header and the memory allocation as two objects,
+`Versionize`'s data format stores the size of the allocation twice:
+once in the header and then again as its own metadata of the memory
+allocation. A serialized `FamStructWrapper` thus looks as follows:
+
++------------------------------------------------------------+\
+| header (containing length of flexible array member `len1`) |\
++------------------------------------------------------------+\
++---------------------------------------+-----------------------+
+| length of flexible array member`len2` | array member contents |
++---------------------------------------+-----------------------+
+
+During deserialization, the library separately deserializes the
+header and the memory allocation. It allocates `len2` bytes of
+memory, and then prefixes it with the separately deserialized header.
+Since `len2` is an implementation detail of the `Versionize`
+implementation, it is forgotten about at the end of the deserialize
+`function`, and all subsequent operations on the `FamStructWrapper`
+assume the memory allocated to have size `len1`. If deserialization
+input was malformed such that `len1 != len2`, then this can lead to
+(safe) functions on ´FamStructWrapper` to read past the end of
+allocated memory (if `len1 > len2`).
+
+The issue was corrected by inserting a check that verifies that these
+two lengths are equal, and aborting deserialization otherwise.
+
+[1]: https://en.wikipedia.org/wiki/Flexible_array_member
+
+Signed-off-by: Patrick Roy <roypat@amazon.co.uk>
+Signed-off-by: Henry Beberman <henry.beberman@microsoft.com>
+---
+
+diff -Naur a/vendor/versionize/.cargo-checksum.json b/vendor/versionize/.cargo-checksum.json
+--- a/vendor/versionize/.cargo-checksum.json	2023-03-22 17:06:45.000000000 -0700
++++ b/vendor/versionize/.cargo-checksum.json	2023-04-03 16:45:40.244088983 -0700
+@@ -1 +1 @@
+-{"files":{"CHANGELOG.md":"4e6046d6e251b09489eb03de9bd9df37726cb2a732e6f069be8300d115228d25","CONTRIBUTING.md":"76bc9cb82c3ebf92872244bde2040512f608cab2d5e328d353882d79740409cf","Cargo.toml":"8a808040e4e3f0552e6c37ff6f1139d0b5505c6a1f517168a92c0cdf53b7c101","LICENSE":"c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4","README.md":"c14a9330579f98aca5ada0fdb824cdd8100a978aaabd043dc0fbf8bfafa749a7","SECURITY-POLICY.md":"443fc8235528bed69d1d9ca3cf3ff5e89b22c3d48e4cbdc2be89b6f38f11718a","coverage_config_aarch64.json":"9a83cd71227b5a0c675cef990896159b81095ff2a583fbad65878b8198a102c8","coverage_config_x86_64.json":"9a83cd71227b5a0c675cef990896159b81095ff2a583fbad65878b8198a102c8","src/crc.rs":"a14116964bfcc4d64d2c52f02867401f08ec50a4ff0060ae77b4c6536f32b990","src/lib.rs":"cf96e0b65de2e7f261e969cc9832391bf8fc428e49805a659c116c78d5a519f0","src/primitives.rs":"6a4a98960f8706516ebd37ac7112434544511dbf73daf5a6de725357fd7ce50c","src/version_map.rs":"1d4e2f8e1f2da0a4f14a75e3bbd8086965dedfe9deaa4f49234eee8d31696276","tests/test.rs":"2f98d40971b6a98988fb1decdae5bb7510783289d046a8c37df9c74cd6c96d6f"},"package":"d6e2495726cf917e7ba7ec8bf0f0fceab543dd38d0a4195ed6bef331e38a290f"}
+\ No newline at end of file
++{"files":{"CHANGELOG.md":"4e6046d6e251b09489eb03de9bd9df37726cb2a732e6f069be8300d115228d25","CONTRIBUTING.md":"76bc9cb82c3ebf92872244bde2040512f608cab2d5e328d353882d79740409cf","Cargo.toml":"8a808040e4e3f0552e6c37ff6f1139d0b5505c6a1f517168a92c0cdf53b7c101","LICENSE":"c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4","README.md":"c14a9330579f98aca5ada0fdb824cdd8100a978aaabd043dc0fbf8bfafa749a7","SECURITY-POLICY.md":"443fc8235528bed69d1d9ca3cf3ff5e89b22c3d48e4cbdc2be89b6f38f11718a","coverage_config_aarch64.json":"9a83cd71227b5a0c675cef990896159b81095ff2a583fbad65878b8198a102c8","coverage_config_x86_64.json":"9a83cd71227b5a0c675cef990896159b81095ff2a583fbad65878b8198a102c8","src/crc.rs":"a14116964bfcc4d64d2c52f02867401f08ec50a4ff0060ae77b4c6536f32b990","src/lib.rs":"cf96e0b65de2e7f261e969cc9832391bf8fc428e49805a659c116c78d5a519f0","src/primitives.rs":"e9711034f5f4b0322e43dc281412234ac84f80542451ed10d0ad6d437d28fd35","src/version_map.rs":"1d4e2f8e1f2da0a4f14a75e3bbd8086965dedfe9deaa4f49234eee8d31696276","tests/test.rs":"ef1298cf5e35ddf14d40259b50c0ffad0aa83e3b2e915db3badadca221ebaed2"},"package":"d6e2495726cf917e7ba7ec8bf0f0fceab543dd38d0a4195ed6bef331e38a290f"}
+diff -Naur a/vendor/versionize/src/primitives.rs b/vendor/versionize/src/primitives.rs
+--- a/vendor/versionize/src/primitives.rs	2023-03-22 17:06:45.000000000 -0700
++++ b/vendor/versionize/src/primitives.rs	2023-04-03 16:42:51.784091255 -0700
+@@ -369,6 +369,18 @@
+         let entries: Vec<<T as FamStruct>::Entry> =
+             Vec::deserialize(reader, version_map, app_version)
+                 .map_err(|ref err| VersionizeError::Deserialize(format!("{:?}", err)))?;
++
++        if header.len() != entries.len() {
++            let msg = format!(
++                "Mismatch between length of FAM specified in FamStruct header ({}) \
++                and actual size of FAM ({})",
++                header.len(),
++                entries.len()
++            );
++
++            return Err(VersionizeError::Deserialize(msg));
++        }
++
+         // Construct the object from the array items.
+         // Header(T) fields will be initialized by Default trait impl.
+         let mut object = FamStructWrapper::from_entries(&entries)
+diff -Naur a/vendor/versionize/tests/test.rs b/vendor/versionize/tests/test.rs
+--- a/vendor/versionize/tests/test.rs	2023-03-22 17:06:45.000000000 -0700
++++ b/vendor/versionize/tests/test.rs	2023-04-03 16:42:51.784091255 -0700
+@@ -1324,6 +1324,32 @@
+ type Message2FamStructWrapper = FamStructWrapper<Message2>;
+ 
+ #[test]
++fn test_deserialize_famstructwrapper_invalid_len() {
++    let mut vm = VersionMap::new();
++    vm.new_version()
++        .set_type_version(Message::type_id(), 2)
++        .new_version()
++        .set_type_version(Message::type_id(), 3)
++        .new_version()
++        .set_type_version(Message::type_id(), 4);
++
++    // Create FamStructWrapper with len 2
++    let state = MessageFamStructWrapper::new(0).unwrap();
++    let mut buffer = [0; 256];
++
++    state.serialize(&mut buffer.as_mut_slice(), &vm, 2).unwrap();
++
++    // the `len` field of the header is the first serialized field.
++    // Let's corrupt it by making it bigger than the actual number of serialized elements
++    buffer[0] = 255;
++
++    assert_eq!(
++        MessageFamStructWrapper::deserialize(&mut buffer.as_slice(), &vm, 2).unwrap_err(),
++        VersionizeError::Deserialize("Mismatch between length of FAM specified in FamStruct header (255) and actual size of FAM (0)".to_string())
++    );
++}
++
++#[test]
+ fn test_versionize_famstructwrapper() {
+     let mut vm = VersionMap::new();
+     vm.new_version()

--- a/SPECS/cloud-hypervisor/cloud-hypervisor.spec
+++ b/SPECS/cloud-hypervisor/cloud-hypervisor.spec
@@ -5,7 +5,7 @@
 Summary:        Cloud Hypervisor is an open source Virtual Machine Monitor (VMM) that runs on top of KVM.
 Name:           cloud-hypervisor
 Version:        30.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        ASL 2.0 OR BSD-3-clause
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -21,6 +21,7 @@ Source0:        https://github.com/cloud-hypervisor/cloud-hypervisor/archive/ref
 #   tar -czf %{name}-%{version}-cargo.tar.gz vendor/
 Source1:        %{name}-%{version}-cargo.tar.gz
 Source2:        config.toml
+Patch0:         CVE-2023-28448.patch
 %endif
 
 BuildRequires:  binutils
@@ -73,6 +74,8 @@ Cloud Hypervisor is an open source Virtual Machine Monitor (VMM) that runs on to
 tar xf %{SOURCE1}
 mkdir -p .cargo
 cp %{SOURCE2} .cargo/
+# Apply CVE-2023-28448.patch to vendor/versionize
+%patch0 -p1
 %endif
 
 %install
@@ -151,6 +154,9 @@ cargo build --release --target=%{rust_musl_target} --package vhost_user_block %{
 %license LICENSE-BSD-3-Clause
 
 %changelog
+* Mon Apr 03 2023 Henry Beberman <henry.beberman@microsoft.com> 30.0-2
+- Patch CVE-2023-28448 in vendor/versionize
+
 * Fri Mar 24 2023 Mitch Zhu <mitchzhu@microsoft.com> 30.0-1
 - Update to v30.0
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
The versionize crate used by cloud-hypervisor is impacted by CVE-2023-28448. This PR patches the vulnerability in the vendored crate.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Patch CVE-2023-28448 in cloud-hypervisor's vendored versionize crate

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2023-28448

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local package build
- Pipeline build id: 337951
