### PR TITLE
nodejs: use ninja to speed up build

### DIFF
--- a/SPECS/nodejs/nodejs.spec
+++ b/SPECS/nodejs/nodejs.spec
@@ -6,7 +6,7 @@ Name:           nodejs
 # WARNINGS: MUST check and update the 'npm_version' macro for every version update of this package.
 #           The version of NPM can be found inside the sources under 'deps/npm/package.json'.
 Version:        16.19.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        BSD and MIT and Public Domain and NAIST-2003 and Artistic-2.0
 Group:          Applications/System
 Vendor:         Microsoft Corporation
@@ -80,7 +80,10 @@ python3 configure.py \
   --without-dtrace \
   --openssl-use-def-ca-store
 
-JOBS=4 make %{?_smp_mflags} V=0
+# ninja build scripts expect a "python" executable - create symlink to python3
+ln -v /usr/bin/python3 /usr/bin/python
+
+%ninja_build -C out/Release
 
 %install
 
@@ -114,6 +117,9 @@ make cctest
 %{_datadir}/systemtap/tapset/node.stp
 
 %changelog
+* Thu May 04 2023 Andrew Phelps <anphel@microsoft.com> - 16.19.1-2
+- Use ninja build system
+
 * Wed Mar 01 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 16.19.1-1
 - Auto-upgrade to 16.19.1 - to fix CVE-2023-23936
 - Update npm version to 8.19.3 to reflect the actual version of npm bundled with v16.19.1

--- a/SPECS/nodejs/nodejs.spec
+++ b/SPECS/nodejs/nodejs.spec
@@ -80,8 +80,8 @@ python3 configure.py \
   --without-dtrace \
   --openssl-use-def-ca-store
 
-# ninja build scripts expect a "python" executable - create symlink to python3
-ln -v /usr/bin/python3 /usr/bin/python
+# Some build scripts expect a "python" executable - create symlink to python3
+ln -sv /usr/bin/python3 /usr/bin/python
 
 %ninja_build -C out/Release
 
@@ -118,7 +118,7 @@ make cctest
 
 %changelog
 * Thu May 04 2023 Andrew Phelps <anphel@microsoft.com> - 16.19.1-2
-- Use ninja build system
+- Speed up compilation by using ninja build system
 
 * Wed Mar 01 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 16.19.1-1
 - Auto-upgrade to 16.19.1 - to fix CVE-2023-23936

--- a/SPECS/nodejs/nodejs18.spec
+++ b/SPECS/nodejs/nodejs18.spec
@@ -6,7 +6,7 @@ Name:           nodejs18
 # WARNINGS: MUST check and update the 'npm_version' macro for every version update of this package.
 #           The version of NPM can be found inside the sources under 'deps/npm/package.json'.
 Version:        18.16.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        BSD and MIT and Public Domain and NAIST-2003 and Artistic-2.0
 Group:          Applications/System
 Vendor:         Microsoft Corporation
@@ -80,7 +80,10 @@ python3 configure.py \
   --without-dtrace \
   --openssl-use-def-ca-store
 
-JOBS=4 make %{?_smp_mflags} V=0
+# Some build scripts expect a "python" executable - create symlink to python3
+ln -sv /usr/bin/python3 /usr/bin/python
+
+%ninja_build -C out/Release
 
 %install
 
@@ -114,6 +117,9 @@ make cctest
 %{_datadir}/systemtap/tapset/node.stp
 
 %changelog
+* Thu May 04 2023 Andrew Phelps <anphel@microsoft.com> - 18.16.0-2
+- Speed up compilation by using ninja build system
+
 * Wed Apr 12 2023 Riken Maharjan <rmaharjan@microsoft.com> - 18.16.0-1
 - Upgrade to 18.16.0
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
The Nodejs packages take a long time to build - up to 6 hours for x86_64 when part of full builds. I've changed them to build with ninja, which is much quicker.

Buddy build of just nodejs 16 with make: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=355493&view=results
    1 hour 21 min
Budd build of just nodejs 16 with ninja: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=355496&view=results
     37 min

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change nodejs to build with ninja
- Change nodejs18 to build with ninja

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
X64 buddy build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=355936&view=results
ARM64 buddy build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=355937&view=results
