### PR TITLE
Fix flaky valgrind tests by including proper check-time requirements

### DIFF
--- a/SPECS/valgrind/valgrind.spec
+++ b/SPECS/valgrind/valgrind.spec
@@ -2,14 +2,17 @@
 Summary:        Memory Management Debugger.
 Name:           valgrind
 Version:        3.18.1
-Release:        1%{?dist}
-License:        GPLv2+
+Release:        2%{?dist}
+License:        GPL-2.0-or-later
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Group:          Development/Debuggers
 URL:            https://valgrind.org
 Source0:        https://sourceware.org/pub/%{name}/%{name}-%{version}.tar.bz2
 BuildRequires:  pkg-config
+%if %{with_check}
+BuildRequires:  docbook-dtd-xml
+%endif
 Provides:       %{name}-devel = %{version}-%{release}
 
 %description
@@ -46,6 +49,10 @@ make %{?_smp_mflags} -k check
 %{_libexecdir}/valgrind/*
 
 %changelog
+* Wed Apr 6 2023 Olivia Crain <oliviacrain@microsoft.com> - 3.18.1-2
+- Fix flaky doctests by installing XML DTD files package during check builds
+- Use SPDX license expression in license tag
+
 * Fri Nov 13 2021 Andrew Phelps <anphel@microsoft.com> - 3.18.1-1
 - Update to version 3.18.1
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
`valgrind` doctests have been flaky for us. These issues are centered around `xmllint` reaching out to the network for XML DTD files. Since we have a package for that, let's just include `docbook-dtd-xml` as a check-time dependency of `valgrind`.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- `valgrind`: Fix flaky doctests by installing XML DTD files package during check builds
- `valgrind`: Use SPDX license expression in license tag

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Several builds on my machine and a couple of buddy builds showed no flakiness
