### PR TITLE
Add workflow to check for required kernel configs

### DIFF
--- a/.github/workflows/check-kernel-config.yml
+++ b/.github/workflows/check-kernel-config.yml
@@ -1,9 +1,9 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-# This action checks that certain groups of specs have matching tags.
-# The main use case is to ensure that signed specs have the same Version and
-#   Release tags as their unsigned counterparts
+# This action checks that required kernel configs have not been removed or
+# modified to an undesirable value. It also checks that new configs added to
+# the kernel config files are in the list of required configs.
 name: Kernel Required Configs Check
 
 on:

--- a/.github/workflows/check-kernel-config.yml
+++ b/.github/workflows/check-kernel-config.yml
@@ -40,7 +40,6 @@ jobs:
           echo "base_sha=${{ github.event.before }}" >> $GITHUB_ENV
           echo "Merging ${{ github.sha }} into ${{ github.event.before }}"
 
-      # For consistency, we use the same major/minor version of Python that CBL-Mariner ships
       - name: Setup Python 3.11
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/check-kernel-config.yml
+++ b/.github/workflows/check-kernel-config.yml
@@ -1,0 +1,74 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# This action checks that certain groups of specs have matching tags.
+# The main use case is to ensure that signed specs have the same Version and
+#   Release tags as their unsigned counterparts
+name: Kernel Required Configs Check
+
+on:
+  push:
+    branches: [main, dev, 1.0*, 2.0*]
+  pull_request:
+    branches: [main, dev, 1.0*, 2.0*]
+
+jobs:
+  check:
+    name: Kernel configs check
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checkout the branch of our repo that triggered this action
+      - name: Workflow trigger checkout
+        uses: actions/checkout@v2
+        
+      - name: Get base commit for PRs
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          git fetch origin ${{ github.base_ref }}
+          echo "base_sha=$(git rev-parse origin/${{ github.base_ref }})" >> $GITHUB_ENV
+          echo "Merging ${{ github.sha }} into ${{ github.base_ref }}"
+
+      - name: Get base commit for Pushes
+        if: ${{ github.event_name == 'push' }}
+        run: |
+          git fetch origin ${{ github.event.before }}
+          echo "base_sha=${{ github.event.before }}" >> $GITHUB_ENV
+          echo "Merging ${{ github.sha }} into ${{ github.event.before }}"
+
+
+      # For consistency, we use the same major/minor version of Python that CBL-Mariner ships
+      - name: Setup Python 3.7
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+
+      - name: Get Python dependencies
+        run: python3 -m pip install -r toolkit/scripts/requirements.txt
+
+      # Check kernel configs
+      - name: Get the changed files and configs
+        run: |
+          echo "Files changed: '$(git diff-tree --no-commit-id --name-only -r ${{ env.base_sha }} ${{ github.sha }})'"
+          changed_configs=$(git diff-tree --diff-filter=d  --no-commit-id --name-only -r ${{ env.base_sha }} ${{ github.sha }} | { grep "SPECS/kernel/config.*$" || test $? = 1; })
+          echo "Files to validate: '${changed_configs}'"
+          echo "updated-configs=$(echo ${changed_configs})" >> $GITHUB_ENV
+
+          # Check for new configs in the PR
+          # and check if they are in required configs
+          if [[ -n $changed_configs ]]; then
+            config_changes=$(git diff-tree -p -r ${{ env.base_sha }} ${{ github.sha }} -- SPECS/kernel/config)
+            echo "AMD config changes:"
+            python3 .github/workflows/check_new_kernel_configs.py --required_configs=toolkit/scripts/mariner-required-configs.json --config_str="${changed_configs}"
+            
+            echo "ARM config changes:"
+            config_aarch64_changes=$(git diff-tree -p -r ${{ env.base_sha }} ${{ github.sha }} -- SPECS/kernel/config_aarch64)
+            python3 .github/workflows/check_new_kernel_configs.py --required_configs=toolkit/scripts/mariner-required-configs.json --config_str="${config_aarch64_changes}"
+          fi
+
+      - name: Run kernel config checking script AMD64
+        run: python3 toolkit/scripts/check_required_kernel_configs.py --required_configs toolkit/scripts/mariner-required-configs.json --config_file SPECS/kernel/config
+      
+      - name: Run kernel config checking script ARM64
+        run: python3 toolkit/scripts/check_required_kernel_configs.py --required_configs toolkit/scripts/mariner-required-configs.json --config_file SPECS/kernel/config_aarch64
+

--- a/.github/workflows/check-kernel-config.yml
+++ b/.github/workflows/check-kernel-config.yml
@@ -46,26 +46,29 @@ jobs:
       - name: Get Python dependencies
         run: python3 -m pip install -r toolkit/scripts/requirements.txt
 
-      # Check kernel configs
-      - name: Get the changed files and configs
+      # Check if kernel configs changed
+      - name: Check if config files changed
         run: |
           echo "Files changed: '$(git diff-tree --no-commit-id --name-only -r ${{ env.base_sha }} ${{ github.sha }})'"
           changed_configs=$(git diff-tree --diff-filter=d  --no-commit-id --name-only -r ${{ env.base_sha }} ${{ github.sha }} | { grep "SPECS/kernel/config.*$" || test $? = 1; })
           echo "Files to validate: '${changed_configs}'"
           echo "updated-configs=$(echo ${changed_configs})" >> $GITHUB_ENV
 
+      # Check if new configs were added
+      - name: Parse for new config changes
+        run: |
           # Check for new configs in the PR
           # and check if they are in required configs
-          if [[ -n $changed_configs ]]; then
-            config_changes=$(git diff-tree -p -r ${{ env.base_sha }} ${{ github.sha }} -- SPECS/kernel/config)
-            echo "AMD config changes:"
-            python3 .github/workflows/check_new_kernel_configs.py --required_configs=toolkit/scripts/mariner-required-configs.json --config_str="${changed_configs}"
-            
-            echo "ARM config changes:"
-            config_aarch64_changes=$(git diff-tree -p -r ${{ env.base_sha }} ${{ github.sha }} -- SPECS/kernel/config_aarch64)
-            python3 .github/workflows/check_new_kernel_configs.py --required_configs=toolkit/scripts/mariner-required-configs.json --config_str="${config_aarch64_changes}"
+          if [[ -n "${{ env.updated-configs }}" ]]; then
+            holder="${{ env.updated-configs }}"
+            for word in $holder; do
+              config_diff=$(git diff-tree -p -r ${{ env.base_sha }} ${{ github.sha }} -- ${word})
+              echo "config_diff for ${word} : ${config_diff}"
+              python3 .github/workflows/check_new_kernel_configs.py --required_configs=toolkit/scripts/mariner-required-configs.json --config_file="${word}" --config_str="${config_diff}"
+            done
           fi
 
+      # Check if required configs were removed or modified
       - name: Run kernel config checking script AMD64
         run: python3 toolkit/scripts/check_required_kernel_configs.py --required_configs toolkit/scripts/mariner-required-configs.json --config_file SPECS/kernel/config
       

--- a/.github/workflows/check-kernel-config.yml
+++ b/.github/workflows/check-kernel-config.yml
@@ -41,10 +41,10 @@ jobs:
           echo "Merging ${{ github.sha }} into ${{ github.event.before }}"
 
       # For consistency, we use the same major/minor version of Python that CBL-Mariner ships
-      - name: Setup Python 3.7
+      - name: Setup Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.11
 
       - name: Get Python dependencies
         run: python3 -m pip install -r toolkit/scripts/requirements.txt

--- a/.github/workflows/check-kernel-config.yml
+++ b/.github/workflows/check-kernel-config.yml
@@ -10,11 +10,11 @@ on:
   push:
     branches: [main, dev, 1.0*, 2.0*]
     paths:
-      - 'SPECS/kernel/config*'
+      - 'SPECS/kernel*/config*'
   pull_request:
     branches: [main, dev, 1.0*, 2.0*]
     paths:
-      - 'SPECS/kernel/config*'
+      - 'SPECS/kernel*/config*'
 
 jobs:
   check:
@@ -53,7 +53,7 @@ jobs:
       - name: Check if config files changed
         run: |
           echo "Files changed: '$(git diff-tree --no-commit-id --name-only -r ${{ env.base_sha }} ${{ github.sha }})'"
-          changed_configs=$(git diff-tree --diff-filter=d  --no-commit-id --name-only -r ${{ env.base_sha }} ${{ github.sha }} | { grep "SPECS/kernel/config.*$" || test $? = 1; })
+          changed_configs=$(git diff-tree --diff-filter=d  --no-commit-id --name-only -r ${{ env.base_sha }} ${{ github.sha }} | { grep "SPECS/kernel.*/config.*$" || test $? = 1; })
           echo "Files to validate: '${changed_configs}'"
           echo "updated_configs=$(echo ${changed_configs})" >> $GITHUB_ENV
 

--- a/.github/workflows/check-kernel-config.yml
+++ b/.github/workflows/check-kernel-config.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       # Checkout the branch of our repo that triggered this action
       - name: Workflow trigger checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         
       - name: Get base commit for PRs
         if: ${{ github.event_name == 'pull_request' }}
@@ -36,10 +36,9 @@ jobs:
           echo "base_sha=${{ github.event.before }}" >> $GITHUB_ENV
           echo "Merging ${{ github.sha }} into ${{ github.event.before }}"
 
-
       # For consistency, we use the same major/minor version of Python that CBL-Mariner ships
       - name: Setup Python 3.7
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.7
 
@@ -52,19 +51,19 @@ jobs:
           echo "Files changed: '$(git diff-tree --no-commit-id --name-only -r ${{ env.base_sha }} ${{ github.sha }})'"
           changed_configs=$(git diff-tree --diff-filter=d  --no-commit-id --name-only -r ${{ env.base_sha }} ${{ github.sha }} | { grep "SPECS/kernel/config.*$" || test $? = 1; })
           echo "Files to validate: '${changed_configs}'"
-          echo "updated-configs=$(echo ${changed_configs})" >> $GITHUB_ENV
+          echo "updated_configs=$(echo ${changed_configs})" >> $GITHUB_ENV
 
       # Check if new configs were added
       - name: Parse for new config changes
         run: |
           # Check for new configs in the PR
           # and check if they are in required configs
-          if [[ -n "${{ env.updated-configs }}" ]]; then
-            holder="${{ env.updated-configs }}"
-            for word in $holder; do
-              config_diff=$(git diff-tree -p -r ${{ env.base_sha }} ${{ github.sha }} -- ${word})
-              echo "config_diff for ${word} : ${config_diff}"
-              python3 .github/workflows/check_new_kernel_configs.py --required_configs=toolkit/scripts/mariner-required-configs.json --config_file="${word}" --config_str="${config_diff}"
+          if [[ -n "${{ env.updated_configs }}" ]]; then
+            holder="${{ env.updated_configs }}"
+            for file in $holder; do
+              config_diff=$(git diff-tree -p -r ${{ env.base_sha }} ${{ github.sha }} -- ${file})
+              echo "config_diff for ${file} : ${config_diff}"
+              python3 .github/workflows/check_new_kernel_configs.py --required_configs=toolkit/scripts/mariner-required-configs.json --config_file="${file}" --config_diff="${config_diff}"
             done
           fi
 

--- a/.github/workflows/check-kernel-config.yml
+++ b/.github/workflows/check-kernel-config.yml
@@ -9,8 +9,12 @@ name: Kernel Required Configs Check
 on:
   push:
     branches: [main, dev, 1.0*, 2.0*]
+    paths:
+      - 'SPECS/kernel/config*'
   pull_request:
     branches: [main, dev, 1.0*, 2.0*]
+    paths:
+      - 'SPECS/kernel/config*'
 
 jobs:
   check:
@@ -58,19 +62,17 @@ jobs:
         run: |
           # Check for new configs in the PR
           # and check if they are in required configs
-          if [[ -n "${{ env.updated_configs }}" ]]; then
-            holder="${{ env.updated_configs }}"
-            for file in $holder; do
-              config_diff=$(git diff-tree -p -r ${{ env.base_sha }} ${{ github.sha }} -- ${file})
-              echo "config_diff for ${file} : ${config_diff}"
-              python3 .github/workflows/check_new_kernel_configs.py --required_configs=toolkit/scripts/mariner-required-configs.json --config_file="${file}" --config_diff="${config_diff}"
-            done
-          fi
+          holder="${{ env.updated_configs }}"
+          for file in $holder; do
+            config_diff=$(git diff-tree -p -r ${{ env.base_sha }} ${{ github.sha }} -- ${file})
+            echo "config_diff for ${file} : ${config_diff}"
+            python3 .github/workflows/check_new_kernel_configs.py --required_configs=toolkit/scripts/mariner-required-configs.json --config_file="${file}" --config_diff="${config_diff}"
+          done
 
       # Check if required configs were removed or modified
-      - name: Run kernel config checking script AMD64
-        run: python3 toolkit/scripts/check_required_kernel_configs.py --required_configs toolkit/scripts/mariner-required-configs.json --config_file SPECS/kernel/config
-      
-      - name: Run kernel config checking script ARM64
-        run: python3 toolkit/scripts/check_required_kernel_configs.py --required_configs toolkit/scripts/mariner-required-configs.json --config_file SPECS/kernel/config_aarch64
-
+      - name: Run kernel config checking script
+        run: |
+          holder="${{ env.updated_configs }}"
+          for file in $holder; do
+            python3 toolkit/scripts/check_required_kernel_configs.py --required_configs toolkit/scripts/mariner-required-configs.json --config_file "${file}"
+          done

--- a/.github/workflows/check-kernel-config.yml
+++ b/.github/workflows/check-kernel-config.yml
@@ -66,7 +66,7 @@ jobs:
           for file in $holder; do
             config_diff=$(git diff-tree -p -r ${{ env.base_sha }} ${{ github.sha }} -- ${file})
             echo "config_diff for ${file} : ${config_diff}"
-            python3 .github/workflows/check_new_kernel_configs.py --required_configs=toolkit/scripts/mariner-required-configs.json --config_file="${file}" --config_diff="${config_diff}"
+            python3 toolkit/scripts/check_new_kernel_configs.py --required_configs=toolkit/scripts/mariner-required-configs.json --config_file="${file}" --config_diff="${config_diff}"
           done
 
       # Check if required configs were removed or modified

--- a/.github/workflows/check-kernel-config.yml
+++ b/.github/workflows/check-kernel-config.yml
@@ -8,11 +8,11 @@ name: Kernel Required Configs Check
 
 on:
   push:
-    branches: [main, dev, 1.0*, 2.0*]
+    branches: [main, 1.0*, 2.0*]
     paths:
       - 'SPECS/kernel*/config*'
   pull_request:
-    branches: [main, dev, 1.0*, 2.0*]
+    branches: [main, 1.0*, 2.0*]
     paths:
       - 'SPECS/kernel*/config*'
 

--- a/.github/workflows/check_new_kernel_configs.py
+++ b/.github/workflows/check_new_kernel_configs.py
@@ -9,6 +9,11 @@ import argparse
 import sys
 import re
 
+def get_data_from_config(input_file):
+    with open(input_file, 'r') as file:
+        input_config_data = file.read()
+    return input_config_data
+
 def check_kernel(input_file):
     match = re.search(r'SPECS/(.*?)/', input_file)
     if match:
@@ -16,12 +21,10 @@ def check_kernel(input_file):
     else:
         return None
 
-def check_config_arch(input_file):
-    with open(input_file, 'r') as file:
-        contents = file.read()
-    if "Linux/x86_64" in contents:
+def check_config_arch(input_config_data):
+    if "Linux/x86_64" in input_config_data:
         return "AMD64"
-    elif "Linux/arm64" in contents:
+    elif "Linux/arm64" in input_config_data:
         return "ARM64"
     else:
         return None
@@ -73,11 +76,12 @@ if kernel == None:
     print("Kernel not found in config filepath")
     sys.exit(1)
 
-arch = check_config_arch(config_file)
+input_config_data = get_data_from_config(config_file)
+
+arch = check_config_arch(input_config_data)
 if arch == None:
     print("Architecture not found in config file")
     sys.exit(1)
