### PR TITLE
Unified `fmt.Error` formatting with Go's conventions.

### DIFF
--- a/toolkit/tools/imageconfigvalidator/imageconfigvalidator.go
+++ b/toolkit/tools/imageconfigvalidator/imageconfigvalidator.go
@@ -101,7 +101,7 @@ func validateKickStartInstall(config configuration.Config) (err error) {
 	for _, systemConfig := range config.SystemConfigs {
 		if systemConfig.IsKickStartBoot {
 			if len(config.Disks) > 0 || len(systemConfig.PartitionSettings) > 0 {
-				return fmt.Errorf("Partition should not be specified in image config file when performing kickstart installation")
+				return fmt.Errorf("partition should not be specified in image config file when performing kickstart installation")
 			}
 		}
 	}

--- a/toolkit/tools/imagegen/configuration/disk.go
+++ b/toolkit/tools/imagegen/configuration/disk.go
@@ -71,7 +71,7 @@ func checkMaxSizeCorrectness(disk *Disk) (err error) {
 		maxSizeString := strconv.FormatUint(maxSize, 10)
 		lastPartitionEndString := strconv.FormatUint(lastPartitionEnd, 10)
 		if maxSize < lastPartitionEnd {
-			return fmt.Errorf("the MaxSize of %s is not large enough to accomodate defined partitions ending at %s.", maxSizeString, lastPartitionEndString)
+			return fmt.Errorf("the MaxSize of %s is not large enough to accomodate defined partitions ending at %s", maxSizeString, lastPartitionEndString)
 		}
 	} else if disk.MaxSize != 0 {
 		logger.Log.Warnf("defining both a maxsize and target disk in the same config should be avoided as maxsize value will not be used")

--- a/toolkit/tools/imagegen/configuration/disk_test.go
+++ b/toolkit/tools/imagegen/configuration/disk_test.go
@@ -143,10 +143,10 @@ func TestShouldFailMaxSizeInsufficient(t *testing.T) {
 	invalidDisk.TargetDisk.Type = ""
 	err := invalidDisk.IsValid()
 	assert.Error(t, err)
-	assert.Equal(t, "invalid [Disk]: the MaxSize of 512 is not large enough to accomodate defined partitions ending at 1024.", err.Error())
+	assert.Equal(t, "invalid [Disk]: the MaxSize of 512 is not large enough to accomodate defined partitions ending at 1024", err.Error())
 
 	// remarshal runs IsValid() on [SystemConfig] prior to running it on [Config], so we get a different error message here.
 	err = remarshalJSON(invalidDisk, &checkedDisk)
 	assert.Error(t, err)
-	assert.Equal(t, "failed to parse [Disk]: invalid [Disk]: the MaxSize of 512 is not large enough to accomodate defined partitions ending at 1024.", err.Error())
+	assert.Equal(t, "failed to parse [Disk]: invalid [Disk]: the MaxSize of 512 is not large enough to accomodate defined partitions ending at 1024", err.Error())
 }

--- a/toolkit/tools/imagegen/configuration/kernelcommandline.go
+++ b/toolkit/tools/imagegen/configuration/kernelcommandline.go
@@ -49,7 +49,7 @@ func (k *KernelCommandLine) IsValid() (err error) {
 
 	// A character needs to be set aside for use as the sed delimiter, make sure it isn't included in the provided string
 	if strings.Contains(k.ExtraCommandLine, k.GetSedDelimeter()) {
-		return fmt.Errorf("extraCommandLine contains character %s which is reserved for use by sed", k.GetSedDelimeter())
+		return fmt.Errorf("the 'ExtraCommandLine' field contains the %s character which is reserved for use by sed", k.GetSedDelimeter())
 	}
 
 	return

--- a/toolkit/tools/imagegen/configuration/kernelcommandline.go
+++ b/toolkit/tools/imagegen/configuration/kernelcommandline.go
@@ -49,7 +49,7 @@ func (k *KernelCommandLine) IsValid() (err error) {
 
 	// A character needs to be set aside for use as the sed delimiter, make sure it isn't included in the provided string
 	if strings.Contains(k.ExtraCommandLine, k.GetSedDelimeter()) {
-		return fmt.Errorf("ExtraCommandLine contains character %s which is reserved for use by sed", k.GetSedDelimeter())
+		return fmt.Errorf("extraCommandLine contains character %s which is reserved for use by sed", k.GetSedDelimeter())
 	}
 
 	return

--- a/toolkit/tools/imagegen/configuration/kernelcommandline_test.go
+++ b/toolkit/tools/imagegen/configuration/kernelcommandline_test.go
@@ -113,11 +113,11 @@ func TestShouldFailWrongSedDelimeter_KernelCommandLine(t *testing.T) {
 
 	err := invalidSedExtraCommandLine.IsValid()
 	assert.Error(t, err)
-	assert.Equal(t, "ExtraCommandLine contains character ` which is reserved for use by sed", err.Error())
+	assert.Equal(t, "extraCommandLine contains character ` which is reserved for use by sed", err.Error())
 
 	err = remarshalJSON(invalidSedExtraCommandLine, &checkedCommandline)
 	assert.Error(t, err)
-	assert.Equal(t, "failed to parse [KernelCommandLine]: ExtraCommandLine contains character ` which is reserved for use by sed", err.Error())
+	assert.Equal(t, "failed to parse [KernelCommandLine]: extraCommandLine contains character ` which is reserved for use by sed", err.Error())
 }
 
 func TestShouldSucceedParsingValidJSON_KernelCommandLine(t *testing.T) {
@@ -138,5 +138,5 @@ func TestShouldFailParsingInvalidJSON_KernelCommandLine(t *testing.T) {
 	checkedCommandline = KernelCommandLine{}
 	err = marshalJSONString(invalidExtraComandLineJSON2, &checkedCommandline)
 	assert.Error(t, err)
-	assert.Equal(t, "failed to parse [KernelCommandLine]: ExtraCommandLine contains character ` which is reserved for use by sed", err.Error())
+	assert.Equal(t, "failed to parse [KernelCommandLine]: extraCommandLine contains character ` which is reserved for use by sed", err.Error())
 }

--- a/toolkit/tools/imagegen/configuration/kernelcommandline_test.go
+++ b/toolkit/tools/imagegen/configuration/kernelcommandline_test.go
@@ -113,11 +113,11 @@ func TestShouldFailWrongSedDelimeter_KernelCommandLine(t *testing.T) {
 
 	err := invalidSedExtraCommandLine.IsValid()
 	assert.Error(t, err)
-	assert.Equal(t, "extraCommandLine contains character ` which is reserved for use by sed", err.Error())
+	assert.Equal(t, "the 'ExtraCommandLine' field contains the ` character which is reserved for use by sed", err.Error())
 
 	err = remarshalJSON(invalidSedExtraCommandLine, &checkedCommandline)
 	assert.Error(t, err)
-	assert.Equal(t, "failed to parse [KernelCommandLine]: extraCommandLine contains character ` which is reserved for use by sed", err.Error())
+	assert.Equal(t, "failed to parse [KernelCommandLine]: the 'ExtraCommandLine' field contains the ` character which is reserved for use by sed", err.Error())
 }
 
 func TestShouldSucceedParsingValidJSON_KernelCommandLine(t *testing.T) {
@@ -138,5 +138,5 @@ func TestShouldFailParsingInvalidJSON_KernelCommandLine(t *testing.T) {
 	checkedCommandline = KernelCommandLine{}
 	err = marshalJSONString(invalidExtraComandLineJSON2, &checkedCommandline)
 	assert.Error(t, err)
-	assert.Equal(t, "failed to parse [KernelCommandLine]: extraCommandLine contains character ` which is reserved for use by sed", err.Error())
+	assert.Equal(t, "failed to parse [KernelCommandLine]: the 'ExtraCommandLine' field contains the ` character which is reserved for use by sed", err.Error())
 }

--- a/toolkit/tools/imagegen/configuration/packagerepo.go
+++ b/toolkit/tools/imagegen/configuration/packagerepo.go
@@ -102,7 +102,7 @@ func UpdatePackageRepo(installChroot *safechroot.Chroot, config SystemConfig) (e
 		err = ferr
 		return
 	} else if !exists {
-		err = fmt.Errorf("Could not find the repo file directory %s to update package repo", repoFileDir)
+		err = fmt.Errorf("could not find the repo file directory %s to update package repo", repoFileDir)
 		return
 	}
 

--- a/toolkit/tools/imagegen/configuration/parse_partition.go
+++ b/toolkit/tools/imagegen/configuration/parse_partition.go
@@ -247,7 +247,7 @@ func processMountPoint(inputMountPoint string, partitionNumber int) (err error) 
 	} else {
 		if !strings.HasPrefix(mountPoint, "/") {
 			// Other types of mount points are currently not supported
-			err = fmt.Errorf("Invalid mount point specified: (%s)", mountPoint)
+			err = fmt.Errorf("invalid mount point specified: (%s)", mountPoint)
 		}
 	}
 

--- a/toolkit/tools/imagegen/configuration/systemconfig.go
+++ b/toolkit/tools/imagegen/configuration/systemconfig.go
@@ -80,7 +80,7 @@ func (s *SystemConfig) IsValid() (err error) {
 
 	// Validate BootType
 	if s.BootType != "efi" && s.BootType != "legacy" && s.BootType != "none" && s.BootType != "" {
-		return fmt.Errorf("invalid [BootType]: %s. Expecting values of either 'efi', 'legacy', 'none' or empty string.", s.BootType)
+		return fmt.Errorf("invalid [BootType]: %s. Expecting values of either 'efi', 'legacy', 'none' or empty string", s.BootType)
 	}
 
 	if len(s.PackageLists) == 0 && len(s.Packages) == 0 {

--- a/toolkit/tools/imagegen/configuration/systemconfig_test.go
+++ b/toolkit/tools/imagegen/configuration/systemconfig_test.go
@@ -163,11 +163,11 @@ func TestShouldFailParsingBadKernelCommandLine_SystemConfig(t *testing.T) {
 
 	err := badKernelCommandConfig.IsValid()
 	assert.Error(t, err)
-	assert.Equal(t, "invalid [KernelCommandLine]: ExtraCommandLine contains character ` which is reserved for use by sed", err.Error())
+	assert.Equal(t, "invalid [KernelCommandLine]: extraCommandLine contains character ` which is reserved for use by sed", err.Error())
 
 	err = remarshalJSON(badKernelCommandConfig, &checkedSystemConfig)
 	assert.Error(t, err)
-	assert.Equal(t, "failed to parse [SystemConfig]: failed to parse [KernelCommandLine]: ExtraCommandLine contains character ` which is reserved for use by sed", err.Error())
+	assert.Equal(t, "failed to parse [SystemConfig]: failed to parse [KernelCommandLine]: extraCommandLine contains character ` which is reserved for use by sed", err.Error())
 }
 
 func TestShouldFailParsingInvalidHostName_SystemConfig(t *testing.T) {
@@ -372,5 +372,5 @@ func TestShouldFailParsingUnexpectedBootType_SystemConfig(t *testing.T) {
 
 	err := invalidBootTypeConfig.IsValid()
 	assert.Error(t, err)
-	assert.Equal(t, "invalid [BootType]: uefi. Expecting values of either 'efi', 'legacy', 'none' or empty string.", err.Error())
+	assert.Equal(t, "invalid [BootType]: uefi. Expecting values of either 'efi', 'legacy', 'none' or empty string", err.Error())
 }

--- a/toolkit/tools/imagegen/configuration/systemconfig_test.go
+++ b/toolkit/tools/imagegen/configuration/systemconfig_test.go
@@ -163,11 +163,11 @@ func TestShouldFailParsingBadKernelCommandLine_SystemConfig(t *testing.T) {
 
 	err := badKernelCommandConfig.IsValid()
 	assert.Error(t, err)
-	assert.Equal(t, "invalid [KernelCommandLine]: extraCommandLine contains character ` which is reserved for use by sed", err.Error())
+	assert.Equal(t, "invalid [KernelCommandLine]: the 'ExtraCommandLine' field contains the ` character which is reserved for use by sed", err.Error())
 
 	err = remarshalJSON(badKernelCommandConfig, &checkedSystemConfig)
 	assert.Error(t, err)
-	assert.Equal(t, "failed to parse [SystemConfig]: failed to parse [KernelCommandLine]: extraCommandLine contains character ` which is reserved for use by sed", err.Error())
+	assert.Equal(t, "failed to parse [SystemConfig]: failed to parse [KernelCommandLine]: the 'ExtraCommandLine' field contains the ` character which is reserved for use by sed", err.Error())
 }
 
 func TestShouldFailParsingInvalidHostName_SystemConfig(t *testing.T) {

--- a/toolkit/tools/imagegen/diskutils/diskutils.go
+++ b/toolkit/tools/imagegen/diskutils/diskutils.go
@@ -536,7 +536,7 @@ func InitializeSinglePartition(diskDevPath string, partitionNumber int, partitio
 		case configuration.PartitionFlagDeviceMapperRoot:
 			//Ignore, only used for internal tooling
 		default:
-			return partDevPath, fmt.Errorf("Partition %v - Unknown partition flag: %v", partitionNumber, flag)
+			return partDevPath, fmt.Errorf("partition %v - Unknown partition flag: %v", partitionNumber, flag)
 		}
 		if flagToSet != "" {
 			args = append(args, flagToSet, "on")
@@ -611,7 +611,7 @@ func FormatSinglePartition(partDevPath string, partition configuration.Partition
 	case "":
 		logger.Log.Debugf("No filesystem type specified. Ignoring for partition: %v", partDevPath)
 	default:
-		return fsType, fmt.Errorf("Unrecognized filesystem format: %v", fsType)
+		return fsType, fmt.Errorf("unrecognized filesystem format: %v", fsType)
 	}
 
 	return

--- a/toolkit/tools/imagegen/diskutils/verity.go
+++ b/toolkit/tools/imagegen/diskutils/verity.go
@@ -147,7 +147,7 @@ func (v *VerityDevice) createVerityDisk(verityDirectory string) (err error) {
 	logger.Log.Info("Generating a dm-verity read-only partition")
 	verityOutput, stderr, err := shell.Execute("veritysetup", append(verityFecArgs, verityArgs...)...)
 	if err != nil {
-		err = fmt.Errorf("Unable to create verity disk '%s': %w", stderr, err)
+		err = fmt.Errorf("unable to create verity disk '%s': %w", stderr, err)
 		return
 	}
 
@@ -155,7 +155,7 @@ func (v *VerityDevice) createVerityDisk(verityDirectory string) (err error) {
 	matches := rootHashLineRegex.FindStringSubmatch(verityOutput)
 
 	if len(matches) != 2 {
-		err = fmt.Errorf("Unable to extract root hash from veritysetup output: '%s', matched: '%#v'", verityOutput, matches)
+		err = fmt.Errorf("unable to extract root hash from veritysetup output: '%s', matched: '%#v'", verityOutput, matches)
 		return
 	}
 	rootHash := matches[1]
@@ -180,7 +180,7 @@ func (v *VerityDevice) createVerityDisk(verityDirectory string) (err error) {
 	verityOutput, stderr, err = shell.Execute("veritysetup", verityVerifyArgs...)
 	if err != nil {
 		logger.Log.Errorf("Verity error: '%s'", verityOutput)
-		err = fmt.Errorf("Unable to validate new verity disk '%s': %w", stderr, err)
+		err = fmt.Errorf("unable to validate new verity disk '%s': %w", stderr, err)
 	}
 
 	return
@@ -198,7 +198,7 @@ func PrepReadOnlyDevice(partDevPath string, partition configuration.Partition, r
 	)
 
 	if !readOnlyConfig.Enable {
-		err = fmt.Errorf("Verity is not enabled, can't update partition '%s'", partition.ID)
+		err = fmt.Errorf("verity is not enabled, can't update partition '%s'", partition.ID)
 		return
 	}
 
@@ -231,7 +231,7 @@ func PrepReadOnlyDevice(partDevPath string, partition configuration.Partition, r
 	}
 	deviceSizeInt, err := strconv.ParseUint(strings.TrimSpace(deviceSizeStr), 10, 64)
 	if err != nil {
-		err = fmt.Errorf("Unable to convert disk size '%s' to integer: %w", deviceSizeStr, err)
+		err = fmt.Errorf("unable to convert disk size '%s' to integer: %w", deviceSizeStr, err)
 		return
 	}
 
@@ -244,7 +244,7 @@ func PrepReadOnlyDevice(partDevPath string, partition configuration.Partition, r
 	}
 	_, stderr, err = shell.Execute("dmsetup", dmsetupArgs...)
 	if err != nil {
-		err = fmt.Errorf("Unable to create a device mapper device '%s': %w", stderr, err)
+		err = fmt.Errorf("unable to create a device mapper device '%s': %w", stderr, err)
 		return
 	}
 
@@ -257,7 +257,7 @@ func PrepReadOnlyDevice(partDevPath string, partition configuration.Partition, r
 func (v *VerityDevice) CleanupVerityDevice() (err error) {
 	stdout, stderr, err := shell.Execute("dmsetup", "remove", v.MappedName)
 	if err != nil {
-		err = fmt.Errorf("Unable to clean up device mapper device '%s' '%s': %w", stdout, stderr, err)
+		err = fmt.Errorf("unable to clean up device mapper device '%s' '%s': %w", stdout, stderr, err)
 		logger.Log.Error(err.Error())
 		return
 	}

--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -1566,7 +1566,7 @@ func selinuxRelabelFiles(systemConfig configuration.SystemConfig, installChroot 
 		case "fat32", "fat16", "vfat":
 			logger.Log.Debugf("SELinux will not label mount at (%s) of type (%s), skipping", mount, fsType)
 		default:
-			err = fmt.Errorf("Unknown fsType (%s) for mount (%s), cannot configure SELinux", fsType, mount)
+			err = fmt.Errorf("unknown fsType (%s) for mount (%s), cannot configure SELinux", fsType, mount)
 			return
 		}
 	}

--- a/toolkit/tools/internal/rpm/rpm.go
+++ b/toolkit/tools/internal/rpm/rpm.go
@@ -90,7 +90,7 @@ var (
 func GetRpmArch(goArch string) (rpmArch string, err error) {
 	rpmArch, ok := goArchToRpmArch[goArch]
 	if !ok {
-		err = fmt.Errorf("Unknown GOARCH detected (%s)", goArch)
+		err = fmt.Errorf("unknown GOARCH detected (%s)", goArch)
 	}
 	return
 }
@@ -105,7 +105,7 @@ func SetMacroDir(newMacroDir string) (origenv []string, err error) {
 	}
 	exists, err := file.DirExists(newMacroDir)
 	if err != nil || exists == false {
-		err = fmt.Errorf("Directory %s does not exist", newMacroDir)
+		err = fmt.Errorf("directory %s does not exist", newMacroDir)
 		return
 	}
 

--- a/toolkit/tools/internal/storage/storage.go
+++ b/toolkit/tools/internal/storage/storage.go
@@ -28,7 +28,7 @@ func CheckDiskSpace(filepath string, quota int) (err error) {
 	sizeInBytes := stat.Bavail * uint64(stat.Bsize)
 	availInKbs := sizeInBytes / 1024
 	if availInKbs < uint64(quota) {
-		err = fmt.Errorf("Not enough space on disk containing file %s. Expected %d 1K Blocks found %d", filepath, quota, availInKbs)
+		err = fmt.Errorf("not enough space on disk containing file %s. Expected %d 1K Blocks found %d", filepath, quota, availInKbs)
 	}
 	return
 }

--- a/toolkit/tools/internal/timestamp/timestamp.go
+++ b/toolkit/tools/internal/timestamp/timestamp.go
@@ -48,7 +48,7 @@ func (ts *TimeStamp) DisplayName() string {
 // Creates a new timestamp object with optional parent ID
 func newTimeStamp(name string, parent *TimeStamp) (ts *TimeStamp, err error) {
 	if strings.Contains(name, pathSeparator) {
-		err = fmt.Errorf("Can't create a timestamp object with a path containing %s", pathSeparator)
+		err = fmt.Errorf("can't create a timestamp object with a path containing %s", pathSeparator)
 		return
 	}
 
@@ -64,7 +64,7 @@ func newTimeStamp(name string, parent *TimeStamp) (ts *TimeStamp, err error) {
 func newTimeStampByPath(root *TimeStamp, path string) (ts *TimeStamp, err error) {
 	components := strings.Split(path, pathSeparator)
 	if components[0] != root.Name {
-		err = fmt.Errorf("Timestamp root mismatch ('%s', expected '%s')", components[0], root.Name)
+		err = fmt.Errorf("timestamp root mismatch ('%s', expected '%s')", components[0], root.Name)
 		return
 	}
 	parent, err := getTimeStampFromPath(root, components[:len(components)-1], 1)
@@ -82,7 +82,7 @@ func getTimeStampFromPath(root *TimeStamp, path []string, nextIndex int) (ts *Ti
 	}
 	nextNode, present := root.subSteps[path[nextIndex]]
 	if !present {
-		err = fmt.Errorf("Node at index %d does not exist in the path from root: %v", nextIndex, path)
+		err = fmt.Errorf("node at index %d does not exist in the path from root: %v", nextIndex, path)
 		return &TimeStamp{}, err
 	}
 	return getTimeStampFromPath(nextNode, path, nextIndex+1)

--- a/toolkit/tools/pkg/profile/profile.go
+++ b/toolkit/tools/pkg/profile/profile.go
@@ -26,11 +26,11 @@ func StartProfiling(pf *exe.ProfileFlags) (*Profiler, error) {
 	if *pf.EnableCpuProf {
 		cpf, err := os.Create(*pf.CpuProfFile)
 		if err != nil {
-			return nil, fmt.Errorf("Unable to create cpu-pprof file: %s", err)
+			return nil, fmt.Errorf("unable to create cpu-pprof file: %s", err)
 		}
 		err = pprof.StartCPUProfile(cpf)
 		if err != nil {
-			return nil, fmt.Errorf("Unable to start cpu-pprof: %s", err)
+			return nil, fmt.Errorf("unable to start cpu-pprof: %s", err)
 		}
 		// Assign the file pointer after starting the profile operation
 		p.cpuProfFile = cpf
@@ -39,11 +39,11 @@ func StartProfiling(pf *exe.ProfileFlags) (*Profiler, error) {
 	if *pf.EnableMemProf {
 		mpf, err := os.Create(*pf.CpuProfFile)
 		if err != nil {
-			return nil, fmt.Errorf("Unable to create mem-pprof file: %s", err)
+			return nil, fmt.Errorf("unable to create mem-pprof file: %s", err)
 		}
 		runtime.GC() // get up-to-date statistics
 		if err := pprof.WriteHeapProfile(mpf); err != nil {
-			return nil, fmt.Errorf("Unable to write mem-pprof file: %s", err)
+			return nil, fmt.Errorf("unable to write mem-pprof file: %s", err)
 		}
 		// Assign the file pointer after starting the profile operation
 		p.memProfFile = mpf
@@ -52,10 +52,10 @@ func StartProfiling(pf *exe.ProfileFlags) (*Profiler, error) {
 	if *pf.EnableTrace {
 		tf, err := os.Create(*pf.TraceFile)
 		if err != nil {
-			return nil, fmt.Errorf("Unable to create trace file: %s", err)
+			return nil, fmt.Errorf("unable to create trace file: %s", err)
 		}
 		if err := trace.Start(tf); err != nil {
-			return nil, fmt.Errorf("Unable to write trace file: %s", err)
+			return nil, fmt.Errorf("unable to write trace file: %s", err)
 		}
 		// Assign the file pointer after starting the trace
 		p.traceFile = tf

--- a/toolkit/tools/pkg/rpmssnapshot/rpmssnapshot.go
+++ b/toolkit/tools/pkg/rpmssnapshot/rpmssnapshot.go
@@ -98,7 +98,7 @@ func (s *SnapshotGenerator) convertResultsToRepoContents(allBuiltRPMs []string) 
 	for _, builtRPM := range allBuiltRPMs {
 		matches := rpmSpecBuiltRPMRegex.FindStringSubmatch(builtRPM)
 		if len(matches) != rpmSpecBuiltRPMRegexMatchesCount {
-			return repoContents, fmt.Errorf("rPM package name (%s) doesn't match the regular expression (%s)", builtRPM, rpmSpecBuiltRPMRegex.String())
+			return repoContents, fmt.Errorf("RPM package name (%s) doesn't match the regular expression (%s)", builtRPM, rpmSpecBuiltRPMRegex.String())
 		}
 
 		repoContents.Repo = append(repoContents.Repo, &repocloner.RepoPackage{

--- a/toolkit/tools/pkg/rpmssnapshot/rpmssnapshot.go
+++ b/toolkit/tools/pkg/rpmssnapshot/rpmssnapshot.go
@@ -98,7 +98,7 @@ func (s *SnapshotGenerator) convertResultsToRepoContents(allBuiltRPMs []string) 
 	for _, builtRPM := range allBuiltRPMs {
 		matches := rpmSpecBuiltRPMRegex.FindStringSubmatch(builtRPM)
 		if len(matches) != rpmSpecBuiltRPMRegexMatchesCount {
-			return repoContents, fmt.Errorf("RPM package name (%s) doesn't match the regular expression (%s)", builtRPM, rpmSpecBuiltRPMRegex.String())
+			return repoContents, fmt.Errorf("rPM package name (%s) doesn't match the regular expression (%s)", builtRPM, rpmSpecBuiltRPMRegex.String())
 		}
 
 		repoContents.Repo = append(repoContents.Repo, &repocloner.RepoPackage{

--- a/toolkit/tools/roast/formats/ova.go
+++ b/toolkit/tools/roast/formats/ova.go
@@ -37,13 +37,13 @@ type Ova struct {
 func filePathFromEnv(variable string) (path string, err error) {
 	path, varExist := unix.Getenv(variable)
 	if !varExist {
-		err = fmt.Errorf("Environment variable not found: %s", variable)
+		err = fmt.Errorf("environment variable not found: %s", variable)
 		return
 	}
 
 	fileExist, _ := file.PathExists(path)
 	if !fileExist {
-		err = fmt.Errorf("File from environment variable %s not found: %s", variable, path)
+		err = fmt.Errorf("file from environment variable %s not found: %s", variable, path)
 		return
 	}
 	return

--- a/toolkit/tools/specreader/specreader.go
+++ b/toolkit/tools/specreader/specreader.go
@@ -114,13 +114,13 @@ func parseSPECsWrapper(buildDir, specsDir, rpmsDir, srpmsDir, toolchainDir, dist
 		if *targetArch == "" {
 			packageRepo, parseError = parseSPECs(specsDir, rpmsDir, srpmsDir, toolchainDir, distTag, buildArch, toolchainRPMs, workers, runCheck)
 			if parseError != nil {
-				err := fmt.Errorf("Failed to parse native specs (%w)", parseError)
+				err := fmt.Errorf("failed to parse native specs (%w)", parseError)
 				return err
 			}
 		} else {
 			packageRepo, parseError = parseSPECs(specsDir, rpmsDir, srpmsDir, toolchainDir, distTag, *targetArch, toolchainRPMs, workers, runCheck)
 			if parseError != nil {
-				err := fmt.Errorf("Failed to parse cross specs (%w)", parseError)
+				err := fmt.Errorf("failed to parse cross specs (%w)", parseError)
 				return err
 			}
 		}


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

Adjusted some of our `fmt.Error*` logs to keep them consistent and align them with the linter's suggestions we kept as a convention.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Refactored `fmt.Error*` messages by removing periods at the end and making them start with lowercase letters.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- N/A, single character change to a few logs.