### PR TITLE
Fix dnf-plugins-core tests by using unittests runner

### DIFF
--- a/SPECS/dnf-plugins-core/dnf-plugins-core.spec
+++ b/SPECS/dnf-plugins-core/dnf-plugins-core.spec
@@ -9,7 +9,7 @@
 Summary:        Core Plugins for DNF
 Name:           dnf-plugins-core
 Version:        4.0.24
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -75,11 +75,6 @@ Summary:        Core Plugins for DNF
 BuildRequires:  python3-dbus
 BuildRequires:  python3-devel
 BuildRequires:  python3-dnf >= %{dnf_lowest_compatible}
-
-%if %{with_check}
-BuildRequires:  python3-nose2
-%endif
-
 Requires:       python3-dateutil
 Requires:       python3-dbus
 Requires:       python3-distro
@@ -252,7 +247,8 @@ ln -sf %{_mandir}/man1/%{yum_utils_subpackage_name}.1.gz %{buildroot}%{_mandir}/
 %endif
 
 %check
-PYTHONPATH=./plugins nosetests-%{python3_version} -s tests/
+export PYTHONPATH=./plugins
+python3 -m unittest discover -t . -s tests/
 
 %files
 %{_mandir}/man8/dnf-builddep.*
@@ -415,16 +411,19 @@ PYTHONPATH=./plugins nosetests-%{python3_version} -s tests/
 %endif
 
 %changelog
+* Mon May 22 2023 Olivia Crain <oliviacrain@microsoft.com> - 4.0.24-3
+- Fix tests by replacing nose with built-in unittests runner, per upstream recommendation
+
 * Tue Feb 08 2022 Cameron Baird <cameronbaird@microsoft.com> - 4.0.24-1
 - Upgrade to undeprecated python3-nose2
 - Update source to 4.0.24
 - License verified
 
-* Tue Jan 18 2022 Thomas Crain <thcrain@microsoft.com> - 4.0.18-5
+* Tue Jan 18 2022 Olivia Crain <oliviacrain@microsoft.com> - 4.0.18-5
 - Only require python3-nose when building tests
 - License verified
 
-* Tue Aug 10 2021 Thomas Crain <thcrain@microsoft.com>  - 4.0.18-4
+* Tue Aug 10 2021 Olivia Crain <oliviacrain@microsoft.com>  - 4.0.18-4
 - Remove python2 support, distro-specific checks
 
 * Mon Jun 28 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 4.0.18-3


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Tests for `dnf-plugins-core` are failing, since they use the name `nosetests-%{python3_version}` to invoke the test runner. That was the correct entrypoint to use when this package used the now-deprecated `python3-nose` package for testing, but became incorrect when upstream switched to the built-in unittests module to run tests in version 4.0.21. So, let's use the correct test runner here.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Invoke `dnf-plugins-core` tests using `python3 -m unittests`.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- [Buddy build](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=365183&view=results), tests pass!
