### PR TITLE
Tobiasb/cis chronyd use chrony user

### DIFF
--- a/SPECS/chrony/chrony.spec
+++ b/SPECS/chrony/chrony.spec
@@ -4,7 +4,7 @@
 
 Name:           chrony
 Version:        4.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        An NTP client/server
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -151,7 +151,7 @@ install -m 755 -p %{SOURCE4} $RPM_BUILD_ROOT%{_libexecdir}/chrony-helper
 
 cat > $RPM_BUILD_ROOT%{_sysconfdir}/sysconfig/chronyd <<EOF
 # Command-line options for chronyd
-OPTIONS=""
+OPTIONS="-u chrony"
 EOF
 
 touch $RPM_BUILD_ROOT%{_localstatedir}/lib/chrony/{drift,rtc}
@@ -206,6 +206,9 @@ systemctl start chronyd.service
 %dir %attr(-,chrony,chrony) %{_localstatedir}/log/chrony
 
 %changelog
+* Thu May 18 2023 Tobias Brick <tobiasb@microsoft.com> - 4.1-2
+- Explicitly run chronyd as the user chrony
+
 * Mon Mar 07 2022 Andrew Phelps <anphel@microsoft.com> - 4.1-1
 - Upgrade to version 4.1
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary
CIS recommendation is to ensure `chronyd` runs as user `chrony`, by specifying it in `/etc/sysconfig/chronyd`.

As it happened, we were already running it as `chrony` in all environments I checked (using `ps -aux | grep -i chrony`), so this is effectively a no-op that makes tools happy.

###### Change Log  
- add `-u chrony` to the options in `/etc/sysconfig/chronyd`; update release and change log.

###### Does this affect the toolchain?
**NO**

###### Associated issues  <!-- optional -->

###### Links to CVEs  <!-- optional -->

###### Test Methodology
Validated locally that the rpm created a `chronyd` file that looked right. Then took the RPM from a build pipeline and applied it to a marketplace VM and an AKs cluster node, validating the user who runs `chronyd` before and after, along with the contents of the file.
Buddy Builds:
- [ARM64](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=362608&view=results)
- [AMD64](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=362640&view=results)