-
 
 missing_configs = find_missing_configs(required_configs, kernel, arch, config_diff)
 if missing_configs == None:

--- a/.github/workflows/check_new_kernel_configs.py
+++ b/.github/workflows/check_new_kernel_configs.py
@@ -9,6 +9,17 @@ import argparse
 import sys
 import re
 
+def check_config_arch(input_file):
+    with open(input_file, 'r') as file:
+        contents = file.read()
+    file.close()
+    if "Linux/x86_64" in contents:
+        return "AMD64"
+    elif "Linux/arm64" in contents:
+        return "ARM64"
+    else:
+        return None
+
 # find the lines in the diff that contain +/- CONFIG
 # ignore the lines that contain @
 def find_matching_lines(input_string):
@@ -19,40 +30,43 @@ def find_matching_lines(input_string):
 
 # parse diff for new kernel configs
 # check if they are in required configs
-def find_missing_words(json_file, string):
+def find_missing_words(json_file, arch, config_diff):
     # Load the JSON object
     with open(json_file, 'r') as file:
         data = json.load(file)
     configData = data['required-configs']
 
     # Extract the words from the string
-    config_words = find_matching_lines(string)
+    config_words = find_matching_lines(config_diff)
     holder = [ s.replace('+', '').replace('-', '').replace('=y','').replace('=m','').replace(' is not set', '').replace('#', '').strip() for s in config_words]
     wordSet = set(holder)
 
     # Find the missing words
     missing_words = []
     for word in wordSet:
-        if word not in configData:
+        if word not in configData or arch not in configData[word]["arch"] :
             missing_words.append(word)
-
     return missing_words
 
 
 parser = argparse.ArgumentParser(
 description="Tool for checking if known required kernel configs are present.")
 parser.add_argument('--required_configs', help='path to json of required configs', required=True)
-parser.add_argument('--config_str', help='path to config being checked', required=True)
+parser.add_argument('--config_file', help='path to config', required=True)
+parser.add_argument('--config_str', help='config diff', required=True)
 args = parser.parse_args()
 requiredConfigs = args.required_configs
-configStr = args.config_str
+configFile = args.config_file
+configDiff = args.config_str
+arch = check_config_arch(configFile)
 
-missing_words = find_missing_words(requiredConfigs, configStr)
+missing_words = find_missing_words(requiredConfigs, arch, configDiff)
 print("Missing words:", missing_words)
 if len(missing_words) == 0:
     print("All configs are present in required configs")
 else:
-    print ("====================== Kernel config verification FAILED ======================")
+    print ("====================== Kernel new config verification FAILED for {0} ======================".format(arch))
+    print("New configs detected for {0}. Please add the following to toolkit/scripts/mariner-required-configs.json".format(arch))
     for word in missing_words:
-        print('{0} is new. Please add to toolkit/scripts/mariner-required-configs.json'.format(word))
+        print('{0}'.format(word))
     sys.exit(1)

--- a/.github/workflows/check_new_kernel_configs.py
+++ b/.github/workflows/check_new_kernel_configs.py
@@ -48,16 +48,16 @@ def find_missing_configs(json_file, kernel, arch, config_diff):
         if kernel not in data:
             print(f"Kernel {kernel} not found in {json_file}")
             return None
-        config_data = data[kernel]['required-configs']
+        required_configs_data = data[kernel]['required-configs']
 
     # Extract the words from the string
     config_words = find_matching_lines(config_diff)
 
     # Find the missing words
     missing_configs = []
-    for word in config_words:
-        if word not in config_data or arch not in config_data[word]["arch"] :
-            missing_configs.append(word)
+    for config_option in config_words:
+        if config_option not in required_configs_data or arch not in required_configs_data[config_option]["arch"] :
+            missing_configs.append(config_option)
     return missing_configs
 
 
@@ -88,7 +88,7 @@ if missing_configs == None:
     print(f"Could not find required configs for {kernel}")
     sys.exit(0)
 
-print("Missing words:", missing_configs)
+print("Missing configs:", missing_configs)
 if len(missing_configs) == 0:
     print("All configs are present in required configs")
 else:

--- a/.github/workflows/check_new_kernel_configs.py
+++ b/.github/workflows/check_new_kernel_configs.py
@@ -1,0 +1,58 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# Script to check for new configs which should be in required kernel configs json
+# Usage: python3 check_new_kernel_configs.py --required_configs <path to json of required configs> --config_str <string of diff for config file>
+
+import json
+import argparse
+import sys
+import re
+
+# find the lines in the diff that contain +/- CONFIG
+# ignore the lines that contain @
+def find_matching_lines(input_string):
+    pattern = r'(?!.*@)[+-]\s*.*CONFIG.*'
+    matching_lines = re.findall(pattern, input_string)
+
+    return matching_lines
+
+# parse diff for new kernel configs
+# check if they are in required configs
+def find_missing_words(json_file, string):
+    # Load the JSON object
+    with open(json_file, 'r') as file:
+        data = json.load(file)
+    configData = data['required-configs']
+
+    # Extract the words from the string
+    config_words = find_matching_lines(string)
+    holder = [ s.replace('+', '').replace('-', '').replace('=y','').replace('=m','').replace(' is not set', '').replace('#', '').strip() for s in config_words]
+    wordSet = set(holder)
+
+    # Find the missing words
+    missing_words = []
+    for word in wordSet:
+        if word not in configData:
+            missing_words.append(word)
+
+    return missing_words
+
+
+parser = argparse.ArgumentParser(
+description="Tool for checking if known required kernel configs are present.")
+parser.add_argument('--required_configs', help='path to json of required configs', required=True)
+parser.add_argument('--config_str', help='path to config being checked', required=True)
+args = parser.parse_args()
+requiredConfigs = args.required_configs
+configStr = args.config_str
+
+missing_words = find_missing_words(requiredConfigs, configStr)
+print("Missing words:", missing_words)
+if len(missing_words) == 0:
+    print("All configs are present in required configs")
+else:
+    print ("====================== Kernel config verification FAILED ======================")
+    for word in missing_words:
+        print('{0} is new. Please add to toolkit/scripts/mariner-required-configs.json'.format(word))
+    sys.exit(1)

--- a/toolkit/scripts/check_new_kernel_configs.py
+++ b/toolkit/scripts/check_new_kernel_configs.py
@@ -12,12 +12,14 @@ from kernel_sources_analysis import get_data_from_config, extract_kernel_dir_nam
 
 # Regex for finding config options
 # Matches words that start with +/-CONFIG_ or +/-# CONFIG_
-CONFIG_REGEX=r'(?:(?<=[-+])|(?<=[-+]# ))CONFIG_\w+'
+# Examples:
+# "+CONFIG_ABC=y" -> "CONFIG_ABC"
+# "-# CONFIG_XYZ is not set" -> "CONFIG_XYZ"
+CONFIG_REGEX=re.compile(r'(?:(?<=[-+])|(?<=[-+]# ))CONFIG_\w+')
 
 def extract_modified_configs(input_string):
-    matching_lines = re.findall(CONFIG_REGEX, input_string)
-    config_set = set(matching_lines)
-    return config_set
+    matching_configs = CONFIG_REGEX.findall(input_string)
+    return set(matching_configs)
 
 # Parse diff for new kernel configs
 # Check if they are in required configs

--- a/toolkit/scripts/check_new_kernel_configs.py
+++ b/toolkit/scripts/check_new_kernel_configs.py
@@ -62,8 +62,7 @@ if __name__ == '__main__':
     if kernel == None:
         print("ERROR: Kernel name not found. Please provide kernel name using --kernel flag or ensure config file path is correct")
         sys.exit(1)
-    else:
-        print(f"Analyzing for Kernel: {kernel}")
+    print(f"Analyzing for Kernel: {kernel}")
 
     input_config_data = get_data_from_config(config_file)
 

--- a/toolkit/scripts/check_new_kernel_configs.py
+++ b/toolkit/scripts/check_new_kernel_configs.py
@@ -76,7 +76,7 @@ if len(missing_configs) == 0:
     print("All configs are present in required configs")
 else:
     print (f"====================== Kernel new config verification FAILED for {arch} ======================")
-    print(f"New configs detected for {arch}. Please add the following to toolkit/scripts/mariner-required-configs.json")
+    print(f"New configs detected for {arch}. Please add the following to {required_configs}")
     for word in missing_configs:
         print(word)
     sys.exit(1)

--- a/toolkit/scripts/check_new_kernel_configs.py
+++ b/toolkit/scripts/check_new_kernel_configs.py
@@ -10,14 +10,13 @@ import sys
 import re
 from kernel_sources_analysis import get_data_from_config, extract_kernel_dir_name, extract_config_arch
 
-# Find the lines in the diff that contain +/- CONFIG
-# Ignore the lines that contain @
-# Return the set of configs that follow +/-
+# Regex for finding config options
+# Matches words that start with +/-CONFIG_ or +/-# CONFIG_
+CONFIG_REGEX=r'(?:(?<=[-+])|(?<=[-+]# ))CONFIG_\w+'
+
 def extract_modified_configs(input_string):
-    pattern = r'(?!.*@)[+-]\s*.*CONFIG.*'
-    matching_lines = re.findall(pattern, input_string)
-    holder=[re.sub(r"\+|\-|=y|=m|\#|is not set", r"", s).strip() for s in matching_lines]
-    config_set = set(holder)
+    matching_lines = re.findall(CONFIG_REGEX, input_string)
+    config_set = set(matching_lines)
     return config_set
 
 # Parse diff for new kernel configs

--- a/toolkit/scripts/check_required_kernel_configs.py
+++ b/toolkit/scripts/check_required_kernel_configs.py
@@ -23,7 +23,7 @@ def check_strings_in_file(json_file, arch, input_file):
     
     with open(json_file, 'r') as file:
         data = json.load(file)
-        configData = data['required-configs']
+        config_data = data['required-configs']
 
     with open(input_file, 'r') as file:
         contents = file.read().split("\n")
@@ -32,7 +32,7 @@ def check_strings_in_file(json_file, arch, input_file):
     missing_configs = {}
 
     # go through required configs
-    for key, value in configData.items():
+    for key, value in config_data.items():
         # check for arch
         if arch not in value['arch']:
             continue
@@ -40,7 +40,7 @@ def check_strings_in_file(json_file, arch, input_file):
         found = False
         for line in contents:
             # check for config in line (without extra _VALUE)
-            if "{0}=".format(key) in line or "{0} is not set".format(key) in line:
+            if f"{key}=" in line or f"{key} is not set" in line:
                 for val in value['value']:
                     if val in line and val != "":
                         found = True
@@ -60,12 +60,12 @@ def print_verbose(json_file, results):
 
     with open(json_file, 'r') as file:
         data = json.load(file)
-        configData = data['required-configs']
+        config_data = data['required-configs']
     print_data = [["Option", "Required Arch", "Expected Value", "Comment"]]
-    for key, value in configData.items():
+    for key, value in config_data.items():
         if arch in value['arch']:
             if key in results:
-                print_data.append([key, value['arch'], value['value'], "FAIL: Unexpected value: {0}. See: {1}".format(results[key][0], value['PR'])])
+                print_data.append([key, value['arch'], value['value'], f"FAIL: Unexpected value: {results[key][0]}. See: {value['PR']}"])
             else:
                 print_data.append([key, value['arch'], value['value'], "OK"])
     # Calculate maximum width for each column
@@ -90,18 +90,18 @@ if __name__ == '__main__':
     parser.add_argument('--config_file', help='path to config being checked', required=True)
     parser.add_argument('--verbose', action='store_true', help='get full report', required=False)
     args = parser.parse_args()
-    requiredConfigs = args.required_configs
-    configFile = args.config_file
-    arch = check_config_arch(configFile)
+    required_configs = args.required_configs
+    config_file = args.config_file
+    arch = check_config_arch(config_file)
 
     # result is map: {config: (newValue, expectedValue, comment, PR)}
-    result = check_strings_in_file(requiredConfigs, arch, configFile)
+    result = check_strings_in_file(required_configs, arch, config_file)
     print()
     print("===============================================================================")
-    print("== Results for {0} ==".format(configFile))
+    print(f"== Results for {config_file} ==")
     print("===============================================================================")
     if args.verbose:
-        print_verbose(requiredConfigs, result)
+        print_verbose(required_configs, result)
     else:
         if result == {}:
             print("All required configs are present")
@@ -109,8 +109,8 @@ if __name__ == '__main__':
             print()
             print ("----------------- Kernel config verification FAILED -----------------")
             for key, value in result.items():
-                print('{0} is "{1}", expected {2}.\nReason: {3}'.format(key, value[0], value[1], value[2]))
+                print(f'{key} is "{value[0]}", expected {value[1]}.\nReason: {value[2]}')
                 if value[3] != None:
-                    print('PR: {0}'.format(value[3]))
+                    print(f"PR: {value[3]}")
                 print()
             sys.exit(1)

--- a/toolkit/scripts/check_required_kernel_configs.py
+++ b/toolkit/scripts/check_required_kernel_configs.py
@@ -63,10 +63,11 @@ def print_verbose(json_file, results):
         configData = data['required-configs']
     print_data = [["Option", "Required Arch", "Expected Value", "Comment"]]
     for key, value in configData.items():
-        if key in results:
-            print_data.append([key, value['arch'], value['value'], "FAIL: Unexpected value: {0}. See: {1}".format(results[key][0], value['PR'])])
-        else:
-            print_data.append([key, value['arch'], value['value'], "OK"])
+        if arch in value['arch']:
+            if key in results:
+                print_data.append([key, value['arch'], value['value'], "FAIL: Unexpected value: {0}. See: {1}".format(results[key][0], value['PR'])])
+            else:
+                print_data.append([key, value['arch'], value['value'], "OK"])
     # Calculate maximum width for each column
     column_widths = [max(len(str(row[i])) for row in print_data) for i in range(len(print_data[0]))]
 
@@ -76,7 +77,7 @@ def print_verbose(json_file, results):
             print(str(column).ljust(column_widths[i] + 2), end='')
         print()
         if j == 0:
-            print("-" * sum(column_widths) + "")
+            print("-------------------------------------------------------------------------------")
 
 
 ## Main

--- a/toolkit/scripts/check_required_kernel_configs.py
+++ b/toolkit/scripts/check_required_kernel_configs.py
@@ -1,0 +1,81 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# Script to check for required kernel configs in a kernel config file
+# Usage: python3 check_required_kernel_configs.py --required_configs <path to json of required configs> --config_file <path to config being checked>
+
+import json
+import argparse
+import sys
+
+def check_config_arch(input_file):
+    with open(input_file, 'r') as file:
+        contents = file.read()
+    file.close()
+    if "Linux/x86_64" in contents:
+        return "AMD64"
+    elif "Linux/arm64" in contents:
+        return "ARM64"
+    else:
+        return None
+
+def check_strings_in_file(json_file, input_file):
+    arch = check_config_arch(input_file)
+    with open(json_file, 'r') as file:
+        data = json.load(file)
+        configData = data['required-configs']
+
+    with open(input_file, 'r') as file:
+        contents = file.read().split("\n")
+
+    missing_configs = {}
+
+    for key, value in configData.items():
+        # check for arch
+        if arch not in value['arch']:
+            continue
+        found = False
+        for line in contents:
+            # check for config in line (without extra _VALUE)
+            if "{0}=".format(key) in line or "{0} is not set".format(key) in line:
+                for val in value['value']:
+                    if val in line and val != "":
+                        found = True
+                        break
+                else:
+                    missing_configs[key] = (line.split(key)[1].replace('=',''), value['value'], value['comment'], value['PR'])
+                    found = True
+                    break
+        if not found:
+            # check if config can be missing
+            if "" not in value['value']:
+                missing_configs[key] = (line, value['value'], value['comment'], value['PR'])
+
+    return missing_configs
+
+## Main
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description="Tool for checking if known required kernel configs are present.")
+
+
+    parser.add_argument('--required_configs', help='path to json of required configs', required=True)
+    parser.add_argument('--config_file', help='path to config being checked', required=True)
+    args = parser.parse_args()
+    requiredConfigs = args.required_configs
+    configFile = args.config_file
+
+    result = check_strings_in_file(requiredConfigs, configFile)
+    if result == {}:
+        print("All required configs are present")
+    else:
+        print ("====================== Kernel config verification FAILED ======================")
+        for key, value in result.items():
+            if value[0] == "" :
+                print('{0} is missing, expected {1}.\nReason: {2}'.format(key, value[1], value[2]))
+            else: 
+                print('{0} is "{1}", expected {2}.\nReason: {3}'.format(key, value[0], value[1], value[2]))
+            if value[3] != None:
+                print('PR: {0}'.format(value[3]))
+            print()
+        sys.exit(1)

