### PR TITLE
Pin version of hypothesis used in numpy tests to avoid test breakage

### DIFF
--- a/SPECS/numpy/numpy.spec
+++ b/SPECS/numpy/numpy.spec
@@ -1,4 +1,3 @@
-
 %global blaslib openblas
 %global blasvar p
 %define majmin %(echo %{version} | cut -d. -f1-2)
@@ -6,7 +5,7 @@
 Summary:        A fast multidimensional array facility for Python
 Name:           numpy
 Version:        1.23.4
-Release:        2%{?dist}
+Release:        3%{?dist}
 # Everything is BSD except for class SafeEval in numpy/lib/utils.py which is Python
 License:        BSD AND Python AND ASL 2.0
 Vendor:         Microsoft Corporation
@@ -134,10 +133,13 @@ chrpath --delete %{buildroot}%{python3_sitearch}/%{name}/linalg/_umath_linalg.*.
 
 %check
 export PYTHONPATH=%{buildroot}%{python3_sitearch}
-pip install pytest==7.2 hypothesis typing-extensions
+
+# Hypothesis 6.72.0 introduced a deprecation error for "Healthcheck.all()" which fails the test run
+pip install 'pytest==7.2' 'hypothesis<6.72.0' typing-extensions
+
 # test_ppc64_ibm_double_double128 is unnecessary now that ppc64le has switched long doubles to IEEE format.
 # https://github.com/numpy/numpy/issues/21094
-python3 runtests.py --no-build -- -ra -k 'not test_ppc64_ibm_double_double128 %{?ix86_k}'
+python3 runtests.py --no-build -- -ra -k 'not test_ppc64_ibm_double_double128'
 
 
 %files -n python3-numpy
@@ -181,6 +183,9 @@ python3 runtests.py --no-build -- -ra -k 'not test_ppc64_ibm_double_double128 %{
 %doc docs/*
 
 %changelog
+* Mon May 22 2023 Olivia Crain <oliviacrain@microsoft.com> - 1.23.4-3
+- Pin version of hypothesis used to avoid deprecation errors
+
 * Tue Nov 15 2022 Osama Esmail <osamaesmail@microsoft.com> - 1.23.4-2
 - Initial CBL-Mariner import from Fedora 37 (license: MIT)
 - License verified.


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
The `numpy` package relies on `hypothesis` as a test dependency.  `hypothesis` 6.72.0 added a deprecation warning for something used in `numpy` tests, which broke testing for that package. So, let's pin `hypothesis` to a version that doesn't break our tests.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Pin version of hypothesis used in numpy tests to avoid deprecation errors

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- [Buddy build](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=365111&view=results)
