### PR TITLE
Update CVE-2022-37601.patch to fix multiple occurrences

### DIFF
--- a/SPECS/reaper/CVE-2022-37601.patch
+++ b/SPECS/reaper/CVE-2022-37601.patch
@@ -1,7 +1,7 @@
-diff --git a/loader-utils/lib/parseQuery.js b/loader-utils/lib/parseQuery.js
+diff --git a/node_modules/loader-utils/lib/parseQuery.js b/node_modules/loader-utils/lib/parseQuery.js
 index 12b3efc6..3dd7cb9b 100644
---- a/loader-utils/lib/parseQuery.js
-+++ b/loader-utils/lib/parseQuery.js
+--- a/node_modules/loader-utils/lib/parseQuery.js
++++ b/node_modules/loader-utils/lib/parseQuery.js
 @@ -26,7 +26,7 @@ function parseQuery(query) {
    }
  
@@ -11,10 +11,10 @@ index 12b3efc6..3dd7cb9b 100644
  
    queryArgs.forEach((arg) => {
      const idx = arg.indexOf('=');
-diff --git a/style-loader/node_modules/loader-utils/lib/parseQuery.js b/style-loader/node_modules/loader-utils/lib/parseQuery.js
+diff --git a/node_modules/style-loader/node_modules/loader-utils/lib/parseQuery.js b/node_modules/style-loader/node_modules/loader-utils/lib/parseQuery.js
 index fdca007d..4a201a2e 100644
---- a/style-loader/node_modules/loader-utils/lib/parseQuery.js
-+++ b/style-loader/node_modules/loader-utils/lib/parseQuery.js
+--- a/node_modules/style-loader/node_modules/loader-utils/lib/parseQuery.js
++++ b/node_modules/style-loader/node_modules/loader-utils/lib/parseQuery.js
 @@ -26,7 +26,7 @@ function parseQuery(query) {
    }
  
@@ -24,10 +24,10 @@ index fdca007d..4a201a2e 100644
  
    queryArgs.forEach((arg) => {
      const idx = arg.indexOf('=');
-diff --git a/url-loader/node_modules/loader-utils/lib/parseQuery.js b/url-loader/node_modules/loader-utils/lib/parseQuery.js
+diff --git a/node_modules/url-loader/node_modules/loader-utils/lib/parseQuery.js b/node_modules/url-loader/node_modules/loader-utils/lib/parseQuery.js
 index fdca007d..4a201a2e 100644
---- a/url-loader/node_modules/loader-utils/lib/parseQuery.js
-+++ b/url-loader/node_modules/loader-utils/lib/parseQuery.js
+--- a/node_modules/url-loader/node_modules/loader-utils/lib/parseQuery.js
++++ b/node_modules/url-loader/node_modules/loader-utils/lib/parseQuery.js
 @@ -26,7 +26,7 @@ function parseQuery(query) {
    }
  

--- a/SPECS/reaper/CVE-2022-37601.patch
+++ b/SPECS/reaper/CVE-2022-37601.patch
@@ -1,7 +1,33 @@
-diff --git a/node_modules/loader-utils/lib/parseQuery.js b/node_modules/loader-utils/lib/parseQuery.js
+diff --git a/loader-utils/lib/parseQuery.js b/loader-utils/lib/parseQuery.js
 index 12b3efc6..3dd7cb9b 100644
---- a/node_modules/loader-utils/lib/parseQuery.js
-+++ b/node_modules/loader-utils/lib/parseQuery.js
+--- a/loader-utils/lib/parseQuery.js
++++ b/loader-utils/lib/parseQuery.js
+@@ -26,7 +26,7 @@ function parseQuery(query) {
+   }
+ 
+   const queryArgs = query.split(/[,&]/g);
+-  const result = {};
++  const result = Object.create(null);
+ 
+   queryArgs.forEach((arg) => {
+     const idx = arg.indexOf('=');
+diff --git a/style-loader/node_modules/loader-utils/lib/parseQuery.js b/style-loader/node_modules/loader-utils/lib/parseQuery.js
+index fdca007d..4a201a2e 100644
+--- a/style-loader/node_modules/loader-utils/lib/parseQuery.js
++++ b/style-loader/node_modules/loader-utils/lib/parseQuery.js
+@@ -26,7 +26,7 @@ function parseQuery(query) {
+   }
+ 
+   const queryArgs = query.split(/[,&]/g);
+-  const result = {};
++  const result = Object.create(null);
+ 
+   queryArgs.forEach((arg) => {
+     const idx = arg.indexOf('=');
+diff --git a/url-loader/node_modules/loader-utils/lib/parseQuery.js b/url-loader/node_modules/loader-utils/lib/parseQuery.js
+index fdca007d..4a201a2e 100644
+--- a/url-loader/node_modules/loader-utils/lib/parseQuery.js
++++ b/url-loader/node_modules/loader-utils/lib/parseQuery.js
 @@ -26,7 +26,7 @@ function parseQuery(query) {
    }
  

--- a/SPECS/reaper/reaper.spec
+++ b/SPECS/reaper/reaper.spec
@@ -12,7 +12,7 @@
 
 Name:           reaper
 Version:        3.1.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Reaper for cassandra is a tool for running Apache Cassandra repairs against single or multi-site clusters.
 License:        ASL 2.0
 Distribution:   Mariner
@@ -179,8 +179,11 @@ fi
 %{_unitdir}/cassandra-%{name}.service
 
 %changelog
+* Tue May 23 2023 Bala <balakumaran.kannan@microsoft.com> - 3.1.1-4
+- Update CVE-2022-37601.patch to patch two other occurances of the same CVE
+
 * Wed Apr 19 2023 Bala <balakumaran.kannan@microsoft.com> - 3.1.1-3
-* Patch CVE-2022-37601 for webpack/loader-utils npm module
+- Patch CVE-2022-37601 for webpack/loader-utils npm module
 
 * Tue Sep 06 2022 Sumedh Sharma <sumsharma@microsoft.com> - 3.1.1-2
 - Adding Runtime requirement on msopenjdk.

--- a/SPECS/reaper/reaper.spec
+++ b/SPECS/reaper/reaper.spec
@@ -108,7 +108,7 @@ tar xf %{SOURCE1}
 
 echo "Installing npm_modules"
 tar fx %{SOURCE2}
-patch -p1 {PATCH0}
+patch -p1 < %{PATCH0}
 popd
 
 # Building using maven in offline mode.


### PR DESCRIPTION
loader-utils module is used by multiple other modules which reaper is depending upon. Instead of reusing already downloaded code, npm redownloades the same module at different subtree level of node_modules. So the same CVE has to be fixed in other two places as well.

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Update CVE-2022-37601.patch to fix multiple occurrences

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Update CVE-2022-37601.patch to fix multiple occurrences

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->


###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2022-37601

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- BuddyBuild Pipeline build id: local build with msopenjdk-11-11.0.18-1.x86_64.rpm from build_cache