### PR TITLE
Enable the graphpkgfetcher to pull build nodes from upstream repos if available

### DIFF
--- a/toolkit/docs/building/building.md
+++ b/toolkit/docs/building/building.md
@@ -509,6 +509,16 @@ If that is not desired all remote sources can be disabled by clearing the follow
 
 > Delete all `marinertoolchain*` containers and images associated with this working directory when running `make clean`.
 
+#### `DELTA_FETCH=...`
+
+##### `DELTA_FETCH=n`
+
+> Don't download pre-built packages to avoid rebuilds..
+
+##### `DELTA_FETCH=`**`y`** *(default)*
+
+> Try to download pre-built packages if the versions match the local spec files.
+
 #### `ALLOW_TOOLCHAIN_DOWNLOAD_FAIL=...`
 
 ##### `ALLOW_TOOLCHAIN_DOWNLOAD_FAIL=`**`n`** *(default)*

--- a/toolkit/scripts/incremental_building.mk
+++ b/toolkit/scripts/incremental_building.mk
@@ -61,6 +61,7 @@ DELTA_BUILD    = y
 # on to be friendly to the user unless they have explicitly set it to off.
 USE_CCACHE    ?= y
 REBUILD_TOOLS ?= y
+DELTA_FETCH   ?= y
 endif
 
 ######## SET REMAINING FLAG DEFAULTS ########
@@ -71,6 +72,7 @@ REBUILD_TOOLS                   ?= n
 USE_CCACHE                      ?= n
 DELTA_BUILD                     ?= n
 CLEAN_TOOLCHAIN_CONTAINERS      ?= y
+DELTA_FETCH                     ?= n
 
 ######## HANDLE INCREMENTAL_TOOLCHAIN DEPRECATION ########
 

--- a/toolkit/scripts/pkggen.mk
+++ b/toolkit/scripts/pkggen.mk
@@ -124,6 +124,14 @@ ifeq ($(STOP_ON_FETCH_FAIL),y)
 graphpkgfetcher_extra_flags += --stop-on-failure
 endif
 
+ifeq ($(DELTA_FETCH),y)
+graphpkgfetcher_extra_flags += --packages="$(PACKAGE_BUILD_LIST)"
+graphpkgfetcher_extra_flags += --image-config-file="$(CONFIG_FILE)"
+graphpkgfetcher_extra_flags += --try-download-delta-rpms
+graphpkgfetcher_extra_flags += $(if $(CONFIG_FILE),--base-dir="$(CONFIG_BASE_DIR)")
+$(cached_file): $(depend_CONFIG_FILE) $(depend_PACKAGE_BUILD_LIST)
+endif
+
 $(cached_file): $(graph_file) $(go-graphpkgfetcher) $(chroot_worker) $(pkggen_local_repo) $(depend_REPO_LIST) $(REPO_LIST) $(rpm_cache_files) $(TOOLCHAIN_MANIFEST) $(toolchain_rpms)
 	mkdir -p $(CACHED_RPMS_DIR)/cache && \
 	$(go-graphpkgfetcher) \

