### PR TITLE
Scan for orphaned mounts when cleaning toolchain

### DIFF
--- a/toolkit/scripts/toolchain.mk
+++ b/toolkit/scripts/toolchain.mk
@@ -202,6 +202,7 @@ endif
 $(final_toolchain): $(raw_toolchain) $(toolchain_rpms_rehydrated) $(STATUS_FLAGS_DIR)/build_toolchain_srpms.flag
 	@echo "Building base packages"
 	# Clean the existing chroot if not doing an incremental build
+	$(if $(filter y,$(INCREMENTAL_TOOLCHAIN)),,$(SCRIPTS_DIR)/safeunmount.sh "$(populated_toolchain_chroot)" || $(call print_error,failed to clean mounts for toolchain build))
 	$(if $(filter y,$(INCREMENTAL_TOOLCHAIN)),,rm -rf $(populated_toolchain_chroot))
 	cd $(SCRIPTS_DIR)/toolchain && \
 		./build_mariner_toolchain.sh \

--- a/toolkit/scripts/toolchain.mk
+++ b/toolkit/scripts/toolchain.mk
@@ -60,6 +60,7 @@ endif
 clean: clean-toolchain
 
 clean-toolchain:
+	$(SCRIPTS_DIR)/safeunmount.sh "$(toolchain_build_dir)"
 	rm -rf $(toolchain_build_dir)
 	rm -rf $(toolchain_local_temp)
 	rm -rf $(toolchain_logs_dir)


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
If the toolchain build fails it may leave behind orphaned mounts, and we delete the parent directory when running `make clean`. We need to unmount everything inside the chroot before we delete the directories or we get errors such as `rm: cannot remove '/home/damcilva/repos/CBL-Mariner/build/toolchain/populated_toolchain/sys/kernel/notes': Operation not permitted`. Even more worrying sometimes we CAN delete similar mounted system files and mess up the host system until it is rebooted.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Run `safeunmount.sh` to clean up `$(populated_toolchain_chroot)` during a build of `$(final_toolchain)`.
- Run `safeunmount.sh` to clean up `$(toolchain_build_dir)` when doing `clean-toolchain`

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build