### PR TITLE
toolchain: use latest 2.0 Mariner container for bootstrap build

### DIFF
--- a/toolkit/scripts/toolchain/cgmanifest.json
+++ b/toolkit/scripts/toolchain/cgmanifest.json
@@ -5,8 +5,8 @@
                 "Type": "DockerImage",
                 "DockerImage": {
                     "Name": "mcr.microsoft.com/cbl-mariner/base/core",
-                    "Digest": "sha256:0a92146c52c59d25475e93d2acb0d7011af9411a57e237750eee7dd7c4fbbe59",
-                    "Tag": "1.0.20220226"
+                    "Digest": "sha256:c159685dca0d770885dbdbe3b39a43537acaba2d61c3c08a86b975b77f87155e",
+                    "Tag": "2.0.20230609"
                 }
             }
         }

--- a/toolkit/scripts/toolchain/container/Dockerfile
+++ b/toolkit/scripts/toolchain/container/Dockerfile
@@ -3,7 +3,7 @@
 #
 # Dockerfile to Mariner toolchain from scratch
 #
-FROM mcr.microsoft.com/cbl-mariner/base/core:1.0.20220226
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0.20230609
 
 # Tag the layers so we can clean up all the containers associated with a build directory
 ARG MARINER_BUILD_DIR

--- a/toolkit/scripts/toolchain/container/Dockerfile
+++ b/toolkit/scripts/toolchain/container/Dockerfile
@@ -34,6 +34,7 @@ RUN tdnf install -y \
     perl \
     rpm \
     sudo \
+    tar \
     texinfo \
     unzip \
     vim \


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Update the bootstrap toolchain code to use the latest 2.0 Mariner container image (replacing an older 1.0 image)

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change toolchain bootstrap code to use mcr.microsoft.com/cbl-mariner/base/core:2.0.20230609
- Change cgmanifest to reference new image
- Add `tar` to the container image, since it has been removed from the 2.0 base container

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- AMD64 toolchain build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=382271&view=results
- ARM64 toolchain build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=382269&view=results