--- a/toolkit/scripts/check_required_kernel_configs.py
+++ b/toolkit/scripts/check_required_kernel_configs.py
@@ -86,8 +86,7 @@ if __name__ == '__main__':
     if kernel == None:
         print("ERROR: Kernel name not found. Please provide kernel name using --kernel flag or ensure config file path is correct")
         sys.exit(1)
-    else:
-        print(f"Analyzing for Kernel: {kernel}")
+    print(f"Analyzing for Kernel: {kernel}")
 
     input_config_data = get_data_from_config(config_file)
 

--- a/toolkit/scripts/check_required_kernel_configs.py
+++ b/toolkit/scripts/check_required_kernel_configs.py
@@ -9,6 +9,17 @@ import argparse
 import sys
 import re
 
+# Define a class
+    #incorrect configs is map: {config: (newValue, expectedValue, comment, PR)}
+class IncorrectConfig:
+    def __init__(self, name, newValue, expectedValue, comment, PR):
+        self.name = name
+        self.newValue = newValue
+        self.expectedValue = expectedValue
+        self.comment = comment
+        self.PR = PR
+
+
 def get_data_from_config(input_file):
     with open(input_file, 'r') as file:
         input_config_data = file.read()
@@ -58,12 +69,12 @@ def check_strings_in_file(json_file, kernel, arch, input_config_data):
                 # config was found but value is not correct
                 # mark as found and add to incorrect_configs
                 if not found:
-                    incorrect_configs[key] = (line.split(key)[1].replace('=',''), value['value'], value['comment'], value['PR'])
+                    incorrect_configs[key] = (IncorrectConfig(key, line.split(key)[1].replace('=',''), value['value'], value['comment'], value['PR']))
                     found = True
         if not found:
             # check if config can be missing
             if "" not in value['value']:
-                incorrect_configs[key] = (line, value['value'], value['comment'], value['PR'])
+                incorrect_configs[key] = (IncorrectConfig(key, line, value['value'], value['comment'], value['PR']))
 
     return incorrect_configs
 
@@ -138,8 +149,7 @@ if __name__ == '__main__':
             print()
             print ("----------------- Kernel config verification FAILED -----------------")
             for key, value in result.items():
-                print(f'{key} is "{value[0]}", expected {value[1]}.\nReason: {value[2]}')
-                if value[3] != None:
-                    print(f"PR: {value[3]}")
+                print(f'{key} is "{value.newValue}", expected {value.expectedValue}.\nReason: {value.comment}')
+                print(f"PR: {value.PR}")
                 print()
             sys.exit(1)

--- a/toolkit/scripts/check_required_kernel_configs.py
+++ b/toolkit/scripts/check_required_kernel_configs.py
@@ -37,7 +37,7 @@ def check_required_configs_in_configfile(req_config_json_file, kernel, arch, inp
                 }
         # check if required configs removed from the kernel's config file
         # Note that some required configs are required to be missing
-        elif "" not in req_value['value']: 
+        elif "<missing>" not in req_value['value']: 
                 incorrect_configs[config_option] = {
                     "newValue": "MISSING",
                     "expectedValue": req_value['value'],

--- a/toolkit/scripts/check_required_kernel_configs.py
+++ b/toolkit/scripts/check_required_kernel_configs.py
@@ -72,25 +72,28 @@ def print_verbose(req_config_json_file, kernel, arch, results):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
         description="Tool for checking if known required kernel configs are present.")
-
-
     parser.add_argument('--required_configs', help='path to json of required configs', required=True)
     parser.add_argument('--config_file', help='path to config being checked', required=True)
     parser.add_argument('--verbose', action='store_true', help='get full report', required=False)
+    parser.add_argument('--kernel', help='kernel for the config being checked', required=False)
     args = parser.parse_args()
     required_configs = args.required_configs
     config_file = args.config_file
-
-    kernel = extract_kernel_dir_name(config_file)
+    if args.kernel:
+        kernel = args.kernel
+    else:
+        kernel = extract_kernel_dir_name(config_file)
     if kernel == None:
-        print("Kernel not found in config filepath")
+        print("ERROR: Kernel name not found. Please provide kernel name using --kernel flag or ensure config file path is correct")
         sys.exit(1)
+    else:
+        print(f"Analyzing for Kernel: {kernel}")
 
     input_config_data = get_data_from_config(config_file)
 
     arch = extract_config_arch(input_config_data)
     if arch == None:
-        print("Architecture not found in config file")
+        print("ERROR: Architecture not found in config file")
         sys.exit(1)
 
     config_map = create_map_of_config_values(input_config_data)

--- a/toolkit/scripts/kernel_sources_analysis.py
+++ b/toolkit/scripts/kernel_sources_analysis.py
@@ -1,0 +1,31 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# Script to check for new configs which should be in required kernel configs json
+# Usage: python3 check_new_kernel_configs.py --required_configs <path to json of required configs> --config_str <string of diff for config file>
+
+import re
+
+def get_data_from_config(input_file):
+    with open(input_file, 'r') as file:
+        input_config_data = file.read()
+    return input_config_data
+
+def extract_kernel_dir_name(input_file):
+    match = re.search(r'SPECS/(.*?)/', input_file)
+    if match:
+        return match.group(1)
+    else:
+        print("Error: Could not find kernel name in path for config file")
+        return None
+
+def extract_config_arch(input_config_data):
+    if "Linux/x86_64" in input_config_data:
+        return "AMD64"
+    elif "Linux/arm64" in input_config_data:
+        return "ARM64"
+    else:
+        print("Error: Could not find architecture in config file")
+        return None
+
+

--- a/toolkit/scripts/kernel_sources_analysis.py
+++ b/toolkit/scripts/kernel_sources_analysis.py
@@ -4,7 +4,7 @@
 # Script to check for new configs which should be in required kernel configs json
 # Usage: python3 check_new_kernel_configs.py --required_configs <path to json of required configs> --config_str <string of diff for config file>
 
-import re
+import os
 import json
 
 def get_data_from_config(input_file):
@@ -18,9 +18,9 @@ def get_jsondata_from_jsonfile(input_json_file):
     return config_json_data
 
 def extract_kernel_dir_name(input_file):
-    match = re.search(r'SPECS/(.*?)/', input_file)
+    match =  os.path.basename(os.path.dirname(input_file))
     if match:
-        return match.group(1)
+        return match
     else:
         print("Error: Could not find kernel name in path for config file")
         return None

--- a/toolkit/scripts/kernel_sources_analysis.py
+++ b/toolkit/scripts/kernel_sources_analysis.py
@@ -19,7 +19,7 @@ def get_jsondata_from_jsonfile(input_json_file):
     return config_json_data
 
 def extract_kernel_dir_name(input_file):
-    match =  os.path.basename(os.path.dirname(input_file))
+    match = os.path.basename(os.path.dirname(input_file))
     if match:
         return match
     else:

--- a/toolkit/scripts/kernel_sources_analysis.py
+++ b/toolkit/scripts/kernel_sources_analysis.py
@@ -5,11 +5,17 @@
 # Usage: python3 check_new_kernel_configs.py --required_configs <path to json of required configs> --config_str <string of diff for config file>
 
 import re
+import json
 
 def get_data_from_config(input_file):
     with open(input_file, 'r') as file:
         input_config_data = file.read()
     return input_config_data
+
+def get_jsondata_from_jsonfile(input_json_file):
+    with open(input_json_file, 'r') as req_config_json_file:
+        config_json_data = json.load(req_config_json_file)
+    return config_json_data
 
 def extract_kernel_dir_name(input_file):
     match = re.search(r'SPECS/(.*?)/', input_file)
@@ -28,4 +34,13 @@ def extract_config_arch(input_config_data):
         print("Error: Could not find architecture in config file")
         return None
 
-
+def create_map_of_config_values(input_config_data):
+    config_map = {}
+    for line in input_config_data.split('\n'):
+        if "=" in line:
+            config_map[line.split('=')[0]] = line.split('=')[1]
+        # Find configs that are not set
+        # Example: # CONFIG_FOO is not set
+        elif "is not set" in line:
+            config_map[line.split()[1]] = "is not set"
+    return config_map

--- a/toolkit/scripts/kernel_sources_analysis.py
+++ b/toolkit/scripts/kernel_sources_analysis.py
@@ -5,6 +5,7 @@
 # Usage: python3 check_new_kernel_configs.py --required_configs <path to json of required configs> --config_str <string of diff for config file>
 
 import os
+import re
 import json
 
 def get_data_from_config(input_file):
@@ -34,13 +35,19 @@ def extract_config_arch(input_config_data):
         print("Error: Could not find architecture in config file")
         return None
 
+# Regex matching pairs of kernel config name and its value.
+#
+# Sample input:
+#   CONFIG_ABC=y
+#   CONFIG_XYZ=""
+#   # CONFIG_111 is not set
+#
+# Result:
+#   {
+#     'CONFIG_ABC': 'y',
+#     'CONFIG_XYZ': '""',
+#     'CONFIG_111': 'is not set'
+#   }
+CONFIG_TO_VALUE_REGEX=re.compile(r'(CONFIG_\w+)[ =](.*)')
 def create_map_of_config_values(input_config_data):
-    config_map = {}
-    for line in input_config_data.split('\n'):
-        if "=" in line:
-            config_map[line.split('=')[0]] = line.split('=')[1]
-        # Find configs that are not set
-        # Example: # CONFIG_FOO is not set
-        elif "is not set" in line:
-            config_map[line.split()[1]] = "is not set"
-    return config_map
+    return dict(CONFIG_TO_VALUE_REGEX.findall(input_config_data))

--- a/toolkit/scripts/mariner-required-configs.json
+++ b/toolkit/scripts/mariner-required-configs.json
@@ -8,7 +8,9 @@
                 "AMD64"
             ],
             "comment": "Needed for customer",
