### PR TITLE
timestamp: Make timestamp flag optional for go tools

### DIFF
--- a/toolkit/tools/grapher/grapher.go
+++ b/toolkit/tools/grapher/grapher.go
@@ -25,7 +25,7 @@ var (
 	logLevel         = exe.LogLevelFlag(app)
 	strictGoals      = app.Flag("strict-goals", "Don't allow missing goal packages").Bool()
 	strictUnresolved = app.Flag("strict-unresolved", "Don't allow missing unresolved packages").Bool()
-	timestampFile    = app.Flag("timestamp-file", "File that stores timestamps for this program.").Required().String()
+	timestampFile    = app.Flag("timestamp-file", "File that stores timestamps for this program.").String()
 
 	depGraph = pkggraph.NewPkgGraph()
 )

--- a/toolkit/tools/graphpkgfetcher/graphpkgfetcher.go
+++ b/toolkit/tools/graphpkgfetcher/graphpkgfetcher.go
@@ -51,7 +51,7 @@ var (
 
 	logFile       = exe.LogFileFlag(app)
 	logLevel      = exe.LogLevelFlag(app)
-	timestampFile = app.Flag("timestamp-file", "File that stores timestamps for this program.").Required().String()
+	timestampFile = app.Flag("timestamp-file", "File that stores timestamps for this program.").String()
 )
 
 func main() {

--- a/toolkit/tools/imageconfigvalidator/imageconfigvalidator.go
+++ b/toolkit/tools/imageconfigvalidator/imageconfigvalidator.go
@@ -29,7 +29,7 @@ var (
 	input       = exe.InputStringFlag(app, "Path to the image config file.")
 	baseDirPath = exe.InputDirFlag(app, "Base directory for relative file paths from the config.")
 
-	timestampFile = app.Flag("timestamp-file", "File that stores timestamps for this program.").Required().String()
+	timestampFile = app.Flag("timestamp-file", "File that stores timestamps for this program.").String()
 )
 
 func main() {

--- a/toolkit/tools/imagepkgfetcher/imagepkgfetcher.go
+++ b/toolkit/tools/imagepkgfetcher/imagepkgfetcher.go
@@ -49,7 +49,7 @@ var (
 
 	logFile       = exe.LogFileFlag(app)
 	logLevel      = exe.LogLevelFlag(app)
-	timestampFile = app.Flag("timestamp-file", "File that stores timestamps for this program.").Required().String()
+	timestampFile = app.Flag("timestamp-file", "File that stores timestamps for this program.").String()
 )
 
 func main() {

--- a/toolkit/tools/imager/imager.go
+++ b/toolkit/tools/imager/imager.go
@@ -34,7 +34,7 @@ var (
 	outputDir       = app.Flag("output-dir", "Path to directory to place final image.").ExistingDir()
 	liveInstallFlag = app.Flag("live-install", "Enable to perform a live install to the disk specified in config file.").Bool()
 	emitProgress    = app.Flag("emit-progress", "Write progress updates to stdout, such as percent complete and current action.").Bool()
-	timestampFile   = app.Flag("timestamp-file", "File that stores timestamps for this program.").Required().String()
+	timestampFile   = app.Flag("timestamp-file", "File that stores timestamps for this program.").String()
 	logFile         = exe.LogFileFlag(app)
 	logLevel        = exe.LogLevelFlag(app)
 )

--- a/toolkit/tools/internal/timestamp/timestamp_mgr.go
+++ b/toolkit/tools/internal/timestamp/timestamp_mgr.go
@@ -135,6 +135,12 @@ func ensureManagerExists() error {
 
 // Begins collecting timing data for a high level component 'toolName' into the file at 'outputFile'
 func BeginTiming(toolName, outputFile string) (*TimeStamp, error) {
+	if outputFile == "" {
+		err := fmt.Errorf("timestamp output file is not specified, the feature will be turned off for %s", toolName)
+		logger.Log.Warn(err)
+		return &TimeStamp{}, err
+	}
+
 	initTimeStampManager()
 
 	outputFileDescriptor, err := os.OpenFile(outputFile, os.O_CREATE|os.O_WRONLY, 0664)
@@ -160,6 +166,12 @@ func BeginTiming(toolName, outputFile string) (*TimeStamp, error) {
 
 // Begins appending timing data for a high level component 'toolName' into the file at 'outputFile'
 func ResumeTiming(toolName, outputFile string) error {
+	if outputFile == "" {
+		err := fmt.Errorf("timestamp output file is not specified, the feature will be turned off for %s", toolName)
+		logger.Log.Warn(err)
+		return err
+	}
+
 	initTimeStampManager()
 
 	outputFileDescriptor, err := os.OpenFile(outputFile, os.O_RDWR, 0664)

--- a/toolkit/tools/internal/timestamp/timestamp_mgr.go
+++ b/toolkit/tools/internal/timestamp/timestamp_mgr.go
@@ -202,8 +202,8 @@ func CompleteTiming() (err error) {
 
 	StopEvent(timestampMgr.root)
 	FlushAndCleanUpResources()
-	timestampMgr = nil
 	logger.Log.Debugf("Completed recording timestamp, results written to %s", timestampMgr.filePath)
+	timestampMgr = nil
 	return
 }
 

--- a/toolkit/tools/roast/roast.go
+++ b/toolkit/tools/roast/roast.go
@@ -54,7 +54,7 @@ var (
 
 	imageTag = app.Flag("image-tag", "Tag (text) appended to the image name. Empty by default.").String()
 
-	timestampFile = app.Flag("timestamp-file", "File that stores timestamps for this program.").Required().String()
+	timestampFile = app.Flag("timestamp-file", "File that stores timestamps for this program.").String()
 )
 
 func main() {

--- a/toolkit/tools/scheduler/scheduler.go
+++ b/toolkit/tools/scheduler/scheduler.go
@@ -89,7 +89,7 @@ var (
 
 	logFile       = exe.LogFileFlag(app)
 	logLevel      = exe.LogLevelFlag(app)
-	timestampFile = app.Flag("timestamp-file", "File that stores timestamps for this program.").Required().String()
+	timestampFile = app.Flag("timestamp-file", "File that stores timestamps for this program.").String()
 )
 
 func main() {

--- a/toolkit/tools/specreader/specreader.go
+++ b/toolkit/tools/specreader/specreader.go
@@ -56,7 +56,7 @@ var (
 	runCheck                = app.Flag("run-check", "Whether or not to run the spec file's check section during package build.").Bool()
 	logFile                 = exe.LogFileFlag(app)
 	logLevel                = exe.LogLevelFlag(app)
-	timestampFile           = app.Flag("timestamp-file", "File that stores timestamps for this program.").Required().String()
+	timestampFile           = app.Flag("timestamp-file", "File that stores timestamps for this program.").String()
 )
 
 func main() {

--- a/toolkit/tools/srpmpacker/srpmpacker.go
+++ b/toolkit/tools/srpmpacker/srpmpacker.go
@@ -102,7 +102,7 @@ var (
 	outDir        = exe.OutputDirFlag(app, "Directory to place the output SRPM.")
 	logFile       = exe.LogFileFlag(app)
 	logLevel      = exe.LogLevelFlag(app)
-	timestampFile = app.Flag("timestamp-file", "File that stores timestamps for this program.").Required().String()
+	timestampFile = app.Flag("timestamp-file", "File that stores timestamps for this program.").String()
 
 	buildDir     = app.Flag("build-dir", "Directory to store temporary files while building.").Default(defaultBuildDir).String()
 	distTag      = app.Flag("dist-tag", "The distribution tag SRPMs will be built with.").Required().String()


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
- Make timestamp flag optional for build tools. If the timestamp output path is not specified when running a go tool, timestamp recording will be skipped for that run.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Make timestamp flag optional for build tools
- Add some logging to inform users when timestamping is disabled 
- Small formatting changes

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local package/image/iso build. Verified that iso installer works and could run until completion.
