### PR TITLE
Add patch for CVE-2023-0795 in libtiff

### DIFF
--- a/SPECS/libtiff/CVE-2023-0795.patch
+++ b/SPECS/libtiff/CVE-2023-0795.patch
@@ -1,0 +1,341 @@
+From 9c22495e5eeeae9e00a1596720c969656bb8d678 Mon Sep 17 00:00:00 2001
+From: Su_Laus <sulau@freenet.de>
+Date: Fri, 3 Feb 2023 15:31:31 +0100
+Subject: [PATCH] tiffcrop correctly update buffersize after rotateImage()
+ fix#520 rotateImage() set up a new buffer and calculates its size
+ individually. Therefore, seg_buffs[] size needs to be updated accordingly.
+ Before this fix, the seg_buffs buffer size was calculated with a different
+ formula than within rotateImage().
+
+diff -ru libtiff-v4.5.0-orig/tools/tiffcrop.c libtiff-v4.5.0/tools/tiffcrop.c
+--- libtiff-v4.5.0-orig/tools/tiffcrop.c	2023-05-12 11:14:02.465594047 -0700
++++ libtiff-v4.5.0/tools/tiffcrop.c	2023-05-12 14:50:24.152164015 -0700
+@@ -577,7 +577,7 @@
+ static int rotateContigSamples32bits(uint16_t, uint16_t, uint16_t, uint32_t,
+                                      uint32_t, uint32_t, uint8_t *, uint8_t *);
+ static int rotateImage(uint16_t, struct image_data *, uint32_t *, uint32_t *,
+-                       unsigned char **);
++                       unsigned char **, size_t *);
+ static int mirrorImage(uint16_t, uint16_t, uint16_t, uint32_t, uint32_t,
+                        unsigned char *);
+ static int invertImage(uint16_t, uint16_t, uint16_t, uint32_t, uint32_t,
+@@ -7243,7 +7243,7 @@
+         }
+ 
+         if (rotateImage(rotation, image, &image->width, &image->length,
+-                        work_buff_ptr))
++                        work_buff_ptr, NULL))
+         {
+             TIFFError("correct_orientation", "Unable to rotate image");
+             return (-1);
+@@ -8563,8 +8563,12 @@
+         if (crop->crop_mode & CROP_ROTATE) /* rotate should be last as it can
+                                               reallocate the buffer */
+         {
++            /* rotateImage() set up a new buffer and calculates its size
++             * individually. Therefore, seg_buffs size  needs to be updated
++             * accordingly. */
++            size_t rot_buf_size = 0;
+             if (rotateImage(crop->rotation, image, &crop->combined_width,
+-                            &crop->combined_length, &crop_buff))
++                            &crop->combined_length, &crop_buff, &rot_buf_size))
+             {
+                 TIFFError("processCropSelections",
+                           "Failed to rotate composite regions by %" PRIu32
+@@ -8573,9 +8577,7 @@
+                 return (-1);
+             }
+             seg_buffs[0].buffer = crop_buff;
+-            seg_buffs[0].size =
+-                (((crop->combined_width * image->bps + 7) / 8) * image->spp) *
+-                crop->combined_length;
++            seg_buffs[0].size = rot_buf_size;
+         }
+     }
+     else /* Separated Images */
+@@ -8686,10 +8688,14 @@
+                  * ->yres, what it schouldn't do here, when more than one
+                  * section is processed. ToDo: Therefore rotateImage() and its
+                  * usage has to be reworked (e.g. like mirrorImage()) !!
+-                 */
+-                if (rotateImage(crop->rotation, image,
+-                                &crop->regionlist[i].width,
+-                                &crop->regionlist[i].length, &crop_buff))
++                 * Furthermore, rotateImage() set up a new buffer and calculates
++                 * its size individually. Therefore, seg_buffs size  needs to be
++                 * updated accordingly. */
++                size_t rot_buf_size = 0;
++                if (rotateImage(
++                        crop->rotation, image, &crop->regionlist[i].width,
++                        &crop->regionlist[i].length, &crop_buff, &rot_buf_size))
++
+                 {
+                     TIFFError("processCropSelections",
+                               "Failed to rotate crop region by %" PRIu16
+@@ -8702,10 +8708,7 @@
+                 crop->combined_width = total_width;
+                 crop->combined_length = total_length;
+                 seg_buffs[i].buffer = crop_buff;
+-                seg_buffs[i].size =
+-                    (((crop->regionlist[i].width * image->bps + 7) / 8) *
+-                     image->spp) *
+-                    crop->regionlist[i].length;
++                seg_buffs[i].size = rot_buf_size;
+             }
+         } /* for crop->selections loop */
+     }     /* Separated Images (else case) */
+@@ -8836,7 +8839,7 @@
+         CROP_ROTATE) /* rotate should be last as it can reallocate the buffer */
+     {
+         if (rotateImage(crop->rotation, image, &crop->combined_width,
+-                        &crop->combined_length, crop_buff_ptr))
++                        &crop->combined_length, crop_buff_ptr, NULL))
+         {
+             TIFFError("createCroppedImage",
+                       "Failed to rotate image or cropped selection by %" PRIu16
+@@ -9552,7 +9555,7 @@
+ /* Rotate an image by a multiple of 90 degrees clockwise */
+ static int rotateImage(uint16_t rotation, struct image_data *image,
+                        uint32_t *img_width, uint32_t *img_length,
+-                       unsigned char **ibuff_ptr)
++                       unsigned char **ibuff_ptr, size_t *rot_buf_size)
+ {
+     int shift_width;
+     uint32_t bytes_per_pixel, bytes_per_sample;
+@@ -9610,6 +9613,8 @@
+         return (-1);
+     }
+     _TIFFmemset(rbuff, '\0', buffsize + NUM_BUFF_OVERSIZE_BYTES);
++    if (rot_buf_size != NULL)
++        *rot_buf_size = buffsize;    
+ 
+     ibuff = *ibuff_ptr;
+     switch (rotation)
+
+From 688012dca2c39033aa2dc7bcea9796787cfd1b44 Mon Sep 17 00:00:00 2001
+From: Su_Laus <sulau@freenet.de>
+Date: Sat, 4 Feb 2023 23:24:21 +0100
+Subject: [PATCH] tiffcrop correctly update buffersize after rotateImage()
+ fix#520  -- enlarge buffsize and check integer overflow within rotateImage().
+
+diff -ru libtiff-v4.5.0-orig/tools/tiffcrop.c libtiff-v4.5.0/tools/tiffcrop.c
+--- libtiff-v4.5.0-orig/tools/tiffcrop.c	2023-05-12 14:55:09.414735471 -0700
++++ libtiff-v4.5.0/tools/tiffcrop.c	2023-05-12 14:59:17.352957542 -0700
+@@ -9561,7 +9561,8 @@
+     uint32_t bytes_per_pixel, bytes_per_sample;
+     uint32_t row, rowsize, src_offset, dst_offset;
+     uint32_t i, col, width, length;
+-    uint32_t colsize, buffsize, col_offset, pix_offset;
++    uint32_t colsize, col_offset, pix_offset;
++    tmsize_t buffsize;
+     unsigned char *ibuff;
+     unsigned char *src;
+     unsigned char *dst;
+@@ -9574,12 +9575,40 @@
+     spp = image->spp;
+     bps = image->bps;
+ 
++    if ((spp != 0 && bps != 0 &&
++         width > (uint32_t)((UINT32_MAX - 7) / spp / bps)) ||
++        (spp != 0 && bps != 0 &&
++         length > (uint32_t)((UINT32_MAX - 7) / spp / bps)))
++    {
++        TIFFError("rotateImage", "Integer overflow detected.");
++        return (-1);
++    }
+     rowsize = ((bps * spp * width) + 7) / 8;
+     colsize = ((bps * spp * length) + 7) / 8;
+     if ((colsize * width) > (rowsize * length))
+-        buffsize = (colsize + 1) * width;
++    {
++        if (((tmsize_t)colsize + 1) != 0 &&
++            (tmsize_t)width > ((TIFF_TMSIZE_T_MAX - NUM_BUFF_OVERSIZE_BYTES) /
++                               ((tmsize_t)colsize + 1)))
++        {
++            TIFFError("rotateImage",
++                      "Integer overflow when calculating buffer size.");
++            return (-1);
++        }
++        buffsize = ((tmsize_t)colsize + 1) * width;
++    }
+     else
++    {
++        if (((tmsize_t)rowsize + 1) != 0 &&
++            (tmsize_t)length > ((TIFF_TMSIZE_T_MAX - NUM_BUFF_OVERSIZE_BYTES) /
++                                ((tmsize_t)rowsize + 1)))
++        {
++            TIFFError("rotateImage",
++                      "Integer overflow when calculating buffer size.");
++            return (-1);
++        }
+         buffsize = (rowsize + 1) * length;
++    }
+ 
+     bytes_per_sample = (bps + 7) / 8;
+     bytes_per_pixel = ((bps * spp) + 7) / 8;
+@@ -9608,7 +9637,8 @@
+               (unsigned char *)limitMalloc(buffsize + NUM_BUFF_OVERSIZE_BYTES)))
+     {
+         TIFFError("rotateImage",
+-                  "Unable to allocate rotation buffer of %1u bytes",
++                  "Unable to allocate rotation buffer of %" TIFF_SSIZE_FORMAT
++                  " bytes ",
+                   buffsize + NUM_BUFF_OVERSIZE_BYTES);
+         return (-1);
+     }
+
+From 69818e2f2d246e6631ac2a2da692c3706b849c38 Mon Sep 17 00:00:00 2001
+From: Su_Laus <sulau@freenet.de>
+Date: Sun, 29 Jan 2023 11:09:26 +0100
+Subject: [PATCH] tiffcrop: Amend rotateImage() not to toggle the input (main)
+ image width and length parameters when only cropped image sections are
+ rotated. Remove buffptr from region structure because never used.
+
+Closes #492 #493 #494 #495 #499 #518 #519
+
+diff -ru libtiff-v4.5.0-orig/tools/tiffcrop.c libtiff-v4.5.0/tools/tiffcrop.c
+--- libtiff-v4.5.0-orig/tools/tiffcrop.c	2023-05-12 15:01:50.666327711 -0700
++++ libtiff-v4.5.0/tools/tiffcrop.c	2023-05-12 15:08:32.732858078 -0700
+@@ -296,7 +296,6 @@
+     uint32_t width;    /* width in pixels */
+     uint32_t length;   /* length in pixels */
+     uint32_t buffsize; /* size of buffer needed to hold the cropped region */
+-    unsigned char *buffptr; /* address of start of the region */
+ };
+ 
+ /* Cropping parameters from command line and image data
+@@ -577,7 +576,7 @@
+ static int rotateContigSamples32bits(uint16_t, uint16_t, uint16_t, uint32_t,
+                                      uint32_t, uint32_t, uint8_t *, uint8_t *);
+ static int rotateImage(uint16_t, struct image_data *, uint32_t *, uint32_t *,
+-                       unsigned char **, size_t *);
++                       unsigned char **, size_t *, int);
+ static int mirrorImage(uint16_t, uint16_t, uint16_t, uint32_t, uint32_t,
+                        unsigned char *);
+ static int invertImage(uint16_t, uint16_t, uint16_t, uint32_t, uint32_t,
+@@ -5779,7 +5778,6 @@
+         cps->regionlist[i].width = 0;
+         cps->regionlist[i].length = 0;
+         cps->regionlist[i].buffsize = 0;
+-        cps->regionlist[i].buffptr = NULL;
+         cps->zonelist[i].position = 0;
+         cps->zonelist[i].total = 0;
+     }
+@@ -7242,8 +7240,13 @@
+             return (-1);
+         }
+ 
+-        if (rotateImage(rotation, image, &image->width, &image->length,
+-                        work_buff_ptr, NULL))
++        /* Dummy variable in order not to switch two times the
++         * image->width,->length within rotateImage(),
++         * but switch xres, yres there. */
++        uint32_t width = image->width;
++        uint32_t length = image->length;
++        if (rotateImage(rotation, image, &width, &length, work_buff_ptr, NULL,
++                        TRUE))
+         {
+             TIFFError("correct_orientation", "Unable to rotate image");
+             return (-1);
+@@ -7312,7 +7315,6 @@
+         /* These should not be needed for composite images */
+         crop->regionlist[i].width = crop_width;
+         crop->regionlist[i].length = crop_length;
+-        crop->regionlist[i].buffptr = crop_buff;
+ 
+         src_rowsize = ((img_width * bps * spp) + 7) / 8;
+         dst_rowsize = (((crop_width * bps * count) + 7) / 8);
+@@ -7573,7 +7575,6 @@
+ 
+     crop->regionlist[region].width = crop_width;
+     crop->regionlist[region].length = crop_length;
+-    crop->regionlist[region].buffptr = crop_buff;
+ 
+     src = read_buff;
+     dst = crop_buff;
+@@ -8568,7 +8569,8 @@
+              * accordingly. */
+             size_t rot_buf_size = 0;
+             if (rotateImage(crop->rotation, image, &crop->combined_width,
+-                            &crop->combined_length, &crop_buff, &rot_buf_size))
++                            &crop->combined_length, &crop_buff, &rot_buf_size,
++                            FALSE))
+             {
+                 TIFFError("processCropSelections",
+                           "Failed to rotate composite regions by %" PRIu32
+@@ -8692,10 +8694,10 @@
+                  * its size individually. Therefore, seg_buffs size  needs to be
+                  * updated accordingly. */
+                 size_t rot_buf_size = 0;
+-                if (rotateImage(
+-                        crop->rotation, image, &crop->regionlist[i].width,
+-                        &crop->regionlist[i].length, &crop_buff, &rot_buf_size))
+-
++                if (rotateImage(crop->rotation, image,
++                                &crop->regionlist[i].width,
++                                &crop->regionlist[i].length, &crop_buff,
++                                &rot_buf_size, FALSE))
+                 {
+                     TIFFError("processCropSelections",
+                               "Failed to rotate crop region by %" PRIu16
+@@ -8839,7 +8841,7 @@
+         CROP_ROTATE) /* rotate should be last as it can reallocate the buffer */
+     {
+         if (rotateImage(crop->rotation, image, &crop->combined_width,
+-                        &crop->combined_length, crop_buff_ptr, NULL))
++                        &crop->combined_length, crop_buff_ptr, NULL, TRUE))
+         {
+             TIFFError("createCroppedImage",
+                       "Failed to rotate image or cropped selection by %" PRIu16
+@@ -9555,7 +9557,8 @@
+ /* Rotate an image by a multiple of 90 degrees clockwise */
+ static int rotateImage(uint16_t rotation, struct image_data *image,
+                        uint32_t *img_width, uint32_t *img_length,
+-                       unsigned char **ibuff_ptr, size_t *rot_buf_size)
++                       unsigned char **ibuff_ptr, size_t *rot_buf_size,
++                       int rot_image_params)
+ {
+     int shift_width;
+     uint32_t bytes_per_pixel, bytes_per_sample;
+@@ -9803,11 +9806,15 @@
+ 
+             *img_width = length;
+             *img_length = width;
+-            image->width = length;
+-            image->length = width;
+-            res_temp = image->xres;
+-            image->xres = image->yres;
+-            image->yres = res_temp;
++            /* Only toggle image parameters if whole input image is rotated. */
++            if (rot_image_params)
++            {
++                image->width = length;
++                image->length = width;
++                res_temp = image->xres;
++                image->xres = image->yres;
++                image->yres = res_temp;
++            }
+             break;
+ 
+         case 270:
+@@ -9890,11 +9897,15 @@
+ 
+             *img_width = length;
+             *img_length = width;
+-            image->width = length;
+-            image->length = width;
+-            res_temp = image->xres;
+-            image->xres = image->yres;
+-            image->yres = res_temp;
++            /* Only toggle image parameters if whole input image is rotated. */
++            if (rot_image_params)
++            {
++                image->width = length;
++                image->length = width;
++                res_temp = image->xres;
++                image->xres = image->yres;
++                image->yres = res_temp;
++            }
+             break;
+         default:
+             break;

--- a/SPECS/libtiff/CVE-2023-0796.nopatch
+++ b/SPECS/libtiff/CVE-2023-0796.nopatch
@@ -1,0 +1,1 @@
+The CVE-2023-0795.patch also fixes CVE-2023-0796

--- a/SPECS/libtiff/CVE-2023-0797.nopatch
+++ b/SPECS/libtiff/CVE-2023-0797.nopatch
@@ -1,0 +1,1 @@
+The CVE-2023-0795.patch also fixes CVE-2023-0797

--- a/SPECS/libtiff/CVE-2023-0798.nopatch
+++ b/SPECS/libtiff/CVE-2023-0798.nopatch
@@ -1,0 +1,1 @@
+The CVE-2023-0795.patch also fixes CVE-2023-0798

--- a/SPECS/libtiff/CVE-2023-0799.nopatch
+++ b/SPECS/libtiff/CVE-2023-0799.nopatch
@@ -1,0 +1,1 @@
+The CVE-2023-0795.patch also fixes CVE-2023-0799

--- a/SPECS/libtiff/libtiff.spec
+++ b/SPECS/libtiff/libtiff.spec
@@ -1,7 +1,7 @@
 Summary:        TIFF libraries and associated utilities.
 Name:           libtiff
 Version:        4.5.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        libtiff
 URL:            https://gitlab.com/libtiff/libtiff
 Group:          System Environment/Libraries
@@ -9,6 +9,7 @@ Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Source0:        https://gitlab.com/libtiff/libtiff/-/archive/v%{version}/libtiff-v%{version}.tar.gz
 Patch0:         CVE-2022-48281.patch
+Patch1:         CVE-2023-0795.patch
 
 BuildRequires:  autoconf
 BuildRequires:  automake
@@ -66,6 +67,9 @@ make %{?_smp_mflags} -k check
 %{_datadir}/doc/*
 
 %changelog
+* Fri May 12 2023 Aadhar Agarwal <aadagarwal@microsoft.com> - 4.5.0-2
+- Patch CVE-2023-0795 CVE-2023-0796 CVE-2023-0797 CVE-2023-0798 CVE-2023-0799
+
 * Tue Feb 28 2023 Mitch Zhu <mitchzhu@microsoft.com> - 4.5.0-1
 - Upgrade version to 4.5.0 to fix CVE-2023-0796,  CVE-2023-0797, CVE-2023-0798,
 - CVE-2023-0799, CVE-2023-0801, CVE-2023-0802, CVE-2023-0803, CVE-2023-0804


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
- CVE-2023-0795 is still affecting libtiff  version 4.5.0
- The patch [linked ](https://gitlab.com/libtiff/libtiff/-/commit/69818e2f2d246e6631ac2a2da692c3706b849c38)in NIST was made after 4.5.0 was tagged in the libtiff gitlab repo
- The patch still needs to be applied to 4.5.0

- CVE-2023-0795.patch consists of the following changes (in order):
  - https://gitlab.com/libtiff/libtiff/-/commit/9c22495e5eeeae9e00a1596720c969656bb8d678
  - https://gitlab.com/libtiff/libtiff/-/commit/688012dca2c39033aa2dc7bcea9796787cfd1b44
  - https://gitlab.com/libtiff/libtiff/-/commit/69818e2f2d246e6631ac2a2da692c3706b849c38 (This is the patch that NIST links to, but in order to apply this patch you need to make the related changes in the 2 commits above before)

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- CVE-2023-0795
- CVE-2023-0796
- CVE-2023-0797
- CVE-2023-0798
- CVE-2023-0799


###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2023-0795

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- AMD buddy build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=359894&view=results
- ARM buddy build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=359895&view=results