### PR TITLE
Fix relative time search tests in gh

### DIFF
--- a/SPECS/gh/fix-relative-time-search-tests.patch
+++ b/SPECS/gh/fix-relative-time-search-tests.patch
@@ -1,0 +1,149 @@
+From b7acb23d583de0e154388dad5ee56b642b500f9e Mon Sep 17 00:00:00 2001
+From: Sam Coe <samcoe@users.noreply.github.com>
+Date: Tue, 25 Apr 2023 17:11:11 -0700
+Subject: [PATCH] Stub out time.Now for search tests (#6299)
+
+Signed-off-by: Olivia Crain <oliviacrain@microsoft.com>
+---
+ pkg/cmd/search/repos/repos.go        | 10 +++++++---
+ pkg/cmd/search/repos/repos_test.go   |  4 +++-
+ pkg/cmd/search/shared/shared.go      |  9 ++++++---
+ pkg/cmd/search/shared/shared_test.go |  6 ++++--
+ 4 files changed, 20 insertions(+), 9 deletions(-)
+
+diff --git a/pkg/cmd/search/repos/repos.go b/pkg/cmd/search/repos/repos.go
+index 57f3766..a54187a 100644
+--- a/pkg/cmd/search/repos/repos.go
++++ b/pkg/cmd/search/repos/repos.go
+@@ -19,6 +19,7 @@ type ReposOptions struct {
+ 	Browser  cmdutil.Browser
+ 	Exporter cmdutil.Exporter
+ 	IO       *iostreams.IOStreams
++	Now      time.Time
+ 	Query    search.Query
+ 	Searcher search.Searcher
+ 	WebMode  bool
+@@ -147,10 +148,13 @@ func reposRun(opts *ReposOptions) error {
+ 	if len(result.Items) == 0 {
+ 		return cmdutil.NewNoResultsError("no repositories matched your search")
+ 	}
+-	return displayResults(io, result)
++	return displayResults(io, opts.Now, result)
+ }
+ 
+-func displayResults(io *iostreams.IOStreams, results search.RepositoriesResult) error {
++func displayResults(io *iostreams.IOStreams, now time.Time, results search.RepositoriesResult) error {
++	if now.IsZero() {
++		now = time.Now()
++	}
+ 	cs := io.ColorScheme()
+ 	tp := utils.NewTablePrinter(io)
+ 	for _, repo := range results.Items {
+@@ -171,7 +175,7 @@ func displayResults(io *iostreams.IOStreams, results search.RepositoriesResult)
+ 		tp.AddField(text.ReplaceExcessiveWhitespace(description), nil, nil)
+ 		tp.AddField(info, nil, infoColor)
+ 		if tp.IsTTY() {
+-			tp.AddField(utils.FuzzyAgoAbbr(time.Now(), repo.UpdatedAt), nil, cs.Gray)
++			tp.AddField(utils.FuzzyAgoAbbr(now, repo.UpdatedAt), nil, cs.Gray)
+ 		} else {
+ 			tp.AddField(repo.UpdatedAt.Format(time.RFC3339), nil, nil)
+ 		}
+diff --git a/pkg/cmd/search/repos/repos_test.go b/pkg/cmd/search/repos/repos_test.go
+index fc7bf6d..5803fcb 100644
+--- a/pkg/cmd/search/repos/repos_test.go
++++ b/pkg/cmd/search/repos/repos_test.go
+@@ -148,6 +148,8 @@ func TestNewCmdRepos(t *testing.T) {
+ }
+ 
+ func TestReposRun(t *testing.T) {
++	var now = time.Date(2022, 2, 28, 12, 30, 0, 0, time.UTC)
++	var updatedAt = time.Date(2021, 2, 28, 12, 30, 0, 0, time.UTC)
+ 	var query = search.Query{
+ 		Keywords: []string{"cli"},
+ 		Kind:     "repositories",
+@@ -157,7 +159,6 @@ func TestReposRun(t *testing.T) {
+ 			Topic: []string{"golang"},
+ 		},
+ 	}
+-	var updatedAt = time.Date(2021, 2, 28, 12, 30, 0, 0, time.UTC)
+ 	tests := []struct {
+ 		errMsg     string
+ 		name       string
+@@ -269,6 +270,7 @@ func TestReposRun(t *testing.T) {
+ 		ios.SetStdoutTTY(tt.tty)
+ 		ios.SetStderrTTY(tt.tty)
+ 		tt.opts.IO = ios
++		tt.opts.Now = now
+ 		t.Run(tt.name, func(t *testing.T) {
+ 			err := reposRun(tt.opts)
+ 			if tt.wantErr {
+diff --git a/pkg/cmd/search/shared/shared.go b/pkg/cmd/search/shared/shared.go
+index 1b506ea..eb8615f 100644
+--- a/pkg/cmd/search/shared/shared.go
++++ b/pkg/cmd/search/shared/shared.go
+@@ -30,6 +30,7 @@ type IssuesOptions struct {
+ 	Entity   EntityType
+ 	Exporter cmdutil.Exporter
+ 	IO       *iostreams.IOStreams
++	Now      time.Time
+ 	Query    search.Query
+ 	Searcher search.Searcher
+ 	WebMode  bool
+@@ -90,10 +91,13 @@ func SearchIssues(opts *IssuesOptions) error {
+ 		return cmdutil.NewNoResultsError(msg)
+ 	}
+ 
+-	return displayIssueResults(io, opts.Entity, result)
++	return displayIssueResults(io, opts.Now, opts.Entity, result)
+ }
+ 
+-func displayIssueResults(io *iostreams.IOStreams, et EntityType, results search.IssuesResult) error {
++func displayIssueResults(io *iostreams.IOStreams, now time.Time, et EntityType, results search.IssuesResult) error {
++	if now.IsZero() {
++		now = time.Now()
++	}
+ 	cs := io.ColorScheme()
+ 	tp := utils.NewTablePrinter(io)
+ 	for _, issue := range results.Items {
+@@ -121,7 +125,6 @@ func displayIssueResults(io *iostreams.IOStreams, et EntityType, results search.
+ 		}
+ 		tp.AddField(text.ReplaceExcessiveWhitespace(issue.Title), nil, nil)
+ 		tp.AddField(listIssueLabels(&issue, cs, tp.IsTTY()), nil, nil)
+-		now := time.Now()
+ 		ago := now.Sub(issue.UpdatedAt)
+ 		if tp.IsTTY() {
+ 			tp.AddField(utils.FuzzyAgo(ago), nil, cs.Gray)
+diff --git a/pkg/cmd/search/shared/shared_test.go b/pkg/cmd/search/shared/shared_test.go
+index 1c4e621..873b846 100644
+--- a/pkg/cmd/search/shared/shared_test.go
++++ b/pkg/cmd/search/shared/shared_test.go
+@@ -23,7 +23,9 @@ func TestSearcher(t *testing.T) {
+ }
+ 
+ func TestSearchIssues(t *testing.T) {
+-	query := search.Query{
++	var now = time.Date(2022, 2, 28, 12, 30, 0, 0, time.UTC)
++	var updatedAt = time.Date(2021, 2, 28, 12, 30, 0, 0, time.UTC)
++	var query = search.Query{
+ 		Keywords: []string{"keyword"},
+ 		Kind:     "issues",
+ 		Limit:    30,
+@@ -34,7 +36,6 @@ func TestSearchIssues(t *testing.T) {
+ 		},
+ 	}
+ 
+-	var updatedAt = time.Date(2021, 2, 28, 12, 30, 0, 0, time.UTC)
+ 	tests := []struct {
+ 		errMsg     string
+ 		name       string
+@@ -193,6 +194,7 @@ func TestSearchIssues(t *testing.T) {
+ 		ios.SetStdoutTTY(tt.tty)
+ 		ios.SetStderrTTY(tt.tty)
+ 		tt.opts.IO = ios
++		tt.opts.Now = now
+ 		t.Run(tt.name, func(t *testing.T) {
+ 			err := SearchIssues(tt.opts)
+ 			if tt.wantErr {
+-- 
+2.34.1
+

--- a/SPECS/gh/gh.spec
+++ b/SPECS/gh/gh.spec
@@ -1,7 +1,7 @@
 Summary:        GitHub official command line tool
 Name:           gh
 Version:        2.13.0
-Release:        10%{?dist}
+Release:        11%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -27,6 +27,8 @@ Source0:        https://github.com/cli/cli/archive/refs/tags/v%{version}.tar.gz#
 #         See: https://reproducible-builds.org/docs/archives/
 #       - For the value of "--mtime" use the date "2021-04-26 00:00Z" to simplify future updates.
 Source1:        %{name}-%{version}-vendor.tar.gz
+# Available upstream in 2.16.0
+Patch0:         fix-relative-time-search-tests.patch
 
 BuildRequires:  golang >= 1.17.1
 BuildRequires:  git
@@ -38,7 +40,7 @@ Requires:       git
 GitHub official command line tool.
 
 %prep
-%setup -q -n cli-%{version}
+%autosetup -p1 -n cli-%{version}
 
 %build
 tar --no-same-owner -xf %{SOURCE1}
@@ -70,6 +72,9 @@ make test
 %{_datadir}/zsh/site-functions/_gh
 
 %changelog
+* Wed Apr 26 2023 Olivia Crain <oliviacrain@microsoft.com> - 2.13.0-11
+- Add upstream patch to fix search tests involving relative time
+
 * Wed Apr 05 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 2.13.0-10
 - Bump release to rebuild with go 1.19.8
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
For the `gh` package, search tests involving relative time started failing due to time not being properly stubbed out. This was [discovered](https://github.com/cli/cli/issues/6259) and [fixed upstream](https://github.com/cli/cli/pull/6299) in version 2.16.0. To fix the tests, let's take the upstream patch.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add backported [upstream patch](https://github.com/cli/cli/commit/de83df12d272966d8ab18b4cb42721473113097d) to fix time stubbing in search tests

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- [AMD64 non-check buddy build](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=350152)
- [AMD64 check buddy build](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=350149)
