### PR TITLE
Use tools, bpftool, and python3-perf subpackages from kernel.spec for all kernels

### DIFF
--- a/SPECS-SIGNED/kernel-azure-signed/kernel-azure-signed.spec
+++ b/SPECS-SIGNED/kernel-azure-signed/kernel-azure-signed.spec
@@ -10,7 +10,7 @@
 Summary:        Signed Linux Kernel for Azure
 Name:           kernel-azure-signed-%{buildarch}
 Version:        5.15.116.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -153,6 +153,9 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %exclude /module_info.ld
 
 %changelog
+* Wed Jul 05 2023 Rachel Menge <rachelmenge@microsoft.com> - 5.15.116.1-2
+- Bump release to match kernel-azure
+
 * Tue Jun 13 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 5.15.116.1-1
 - Auto-upgrade to 5.15.116.1
 

--- a/SPECS-SIGNED/kernel-hci-signed/kernel-hci-signed.spec
+++ b/SPECS-SIGNED/kernel-hci-signed/kernel-hci-signed.spec
@@ -5,7 +5,7 @@
 Summary:        Signed Linux Kernel for HCI
 Name:           kernel-hci-signed-%{buildarch}
 Version:        5.15.116.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -149,6 +149,9 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %exclude /module_info.ld
 
 %changelog
+* Wed Jul 05 2023 Rachel Menge <rachelmenge@microsoft.com> - 5.15.116.1-2
+- Bump release to match kernel-hci
+
 * Tue Jun 13 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 5.15.116.1-1
 - Auto-upgrade to 5.15.116.1
 

--- a/SPECS-SIGNED/kernel-signed/kernel-signed.spec
+++ b/SPECS-SIGNED/kernel-signed/kernel-signed.spec
@@ -10,7 +10,7 @@
 Summary:        Signed Linux Kernel for %{buildarch} systems
 Name:           kernel-signed-%{buildarch}
 Version:        5.15.116.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -153,6 +153,9 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %exclude /module_info.ld
 
 %changelog
+*  Wed Jul 05 2023 Rachel Menge <rachelmenge@microsoft.com> - 5.15.116.1-3
+- Bump release to match kernel
+
 * Tue Jun 20 2023 Rachel Menge <rachelmenge@microsoft.com> - 5.15.116.1-2
 - Bump release to match kernel
 

--- a/SPECS/kernel-hci/kernel-hci.spec
+++ b/SPECS/kernel-hci/kernel-hci.spec
@@ -18,7 +18,7 @@
 Summary:        Linux Kernel for HCI
 Name:           kernel-hci
 Version:        5.15.116.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -137,35 +137,12 @@ Requires:       python3
 %description docs
 This package contains the Linux kernel doc files
 
-%package tools
-Summary:        This package contains the 'perf' performance analysis tools for Linux kernel
-Group:          System/Tools
-Requires:       %{name} = %{version}-%{release}
-Requires:       audit
-
-%description tools
-This package contains the 'perf' performance analysis tools for Linux kernel.
-
-%package -n     python3-perf
-Summary:        Python 3 extension for perf tools
-Requires:       python3
-
-%description -n python3-perf
-This package contains the Python 3 extension for the 'perf' performance analysis tools for Linux kernel.
-
 %package dtb
 Summary:        This package contains common device tree blobs (dtb)
 Group:          System Environment/Kernel
 
 %description dtb
 This package contains common device tree blobs (dtb)
-
-%package -n     bpftool
-Summary:        Inspection and simple manipulation of eBPF programs and maps
-
-%description -n bpftool
-This package contains the bpftool, which allows inspection and simple
-manipulation of eBPF programs and maps.
 
 %prep
 %setup -q -n CBL-Mariner-Linux-Kernel-rolling-lts-mariner-2-%{version}
@@ -226,14 +203,6 @@ fi
 
 %build
 make VERBOSE=1 KBUILD_BUILD_VERSION="1" KBUILD_BUILD_HOST="CBL-Mariner" ARCH=%{arch} %{?_smp_mflags}
-
-# Compile perf, python3-perf
-make -C tools/perf PYTHON=%{python3} all
-
-make -C tools turbostat cpupower
-
-#Compile bpftool
-make -C tools/bpf/bpftool
 
 %define __modules_install_post \
 for MODULE in `find %{buildroot}/lib/modules/%{uname_r} -name *.ko` ; do \
