### PR TITLE
systemd: Enable audit integration.

### DIFF
--- a/SPECS/systemd/systemd.spec
+++ b/SPECS/systemd/systemd.spec
@@ -48,7 +48,6 @@ BuildRequires:  tpm2-tss-devel
 BuildRequires:  util-linux-devel
 BuildRequires:  xz-devel
 Requires:       %{name}-rpm-macros = %{version}-%{release}
-Requires:       audit
 Requires:       glib
 Requires:       kmod
 Requires:       libcap

--- a/SPECS/systemd/systemd.spec
+++ b/SPECS/systemd/systemd.spec
@@ -1,7 +1,7 @@
 Summary:        Systemd-250
 Name:           systemd
 Version:        250.3
-Release:        15%{?dist}
+Release:        16%{?dist}
 License:        LGPLv2+ AND GPLv2+ AND MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -25,6 +25,7 @@ Patch3:         CVE-2022-3821.patch
 Patch4:         CVE-2022-45873.patch
 Patch5:         backport-helper-util-macros.patch
 Patch6:         CVE-2022-4415.patch
+BuildRequires:  audit-devel
 BuildRequires:  cryptsetup-devel
 BuildRequires:  docbook-dtd-xml
 BuildRequires:  docbook-style-xsl
@@ -47,6 +48,7 @@ BuildRequires:  tpm2-tss-devel
 BuildRequires:  util-linux-devel
 BuildRequires:  xz-devel
 Requires:       %{name}-rpm-macros = %{version}-%{release}
+Requires:       audit
 Requires:       glib
 Requires:       kmod
 Requires:       libcap
@@ -138,6 +140,7 @@ meson  --prefix %{_prefix}                                            \
        -Dsysvinit-path=%{_sysconfdir}/rc.d/init.d                     \
        -Drc-local=%{_sysconfdir}/rc.d/rc.local                        \
        -Dselinux=true                                                 \
+       -Daudit=true                                                   \
        $PWD build &&
        cd build &&
        %ninja_build
@@ -279,6 +282,9 @@ fi
 %files lang -f %{name}.lang
 
 %changelog
+* Tue Jun 20 2023 Chris Gunn <chrisgun@microsoft.com> - 250.3-16
+- Enable audit integration
+
 * Fri Mar 03 2023 Dan Streetman <ddstreet@microsoft.com> - 250.3-15
 - Build with libtss to enable tpm2 support
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->

<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->

Enabled audit integration in systemd package. This is needed so that systemd will report any SELinux violations for service control operations (start/stop/etc.) to the audit logs. This will ensure that audits of a system's security can be done accurately. In addition, it greatly helps with debugging SELinux issues.

###### Change Log  <!-- REQUIRED -->

- Enabled audit integration in systemd package.

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

1. Built the package locally.
2. Installed the updated package in a test VM.
3. Ran a `systemctl restart` command that I knew would hit an SELinux violation.
4. Ensured that the expected SELinux violation showed up in the audit logs.
