### PR TITLE
Patch CVE-2022-2989 in podman

### DIFF
--- a/SPECS-EXTENDED/podman/CVE-2022-2989.patch
+++ b/SPECS-EXTENDED/podman/CVE-2022-2989.patch
@@ -1,0 +1,93 @@
+From 21540161f20daffd884eba99b2cc31373c9a0ec4 Mon Sep 17 00:00:00 2001
+From: Matthew Heon <mheon@redhat.com>
+Date: Fri, 2 Sep 2022 13:40:29 -0400
+Subject: [PATCH] Add container GID to additional groups
+
+Mitigates a potential permissions issue. Mirrors Buildah PR #4200
+and CRI-O PR #6159.
+
+Signed-off-by: Matthew Heon <mheon@redhat.com>
+---
+ libpod/container_internal_linux.go |  1 +
+ pkg/specgen/namespaces.go          |  2 ++
+ test/e2e/run_test.go               | 14 +++++++++++---
+ 3 files changed, 14 insertions(+), 3 deletions(-)
+
+diff --git a/libpod/container_internal_linux.go b/libpod/container_internal_linux.go
+index a131ab36740..39aaac923e4 100644
+--- a/libpod/container_internal_linux.go
++++ b/libpod/container_internal_linux.go
+@@ -682,6 +682,7 @@ func (c *Container) generateSpec(ctx context.Context) (*spec.Spec, error) {
+ 		// User and Group must go together
+ 		g.SetProcessUID(uint32(execUser.Uid))
+ 		g.SetProcessGID(uint32(execUser.Gid))
++		g.AddProcessAdditionalGid(uint32(execUser.Gid))
+ 	}
+ 
+ 	if c.config.Umask != "" {
+diff --git a/pkg/specgen/namespaces.go b/pkg/specgen/namespaces.go
+index 03a2049f60e..2578e61631f 100644
+--- a/pkg/specgen/namespaces.go
++++ b/pkg/specgen/namespaces.go
+@@ -497,6 +497,7 @@ func SetupUserNS(idmappings *storage.IDMappingOptions, userns Namespace, g *gene
+ 		idmappings = mappings
+ 		g.SetProcessUID(uint32(uid))
+ 		g.SetProcessGID(uint32(gid))
++		g.AddProcessAdditionalGid(uint32(gid))
+ 		user = fmt.Sprintf("%d:%d", uid, gid)
+ 		if err := privateUserNamespace(idmappings, g); err != nil {
+ 			return user, err
+@@ -509,6 +510,7 @@ func SetupUserNS(idmappings *storage.IDMappingOptions, userns Namespace, g *gene
+ 		idmappings = mappings
+ 		g.SetProcessUID(uint32(uid))
+ 		g.SetProcessGID(uint32(gid))
++		g.AddProcessAdditionalGid(uint32(gid))
+ 		user = fmt.Sprintf("%d:%d", uid, gid)
+ 		if err := privateUserNamespace(idmappings, g); err != nil {
+ 			return user, err
+diff --git a/test/e2e/run_test.go b/test/e2e/run_test.go
+index 7e00326f48e..c4f0214be33 100644
+--- a/test/e2e/run_test.go
++++ b/test/e2e/run_test.go
+@@ -944,7 +944,7 @@ echo -n %s >%s
+ 		session := podmanTest.Podman([]string{"run", "--rm", "--user=1234", ALPINE, "id"})
+ 		session.WaitWithDefaultTimeout()
+ 		Expect(session).Should(Exit(0))
+-		Expect(session.OutputToString()).To(Equal("uid=1234(1234) gid=0(root)"))
++		Expect(session.OutputToString()).To(Equal("uid=1234(1234) gid=0(root) groups=0(root)"))
+ 	})
+ 
+ 	It("podman run with user (integer, in /etc/passwd)", func() {
+@@ -965,14 +965,14 @@ echo -n %s >%s
+ 		session := podmanTest.Podman([]string{"run", "--rm", "--user=mail:21", ALPINE, "id"})
+ 		session.WaitWithDefaultTimeout()
+ 		Expect(session).Should(Exit(0))
+-		Expect(session.OutputToString()).To(Equal("uid=8(mail) gid=21(ftp)"))
++		Expect(session.OutputToString()).To(Equal("uid=8(mail) gid=21(ftp) groups=21(ftp)"))
+ 	})
+ 
+ 	It("podman run with user:group (integer:groupname)", func() {
+ 		session := podmanTest.Podman([]string{"run", "--rm", "--user=8:ftp", ALPINE, "id"})
+ 		session.WaitWithDefaultTimeout()
+ 		Expect(session).Should(Exit(0))
+-		Expect(session.OutputToString()).To(Equal("uid=8(mail) gid=21(ftp)"))
++		Expect(session.OutputToString()).To(Equal("uid=8(mail) gid=21(ftp) groups=21(ftp)"))
+ 	})
+ 
+ 	It("podman run with user, verify caps dropped", func() {
+@@ -983,6 +983,14 @@ echo -n %s >%s
+ 		Expect("0000000000000000").To(Equal(capEff[1]))
+ 	})
+ 
++	It("podman run with user, verify group added", func() {
++		session := podmanTest.Podman([]string{"run", "--rm", "--user=1000:1000", ALPINE, "grep", "Groups:", "/proc/self/status"})
++		session.WaitWithDefaultTimeout()
++		Expect(session).Should(Exit(0))
++		groups := strings.Split(session.OutputToString(), " ")[1]
++		Expect("1000").To(Equal(groups))
++	})
++
+ 	It("podman run with attach stdin outputs container ID", func() {
+ 		session := podmanTest.Podman([]string{"run", "--attach", "stdin", ALPINE, "printenv"})
+ 		session.WaitWithDefaultTimeout()
+        

--- a/SPECS-EXTENDED/podman/podman.spec
+++ b/SPECS-EXTENDED/podman/podman.spec
@@ -36,7 +36,7 @@
 
 Name:           podman
 Version:        4.1.1
-Release:        9%{?dist}
+Release:        10%{?dist}
 License:        ASL 2.0 and BSD and ISC and MIT and MPLv2.0
 Summary:        Manage Pods, Containers and Container Images
 Vendor:         Microsoft Corporation
@@ -45,6 +45,7 @@ URL:            https://%{name}.io/
 Source0:        %{git0}/archive/%{built_tag}.tar.gz#/%{name}-%{version}.tar.gz
 Source1:        %{git_plugins}/archive/%{commit_plugins}/%{repo_plugins}-%{commit_plugins}.tar.gz#/%{repo_plugins}-%{shortcommit_plugins}.tar.gz
 Source2:        %{git_gvproxy}/archive/%{commit_gvproxy}/%{repo_gvproxy}-%{commit_gvproxy}.tar.gz#/%{repo_gvproxy}-%{shortcommit_gvproxy}.tar.gz
+Patch0:         CVE-2022-2989.patch
 Provides:       %{name}-manpages = %{version}-%{release}
 BuildRequires:  go-md2man
 BuildRequires:  golang
@@ -225,7 +226,7 @@ gvisor-tap-vsock brings a configurable DNS server and
 dynamic port forwarding.
 
 %prep
-%autosetup -Sgit
+%autosetup -Sgit -p1
 sed -i 's;@@PODMAN@@\;$(BINDIR);@@PODMAN@@\;%{_bindir};' Makefile
 
 # untar dnsname
@@ -386,6 +387,9 @@ cp -pav test/system %{buildroot}/%{_datadir}/%{name}/test/
 
 # rhcontainerbot account currently managed by lsm5
 %changelog
+* Thu Apr 20 2023 Amrita Kohli <amritakohli@microsoft.com> - 4.1.1-10
+- Patch CVE-2022-2989
+
 * Wed Apr 05 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 4.1.1-9
 - Bump release to rebuild with go 1.19.8
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
This patches CVE-2022-2989 in podman.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Added a patch file to fix CVE-2022-2989 for podman.
- Updated changelog and release version.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2022-2989

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=348096&view=results and https://dev.azure.com/mariner-org/mariner/_build/results?buildId=348097&view=results 

Note: the pipeline fails due to an issue unrelated to the changes made to podman. The podman package builds successfully. Here is the failure shown even when building podman in the 2.0 branch: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=347701&view=logs&j=ca395085-040a-526b-2ce8-bdc85f692774&t=d723e8ff-9fe0-5a1d-bed2-08b8dc44a520