### PR TITLE
Patch CVE-2023-2650 in cloud-hypervisor

### DIFF
--- a/SPECS/cloud-hypervisor/CVE-2023-2650.patch
+++ b/SPECS/cloud-hypervisor/CVE-2023-2650.patch
@@ -1,0 +1,24 @@
+From 0a06e621c24ec8c729e7e4dd345ec50387665352 Mon Sep 17 00:00:00 2001
+From: Suresh Thelkar <sthelkar@microsoft.com>
+Date: Wed, 14 Jun 2023 14:56:27 +0530
+Subject: [PATCH] Upgrading ssh2 to version 0.9.4
+
+---
+ test_infra/Cargo.toml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/test_infra/Cargo.toml b/test_infra/Cargo.toml
+index 8fca369..87fd073 100644
+--- a/test_infra/Cargo.toml
++++ b/test_infra/Cargo.toml
+@@ -9,6 +9,6 @@ dirs = "4.0.0"
+ epoll = "4.3.1"
+ lazy_static = "1.4.0"
+ libc = "0.2.91"
+-ssh2 = { version = "0.9.1", features = ["vendored-openssl"]}
++ssh2 = { version = "0.9.4", features = ["vendored-openssl"]}
+ vmm-sys-util = "0.9.0"
+ wait-timeout = "0.2.0"
+-- 
+2.38.1
+

--- a/SPECS/cloud-hypervisor/cloud-hypervisor.signatures.json
+++ b/SPECS/cloud-hypervisor/cloud-hypervisor.signatures.json
@@ -1,6 +1,6 @@
 {
  "Signatures": {
-  "cloud-hypervisor-22.0-cargo.tar.gz": "550e2e2ad6c64ae7fa4786582c2357993cfad1f205566f6c80bcef7888cbd702",
+  "cloud-hypervisor-22.0-3.cm1-cargo.tar.gz": "84b486e3014d8bc26b83299222692b5f386edd4b20c55a34665d1051c2712044",
   "cloud-hypervisor-22.0.tar.gz": "5c5440435f78d4acdbb3ea91abe17d6704da6c18b6f52fe77f15835cfc60d17a"
  }
 }

--- a/SPECS/cloud-hypervisor/cloud-hypervisor.spec
+++ b/SPECS/cloud-hypervisor/cloud-hypervisor.spec
@@ -1,7 +1,7 @@
 Summary:        A Rust-VMM based cloud hypervisor from Intel
 Name:           cloud-hypervisor
 Version:        22.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        ASL 2.0 or BSD
 URL:            https://github.com/cloud-hypervisor/cloud-hypervisor
 Group:          Development/Tools
@@ -11,8 +11,9 @@ Source0:       %{url}/archive/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
 # Note: the %%{name}-%%{version}-cargo.tar.gz file contains a cache created by capturing the contents downloaded into $CARGO_HOME.
 # To update the cache run:
 #   [repo_root]/toolkit/scripts/build_cargo_cache.sh %%{name}-%%{version}.tar.gz
-Source1:        %{name}-%{version}-cargo.tar.gz
+Source1:        %{name}-%{version}-%{release}-cargo.tar.gz
 Patch0:         CVE-2023-28448.patch
+Patch1:         CVE-2023-2650.patch
 ExclusiveArch:  x86_64
 
 BuildRequires:  gcc
@@ -32,6 +33,7 @@ tar xf %{SOURCE1} --no-same-owner
 %patch0 -p1
 popd
 %setup -q
+%patch1 -p1
 
 %build
 cargo build --release
@@ -51,6 +53,9 @@ install -d %{buildroot}%{_libdir}/cloud-hypervisor
 %exclude %{_libdir}/debug
 
 %changelog
+* Thu Jun 15 2023 Suresh Thelkar <sthelkar@microsoft.com> - 22.0-3
+- Patch CVE-2023-2650.patch in vendored versionize crate
+
 * Wed Apr 05 2023 Henry Beberman <henry.beberman@microsoft.com> - 22.0-2
 - Patch CVE-2023-28448 in vendored versionize crate
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Patch CVE-2023-2650 in cloud-hypervisor
**Details**
- Following details show that the [CVE](https://nvd.nist.gov/vuln/detail/CVE-2023-2650) is impacted for 1.0
        ssh2 → vendored_openssl → libssh2-sys/vendored-openssl → openssl-sys/vendored → openssl-src
- openssl-src has version 111.17.0+1.1.1m which is affected by the [CVE](https://nvd.nist.gov/vuln/detail/CVE-2023-2650). So this means we have an impact of this CVE in 1.0
- My analysis revealed that the given CVE is fixed in OpenSSL 1.1.1u [(git commit)](https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=9e209944b35cf82368071f160a744b6178f9b098)
- So we need to make sure that we should have OpenSSL 1.1.1u crate to resolve the issue. 
- Further investigation reveals that ssh2 module with version 0.9.4 has the above OpenSSL 1.1.1u version.
- Added a patch CVE-2023-2650.patch to the cloud-hypervisor.spec file where in we are upgrading ssh2 version from 0.9.1 to 0.9.4
- Made the corresponding changes in the spec file to properly handle this patch.
- Also generated the updated cloud-hypervisor-22.0-3.cm1-cargo.tar.gz and uploaded to our blob store. 

I have run a Buddy build to make sure all the changes are fine. Test results are given in the Test Methodology section. 

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- CVE-2023-2650

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- NA

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2023-2650

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
Buddy Build
- [AMD64](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=378393&view=results)
Please note that this package is exclusive for AMD64. 
