### PR TITLE
toolkit: exclude ccache directory from cleanup

### DIFF
--- a/toolkit/tools/internal/buildpipeline/buildpipeline.go
+++ b/toolkit/tools/internal/buildpipeline/buildpipeline.go
@@ -188,6 +188,7 @@ func GetRpmsDir(chrootDir string, proposedDir string) string {
 func CleanupDockerChroot(chroot string) (err error) {
 	var folderToKeep = []string{
 		"dev",
+		"ccache-dir",
 		"proc",
 		"localrpms",
 		"toolchainrpms",

--- a/toolkit/tools/pkgworker/pkgworker.go
+++ b/toolkit/tools/pkgworker/pkgworker.go
@@ -359,7 +359,7 @@ func tdnfInstall(packages []string) (err error) {
 // the build environment has libtool archive files present, gnu configure could
 // detect it and create more libtool archive files which can cause build failures.
 func removeLibArchivesFromSystem() (err error) {
-	dirsToExclude := []string{"/proc", "/dev", "/sys", "/run"}
+	dirsToExclude := []string{"/proc", "/dev", "/sys", "/run", "/ccache-dir"}
 
 	err = filepath.Walk("/", func(path string, info os.FileInfo, err error) error {
 		if err != nil {
@@ -368,6 +368,7 @@ func removeLibArchivesFromSystem() (err error) {
 
 		// Skip directories that are meant for device files and kernel virtual filesystems.
 		// These will not contain .la files and are mounted into the safechroot from the host.
+		// Also skip /ccache-dir, which is shared between chroots
 		if info.IsDir() && sliceutils.Contains(dirsToExclude, path, sliceutils.StringMatch) {
 			return filepath.SkipDir
 		}


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Exclude the `ccache-dir` directory from cleanup. Since this directory persists across builds to accumulate ccache artifacts, there is no need to perform the cleanup.
This should resolve errors like the following seen building multiple packages with USE_CCACHE=y:
```
Unable to remove lib archive file: lstat /ccache-dir/0/stats.alive: no such file or directory"
Unable to remove lib archive file: lstat /ccache-dir/0/stats.lock: no such file or directory
```

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change CleanupDockerChroot() to skip ccache-dir
- Change removeLibArchivesFromSystem() to skip ccache-dir

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build
