### PR TITLE
fix: add setuid bit to necessary binaries so regular users can run them

### DIFF
--- a/SPECS/shadow-utils/shadow-utils.spec
+++ b/SPECS/shadow-utils/shadow-utils.spec
@@ -1,7 +1,7 @@
 Summary:        Programs for handling passwords in a secure way
 Name:           shadow-utils
 Version:        4.9
-Release:        11%{?dist}
+Release:        12%{?dist}
 License:        BSD
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -163,7 +163,7 @@ chmod 000 %{_sysconfdir}/shadow
 %{_bindir}/*
 %{_sbindir}/*
 %{_mandir}/*
-%attr(0755,root,root) /bin/passwd
+%attr(4755,root,root) /bin/passwd
 %config(noreplace) %{_sysconfdir}/pam.d/*
 %attr(0000,root,root) %config(noreplace,missingok) %ghost %{_sysconfdir}/shadow
 
@@ -176,8 +176,11 @@ chmod 000 %{_sysconfdir}/shadow
 %{_libdir}/libsubid.so
 
 %changelog
+* Wed May 24 2023 Tobias Brick <tobiasb@microsoft.com> - 4.9-12
+- Add SETUID bit to passwd binary
+
 * Mon Jul 18 2022 Minghe Ren <mingheren@microsoft.com> - 4.9-11
-- Update login-defs, system-auth, passwd to improve security 
+- Update login-defs, system-auth, passwd to improve security
 
 * Fri Jul 01 2022 Andrew Phelps <anphel@microsoft.com> - 4.9-10
 - Remove su binary which is now provided by util-linux

--- a/SPECS/util-linux/util-linux.spec
+++ b/SPECS/util-linux/util-linux.spec
@@ -1,7 +1,7 @@
 Summary:        Utilities for file systems, consoles, partitions, and messages
 Name:           util-linux
 Version:        2.37.4
-Release:        5%{?dist}
+Release:        6%{?dist}
 License:        GPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -113,8 +113,8 @@ rm -rf %{buildroot}/lib/systemd/system
 %dir %{_prefix}%{_var}/run/uuidd
 %dir %{_sharedstatedir}/libuuid
 /bin/*
-%attr(0755,root,root) /bin/mount
-%attr(0755,root,root) /bin/umount
+%attr(4755,root,root) /bin/mount
+%attr(4755,root,root) /bin/umount
 /sbin/*
 %{_bindir}/*
 %{_sbindir}/*
@@ -148,6 +148,9 @@ rm -rf %{buildroot}/lib/systemd/system
 %{_mandir}/man3/*
 
 %changelog
+* Wed May 24 2023 Tobias Brick <tobiasb@microsoft.com> - 2.37.4-6
+- Add SETUID bit to mount and umount.
+
 * Mon Feb 06 2023 Mitch Zhu <mitchzhu@microsoft.com> - 2.37.4-5
 - Add patch to prevent cdrom probe on Azure VMs
 

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -66,9 +66,9 @@ make-4.3-2.cm2.aarch64.rpm
 patch-2.7.6-7.cm2.aarch64.rpm
 libcap-ng-0.8.2-2.cm2.aarch64.rpm
 libcap-ng-devel-0.8.2-2.cm2.aarch64.rpm
-util-linux-2.37.4-5.cm2.aarch64.rpm
-util-linux-devel-2.37.4-5.cm2.aarch64.rpm
-util-linux-libs-2.37.4-5.cm2.aarch64.rpm
+util-linux-2.37.4-6.cm2.aarch64.rpm
+util-linux-devel-2.37.4-6.cm2.aarch64.rpm
+util-linux-libs-2.37.4-6.cm2.aarch64.rpm
 tar-1.34-1.cm2.aarch64.rpm
 xz-5.2.5-1.cm2.aarch64.rpm
 xz-devel-5.2.5-1.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -66,9 +66,9 @@ make-4.3-2.cm2.x86_64.rpm
 patch-2.7.6-7.cm2.x86_64.rpm
 libcap-ng-0.8.2-2.cm2.x86_64.rpm
 libcap-ng-devel-0.8.2-2.cm2.x86_64.rpm
-util-linux-2.37.4-5.cm2.x86_64.rpm
-util-linux-devel-2.37.4-5.cm2.x86_64.rpm
-util-linux-libs-2.37.4-5.cm2.x86_64.rpm
+util-linux-2.37.4-6.cm2.x86_64.rpm
+util-linux-devel-2.37.4-6.cm2.x86_64.rpm
+util-linux-libs-2.37.4-6.cm2.x86_64.rpm
 tar-1.34-1.cm2.x86_64.rpm
 xz-5.2.5-1.cm2.x86_64.rpm
 xz-devel-5.2.5-1.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -568,11 +568,11 @@ texinfo-6.8-1.cm2.aarch64.rpm
 texinfo-debuginfo-6.8-1.cm2.aarch64.rpm
 unzip-6.0-20.cm2.aarch64.rpm
 unzip-debuginfo-6.0-20.cm2.aarch64.rpm
-util-linux-2.37.4-5.cm2.aarch64.rpm
-util-linux-libs-2.37.4-5.cm2.aarch64.rpm
-util-linux-debuginfo-2.37.4-5.cm2.aarch64.rpm
-util-linux-devel-2.37.4-5.cm2.aarch64.rpm
-util-linux-lang-2.37.4-5.cm2.aarch64.rpm
+util-linux-2.37.4-6.cm2.aarch64.rpm
+util-linux-libs-2.37.4-6.cm2.aarch64.rpm
+util-linux-debuginfo-2.37.4-6.cm2.aarch64.rpm
+util-linux-devel-2.37.4-6.cm2.aarch64.rpm
+util-linux-lang-2.37.4-6.cm2.aarch64.rpm
 which-2.21-8.cm2.aarch64.rpm
 which-debuginfo-2.21-8.cm2.aarch64.rpm
 xz-5.2.5-1.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -568,11 +568,11 @@ texinfo-6.8-1.cm2.x86_64.rpm
 texinfo-debuginfo-6.8-1.cm2.x86_64.rpm
 unzip-6.0-20.cm2.x86_64.rpm
 unzip-debuginfo-6.0-20.cm2.x86_64.rpm
-util-linux-2.37.4-5.cm2.x86_64.rpm
-util-linux-libs-2.37.4-5.cm2.x86_64.rpm
-util-linux-debuginfo-2.37.4-5.cm2.x86_64.rpm
-util-linux-devel-2.37.4-5.cm2.x86_64.rpm
-util-linux-lang-2.37.4-5.cm2.x86_64.rpm
+util-linux-2.37.4-6.cm2.x86_64.rpm
+util-linux-libs-2.37.4-6.cm2.x86_64.rpm
+util-linux-debuginfo-2.37.4-6.cm2.x86_64.rpm
+util-linux-devel-2.37.4-6.cm2.x86_64.rpm
+util-linux-lang-2.37.4-6.cm2.x86_64.rpm
 which-2.21-8.cm2.x86_64.rpm
 which-debuginfo-2.21-8.cm2.x86_64.rpm
 xz-5.2.5-1.cm2.x86_64.rpm


### PR DESCRIPTION
###### Merge Checklist
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary
A [change from last year](https://github.com/microsoft/CBL-Mariner/pull/3713) changed the mode on some executables to `0755`, as a security lockdown. However, for `passwd`, `mount` and `umount`, the `set-uid` bit should be set so they can elevate as needed. Without it, for example, users can't change their own password. Our security tools for Ubuntu allow these executables as exceptions for the "don't have set-uid" check, but they have a different path in Ubuntu so we accidentally didn't exempt them from this change.

This change sets the mode on those files to `4755`, which adds the `set-uid` back.

###### Change Log
- packages: shadow-utils and util-linux
- Changed the file copy `%attr` command to use correct modes
- Updated pkggen lists

###### Does this affect the toolchain?
**YES** -- `util-linux` is in the toolchain.

###### Test Methodology
- Manually built locally and validated installed files are correct.
- Did an update install on a marketplace vm and validated permissions were correct afterwards.
- [AMD64 Buddy Build](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=366444&view=results)
- [ARM64 Buddy Build](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=366445&view=results)
- [AMD64 Toolchain Build](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=366364&view=results)
- [ARM64 Toolchain Build](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=366365&view=results)
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: xxxx
