### PR TITLE
Allow goal nodes to match based on SRPM

### DIFF
--- a/toolkit/tools/grapher/grapher.go
+++ b/toolkit/tools/grapher/grapher.go
@@ -49,7 +49,7 @@ func main() {
 	}
 
 	// Add a default "ALL" goal to build everything local
-	_, err = depGraph.AddGoalNode(goalNodeName, nil, *strictGoals)
+	_, err = depGraph.AddGoalNode(goalNodeName, nil, *strictGoals, false)
 	if err != nil {
 		logger.Log.Panic(err)
 	}

--- a/toolkit/tools/internal/pkggraph/cyclefind.go
+++ b/toolkit/tools/internal/pkggraph/cyclefind.go
@@ -37,7 +37,7 @@ func (g *PkgGraph) FindAnyDirectedCycle() (nodes []*PkgNode, err error) {
 
 	// Create a temporary root node, by using a constant goalNodeName, it will act as a mutex against concurrent
 	// cycle searches on a given graph as this below call will fail if there is already a goal node with the same value.
-	rootNode, err := g.AddGoalNode(goalNodeName, nil, false)
+	rootNode, err := g.AddGoalNode(goalNodeName, nil, false, false)
 	if err != nil {
 		return
 	}

--- a/toolkit/tools/internal/pkggraph/pkggraph.go
+++ b/toolkit/tools/internal/pkggraph/pkggraph.go
@@ -1093,11 +1093,13 @@ func (g *PkgGraph) AddGoalNode(goalName string, packages []*pkgjson.PackageVer, 
 	}
 
 	//Now grab the nodes by SRPM path if we set useSRPMPath
-	for _, node := range g.AllRunNodes() {
-		if srpmPathSet[node.SrpmPath] {
-			logger.Log.Tracef("Found %s to satisfy SRPM linked goal %s", node, node.SrpmPath)
-			goalEdge := g.NewEdge(goalNode, node)
-			g.SetEdge(goalEdge)
+	if useSRPMPath {
+		for _, node := range g.AllRunNodes() {
+			if srpmPathSet[node.SrpmPath] {
+				logger.Log.Tracef("Found %s to satisfy SRPM linked goal %s", node, node.SrpmPath)
+				goalEdge := g.NewEdge(goalNode, node)
+				g.SetEdge(goalEdge)
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
The upcomming delta fetcher will try to download .rpms for any local nodes that appear up to date with PMC already. To optimize the download process we should try to only download packages we will actually use. The graph package fetcher tool will want to find all nodes in the graph based on the desired build artifacts. However the scheduler will only consider a package 'prebuilt' if ALL the associated .rpm files are present. There will often be a case were only a subset of the sub packages for a SRPM are needed, and in this case the `AddGoalNode()` function + optimize algorithm will prune away the other sub packages' nodes. When this happens the new delta fetcher code will not know to download those sub packages.

Allow `AddGoalNode()` to increase its matched scope based on SRPM path. i.e., if we match any node with a given SRPM, also match all other nodes with that SRPM as well.

> e.g., if we add a goal for 'foo', we will also automatically add 'foo-sub1` and `foo-sub2` since they share the same SRPM path.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Allow `AddGoalNode()` to also match additional nodes that share a SRPM path.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
*NO**


###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local builds
- Pipeline build to follow