### PR TITLE
Fix against race condition in unattended install

### DIFF
--- a/toolkit/resources/imageconfigs/additionalfiles/iso_initrd/root/runliveinstaller
+++ b/toolkit/resources/imageconfigs/additionalfiles/iso_initrd/root/runliveinstaller
@@ -109,11 +109,12 @@ if [[ -f "$UNATTENDED_CONFIG_FILE" ]]; then
     # If the file descriptor is already locked bail out immediately and just follow the other installer's log. The tail
     # command will follow the log file and should never exit. We must ensure that this instance of the installer does
     # not run any further so we always exit 0 just in case.
-    flock -x -n 200 || \
-        { echo "Unattended install already running, following other installer's log instead" ; \
-        sleep 5 ; \
-        tail -f -n 10000 /installer/log.txt ; \
-        exit 0 ; }
+    if ! flock -x -n 200; then
+        echo "Unattended install already running, following other installer's log instead" 
+        sleep 5
+        tail -f -n 10000 /installer/log.txt 
+        exit 0
+    fi
 fi
 
 if [[ ! -f "$UNATTENDED_CONFIG_FILE" ]]; then

--- a/toolkit/resources/imageconfigs/additionalfiles/iso_initrd/root/runliveinstaller
+++ b/toolkit/resources/imageconfigs/additionalfiles/iso_initrd/root/runliveinstaller
@@ -8,6 +8,7 @@ export TERM=mariner-installer
 ISO_ROOT=/mnt/cdrom
 CONFIG_ROOT=$ISO_ROOT/config
 UNATTENDED_CONFIG_FILE=$CONFIG_ROOT/unattended_config.json
+UNATTENDED_LOCK_FILE=/var/lock/unattended.lock
 
 # PXE boot setup
 CMDLINE=/proc/cmdline
@@ -32,6 +33,39 @@ while getopts ":c:u:" OPTIONS; do
         ;;
   esac
 done
+
+# If we are running unattended, we need to make sure that we only run once.
+# We can use the unattended config file via flock to synchronize the unattended
+# install flows.
+if [[ ! -f "$UNATTENDED_CONFIG_FILE" ]]; then
+    echo "Synchronizing unattended install flows... current sessions are:"
+    who
+    thisTerminal=$(who -m | xargs | cut -d' ' -f2)
+    echo "This instance is on '$thisTerminal'"
+
+    # Generally we want to prioritize ttyS0 since that will be used for debugging. The output from the log file will
+    # contain the timestamp and color codes so it is still useful for debugging and showing liveness but it will look
+    # messy.
+    if [[ "$thisTerminal" != "ttyS0" ]]; then
+        echo "Pausing for 2 seconds to allow other session to take priority"
+        sleep 2
+    fi
+
+    # Create a lock file and open file descriptor 200 to it (200 is chosen arbitrarily)
+    # The exec will hold the file descriptor open for the duration of the script since the flock will only
+    # work on file descriptors that are open.
+    touch "$UNATTENDED_LOCK_FILE"
+    exec 200>> "$UNATTENDED_LOCK_FILE"
+
+    # If the file descriptor is already locked bail out immediately and just follow the other installer's log. The tail
+    # command will follow the log file and should never exit. We must ensure that this instance of the installer does
+    # not run any further so we always exit 0 just in case.
+    flock -x -n 200 || \
+        { echo "Unattended install already running, following other installer's log instead" ; \
+        sleep 5 ; \
+        tail -f -n 10000 /installer/log.txt ; \
+        exit 0 ; }
+fi
 
 # Mounting the ISO root for the installer.
 mkdir -p $ISO_ROOT

--- a/toolkit/resources/imageconfigs/additionalfiles/iso_initrd/root/runliveinstaller
+++ b/toolkit/resources/imageconfigs/additionalfiles/iso_initrd/root/runliveinstaller
@@ -34,39 +34,6 @@ while getopts ":c:u:" OPTIONS; do
   esac
 done
 
-# If we are running unattended, we need to make sure that we only run once.
-# We can use the unattended config file via flock to synchronize the unattended
-# install flows.
-if [[ ! -f "$UNATTENDED_CONFIG_FILE" ]]; then
-    echo "Synchronizing unattended install flows... current sessions are:"
-    who
-    thisTerminal=$(who -m | xargs | cut -d' ' -f2)
-    echo "This instance is on '$thisTerminal'"
-
-    # Generally we want to prioritize ttyS0 since that will be used for debugging. The output from the log file will
-    # contain the timestamp and color codes so it is still useful for debugging and showing liveness but it will look
-    # messy.
-    if [[ "$thisTerminal" != "ttyS0" ]]; then
-        echo "Pausing for 2 seconds to allow other session to take priority"
-        sleep 2
-    fi
-
-    # Create a lock file and open file descriptor 200 to it (200 is chosen arbitrarily)
-    # The exec will hold the file descriptor open for the duration of the script since the flock will only
-    # work on file descriptors that are open.
-    touch "$UNATTENDED_LOCK_FILE"
-    exec 200>> "$UNATTENDED_LOCK_FILE"
-
-    # If the file descriptor is already locked bail out immediately and just follow the other installer's log. The tail
-    # command will follow the log file and should never exit. We must ensure that this instance of the installer does
-    # not run any further so we always exit 0 just in case.
-    flock -x -n 200 || \
-        { echo "Unattended install already running, following other installer's log instead" ; \
-        sleep 5 ; \
-        tail -f -n 10000 /installer/log.txt ; \
-        exit 0 ; }
-fi
-
 # Mounting the ISO root for the installer.
 mkdir -p $ISO_ROOT
 LABEL=CDROM
