### PR TITLE
Package cmake modules in grpc-devel

### DIFF
--- a/SPECS/grpc/grpc.spec
+++ b/SPECS/grpc/grpc.spec
@@ -1,7 +1,7 @@
 Summary:        Open source remote procedure call (RPC) framework
 Name:           grpc
 Version:        1.42.0
-Release:        5%{?dist}
+Release:        6%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -98,7 +98,6 @@ popd
 %install
 pushd cmake/build
 %cmake_install
-find %{buildroot} -name '*.cmake' -delete
 popd
 
 #python
@@ -135,6 +134,7 @@ export GRPC_PYTHON_BUILD_SYSTEM_ABSL=True
 %{_libdir}/libgrpcpp_channelz.so
 %{_libdir}/libupb.so
 %{_libdir}/pkgconfig/*.pc
+%{_libdir}/cmake/*
 
 %files plugins
 %license LICENSE

--- a/SPECS/grpc/grpc.spec
+++ b/SPECS/grpc/grpc.spec
@@ -148,6 +148,9 @@ export GRPC_PYTHON_BUILD_SYSTEM_ABSL=True
 
 
 %changelog
+* Thu Jun 22 2023 Reuben Olinsky <reubeno@microsoft.com> - 1.42.0-6
+- Add cmake modules to grpc-devel package.
+
 * Tue May 31 2023 Dallas Delaney <dadelan@microsoft.com> - 1.42.0-5
 - Rebuild against c-ares to Fix CVE-2023-32067, CVE-2023-31130, CVE-2023-31147
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
I've encounted some source code that expects to find gRPCConfig.cmake under /usr/lib/cmake. The grpc upstream package typically provides this, but the Mariner spec was deleting these cmake files for some reason.

###### Change Log  <!-- REQUIRED -->
Removes the logic to delete the *.cmake files, and packages them up in grpc-devel.

###### Does this affect the toolchain?  <!-- REQUIRED -->
No.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
In progress.
