### PR TITLE
Toolkit: Add MAX_CPU flag to limit number of CPUS used for package building

### DIFF
--- a/toolkit/Makefile
+++ b/toolkit/Makefile
@@ -25,7 +25,7 @@ SRPM_PACK_LIST          ?=
 ######## SET INCREMENTAL BUILD FLAGS ########
 
 # Logic to auto configure build options for optimized builds
-# These will set the default values for: REBUILD_TOOLS, USE_CCACHE, REBUILD_TOOLCHAIN, DELTA_BUILD, INCREMENTAL_TOOLCHAIN, ALLOW_TOOLCHAIN_DOWNLOAD_FAIL, and CLEAN_TOOLCHAIN_CONTAINERS
+# These will set the default values for: REBUILD_TOOLS, USE_CCACHE, MAX_CPU, REBUILD_TOOLCHAIN, DELTA_BUILD, INCREMENTAL_TOOLCHAIN, ALLOW_TOOLCHAIN_DOWNLOAD_FAIL, and CLEAN_TOOLCHAIN_CONTAINERS
 include $(SCRIPTS_DIR)/incremental_building.mk
 
 ######## SET REMAINING FLAGS ########

--- a/toolkit/docs/building/building.md
+++ b/toolkit/docs/building/building.md
@@ -801,6 +801,7 @@ To reproduce an ISO build, run the same make invocation as before, but set:
 | REBUILD_DEP_CHAINS            | y                                                                                                      | Rebuild packages if their dependencies need to be built, even though the package has already been built.
 | TARGET_ARCH                   |                                                                                                        | The architecture of the machine that will run the package binaries.
 | USE_CCACHE                    | n                                                                                                      | Use ccache automatically to speed up repeat package builds.
+| MAX_CPU                       | 0                                                                                                      | Max number of CPUs used for package building. 0 for unlimited. Overrides `%_smp_ncpus_max` macro
 
 ---
 

--- a/toolkit/docs/building/building.md
+++ b/toolkit/docs/building/building.md
@@ -801,7 +801,7 @@ To reproduce an ISO build, run the same make invocation as before, but set:
 | REBUILD_DEP_CHAINS            | y                                                                                                      | Rebuild packages if their dependencies need to be built, even though the package has already been built.
 | TARGET_ARCH                   |                                                                                                        | The architecture of the machine that will run the package binaries.
 | USE_CCACHE                    | n                                                                                                      | Use ccache automatically to speed up repeat package builds.
-| MAX_CPU                       | 0                                                                                                      | Max number of CPUs used for package building. 0 for unlimited. Overrides `%_smp_ncpus_max` macro
+| MAX_CPU                       |                                                                                                        | Max number of CPUs used for package building. Use 0 for unlimited. Overrides `%_smp_ncpus_max` macro.
 
 ---
 

--- a/toolkit/scripts/incremental_building.mk
+++ b/toolkit/scripts/incremental_building.mk
@@ -71,6 +71,7 @@ REBUILD_TOOLS                   ?= n
 USE_CCACHE                      ?= n
 DELTA_BUILD                     ?= n
 CLEAN_TOOLCHAIN_CONTAINERS      ?= y
+MAX_CPU                         ?= 0
 
 ######## HANDLE INCREMENTAL_TOOLCHAIN DEPRECATION ########
 

--- a/toolkit/scripts/incremental_building.mk
+++ b/toolkit/scripts/incremental_building.mk
@@ -71,7 +71,7 @@ REBUILD_TOOLS                   ?= n
 USE_CCACHE                      ?= n
 DELTA_BUILD                     ?= n
 CLEAN_TOOLCHAIN_CONTAINERS      ?= y
-MAX_CPU                         ?= 0
+MAX_CPU                         ?=
 
 ######## HANDLE INCREMENTAL_TOOLCHAIN DEPRECATION ########
 

