### PR TITLE
Cloud-init disable root

### DIFF
--- a/toolkit/imageconfigs/additionalconfigs/cloud-init.cfg
+++ b/toolkit/imageconfigs/additionalconfigs/cloud-init.cfg
@@ -11,7 +11,7 @@ users:
 
 # If this is set, 'root' will not be able to ssh in and they 
 # will get a message to login instead as the above $user (ubuntu)
-disable_root: false
+disable_root: true
 
 #Vmware guest customization.
 disable_vmware_customization: true


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
This PR is to change disable_root option to true in cloud-init.cfg to prevent SSH logging in for root access. The Penguinator test called verify_no_pre_exist_users() which also failed due to this as when disable_root is set to false.
From cloud-init: [Root login can be enabled/disabled using the disable_root config key.](https://canonical-cloud-init.readthedocs-hosted.com/en/latest/reference/modules.html)
Verify_no_pre_exist_users() checks if [matching pattern string](https://github.com/microsoft/lisa/blob/ae6f8998fafc4b8c8b746ad67f1c5f7d9f11acf9/microsoft/testsuites/core/azure_image_standard.py#L892) exits in /root/.ssh/authorized_keys and if not, fails the test. disable_root is responsible to add that matching string.

This change is already merged and tested in Mariner 2.0 branch and this PR backports to 1.0.  
Linking to 2.0 commit - https://github.com/microsoft/CBL-Mariner/pull/4832

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- set disable_root to true in cloud-init.cfg. This will add extra strings in /root/.ssh/authorized_keys: 
![image](https://user-images.githubusercontent.com/31802333/218530595-c2c39fb7-935f-4618-8ed1-e25745e80a44.png)

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
NO

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- [Bug 42949053](https://microsoft.visualstudio.com/OS/_workitems/edit/42949053): [Mariner 2] root user has authorized_keys file when deployed to Azure
- [Bug 43185302](https://microsoft.visualstudio.com/OS/_workitems/edit/43185302): [Penguinator Distro test] - verify_no_pre_exist_users failing

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- local image build 
- Verify "verify_no_pre_exist_users()" Penguinator test passed:
https://penguinatorstarter.powerappsportals.com/mytests/myjobs/results/?id=9ac4f467-add8-ed11-a81c-000d3adfb051

