### PR TITLE
Add rootfs partition name in gen2 market place image

### DIFF
--- a/toolkit/imageconfigs/marketplace-gen2-aarch64.json
+++ b/toolkit/imageconfigs/marketplace-gen2-aarch64.json
@@ -28,6 +28,7 @@
                 },
                 {
                     "ID": "rootfs",
+                    "Name": "rootfs",
                     "Start": 565,
                     "End": 0,
                     "FsType": "ext4"
@@ -51,7 +52,8 @@
                 },
                 {
                     "ID": "rootfs",
-                    "MountPoint": "/"
+                    "MountPoint": "/",
+                    "MountIdentifier": "partlabel"
                 }
             ],
             "PackageLists": [

--- a/toolkit/imageconfigs/marketplace-gen2-aarch64.json
+++ b/toolkit/imageconfigs/marketplace-gen2-aarch64.json
@@ -52,8 +52,7 @@
                 },
                 {
                     "ID": "rootfs",
-                    "MountPoint": "/",
-                    "MountIdentifier": "partlabel"
+                    "MountPoint": "/"
                 }
             ],
             "PackageLists": [

--- a/toolkit/imageconfigs/marketplace-gen2.json
+++ b/toolkit/imageconfigs/marketplace-gen2.json
@@ -28,6 +28,7 @@
                 },
                 {
                     "ID": "rootfs",
+                    "Name": "rootfs",
                     "Start": 565,
                     "End": 0,
                     "FsType": "ext4"
@@ -51,7 +52,8 @@
                 },
                 {
                     "ID": "rootfs",
-                    "MountPoint": "/"
+                    "MountPoint": "/",
+                    "MountIdentifier": "partlabel"
                 }
             ],
             "PackageLists": [

--- a/toolkit/imageconfigs/marketplace-gen2.json
+++ b/toolkit/imageconfigs/marketplace-gen2.json
@@ -52,8 +52,7 @@
                 },
                 {
                     "ID": "rootfs",
-                    "MountPoint": "/",
-                    "MountIdentifier": "partlabel"
+                    "MountPoint": "/"
                 }
             ],
             "PackageLists": [


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Add rootfs partition name in gen2 market place image to enable kata image's grub.cfg to find mshv-bootloader file.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add rootfs partition name in amd64 gen2 market place image 
- Add rootfs partition name in aarch64 gen2 market place image (for future images only)

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Manual test done with https://dev.azure.com/mariner-org/mariner/_build/results?buildId=361715&view=results