### PR TITLE
Nopatch Kernel for CVE-2022-4095, CVE-2022-4379, CVE-2023-1855, CVE-2023-1989, CVE-2023-1990, CVE-2023-25012

### DIFF
--- a/SPECS/kernel/CVE-2022-4095.nopatch
+++ b/SPECS/kernel/CVE-2022-4095.nopatch
@@ -1,0 +1,3 @@
+CVE-2022-4095 - in version 5.10.142 
+Note that the NIST 'patch' is a set of 3 commits but only the following applies.
+upstream commit ID e230a4455ac3e9b112f0367d1b8e255e141afae0 -> stable commit ID 19e3f69d19801940abc2ac37c169882769ed9770 

--- a/SPECS/kernel/CVE-2022-4379.nopatch
+++ b/SPECS/kernel/CVE-2022-4379.nopatch
@@ -1,0 +1,2 @@
+CVE-2022-4379 - fixed in version 5.10.177
+upstream commit ID 75333d48f92256a0dec91dbf07835e804fc411c0 -> stable commit ID 01e4c9c03de8a9f8839cb7342bc4bccf9104efe5 

--- a/SPECS/kernel/CVE-2023-1855.nopatch
+++ b/SPECS/kernel/CVE-2023-1855.nopatch
@@ -1,0 +1,2 @@
+CVE-2023-1855 - in version 5.10.176
+upstream commit ID cb090e64cf25602b9adaf32d5dfc9c8bec493cd1 -> stable commit ID 0a73c8b3cc99d214dff83c51805c844240c4f749 

--- a/SPECS/kernel/CVE-2023-1989.nopatch
+++ b/SPECS/kernel/CVE-2023-1989.nopatch
@@ -1,0 +1,2 @@
+CVE-2023-1989 - in version 5.10.177
+upstream commit ID 1e9ac114c4428fdb7ff4635b45d4f46017e8916f -> stable commit ID da3d3fdfb4d523c5da30e35a8dd90e04f0fd8962 

--- a/SPECS/kernel/CVE-2023-1990.nopatch
+++ b/SPECS/kernel/CVE-2023-1990.nopatch
@@ -1,0 +1,2 @@
+CVE-2023-1990 - in version 5.10.176
+upstream commit ID 5000fe6c27827a61d8250a7e4a1d26c3298ef4f6 -> stable commit ID 43aa468df246175207a7d5d7d6d31b231f15b49c 

--- a/SPECS/kernel/CVE-2023-25012.nopatch
+++ b/SPECS/kernel/CVE-2023-25012.nopatch
@@ -1,0 +1,2 @@
+CVE-2023-25012 - in version 5.10.173
+upstream commit ID 76ca8da989c7d97a7f76c75d475fe95a584439d7 -> stable commit ID fddde36316da8acb45a3cca2e5fda102f5215877 (in version 5.10.173)


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Nopatch Kernel for CVE-2022-4095, CVE-2022-4379, CVE-2023-1855, CVE-2023-1989, CVE-2023-1990, CVE-2023-25012

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
-Nopatch Kernel for CVE-2022-4095, CVE-2022-4379, CVE-2023-1855, CVE-2023-1989, CVE-2023-1990, CVE-2023-25012

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
 - https://nvd.nist.gov/vuln/detail/CVE-2022-4095
 - https://nvd.nist.gov/vuln/detail/CVE-2022-4379
 - https://nvd.nist.gov/vuln/detail/CVE-2023-1855
 - https://nvd.nist.gov/vuln/detail/CVE-2023-1989
 - https://nvd.nist.gov/vuln/detail/CVE-2023-1990
 - https://nvd.nist.gov/vuln/detail/CVE-2023-25012

