### PR TITLE
Upgrade debootstrap to 1.0.128+nmu2 and promote to base repo

### DIFF
--- a/SPECS-EXTENDED/debootstrap/debootstrap.signatures.json
+++ b/SPECS-EXTENDED/debootstrap/debootstrap.signatures.json
@@ -1,5 +1,0 @@
-{
- "Signatures": {
-  "debootstrap_1.0.123.tar.gz": "5e5a8147ecdd6be0eea5ac4d6ed8192cc653e93f744dd3306c9b1cc51d6ca328"
- }
-}

--- a/SPECS/debootstrap/debootstrap.signatures.json
+++ b/SPECS/debootstrap/debootstrap.signatures.json
@@ -1,0 +1,5 @@
+{
+ "Signatures": {
+  "debootstrap_1.0.128+nmu2.tar.gz": "528523228d93a31c9e0cd4eb932977ea8ceec2bfbf8db1103bec2397cc7434fa"
+ }
+}

--- a/SPECS/debootstrap/debootstrap.spec
+++ b/SPECS/debootstrap/debootstrap.spec
@@ -1,32 +1,28 @@
-Vendor:         Microsoft Corporation
-Distribution:   Mariner
-# Read https://bugzilla.redhat.com/show_bug.cgi?id=1654765
-# mangling shebang in /usr/sbin/debootstrap from /bin/sh to /usr/bin/sh
+# Mariner does not use the %%__brp_mangle_shebangs buildroot policy, but may in the future
+# Mangling shebang in /usr/sbin/debootstrap from /bin/sh to /usr/bin/sh
 %undefine __brp_mangle_shebangs
 
-Name:           debootstrap
-Version:        1.0.123
-Release:        2%{?dist}
 Summary:        Debian GNU/Linux bootstrapper
-
+Name:           debootstrap
+Version:        1.0.128+nmu2
+Release:        1%{?dist}
 License:        MIT
+Vendor:         Microsoft Corporation
+Distribution:   Mariner
 URL:            https://wiki.debian.org/Debootstrap
-Source0:        http://ftp.debian.org/debian/pool/main/d/debootstrap/debootstrap_%{version}.tar.gz
-
-BuildArch:      noarch
-
+Source0:        https://deb.debian.org/debian/pool/main/d/%{name}/%{name}_%{version}.tar.gz
 BuildRequires:  fakeroot
+BuildRequires:  make
+Requires:       binutils
 Requires:       gettext
+Requires:       gpg
 Requires:       perl-interpreter
 Requires:       wget
 Requires:       tar
 Requires:       gzip
-Requires:       dpkg
 Requires:       xz
-%if 0%{?fedora} || 0%{?rhel} >= 8
-Recommends:     ubu-keyring
-Recommends:     debian-keyring
-%endif
+Requires:       zstd
+BuildArch:      noarch
 
 %description
 debootstrap is used to create a Debian base system from scratch, without
@@ -39,7 +35,7 @@ Debian GNU/Linux guest system.
 
 
 %prep
-%setup -q -n debootstrap
+%autosetup -n %{name}
 
 %build
 # nothing to do
@@ -52,13 +48,20 @@ mkdir -p %{buildroot}%{_mandir}/man8
 install -p -m 0644 debootstrap.8 %{buildroot}%{_mandir}/man8
 
 %files
-%doc debian/changelog README
 %license debian/copyright
+%doc README
 %{_datadir}/debootstrap
+%{_datadir}/debootstrap/scripts/*
 %{_sbindir}/debootstrap
 %{_mandir}/man8/debootstrap.8*
 
 %changelog
+* Tue Jun 06 2023 Olivia Crain <oliviacrain@microsoft.com> - 1.0.128+nmu2-1
+- Upgrade to latest upstream version and promote to base repo
+- Remove requirement on dpkg- ar (from binutils) is sufficient to unpack debs
+- Verified license
+- Verified license tag uses SPDX expression
+
 * Fri Oct 15 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.0.123-2
 - Initial CBL-Mariner import from Fedora 20 (license: MIT).
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -2497,8 +2497,8 @@
         "type": "other",
         "other": {
           "name": "debootstrap",
-          "version": "1.0.123",
-          "downloadUrl": "http://ftp.debian.org/debian/pool/main/d/debootstrap/debootstrap_1.0.123.tar.gz"
+          "version": "1.0.128+nmu2",
+          "downloadUrl": "https://deb.debian.org/debian/pool/main/d/debootstrap/debootstrap_1.0.128+nmu2.tar.gz"
         }
       }
     },


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
An internal user needs `debootstrap` to be promoted to the base repo. For good measure, we'll update to the latest upstream version while doing so.

I removed the requirement on `dpkg` (from extended) to speed up the process of getting this promoted- this package functions equivalently by replacing `dpkg` extraction functionality with the `ar` tool from `binutils`.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Upgrade to latest upstream version and promote to base repo
- Remove requirement on dpkg- ar (from binutils) is sufficient to unpack debs
- Verified license
- Verified license tag uses SPDX expression

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- [Buddy build](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=372584&view=results)
- Was able to successfully chroot into a Debian 11 install created by `debootstrap` in a privileged Mariner container
