### PR TITLE
Update __Python macro to point to existing interpreter

### DIFF
--- a/SPECS/mariner-rpm-macros/macros.python-srpm
+++ b/SPECS/mariner-rpm-macros/macros.python-srpm
@@ -12,15 +12,7 @@
 # Set default python macro to the version of python shipped with the OS
 %__python /usr/bin/python3
 
-# Users can use %%python only if they redefined %%__python (e.g. to %%__python3)
-%python() %{lua:\
-    __python = rpm.expand("%__python")\
-    if __python == "/usr/bin/python" then\
-        rpm.expand("%{error:Cannot use %%python if %%__python wasn't redefined to something other than /usr/bin/python.}")\
-    else\
-        print(__python)\
-    end\
-}
+%python %__python
 
 # python3_pkgversion specifies the version of Python 3 in the distro.  It can be
 # a specific version (e.g. 34 in Fedora EPEL7)

--- a/SPECS/mariner-rpm-macros/macros.python-srpm
+++ b/SPECS/mariner-rpm-macros/macros.python-srpm
@@ -9,9 +9,8 @@
 # use the non-underscored macros to refer to Python in spec, etc.
 %python3 %__python3
 
-# For backwards compatibility only
-# See the comments in https://src.fedoraproject.org/rpms/python-rpm-macros/pull-request/22
-%__python /usr/bin/python
+# Set default python macro to the version of python shipped with the OS
+%__python /usr/bin/python3
 
 # Users can use %%python only if they redefined %%__python (e.g. to %%__python3)
 %python() %{lua:\

--- a/SPECS/mariner-rpm-macros/mariner-rpm-macros.signatures.json
+++ b/SPECS/mariner-rpm-macros/mariner-rpm-macros.signatures.json
@@ -22,7 +22,7 @@
   "macros.perl-srpm": "27f09c386944fc7478cdde55168bbc720d03ecd11ec60ae1133a42db6432e7f7",
   "macros.pybytecompile": "4adea0fca2118af964997d0bf9932a28f3148ea72323fb161c1fb3bd6e2a8bdb",
   "macros.python": "791e0b9070d49790ef437d89e541287ce305d8e424afe42dafdab89f59106362",
-  "macros.python-srpm": "69300f96c94c709fe87c16f3bcaf089faf9c751837eb404b2e13619955dd84ab",
+  "macros.python-srpm": "27701acb0aa4a35e1c81e34e469e6c8a3b5be7aad41066ec70cd6bf065a58d11",
   "macros.python3": "b5a82a6bdfa40cd481c5139c957b95d0b126ff108cc964432d0b6b90972b743b",
   "macros.rust-srpm": "ea69ab49a243c44ab75cfe506ba5d73046bf31e561698cc389ad5b4edb82f2b2",
   "macros.suse": "7cd64820e12a37fb22f3b09e4c5184b1f9eac94acbeea2783b1ec4940248e310",

--- a/SPECS/mariner-rpm-macros/mariner-rpm-macros.signatures.json
+++ b/SPECS/mariner-rpm-macros/mariner-rpm-macros.signatures.json
@@ -22,7 +22,7 @@
   "macros.perl-srpm": "27f09c386944fc7478cdde55168bbc720d03ecd11ec60ae1133a42db6432e7f7",
   "macros.pybytecompile": "4adea0fca2118af964997d0bf9932a28f3148ea72323fb161c1fb3bd6e2a8bdb",
   "macros.python": "791e0b9070d49790ef437d89e541287ce305d8e424afe42dafdab89f59106362",
-  "macros.python-srpm": "34876cbf3bae90136bec7b36f75ed590d251c47c123faddf700a963aaa9a2c14",
+  "macros.python-srpm": "69300f96c94c709fe87c16f3bcaf089faf9c751837eb404b2e13619955dd84ab",
   "macros.python3": "b5a82a6bdfa40cd481c5139c957b95d0b126ff108cc964432d0b6b90972b743b",
   "macros.rust-srpm": "ea69ab49a243c44ab75cfe506ba5d73046bf31e561698cc389ad5b4edb82f2b2",
   "macros.suse": "7cd64820e12a37fb22f3b09e4c5184b1f9eac94acbeea2783b1ec4940248e310",

--- a/SPECS/mariner-rpm-macros/mariner-rpm-macros.spec
+++ b/SPECS/mariner-rpm-macros/mariner-rpm-macros.spec
@@ -6,7 +6,7 @@
 Summary:        Mariner specific rpm macro files
 Name:           mariner-rpm-macros
 Version:        2.0
-Release:        20%{?dist}
+Release:        21%{?dist}
 License:        GPL+ AND MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -125,6 +125,9 @@ install -p -m 644 -t %{buildroot}%{rcluadir}/srpm forge.lua
 %{_rpmconfigdir}/macros.d/macros.check
 
 %changelog
+* Tue May 09 2023 Andy Zaugg <azaugg@linkedin.com> - 2.0-21
+- Set __python macro to python3 interpreter
+
 * Mon Dec 05 2022 Andrew Phelps <anphel@microsoft.com> - 2.0-20
 - Add support to build with ccache when 'mariner_ccache_enabled' is set.
 

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -209,7 +209,7 @@ pcre-libs-8.45-2.cm2.aarch64.rpm
 lua-5.4.3-5.cm2.aarch64.rpm
 lua-libs-5.4.3-5.cm2.aarch64.rpm
 mariner-rpm-macros-2.0-21.cm2.noarch.rpm
-mariner-check-macros-2.0-20.cm2.noarch.rpm
+mariner-check-macros-2.0-21.cm2.noarch.rpm
 libassuan-2.5.5-2.cm2.aarch64.rpm
 libassuan-devel-2.5.5-2.cm2.aarch64.rpm
 libgpg-error-1.46-1.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -208,7 +208,7 @@ pcre-8.45-2.cm2.aarch64.rpm
 pcre-libs-8.45-2.cm2.aarch64.rpm
 lua-5.4.3-5.cm2.aarch64.rpm
 lua-libs-5.4.3-5.cm2.aarch64.rpm
-mariner-rpm-macros-2.0-20.cm2.noarch.rpm
+mariner-rpm-macros-2.0-21.cm2.noarch.rpm
 mariner-check-macros-2.0-20.cm2.noarch.rpm
 libassuan-2.5.5-2.cm2.aarch64.rpm
 libassuan-devel-2.5.5-2.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -208,7 +208,7 @@ pcre-8.45-2.cm2.x86_64.rpm
 pcre-libs-8.45-2.cm2.x86_64.rpm
 lua-5.4.3-5.cm2.x86_64.rpm
 lua-libs-5.4.3-5.cm2.x86_64.rpm
-mariner-rpm-macros-2.0-20.cm2.noarch.rpm
+mariner-rpm-macros-2.0-21.cm2.noarch.rpm
 mariner-check-macros-2.0-20.cm2.noarch.rpm
 libassuan-2.5.5-2.cm2.x86_64.rpm
 libassuan-devel-2.5.5-2.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -209,7 +209,7 @@ pcre-libs-8.45-2.cm2.x86_64.rpm
 lua-5.4.3-5.cm2.x86_64.rpm
 lua-libs-5.4.3-5.cm2.x86_64.rpm
 mariner-rpm-macros-2.0-21.cm2.noarch.rpm
-mariner-check-macros-2.0-20.cm2.noarch.rpm
+mariner-check-macros-2.0-21.cm2.noarch.rpm
 libassuan-2.5.5-2.cm2.x86_64.rpm
 libassuan-devel-2.5.5-2.cm2.x86_64.rpm
 libgpg-error-1.46-1.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -242,7 +242,7 @@ mariner-repos-microsoft-2.0-8.cm2.noarch.rpm
 mariner-repos-microsoft-preview-2.0-8.cm2.noarch.rpm
 mariner-repos-preview-2.0-8.cm2.noarch.rpm
 mariner-repos-shared-2.0-8.cm2.noarch.rpm
-mariner-rpm-macros-2.0-20.cm2.noarch.rpm
+mariner-rpm-macros-2.0-21.cm2.noarch.rpm
 meson-0.60.2-2.cm2.noarch.rpm
 mpfr-4.1.0-1.cm2.aarch64.rpm
 mpfr-debuginfo-4.1.0-1.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -228,7 +228,7 @@ m4-1.4.19-1.cm2.aarch64.rpm
 m4-debuginfo-1.4.19-1.cm2.aarch64.rpm
 make-4.3-2.cm2.aarch64.rpm
 make-debuginfo-4.3-2.cm2.aarch64.rpm
-mariner-check-macros-2.0-20.cm2.noarch.rpm
+mariner-check-macros-2.0-21.cm2.noarch.rpm
 mariner-repos-2.0-8.cm2.noarch.rpm
 mariner-repos-debug-2.0-8.cm2.noarch.rpm
 mariner-repos-debug-preview-2.0-8.cm2.noarch.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -242,7 +242,7 @@ mariner-repos-microsoft-2.0-8.cm2.noarch.rpm
 mariner-repos-microsoft-preview-2.0-8.cm2.noarch.rpm
 mariner-repos-preview-2.0-8.cm2.noarch.rpm
 mariner-repos-shared-2.0-8.cm2.noarch.rpm
-mariner-rpm-macros-2.0-20.cm2.noarch.rpm
+mariner-rpm-macros-2.0-21.cm2.noarch.rpm
 meson-0.60.2-2.cm2.noarch.rpm
 mpfr-4.1.0-1.cm2.x86_64.rpm
 mpfr-debuginfo-4.1.0-1.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -228,7 +228,7 @@ m4-1.4.19-1.cm2.x86_64.rpm
 m4-debuginfo-1.4.19-1.cm2.x86_64.rpm
 make-4.3-2.cm2.x86_64.rpm
 make-debuginfo-4.3-2.cm2.x86_64.rpm
-mariner-check-macros-2.0-20.cm2.noarch.rpm
+mariner-check-macros-2.0-21.cm2.noarch.rpm
 mariner-repos-2.0-8.cm2.noarch.rpm
 mariner-repos-debug-2.0-8.cm2.noarch.rpm
 mariner-repos-debug-preview-2.0-8.cm2.noarch.rpm


### PR DESCRIPTION

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
So this is controversial, however, it's kinda annoying when running tools like rpmlint, etc, which expand out __python to a non existing interpreter. With Mariner2.0 only shipping python3.0 I feel that it is time to point __python to the python3 interpreter. In addition, other standard python macro paths, already point to the respective interpreter paths that exist on the system today

```
$ rpm  --eval '%python_version'
3.9
$ rpm --eval '%python_sitelib'
/usr/lib/python3.9/site-packages
```

After making the change
```
$ rpm --eval %{__python}
/usr/bin/python3
```

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Update the macros file to point to the installed python interpreter


###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Added the macro to the file
- ran rpm --eval "%{__python}"