--- a/toolkit/tools/graphpkgfetcher/graphpkgfetcher.go
+++ b/toolkit/tools/graphpkgfetcher/graphpkgfetcher.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/exe"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/file"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/logger"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/packagerepo/repocloner/rpmrepocloner"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/packagerepo/repoutils"
@@ -43,6 +44,11 @@ var (
 	tlsClientKey  = app.Flag("tls-key", "TLS client key to use when downloading files.").String()
 
 	stopOnFailure = app.Flag("stop-on-failure", "Stop if failed to cache all unresolved nodes.").Bool()
+
+	tryDownloadDeltaRPMs = app.Flag("try-download-delta-rpms", "Automatically download the RPMs we will try to build into the cache if they are available, so we can skip building them later.").Bool()
+	pkgsToBuild          = app.Flag("packages", "Space separated list of top-level packages that should be built. Omit this argument to build all packages. Used with '--try-download-delta-rpms'").String()
+	imageConfig          = app.Flag("image-config-file", "Optional image config file to extract a package list from. Used with '--try-download-delta-rpms'").String()
+	baseDirPath          = app.Flag("base-dir", "Base directory for relative file paths from the config. Defaults to config's directory. Used with '--try-download-delta-rpms'").ExistingDir()
 
 	inputSummaryFile  = app.Flag("input-summary-file", "Path to a file with the summary of packages cloned to be restored").String()
 	outputSummaryFile = app.Flag("output-summary-file", "Path to save the summary of packages cloned").String()
@@ -79,7 +85,7 @@ func fetchPackages() (err error) {
 
 	var cloner *rpmrepocloner.RpmRepoCloner
 	hasUnresolvedNodes := hasUnresolvedNodes(dependencyGraph)
-	if hasUnresolvedNodes {
+	if *tryDownloadDeltaRPMs || hasUnresolvedNodes {
 		// Create the worker environment
 		cloner, err = prepRpmCloner(*outDir, *disableUpstreamRepos)
 		if err != nil {
@@ -105,6 +111,78 @@ func fetchPackages() (err error) {
 		err = fmt.Errorf("failed to write cache graph to file: %w", err)
 		return
 	}
+
+	// Optional delta build cache hydration
+	if *tryDownloadDeltaRPMs {
+		logger.Log.Info("Attempting to download delta RPMs for build nodes")
+		err = downloadDeltaNodes(dependencyGraph, cloner)
+		if err != nil {
+			err = fmt.Errorf("failed to download delta RPMs: %w", err)
+			return
+		}
+		// Update the package graph with the paths to the delta RPMs we downloaded
+		err = pkggraph.WriteDOTGraphFile(dependencyGraph, *outputGraph)
+		if err != nil {
+			err = fmt.Errorf("failed to write cache graph to file: %w", err)
+			return
+		}
+	}
+
+	// If we grabbed any RPMs, we need to convert them into a local repo
+	if *tryDownloadDeltaRPMs || hasUnresolvedNodes {
+		logger.Log.Info("Configuring downloaded RPMs as a local repository")
+		err = cloner.ConvertDownloadedPackagesIntoRepo()
+		if err != nil {
+			err = fmt.Errorf("failed to convert downloaded RPMs into a repo: %w", err)
+			return
+		}
+	}
+	return
+}
+
+// downloadDeltaNodes will look at the final cached graph we saved and see if any RPMS can be download instead of built.
+// If the previous part of the fetcher worked well we should be able to download only the delta RPMs we need
+// to build our packages or image (i.e. we should be able to create a subgraph just like we would for the build step)
+//   - dependencyGraph: The graph to use to find the packages we need to build. Should have any caching operations already
+//     performed on it. Will be updated with the paths to the delta RPMs we download.
+//   - cloner: The cloner to use to download the RPMs
+func downloadDeltaNodes(dependencyGraph *pkggraph.PkgGraph, cloner *rpmrepocloner.RpmRepoCloner) (err error) {
+	const (
+		deltaBuildGraph = true
+	)
+
+	// Generate the list of packages that need to be built. If none are requested then all packages will be built. We
+	// don't care about explicit rebuilds here since we are going to rebuild them anyway.
+	packagesNamesToBuild := exe.ParseListArgument(*pkgsToBuild)
+
+	packageVersToBuild, err := schedulerutils.CalculatePackagesToBuild(packagesNamesToBuild, nil, *outputGraph, *imageConfig, *baseDirPath)
+	if err != nil {
+		err = fmt.Errorf("unable to generate package build list to calculate delta downloads: %w", err)
+		return
+	}
+
+	// The scheduler utils expect to pick a graph up from a file, so we will write the graph we wrote it to a file and
+	// now we read it back in and optimize it. We will heavily modify this graph so it should not be used for anything
+	// else.
+	isGraphOptimized, deltaPkgGraphCopy, _, err := schedulerutils.InitializeGraph(*outputGraph, packageVersToBuild, deltaBuildGraph)
+	if err != nil {
+		err = fmt.Errorf("failed to initialize graph for delta package downloading: %w", err)
+		return
+	}
+
+	if !isGraphOptimized {
+		logger.Log.Warnf("Graph is not optimized, delta package downloading will be very slow!")
+	}
+
+	if len(deltaPkgGraphCopy.AllBuildNodes()) > 0 {
+		err = downloadAllAvailableDeltaRPMs(dependencyGraph, deltaPkgGraphCopy, cloner, *stopOnFailure)
+		if err != nil {
+			err = fmt.Errorf("failed to download delta RPMs: %w", err)
+			return
+		}
+	}
+
+	return
 }
 
 // hasUnresolvedNodes scans through the graph to see if there is anything to do
@@ -163,6 +241,194 @@ func resolveGraphNodes(dependencyGraph *pkggraph.PkgGraph, inputSummaryFile, out
 	return
 }
 
+// downloadDeltaRPMs scans a graph and for each build node in the graph and tries to replace it with a cached node instead.
+// to satisfy it.
+//   - realDependencyGraph: The graph to use to find the packages we need to build. Should have any caching operations already
+//     performed on it. Will be updated with the paths to the delta RPMs we download.
+//   - dependencyGraphDeltaCopy: A copy of the graph we will use to try to optimize the build nodes. This graph should be
+//     optimized to only contain the nodes we need to build.
+//   - cloner: The cloner to use to download the RPMs
+//   - stopOnFailure: If true, will stop the build if we fail to download any delta RPMs.
+func downloadAllAvailableDeltaRPMs(realDependencyGraph, dependencyGraphDeltaCopy *pkggraph.PkgGraph, cloner *rpmrepocloner.RpmRepoCloner, stopOnFailure bool) (err error) {
+	// First scan the copy of the graph we tried to optimize for all the SRPMs we need to build. We will use this list to
+	// match against all the nodes in the full graph.
+	srpmPaths := make(map[string]bool)
+	for _, n := range dependencyGraphDeltaCopy.AllBuildNodes() {
+		srpmPaths[n.SrpmPath] = true
+	}
+
+	// We don't want to download implicit nodes since they will be included in another node with the same SRPM. Keep a list
+	// of them so we can fix them up later.
+	skippedNodes := []*pkggraph.PkgNode{}
+	// We will need to keep track of the original path to delta path mapping so we can fix up the implicit nodes later.
+	originalPathToDeltaPathMap := make(map[string]string)
+
+	// For each build node, try to update it to a delta node with a downloaded RPM backing it.
+	logger.Log.Debugf("Resolving build nodes")
+	for _, n := range realDependencyGraph.AllBuildNodes() {
+		// Implicit nodes cause us troubles since we don't know exactly which RPMs they will build (so the cache fetcher
+		// will pull all of the possible matches). Since we are already matching against SRPMs, we can safely skip these
+		// nodes since they will be included in another node with the same SRPM.
+		if n.Implicit {
+			logger.Log.Debugf("Skipping implicit delta build node %s", n)
+			skippedNodes = append(skippedNodes, n)
+			continue
+		}
+
+		logger.Log.Debugf("Resolving build node %s", n)
+		if n.State == pkggraph.StateBuild {
+			foundMatch, err := downloadSingleDeltaRPM(realDependencyGraph, n, cloner, *outDir, &originalPathToDeltaPathMap)
+			if err != nil {
+				return fmt.Errorf("failed to download delta RPM for build node %s: %w", n, err)
+			}
+			if !foundMatch {
+				// Throw any nodes we fail to resolve the fist time into a list so we can try to resolve them again later.
+				// This will help with cases were a new sub-package is added to a build node, but we won't be able to download
+				// the delta RPM since it doesn't exist yet.
+				skippedNodes = append(skippedNodes, n)
+			}
+		}
+	}
+
+	// Fix up the implicit nodes to point to the correct delta RPMs that we parsed earlier.
+	for _, n := range skippedNodes {
+		logger.Log.Debugf("Fixing up skipped node %s", n)
+		err = fixupDeltaImplicitNode(realDependencyGraph, n, &originalPathToDeltaPathMap)
+		if err != nil {
+			return fmt.Errorf("failed to fixup skipped node %s: %w", n, err)
+		}
+	}
+
+	logger.Log.Info("Configuring additional delta RPMs as a local repository")
+	err = cloner.ConvertDownloadedPackagesIntoRepo()
+	if err != nil {
+		logger.Log.Errorf("Failed to convert downloaded RPMs into a repo. Error: %s", err)
+		return
+	}
+
+	return
+}
+
+// downloadSingleDeltaRPM attempts to download a single delta RPM for a build node. If the delta RPM is available
+// it will be downloaded and the build node will be updated to point to the new RPM. The associated run node will
+// also be updated to point to the new RPM since the scheduler uses the run node to find the RPM to install.
+//   - realDependencyGraph: The graph to update
+//   - realBuildNode: The build node to update. This node should be from the real graph as we will be updating it directly.
+//     to find the actual build node in the graph.
+//   - cloner: The cloner to use to download the RPMs
+//   - deltaRpmDir: The directory to download the RPMs into (likely the same as the normal RPM cache)
+//   - pathMap: A map of the original path to the delta path for each RPM that was downloaded. This is used to fix up
+//     the implicit nodes later.
+func downloadSingleDeltaRPM(realDependencyGraph *pkggraph.PkgGraph, realBuildNode *pkggraph.PkgNode, cloner *rpmrepocloner.RpmRepoCloner, deltaRpmDir string, pathMap *map[string]string) (foundMatch bool, err error) {
+	//TODO: downloadDependencies is broken right now, fix it
+	const downloadDependencies = true
+	var lookup *pkggraph.LookupNode
+
+	// Find the real build node in the graph we want to keep (we will be discarding the graph the node was passed in from so we can't use it)
+	if realBuildNode.Type != pkggraph.TypeBuild {
+		err = fmt.Errorf("node '%s' is not a build node, can't download delta RPM", realBuildNode)
+		return false, err
+	}
+	lookup, err = realDependencyGraph.FindExactPkgNodeFromPkg(realBuildNode.VersionedPkg)
+	if err != nil {
+		err = fmt.Errorf("can't find build node '%s' in graph: %w", realBuildNode, err)
+		return false, err
+	}
+	if lookup == nil || lookup.RunNode == nil {
+		err = fmt.Errorf("can't find run lookup '%v' in graph", lookup)
+		return false, err
+	}
+
+	if lookup.BuildNode != realBuildNode {
+		err = fmt.Errorf("real build node '%v' does not match build node in the graph lookup '%v'", realBuildNode, lookup.BuildNode)
+		return false, err
+	}
+
+	realRunNode := lookup.RunNode
+
+	// Get the final output path for the build node if we don't convert it to a delta node
+	originalRpmPath := realBuildNode.RpmPath
+	foundFinalRPM, _ := file.IsFile(originalRpmPath)
+
+	// Only download dependencies for delta RPMs if we don't already have the RPM in the out/RPMS folder
+	if !foundFinalRPM {
+		resolveErr := resolveSingleNode(cloner, realBuildNode, downloadDependencies, nil, make(map[string]bool), make(map[string]bool), deltaRpmDir)
+		// Failing to clone a dependency should not halt a build.
+		// The build should continue and attempt best effort to build as many packages as possible.
+		if resolveErr != nil {
+			logger.Log.Warnf("Can't find delta RPM to download for %s: %s", realBuildNode, resolveErr)
+			return false, nil
+		}
+		logger.Log.Tracef("Updating real node '%s' with info from newly cached delta node '%s'", realBuildNode, realBuildNode)
+
+		// Check that the RPM we are getting matches the expected out/RPM path using the base name of the file path
+		cachedRPMPath := realBuildNode.RpmPath
+		if filepath.Base(cachedRPMPath) != filepath.Base(originalRpmPath) {
+			err = fmt.Errorf("cached RPM '%s' does not match expected RPM '%s'", filepath.Base(cachedRPMPath), filepath.Base(originalRpmPath))
+			return false, err
+		}
+
+		realBuildNode.State = pkggraph.StateDelta
+		realRunNode.State = pkggraph.StateDelta
+
+		// Record the original path to delta path mapping so we can fix up the implicit nodes later.
+		(*pathMap)[originalRpmPath] = realBuildNode.RpmPath
+		realRunNode.RpmPath = realBuildNode.RpmPath
+
+		logger.Log.Tracef("PathMap updated: %v", *pathMap)
+
+		logger.Log.Tracef("Converted delta build node is now: '%s'", realBuildNode)
+		logger.Log.Tracef("Converted delta run node is now: '%s'", realRunNode)
+	} else {
+		logger.Log.Debugf("Found out RPM for '%s' at '%s', skipping delta download.", realBuildNode, originalRpmPath)
+	}
+
+	return true, err
+}
+
+// downloadSingleDeltaRPM attempts to download a single delta RPM for a build node. If the delta RPM is available
+// it will be downloaded and the build node will be updated to point to the new RPM. The associated run node will
+// also be updated to point to the new RPM since the scheduler uses the run node to find the RPM to install.
+//   - pkgGraph: The graph to update
+//   - implicitNode: The implicit build node to update, this node need not be in the actual graph and will be used as a reference
+//     to find the actual build node in the graph.
+//   - pathMap: The map of original RPM paths to delta RPM paths that we have already downloaded.
+func fixupDeltaImplicitNode(realPkgGraph *pkggraph.PkgGraph, implicitNode *pkggraph.PkgNode, pathMap *map[string]string) (err error) {
+	var lookup *pkggraph.LookupNode
+
+	logger.Log.Debugf("Implicit node '%s' is a delta RPM, fixing up associated build and run nodes.", implicitNode)
+
+	lookup, err = realPkgGraph.FindExactPkgNodeFromPkg(implicitNode.VersionedPkg)
+	if err != nil {
+		err = fmt.Errorf("can't find implicit lookup node '%s' in graph: %w", implicitNode, err)
+		return
+	}
+	if lookup == nil || lookup.BuildNode == nil || lookup.RunNode == nil {
+		err = fmt.Errorf("can't find implicit build and run lookup '%v' in graph", lookup)
+		return
+	}
+
+	realBuildNode := lookup.BuildNode
+	realRunNode := lookup.RunNode
+
+	// Check if we have a path saved for this rpm
+	dstPath := realRunNode.RpmPath
+	if deltaPath, ok := (*pathMap)[dstPath]; ok {
+		logger.Log.Tracef("Found delta RPM for '%s' at '%s', updating build and run nodes.", implicitNode, dstPath)
+		realBuildNode.State = pkggraph.StateDelta
+		realRunNode.State = pkggraph.StateDelta
+
+		// Update the build and run nodes to point to the delta RPM
+		realBuildNode.RpmPath = deltaPath
+		realRunNode.RpmPath = deltaPath
+	} else {
+		logger.Log.Tracef("Can't find delta RPM for '%s' at '%s', skipping implicit delta update.", implicitNode, dstPath)
+		return
+	}
+
+	return
+}
+
 // resolveSingleNode caches the RPM for a single node.
 // It will modify fetchedPackages on a successful package clone.
 func resolveSingleNode(cloner *rpmrepocloner.RpmRepoCloner, node *pkggraph.PkgNode, cloneDeps bool, toolchainPackages []string, fetchedPackages, prebuiltPackages map[string]bool, outDir string) (err error) {
@@ -178,7 +444,7 @@ func resolveSingleNode(cloner *rpmrepocloner.RpmRepoCloner, node *pkggraph.PkgNo
 		if node.Implicit {
 			logger.Log.Debug(msg)
 		} else {
-			logger.Log.Error(msg)
+			logger.Log.Warn(msg)
 		}
 		return
 	}

--- a/toolkit/tools/internal/pkggraph/pkggraph.go
+++ b/toolkit/tools/internal/pkggraph/pkggraph.go
@@ -41,6 +41,7 @@ const (
 	StateUnresolved NodeState = iota            // A dependency is not available locally and must be acquired from a remote repo
 	StateCached     NodeState = iota            // A dependency was not available locally, but is now available in the chache
 	StateBuildError NodeState = iota            // A package from a local SRPM which failed to build
+	StateDelta      NodeState = iota            // Same as build state, but an attempt has been made to pre-download the .rpm to the cache
 	StateMAX        NodeState = StateBuildError // Max allowable state
 )
 
@@ -119,6 +120,8 @@ func (n NodeState) String() string {
 		return "Unresolved"
 	case StateCached:
 		return "Cached"
+	case StateDelta:
+		return "Delta"
 	default:
 		logger.Log.Panic("Invalid NodeState encountered when serializing to string!")
 		return "error"
@@ -166,6 +169,8 @@ func (n *PkgNode) DOTColor() string {
 		return "crimson"
 	case StateCached:
 		return "darkorchid"
+	case StateDelta:
+		return "gold4"
 	default:
 		logger.Log.Panic("Invalid NodeState encountered when serializing to color!")
 		return "error"

--- a/toolkit/tools/scheduler/schedulerutils/buildworker.go
+++ b/toolkit/tools/scheduler/schedulerutils/buildworker.go
@@ -37,6 +37,7 @@ type BuildRequest struct {
 	PkgGraph       *pkggraph.PkgGraph
 	AncillaryNodes []*pkggraph.PkgNode
 	CanUseCache    bool
+	IsDelta        bool
 }
 
 // BuildResult represents the results of a build agent trying to build a given node.
@@ -48,6 +49,7 @@ type BuildResult struct {
 	Node           *pkggraph.PkgNode
 	Skipped        bool
 	UsedCache      bool
+	WasDelta       bool
 }
 
 // selectNextBuildRequest selects a job based on priority:
@@ -97,6 +99,7 @@ func BuildNodeWorker(channels *BuildChannels, agent buildagents.BuildAgent, grap
 		res := &BuildResult{
 			Node:           req.Node,
 			AncillaryNodes: req.AncillaryNodes,
+			WasDelta:       req.IsDelta,
 		}
 
 		switch req.Node.Type {

--- a/toolkit/tools/scheduler/schedulerutils/graphbuildstate.go
+++ b/toolkit/tools/scheduler/schedulerutils/graphbuildstate.go
@@ -16,6 +16,7 @@ import (
 type nodeState struct {
 	available bool
 	cached    bool
+	usedDelta bool
 }
 
 // GraphBuildState represents the build state of a graph.
@@ -65,6 +66,12 @@ func (g *GraphBuildState) IsNodeAvailable(node *pkggraph.PkgNode) bool {
 func (g *GraphBuildState) IsNodeCached(node *pkggraph.PkgNode) bool {
 	state := g.nodeToState[node]
 	return state != nil && state.cached
+}
+
+// IsNodeDelta returns true if the requested node was pre-downloaded as a delta package.
+func (g *GraphBuildState) IsNodeDelta(node *pkggraph.PkgNode) bool {
+	state := g.nodeToState[node]
+	return state != nil && state.usedDelta
 }
 
 // ActiveBuilds returns a map of Node IDs to BuildRequests that represents all outstanding builds.
@@ -139,6 +146,7 @@ func (g *GraphBuildState) RecordBuildResult(res *BuildResult, allowToolchainRebu
 	state := &nodeState{
 		available: res.Err == nil,
 		cached:    res.UsedCache,
+		usedDelta: res.WasDelta,
 	}
 
 	for _, node := range res.AncillaryNodes {


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
For running fast builds it would be great to avoid rebuilding nodes if they are already available from a remote repo. We should scan each build node we find in the graph and try to match it to an exact `.rpm` file in the repo. If we can make an exact update the graph node's `rpmPath` to point into the cache instead of the expected `out/RPMS` location.

The scheduler will still treat the nodes in the same way as before, if all the expected files are present, and we don't want to rebuild it for another reason, skip it. If we do need to rebuild it for any reason the `.rpm`s will end up in `out/RPMS` still.

To make sure delta packages are not confused with normal packages we will only place `.rpm` files into `out/RPMS` if they are rebuilt by the scheduler, regardless of if the user selects `PACKAGE_BUILD_LIST` or not. The built package summary lists these packages in different lists now.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- `graphpkgfetcher` tool will try and hydrate build nodes if an exact matching .rpm is available from a repo.
- `scheduler` will know to check the delta nodes for prebuilt rpms if enabled, and will skip building new .rpms if all expected files are available in either out/RPMS or the cache.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**


###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local builds only for now
