### PR TITLE
Increase amd64 market place image EFI boot partition size

### DIFF
--- a/toolkit/imageconfigs/marketplace-gen2.json
+++ b/toolkit/imageconfigs/marketplace-gen2.json
@@ -17,18 +17,18 @@
                         "boot"
                     ],
                     "Start": 1,
-                    "End": 9,
+                    "End": 65,
                     "FsType": "fat32"
                 },
                 {
                     "ID": "boot",
-                    "Start": 9,
-                    "End": 509,
+                    "Start": 65,
+                    "End": 565,
                     "FsType": "ext4"
                 },
                 {
                     "ID": "rootfs",
-                    "Start": 509,
+                    "Start": 565,
                     "End": 0,
                     "FsType": "ext4"
                 }


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Increase amd64 2.0 market place image EFI partition size from 2MB to 64MB to accommodate space for Kata packages during the new Kata image AgentBaker curation flow.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Increased amd64 2.0 market place image EFI partition size from 2MB to 64MB.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Manually tested image by creating a VM that has increased EFI partition. After installing all Kata packages, the EFI partition has 35MB of content.
- Existing Kata release image has been shipping with 64MB EFI partition.