@@ -115,6 +82,38 @@ else
     # is handled by the 'or' in the retry loop which will grep for the mount point and
     # break out of the loop if it is found.
     retry "{ mount -L $LABEL -o ro $ISO_ROOT || grep -qs $ISO_ROOT /proc/mounts ; }"
+fi
+
+# If we are running unattended (i.e., have $UNATTENDED_CONFIG_FILE), we need to make sure that we only run once.
+# We can use flock to synchronize the unattended install flows.
+if [[ -f "$UNATTENDED_CONFIG_FILE" ]]; then
+    echo "Synchronizing unattended install flows... current sessions are:"
+    who
+    thisTerminal=$(who -m | xargs | cut -d' ' -f2)
+    echo "This instance is on '$thisTerminal'"
+
+    # Generally we want to prioritize ttyS0 since that will be used for debugging. The output from the log file will
+    # contain the timestamp and color codes so it is still useful for debugging and showing liveness but it will look
+    # messy.
+    if [[ "$thisTerminal" != "ttyS0" ]]; then
+        echo "Pausing for 2 seconds to allow other session to take priority"
+        sleep 2
+    fi
+
+    # Create a lock file and open file descriptor 200 to it (200 is chosen arbitrarily)
+    # The exec will hold the file descriptor open for the duration of the script since the flock will only
+    # work on file descriptors that are open.
+    touch "$UNATTENDED_LOCK_FILE"
+    exec 200>> "$UNATTENDED_LOCK_FILE"
+
+    # If the file descriptor is already locked bail out immediately and just follow the other installer's log. The tail
+    # command will follow the log file and should never exit. We must ensure that this instance of the installer does
+    # not run any further so we always exit 0 just in case.
+    flock -x -n 200 || \
+        { echo "Unattended install already running, following other installer's log instead" ; \
+        sleep 5 ; \
+        tail -f -n 10000 /installer/log.txt ; \
+        exit 0 ; }
 fi
 
 if [[ ! -f "$UNATTENDED_CONFIG_FILE" ]]; then

--- a/toolkit/scripts/imggen.mk
+++ b/toolkit/scripts/imggen.mk
@@ -60,7 +60,7 @@ $(call create_folder,$(imager_disk_output_dir))
 $(call create_folder,$(artifact_dir))
 $(call create_folder,$(meta_user_data_tmp_dir))
 
-.PHONY: fetch-image-packages fetch-external-image-packages make-raw-image image iso validate-image-config clean-imagegen
+.PHONY: fetch-image-packages fetch-external-image-packages make-raw-image image iso installer-initrd validate-image-config clean-imagegen
 
 clean: clean-imagegen
 clean-imagegen:
@@ -193,6 +193,7 @@ $(initrd_img): $(initrd_bundled_files) $(initrd_config_json) $(INITRD_CACHE_SUMM
 	# Recursive make call to build the initrd image $(artifact_dir)/iso-initrd.img
 	$(MAKE) image MAKEOVERRIDES= CONFIG_FILE=$(initrd_config_json) IMAGE_CACHE_SUMMARY=$(INITRD_CACHE_SUMMARY) IMAGE_TAG=
 
+installer-initrd: $(initrd_img)
 iso: $(initrd_img) $(iso_deps)
 	$(if $(CONFIG_FILE),,$(error Must set CONFIG_FILE=))
 	$(go-isomaker) \


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
The ISO installer will start on every available console (currently `tty1` and `ttyS0`). For normal install flows this is fine since they will both wait for the user to select the desired installer flow. The unattended installer however will proceed automatically. Since we have two instances they will both attempt to install at the same time generally causing one to fail to partition. Anecdotally this is usually the serial console failing making it look like the install has failed, however the `tty1` installer is actually running successfully in the background. If left alone the image will generally install correctly and restart after a minute or two.

Lets prioritize` ttyS0` as the 'correct' installer, and have all other instances give up and just follow the log output from the running copy.

Also add a `installer-initrd` PHONY target that builds the ISO image.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Prioritize unattended installer on `ttyS0` and block all others.
- Add `installer-initrd` target

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://microsoft.visualstudio.com/OS/_workitems/edit/44974720

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local testing against VMs
