### PR TITLE
Fix ocaml-ppxlib tests failure due to ocaml-sexplib0-0.15.0 changes

### DIFF
--- a/SPECS/ocaml-ppxlib/ocaml-ppxlib.spec
+++ b/SPECS/ocaml-ppxlib/ocaml-ppxlib.spec
@@ -11,7 +11,7 @@
 Summary:        Base library and tools for ppx rewriters
 Name:           ocaml-%{srcname}
 Version:        0.24.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -19,6 +19,7 @@ URL:            https://github.com/ocaml-ppx/ppxlib
 Source0:        https://github.com/ocaml-ppx/ppxlib/releases/download/%{version}/%{srcname}-%{version}.tbz
 # We do not have 'stdlib-shims'.
 Patch0:         %{name}-stdlib-shims.patch
+Patch1:         test-fix-sexplib0-0.15.0.patch
 
 BuildRequires:  ocaml >= 4.04.1
 BuildRequires:  ocaml-base-devel
@@ -29,7 +30,7 @@ BuildRequires:  ocaml-findlib
 BuildRequires:  ocaml-migrate-parsetree-devel >= 2.1.0
 BuildRequires:  ocaml-ppx-derivers-devel >= 1.0
 BuildRequires:  ocaml-re-devel >= 1.9.0
-BuildRequires:  ocaml-sexplib0-devel
+BuildRequires:  ocaml-sexplib0-devel >= 0.15.0
 BuildRequires:  ocaml-stdio-devel
 
 %if %{with doc}
@@ -104,16 +105,8 @@ find %{buildroot}%{_libdir}/ocaml -name \*.cmxs -exec chmod a+x {} \+
 # We do not want to install the test binaries
 rm -fr %{buildroot}%{_bindir}
 
-# FIXME: On arm only, building the tests fails:
-# /usr/bin/ld: src/.cinaps/.cinaps.eobjs/native/dune__exe__Cinaps.o: relocation R_ARM_THM_MOVW_ABS_NC against `camlCinaps_runtime' can not be used when making a shared object; recompile with -fPIC
-# src/.cinaps/.cinaps.eobjs/native/dune__exe__Cinaps.o: in function `.L297': :(.text+0xdec): dangerous relocation: unsupported relocation
-# <many more such warnings>
-#
-# Disable the tests on arm until we can figure out what is going wrong.
-%ifnarch %{arm}
 %check
 dune runtest
-%endif
 
 %files
 %doc CHANGES.md HISTORY.md README.md
@@ -165,10 +158,14 @@ dune runtest
 %endif
 
 %changelog
+* Fri May 19 2023 Olivia Crain <oliviacrain@microsoft.com> - 0.24.0-3
+- Add upstream patch to fix tests with ocaml-sexplib0-0.15.0
+- Remove %%{arm} arch gating on tests (not supported by Mariner)
+
 * Thu Mar 31 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 0.24.0-2
 - Cleaning-up spec. License verified.
 
-* Tue Jan 18 2022 Thomas Crain <thcrain@microsoft.com> - 0.24.0-1
+* Tue Jan 18 2022 Olivia Crain <oliviacrain@microsoft.com> - 0.24.0-1
 - Upgrade to latest version
 - License verified
 