--- a/toolkit/scripts/pkggen.mk
+++ b/toolkit/scripts/pkggen.mk
@@ -229,6 +229,7 @@ $(STATUS_FLAGS_DIR)/build-rpms.flag: $(preprocessed_file) $(chroot_worker) $(go-
 		$(if $(filter y,$(DELTA_BUILD)),--delta-build) \
 		$(if $(filter y,$(USE_CCACHE)),--use-ccache) \
 		$(if $(filter y,$(ALLOW_TOOLCHAIN_REBUILDS)),--allow-toolchain-rebuilds) \
+		--max-cpu="$(MAX_CPU)" \
 		$(logging_command) && \
 	touch $@
 

--- a/toolkit/tools/internal/rpm/rpm.go
+++ b/toolkit/tools/internal/rpm/rpm.go
@@ -55,8 +55,8 @@ const (
 	// MarinerCCacheDefine enables ccache in the Mariner build system
 	MarinerCCacheDefine = "mariner_ccache_enabled"
 
-    // MaxCPUDefine specifies the max number of CPUs to use for parallel build
-    MaxCPUDefine = "_smp_ncpus_max"
+	// MaxCPUDefine specifies the max number of CPUs to use for parallel build
+	MaxCPUDefine = "_smp_ncpus_max"
 )
 
 const (

--- a/toolkit/tools/internal/rpm/rpm.go
+++ b/toolkit/tools/internal/rpm/rpm.go
@@ -54,6 +54,9 @@ const (
 
 	// MarinerCCacheDefine enables ccache in the Mariner build system
 	MarinerCCacheDefine = "mariner_ccache_enabled"
+
+    // MaxCPUDefine specifies the max number of CPUs to use for parallel build
+    MaxCPUDefine = "_smp_ncpus_max"
 )
 
 const (

--- a/toolkit/tools/pkgworker/pkgworker.go
+++ b/toolkit/tools/pkgworker/pkgworker.go
@@ -54,6 +54,7 @@ var (
 	packagesToInstall    = app.Flag("install-package", "Filepaths to RPM packages that should be installed before building.").Strings()
 	outArch              = app.Flag("out-arch", "Architecture of resulting package").String()
 	useCcache            = app.Flag("use-ccache", "Automatically install and use ccache during package builds").Bool()
+	maxCPU               = app.Flag("max-cpu", "Max number of CPUs used for package building").String()
 
 	logFile  = exe.LogFileFlag(app)
 	logLevel = exe.LogLevelFlag(app)
@@ -93,6 +94,7 @@ func main() {
 	if *useCcache {
 		defines[rpm.MarinerCCacheDefine] = "true"
 	}
+	defines[rpm.MaxCPUDefine] = *maxCPU
 
 	builtRPMs, err := buildSRPMInChroot(chrootDir, rpmsDirAbsPath, toolchainDirAbsPath, *workerTar, *srpmFile, *repoFile, *rpmmacrosFile, *outArch, defines, *noCleanup, *runCheck, *packagesToInstall, *useCcache)
 	logger.PanicOnError(err, "Failed to build SRPM '%s'. For details see log file: %s .", *srpmFile, *logFile)

--- a/toolkit/tools/pkgworker/pkgworker.go
+++ b/toolkit/tools/pkgworker/pkgworker.go
@@ -54,7 +54,7 @@ var (
 	packagesToInstall    = app.Flag("install-package", "Filepaths to RPM packages that should be installed before building.").Strings()
 	outArch              = app.Flag("out-arch", "Architecture of resulting package").String()
 	useCcache            = app.Flag("use-ccache", "Automatically install and use ccache during package builds").Bool()
-	maxCPU               = app.Flag("max-cpu", "Max number of CPUs used for package building").String()
+	maxCPU               = app.Flag("max-cpu", "Max number of CPUs used for package building").Default("").String()
 
 	logFile  = exe.LogFileFlag(app)
 	logLevel = exe.LogLevelFlag(app)
@@ -94,7 +94,9 @@ func main() {
 	if *useCcache {
 		defines[rpm.MarinerCCacheDefine] = "true"
 	}
-	defines[rpm.MaxCPUDefine] = *maxCPU
+	if *maxCPU != "" {
+		defines[rpm.MaxCPUDefine] = *maxCPU
+	}
 
 	builtRPMs, err := buildSRPMInChroot(chrootDir, rpmsDirAbsPath, toolchainDirAbsPath, *workerTar, *srpmFile, *repoFile, *rpmmacrosFile, *outArch, defines, *noCleanup, *runCheck, *packagesToInstall, *useCcache)
 	logger.PanicOnError(err, "Failed to build SRPM '%s'. For details see log file: %s .", *srpmFile, *logFile)

--- a/toolkit/tools/scheduler/buildagents/chrootagent.go
+++ b/toolkit/tools/scheduler/buildagents/chrootagent.go
@@ -91,6 +91,7 @@ func serializeChrootBuildAgentConfig(config *BuildAgentConfig, inputFile, logFil
 		fmt.Sprintf("--log-file=%s", logFile),
 		fmt.Sprintf("--log-level=%s", config.LogLevel),
 		fmt.Sprintf("--out-arch=%s", outArch),
+		fmt.Sprintf("--max-cpu=%s", config.MaxCpu),
 	}
 
 	if config.RpmmacrosFile != "" {

--- a/toolkit/tools/scheduler/buildagents/definition.go
+++ b/toolkit/tools/scheduler/buildagents/definition.go
@@ -26,6 +26,7 @@ type BuildAgentConfig struct {
 	NoCleanup bool
 	RunCheck  bool
 	UseCcache bool
+	MaxCpu    string
 
 	LogDir   string
 	LogLevel string

--- a/toolkit/tools/scheduler/scheduler.go
+++ b/toolkit/tools/scheduler/scheduler.go
@@ -76,6 +76,7 @@ var (
 	deltaBuild             = app.Flag("delta-build", "Enable delta build using remote cached packages.").Bool()
 	useCcache              = app.Flag("use-ccache", "Automatically install and use ccache during package builds").Bool()
 	allowToolchainRebuilds = app.Flag("allow-toolchain-rebuilds", "Allow toolchain packages to rebuild without causing an error.").Bool()
+	maxCPU                 = app.Flag("max-cpu", "Max number of CPUs used for package building").String()
 
 	validBuildAgentFlags = []string{buildagents.TestAgentFlag, buildagents.ChrootAgentFlag}
 	buildAgent           = app.Flag("build-agent", "Type of build agent to build packages with.").PlaceHolder(exe.PlaceHolderize(validBuildAgentFlags)).Required().Enum(validBuildAgentFlags...)
@@ -173,6 +174,7 @@ func main() {
 		NoCleanup: *noCleanup,
 		RunCheck:  *runCheck,
 		UseCcache: *useCcache,
+		MaxCpu:    *maxCPU,
 
 		LogDir:   *buildLogsDir,
 		LogLevel: *logLevel,

--- a/toolkit/tools/scheduler/scheduler.go
+++ b/toolkit/tools/scheduler/scheduler.go
@@ -76,7 +76,7 @@ var (
 	deltaBuild             = app.Flag("delta-build", "Enable delta build using remote cached packages.").Bool()
 	useCcache              = app.Flag("use-ccache", "Automatically install and use ccache during package builds").Bool()
 	allowToolchainRebuilds = app.Flag("allow-toolchain-rebuilds", "Allow toolchain packages to rebuild without causing an error.").Bool()
-	maxCPU                 = app.Flag("max-cpu", "Max number of CPUs used for package building").String()
+	maxCPU                 = app.Flag("max-cpu", "Max number of CPUs used for package building").Default("").String()
 
 	validBuildAgentFlags = []string{buildagents.TestAgentFlag, buildagents.ChrootAgentFlag}
 	buildAgent           = app.Flag("build-agent", "Type of build agent to build packages with.").PlaceHolder(exe.PlaceHolderize(validBuildAgentFlags)).Required().Enum(validBuildAgentFlags...)


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Add MAX_CPU flag to limit number of CPUS used for package building. When set, this value is used to set the `%_smp_ncpus_max` in each package build chroot. This value sets an upper limit on CPUs to use for all packages that build with `make %{?_smp_mflags}`.
Our immediate need for this is to prevent OOM errors on ARM64 machines, which are typically 32 core, and regularly run out of memory during full package builds.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add MAX_CPU option to toolkit
- Update documentation

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build test - setting MAX_CPU to 3:
- -  time sudo make build-packages SRPM_PACK_LIST="tree" REBUILD_TOOLS=y REFRESH_WORKER_CHROOT=n USE_CCACHE=y RUN_CHECK=n MAX_CPU=3
- - Observed in tree-1.8.0-2.cm2.src.rpm.log on 8 core machine: cd tree-1.8.0; make -j3

- Local build test - not specifying MAX_CPU at all
- -  time sudo make build-packages SRPM_PACK_LIST="tree" REBUILD_TOOLS=y REFRESH_WORKER_CHROOT=n USE_CCACHE=y RUN_CHECK=n
- - Observed in tree-1.8.0-2.cm2.src.rpm.log on 8 core machine: cd tree-1.8.0; make -j8