### PR TITLE
Remove influx-cli-bash-completion subpackage as duplicate and conflict with bash-completion

### DIFF
--- a/SPECS/influx-cli/influx-cli.spec
+++ b/SPECS/influx-cli/influx-cli.spec
@@ -18,7 +18,7 @@
 Summary:        CLI for managing resources in InfluxDB
 Name:           influx-cli
 Version:        2.6.1
-Release:        7%{?dist}
+Release:        8%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -46,17 +46,6 @@ BuildRequires:  systemd-rpm-macros
 %description
 CLI for managing resources in InfluxDB v2.
 
-%package bash-completion
-Summary:        Bash Completion for %{name}
-Group:          Productivity/Databases/Servers
-Requires:       bash-completion
-Supplements:    (%{name} and bash-completion)
-BuildArch:      noarch
-
-%description bash-completion
-The official bash completion script for influx. It includes support
-for every argument that can currently be passed to influx.
-
 %package zsh-completion
 Summary:        ZSH Completion for %{name}
 Group:          Productivity/Databases/Servers
@@ -80,9 +69,6 @@ go build -mod vendor -ldflags="-X main.version=%{version}" -o bin/influx ./cmd/i
 mkdir -p %{buildroot}%{_bindir}
 install -D -m 0755 bin/influx %{buildroot}%{_bindir}/
 
-mkdir -p %{buildroot}/%{_datadir}/bash-completion/completions
-bin/influx completion bash > %{buildroot}/%{_datadir}/bash-completion/completions/influx
-
 mkdir -p %{buildroot}/%{_datadir}/zsh/site-functions
 bin/influx completion zsh > %{buildroot}/%{_datadir}/zsh/site-functions/_influx
 
@@ -91,13 +77,13 @@ bin/influx completion zsh > %{buildroot}/%{_datadir}/zsh/site-functions/_influx
 %doc README.md CHANGELOG.md
 %{_bindir}/influx
 
-%files bash-completion
-%{_datadir}/bash-completion
-
 %files zsh-completion
 %{_datadir}/zsh
 
 %changelog
+* Thu May 25 2023 Mykhailo Bykhovtsev <mbykhovtsev@microsft.com> - 2.6.1-8
+- Removed bash-completion subpackage since the script produced is included in original bash-completion.
+
 * Wed Apr 05 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 2.6.1-7
 - Bump release to rebuild with go 1.19.8
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Removed `bash-completion` subpackage from `influx-cli` package. It seems like `bash-completion` is already including the `influx` script that we produce in `influx-cli` for `bash-completion` subpackage. This causes file conflict when installing both, but given that they are the same script we do not need the `bash-completion` subpackage for `influx-cli`.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Removed `bash-completion` subpackage from `influx-cli` pacakge.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Built locally
- Pipeline id: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=367167&view=results