### PR TITLE
libtiff: add patch for CVE-2023-0801

### DIFF
--- a/SPECS/libtiff/CVE-2023-0800.nopatch
+++ b/SPECS/libtiff/CVE-2023-0800.nopatch
@@ -1,0 +1,1 @@
+The CVE-2023-0801.patch also fixes CVE-2023-0800

--- a/SPECS/libtiff/CVE-2023-0801.nopatch
+++ b/SPECS/libtiff/CVE-2023-0801.nopatch
@@ -1,1 +1,0 @@
-The CVE-2023-0800.patch also fixes CVE-2023-0801

--- a/SPECS/libtiff/CVE-2023-0801.patch
+++ b/SPECS/libtiff/CVE-2023-0801.patch
@@ -1,0 +1,114 @@
+https://gitlab.com/libtiff/libtiff/-/commit/33aee1275d9d1384791d2206776eb8152d397f00
+
+diff --git a/tools/tiffcrop.c b/tools/tiffcrop.c
+index 84e26ac66cf342ccc1a32876ef6a384c278c6119..480b927ce967d0d930e70e374552eef2f50d70cd 100644
+--- a/tools/tiffcrop.c
++++ b/tools/tiffcrop.c
+@@ -5935,18 +5935,40 @@ static int computeInputPixelOffsets(struct crop_mask *crop,
+ 
+             crop->regionlist[i].buffsize = buffsize;
+             crop->bufftotal += buffsize;
++
++            /* For composite images with more than one region, the
++             * combined_length or combined_width always needs to be equal,
++             * respectively.
++             * Otherwise, even the first section/region copy
++             * action might cause buffer overrun. */
+             if (crop->img_mode == COMPOSITE_IMAGES)
+             {
+                 switch (crop->edge_ref)
+                 {
+                     case EDGE_LEFT:
+                     case EDGE_RIGHT:
++                        if (i > 0 && zlength != crop->combined_length)
++                        {
++                            TIFFError(
++                                "computeInputPixelOffsets",
++                                "Only equal length regions can be combined for "
++                                "-E left or right");
++                            return (-1);
++                        }
+                         crop->combined_length = zlength;
+                         crop->combined_width += zwidth;
+                         break;
+                     case EDGE_BOTTOM:
+                     case EDGE_TOP: /* width from left, length from top */
+                     default:
++                        if (i > 0 && zwidth != crop->combined_width)
++                        {
++                            TIFFError("computeInputPixelOffsets",
++                                      "Only equal width regions can be "
++                                      "combined for -E "
++                                      "top or bottom");
++                            return (-1);
++                        }
+                         crop->combined_width = zwidth;
+                         crop->combined_length += zlength;
+                         break;
+@@ -7301,6 +7323,46 @@ static int extractCompositeRegions(struct image_data *image,
+     crop->combined_width = 0;
+     crop->combined_length = 0;
+ 
++    /* If there is more than one region, check beforehand whether all the width
++     * and length values of the regions are the same, respectively. */
++    switch (crop->edge_ref)
++    {
++        default:
++        case EDGE_TOP:
++        case EDGE_BOTTOM:
++            for (i = 1; i < crop->selections; i++)
++            {
++                uint32_t crop_width0 =
++                    crop->regionlist[i - 1].x2 - crop->regionlist[i - 1].x1 + 1;
++                uint32_t crop_width1 =
++                    crop->regionlist[i].x2 - crop->regionlist[i].x1 + 1;
++                if (crop_width0 != crop_width1)
++                {
++                    TIFFError("extractCompositeRegions",
++                              "Only equal width regions can be combined for -E "
++                              "top or bottom");
++                    return (1);
++                }
++            }
++            break;
++        case EDGE_LEFT:
++        case EDGE_RIGHT:
++            for (i = 1; i < crop->selections; i++)
++            {
++                uint32_t crop_length0 =
++                    crop->regionlist[i - 1].y2 - crop->regionlist[i - 1].y1 + 1;
++                uint32_t crop_length1 =
++                    crop->regionlist[i].y2 - crop->regionlist[i].y1 + 1;
++                if (crop_length0 != crop_length1)
++                {
++                    TIFFError("extractCompositeRegions",
++                              "Only equal length regions can be combined for "
++                              "-E left or right");
++                    return (1);
++                }
++            }
++    }
++
+     for (i = 0; i < crop->selections; i++)
+     {
+         /* rows, columns, width, length are expressed in pixels */
+@@ -7325,7 +7387,8 @@ static int extractCompositeRegions(struct image_data *image,
+             default:
+             case EDGE_TOP:
+             case EDGE_BOTTOM:
+-                if ((i > 0) && (crop_width != crop->regionlist[i - 1].width))
++                if ((crop->selections > i + 1) &&
++                    (crop_width != crop->regionlist[i + 1].width))
+                 {
+                     TIFFError("extractCompositeRegions",
+                               "Only equal width regions can be combined for -E "
+@@ -7418,7 +7481,8 @@ static int extractCompositeRegions(struct image_data *image,
+             case EDGE_LEFT: /* splice the pieces of each row together, side by
+                                side */
+             case EDGE_RIGHT:
+-                if ((i > 0) && (crop_length != crop->regionlist[i - 1].length))
++                if ((crop->selections > i + 1) &&
++                    (crop_length != crop->regionlist[i + 1].length))
+                 {
+                     TIFFError("extractCompositeRegions",
+                               "Only equal length regions can be combined for "

--- a/SPECS/libtiff/CVE-2023-0802.nopatch
+++ b/SPECS/libtiff/CVE-2023-0802.nopatch
@@ -1,1 +1,1 @@
-The CVE-2023-0800.patch also fixes CVE-2023-0802
+The CVE-2023-0801.patch also fixes CVE-2023-0802

--- a/SPECS/libtiff/CVE-2023-0803.nopatch
+++ b/SPECS/libtiff/CVE-2023-0803.nopatch
@@ -1,1 +1,1 @@
-The CVE-2023-0800.patch also fixes CVE-2023-0803
+The CVE-2023-0801.patch also fixes CVE-2023-0803

--- a/SPECS/libtiff/CVE-2023-0804.nopatch
+++ b/SPECS/libtiff/CVE-2023-0804.nopatch
@@ -1,1 +1,1 @@
-The CVE-2023-0800.patch also fixes CVE-2023-0804
+The CVE-2023-0801.patch also fixes CVE-2023-0804

--- a/SPECS/libtiff/libtiff.spec
+++ b/SPECS/libtiff/libtiff.spec
@@ -65,7 +65,7 @@ make %{?_smp_mflags} -k check
 %changelog
 * Mon May 15 2023 Andrew Phelps <anphel@microsoft.com> - 4.5.0-2
 - Patch CVE-2023-0795 CVE-2023-0796 CVE-2023-0797 CVE-2023-0798 CVE-2023-0799
-- Patch CVE-2023-0801 CVE-2023-0802 CVE-2023-0803 CVE-2023-0804
+- Patch CVE-2023-0800 CVE-2023-0801 CVE-2023-0802 CVE-2023-0803 CVE-2023-0804
 
 * Mon Mar 27 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 4.5.0-1
 - Auto-upgrade to 4.5.0 - to fix CVE-2022-4645

--- a/SPECS/libtiff/libtiff.spec
+++ b/SPECS/libtiff/libtiff.spec
@@ -10,6 +10,7 @@ URL:            https://gitlab.com/libtiff/libtiff
 Source0:        https://gitlab.com/libtiff/libtiff/-/archive/v%{version}/libtiff-v%{version}.tar.gz
 Patch0:         CVE-2022-48281.patch
 Patch1:         CVE-2023-0795.patch
+Patch2:         CVE-2023-0801.patch
 BuildRequires:  autoconf
 BuildRequires:  automake
 BuildRequires:  libjpeg-turbo-devel
@@ -64,6 +65,7 @@ make %{?_smp_mflags} -k check
 %changelog
 * Mon May 15 2023 Andrew Phelps <anphel@microsoft.com> - 4.5.0-2
 - Patch CVE-2023-0795 CVE-2023-0796 CVE-2023-0797 CVE-2023-0798 CVE-2023-0799
+- Patch CVE-2023-0801 CVE-2023-0802 CVE-2023-0803 CVE-2023-0804
 
 * Mon Mar 27 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 4.5.0-1
 - Auto-upgrade to 4.5.0 - to fix CVE-2022-4645


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Add patch to libtiff for CVE-2023-0801. The patch also fixes CVE-2023-0800 CVE-2023-0802 CVE-2023-0803 CVE-2023-0804

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add patch for CVE-2023-0801 CVE-2023-0802 CVE-2023-0803 CVE-2023-0804
- Not incrementing release number since the current has not been published

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2023-0800
- https://nvd.nist.gov/vuln/detail/CVE-2023-0801
- https://nvd.nist.gov/vuln/detail/CVE-2023-0802
- https://nvd.nist.gov/vuln/detail/CVE-2023-0803
- https://nvd.nist.gov/vuln/detail/CVE-2023-0804

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
X64: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=362011&view=results
ARM64: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=362012&view=results