### PR TITLE
Remove explicit build-time dependency on npm in nodejs-nodemon

### DIFF
--- a/SPECS-EXTENDED/nodejs-nodemon/nodejs-nodemon.spec
+++ b/SPECS-EXTENDED/nodejs-nodemon/nodejs-nodemon.spec
@@ -8,7 +8,7 @@ Distribution:   Mariner
 
 Name:          nodejs-%{npm_name}
 Version:       2.0.3
-Release:       3%{?dist}
+Release:       4%{?dist}
 Summary:       Simple monitor script for use during development of a node.js app
 License:       MIT
 URL:           https://github.com/remy/nodemon
@@ -16,7 +16,6 @@ Source0:       %{_mariner_sources_url}/%{npm_name}-v%{version}-bundled.tar.gz
 
 BuildRequires: nodejs-devel
 BuildRequires: nodejs-packaging
-BuildRequires: npm
 
 ExclusiveArch: %{nodejs_arches} noarch
 BuildArch:     noarch
@@ -79,6 +78,9 @@ npm run test
 %{_bindir}/nodemon
 
 %changelog
+* Mon May 15 2023 Olivia Crain <oliviacrain@microsoft.com> - 2.0.3-4
+- Remove explicit build-time dependency on npm (provided by nodejs-devel)
+
 * Tue Apr 26 2022 Mandeep Plaha <mandeepplaha@microsoft.com> - 2.0.3-3
 - Updated source URL.
 - License verified.


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
The `nodejs-nodemon` package has a build-time dependency on `npm`. With [the addition of `nodejs18`](#5295), this is an ambiguous dependency that could resolve to either `nodejs` or `nodejs18`. Our toolkit has trouble processing these competing packages and gives up (see error below).

A long-term fix would require either decoupling `npm` from `nodejs` or reworking the way we resolve competing provides in our toolkit. Those changes are more suitable for Mariner 3.0, so for now, let's remove the build-time dependency on `npm`, since that's already covered by the dependency on `nodejs-devel`.

Sample error from a recent failed full build of extended:

```shell
WARN[0786] D: ============== /tmp/mariner/build/rpm_cache/cache/nodejs18-18.16.0-2.cm2.x86_64.rpm
D: loading keyring from rpmdb
D: PRAGMA secure_delete = OFF: 0
D: PRAGMA case_sensitive_like = ON: 0
D: /tmp/mariner/build/rpm_cache/cache/nodejs18-18.16.0-2.cm2.x86_64.rpm: Header SHA256 digest: OK
D: /tmp/mariner/build/rpm_cache/cache/nodejs18-18.16.0-2.cm2.x86_64.rpm: Header SHA1 digest: OK
D: Plugin: calling hook init in fsverity plugin
D: fsverity_init
D: Plugin: calling hook init in ima plugin
D: Plugin: calling hook init in syslog plugin
D: 	added binary package [0]
D: ============== /tmp/mariner/build/rpm_cache/cache/nodejs-16.19.1-2.cm2.x86_64.rpm
D: /tmp/mariner/build/rpm_cache/cache/nodejs-16.19.1-2.cm2.x86_64.rpm: Header SHA256 digest: OK
D: /tmp/mariner/build/rpm_cache/cache/nodejs-16.19.1-2.cm2.x86_64.rpm: Header SHA1 digest: OK
D: 	added binary package [1]
D: found 0 source and 2 binary packages
D: ========== recording tsort relations
D: ========== tsorting packages (order, #predecessors, #succesors, depth)
D:     0    0    0    1   +nodejs-16.19.1-2.cm2.x86_64
D:     1    0    0    1   +nodejs18-18.16.0-2.cm2.x86_64
D: installing binary packages
D: sanity checking 2 elements
D: Plugin: calling hook tsm_pre in selinux plugin
D: Plugin: calling hook tsm_pre in syslog plugin
D: computing 5098 file fingerprints
D: entering chroot /tmp/mariner/build/pkg_artifacts/tdnf_cache_worker/
D: computing file dispositions
D: 0x00000801     4096    222116299    129912855 rotational:-1 /
D: exiting chroot /tmp/mariner/build/pkg_artifacts/tdnf_cache_worker/
D: Plugin: calling hook tsm_post in selinux plugin
D: Plugin: calling hook tsm_post in syslog plugin
	file /usr/bin/node conflicts between attempted installs of nodejs18-18.16.0-2.cm2.x86_64 and nodejs-16.19.1-2.cm2.x86_64
	file /usr/lib/node_modules/corepack/CHANGELOG.md conflicts between attempted installs of nodejs18-18.16.0-2.cm2.x86_64 and nodejs-16.19.1-2.cm2.x86_64
<CUT>
	file /usr/lib/node_modules/npm/package.json conflicts between attempted installs of nodejs18-18.16.0-2.cm2.x86_64 and nodejs-16.19.1-2.cm2.x86_64
	file /usr/share/man/man1/node.1.gz conflicts between attempted installs of nodejs18-18.16.0-2.cm2.x86_64 and nodejs-16.19.1-2.cm2.x86_64
D: Exit status: 2 
ERRO[0786] Failed while trying to pick an RPM providing 'npm' from the following RPMs: [/tmp/mariner/build/rpm_cache/cache/nodejs18-18.16.0-2.cm2.x86_64.rpm /tmp/mariner/build/rpm_cache/cache/nodejs-16.19.1-2.cm2.x86_64.rpm] 
```

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- `nodejs-nodemon`: Remove explicit build-time dependency on npm

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- [Buddy build](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=360886&view=results)
