### PR TITLE
Include arch in ResolveCompetingPackages() output

### DIFF
--- a/toolkit/tools/depsearch/depsearch.go
+++ b/toolkit/tools/depsearch/depsearch.go
@@ -36,7 +36,7 @@ var (
 	reverseSearch = app.Flag("reverse", "Reverse the search to give a traditional dependency list for the packages instead of dependants.").Bool()
 
 	printTree       = app.Flag("tree", "Print output as a simple tree instead of a list").Bool()
-	verbosity       = app.Flag("verbosity", "Print the full node details (3), RPM (2), or SPEC name (1) for each result").Default("1").Int()
+	verbosity       = app.Flag("verbosity", "Print the full node details (4), limited details (3), RPM (2), or SPEC name (1) for each result").Default("1").Int()
 	maxDepth        = app.Flag("max-depth", "Maximum depth into the tree to scan, -1 for unlimited").Default("-1").Int()
 	printDuplicates = app.Flag("print-duplicates", "In tree mode, if there is a duplicate node in the tree don't replace it with '...'").Bool()
 	filterFile      = app.Flag("rpm-filter-file", "Filter the returned packages based on this list of *.rpm filenames (defaults to the x86_64 toolchain manifest './resources/manifests/package/toolchain_x86_64.txt' if it exists)").ExistingFile()
@@ -56,8 +56,8 @@ func main() {
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	logger.InitBestEffort(*logFile, *logLevel)
 
-	// only understand verbosity from 1 - 3 (spec, rpm, full node)
-	if verbosity == nil || *verbosity > 3 || *verbosity < 1 {
+	// only understand verbosity from 1 - 4 (spec, rpm, details, full node)
+	if verbosity == nil || *verbosity > 4 || *verbosity < 1 {
 		verbosity = new(int)
 		*verbosity = 1
 	}
@@ -242,6 +242,8 @@ func formatNode(n *pkggraph.PkgNode, verbosity int) string {
 		return filepath.Base(n.RpmPath)
 	case 3:
 		return fmt.Sprintf("'%s' from node '%s'", filepath.Base(n.RpmPath), n.FriendlyName())
+	case 4:
+		return fmt.Sprintf("'%s'", n)
 	default:
 		logger.Log.Fatalf("Invalid verbosity level %v", verbosity)
 	}


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
When we call `ResolveCompetingPackages()` it would return a name of the form `pkg-name-1.2.3-4.cm2.rpm`, but it should also include the architecture in that path `pkg-name-1.2.3-4.cm2.x86_64`. These names are used to create paths to .rpm files. Previously we have not consumed the resulting paths once they are entered into the graph, but the upcoming delta fetcher feature uses these paths to validate the acquired .rpms from the package repo. If the names do not match the delta fetcher does not believe it has acquired the correct packages.

Also enhanced the `depsearch` tool as part of the debugging for this issue.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Include the arch in the output from `ResolveCompetingPackages()`.
- Add new level 4 verbosity to depsearch tool

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local builds
- Pipeline to follow