### PR TITLE
Fix FRR incompatible installation macros to resolve installation errors for the package.

### DIFF
--- a/SPECS-EXTENDED/frr/frr.spec
+++ b/SPECS-EXTENDED/frr/frr.spec
@@ -54,10 +54,8 @@ BuildRequires:  readline-devel
 BuildRequires:  systemd-devel
 BuildRequires:  systemd-rpm-macros
 BuildRequires:  texinfo
-%if %{with_check}
 BuildRequires:  python3-pip
 BuildRequires:  python3-pytest
-%endif
 Requires:       ncurses
 Requires:       net-snmp
 Requires(post): hostname
@@ -95,7 +93,12 @@ SELinux policy modules for FRR package
 %endif
 
 %prep
-%autosetup -p1 -n %{name}-%{name}-%{version}
+%setup -n %{name}-%{name}-%{version}
+%patch0 -p1
+%patch1 -p1
+%patch2 -p1
+%patch3 -p1
+%patch4 -p1
 #Selinux
 mkdir selinux
 cp -p %{SOURCE3} %{SOURCE4} %{SOURCE5} selinux
@@ -179,7 +182,7 @@ rm %{buildroot}%{_libdir}/frr/*.so
 rm -r %{buildroot}%{_includedir}/frr/
 
 %pre
-%sysusers_create_compat %{SOURCE2}
+%sysusers_create_package %{name} %{SOURCE2}
 
 %post
 %systemd_post frr.service


### PR DESCRIPTION
…tall package.

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
This PR removes the %sysusers_create_compat macro from the %preinstall script for frr-8.4.2 (which was not available on Mariner) and replaces it with the available %sysusers_create_package macro.

###### Change Log  <!-- REQUIRED -->
The frr.spec file has had the above mentioned macro replaced by its available counterpart, additionally, the autosetup macro was failing, so it was replaced with explicit patch commands.

<!-- Please list any packages which will be affected by this change, if applicable. -->
frr-8.4.2

<!-- Please list any CVES fixed by this change, if applicable. -->
N/A

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Associated issues
Internally this is Bug #44265925

###### Links to CVEs  <!-- optional -->
N/A

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
Change were made, built, and tested in a clean mariner environment.
<img width="437" alt="ExecSuccess" src="https://user-images.githubusercontent.com/97132586/235249249-5ef9cd55-ccb8-47e8-9aa9-6f606e3a3780.png">
<img width="618" alt="InstallSuccess" src="https://user-images.githubusercontent.com/97132586/235249251-bdf59768-2d1f-4053-8161-495e3dd7f41f.png">