-            "PR": "https://github.com/microsoft/CBL-Mariner/pull/84"
+            "PR": [
+                "https://github.com/microsoft/CBL-Mariner/pull/84"
+            ]
         },
         "CONFIG_DRM_AMDGPU_SI": {
             "value": [
@@ -18,7 +20,9 @@
                 "AMD64"
             ],
             "comment": "Needed for customer",
-            "PR": "https://github.com/microsoft/CBL-Mariner/pull/5416"
+            "PR": [
+                "https://github.com/microsoft/CBL-Mariner/pull/5416"
+            ]
         },
         "CONFIG_TLS": {
             "value": [
@@ -29,7 +33,9 @@
                 "AMD64"
             ],
             "comment": "Needed for customer",
-            "PR": "https://github.com/microsoft/CBL-Mariner/pull/5406"
+            "PR": [
+                "https://github.com/microsoft/CBL-Mariner/pull/5406"
+            ]
         },
         "CONFIG_NVME_TARGET_TCP": {
             "value": [
@@ -40,7 +46,9 @@
                 "AMD64"
             ],
             "comment": "Needed for customer",
-            "PR": "https://github.com/microsoft/CBL-Mariner/pull/5406"
+            "PR": [
+                "https://github.com/microsoft/CBL-Mariner/pull/5406"
+            ]
         },
         "CONFIG_DELL_WMI_DESCRIPTOR": {
             "value": [
@@ -51,7 +59,9 @@
                 "AMD64"
             ],
             "comment": "Needed for customer",
-            "PR": "https://github.com/microsoft/CBL-Mariner/pull/5406"
+            "PR": [
+                "https://github.com/microsoft/CBL-Mariner/pull/5406"
+            ]
         },
         "CONFIG_X86_PLATFORM_DRIVERS_DELL": {
             "value": [
@@ -61,7 +71,9 @@
                 "AMD64"
             ],
             "comment": "Needed for customer",
-            "PR": "https://github.com/microsoft/CBL-Mariner/pull/2671"
+            "PR": [
+                "https://github.com/microsoft/CBL-Mariner/pull/2671"
+            ]
         },
         "CONFIG_DRM_AMDGPU": {
             "value": [
@@ -72,7 +84,9 @@
                 "AMD64"
             ],
             "comment": "Needed for customer",
-            "PR": "https://github.com/microsoft/CBL-Mariner/pull/5416"
+            "PR": [
+                "https://github.com/microsoft/CBL-Mariner/pull/5416"
+            ]
         },
         "CONFIG_BINFMT_MISC": {
             "value": [
@@ -82,7 +96,9 @@
                 "AMD64"
             ],
             "comment": "Needed for customer",
-            "PR": "https://github.com/microsoft/CBL-Mariner/pull/3300"
+            "PR": [
+                "https://github.com/microsoft/CBL-Mariner/pull/3300"
+            ]
         },
         "CONFIG_SCHEDSTATS": {
             "value": [
@@ -92,7 +108,9 @@
                 "AMD64"
             ],
             "comment": "Needed for customer",
-            "PR": "Initial CBL-Mariner PR"
+            "PR": [
+                "Initial CBL-Mariner PR"
+            ]
         },
         "CONFIG_BLK_DEV_IO_TRACE": {
             "value": [
@@ -102,7 +120,9 @@
                 "AMD64"
             ],
             "comment": "Needed for customer",
-            "PR": "https://github.com/microsoft/CBL-Mariner/pull/5417"
+            "PR": [
+                "https://github.com/microsoft/CBL-Mariner/pull/5417"
+            ]
         },
         "CONFIG_ISO9660_FS": {
             "value": [
@@ -112,7 +132,9 @@
                 "AMD64"
             ],
             "comment": "Needed for customer",
-            "PR": "Initial CBL-Mariner PR"
+            "PR": [
+                "Initial CBL-Mariner PR"
+            ]
         },
         "CONFIG_DELL_WMI_LED": {
             "value": [
@@ -123,7 +145,9 @@
                 "AMD64"
             ],
             "comment": "Needed for customer",
-            "PR": "https://github.com/microsoft/CBL-Mariner/pull/5406"
+            "PR": [
+                "https://github.com/microsoft/CBL-Mariner/pull/5406"
+            ]
         },
         "CONFIG_TASKSTATS": {
             "value": [
@@ -133,7 +157,9 @@
                 "AMD64"
             ],
             "comment": "Needed for customer",
-            "PR": "Initial CBL-Mariner PR"
+            "PR": [
+                "Initial CBL-Mariner PR"
+            ]
         },
         "CONFIG_TASK_IO_ACCOUNTING": {
             "value": [
@@ -143,7 +169,9 @@
                 "AMD64"
             ],
             "comment": "Needed for customer",
-            "PR": "Initial CBL-Mariner PR"
+            "PR": [
+                "Initial CBL-Mariner PR"
+            ]
         },
         "CONFIG_DELL_SMBIOS_SMM": {
             "value": [
@@ -153,7 +181,9 @@
                 "AMD64"
             ],
             "comment": "Needed for customer",
-            "PR": "https://github.com/microsoft/CBL-Mariner/pull/2671"
+            "PR": [
+                "https://github.com/microsoft/CBL-Mariner/pull/2671"
+            ]
         },
         "CONFIG_IO_URING": {
             "value": [
@@ -163,7 +193,9 @@
                 "AMD64"
             ],
             "comment": "Needed for customer",
-            "PR": "Initial CBL-Mariner PR"
+            "PR": [
+                "Initial CBL-Mariner PR"
+            ]
         },
         "CONFIG_TASK_XACCT": {
             "value": [
@@ -173,7 +205,9 @@
                 "AMD64"
             ],
             "comment": "Needed for customer",
-            "PR": "Initial CBL-Mariner PR"
+            "PR": [
+                "Initial CBL-Mariner PR"
+            ]
         },
         "CONFIG_INFINIBAND_BNXT_RE": {
             "value": [
@@ -184,7 +218,9 @@
                 "AMD64"
             ],
             "comment": "Needed for customer",
-            "PR": "https://github.com/microsoft/CBL-Mariner/pull/5406"
+            "PR": [
+                "https://github.com/microsoft/CBL-Mariner/pull/5406"
+            ]
         },
         "CONFIG_DELL_WMI_PRIVACY": {
             "value": [
@@ -194,7 +230,9 @@
                 "AMD64"
             ],
             "comment": "Needed for customer",
-            "PR": "https://github.com/microsoft/CBL-Mariner/pull/5406"
+            "PR": [
+                "https://github.com/microsoft/CBL-Mariner/pull/5406"
+            ]
         },
         "CONFIG_DELL_SMO8800": {
             "value": [
@@ -205,7 +243,9 @@
                 "AMD64"
             ],
             "comment": "Needed for customer",
-            "PR": "https://github.com/microsoft/CBL-Mariner/pull/2671"
+            "PR": [
+                "https://github.com/microsoft/CBL-Mariner/pull/2671"
+            ]
         },
         "CONFIG_SENSORS_DELL_SMM": {
             "value": [
@@ -216,7 +256,9 @@
                 "AMD64"
             ],
             "comment": "Needed for customer",
-            "PR": "https://github.com/microsoft/CBL-Mariner/pull/5406"
+            "PR": [
+                "https://github.com/microsoft/CBL-Mariner/pull/5406"
+            ]
         },
         "CONFIG_DELL_RBU": {
             "value": [
@@ -227,7 +269,9 @@
                 "AMD64"
             ],
             "comment": "Needed for customer",
-            "PR": "https://github.com/microsoft/CBL-Mariner/pull/2671"
+            "PR": [
+                "https://github.com/microsoft/CBL-Mariner/pull/2671"
+            ]
         },
         "CONFIG_NVME_RDMA": {
             "value": [
@@ -238,7 +282,9 @@
                 "AMD64"
             ],
             "comment": "Needed for customer",
-            "PR": "https://github.com/microsoft/CBL-Mariner/pull/5283"
+            "PR": [
+                "https://github.com/microsoft/CBL-Mariner/pull/5283"
+            ]
         },
         "CONFIG_DELL_SMBIOS_WMI": {
             "value": [
@@ -248,7 +294,9 @@
                 "AMD64"
             ],
             "comment": "Needed for customer",
-            "PR": "https://github.com/microsoft/CBL-Mariner/pull/2671"
+            "PR": [
+                "https://github.com/microsoft/CBL-Mariner/pull/2671"
+            ]
         },
         "CONFIG_RAS_CEC": {
             "value": [
@@ -258,7 +306,9 @@
                 "AMD64"
             ],
             "comment": "Needed for customer",
-            "PR": "https://github.com/microsoft/CBL-Mariner/pull/5417"
+            "PR": [
+                "https://github.com/microsoft/CBL-Mariner/pull/5417"
+            ]
         },
         "CONFIG_DRM_AMDGPU_CIK": {
             "value": [
@@ -268,7 +318,9 @@
                 "AMD64"
             ],
             "comment": "Needed for customer",
-            "PR": "https://github.com/microsoft/CBL-Mariner/pull/5416"
+            "PR": [
+                "https://github.com/microsoft/CBL-Mariner/pull/5416"
+            ]
         },
         "CONFIG_DELL_WMI": {
             "value": [
@@ -279,7 +331,9 @@
                 "AMD64"
             ],
             "comment": "Needed for customer",
-            "PR": "https://github.com/microsoft/CBL-Mariner/pull/5406"
+            "PR": [
+                "https://github.com/microsoft/CBL-Mariner/pull/5406"
+            ]
         },
         "CONFIG_NVME_TCP": {
             "value": [
@@ -290,7 +344,9 @@
                 "AMD64"
             ],
             "comment": "Needed for customer",
-            "PR": "https://github.com/microsoft/CBL-Mariner/pull/5283"
+            "PR": [
+                "https://github.com/microsoft/CBL-Mariner/pull/5283"
+            ]
         },
         "CONFIG_DELL_WMI_AIO": {
             "value": [
@@ -301,7 +357,9 @@
                 "AMD64"
             ],
             "comment": "Needed for customer",
-            "PR": "https://github.com/microsoft/CBL-Mariner/pull/2671"
+            "PR": [
+                "https://github.com/microsoft/CBL-Mariner/pull/2671"
+            ]
         },
         "CONFIG_DELL_WMI_SYSMAN": {
             "value": [
@@ -312,7 +370,9 @@
                 "AMD64"
             ],
             "comment": "Needed for customer",
-            "PR": "https://github.com/microsoft/CBL-Mariner/pull/5406"
+            "PR": [
+                "https://github.com/microsoft/CBL-Mariner/pull/5406"
+            ]
         },
         "CONFIG_TASK_DELAY_ACCT": {
             "value": [
@@ -322,7 +382,9 @@
                 "AMD64"
             ],
             "comment": "Needed for customer",
-            "PR": "Initial CBL-Mariner PR"
+            "PR": [
+                "Initial CBL-Mariner PR"
+            ]
         },
         "CONFIG_DELL_SMBIOS": {
             "value": [
@@ -333,7 +395,9 @@
                 "AMD64"
             ],
             "comment": "Needed for customer",
-            "PR": "https://github.com/microsoft/CBL-Mariner/pull/2671"
+            "PR": [
+                "https://github.com/microsoft/CBL-Mariner/pull/2671"
+            ]
         },
         "CONFIG_THERMAL_HWMON": {
             "value": [
@@ -344,7 +408,9 @@
                 "AMD64"
             ],
             "comment": "Needed for customer",
-            "PR": "https://github.com/microsoft/CBL-Mariner/pull/5417"
+            "PR": [
+                "https://github.com/microsoft/CBL-Mariner/pull/5417"
+            ]
         },
         "CONFIG_TCG_TPM": {
             "value": [
@@ -354,7 +420,9 @@
                 "AMD64"
             ],
             "comment": "Needed for customer",
-            "PR": "https://github.com/microsoft/CBL-Mariner/pull/135"
+            "PR": [
+                "https://github.com/microsoft/CBL-Mariner/pull/135"
+            ]
         },
         "CONFIG_HW_RANDOM_TPM": {
             "value": [
@@ -364,7 +432,9 @@
                 "AMD64"
             ],
             "comment": "Needed for customer",
-            "PR": "Initial CBL-Mariner PR"
+            "PR": [
+                "Initial CBL-Mariner PR"
+            ]
         },
         "CONFIG_EDAC_SKX": {
             "value": [
@@ -375,7 +445,9 @@
                 "AMD64"
             ],
             "comment": "Needed for customer",
-            "PR": "https://github.com/microsoft/CBL-Mariner/pull/5487"
+            "PR": [
+                "https://github.com/microsoft/CBL-Mariner/pull/5487"
+            ]
         },
         "CONFIG_NET_CLS_FLOWER": {
             "value": [
@@ -386,7 +458,9 @@
                 "AMD64"
             ],
             "comment": "Needed for customer",
-            "PR": "https://github.com/microsoft/CBL-Mariner/pull/5170"
+            "PR": [
+                "https://github.com/microsoft/CBL-Mariner/pull/5170"
+            ]
         },
         "CONFIG_HIST_TRIGGERS": {
             "value": [
@@ -396,7 +470,9 @@
                 "AMD64"
             ],
             "comment": "Needed for auoms metrics",
-            "PR": "https://github.com/microsoft/CBL-Mariner/pull/5292"
+            "PR": [
+                "https://github.com/microsoft/CBL-Mariner/pull/5292"
+            ]
         },
         "CONFIG_INIT_ON_FREE_DEFAULT_ON": {
             "value": [
@@ -408,7 +484,9 @@
                 "ARM64"
             ],
             "comment": "Creates increased boot times and errors on large memory systems",
-            "PR": "https://github.com/microsoft/CBL-Mariner/pull/4829"
+            "PR": [
+                "https://github.com/microsoft/CBL-Mariner/pull/4829"
+            ]
         },
         "CONFIG_WIREGUARD": {
             "value": [
@@ -419,7 +497,9 @@
                 "AMD64"
             ],
             "comment": "Needed for customer",
-            "PR": "https://github.com/microsoft/CBL-Mariner/pull/5135"
+            "PR": [
+                "https://github.com/microsoft/CBL-Mariner/pull/5135"
+            ]
         },
         "CONFIG_TARGET_CORE": {
             "value": [
@@ -430,7 +510,9 @@
                 "AMD64"
             ],
             "comment": "Needed for customer",
-            "PR": "https://github.com/microsoft/CBL-Mariner/pull/4473"
+            "PR": [
+                "https://github.com/microsoft/CBL-Mariner/pull/4473"
+            ]
         },
         "CONFIG_HIBERNATION": {
             "value": [
@@ -440,7 +522,9 @@
                 "AMD64"
             ],
             "comment": "Needed for customer",
-            "PR": "https://github.com/microsoft/CBL-Mariner/pull/4369"
+            "PR": [
+                "https://github.com/microsoft/CBL-Mariner/pull/4369"
+            ]
         },
         "CONFIG_TCP_CONG_BBR": {
             "value": [
@@ -451,7 +535,9 @@
                 "AMD64"
             ],
             "comment": "Needed for customer",
-            "PR": "https://github.com/microsoft/CBL-Mariner/pull/4122"
+            "PR": [
+                "https://github.com/microsoft/CBL-Mariner/pull/4122"
+            ]
         },
         "CONFIG_CC_CAN_LINK_STATIC": {
             "value": [
@@ -462,7 +548,9 @@
                 "ARM64"
             ],
             "comment": "Remove static linking support from the kernel",
-            "PR": "https://github.com/microsoft/CBL-Mariner/pull/3748"
+            "PR": [
+                "https://github.com/microsoft/CBL-Mariner/pull/3748"
+            ]
         },
         "CONFIG_SCSI_LOGGING": {
             "value": [
@@ -473,7 +561,9 @@
                 "AMD64"
             ],
             "comment": "Needed for customer",
-            "PR": "https://github.com/microsoft/CBL-Mariner/pull/3826"
+            "PR": [
+                "https://github.com/microsoft/CBL-Mariner/pull/3826"
+            ]
         },
         "CONFIG_NETFILTER_XT_TARGET_TRACE": {
             "value": [
@@ -484,7 +574,9 @@
                 "AMD64"
             ],
             "comment": "Needed for the iptables TRACE target",
-            "PR": "https://github.com/microsoft/CBL-Mariner/pull/3783"
+            "PR": [
+                "https://github.com/microsoft/CBL-Mariner/pull/3783"
+            ]
         },
         "CONFIG_VFAT_FS": {
             "value": [
@@ -494,7 +586,9 @@
                 "AMD64"
             ],
             "comment": "Make vfat always available",
-            "PR": "https://github.com/microsoft/CBL-Mariner/pull/3733"
+            "PR": [
+                "https://github.com/microsoft/CBL-Mariner/pull/3733"
+            ]
         },
         "CONFIG_COMPAT_32BIT_TIME": {
             "value": [
@@ -505,7 +599,9 @@
                 "AMD64"
             ],
             "comment": "Avoid error that 2 bit get_time syscalls aren't available",
-            "PR": "https://github.com/microsoft/CBL-Mariner/pull/3812"
+            "PR": [
+                "https://github.com/microsoft/CBL-Mariner/pull/3812"
+            ]
         },
         "CONFIG_SECURITY_LANDLOCK": {
             "value": [
@@ -516,7 +612,9 @@
                 "AMD64"
             ],
             "comment": "Security",
-            "PR": "https://github.com/microsoft/CBL-Mariner/pull/3484"
+            "PR": [
+                "https://github.com/microsoft/CBL-Mariner/pull/3484"
+            ]
         },
         "CONFIG_BLK_DEV_ZONED": {
             "value": [
@@ -527,7 +625,9 @@
                 "AMD64"
             ],
             "comment": "Zoned block device support",
-            "PR": "https://github.com/microsoft/CBL-Mariner/pull/3465"
+            "PR": [
+                "https://github.com/microsoft/CBL-Mariner/pull/3465"
+            ]
         },
         "CONFIG_FTRACE_SYSCALLS": {
             "value": [
@@ -538,7 +638,9 @@
                 "AMD64"
             ],
             "comment": "Needed to enable eBPF CO-RE syscalls tracers",
-            "PR": "https://github.com/microsoft/CBL-Mariner/pull/3210"
+            "PR": [
+                "https://github.com/microsoft/CBL-Mariner/pull/3210"
+            ]
         },
         "CONFIG_VIRTIO_FS": {
             "value": [
@@ -549,7 +651,9 @@
                 "AMD64"
             ],
             "comment": "Needed to see logs in Azure serial console",
-            "PR": "https://github.com/microsoft/CBL-Mariner/pull/3264"
+            "PR": [
+                "https://github.com/microsoft/CBL-Mariner/pull/3264"
+            ]
         },
         "CONFIG_DRM_VGEM": {
             "value": [
@@ -560,7 +664,9 @@
                 "AMD64"
             ],
             "comment": "Needed to enable media acceleration",
-            "PR": "https://github.com/microsoft/CBL-Mariner/pull/3227"
+            "PR": [
+                "https://github.com/microsoft/CBL-Mariner/pull/3227"
+            ]
         },
         "CONFIG_PTP_1588_CLOCK_KVM": {
             "value": [
@@ -571,7 +677,9 @@
                 "AMD64"
             ],
             "comment": "Removes error boot message 'failed to initialize ptp kvm'",
-            "PR": "https://github.com/microsoft/CBL-Mariner/pull/3122"
+            "PR": [
+                "https://github.com/microsoft/CBL-Mariner/pull/3122"
+            ]
         },
         "CONFIG_LIVEPATCH": {
             "value": [
@@ -581,7 +689,9 @@
                 "AMD64"
             ],
             "comment": "Needed for livepatching",
-            "PR": "https://github.com/microsoft/CBL-Mariner/pull/3107"
+            "PR": [
+                "https://github.com/microsoft/CBL-Mariner/pull/3107"
+            ]
         },
         "CONFIG_SECURITY_SMACK": {
             "value": [
@@ -593,7 +703,9 @@
                 "ARM64"
             ],
             "comment": "Removed in favor of SELinux",
-            "PR": "https://github.com/microsoft/CBL-Mariner/pull/3080"
+            "PR": [
+                "https://github.com/microsoft/CBL-Mariner/pull/3080"
+            ]
         },
         "CONFIG_FW_LOADER_COMPRESS": {
             "value": [
@@ -603,7 +715,9 @@
                 "AMD64"
             ],
             "comment": " QLogic NIC firmware in linux-firmware is compressed",
-            "PR": "https://github.com/microsoft/CBL-Mariner/pull/2201"
+            "PR": [
+                "https://github.com/microsoft/CBL-Mariner/pull/2201"
+            ]
         },
         "CONFIG_VFIO_NOIOMMU": {
             "value": [
@@ -613,7 +727,9 @@
                 "AMD64"
             ],
             "comment": "VMs may not have access to iommu",
-            "PR": "https://github.com/microsoft/CBL-Mariner/pull/2385"
+            "PR": [
+                "https://github.com/microsoft/CBL-Mariner/pull/2385"
+            ]
         },
         "CONFIG_IO_STRICT_DEVMEM": {
             "value": [
@@ -623,7 +739,9 @@
                 "AMD64"
             ],
             "comment": "Needed for tboot",
-            "PR": "https://github.com/microsoft/CBL-Mariner/pull/2357"
+            "PR": [
+                "https://github.com/microsoft/CBL-Mariner/pull/2357"
+            ]
         },
         "CONFIG_BPF_UNPRIV_DEFAULT_OFF": {
             "value": [
@@ -634,7 +752,9 @@
                 "ARM64"
             ],
             "comment": "Needed for CVE-2021-20194",
-            "PR": "https://github.com/microsoft/CBL-Mariner/pull/2352"
+            "PR": [
+                "https://github.com/microsoft/CBL-Mariner/pull/2352"
+            ]
         }
     }
 }

