### PR TITLE
Add toolchainrpms to protected directory list for docker-based builds

### DIFF
--- a/toolkit/tools/internal/buildpipeline/buildpipeline.go
+++ b/toolkit/tools/internal/buildpipeline/buildpipeline.go
@@ -190,6 +190,9 @@ func CleanupDockerChroot(chroot string) (err error) {
 		"dev",
 		"proc",
 		"localrpms",
+		// toolchainrpms is not used by Mariner 1.0 builds, but is still mounted in our chroots
+		// and we should not attempt to delete it.
+		"toolchainrpms",
 		"upstream-cached-rpms",
 		"sys",
 		chrootUse,


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
When removing the contents of worker chroots before they are provisioned, our toolkit attempts to delete the `/toolchainrpms` folder within the chroot. In our docker-based builds, this folder is populated as a mount that persists between chroot folder usages. Attempting to delete `/toolchainrpms` in the chroot creates warnings like the following:

```
WARN[0000] Removing files in chroot /temp/DockerStage/docker-chroot-10 failed: unlinkat /temp/DockerStage/docker-chroot-10/toolchainrpms: device or resource busy 
```

This doesn't break anything, and this folder isn't even used for 1.0 builds, but it does pollute the logs with a harmless warning.

So, let's not try to delete that directory, just as we don't try to delete the other volumes created by docker.

Cherry-pick of #5479 for 1.0

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- `tools/internal/buildpipeline`: Add `/toolchainrpms` to the list of folders that are not cleaned up during docker-based builds

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
-[Buddy build](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=357727&view=results) of an unrelated spec- error previously seen is not present.
