### PR TITLE
Patch fluent-bit for CVE-2021-46878 and CVE-2021-46879

### DIFF
--- a/SPECS/fluent-bit/CVE-2021-46878.patch
+++ b/SPECS/fluent-bit/CVE-2021-46878.patch
@@ -1,0 +1,41 @@
+Modified patch 8040e0b04e48d2cf1a2853e8ac2c2561e18c4a11 to apply to
+CBL-Mariner: Applied patch changes in older version of file
+Modified-by: Sumedh Sharma<sumsharma@microsoft.com>
+From 2f827a0e72ffba3f0ebf7e541a802abb70557213 Mon Sep 17 00:00:00 2001
+From: davkor <david@adalogics.com>
+Date: Tue, 23 Feb 2021 22:17:32 +0000
+Subject: [PATCH] pack: fix type confusion bugs. Amongst other OSS-Fuzz
+ 5136174263566336
+
+Signed-off-by: davkor <david@adalogics.com>
+---
+ src/flb_pack.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/src/flb_pack.c b/src/flb_pack.c
+index a53cb19..8d45e58 100644
+--- a/src/flb_pack.c
++++ b/src/flb_pack.c
+@@ -760,6 +760,9 @@ flb_sds_t flb_pack_msgpack_to_json_format(const char *data, uint64_t bytes,
+     while (msgpack_unpack_next(&result, data, bytes, &off) == ok) {
+         /* Each array must have two entries: time and record */
+         root = result.data;
++        if (root.type != MSGPACK_OBJECT_ARRAY) {
++            continue;
++        }
+         if (root.via.array.size != 2) {
+             continue;
+         }
+@@ -769,6 +772,9 @@ flb_sds_t flb_pack_msgpack_to_json_format(const char *data, uint64_t bytes,
+ 
+         /* Get the record/map */
+         map = root.via.array.ptr[1];
++        if (map.type != MSGPACK_OBJECT_MAP) {
++            continue;
++        }
+         map_size = map.via.map.size;
+         msgpack_pack_map(&tmp_pck, map_size + 1);
+ 
+-- 
+2.25.1
+

--- a/SPECS/fluent-bit/CVE-2021-46879.patch
+++ b/SPECS/fluent-bit/CVE-2021-46879.patch
@@ -1,0 +1,25 @@
+From 75f0e0e5f7267682674029820524d22460f498b0 Mon Sep 17 00:00:00 2001
+From: davkor <david@adalogics.com>
+Date: Mon, 22 Feb 2021 13:44:50 +0000
+Subject: [PATCH] flb_pack: fix OSS-Fuzz issue 5076752961110016
+
+Signed-off-by: davkor <david@adalogics.com>
+---
+ src/flb_pack_gelf.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/flb_pack_gelf.c b/src/flb_pack_gelf.c
+index 9991a239410..883e489b7c4 100644
+--- a/src/flb_pack_gelf.c
++++ b/src/flb_pack_gelf.c
+@@ -719,8 +719,8 @@ flb_sds_t flb_msgpack_to_gelf(flb_sds_t *s, msgpack_object *o,
+                 }
+                 else if (v->type == MSGPACK_OBJECT_EXT) {
+                     quote   = FLB_TRUE;
+-                    val     = o->via.ext.ptr;
+-                    val_len = o->via.ext.size;
++                    val     = v->via.ext.ptr;
++                    val_len = v->via.ext.size;
+                 }
+ 
+                 if (!val || !key) {

--- a/SPECS/fluent-bit/fluent-bit.spec
+++ b/SPECS/fluent-bit/fluent-bit.spec
@@ -3,13 +3,15 @@
 Name:           fluent-bit
 Summary:        Fast and Lightweight Log processor and forwarder for Linux, BSD and OSX
 Version:        1.5.2
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 URL:            https://fluentbit.io
 #Source0:       https://github.com/fluent/%{name}/archive/v%{version}.tar.gz
 Source0:        %{name}-%{version}.tar.gz
+Patch0:         CVE-2021-46878.patch
+Patch1:         CVE-2021-46879.patch
 
 BuildRequires:  cmake
 BuildRequires:  systemd-devel
@@ -26,7 +28,7 @@ Requires:       %{name} = %{version}
 Development files for %{name}
 
 %prep
-%setup -q
+%autosetup -p1
 
 %build
 cd build
@@ -50,6 +52,9 @@ make install DESTDIR=%{buildroot}
 /usr/lib64/fluent-bit/*.so
 
 %changelog
+* Tue May 02 2023 Sumedh Sharma <sumsharma@microsoft.com> - 1.5.2-3
+- Add patch for CVE-2021-46879 & CVE-2021-46878.
+
 * Fri Sep 10 2021 Suresh Babu Chalamalasetty <schalam@microsoft.com> 1.5.2-2
 - Enable plug-in for systemd support
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
Add patches for CVE-2021-46878 and CVE-2021-46879

###### Change Log  <!-- REQUIRED -->
- Add patch files
- Update spec file

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Associated issues  <!-- optional -->

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2021-46878
- https://nvd.nist.gov/vuln/detail/CVE-2021-46879

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: Buddy Build
  [AMD64](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=353793)
  [ARM64](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=353796)