@@ -306,23 +275,6 @@ install -vsm 755 tools/objtool/fixdep %{buildroot}%{_prefix}/src/linux-headers-%
 cp .config %{buildroot}%{_prefix}/src/linux-headers-%{uname_r} # copy .config manually to be where it's expected to be
 ln -sf "%{_prefix}/src/linux-headers-%{uname_r}" "%{buildroot}/lib/modules/%{uname_r}/build"
 find %{buildroot}/lib/modules -name '*.ko' -print0 | xargs -0 chmod u+x
-
-# disable (JOBS=1) parallel build to fix this issue:
-# fixdep: error opening depfile: ./.plugin_cfg80211.o.d: No such file or directory
-# Linux version that was affected is 4.4.26
-make -C tools JOBS=1 DESTDIR=%{buildroot} prefix=%{_prefix} perf_install
-
-# Install python3-perf
-make -C tools/perf DESTDIR=%{buildroot} prefix=%{_prefix} install-python_ext
-
-# Install bpftool
-make -C tools/bpf/bpftool DESTDIR=%{buildroot} prefix=%{_prefix} bash_compdir=%{_sysconfdir}/bash_completion.d/ mandir=%{_mandir} install
-
-# Install turbostat cpupower
-make -C tools DESTDIR=%{buildroot} prefix=%{_prefix} bash_compdir=%{_sysconfdir}/bash_completion.d/ mandir=%{_mandir} turbostat_install cpupower_install
-
-# Remove trace (symlink to perf). This file causes duplicate identical debug symbols
-rm -vf %{buildroot}%{_bindir}/trace
 
 %triggerin -- initramfs
 mkdir -p %{_localstatedir}/lib/rpm-state/initramfs/pending
@@ -397,38 +349,10 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %defattr(-,root,root)
 /lib/modules/%{uname_r}/kernel/sound
 
