### PR TITLE
Nopatch kernel for CVE-2022-4696, CVE-2023-1382, CVE-2023-1859, CVE-2023-2006, CVE-2023-2008, CVE-2023-2162, CVE-2023-2166, CVE-2023-2177, CVE-2023-2194, CVE-2023-2513, CVE-2023-28328

### DIFF
--- a/SPECS/kernel/CVE-2022-4696.nopatch
+++ b/SPECS/kernel/CVE-2022-4696.nopatch
@@ -1,0 +1,2 @@
+CVE-2022-4696 - patched in 5.10.180.1
+upstream commit ID 75454b4bbfc7e6a4dd8338556f36ea9107ddf61a -> stable commit ID 75454b4bbfc7e6a4dd8338556f36ea9107ddf61a (in version 5.10.180.1)

--- a/SPECS/kernel/CVE-2023-1382.nopatch
+++ b/SPECS/kernel/CVE-2023-1382.nopatch
@@ -1,0 +1,3 @@
+CVE-2023-1382 - patched in 5.10.157.1
+upstream commit ID 0e5d56c64afcd6fd2d132ea972605b66f8a7d3c4 -> stable commit ID e87a077d09c05985a0edac7c6c49bb307f775d12 (in version 5.10.157.1)
+upstream commit ID a7b42969d63f47320853a802efd879fbdc4e010e -> stable commit ID 4058e3b74ab3eabe0835cee9a0c6deda79e8a295 (in version 5.10.157.1)

--- a/SPECS/kernel/CVE-2023-1859.nopatch
+++ b/SPECS/kernel/CVE-2023-1859.nopatch
@@ -1,0 +1,2 @@
+CVE-2023-1859 - patched in 5.10.178.1
+upstream commit ID ea4f1009408efb4989a0f139b70fb338e7f687d0 -> stable commit ID 9266e939d76279d8710196d86215ba2be6345041 (in version 5.10.178.1)

--- a/SPECS/kernel/CVE-2023-2006.nopatch
+++ b/SPECS/kernel/CVE-2023-2006.nopatch
@@ -1,0 +1,2 @@
+CVE-2023-2006 - patched in 5.10.157.1
+upstream commit ID 3bcd6c7eaa53b56c3f584da46a1f7652e759d0e5 -> stable commit ID 3535c632e6d16c98f76e615da8dc0cb2750c66cc (in version 5.10.157.1)

--- a/SPECS/kernel/CVE-2023-2008.nopatch
+++ b/SPECS/kernel/CVE-2023-2008.nopatch
@@ -1,0 +1,2 @@
+CVE-2023-2008 - patched in 5.10.127.1
+upstream commit ID 05b252cccb2e5c3f56119d25de684b4f810ba40a -> stable commit ID 20119c1e0fff89542ff3272ace87e04cf6ee6bea (in version 5.10.127.1)

--- a/SPECS/kernel/CVE-2023-2162.nopatch
+++ b/SPECS/kernel/CVE-2023-2162.nopatch
@@ -1,0 +1,2 @@
+CVE-2023-2162 - patched in 5.10.168.1
+upstream commit ID f484a794e4ee2a9ce61f52a78e810ac45f3fe3b3 -> stable commit ID 9758ffe1c07b86aefd7ca8e40d9a461293427ca0 (in version 5.10.168.1)

--- a/SPECS/kernel/CVE-2023-2166.nopatch
+++ b/SPECS/kernel/CVE-2023-2166.nopatch
@@ -1,0 +1,2 @@
+CVE-2023-2166 - patched in 5.10.159.1
+upstream commit ID 0acc442309a0a1b01bcdaa135e56e6398a49439c -> stable commit ID c42221efb1159d6a3c89e96685ee38acdce86b6f (in version 5.10.159.1)

--- a/SPECS/kernel/CVE-2023-2177.nopatch
+++ b/SPECS/kernel/CVE-2023-2177.nopatch
@@ -1,0 +1,2 @@
+CVE-2023-2177 - patched in 5.10.135.1
+upstream commit ID 181d8d2066c000ba0a0e6940a7ad80f1a0e68e9d -> stable commit ID 6f3505588d66b27220f07d0cab18da380fae2e2d (in version 5.10.135.1)

--- a/SPECS/kernel/CVE-2023-2194.nopatch
+++ b/SPECS/kernel/CVE-2023-2194.nopatch
@@ -1,0 +1,2 @@
+CVE-2023-2194 - patched in 5.10.177.1
+upstream commit ID 92fbb6d1296f81f41f65effd7f5f8c0f74943d15 -> stable commit ID 1eaa2b7ae90c5a5e05586df310d804de250747d3 (in version 5.10.177.1)

--- a/SPECS/kernel/CVE-2023-2513.nopatch
+++ b/SPECS/kernel/CVE-2023-2513.nopatch
@@ -1,0 +1,2 @@
+CVE-2023-2513 - patched in 5.10.179.1
+upstream commit ID 67d7d8ad99beccd9fe92d585b87f1760dc9018e3 -> stable commit ID 05cf34a2b6414a1172552d16159b3e17e9da36a3 (in version 5.10.179.1)

--- a/SPECS/kernel/CVE-2023-28328.nopatch
+++ b/SPECS/kernel/CVE-2023-28328.nopatch
@@ -1,0 +1,2 @@
+CVE-2023-28328 - patched in 5.10.163.1
+upstream commit ID 0ed554fd769a19ea8464bb83e9ac201002ef74ad -> stable commit ID 559891d430e3f3a178040c4371ed419edbfa7d65 (in version 5.10.163.1)


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
- Address CVE-2022-4696, CVE-2023-1382, CVE-2023-1859, CVE-2023-2006, CVE-2023-2008, CVE-2023-2162, CVE-2023-2166, CVE-2023-2177, CVE-2023-2194, CVE-2023-2513, CVE-2023-28328

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Address CVE-2022-4696, CVE-2023-1382, CVE-2023-1859, CVE-2023-2006, CVE-2023-2008, CVE-2023-2162, CVE-2023-2166, CVE-2023-2177, CVE-2023-2194, CVE-2023-2513, CVE-2023-28328

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2022-4696
- https://nvd.nist.gov/vuln/detail/CVE-2023-1382
- https://nvd.nist.gov/vuln/detail/CVE-2023-1859
- https://nvd.nist.gov/vuln/detail/CVE-2023-2006
- https://nvd.nist.gov/vuln/detail/CVE-2023-2008
- https://nvd.nist.gov/vuln/detail/CVE-2023-2162
- https://nvd.nist.gov/vuln/detail/CVE-2023-2166
- https://nvd.nist.gov/vuln/detail/CVE-2023-2177
- https://nvd.nist.gov/vuln/detail/CVE-2023-2194
- https://nvd.nist.gov/vuln/detail/CVE-2023-2513
- https://nvd.nist.gov/vuln/detail/CVE-2023-28328

