### PR TITLE
Patch cloud-hypervisor for CVE-2023-28448 in vendored versionize crate

### DIFF
--- a/SPECS/cloud-hypervisor/CVE-2023-28448.patch
+++ b/SPECS/cloud-hypervisor/CVE-2023-28448.patch
@@ -1,0 +1,56 @@
+diff -Naur a/.cargo/registry/src/github.com-1ecc6299db9ec823/versionize-0.1.6/src/primitives.rs b/.cargo/registry/src/github.com-1ecc6299db9ec823/versionize-0.1.6/src/primitives.rs
+--- a/.cargo/registry/src/github.com-1ecc6299db9ec823/versionize-0.1.6/src/primitives.rs	2021-04-25 17:00:00.000000000 -0700
++++ b/.cargo/registry/src/github.com-1ecc6299db9ec823/versionize-0.1.6/src/primitives.rs	2023-04-05 15:33:56.893718099 -0700
+@@ -367,6 +367,16 @@
+         let entries: Vec<<T as FamStruct>::Entry> =
+             Vec::deserialize(reader, version_map, app_version)
+                 .map_err(|ref err| VersionizeError::Deserialize(format!("{:?}", err)))?;
++        if header.len() != entries.len() {
++            let msg = format!(
++                "Mismatch between length of FAM specified in FamStruct header ({}) \
++                and actual size of FAM ({})",
++                header.len(),
++                entries.len()
++            );
++
++            return Err(VersionizeError::Deserialize(msg));
++        }
+         // Construct the object from the array items.
+         // Header(T) fields will be initialized by Default trait impl.
+         let mut object = FamStructWrapper::from_entries(&entries)
+diff -Naur a/.cargo/registry/src/github.com-1ecc6299db9ec823/versionize-0.1.6/tests/test.rs b/.cargo/registry/src/github.com-1ecc6299db9ec823/versionize-0.1.6/tests/test.rs
+--- a/.cargo/registry/src/github.com-1ecc6299db9ec823/versionize-0.1.6/tests/test.rs	2021-04-25 17:00:00.000000000 -0700
++++ b/.cargo/registry/src/github.com-1ecc6299db9ec823/versionize-0.1.6/tests/test.rs	2023-04-05 15:34:57.145737780 -0700
+@@ -1321,6 +1321,32 @@
+ type Message2FamStructWrapper = FamStructWrapper<Message2>;
+ 
+ #[test]
++fn test_deserialize_famstructwrapper_invalid_len() {
++    let mut vm = VersionMap::new();
++    vm.new_version()
++        .set_type_version(Message::type_id(), 2)
++        .new_version()
++        .set_type_version(Message::type_id(), 3)
++        .new_version()
++        .set_type_version(Message::type_id(), 4);
++
++    // Create FamStructWrapper with len 2
++    let state = MessageFamStructWrapper::new(0).unwrap();
++    let mut buffer = [0; 256];
++
++    state.serialize(&mut buffer.as_mut_slice(), &vm, 2).unwrap();
++
++    // the `len` field of the header is the first serialized field.
++    // Let's corrupt it by making it bigger than the actual number of serialized elements
++    buffer[0] = 255;
++
++    assert_eq!(
++        MessageFamStructWrapper::deserialize(&mut buffer.as_slice(), &vm, 2).unwrap_err(),
++        VersionizeError::Deserialize("Mismatch between length of FAM specified in FamStruct header (255) and actual size of FAM (0)".to_string())
++    );
++}
++
++#[test]
+ fn test_versionize_famstructwrapper() {
+     let mut vm = VersionMap::new();
+     vm.new_version()

--- a/SPECS/cloud-hypervisor/cloud-hypervisor.spec
+++ b/SPECS/cloud-hypervisor/cloud-hypervisor.spec
@@ -1,7 +1,7 @@
 Summary:        A Rust-VMM based cloud hypervisor from Intel
 Name:           cloud-hypervisor
 Version:        22.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        ASL 2.0 or BSD
 URL:            https://github.com/cloud-hypervisor/cloud-hypervisor
 Group:          Development/Tools
@@ -12,6 +12,7 @@ Source0:       %{url}/archive/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
 # To update the cache run:
 #   [repo_root]/toolkit/scripts/build_cargo_cache.sh %%{name}-%%{version}.tar.gz
 Source1:        %{name}-%{version}-cargo.tar.gz
+Patch0:         CVE-2023-28448.patch
 ExclusiveArch:  x86_64
 
 BuildRequires:  gcc
@@ -28,6 +29,7 @@ A Rust-VMM based cloud hypervisor from Intel.
 mkdir -p $HOME
 pushd $HOME
 tar xf %{SOURCE1} --no-same-owner
+%patch0 -p1
 popd
 %setup -q
 
@@ -49,6 +51,9 @@ install -d %{buildroot}%{_libdir}/cloud-hypervisor
 %exclude %{_libdir}/debug
 
 %changelog
+* Wed Apr 05 2023 Henry Beberman <henry.beberman@microsoft.com> - 22.0-2
+- Patch CVE-2023-28448 in vendored versionize crate
+
 * Wed Mar 09 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 22.0-1
 - Updating to version 22.0 to build with 'rust' 1.59.0.
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Patch cloud-hypervisor for CVE-2023-28448 in vendored versionize crate

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Patch cloud-hypervisor for CVE-2023-28448 in vendored versionize crate

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2023-28448

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local individual package build succeeded
- Pipeline build id: 339285