-%files tools
-%defattr(-,root,root)
-%{_libexecdir}
-%exclude %dir %{_libdir}/debug
-%{_sbindir}/cpufreq-bench
-%{_lib64dir}/traceevent
-%{_lib64dir}/libperf-jvmti.so
-%{_lib64dir}/libcpupower.so*
-%{_sysconfdir}/cpufreq-bench.conf
-%{_includedir}/cpuidle.h
-%{_includedir}/cpufreq.h
-%{_mandir}/man1/cpupower*.gz
-%{_mandir}/man8/turbostat*.gz
-%{_datadir}/locale/*/LC_MESSAGES/cpupower.mo
-%{_datadir}/bash-completion/completions/cpupower
-%{_bindir}
-%{_sysconfdir}/bash_completion.d/*
-%{_datadir}/perf-core/strace/groups/file
-%{_datadir}/perf-core/strace/groups/string
-%{_docdir}/*
-%{_libdir}/perf/examples/bpf/*
-%{_libdir}/perf/include/bpf/*
-%{_includedir}/perf/perf_dlfilter.h
-
-%files -n python3-perf
-%{python3_sitearch}/*
-
-%files -n bpftool
-%{_sbindir}/bpftool
-%{_sysconfdir}/bash_completion.d/bpftool
-
 %changelog
+* Wed Jul 05 2023 Rachel Menge <rachelmenge@microsoft.com> - 5.15.116.1-2
+- Use tools, bpftool, and python3-perf subpackages from kernel.spec
+
 * Tue Jun 13 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 5.15.116.1-1
 - Auto-upgrade to 5.15.116.1
 

--- a/SPECS/kernel-headers/kernel-headers.spec
+++ b/SPECS/kernel-headers/kernel-headers.spec
@@ -1,7 +1,7 @@
 Summary:        Linux API header files
 Name:           kernel-headers
 Version:        5.15.116.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -36,6 +36,9 @@ cp -rv usr/include/* /%{buildroot}%{_includedir}
 %{_includedir}/*
 
 %changelog
+* Wed Jul 05 2023 Rachel Menge <rachelmenge@microsoft.com> - 5.15.116.1-3
+- Bump release to match kernel
+
 * Tue Jun 20 2023 Rachel Menge <rachelmenge@microsoft.com> - 5.15.116.1-2
 - Bump release to match kernel
 

--- a/SPECS/kernel/kernel.spec
+++ b/SPECS/kernel/kernel.spec
@@ -28,7 +28,7 @@
 Summary:        Linux Kernel
 Name:           kernel
 Version:        5.15.116.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -131,7 +131,6 @@ This package contains the Linux kernel doc files
 %package tools
 Summary:        This package contains the 'perf' performance analysis tools for Linux kernel
 Group:          System/Tools
-Requires:       %{name} = %{version}-%{release}
 Requires:       audit
 
 %description tools
@@ -422,6 +421,9 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %{_sysconfdir}/bash_completion.d/bpftool
 
 %changelog
+* Wed Jul 05 2023 Rachel Menge <rachelmenge@microsoft.com> - 5.15.116.1-3
+- Remove requires for name-version for kernel-tools
+
 * Tue Jun 20 2023 Rachel Menge <rachelmenge@microsoft.com> - 5.15.116.1-2
 - Enable CONFIG_IP_VS_MH module
 

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -1,5 +1,5 @@
 filesystem-1.1-15.cm2.aarch64.rpm
-kernel-headers-5.15.116.1-2.cm2.noarch.rpm
+kernel-headers-5.15.116.1-3.cm2.noarch.rpm
 glibc-2.35-3.cm2.aarch64.rpm
 glibc-devel-2.35-3.cm2.aarch64.rpm
 glibc-i18n-2.35-3.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -1,5 +1,5 @@
 filesystem-1.1-15.cm2.x86_64.rpm
-kernel-headers-5.15.116.1-2.cm2.noarch.rpm
+kernel-headers-5.15.116.1-3.cm2.noarch.rpm
 glibc-2.35-3.cm2.x86_64.rpm
 glibc-devel-2.35-3.cm2.x86_64.rpm
 glibc-i18n-2.35-3.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -135,7 +135,7 @@ intltool-0.51.0-7.cm2.noarch.rpm
 itstool-2.0.6-4.cm2.noarch.rpm
 kbd-2.2.0-1.cm2.aarch64.rpm
 kbd-debuginfo-2.2.0-1.cm2.aarch64.rpm
-kernel-headers-5.15.116.1-2.cm2.noarch.rpm
+kernel-headers-5.15.116.1-3.cm2.noarch.rpm
 kmod-29-1.cm2.aarch64.rpm
 kmod-debuginfo-29-1.cm2.aarch64.rpm
 kmod-devel-29-1.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -135,7 +135,7 @@ intltool-0.51.0-7.cm2.noarch.rpm
 itstool-2.0.6-4.cm2.noarch.rpm
 kbd-2.2.0-1.cm2.x86_64.rpm
 kbd-debuginfo-2.2.0-1.cm2.x86_64.rpm
-kernel-headers-5.15.116.1-2.cm2.noarch.rpm
+kernel-headers-5.15.116.1-3.cm2.noarch.rpm
 kmod-29-1.cm2.x86_64.rpm
 kmod-debuginfo-29-1.cm2.x86_64.rpm
 kmod-devel-29-1.cm2.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
rework of #5131, #5305

There was a bug where certain specialized kernels (`kernel-azure`, `kernel-hci`) would create subpackages of the same name (`bpftool`, `python3-perf`) as the generic kernel. This will cause packages to be published and overwritten. However, these packages along with the tools subpackage are not dependent on the configs and can therefore be produced from only the kernel.spec.

Notes:
- photon and [fedora](https://src.fedoraproject.org/rpms/kernel/blob/rawhide/f/kernel.spec#_1059) both have the generic kernel produce the tools and bpftool packages
- subpackages should be installed using `sudo tdnf install -y kernel-tools-$(uname -r)` (as stated in https://microsoft.visualstudio.com/OS/_workitems/edit/44344054) which should account for version issues

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Use tools, bpftool, and python3-perf subpackages from kernel.spec for all kernels
 
###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**Yes**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://microsoft.visualstudio.com/OS/_workitems/edit/43814917/

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Buddy Build (AMD): https://dev.azure.com/mariner-org/mariner/_build/results?buildId=355600&view=results
- Buddy Build (ARM): https://dev.azure.com/mariner-org/mariner/_build/results?buildId=355591&view=results
- rebase: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=355665&view=results
- rebase (7/5): https://dev.azure.com/mariner-org/mariner/_build/results?buildId=389211&view=results

<img width="262" alt="image" src="https://user-images.githubusercontent.com/10325590/236379590-13751939-4647-43a4-9cfe-aa99e5915ab1.png">

