### PR TITLE
Fix CVE-2023-27477 by patching cranelift vulnerability that is exposed in rust

### DIFF
--- a/SPECS/rust/CVE-2023-27477.patch
+++ b/SPECS/rust/CVE-2023-27477.patch
@@ -1,0 +1,82 @@
+Fixes CVE-2023-27477: https://nvd.nist.gov/vuln/detail/CVE-2023-27477, which is a
+vulnerability in cranelift that is exposed in rust.
+
+Adapted by tobiasb@microsoft.com from patch to wasmtime/cranelift:
+    https://github.com/bytecodealliance/wasmtime/commit/5dc2bbccbb363e474d2c9a1b8e38a89a43bbd5d1.
+
+From 5dc2bbccbb363e474d2c9a1b8e38a89a43bbd5d1 Mon Sep 17 00:00:00 2001
+From: <redacted>
+Date: Wed, 8 Mar 2023 13:00:00 -0600
+Subject: [PATCH] Merge pull request from GHSA-xm67-587q-r2vw
+
+This commit fixes an off-by-one error in the subtraction of indices when
+shuffling a vector with itself. Lanes 16-and-above are mapped to select
+from the first vector since the first and second element are the same,
+but the subtraction was with 15 rather than 16 by accident.
+---
+PATCH NOTE -- ORIGINAL:
+ cranelift/codegen/src/isa/x64/lower/isle.rs                | 2 +-
+PATCH NOTE -- UPDATED:
+ vendor/cranelift-codegen/src/isa/x64/lower/isle.rs                | 2 +-
+
+PATCH NOTE: These clif files are not included in the rust source, so they are not included in the patch.
+ .../filetests/isa/x64/simd-lane-access-compile.clif        | 3 ++-
+ cranelift/filetests/filetests/runtests/simd-shuffle.clif   | 7 +++++++
+
+PATCH NOTE -- ORIGINAL:
+ 3 files changed, 10 insertions(+), 2 deletions(-)
+PATCH NOTE -- UPDATED:
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+# PATCH NOTE -- ORIGINAL:
+#diff --git a/cranelift/codegen/src/isa/x64/lower/isle.rs b/cranelift/codegen/src/isa/x64/lower/isle.rs
+# PATCH NOTE: UPDATED with path used within rust source:
+diff --git a/vendor/cranelift-codegen/src/isa/x64/lower/isle.rs b/vendor/cranelift-codegen/src/isa/x64/lower/isle.rs
+
+index 0267c3d32ce..61be54a0052 100644
+# PATCH NOTE -- ORIGINAL:
+#--- a/cranelift/codegen/src/isa/x64/lower/isle.rs
+#+++ b/cranelift/codegen/src/isa/x64/lower/isle.rs
+# PATCH NOTE: UPDATED with path used within rust source:
+--- a/vendor/cranelift-codegen/src/isa/x64/lower/isle.rs
++++ b/vendor/cranelift-codegen/src/isa/x64/lower/isle.rs
+@@ -752,7 +752,7 @@ impl Context for IsleContext<'_, '_, MInst, X64Backend> {
+     fn shuffle_0_31_mask(&mut self, mask: &VecMask) -> VCodeConstant {
+         let mask = mask
+             .iter()
+-            .map(|&b| if b > 15 { b.wrapping_sub(15) } else { b })
++            .map(|&b| if b > 15 { b.wrapping_sub(16) } else { b })
+             .map(|b| if b > 15 { 0b10000000 } else { b })
+             .collect();
+         self.lower_ctx
+
+# PATCH NOTE: The rest of the diffs are not applied because the tests are not included in the rust source.
+# diff --git a/cranelift/filetests/filetests/isa/x64/simd-lane-access-compile.clif b/cranelift/filetests/filetests/isa/x64/simd-lane-access-compile.clif
+# index f58cad93a64..f414054edb8 100644
+# --- a/cranelift/filetests/filetests/isa/x64/simd-lane-access-compile.clif
+# +++ b/cranelift/filetests/filetests/isa/x64/simd-lane-access-compile.clif
+# @@ -101,7 +101,8 @@ block0:
+#  ;   addb %al, (%rax)
+#  ;   addb %al, (%rax)
+#  ;   addb %al, (%rax)
+# -;   addb %al, (%rcx, %rax)
+# +;   addb %al, (%rbx)
+# +;   addl %eax, (%rax)
+#  ;   addb %al, (%rax)
+#  ;   addb %al, (%rax)
+#  ;   addb %al, (%rax)
+# diff --git a/cranelift/filetests/filetests/runtests/simd-shuffle.clif b/cranelift/filetests/filetests/runtests/simd-shuffle.clif
+# index cbb8bef5aed..621eebda629 100644
+# --- a/cranelift/filetests/filetests/runtests/simd-shuffle.clif
+# +++ b/cranelift/filetests/filetests/runtests/simd-shuffle.clif
+# @@ -19,3 +19,10 @@ block0(v0: i8x16, v1: i8x16):
+#      return v2
+#  }
+#  ; run: %shuffle_zeros([1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16], [17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32]) == [4 1 0 0 5 7 13 12 24 14 25 5 3 0 18 6]
+# +
+# +function %shuffle1(i8x16) -> i8x16 {
+# +block0(v0: i8x16):
+# +    v1 = shuffle v0, v0, [8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23]
+# +    return v1
+# +}
+# +; run: %shuffle1([0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15]) == [8 9 10 11 12 13 14 15 0 1 2 3 4 5 6 7]

--- a/SPECS/rust/rust.spec
+++ b/SPECS/rust/rust.spec
@@ -9,20 +9,20 @@
 Summary:        Rust Programming Language
 Name:           rust
 Version:        1.68.2
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        (ASL 2.0 OR MIT) AND BSD AND CC-BY-3.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Group:          Applications/System
 URL:            https://www.rust-lang.org/
-# Notes: 
+# Notes:
 #  - rust source official repo is https://github.com/rust-lang/rust
 #  - cargo source official repo is https://github.com/rust-lang/cargo
 #  - crates.io source official repo is https://github.com/rust-lang/crates.io
 Source0:        https://static.rust-lang.org/dist/rustc-%{version}-src.tar.xz
 # Note: the rust-%%{version}-cargo.tar.gz file contains a cache created by capturing the contents downloaded into $CARGO_HOME.
 # To update the cache, leverage the: generate_source_tarball.sh
-#   
+#
 # An example run for rust 1.68.2:
 # - Download Rust Source (1.68.2):
 #   wget https://static.rust-lang.org/dist/rustc-1.68.2-src.tar.xz
@@ -39,6 +39,7 @@ Source4:        https://static.rust-lang.org/dist/%{release_date}/rust-std-%{sta
 Source5:        https://static.rust-lang.org/dist/%{release_date}/cargo-%{stage0_version}-aarch64-unknown-linux-gnu.tar.gz
 Source6:        https://static.rust-lang.org/dist/%{release_date}/rustc-%{stage0_version}-aarch64-unknown-linux-gnu.tar.gz
 Source7:        https://static.rust-lang.org/dist/%{release_date}/rust-std-%{stage0_version}-aarch64-unknown-linux-gnu.tar.gz
+Patch0:         CVE-2023-27477.patch
 BuildRequires:  binutils
 BuildRequires:  cmake
 # make sure rust relies on curl from CBL-Mariner (instead of using its vendored flavor)
@@ -162,6 +163,9 @@ rm %{buildroot}%{_docdir}/%{name}/*.old
 %{_mandir}/man1/*
 
 %changelog
+* Wed May 17 2023 Tobias Brick <tobiasb@microsoft.com> - 1.68.2-2
+- Fix CVE-2023-27477 by patching cranelift vulnerability that is exposed in rust
+
 * Tue Mar 28 2023 Muhammad Falak <mwani@microsoft.com> - 1.68.2-1
 - Bump version to 1.68.2 to revoke leaked github keys
 


### PR DESCRIPTION
###### Merge Checklist
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary
Patch `rust` for [CVE-2023-27477](https://nvd.nist.gov/vuln/detail/CVE-2023-27477), which is a vulnerability in `cranelift`, upon which `rust` depends. Tweaked the [cranelift patch](https://github.com/bytecodealliance/wasmtime/commit/5dc2bbccbb363e474d2c9a1b8e38a89a43bbd5d1) to apply to the `rust` vendor sources.

###### Change Log  <!-- REQUIRED -->
Patch [CVE-2023-27477](https://nvd.nist.gov/vuln/detail/CVE-2023-27477)

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2023-27477

###### Test Methodology
- Locally built and verified patch was applied during the %config step.
- ARM64 Buddy Build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=359212&view=results
- AMD64 Buddy Build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=359214&view=results
