### PR TITLE
Fix occasional test failure in timestamp test

### DIFF
--- a/toolkit/tools/internal/timestamp/timestamp_test.go
+++ b/toolkit/tools/internal/timestamp/timestamp_test.go
@@ -176,7 +176,7 @@ func TestResumeAndAppend(t *testing.T) {
 	assert.Equal(root.ID, ts.ParentID)
 	FlushAndCleanUpResources()
 
-	err = ResumeTiming("test", testFile)
+	ResumeTiming("test", testFile)
 	ts, err = StopEventByPath("test/A")
 	assert.NoError(err)
 	FlushAndCleanUpResources()
@@ -226,14 +226,14 @@ func TestStartStopEvent(t *testing.T) {
 func TestPauseResumeEvent(t *testing.T) {
 	assert := assert.New(t)
 
-	testFile := testOutputDir + "test_start_stop_event.jsonl"
-	root, err := BeginTiming("test", testFile)
+	testFile := testOutputDir + "test_pause_resume_event.jsonl"
+	root, _ := BeginTiming("test", testFile)
 
-	ts, err := StartEvent("A", root)
+	ts, _ := StartEvent("A", root)
 	idA := ts.ID
-	ts, err = PauseEvent(ts)
-	ts, err = ResumeEvent(ts)
-	ts, err = StopEvent(ts)
+	ts, _ = PauseEvent(ts)
+	ts, _ = ResumeEvent(ts)
+	StopEvent(ts)
 
 	FlushAndCleanUpResources()
 
@@ -258,7 +258,7 @@ func TestPauseResumeEvent(t *testing.T) {
 	}
 
 	assert.Equal(len(records), 2)
-	assert.Greater(records[0].ElapsedTime(), 0)
-	assert.Greater(records[1].ElapsedTime(), 0)
-	assert.Less(records[0].EndTime, records[1].StartTime)
+	assert.Greater(records[0].ElapsedTime(), time.Duration(0))
+	assert.Greater(records[1].ElapsedTime(), time.Duration(0))
+	assert.Less(*records[0].EndTime, *records[1].StartTime)
 }


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
- Fix a flaky test due to using duplicate test output file and missing explicit type conversion

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Duplicate test output filename between different test cases in timestamp_test.go led to a specific test case being flaky. Dedupped the filename helps avoid any unexpected behaviour
- Fix type error in assertion statements
- Compare structs instead of pointers

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local test run
