### PR TITLE
Fix python-pbr tests by pinning sphinx version used

### DIFF
--- a/SPECS/python-pbr/python-pbr.spec
+++ b/SPECS/python-pbr/python-pbr.spec
@@ -1,14 +1,15 @@
 Summary:        Python Build Reasonableness
 Name:           python-pbr
 Version:        5.8.1
-Release:        3%{?dist}
-License:        ASL 2.0
+Release:        4%{?dist}
+License:        Apache-2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Group:          Development/Languages/Python
 URL:            https://docs.openstack.org/developer/pbr/
 Source0:        https://pypi.io/packages/source/p/pbr/pbr-%{version}.tar.gz
 Patch0:         disable-test-wsgi.patch
+Patch1:         test-pin-sphinx.patch
 BuildArch:      noarch
 
 %description
@@ -41,7 +42,7 @@ export SKIP_PIP_INSTALL=1
 ln -s pbr %{buildroot}/%{_bindir}/pbr3
 
 %check
-pip3 install coverage hacking mock testrepository testresources testscenarios virtualenv wheel 'tox>=3.27.1,<4.0.0'
+pip3 install 'tox>=3.27.1,<4.0.0'
 tox -e py%{python3_version_nodots}
 
 %files -n python3-pbr
@@ -54,6 +55,11 @@ tox -e py%{python3_version_nodots}
 %{python3_sitelib}/pbr
 
 %changelog
+* Fri May 19 2023 Olivia Crain <oliviacrain@microsoft.com> - 5.8.1-4
+- Add patch to pin version of sphinx used in tests to a known compatible version
+- Remove check-time install of packages that should be handled by tox
+- Use SPDX license expression in license tag
+
 * Fri Dec 16 2022 Sam Meluch <sammeluch@microsoft.com> - 5.8.1-3
 - Update version of tox used for package tests
 

--- a/SPECS/python-pbr/test-pin-sphinx.patch
+++ b/SPECS/python-pbr/test-pin-sphinx.patch
@@ -1,0 +1,29 @@
+From 5197ac16ec7286ee610eb47f8647f6ddf69cc340 Mon Sep 17 00:00:00 2001
+From: Olivia Crain <olivia@olivia.dev>
+Date: Fri, 19 May 2023 15:01:31 -0700
+Subject: [PATCH] Pin sphinx used in tests to <7.0.0
+
+Sphinx 7.0.0 removed setuptools support, which is tested by the pbr
+package
+
+Signed-off-by: Olivia Crain <olivia@olivia.dev>
+---
+ test-requirements.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/test-requirements.txt b/test-requirements.txt
+index 3af261d..79f8267 100644
+--- a/test-requirements.txt
++++ b/test-requirements.txt
+@@ -17,7 +17,7 @@ coverage!=4.4,>=4.0 # Apache-2.0
+ 
+ # optionally exposed by distutils commands
+ sphinx!=1.6.6,!=1.6.7,>=1.6.2,<2.0.0;python_version=='2.7' # BSD
+-sphinx!=1.6.6,!=1.6.7,>=1.6.2;python_version>='3.4' # BSD
++sphinx!=1.6.6,!=1.6.7,>=1.6.2,<7.0.0;python_version>='3.4' # BSD
+ testrepository>=0.0.18 # Apache-2.0/BSD
+ 
+ pre-commit>=2.6.0;python_version>='3.6' # MIT
+-- 
+2.34.1
+


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
`python-pbr` package tests started failing around the time when `sphinx 7.0.0` was release. That release removed sphinx's setuptools integration, which is used by some `python-pbr` tests. So, let's restrict the versions of sphinx that `tox` considers when installing test requirements.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add patch to pin version of sphinx used in tests to a known compatible version
- Remove check-time install of packages that should be handled by tox
- Use SPDX license expression in license tag

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- [Buddy build](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=364051), tests now pass!