--- a/SPECS/ocaml-ppxlib/test-fix-sexplib0-0.15.0.patch
+++ b/SPECS/ocaml-ppxlib/test-fix-sexplib0-0.15.0.patch
@@ -1,0 +1,86 @@
+From 99a8134486f3f5ffc5360034b7bd4ce3ada27112 Mon Sep 17 00:00:00 2001
+From: Kate <kit.ty.kate@disroot.org>
+Date: Fri, 5 Aug 2022 21:56:46 +0100
+Subject: [PATCH] Upgrade the tests to sexplib0.v0.15
+
+Signed-off-by: Kate <kit.ty.kate@disroot.org>
+Signed-off-by: Olivia Crain <oliviacrain@microsoft.com>
+---
+ test/base/test.ml                    |  6 +++---
+ test/driver/exception_handling/run.t | 10 +++++-----
+ test/ppx_import_support/test.ml      |  4 ++--
+ 3 files changed, 10 insertions(+), 10 deletions(-)
+
+diff --git a/test/base/test.ml b/test/base/test.ml
+index 7cf282a5..77c27e52 100644
+--- a/test/base/test.ml
++++ b/test/base/test.ml
+@@ -106,17 +106,17 @@ let _ = convert_longident "Base.( land )"
+ 
+ let _ = convert_longident "A(B)"
+ [%%expect{|
+-Exception: (Invalid_argument "Ppxlib.Longident.parse: \"A(B)\"")
++Exception: Invalid_argument "Ppxlib.Longident.parse: \"A(B)\"".
+ |}]
+ 
+ let _ = convert_longident "A.B(C)"
+ [%%expect{|
+-Exception: (Invalid_argument "Ppxlib.Longident.parse: \"A.B(C)\"")
++Exception: Invalid_argument "Ppxlib.Longident.parse: \"A.B(C)\"".
+ |}]
+ 
+ let _ = convert_longident ")"
+ [%%expect{|
+-Exception: (Invalid_argument "Ppxlib.Longident.parse: \")\"")
++Exception: Invalid_argument "Ppxlib.Longident.parse: \")\"".
+ |}]
+ 
+ let _ = Ppxlib.Code_path.(file_path @@ top_level ~file_path:"dir/main.ml")
+diff --git a/test/driver/exception_handling/run.t b/test/driver/exception_handling/run.t
+index f0a5cc6f..d303b148 100644
+--- a/test/driver/exception_handling/run.t
++++ b/test/driver/exception_handling/run.t
+@@ -102,10 +102,10 @@ and the whole AST is prepended with an error extension node.
+ 
+   $ echo "let _ = [%gen_raise_exc] + [%gen_raise_exc]" > impl.ml
+   $ ./extender.exe impl.ml
+-  Fatal error: exception (Failure "A raised exception")
++  Fatal error: exception Failure("A raised exception")
+   [2]
+   $ ./extender.exe -embed-errors impl.ml
+-  Fatal error: exception (Failure "A raised exception")
++  Fatal error: exception Failure("A raised exception")
+   [2]
+ 
+  In the case of derivers
+@@ -113,14 +113,14 @@ and the whole AST is prepended with an error extension node.
+   $ echo "type a = int" > impl.ml
+   $ echo "type b = int [@@deriving deriver_raised_exception]" >> impl.ml
+   $ ./deriver.exe -embed-errors impl.ml
+-  Fatal error: exception (Failure "A raised exception")
++  Fatal error: exception Failure("A raised exception")
+   [2]
+ 
+  In the case of whole file transformations:
+ 
+   $ ./whole_file_exception.exe impl.ml
+-  Fatal error: exception (Failure "An exception in a whole file transform")
++  Fatal error: exception Failure("An exception in a whole file transform")
+   [2]
+   $ ./whole_file_exception.exe -embed-errors impl.ml
+-  Fatal error: exception (Failure "An exception in a whole file transform")
++  Fatal error: exception Failure("An exception in a whole file transform")
+   [2]
+diff --git a/test/ppx_import_support/test.ml b/test/ppx_import_support/test.ml
+index e32d39b0..66fd12bf 100644
+--- a/test/ppx_import_support/test.ml
++++ b/test/ppx_import_support/test.ml
+@@ -108,6 +108,6 @@ let id_for_core_types =
+     (fun ~ctxt:_ core_type -> core_type)
+ [%%expect{|
+ Exception:
+-(Failure
+-  "Some ppx-es tried to register conflicting transformations: Extension 'id' on type declarations matches extension 'id'")
++Failure
++ "Some ppx-es tried to register conflicting transformations: Extension 'id' on type declarations matches extension 'id'".
+ |}]


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
`ocaml-ppxlib` tests are failing due to an incompatibility with `ocaml-sexplib0 >= 0.15.0`. Add the upstream patch to fix the bad test data.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add upstream patch to fix tests with ocaml-sexplib0-0.15.0
- Remove %{arm} arch gating on tests (not supported by Mariner)

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- [Buddy build](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=363967&view=results), tests now pass
