### PR TITLE
Fix Mariner Release Bump

### DIFF
--- a/SPECS/mariner-release/mariner-release.spec
+++ b/SPECS/mariner-release/mariner-release.spec
@@ -1,7 +1,7 @@
 Summary:        CBL-Mariner release files
 Name:           mariner-release
 Version:        2.0
-Release:        36%{?dist}
+Release:        37%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -62,8 +62,11 @@ EOF
 %config(noreplace) %{_sysconfdir}/issue.net
 
 %changelog
-* Thu Apr 06 2023 Jon Slobodzian <joslobo@microsoft.com> - 2.0-36
+* Thu Apr 06 2023 Jon Slobodzian <joslobo@microsoft.com> - 2.0-37
 - Updating version for April update.
+
+* Fri Mar 17 2023 Pawel Winogrodzki <pawelwi@microsoft.com> - 2.0-36
+- Updating version for March 2023 update 2.
 
 * Thu Mar 02 2023 Andrew Phelps <anphel@microsoft.com> - 2.0-35
 - Updating version for March 2023 update 1.


### PR DESCRIPTION
The Mariner Release version on main was behind the version on the Mariner 2.0 branch.  This fix merges the change I just made to bump the Mariner Release with the version that was on the 2.0 branch.  This fixes the ChangeLog and bumps the release version by 1 again.

In short the main branch was at -35, the 2.0 branch was at -36.  My previous PR bumped main to -36.  But main should have already been at -36 and the bump should have taken it to -37.  This change corrects that.