### PR TITLE
Install known-good pytest for python-click package test

### DIFF
--- a/SPECS/python-click/python-click.spec
+++ b/SPECS/python-click/python-click.spec
@@ -1,9 +1,3 @@
-%{!?python3_pkgversion: %global python3_pkgversion 3}
-%{!?python3_version: %define python3_version %(python3 -c "import sys; sys.stdout.write(sys.version[:3])")}
-%{!?python3_sitelib: %define python3_sitelib %(python3 -c "from distutils.sysconfig import get_python_lib;print(get_python_lib())")}
-%{!?__python3: %global __python3 %{_bindir}/python3}
-%{!?py3_build: %define py3_build CFLAGS="%{optflags}"  %{__python3} setup.py build}
-%{!?py3_install: %define py3_install  %{__python3} setup.py install --skip-build --root %{buildroot}}
 %global pypi_name click
 %global _description \
 click is a Python package for creating beautiful command line\
@@ -14,8 +8,8 @@ comes with good defaults out of the box.
 Summary:        Simple wrapper around optparse for powerful command line utilities
 Name:           python-%{pypi_name}
 Version:        7.1.2
-Release:        6%{?dist}
-License:        BSD
+Release:        7%{?dist}
+License:        BSD-3-Clause
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 URL:            https://github.com/mitsuhiko/click
@@ -45,7 +39,7 @@ BuildRequires:  python%{python3_pkgversion}-setuptools
 %py3_install
 
 %check
-pip3 install pytest
+pip3 install pytest==7.2.2
 pip3 install .
 pytest -v tests
 
@@ -56,6 +50,10 @@ pytest -v tests
 %{python3_sitelib}/%{pypi_name}-*.egg-info/
 
 %changelog
+* Tue May 30 2023 Olivia Crain <oliviacrain@microsoft.com> - 7.1.2-7
+- Change %%check to install known-good version of pytest
+- Use SPDX license expression in license tag
+
 * Mon Oct 17 2022 Riken Maharjan <rmaharjan@microsft.com> - 7.1.2-6
 - Migrate the package to Mariner Core.
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
The package test for `python-click` fails with `pytest >= 7.3.0` for reasons documented [upstream](https://github.com/pallets/click/issues/2489). So, let's pin `pytest` to a version we know is compatible with `python-click`.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Pin pytest used in python-click package test to 7.2.2

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- [ADO#44714945](https://microsoft.visualstudio.com/OS/_workitems/edit/44714945)

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- [Buddy build](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=369014&view=results)