--- a/toolkit/scripts/mariner-required-configs.json
+++ b/toolkit/scripts/mariner-required-configs.json
@@ -8,7 +8,7 @@
                 "AMD64"
             ],
             "comment": "Needed for customer",
-            "PR": null
+            "PR": "https://github.com/microsoft/CBL-Mariner/pull/84"
         },
         "CONFIG_DRM_AMDGPU_SI": {
             "value": [
@@ -82,7 +82,7 @@
                 "AMD64"
             ],
             "comment": "Needed for customer",
-            "PR": null
+            "PR": "https://github.com/microsoft/CBL-Mariner/pull/3300"
         },
         "CONFIG_SCHEDSTATS": {
             "value": [
@@ -92,7 +92,7 @@
                 "AMD64"
             ],
             "comment": "Needed for customer",
-            "PR": null
+            "PR": "Initial CBL-Mariner PR"
         },
         "CONFIG_BLK_DEV_IO_TRACE": {
             "value": [
@@ -112,7 +112,7 @@
                 "AMD64"
             ],
             "comment": "Needed for customer",
-            "PR": null
+            "PR": "Initial CBL-Mariner PR"
         },
         "CONFIG_DELL_WMI_LED": {
             "value": [
@@ -133,7 +133,7 @@
                 "AMD64"
             ],
             "comment": "Needed for customer",
-            "PR": null
+            "PR": "Initial CBL-Mariner PR"
         },
         "CONFIG_TASK_IO_ACCOUNTING": {
             "value": [
@@ -143,7 +143,7 @@
                 "AMD64"
             ],
             "comment": "Needed for customer",
-            "PR": null
+            "PR": "Initial CBL-Mariner PR"
         },
         "CONFIG_DELL_SMBIOS_SMM": {
             "value": [
@@ -163,7 +163,7 @@
                 "AMD64"
             ],
             "comment": "Needed for customer",
-            "PR": null
+            "PR": "Initial CBL-Mariner PR"
         },
         "CONFIG_TASK_XACCT": {
             "value": [
@@ -173,7 +173,7 @@
                 "AMD64"
             ],
             "comment": "Needed for customer",
-            "PR": null
+            "PR": "Initial CBL-Mariner PR"
         },
         "CONFIG_INFINIBAND_BNXT_RE": {
             "value": [
@@ -216,7 +216,7 @@
                 "AMD64"
             ],
             "comment": "Needed for customer",
-            "PR": null
+            "PR": "https://github.com/microsoft/CBL-Mariner/pull/5406"
         },
         "CONFIG_DELL_RBU": {
             "value": [
@@ -238,7 +238,7 @@
                 "AMD64"
             ],
             "comment": "Needed for customer",
-            "PR": null
+            "PR": "https://github.com/microsoft/CBL-Mariner/pull/5283"
         },
         "CONFIG_DELL_SMBIOS_WMI": {
             "value": [
@@ -290,7 +290,7 @@
                 "AMD64"
             ],
             "comment": "Needed for customer",
-            "PR": null
+            "PR": "https://github.com/microsoft/CBL-Mariner/pull/5283"
         },
         "CONFIG_DELL_WMI_AIO": {
             "value": [
@@ -322,7 +322,7 @@
                 "AMD64"
             ],
             "comment": "Needed for customer",
-            "PR": null
+            "PR": "Initial CBL-Mariner PR"
         },
         "CONFIG_DELL_SMBIOS": {
             "value": [
@@ -354,7 +354,7 @@
                 "AMD64"
             ],
             "comment": "Needed for customer",
-            "PR": null
+            "PR": "https://github.com/microsoft/CBL-Mariner/pull/135"
         },
         "CONFIG_HW_RANDOM_TPM": {
             "value": [
@@ -364,7 +364,7 @@
                 "AMD64"
             ],
             "comment": "Needed for customer",
-            "PR": null
+            "PR": "Initial CBL-Mariner PR"
         },
         "CONFIG_EDAC_SKX": {
             "value": [

--- a/toolkit/scripts/mariner-required-configs.json
+++ b/toolkit/scripts/mariner-required-configs.json
@@ -1,760 +1,762 @@
 {
-    "required-configs": {
-        "CONFIG_INTEL_IOMMU_SVM": {
-            "value": [
-                "y"
-            ],
-            "arch": [
-                "AMD64"
-            ],
-            "comment": "Needed for customer",
-            "PR": [
-                "https://github.com/microsoft/CBL-Mariner/pull/84"
-            ]
-        },
-        "CONFIG_DRM_AMDGPU_SI": {
-            "value": [
-                "y"
-            ],
-            "arch": [
-                "AMD64"
-            ],
-            "comment": "Needed for customer",
-            "PR": [
-                "https://github.com/microsoft/CBL-Mariner/pull/5416"
-            ]
-        },
-        "CONFIG_TLS": {
-            "value": [
-                "m",
-                "y"
-            ],
-            "arch": [
-                "AMD64"
-            ],
-            "comment": "Needed for customer",
-            "PR": [
-                "https://github.com/microsoft/CBL-Mariner/pull/5406"
-            ]
-        },
-        "CONFIG_NVME_TARGET_TCP": {
-            "value": [
-                "m",
-                "y"
-            ],
-            "arch": [
-                "AMD64"
-            ],
-            "comment": "Needed for customer",
-            "PR": [
-                "https://github.com/microsoft/CBL-Mariner/pull/5406"
-            ]
-        },
-        "CONFIG_DELL_WMI_DESCRIPTOR": {
-            "value": [
-                "m",
-                "y"
-            ],
-            "arch": [
-                "AMD64"
-            ],
-            "comment": "Needed for customer",
-            "PR": [
-                "https://github.com/microsoft/CBL-Mariner/pull/5406"
-            ]
-        },
-        "CONFIG_X86_PLATFORM_DRIVERS_DELL": {
-            "value": [
-                "y"
-            ],
-            "arch": [
-                "AMD64"
-            ],
-            "comment": "Needed for customer",
-            "PR": [
-                "https://github.com/microsoft/CBL-Mariner/pull/2671"
-            ]
-        },
-        "CONFIG_DRM_AMDGPU": {
-            "value": [
-                "m",
-                "y"
-            ],
-            "arch": [
-                "AMD64"
-            ],
-            "comment": "Needed for customer",
-            "PR": [
-                "https://github.com/microsoft/CBL-Mariner/pull/5416"
-            ]
-        },
-        "CONFIG_BINFMT_MISC": {
-            "value": [
-                "y"
-            ],
-            "arch": [
-                "AMD64"
-            ],
-            "comment": "Needed for customer",
-            "PR": [
-                "https://github.com/microsoft/CBL-Mariner/pull/3300"
-            ]
-        },
-        "CONFIG_SCHEDSTATS": {
-            "value": [
-                "y"
-            ],
-            "arch": [
-                "AMD64"
-            ],
-            "comment": "Needed for customer",
-            "PR": [
-                "Initial CBL-Mariner PR"
-            ]
-        },
-        "CONFIG_BLK_DEV_IO_TRACE": {
-            "value": [
-                "y"
-            ],
-            "arch": [
-                "AMD64"
-            ],
-            "comment": "Needed for customer",
-            "PR": [
-                "https://github.com/microsoft/CBL-Mariner/pull/5417"
-            ]
-        },
-        "CONFIG_ISO9660_FS": {
-            "value": [
-                "y"
-            ],
-            "arch": [
-                "AMD64"
-            ],
-            "comment": "Needed for customer",
-            "PR": [
-                "Initial CBL-Mariner PR"
-            ]
-        },
-        "CONFIG_DELL_WMI_LED": {
-            "value": [
-                "m",
-                "y"
-            ],
-            "arch": [
-                "AMD64"
-            ],
-            "comment": "Needed for customer",
-            "PR": [
-                "https://github.com/microsoft/CBL-Mariner/pull/5406"
-            ]
-        },
-        "CONFIG_TASKSTATS": {
-            "value": [
-                "y"
-            ],
-            "arch": [
-                "AMD64"
-            ],
-            "comment": "Needed for customer",
-            "PR": [
-                "Initial CBL-Mariner PR"
-            ]
-        },
-        "CONFIG_TASK_IO_ACCOUNTING": {
-            "value": [
-                "y"
-            ],
-            "arch": [
-                "AMD64"
-            ],
-            "comment": "Needed for customer",
-            "PR": [
-                "Initial CBL-Mariner PR"
-            ]
-        },
-        "CONFIG_DELL_SMBIOS_SMM": {
-            "value": [
-                "y"
-            ],
-            "arch": [
-                "AMD64"
-            ],
-            "comment": "Needed for customer",
-            "PR": [
-                "https://github.com/microsoft/CBL-Mariner/pull/2671"
-            ]
-        },
-        "CONFIG_IO_URING": {
-            "value": [
-                "y"
-            ],
-            "arch": [
-                "AMD64"
-            ],
-            "comment": "Needed for customer",
-            "PR": [
-                "Initial CBL-Mariner PR"
-            ]
-        },
-        "CONFIG_TASK_XACCT": {
-            "value": [
-                "y"
-            ],
-            "arch": [
-                "AMD64"
-            ],
-            "comment": "Needed for customer",
-            "PR": [
-                "Initial CBL-Mariner PR"
-            ]
-        },
-        "CONFIG_INFINIBAND_BNXT_RE": {
-            "value": [
-                "m",
-                "y"
-            ],
-            "arch": [
-                "AMD64"
-            ],
-            "comment": "Needed for customer",
-            "PR": [
-                "https://github.com/microsoft/CBL-Mariner/pull/5406"
-            ]
-        },
-        "CONFIG_DELL_WMI_PRIVACY": {
-            "value": [
-                "y"
-            ],
-            "arch": [
-                "AMD64"
-            ],
-            "comment": "Needed for customer",
-            "PR": [
-                "https://github.com/microsoft/CBL-Mariner/pull/5406"
-            ]
-        },
-        "CONFIG_DELL_SMO8800": {
-            "value": [
-                "m",
-                "y"
-            ],
-            "arch": [
-                "AMD64"
-            ],
-            "comment": "Needed for customer",
-            "PR": [
-                "https://github.com/microsoft/CBL-Mariner/pull/2671"
-            ]
-        },
-        "CONFIG_SENSORS_DELL_SMM": {
-            "value": [
-                "m",
-                "y"
-            ],
-            "arch": [
-                "AMD64"
-            ],
-            "comment": "Needed for customer",
-            "PR": [
-                "https://github.com/microsoft/CBL-Mariner/pull/5406"
-            ]
-        },
-        "CONFIG_DELL_RBU": {
-            "value": [
-                "m",
-                "y"
-            ],
-            "arch": [
-                "AMD64"
-            ],
-            "comment": "Needed for customer",
-            "PR": [
-                "https://github.com/microsoft/CBL-Mariner/pull/2671"
-            ]
-        },
-        "CONFIG_NVME_RDMA": {
-            "value": [
-                "m",
-                "y"
-            ],
-            "arch": [
-                "AMD64"
-            ],
-            "comment": "Needed for customer",
-            "PR": [
-                "https://github.com/microsoft/CBL-Mariner/pull/5283"
-            ]
-        },
-        "CONFIG_DELL_SMBIOS_WMI": {
-            "value": [
-                "y"
-            ],
-            "arch": [
-                "AMD64"
-            ],
-            "comment": "Needed for customer",
-            "PR": [
-                "https://github.com/microsoft/CBL-Mariner/pull/2671"
-            ]
-        },
-        "CONFIG_RAS_CEC": {
-            "value": [
-                "y"
-            ],
-            "arch": [
-                "AMD64"
-            ],
-            "comment": "Needed for customer",
-            "PR": [
-                "https://github.com/microsoft/CBL-Mariner/pull/5417"
-            ]
-        },
-        "CONFIG_DRM_AMDGPU_CIK": {
-            "value": [
-                "y"
-            ],
-            "arch": [
-                "AMD64"
-            ],
-            "comment": "Needed for customer",
-            "PR": [
-                "https://github.com/microsoft/CBL-Mariner/pull/5416"
-            ]
-        },
-        "CONFIG_DELL_WMI": {
-            "value": [
-                "m",
-                "y"
-            ],
-            "arch": [
-                "AMD64"
-            ],
-            "comment": "Needed for customer",
-            "PR": [
-                "https://github.com/microsoft/CBL-Mariner/pull/5406"
-            ]
-        },
-        "CONFIG_NVME_TCP": {
-            "value": [
-                "m",
-                "y"
-            ],
-            "arch": [
-                "AMD64"
-            ],
-            "comment": "Needed for customer",
-            "PR": [
-                "https://github.com/microsoft/CBL-Mariner/pull/5283"
-            ]
-        },
-        "CONFIG_DELL_WMI_AIO": {
-            "value": [
-                "m",
-                "y"
-            ],
-            "arch": [
-                "AMD64"
-            ],
-            "comment": "Needed for customer",
-            "PR": [
-                "https://github.com/microsoft/CBL-Mariner/pull/2671"
-            ]
-        },
-        "CONFIG_DELL_WMI_SYSMAN": {
-            "value": [
-                "m",
-                "y"
-            ],
-            "arch": [
-                "AMD64"
-            ],
-            "comment": "Needed for customer",
-            "PR": [
-                "https://github.com/microsoft/CBL-Mariner/pull/5406"
-            ]
-        },
-        "CONFIG_TASK_DELAY_ACCT": {
-            "value": [
-                "y"
-            ],
-            "arch": [
-                "AMD64"
-            ],
-            "comment": "Needed for customer",
-            "PR": [
-                "Initial CBL-Mariner PR"
-            ]
-        },
-        "CONFIG_DELL_SMBIOS": {
-            "value": [
-                "m",
-                "y"
-            ],
-            "arch": [
-                "AMD64"
-            ],
-            "comment": "Needed for customer",
-            "PR": [
-                "https://github.com/microsoft/CBL-Mariner/pull/2671"
-            ]
-        },
-        "CONFIG_THERMAL_HWMON": {
-            "value": [
-                "m",
-                "y"
-            ],
-            "arch": [
-                "AMD64"
-            ],
-            "comment": "Needed for customer",
-            "PR": [
-                "https://github.com/microsoft/CBL-Mariner/pull/5417"
-            ]
-        },
-        "CONFIG_TCG_TPM": {
-            "value": [
-                "y"
-            ],
-            "arch": [
-                "AMD64"
-            ],
-            "comment": "Needed for customer",
-            "PR": [
-                "https://github.com/microsoft/CBL-Mariner/pull/135"
-            ]
-        },
-        "CONFIG_HW_RANDOM_TPM": {
-            "value": [
-                "y"
-            ],
-            "arch": [
-                "AMD64"
-            ],
-            "comment": "Needed for customer",
-            "PR": [
-                "Initial CBL-Mariner PR"
-            ]
-        },
-        "CONFIG_EDAC_SKX": {
-            "value": [
-                "m",
-                "y"
-            ],
-            "arch": [
-                "AMD64"
-            ],
-            "comment": "Needed for customer",
-            "PR": [
-                "https://github.com/microsoft/CBL-Mariner/pull/5487"
-            ]
-        },
-        "CONFIG_NET_CLS_FLOWER": {
-            "value": [
-                "m",
-                "y"
-            ],
-            "arch": [
-                "AMD64"
-            ],
-            "comment": "Needed for customer",
-            "PR": [
-                "https://github.com/microsoft/CBL-Mariner/pull/5170"
-            ]
-        },
-        "CONFIG_HIST_TRIGGERS": {
-            "value": [
-                "y"
-            ],
-            "arch": [
-                "AMD64"
-            ],
-            "comment": "Needed for auoms metrics",
-            "PR": [
-                "https://github.com/microsoft/CBL-Mariner/pull/5292"
-            ]
-        },
-        "CONFIG_INIT_ON_FREE_DEFAULT_ON": {
-            "value": [
-                "is not set",
-                ""
-            ],
-            "arch": [
-                "AMD64",
-                "ARM64"
-            ],
-            "comment": "Creates increased boot times and errors on large memory systems",
-            "PR": [
-                "https://github.com/microsoft/CBL-Mariner/pull/4829"
-            ]
-        },
-        "CONFIG_WIREGUARD": {
-            "value": [
-                "m",
-                "y"
-            ],
-            "arch": [
-                "AMD64"
-            ],
-            "comment": "Needed for customer",
-            "PR": [
-                "https://github.com/microsoft/CBL-Mariner/pull/5135"
-            ]
-        },
-        "CONFIG_TARGET_CORE": {
-            "value": [
-                "m",
-                "y"
-            ],
-            "arch": [
-                "AMD64"
-            ],
-            "comment": "Needed for customer",
-            "PR": [
-                "https://github.com/microsoft/CBL-Mariner/pull/4473"
-            ]
-        },
-        "CONFIG_HIBERNATION": {
-            "value": [
-                "y"
-            ],
-            "arch": [
-                "AMD64"
-            ],
-            "comment": "Needed for customer",
-            "PR": [
-                "https://github.com/microsoft/CBL-Mariner/pull/4369"
-            ]
-        },
-        "CONFIG_TCP_CONG_BBR": {
-            "value": [
-                "m",
-                "y"
-            ],
-            "arch": [
-                "AMD64"
-            ],
-            "comment": "Needed for customer",
-            "PR": [
-                "https://github.com/microsoft/CBL-Mariner/pull/4122"
-            ]
-        },
-        "CONFIG_CC_CAN_LINK_STATIC": {
-            "value": [
-                ""
-            ],
-            "arch": [
-                "AMD64",
-                "ARM64"
-            ],
-            "comment": "Remove static linking support from the kernel",
-            "PR": [
-                "https://github.com/microsoft/CBL-Mariner/pull/3748"
-            ]
-        },
-        "CONFIG_SCSI_LOGGING": {
-            "value": [
-                "m",
-                "y"
-            ],
-            "arch": [
-                "AMD64"
-            ],
-            "comment": "Needed for customer",
-            "PR": [
-                "https://github.com/microsoft/CBL-Mariner/pull/3826"
-            ]
-        },
-        "CONFIG_NETFILTER_XT_TARGET_TRACE": {
-            "value": [
-                "m",
-                "y"
-            ],
-            "arch": [
-                "AMD64"
-            ],
-            "comment": "Needed for the iptables TRACE target",
-            "PR": [
-                "https://github.com/microsoft/CBL-Mariner/pull/3783"
-            ]
-        },
-        "CONFIG_VFAT_FS": {
-            "value": [
-                "y"
-            ],
-            "arch": [
-                "AMD64"
-            ],
-            "comment": "Make vfat always available",
-            "PR": [
-                "https://github.com/microsoft/CBL-Mariner/pull/3733"
-            ]
-        },
-        "CONFIG_COMPAT_32BIT_TIME": {
-            "value": [
-                "m",
-                "y"
-            ],
-            "arch": [
-                "AMD64"
-            ],
-            "comment": "Avoid error that 2 bit get_time syscalls aren't available",
-            "PR": [
-                "https://github.com/microsoft/CBL-Mariner/pull/3812"
-            ]
-        },
-        "CONFIG_SECURITY_LANDLOCK": {
-            "value": [
-                "m",
-                "y"
-            ],
-            "arch": [
-                "AMD64"
-            ],
-            "comment": "Security",
-            "PR": [
-                "https://github.com/microsoft/CBL-Mariner/pull/3484"
-            ]
-        },
-        "CONFIG_BLK_DEV_ZONED": {
-            "value": [
-                "m",
-                "y"
-            ],
-            "arch": [
-                "AMD64"
-            ],
-            "comment": "Zoned block device support",
-            "PR": [
-                "https://github.com/microsoft/CBL-Mariner/pull/3465"
-            ]
-        },
-        "CONFIG_FTRACE_SYSCALLS": {
-            "value": [
-                "m",
-                "y"
-            ],
-            "arch": [
-                "AMD64"
-            ],
-            "comment": "Needed to enable eBPF CO-RE syscalls tracers",
-            "PR": [
-                "https://github.com/microsoft/CBL-Mariner/pull/3210"
-            ]
-        },
-        "CONFIG_VIRTIO_FS": {
-            "value": [
-                "m",
-                "y"
-            ],
-            "arch": [
-                "AMD64"
-            ],
-            "comment": "Needed to see logs in Azure serial console",
-            "PR": [
-                "https://github.com/microsoft/CBL-Mariner/pull/3264"
-            ]
-        },
-        "CONFIG_DRM_VGEM": {
-            "value": [
-                "m",
-                "y"
-            ],
-            "arch": [
-                "AMD64"
-            ],
-            "comment": "Needed to enable media acceleration",
-            "PR": [
-                "https://github.com/microsoft/CBL-Mariner/pull/3227"
-            ]
-        },
-        "CONFIG_PTP_1588_CLOCK_KVM": {
-            "value": [
-                "m",
-                "y"
-            ],
-            "arch": [
-                "AMD64"
-            ],
-            "comment": "Removes error boot message 'failed to initialize ptp kvm'",
-            "PR": [
-                "https://github.com/microsoft/CBL-Mariner/pull/3122"
-            ]
-        },
-        "CONFIG_LIVEPATCH": {
-            "value": [
-                "y"
-            ],
-            "arch": [
-                "AMD64"
-            ],
-            "comment": "Needed for livepatching",
-            "PR": [
-                "https://github.com/microsoft/CBL-Mariner/pull/3107"
-            ]
-        },
-        "CONFIG_SECURITY_SMACK": {
-            "value": [
-                "is not set",
-                ""
-            ],
-            "arch": [
-                "AMD64",
-                "ARM64"
-            ],
-            "comment": "Removed in favor of SELinux",
-            "PR": [
-                "https://github.com/microsoft/CBL-Mariner/pull/3080"
-            ]
-        },
-        "CONFIG_FW_LOADER_COMPRESS": {
-            "value": [
-                "y"
-            ],
-            "arch": [
-                "AMD64"
-            ],
-            "comment": " QLogic NIC firmware in linux-firmware is compressed",
-            "PR": [
-                "https://github.com/microsoft/CBL-Mariner/pull/2201"
-            ]
-        },
-        "CONFIG_VFIO_NOIOMMU": {
-            "value": [
-                "y"
-            ],
-            "arch": [
-                "AMD64"
-            ],
-            "comment": "VMs may not have access to iommu",
-            "PR": [
-                "https://github.com/microsoft/CBL-Mariner/pull/2385"
-            ]
-        },
-        "CONFIG_IO_STRICT_DEVMEM": {
-            "value": [
-                "y"
-            ],
-            "arch": [
-                "AMD64"
-            ],
-            "comment": "Needed for tboot",
-            "PR": [
-                "https://github.com/microsoft/CBL-Mariner/pull/2357"
-            ]
-        },
-        "CONFIG_BPF_UNPRIV_DEFAULT_OFF": {
-            "value": [
-                "y"
-            ],
-            "arch": [
-                "AMD64",
-                "ARM64"
-            ],
-            "comment": "Needed for CVE-2021-20194",
-            "PR": [
-                "https://github.com/microsoft/CBL-Mariner/pull/2352"
-            ]
+    "kernel": {
+        "required-configs": {
+            "CONFIG_INTEL_IOMMU_SVM": {
+                "value": [
+                    "y"
+                ],
+                "arch": [
+                    "AMD64"
+                ],
+                "comment": "Needed for customer",
+                "PR": [
+                    "https://github.com/microsoft/CBL-Mariner/pull/84"
+                ]
+            },
+            "CONFIG_DRM_AMDGPU_SI": {
+                "value": [
+                    "y"
+                ],
+                "arch": [
+                    "AMD64"
+                ],
+                "comment": "Needed for customer",
+                "PR": [
+                    "https://github.com/microsoft/CBL-Mariner/pull/5416"
+                ]
+            },
+            "CONFIG_TLS": {
+                "value": [
+                    "m",
+                    "y"
+                ],
+                "arch": [
+                    "AMD64"
+                ],
+                "comment": "Needed for customer",
+                "PR": [
+                    "https://github.com/microsoft/CBL-Mariner/pull/5406"
+                ]
+            },
+            "CONFIG_NVME_TARGET_TCP": {
+                "value": [
+                    "m",
+                    "y"
+                ],
+                "arch": [
+                    "AMD64"
+                ],
+                "comment": "Needed for customer",
+                "PR": [
+                    "https://github.com/microsoft/CBL-Mariner/pull/5406"
+                ]
+            },
+            "CONFIG_DELL_WMI_DESCRIPTOR": {
+                "value": [
+                    "m",
+                    "y"
+                ],
+                "arch": [
+                    "AMD64"
+                ],
+                "comment": "Needed for customer",
+                "PR": [
+                    "https://github.com/microsoft/CBL-Mariner/pull/5406"
+                ]
+            },
+            "CONFIG_X86_PLATFORM_DRIVERS_DELL": {
+                "value": [
+                    "y"
+                ],
+                "arch": [
+                    "AMD64"
+                ],
+                "comment": "Needed for customer",
+                "PR": [
+                    "https://github.com/microsoft/CBL-Mariner/pull/2671"
+                ]
+            },
+            "CONFIG_DRM_AMDGPU": {
+                "value": [
+                    "m",
+                    "y"
+                ],
+                "arch": [
+                    "AMD64"
+                ],
+                "comment": "Needed for customer",
+                "PR": [
+                    "https://github.com/microsoft/CBL-Mariner/pull/5416"
+                ]
+            },
+            "CONFIG_BINFMT_MISC": {
+                "value": [
+                    "y"
+                ],
+                "arch": [
+                    "AMD64"
+                ],
+                "comment": "Needed for customer",
+                "PR": [
+                    "https://github.com/microsoft/CBL-Mariner/pull/3300"
+                ]
+            },
+            "CONFIG_SCHEDSTATS": {
+                "value": [
+                    "y"
+                ],
+                "arch": [
+                    "AMD64"
+                ],
+                "comment": "Needed for customer",
+                "PR": [
+                    "Initial CBL-Mariner PR"
+                ]
+            },
+            "CONFIG_BLK_DEV_IO_TRACE": {
+                "value": [
+                    "y"
+                ],
+                "arch": [
+                    "AMD64"
+                ],
+                "comment": "Needed for customer",
+                "PR": [
+                    "https://github.com/microsoft/CBL-Mariner/pull/5417"
+                ]
+            },
+            "CONFIG_ISO9660_FS": {
+                "value": [
+                    "y"
+                ],
+                "arch": [
+                    "AMD64"
+                ],
+                "comment": "Needed for customer",
+                "PR": [
+                    "Initial CBL-Mariner PR"
+                ]
+            },
+            "CONFIG_DELL_WMI_LED": {
+                "value": [
+                    "m",
+                    "y"
+                ],
+                "arch": [
+                    "AMD64"
+                ],
+                "comment": "Needed for customer",
+                "PR": [
+                    "https://github.com/microsoft/CBL-Mariner/pull/5406"
+                ]
+            },
+            "CONFIG_TASKSTATS": {
+                "value": [
+                    "y"
+                ],
+                "arch": [
+                    "AMD64"
+                ],
+                "comment": "Needed for customer",
+                "PR": [
+                    "Initial CBL-Mariner PR"
+                ]
+            },
+            "CONFIG_TASK_IO_ACCOUNTING": {
+                "value": [
+                    "y"
+                ],
+                "arch": [
+                    "AMD64"
+                ],
+                "comment": "Needed for customer",
+                "PR": [
+                    "Initial CBL-Mariner PR"
+                ]
+            },
+            "CONFIG_DELL_SMBIOS_SMM": {
+                "value": [
+                    "y"
+                ],
+                "arch": [
+                    "AMD64"
+                ],
+                "comment": "Needed for customer",
+                "PR": [
+                    "https://github.com/microsoft/CBL-Mariner/pull/2671"
+                ]
+            },
+            "CONFIG_IO_URING": {
+                "value": [
+                    "y"
+                ],
+                "arch": [
+                    "AMD64"
+                ],
+                "comment": "Needed for customer",
+                "PR": [
+                    "Initial CBL-Mariner PR"
+                ]
+            },
+            "CONFIG_TASK_XACCT": {
+                "value": [
+                    "y"
+                ],
+                "arch": [
+                    "AMD64"
+                ],
+                "comment": "Needed for customer",
+                "PR": [
+                    "Initial CBL-Mariner PR"
+                ]
+            },
+            "CONFIG_INFINIBAND_BNXT_RE": {
+                "value": [
+                    "m",
+                    "y"
+                ],
+                "arch": [
+                    "AMD64"
+                ],
+                "comment": "Needed for customer",
+                "PR": [
+                    "https://github.com/microsoft/CBL-Mariner/pull/5406"
+                ]
+            },
+            "CONFIG_DELL_WMI_PRIVACY": {
+                "value": [
+                    "y"
+                ],
+                "arch": [
+                    "AMD64"
+                ],
+                "comment": "Needed for customer",
+                "PR": [
+                    "https://github.com/microsoft/CBL-Mariner/pull/5406"
+                ]
+            },
+            "CONFIG_DELL_SMO8800": {
+                "value": [
+                    "m",
+                    "y"
+                ],
+                "arch": [
+                    "AMD64"
+                ],
+                "comment": "Needed for customer",
+                "PR": [
+                    "https://github.com/microsoft/CBL-Mariner/pull/2671"
+                ]
+            },
+            "CONFIG_SENSORS_DELL_SMM": {
+                "value": [
+                    "m",
+                    "y"
+                ],
+                "arch": [
+                    "AMD64"
+                ],
+                "comment": "Needed for customer",
+                "PR": [
+                    "https://github.com/microsoft/CBL-Mariner/pull/5406"
+                ]
+            },
+            "CONFIG_DELL_RBU": {
+                "value": [
+                    "m",
+                    "y"
+                ],
+                "arch": [
+                    "AMD64"
+                ],
+                "comment": "Needed for customer",
+                "PR": [
+                    "https://github.com/microsoft/CBL-Mariner/pull/2671"
+                ]
+            },
+            "CONFIG_NVME_RDMA": {
+                "value": [
+                    "m",
+                    "y"
+                ],
+                "arch": [
+                    "AMD64"
+                ],
+                "comment": "Needed for customer",
+                "PR": [
+                    "https://github.com/microsoft/CBL-Mariner/pull/5283"
+                ]
+            },
+            "CONFIG_DELL_SMBIOS_WMI": {
+                "value": [
+                    "y"
+                ],
+                "arch": [
+                    "AMD64"
+                ],
+                "comment": "Needed for customer",
+                "PR": [
+                    "https://github.com/microsoft/CBL-Mariner/pull/2671"
+                ]
+            },
+            "CONFIG_RAS_CEC": {
+                "value": [
+                    "y"
+                ],
+                "arch": [
+                    "AMD64"
+                ],
+                "comment": "Needed for customer",
+                "PR": [
+                    "https://github.com/microsoft/CBL-Mariner/pull/5417"
+                ]
+            },
+            "CONFIG_DRM_AMDGPU_CIK": {
+                "value": [
+                    "y"
+                ],
+                "arch": [
+                    "AMD64"
+                ],
+                "comment": "Needed for customer",
+                "PR": [
+                    "https://github.com/microsoft/CBL-Mariner/pull/5416"
+                ]
+            },
+            "CONFIG_DELL_WMI": {
+                "value": [
+                    "m",
+                    "y"
+                ],
+                "arch": [
+                    "AMD64"
+                ],
+                "comment": "Needed for customer",
+                "PR": [
+                    "https://github.com/microsoft/CBL-Mariner/pull/5406"
+                ]
+            },
+            "CONFIG_NVME_TCP": {
+                "value": [
+                    "m",
+                    "y"
+                ],
+                "arch": [
+                    "AMD64"
+                ],
+                "comment": "Needed for customer",
+                "PR": [
+                    "https://github.com/microsoft/CBL-Mariner/pull/5283"
+                ]
+            },
+            "CONFIG_DELL_WMI_AIO": {
+                "value": [
+                    "m",
+                    "y"
+                ],
+                "arch": [
+                    "AMD64"
+                ],
+                "comment": "Needed for customer",
+                "PR": [
+                    "https://github.com/microsoft/CBL-Mariner/pull/2671"
+                ]
+            },
+            "CONFIG_DELL_WMI_SYSMAN": {
+                "value": [
+                    "m",
+                    "y"
+                ],
+                "arch": [
+                    "AMD64"
+                ],
+                "comment": "Needed for customer",
+                "PR": [
+                    "https://github.com/microsoft/CBL-Mariner/pull/5406"
+                ]
+            },
+            "CONFIG_TASK_DELAY_ACCT": {
+                "value": [
+                    "y"
+                ],
+                "arch": [
+                    "AMD64"
+                ],
+                "comment": "Needed for customer",
+                "PR": [
+                    "Initial CBL-Mariner PR"
+                ]
+            },
+            "CONFIG_DELL_SMBIOS": {
+                "value": [
+                    "m",
+                    "y"
+                ],
+                "arch": [
+                    "AMD64"
+                ],
+                "comment": "Needed for customer",
+                "PR": [
+                    "https://github.com/microsoft/CBL-Mariner/pull/2671"
+                ]
+            },
+            "CONFIG_THERMAL_HWMON": {
+                "value": [
+                    "m",
+                    "y"
+                ],
+                "arch": [
+                    "AMD64"
+                ],
+                "comment": "Needed for customer",
+                "PR": [
+                    "https://github.com/microsoft/CBL-Mariner/pull/5417"
+                ]
+            },
+            "CONFIG_TCG_TPM": {
+                "value": [
+                    "y"
+                ],
+                "arch": [
+                    "AMD64"
+                ],
+                "comment": "Needed for customer",
+                "PR": [
+                    "https://github.com/microsoft/CBL-Mariner/pull/135"
+                ]
+            },
+            "CONFIG_HW_RANDOM_TPM": {
+                "value": [
+                    "y"
+                ],
+                "arch": [
+                    "AMD64"
+                ],
+                "comment": "Needed for customer",
+                "PR": [
+                    "Initial CBL-Mariner PR"
+                ]
+            },
+            "CONFIG_EDAC_SKX": {
+                "value": [
+                    "m",
+                    "y"
+                ],
+                "arch": [
+                    "AMD64"
+                ],
+                "comment": "Needed for customer",
+                "PR": [
+                    "https://github.com/microsoft/CBL-Mariner/pull/5487"
+                ]
+            },
+            "CONFIG_NET_CLS_FLOWER": {
+                "value": [
+                    "m",
+                    "y"
+                ],
+                "arch": [
+                    "AMD64"
+                ],
+                "comment": "Needed for customer",
+                "PR": [
+                    "https://github.com/microsoft/CBL-Mariner/pull/5170"
+                ]
+            },
+            "CONFIG_HIST_TRIGGERS": {
+                "value": [
+                    "y"
+                ],
+                "arch": [
+                    "AMD64"
+                ],
+                "comment": "Needed for auoms metrics",
+                "PR": [
+                    "https://github.com/microsoft/CBL-Mariner/pull/5292"
+                ]
+            },
+            "CONFIG_INIT_ON_FREE_DEFAULT_ON": {
+                "value": [
+                    "is not set",
+                    ""
+                ],
+                "arch": [
+                    "AMD64",
+                    "ARM64"
+                ],
+                "comment": "Creates increased boot times and errors on large memory systems",
+                "PR": [
+                    "https://github.com/microsoft/CBL-Mariner/pull/4829"
+                ]
+            },
+            "CONFIG_WIREGUARD": {
+                "value": [
+                    "m",
+                    "y"
+                ],
+                "arch": [
+                    "AMD64"
+                ],
+                "comment": "Needed for customer",
+                "PR": [
+                    "https://github.com/microsoft/CBL-Mariner/pull/5135"
+                ]
+            },
+            "CONFIG_TARGET_CORE": {
+                "value": [
+                    "m",
+                    "y"
+                ],
+                "arch": [
+                    "AMD64"
+                ],
+                "comment": "Needed for customer",
+                "PR": [
+                    "https://github.com/microsoft/CBL-Mariner/pull/4473"
+                ]
+            },
+            "CONFIG_HIBERNATION": {
+                "value": [
+                    "y"
+                ],
+                "arch": [
+                    "AMD64"
+                ],
+                "comment": "Needed for customer",
+                "PR": [
+                    "https://github.com/microsoft/CBL-Mariner/pull/4369"
+                ]
+            },
+            "CONFIG_TCP_CONG_BBR": {
+                "value": [
+                    "m",
+                    "y"
+                ],
+                "arch": [
+                    "AMD64"
+                ],
+                "comment": "Needed for customer",
+                "PR": [
+                    "https://github.com/microsoft/CBL-Mariner/pull/4122"
+                ]
+            },
+            "CONFIG_CC_CAN_LINK_STATIC": {
+                "value": [
+                    ""
+                ],
+                "arch": [
+                    "AMD64",
+                    "ARM64"
+                ],
+                "comment": "Remove static linking support from the kernel",
+                "PR": [
+                    "https://github.com/microsoft/CBL-Mariner/pull/3748"
+                ]
+            },
+            "CONFIG_SCSI_LOGGING": {
+                "value": [
+                    "m",
+                    "y"
+                ],
+                "arch": [
+                    "AMD64"
+                ],
+                "comment": "Needed for customer",
+                "PR": [
+                    "https://github.com/microsoft/CBL-Mariner/pull/3826"
+                ]
+            },
+            "CONFIG_NETFILTER_XT_TARGET_TRACE": {
+                "value": [
+                    "m",
+                    "y"
+                ],
+                "arch": [
+                    "AMD64"
+                ],
+                "comment": "Needed for the iptables TRACE target",
+                "PR": [
+                    "https://github.com/microsoft/CBL-Mariner/pull/3783"
+                ]
+            },
+            "CONFIG_VFAT_FS": {
+                "value": [
+                    "y"
+                ],
+                "arch": [
+                    "AMD64"
+                ],
+                "comment": "Make vfat always available",
+                "PR": [
+                    "https://github.com/microsoft/CBL-Mariner/pull/3733"
+                ]
+            },
+            "CONFIG_COMPAT_32BIT_TIME": {
+                "value": [
+                    "m",
+                    "y"
+                ],
+                "arch": [
+                    "AMD64"
+                ],
+                "comment": "Avoid error that 2 bit get_time syscalls aren't available",
+                "PR": [
+                    "https://github.com/microsoft/CBL-Mariner/pull/3812"
+                ]
+            },
+            "CONFIG_SECURITY_LANDLOCK": {
+                "value": [
+                    "m",
+                    "y"
+                ],
+                "arch": [
+                    "AMD64"
+                ],
+                "comment": "Security",
+                "PR": [
+                    "https://github.com/microsoft/CBL-Mariner/pull/3484"
+                ]
+            },
+            "CONFIG_BLK_DEV_ZONED": {
+                "value": [
+                    "m",
+                    "y"
+                ],
+                "arch": [
+                    "AMD64"
+                ],
+                "comment": "Zoned block device support",
+                "PR": [
+                    "https://github.com/microsoft/CBL-Mariner/pull/3465"
+                ]
+            },
+            "CONFIG_FTRACE_SYSCALLS": {
+                "value": [
+                    "m",
+                    "y"
+                ],
+                "arch": [
+                    "AMD64"
+                ],
+                "comment": "Needed to enable eBPF CO-RE syscalls tracers",
+                "PR": [
+                    "https://github.com/microsoft/CBL-Mariner/pull/3210"
+                ]
+            },
+            "CONFIG_VIRTIO_FS": {
+                "value": [
+                    "m",
+                    "y"
+                ],
+                "arch": [
+                    "AMD64"
+                ],
+                "comment": "Needed to see logs in Azure serial console",
+                "PR": [
+                    "https://github.com/microsoft/CBL-Mariner/pull/3264"
+                ]
+            },
+            "CONFIG_DRM_VGEM": {
+                "value": [
+                    "m",
+                    "y"
+                ],
+                "arch": [
+                    "AMD64"
+                ],
+                "comment": "Needed to enable media acceleration",
+                "PR": [
+                    "https://github.com/microsoft/CBL-Mariner/pull/3227"
+                ]
+            },
+            "CONFIG_PTP_1588_CLOCK_KVM": {
+                "value": [
+                    "m",
+                    "y"
+                ],
+                "arch": [
+                    "AMD64"
+                ],
+                "comment": "Removes error boot message 'failed to initialize ptp kvm'",
+                "PR": [
+                    "https://github.com/microsoft/CBL-Mariner/pull/3122"
+                ]
+            },
+            "CONFIG_LIVEPATCH": {
+                "value": [
+                    "y"
+                ],
+                "arch": [
+                    "AMD64"
+                ],
+                "comment": "Needed for livepatching",
+                "PR": [
+                    "https://github.com/microsoft/CBL-Mariner/pull/3107"
+                ]
+            },
+            "CONFIG_SECURITY_SMACK": {
+                "value": [
+                    "is not set",
+                    ""
+                ],
+                "arch": [
+                    "AMD64",
+                    "ARM64"
+                ],
+                "comment": "Removed in favor of SELinux",
+                "PR": [
+                    "https://github.com/microsoft/CBL-Mariner/pull/3080"
+                ]
+            },
+            "CONFIG_FW_LOADER_COMPRESS": {
+                "value": [
+                    "y"
+                ],
+                "arch": [
+                    "AMD64"
+                ],
+                "comment": " QLogic NIC firmware in linux-firmware is compressed",
+                "PR": [
+                    "https://github.com/microsoft/CBL-Mariner/pull/2201"
+                ]
+            },
+            "CONFIG_VFIO_NOIOMMU": {
+                "value": [
+                    "y"
+                ],
+                "arch": [
+                    "AMD64"
+                ],
+                "comment": "VMs may not have access to iommu",
+                "PR": [
+                    "https://github.com/microsoft/CBL-Mariner/pull/2385"
+                ]
+            },
+            "CONFIG_IO_STRICT_DEVMEM": {
+                "value": [
+                    "y"
+                ],
+                "arch": [
+                    "AMD64"
+                ],
+                "comment": "Needed for tboot",
+                "PR": [
+                    "https://github.com/microsoft/CBL-Mariner/pull/2357"
+                ]
+            },
+            "CONFIG_BPF_UNPRIV_DEFAULT_OFF": {
+                "value": [
+                    "y"
+                ],
+                "arch": [
+                    "AMD64",
+                    "ARM64"
+                ],
+                "comment": "Needed for CVE-2021-20194",
+                "PR": [
+                    "https://github.com/microsoft/CBL-Mariner/pull/2352"
+                ]
+            }
         }
     }
 }

--- a/toolkit/scripts/mariner-required-configs.json
+++ b/toolkit/scripts/mariner-required-configs.json
@@ -478,7 +478,7 @@
             "CONFIG_INIT_ON_FREE_DEFAULT_ON": {
                 "value": [
                     "is not set",
-                    ""
+                    "<missing>"
                 ],
                 "arch": [
                     "AMD64",
@@ -542,7 +542,7 @@
             },
             "CONFIG_CC_CAN_LINK_STATIC": {
                 "value": [
-                    ""
+                    "<missing>"
                 ],
                 "arch": [
                     "AMD64",
@@ -697,7 +697,7 @@
             "CONFIG_SECURITY_SMACK": {
                 "value": [
                     "is not set",
-                    ""
+                    "<missing>"
                 ],
                 "arch": [
                     "AMD64",

--- a/toolkit/scripts/mariner-required-configs.json
+++ b/toolkit/scripts/mariner-required-configs.json
@@ -1,0 +1,640 @@
+{
+    "required-configs": {
+        "CONFIG_INTEL_IOMMU_SVM": {
+            "value": [
+                "y"
+            ],
+            "arch": [
+                "AMD64"
+            ],
+            "comment": "Needed for customer",
+            "PR": null
+        },
+        "CONFIG_DRM_AMDGPU_SI": {
+            "value": [
+                "y"
+            ],
+            "arch": [
+                "AMD64"
+            ],
+            "comment": "Needed for customer",
+            "PR": "https://github.com/microsoft/CBL-Mariner/pull/5416"
+        },
+        "CONFIG_TLS": {
+            "value": [
+                "m",
+                "y"
+            ],
+            "arch": [
+                "AMD64"
+            ],
+            "comment": "Needed for customer",
+            "PR": "https://github.com/microsoft/CBL-Mariner/pull/5406"
+        },
+        "CONFIG_NVME_TARGET_TCP": {
+            "value": [
+                "m",
+                "y"
+            ],
+            "arch": [
+                "AMD64"
+            ],
+            "comment": "Needed for customer",
+            "PR": "https://github.com/microsoft/CBL-Mariner/pull/5406"
+        },
+        "CONFIG_DELL_WMI_DESCRIPTOR": {
+            "value": [
+                "m",
+                "y"
+            ],
+            "arch": [
+                "AMD64"
+            ],
+            "comment": "Needed for customer",
+            "PR": "https://github.com/microsoft/CBL-Mariner/pull/5406"
+        },
+        "CONFIG_X86_PLATFORM_DRIVERS_DELL": {
+            "value": [
+                "y"
+            ],
+            "arch": [
+                "AMD64"
+            ],
+            "comment": "Needed for customer",
+            "PR": "https://github.com/microsoft/CBL-Mariner/pull/2671"
+        },
+        "CONFIG_DRM_AMDGPU": {
+            "value": [
+                "m",
+                "y"
+            ],
+            "arch": [
+                "AMD64"
+            ],
+            "comment": "Needed for customer",
+            "PR": "https://github.com/microsoft/CBL-Mariner/pull/5416"
+        },
+        "CONFIG_BINFMT_MISC": {
+            "value": [
+                "y"
+            ],
+            "arch": [
+                "AMD64"
+            ],
+            "comment": "Needed for customer",
+            "PR": null
+        },
+        "CONFIG_SCHEDSTATS": {
+            "value": [
+                "y"
+            ],
+            "arch": [
+                "AMD64"
+            ],
+            "comment": "Needed for customer",
+            "PR": null
+        },
+        "CONFIG_BLK_DEV_IO_TRACE": {
+            "value": [
+                "y"
+            ],
+            "arch": [
+                "AMD64"
+            ],
+            "comment": "Needed for customer",
+            "PR": "https://github.com/microsoft/CBL-Mariner/pull/5417"
+        },
+        "CONFIG_ISO9660_FS": {
+            "value": [
+                "y"
+            ],
+            "arch": [
+                "AMD64"
+            ],
+            "comment": "Needed for customer",
+            "PR": null
+        },
+        "CONFIG_DELL_WMI_LED": {
+            "value": [
+                "m",
+                "y"
+            ],
+            "arch": [
+                "AMD64"
+            ],
+            "comment": "Needed for customer",
+            "PR": "https://github.com/microsoft/CBL-Mariner/pull/5406"
+        },
+        "CONFIG_TASKSTATS": {
+            "value": [
+                "y"
+            ],
+            "arch": [
+                "AMD64"
+            ],
+            "comment": "Needed for customer",
+            "PR": null
+        },
+        "CONFIG_TASK_IO_ACCOUNTING": {
+            "value": [
+                "y"
+            ],
+            "arch": [
+                "AMD64"
+            ],
+            "comment": "Needed for customer",
+            "PR": null
+        },
+        "CONFIG_DELL_SMBIOS_SMM": {
+            "value": [
+                "y"
+            ],
+            "arch": [
+                "AMD64"
+            ],
+            "comment": "Needed for customer",
+            "PR": "https://github.com/microsoft/CBL-Mariner/pull/2671"
+        },
+        "CONFIG_IO_URING": {
+            "value": [
+                "y"
+            ],
+            "arch": [
+                "AMD64"
+            ],
+            "comment": "Needed for customer",
+            "PR": null
+        },
+        "CONFIG_TASK_XACCT": {
+            "value": [
+                "y"
+            ],
+            "arch": [
+                "AMD64"
+            ],
+            "comment": "Needed for customer",
+            "PR": null
+        },
+        "CONFIG_INFINIBAND_BNXT_RE": {
+            "value": [
+                "m",
+                "y"
+            ],
+            "arch": [
+                "AMD64"
+            ],
+            "comment": "Needed for customer",
+            "PR": "https://github.com/microsoft/CBL-Mariner/pull/5406"
+        },
+        "CONFIG_DELL_WMI_PRIVACY": {
+            "value": [
+                "y"
+            ],
+            "arch": [
+                "AMD64"
+            ],
+            "comment": "Needed for customer",
+            "PR": "https://github.com/microsoft/CBL-Mariner/pull/5406"
+        },
+        "CONFIG_DELL_SMO8800": {
+            "value": [
+                "m",
+                "y"
+            ],
+            "arch": [
+                "AMD64"
+            ],
+            "comment": "Needed for customer",
+            "PR": "https://github.com/microsoft/CBL-Mariner/pull/2671"
+        },
+        "CONFIG_SENSORS_DELL_SMM": {
+            "value": [
+                "m",
+                "y"
+            ],
+            "arch": [
+                "AMD64"
+            ],
+            "comment": "Needed for customer",
+            "PR": null
+        },
+        "CONFIG_DELL_RBU": {
+            "value": [
+                "m",
+                "y"
+            ],
+            "arch": [
+                "AMD64"
+            ],
+            "comment": "Needed for customer",
+            "PR": "https://github.com/microsoft/CBL-Mariner/pull/2671"
+        },
+        "CONFIG_NVME_RDMA": {
+            "value": [
+                "m",
+                "y"
+            ],
+            "arch": [
+                "AMD64"
+            ],
+            "comment": "Needed for customer",
+            "PR": null
+        },
+        "CONFIG_DELL_SMBIOS_WMI": {
+            "value": [
+                "y"
+            ],
+            "arch": [
+                "AMD64"
+            ],
+            "comment": "Needed for customer",
+            "PR": "https://github.com/microsoft/CBL-Mariner/pull/2671"
+        },
+        "CONFIG_RAS_CEC": {
+            "value": [
+                "y"
+            ],
+            "arch": [
+                "AMD64"
+            ],
+            "comment": "Needed for customer",
+            "PR": "https://github.com/microsoft/CBL-Mariner/pull/5417"
+        },
+        "CONFIG_DRM_AMDGPU_CIK": {
+            "value": [
+                "y"
+            ],
+            "arch": [
+                "AMD64"
+            ],
+            "comment": "Needed for customer",
+            "PR": "https://github.com/microsoft/CBL-Mariner/pull/5416"
+        },
+        "CONFIG_DELL_WMI": {
+            "value": [
+                "m",
+                "y"
+            ],
+            "arch": [
+                "AMD64"
+            ],
+            "comment": "Needed for customer",
+            "PR": "https://github.com/microsoft/CBL-Mariner/pull/5406"
+        },
+        "CONFIG_NVME_TCP": {
+            "value": [
+                "m",
+                "y"
+            ],
+            "arch": [
+                "AMD64"
+            ],
+            "comment": "Needed for customer",
+            "PR": null
+        },
+        "CONFIG_DELL_WMI_AIO": {
+            "value": [
+                "m",
+                "y"
+            ],
+            "arch": [
+                "AMD64"
+            ],
+            "comment": "Needed for customer",
+            "PR": "https://github.com/microsoft/CBL-Mariner/pull/2671"
+        },
+        "CONFIG_DELL_WMI_SYSMAN": {
+            "value": [
+                "m",
+                "y"
+            ],
+            "arch": [
+                "AMD64"
+            ],
+            "comment": "Needed for customer",
+            "PR": "https://github.com/microsoft/CBL-Mariner/pull/5406"
+        },
+        "CONFIG_TASK_DELAY_ACCT": {
+            "value": [
+                "y"
+            ],
+            "arch": [
+                "AMD64"
+            ],
+            "comment": "Needed for customer",
+            "PR": null
+        },
+        "CONFIG_DELL_SMBIOS": {
+            "value": [
+                "m",
+                "y"
+            ],
+            "arch": [
+                "AMD64"
+            ],
+            "comment": "Needed for customer",
+            "PR": "https://github.com/microsoft/CBL-Mariner/pull/2671"
+        },
+        "CONFIG_THERMAL_HWMON": {
+            "value": [
+                "m",
+                "y"
+            ],
+            "arch": [
+                "AMD64"
+            ],
+            "comment": "Needed for customer",
+            "PR": "https://github.com/microsoft/CBL-Mariner/pull/5417"
+        },
+        "CONFIG_TCG_TPM": {
+            "value": [
+                "y"
+            ],
+            "arch": [
+                "AMD64"
+            ],
+            "comment": "Needed for customer",
+            "PR": null
+        },
+        "CONFIG_HW_RANDOM_TPM": {
+            "value": [
+                "y"
+            ],
+            "arch": [
+                "AMD64"
+            ],
+            "comment": "Needed for customer",
+            "PR": null
+        },
+        "CONFIG_EDAC_SKX": {
+            "value": [
+                "m",
+                "y"
+            ],
+            "arch": [
+                "AMD64"
+            ],
+            "comment": "Needed for customer",
+            "PR": "https://github.com/microsoft/CBL-Mariner/pull/5487"
+        },
+        "CONFIG_NET_CLS_FLOWER": {
+            "value": [
+                "m",
+                "y"
+            ],
+            "arch": [
+                "AMD64"
+            ],
+            "comment": "Needed for customer",
+            "PR": "https://github.com/microsoft/CBL-Mariner/pull/5170"
+        },
+        "CONFIG_HIST_TRIGGERS": {
+            "value": [
+                "y"
+            ],
+            "arch": [
+                "AMD64"
+            ],
+            "comment": "Needed for auoms metrics",
+            "PR": "https://github.com/microsoft/CBL-Mariner/pull/5292"
+        },
+        "CONFIG_INIT_ON_FREE_DEFAULT_ON": {
+            "value": [
+                "is not set",
+                ""
+            ],
+            "arch": [
+                "AMD64",
+                "ARM64"
+            ],
+            "comment": "Creates increased boot times and errors on large memory systems",
+            "PR": "https://github.com/microsoft/CBL-Mariner/pull/4829"
+        },
+        "CONFIG_WIREGUARD": {
+            "value": [
+                "m",
+                "y"
+            ],
+            "arch": [
+                "AMD64"
+            ],
+            "comment": "Needed for customer",
+            "PR": "https://github.com/microsoft/CBL-Mariner/pull/5135"
+        },
+        "CONFIG_TARGET_CORE": {
+            "value": [
+                "m",
+                "y"
+            ],
+            "arch": [
+                "AMD64"
+            ],
+            "comment": "Needed for customer",
+            "PR": "https://github.com/microsoft/CBL-Mariner/pull/4473"
+        },
+        "CONFIG_HIBERNATION": {
+            "value": [
+                "y"
+            ],
+            "arch": [
+                "AMD64"
+            ],
+            "comment": "Needed for customer",
+            "PR": "https://github.com/microsoft/CBL-Mariner/pull/4369"
+        },
+        "CONFIG_TCP_CONG_BBR": {
+            "value": [
+                "m",
+                "y"
+            ],
+            "arch": [
+                "AMD64"
+            ],
+            "comment": "Needed for customer",
+            "PR": "https://github.com/microsoft/CBL-Mariner/pull/4122"
+        },
+        "CONFIG_CC_CAN_LINK_STATIC": {
+            "value": [
+                ""
+            ],
+            "arch": [
+                "AMD64",
+                "ARM64"
+            ],
+            "comment": "Remove static linking support from the kernel",
+            "PR": "https://github.com/microsoft/CBL-Mariner/pull/3748"
+        },
+        "CONFIG_SCSI_LOGGING": {
+            "value": [
+                "m",
+                "y"
+            ],
+            "arch": [
+                "AMD64"
+            ],
+            "comment": "Needed for customer",
+            "PR": "https://github.com/microsoft/CBL-Mariner/pull/3826"
+        },
+        "CONFIG_NETFILTER_XT_TARGET_TRACE": {
+            "value": [
+                "m",
+                "y"
+            ],
+            "arch": [
+                "AMD64"
+            ],
+            "comment": "Needed for the iptables TRACE target",
+            "PR": "https://github.com/microsoft/CBL-Mariner/pull/3783"
+        },
+        "CONFIG_VFAT_FS": {
+            "value": [
+                "y"
+            ],
+            "arch": [
+                "AMD64"
+            ],
+            "comment": "Make vfat always available",
+            "PR": "https://github.com/microsoft/CBL-Mariner/pull/3733"
+        },
+        "CONFIG_COMPAT_32BIT_TIME": {
+            "value": [
+                "m",
+                "y"
+            ],
+            "arch": [
+                "AMD64"
+            ],
+            "comment": "Avoid error that 2 bit get_time syscalls aren't available",
+            "PR": "https://github.com/microsoft/CBL-Mariner/pull/3812"
+        },
+        "CONFIG_SECURITY_LANDLOCK": {
+            "value": [
+                "m",
+                "y"
+            ],
+            "arch": [
+                "AMD64"
+            ],
+            "comment": "Security",
+            "PR": "https://github.com/microsoft/CBL-Mariner/pull/3484"
+        },
+        "CONFIG_BLK_DEV_ZONED": {
+            "value": [
+                "m",
+                "y"
+            ],
+            "arch": [
+                "AMD64"
+            ],
+            "comment": "Zoned block device support",
+            "PR": "https://github.com/microsoft/CBL-Mariner/pull/3465"
+        },
+        "CONFIG_FTRACE_SYSCALLS": {
+            "value": [
+                "m",
+                "y"
+            ],
+            "arch": [
+                "AMD64"
+            ],
+            "comment": "Needed to enable eBPF CO-RE syscalls tracers",
+            "PR": "https://github.com/microsoft/CBL-Mariner/pull/3210"
+        },
+        "CONFIG_VIRTIO_FS": {
+            "value": [
+                "m",
+                "y"
+            ],
+            "arch": [
+                "AMD64"
+            ],
+            "comment": "Needed to see logs in Azure serial console",
+            "PR": "https://github.com/microsoft/CBL-Mariner/pull/3264"
+        },
+        "CONFIG_DRM_VGEM": {
+            "value": [
+                "m",
+                "y"
+            ],
+            "arch": [
+                "AMD64"
+            ],
+            "comment": "Needed to enable media acceleration",
+            "PR": "https://github.com/microsoft/CBL-Mariner/pull/3227"
+        },
+        "CONFIG_PTP_1588_CLOCK_KVM": {
+            "value": [
+                "m",
+                "y"
+            ],
+            "arch": [
+                "AMD64"
+            ],
+            "comment": "Removes error boot message 'failed to initialize ptp kvm'",
+            "PR": "https://github.com/microsoft/CBL-Mariner/pull/3122"
+        },
+        "CONFIG_LIVEPATCH": {
+            "value": [
+                "y"
+            ],
+            "arch": [
+                "AMD64"
+            ],
+            "comment": "Needed for livepatching",
+            "PR": "https://github.com/microsoft/CBL-Mariner/pull/3107"
+        },
+        "CONFIG_SECURITY_SMACK": {
+            "value": [
+                "is not set",
+                ""
+            ],
+            "arch": [
+                "AMD64",
+                "ARM64"
+            ],
+            "comment": "Removed in favor of SELinux",
+            "PR": "https://github.com/microsoft/CBL-Mariner/pull/3080"
+        },
+        "CONFIG_FW_LOADER_COMPRESS": {
+            "value": [
+                "y"
+            ],
+            "arch": [
+                "AMD64"
+            ],
+            "comment": " QLogic NIC firmware in linux-firmware is compressed",
+            "PR": "https://github.com/microsoft/CBL-Mariner/pull/2201"
+        },
+        "CONFIG_VFIO_NOIOMMU": {
+            "value": [
+                "y"
+            ],
+            "arch": [
+                "AMD64"
+            ],
+            "comment": "VMs may not have access to iommu",
+            "PR": "https://github.com/microsoft/CBL-Mariner/pull/2385"
+        },
+        "CONFIG_IO_STRICT_DEVMEM": {
+            "value": [
+                "y"
+            ],
+            "arch": [
+                "AMD64"
+            ],
+            "comment": "Needed for tboot",
+            "PR": "https://github.com/microsoft/CBL-Mariner/pull/2357"
+        },
+        "CONFIG_BPF_UNPRIV_DEFAULT_OFF": {
+            "value": [
+                "y"
+            ],
+            "arch": [
+                "AMD64",
+                "ARM64"
+            ],
+            "comment": "Needed for CVE-2021-20194",
+            "PR": "https://github.com/microsoft/CBL-Mariner/pull/2352"
+        }
+    }
+}


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
In an effort to reduce relying on my memory and to ensure that critical customer configs are not modified, add a new PR check which checks if
1. any configs with known required values have been changed to undesired values/removed
2. new configs are being added and have not added to the json of required kernel configs

Required configs are currently only set for the "kernel" spec but other kernels can created fields in the json to account for their configs.

For case 1, a failure looks like
```
===============================================================================
== Results for SPECS/kernel/config ==
===============================================================================

----------------- Kernel config verification FAILED -----------------
CONFIG_DRM_AMDGPU_SI is "", expected ['y'].
Reason: Needed for customer
PR: https://github.com/microsoft/CBL-Mariner/pull/54[16](https://github.com/rlmenge/CBL-Mariner/actions/runs/5010776690/jobs/8980970694?pr=30#step:9:17)

CONFIG_TLS is " is not set", expected ['m', 'y'].
Reason: Needed for customer
PR: https://github.com/microsoft/CBL-Mariner/pull/5406

CONFIG_X86_PLATFORM_DRIVERS_DELL is "m", expected ['y'].
Reason: Needed for customer
PR: https://github.com/microsoft/CBL-Mariner/pull/[26](https://github.com/rlmenge/CBL-Mariner/actions/runs/5010776690/jobs/8980970694?pr=30#step:9:27)71

CONFIG_INIT_ON_FREE_DEFAULT_ON is "y", expected ['is not set', ''].
Reason: Creates increased boot times and errors on large memory systems
PR: https://github.com/microsoft/CBL-Mariner/pull/48[29](https://github.com/rlmenge/CBL-Mariner/actions/runs/5010776690/jobs/8980970694?pr=30#step:9:30)
```

For case 2 a failure looks like
```
====================== Kernel new config verification FAILED for ARM64 ======================
New configs detected for ARM64. Please add the following to toolkit/scripts/mariner-required-configs.json
CONFIG_CRYPTO_ECDSA
```
There is also a verbose flag when checking required configs  (1)
```
===============================================================================
== Results for /home/rachel/repos/CBL-Mariner-main/SPECS/kernel/config_aarch64 ==
===============================================================================
Option                          Required Arch       Expected Value      Comment  
-------------------------------------------------------------------------------
CONFIG_INIT_ON_FREE_DEFAULT_ON  ['AMD64', 'ARM64']  ['is not set', '']  OK       
CONFIG_CC_CAN_LINK_STATIC       ['AMD64', 'ARM64']  ['']                OK       
CONFIG_SECURITY_SMACK           ['AMD64', 'ARM64']  ['is not set', '']  OK       
CONFIG_BPF_UNPRIV_DEFAULT_OFF   ['AMD64', 'ARM64']  ['y']               OK     
```

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Create new workflow to check for critical configs

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- PR which tests new config: https://github.com/rlmenge/CBL-Mariner/pull/29
- PR which tests modifying required config: https://github.com/rlmenge/CBL-Mariner/pull/30
- PR to test changing kernel-azure config: https://github.com/rlmenge/CBL-Mariner/pull/32
- this pr does not run the check because the configs did not change :)