### PR TITLE
Nopatch kernel for CVE-2021-3923, CVE-2023-0179, CVE-2023-0590, CVE-2023-1249, CVE-2023-1252, CVE-2023-1838, CVE-2023-30456

### DIFF
--- a/SPECS/kernel/CVE-2021-3923.nopatch
+++ b/SPECS/kernel/CVE-2021-3923.nopatch
@@ -1,0 +1,2 @@
+CVE-2021-3923 - patched in version 5.10.91.1
+upstream commit ID b35a0f4dd544eaa6162b6d2f13a2557a121ae5fd -> stable commit ID beeb0fdedae802a7fb606e955a81a56a2e3bbac1 (in version 5.10.91)

--- a/SPECS/kernel/CVE-2023-0179.nopatch
+++ b/SPECS/kernel/CVE-2023-0179.nopatch
@@ -1,0 +1,2 @@
+CVE-2023-0179 - patched in 5.10.164.1
+upstream commit ID 696e1a48b1a1b01edad542a1ef293665864a4dd0 -> stable commit ID 550efeff989b041f3746118c0ddd863c39ddc1aa (in version 5.10.164)

--- a/SPECS/kernel/CVE-2023-0590.nopatch
+++ b/SPECS/kernel/CVE-2023-0590.nopatch
@@ -1,0 +1,2 @@
+CVE-2023-0590 - patched in 5.10.152.1
+upstream commit ID ebda44da44f6f309d302522b049f43d6f829f7aa -> stable commit ID 7aa3d623c11b9ab60f86b7833666e5d55bac4be9 (in version 5.10.152)

--- a/SPECS/kernel/CVE-2023-1249.nopatch
+++ b/SPECS/kernel/CVE-2023-1249.nopatch
@@ -1,0 +1,2 @@
+CVE-2023-1249 - patched in 5.10.110.1
+upstream commit ID 390031c942116d4733310f0684beb8db19885fe6 -> stable commit ID 558564db44755dfb3e48b0d64de327d20981e950 (in version 5.10.110)

--- a/SPECS/kernel/CVE-2023-1252.nopatch
+++ b/SPECS/kernel/CVE-2023-1252.nopatch
@@ -1,0 +1,2 @@
+CVE-2023-1252 - patched in 5.10.80.1
+upstream commit ID 9a254403760041528bc8f69fe2f5e1ef86950991 -> stable commit ID 4fd9f0509a1452b45e89c668e2bab854cb05cd25 (in version 5.10.80)

--- a/SPECS/kernel/CVE-2023-1838.nopatch
+++ b/SPECS/kernel/CVE-2023-1838.nopatch
@@ -1,0 +1,2 @@
+CVE-2023-1838 - patched in 5.10.118.1
+upstream commit ID fb4554c2232e44d595920f4d5c66cf8f7d13f9bc -> stable commit ID ec0d801d1a44d9259377142c6218885ecd685e41 (in version 5.10.118)

--- a/SPECS/kernel/CVE-2023-30456.nopatch
+++ b/SPECS/kernel/CVE-2023-30456.nopatch
@@ -1,0 +1,2 @@
+CVE-2023-30456 - patched in version 5.10.176.1
+upstream commit ID 112e66017bff7f2837030f34c2bc19501e9212d5 -> stable commit ID c54974ccaff73525462e278602dfe4069877cfaa (in version 5.10.176)


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Nopatch CVE-2021-3923, CVE-2023-0179, CVE-2023-0590, CVE-2023-1249, CVE-2023-1252, CVE-2023-1838, CVE-2023-30456

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Nopatch CVE-2021-3923, CVE-2023-0179, CVE-2023-0590, CVE-2023-1249, CVE-2023-1252, CVE-2023-1838, CVE-2023-30456

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
-https://nvd.nist.gov/vuln/detail/CVE-2021-3923
-https://nvd.nist.gov/vuln/detail/CVE-2023-0179
-https://nvd.nist.gov/vuln/detail/CVE-2023-0590
-https://nvd.nist.gov/vuln/detail/CVE-2023-1249
-https://nvd.nist.gov/vuln/detail/CVE-2023-1252
-https://nvd.nist.gov/vuln/detail/CVE-2023-1838
-https://nvd.nist.gov/vuln/detail/CVE-2023-30456
