### PR TITLE
Upgrade redis to 6.2.12 to fix CVE-2023-28856

### DIFF
--- a/SPECS/redis/redis.signatures.json
+++ b/SPECS/redis/redis.signatures.json
@@ -1,5 +1,5 @@
 {
   "Signatures": {
-    "redis-6.2.11.tar.gz": "8c75fb9cdd01849e92c23f30cb7fe205ea0032a38d11d46af191014e9acc3098"
+    "redis-6.2.12.tar.gz": "75352eef41e97e84bfa94292cbac79e5add5345fc79787df5cbdff703353fb1b"
   }
 }

--- a/SPECS/redis/redis.spec
+++ b/SPECS/redis/redis.spec
@@ -1,6 +1,6 @@
 Summary:        advanced key-value store
 Name:           redis
-Version:        6.2.11
+Version:        6.2.12
 Release:        1%{?dist}
 License:        BSD
 Vendor:         Microsoft Corporation
@@ -83,6 +83,9 @@ exit 0
 %config(noreplace) %attr(0640, %{name}, %{name}) %{_sysconfdir}/redis.conf
 
 %changelog
+* Thu May 04 2023 Sumedh Sharma <sumsharma@microsoft.com> - 6.2.12-1
+- Upgrade to 6.2.12 to fix CVE-2023-28856
+
 * Mon Mar 13 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 6.2.11-1
 - Auto-upgrade to 6.2.11 - to fix CVE-2022-36021, CVE-2023-25155
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -6455,7 +6455,6 @@
         }
       }
     },
-
     {
       "component": {
         "type": "other",
@@ -25155,8 +25154,8 @@
         "type": "other",
         "other": {
           "name": "redis",
-          "version": "6.2.11",
-          "downloadUrl": "https://download.redis.io/releases/redis-6.2.11.tar.gz"
+          "version": "6.2.12",
+          "downloadUrl": "https://download.redis.io/releases/redis-6.2.12.tar.gz"
         }
       }
     },


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
Upgrade to version 6.2.12 to fix CVE-2023-28856

###### Change Log  <!-- REQUIRED -->
- upgrade to 6.2.12
- update cgmanifest

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Associated issues  <!-- optional -->

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2023-28856

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: Buddy Build
   [AMD64](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=355108)
   [ARM64](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=355109)
