### PR TITLE
KubeVirt: Add grace period for hotplug detach when hotplug pod is deleted

### DIFF
--- a/SPECS/kubevirt/Hotplug_detach_grace_period.patch
+++ b/SPECS/kubevirt/Hotplug_detach_grace_period.patch
@@ -1,21 +1,20 @@
 diff --git a/pkg/virt-launcher/virtwrap/manager.go b/pkg/virt-launcher/virtwrap/manager.go
-index 63d8d43d2..35cdc31d8 100644
+index 63d8d43d2..19719993a 100644
 --- a/pkg/virt-launcher/virtwrap/manager.go
 +++ b/pkg/virt-launcher/virtwrap/manager.go
-@@ -97,6 +97,12 @@ const (
+@@ -97,6 +97,11 @@ const (
  const maxConcurrentHotplugHostDevices = 1
  const maxConcurrentMemoryDumps = 1
  
 +// TODO: Make this configurable from the VMI object?
 +const hotplugDetachmentGracePeriod = 5 * time.Second
 +
-+// TODO: Either delete logging statements that use this or increase the value to 5
-+const hotplugDetachmentVerbosity = 1
++const hotplugDetachmentVerbosity = 4
 +
  type contextStore struct {
  	ctx    context.Context
  	cancel context.CancelFunc
-@@ -142,6 +148,7 @@ type LibvirtDomainManager struct {
+@@ -142,6 +147,7 @@ type LibvirtDomainManager struct {
  
  	hotplugHostDevicesInProgress chan struct{}
  	memoryDumpInProgress         chan struct{}
@@ -23,7 +22,7 @@ index 63d8d43d2..35cdc31d8 100644
  
  	virtShareDir             string
  	ephemeralDiskDir         string
-@@ -204,6 +211,7 @@ func newLibvirtDomainManager(connection cli.Connection, virtShareDir, ephemeralD
+@@ -204,6 +210,7 @@ func newLibvirtDomainManager(connection cli.Connection, virtShareDir, ephemeralD
  		cancelSafetyUnfreezeChan: make(chan struct{}),
  		migrateInfoStats:         &stats.DomainJobInfo{},
  		metadataCache:            metadataCache,
@@ -31,7 +30,7 @@ index 63d8d43d2..35cdc31d8 100644
  	}
  
  	manager.hotplugHostDevicesInProgress = make(chan struct{}, maxConcurrentHotplugHostDevices)
-@@ -922,19 +930,75 @@ func (l *LibvirtDomainManager) SyncVMI(vmi *v1.VirtualMachineInstance, allowEmul
+@@ -922,19 +929,75 @@ func (l *LibvirtDomainManager) SyncVMI(vmi *v1.VirtualMachineInstance, allowEmul
  		return nil, err
  	}
  
@@ -114,7 +113,7 @@ index 63d8d43d2..35cdc31d8 100644
  	}
  	// Look up all the disks to attach
  	for _, attachDisk := range getAttachedDisks(oldSpec.Devices.Disks, domain.Spec.Devices.Disks) {
-@@ -945,7 +1009,18 @@ func (l *LibvirtDomainManager) SyncVMI(vmi *v1.VirtualMachineInstance, allowEmul
+@@ -945,7 +1008,18 @@ func (l *LibvirtDomainManager) SyncVMI(vmi *v1.VirtualMachineInstance, allowEmul
  		if !allowAttach {
  			continue
  		}
@@ -134,7 +133,7 @@ index 63d8d43d2..35cdc31d8 100644
  		// set drivers cache mode
  		err = converter.SetDriverCacheMode(&attachDisk, l.directIOChecker)
  		if err != nil {
-@@ -1032,7 +1107,7 @@ func isHotplugDisk(disk api.Disk) bool {
+@@ -1032,7 +1106,7 @@ func isHotplugDisk(disk api.Disk) bool {
  	return strings.HasPrefix(getSourceFile(disk), v1.HotplugDiskDir)
  }
  
@@ -143,7 +142,7 @@ index 63d8d43d2..35cdc31d8 100644
  	newDiskMap := make(map[string]api.Disk)
  	for _, disk := range newDisks {
  		file := getSourceFile(disk)
-@@ -1040,14 +1115,15 @@ func getDetachedDisks(oldDisks, newDisks []api.Disk) []api.Disk {
+@@ -1040,14 +1114,15 @@ func getDetachedDisks(oldDisks, newDisks []api.Disk) []api.Disk {
  			newDiskMap[file] = disk
  		}
  	}
@@ -163,28 +162,27 @@ index 63d8d43d2..35cdc31d8 100644
  	return res
 diff --git a/prototype.patch b/prototype.patch
 new file mode 100644
-index 000000000..4925fa045
+index 000000000..a7d83eb93
 --- /dev/null
 +++ b/prototype.patch
-@@ -0,0 +1,86 @@
+@@ -0,0 +1,87 @@
 +diff --git a/pkg/virt-launcher/virtwrap/manager.go b/pkg/virt-launcher/virtwrap/manager.go
-+index 63d8d43d2..35cdc31d8 100644
++index 63d8d43d2..19719993a 100644
 +--- a/pkg/virt-launcher/virtwrap/manager.go
 ++++ b/pkg/virt-launcher/virtwrap/manager.go
-+@@ -97,6 +97,12 @@ const (
++@@ -97,6 +97,11 @@ const (
 + const maxConcurrentHotplugHostDevices = 1
 + const maxConcurrentMemoryDumps = 1
 + 
 ++// TODO: Make this configurable from the VMI object?
 ++const hotplugDetachmentGracePeriod = 5 * time.Second
 ++
-++// TODO: Either delete logging statements that use this or increase the value to 5
-++const hotplugDetachmentVerbosity = 1
+++const hotplugDetachmentVerbosity = 4
 ++
 + type contextStore struct {
 + 	ctx    context.Context
 + 	cancel context.CancelFunc
-+@@ -142,6 +148,7 @@ type LibvirtDomainManager struct {
++@@ -142,6 +147,7 @@ type LibvirtDomainManager struct {
 + 
 + 	hotplugHostDevicesInProgress chan struct{}
 + 	memoryDumpInProgress         chan struct{}
@@ -192,7 +190,7 @@ index 000000000..4925fa045
 + 
 + 	virtShareDir             string
 + 	ephemeralDiskDir         string
-+@@ -204,6 +211,7 @@ func newLibvirtDomainManager(connection cli.Connection, virtShareDir, ephemeralD
++@@ -204,6 +210,7 @@ func newLibvirtDomainManager(connection cli.Connection, virtShareDir, ephemeralD
 + 		cancelSafetyUnfreezeChan: make(chan struct{}),
 + 		migrateInfoStats:         &stats.DomainJobInfo{},
 + 		metadataCache:            metadataCache,
@@ -200,7 +198,7 @@ index 000000000..4925fa045
 + 	}
 + 
 + 	manager.hotplugHostDevicesInProgress = make(chan struct{}, maxConcurrentHotplugHostDevices)
-+@@ -922,19 +930,75 @@ func (l *LibvirtDomainManager) SyncVMI(vmi *v1.VirtualMachineInstance, allowEmul
++@@ -922,19 +929,75 @@ func (l *LibvirtDomainManager) SyncVMI(vmi *v1.VirtualMachineInstance, allowEmul
 + 		return nil, err
 + 	}
 + 
@@ -252,5 +250,7 @@ index 000000000..4925fa045
 ++			// so there aren't multiple goroutines waiting to detach the same disk.
 ++			if _, ok := l.cancelDiskDetachChannels[namespacedDiskName]; ok {
 ++				logger.V(hotplugDetachmentVerbosity).Infof("Potential hotplug disk detaching already handled: %s", namespacedDiskName)
-++	
+++				return
+++			}
+++			// There are no other goroutines waiting to detach this disk, cr
 \ No newline at end of file

--- a/SPECS/kubevirt/Hotplug_detach_grace_period.patch
+++ b/SPECS/kubevirt/Hotplug_detach_grace_period.patch
@@ -1,0 +1,256 @@
+diff --git a/pkg/virt-launcher/virtwrap/manager.go b/pkg/virt-launcher/virtwrap/manager.go
+index 63d8d43d2..35cdc31d8 100644
+--- a/pkg/virt-launcher/virtwrap/manager.go
++++ b/pkg/virt-launcher/virtwrap/manager.go
+@@ -97,6 +97,12 @@ const (
+ const maxConcurrentHotplugHostDevices = 1
+ const maxConcurrentMemoryDumps = 1
+ 
++// TODO: Make this configurable from the VMI object?
++const hotplugDetachmentGracePeriod = 5 * time.Second
++
++// TODO: Either delete logging statements that use this or increase the value to 5
++const hotplugDetachmentVerbosity = 1
++
+ type contextStore struct {
+ 	ctx    context.Context
+ 	cancel context.CancelFunc
+@@ -142,6 +148,7 @@ type LibvirtDomainManager struct {
+ 
+ 	hotplugHostDevicesInProgress chan struct{}
+ 	memoryDumpInProgress         chan struct{}
++	cancelDiskDetachChannels     map[string]chan struct{}
+ 
+ 	virtShareDir             string
+ 	ephemeralDiskDir         string
+@@ -204,6 +211,7 @@ func newLibvirtDomainManager(connection cli.Connection, virtShareDir, ephemeralD
+ 		cancelSafetyUnfreezeChan: make(chan struct{}),
+ 		migrateInfoStats:         &stats.DomainJobInfo{},
+ 		metadataCache:            metadataCache,
++		cancelDiskDetachChannels: make(map[string]chan struct{}),
+ 	}
+ 
+ 	manager.hotplugHostDevicesInProgress = make(chan struct{}, maxConcurrentHotplugHostDevices)
+@@ -922,19 +930,75 @@ func (l *LibvirtDomainManager) SyncVMI(vmi *v1.VirtualMachineInstance, allowEmul
+ 		return nil, err
+ 	}
+ 
++	// Get list of disks that should be detached
++	detachedDisks := getDetachedDisks(vmi.Name, vmi.Namespace, oldSpec.Devices.Disks, domain.Spec.Devices.Disks)
++
++	// Check list of detached disks against the list of detachment goroutines.  Cancel the goroutines
++	// that are no longer needed.
++	for cancelDiskDetachChannelName, cancelDiskDetachChannel := range l.cancelDiskDetachChannels {
++		if _, ok := detachedDisks[cancelDiskDetachChannelName]; ok {
++			// If disk is already a detach goroutine and in the detachedDisk list, do not cancel
++			// the goroutine.
++			logger.V(hotplugDetachmentVerbosity).Infof("Hotplug detach stil requested, continue grace period = [%+v]", cancelDiskDetachChannelName)
++		} else {
++			// If disk is already a detach goroutine and is no longer in detachedDisk list, it no
++			// longer needs to be detached.  Signal detach cancellation and remove from detachedDisks
++			// list.
++			logger.V(hotplugDetachmentVerbosity).Infof("Hotplug detach not longer needed, cancel it [%+v]", cancelDiskDetachChannelName)
++			// Signal detach goutine to cancel
++			cancelDiskDetachChannel <- struct{}{}
++			// Remove from detachedDisks list so detach goutine is not recreated
++			delete(detachedDisks, cancelDiskDetachChannelName)
++		}
++	}
+ 	// Look up all the disks to detach
+-	for _, detachDisk := range getDetachedDisks(oldSpec.Devices.Disks, domain.Spec.Devices.Disks) {
+-		logger.V(1).Infof("Detaching disk %s, target %s", detachDisk.Alias.GetName(), detachDisk.Target.Device)
++	for namespacedDiskName, detachDisk := range detachedDisks {
++		detachDiskName := detachDisk.Alias.GetName()
++		detachDiskTargetDevice := detachDisk.Target.Device
++		domainName := domain.Spec.Name
++
+ 		detachBytes, err := xml.Marshal(detachDisk)
+ 		if err != nil {
+ 			logger.Reason(err).Error("marshalling detached disk failed")
+ 			return nil, err
+ 		}
+-		err = dom.DetachDeviceFlags(strings.ToLower(string(detachBytes)), affectLiveAndConfigLibvirtFlags)
+-		if err != nil {
+-			logger.Reason(err).Error("detaching device")
+-			return nil, err
+-		}
++
++		// Create goroutine to do detachment so we can wait to see if the disk is reattached.
++		go func() {
++			logger.V(hotplugDetachmentVerbosity).Infof("Potentially detaching hotplug disk %s", namespacedDiskName)
++
++			// If channel has already been created, a goroutine is already waiting for the disk to be detached.  Exit
++			// so there aren't multiple goroutines waiting to detach the same disk.
++			if _, ok := l.cancelDiskDetachChannels[namespacedDiskName]; ok {
++				logger.V(hotplugDetachmentVerbosity).Infof("Potential hotplug disk detaching already handled: %s", namespacedDiskName)
++				return
++			}
++			// There are no other goroutines waiting to detach this disk, create a channel enable subsequent calls to
++			// SyncVMI to cancel this detach (if attach is requested within the grace period: 5 seconds)
++			l.cancelDiskDetachChannels[namespacedDiskName] = make(chan struct{})
++			// Wait for either the grace period to expire (in which case: proceed to detach) or for the attach channel
++			// to be triggered (in which case: cancel the detach)
++			select {
++			case <-l.cancelDiskDetachChannels[namespacedDiskName]:
++				// Disk attach has been requested within the grace period, cancel the detach
++				logger.V(hotplugDetachmentVerbosity).Infof("Potential hotplug disk detaching was cancelled: %s", namespacedDiskName)
++			case <-time.After(5 * time.Second):
++				// Grace period has expired without an attache request, proceed to detach
++				logger.V(1).Infof("Detaching disk %s, target %s", detachDiskName, detachDiskTargetDevice)
++				dom, err := l.virConn.LookupDomainByName(domainName)
++				if err != nil {
++					logger.Reason(err).Error("getting domain for device detach")
++					break
++				}
++
++				err = dom.DetachDeviceFlags(strings.ToLower(string(detachBytes)), affectLiveAndConfigLibvirtFlags)
++				if err != nil {
++					logger.Reason(err).Error("detaching device")
++				}
++			}
++			// Detach request has been handled, remove channel from map
++			delete(l.cancelDiskDetachChannels, namespacedDiskName)
++		}()
+ 	}
+ 	// Look up all the disks to attach
+ 	for _, attachDisk := range getAttachedDisks(oldSpec.Devices.Disks, domain.Spec.Devices.Disks) {
+@@ -945,7 +1009,18 @@ func (l *LibvirtDomainManager) SyncVMI(vmi *v1.VirtualMachineInstance, allowEmul
+ 		if !allowAttach {
+ 			continue
+ 		}
+-		logger.V(1).Infof("Attaching disk %s, target %s", attachDisk.Alias.GetName(), attachDisk.Target.Device)
++		attachDiskName := attachDisk.Alias.GetName()
++		namespacedDiskName := fmt.Sprintf("%s_%s_%s", vmi.Namespace, vmi.Name, attachDiskName)
++		if _, ok := l.cancelDiskDetachChannels[namespacedDiskName]; ok {
++			logger.V(hotplugDetachmentVerbosity).Infof("Hotplug attach during detach grace period, signal detach goroutine: %s", namespacedDiskName)
++			// a goroutine is waiting to detach this disk, signal it to stop
++			l.cancelDiskDetachChannels[namespacedDiskName] <- struct{}{}
++			// no need to reattach if the disk is already attached
++			logger.V(hotplugDetachmentVerbosity).Infof("Skip hotplug detach/reattach disk: %s", namespacedDiskName)
++			continue
++		}
++
++		logger.V(1).Infof("Attaching disk %s, target %s", attachDiskName, attachDisk.Target.Device)
+ 		// set drivers cache mode
+ 		err = converter.SetDriverCacheMode(&attachDisk, l.directIOChecker)
+ 		if err != nil {
+@@ -1032,7 +1107,7 @@ func isHotplugDisk(disk api.Disk) bool {
+ 	return strings.HasPrefix(getSourceFile(disk), v1.HotplugDiskDir)
+ }
+ 
+-func getDetachedDisks(oldDisks, newDisks []api.Disk) []api.Disk {
++func getDetachedDisks(vmiName, vmiNamespace string, oldDisks, newDisks []api.Disk) map[string]api.Disk {
+ 	newDiskMap := make(map[string]api.Disk)
+ 	for _, disk := range newDisks {
+ 		file := getSourceFile(disk)
+@@ -1040,14 +1115,15 @@ func getDetachedDisks(oldDisks, newDisks []api.Disk) []api.Disk {
+ 			newDiskMap[file] = disk
+ 		}
+ 	}
+-	res := make([]api.Disk, 0)
++	res := map[string]api.Disk{}
+ 	for _, oldDisk := range oldDisks {
+ 		if !isHotplugDisk(oldDisk) {
+ 			continue
+ 		}
+ 		if _, ok := newDiskMap[getSourceFile(oldDisk)]; !ok {
+ 			// This disk got detached, add it to the list
+-			res = append(res, oldDisk)
++			namespacedDiskName := fmt.Sprintf("%s_%s_%s", vmiNamespace, vmiName, oldDisk.Alias.GetName())
++			res[namespacedDiskName] = oldDisk
+ 		}
+ 	}
+ 	return res
+diff --git a/prototype.patch b/prototype.patch
+new file mode 100644
+index 000000000..4925fa045
+--- /dev/null
++++ b/prototype.patch
+@@ -0,0 +1,86 @@
++diff --git a/pkg/virt-launcher/virtwrap/manager.go b/pkg/virt-launcher/virtwrap/manager.go
++index 63d8d43d2..35cdc31d8 100644
++--- a/pkg/virt-launcher/virtwrap/manager.go
+++++ b/pkg/virt-launcher/virtwrap/manager.go
++@@ -97,6 +97,12 @@ const (
++ const maxConcurrentHotplugHostDevices = 1
++ const maxConcurrentMemoryDumps = 1
++ 
+++// TODO: Make this configurable from the VMI object?
+++const hotplugDetachmentGracePeriod = 5 * time.Second
+++
+++// TODO: Either delete logging statements that use this or increase the value to 5
+++const hotplugDetachmentVerbosity = 1
+++
++ type contextStore struct {
++ 	ctx    context.Context
++ 	cancel context.CancelFunc
++@@ -142,6 +148,7 @@ type LibvirtDomainManager struct {
++ 
++ 	hotplugHostDevicesInProgress chan struct{}
++ 	memoryDumpInProgress         chan struct{}
+++	cancelDiskDetachChannels     map[string]chan struct{}
++ 
++ 	virtShareDir             string
++ 	ephemeralDiskDir         string
++@@ -204,6 +211,7 @@ func newLibvirtDomainManager(connection cli.Connection, virtShareDir, ephemeralD
++ 		cancelSafetyUnfreezeChan: make(chan struct{}),
++ 		migrateInfoStats:         &stats.DomainJobInfo{},
++ 		metadataCache:            metadataCache,
+++		cancelDiskDetachChannels: make(map[string]chan struct{}),
++ 	}
++ 
++ 	manager.hotplugHostDevicesInProgress = make(chan struct{}, maxConcurrentHotplugHostDevices)
++@@ -922,19 +930,75 @@ func (l *LibvirtDomainManager) SyncVMI(vmi *v1.VirtualMachineInstance, allowEmul
++ 		return nil, err
++ 	}
++ 
+++	// Get list of disks that should be detached
+++	detachedDisks := getDetachedDisks(vmi.Name, vmi.Namespace, oldSpec.Devices.Disks, domain.Spec.Devices.Disks)
+++
+++	// Check list of detached disks against the list of detachment goroutines.  Cancel the goroutines
+++	// that are no longer needed.
+++	for cancelDiskDetachChannelName, cancelDiskDetachChannel := range l.cancelDiskDetachChannels {
+++		if _, ok := detachedDisks[cancelDiskDetachChannelName]; ok {
+++			// If disk is already a detach goroutine and in the detachedDisk list, do not cancel
+++			// the goroutine.
+++			logger.V(hotplugDetachmentVerbosity).Infof("Hotplug detach stil requested, continue grace period = [%+v]", cancelDiskDetachChannelName)
+++		} else {
+++			// If disk is already a detach goroutine and is no longer in detachedDisk list, it no
+++			// longer needs to be detached.  Signal detach cancellation and remove from detachedDisks
+++			// list.
+++			logger.V(hotplugDetachmentVerbosity).Infof("Hotplug detach not longer needed, cancel it [%+v]", cancelDiskDetachChannelName)
+++			// Signal detach goutine to cancel
+++			cancelDiskDetachChannel <- struct{}{}
+++			// Remove from detachedDisks list so detach goutine is not recreated
+++			delete(detachedDisks, cancelDiskDetachChannelName)
+++		}
+++	}
++ 	// Look up all the disks to detach
++-	for _, detachDisk := range getDetachedDisks(oldSpec.Devices.Disks, domain.Spec.Devices.Disks) {
++-		logger.V(1).Infof("Detaching disk %s, target %s", detachDisk.Alias.GetName(), detachDisk.Target.Device)
+++	for namespacedDiskName, detachDisk := range detachedDisks {
+++		detachDiskName := detachDisk.Alias.GetName()
+++		detachDiskTargetDevice := detachDisk.Target.Device
+++		domainName := domain.Spec.Name
+++
++ 		detachBytes, err := xml.Marshal(detachDisk)
++ 		if err != nil {
++ 			logger.Reason(err).Error("marshalling detached disk failed")
++ 			return nil, err
++ 		}
++-		err = dom.DetachDeviceFlags(strings.ToLower(string(detachBytes)), affectLiveAndConfigLibvirtFlags)
++-		if err != nil {
++-			logger.Reason(err).Error("detaching device")
++-			return nil, err
++-		}
+++
+++		// Create goroutine to do detachment so we can wait to see if the disk is reattached.
+++		go func() {
+++			logger.V(hotplugDetachmentVerbosity).Infof("Potentially detaching hotplug disk %s", namespacedDiskName)
+++
+++			// If channel has already been created, a goroutine is already waiting for the disk to be detached.  Exit
+++			// so there aren't multiple goroutines waiting to detach the same disk.
+++			if _, ok := l.cancelDiskDetachChannels[namespacedDiskName]; ok {
+++				logger.V(hotplugDetachmentVerbosity).Infof("Potential hotplug disk detaching already handled: %s", namespacedDiskName)
+++	
+\ No newline at end of file

--- a/SPECS/kubevirt/Hotplug_detach_grace_period.patch
+++ b/SPECS/kubevirt/Hotplug_detach_grace_period.patch
@@ -1,5 +1,5 @@
 diff --git a/pkg/virt-launcher/virtwrap/manager.go b/pkg/virt-launcher/virtwrap/manager.go
-index 63d8d43d2..2115b7950 100644
+index 63d8d43d2..0e608c4bb 100644
 --- a/pkg/virt-launcher/virtwrap/manager.go
 +++ b/pkg/virt-launcher/virtwrap/manager.go
 @@ -97,6 +97,11 @@ const (
@@ -30,12 +30,26 @@ index 63d8d43d2..2115b7950 100644
  	}
  
  	manager.hotplugHostDevicesInProgress = make(chan struct{}, maxConcurrentHotplugHostDevices)
-@@ -922,19 +929,77 @@ func (l *LibvirtDomainManager) SyncVMI(vmi *v1.VirtualMachineInstance, allowEmul
+@@ -828,11 +835,11 @@ func (l *LibvirtDomainManager) generateConverterContext(vmi *v1.VirtualMachineIn
+ }
+ 
+ func (l *LibvirtDomainManager) SyncVMI(vmi *v1.VirtualMachineInstance, allowEmulation bool, options *cmdv1.VirtualMachineOptions) (*api.DomainSpec, error) {
++
+ 	l.domainModifyLock.Lock()
+ 	defer l.domainModifyLock.Unlock()
+ 
+ 	logger := log.Log.Object(vmi)
+-
+ 	domain := &api.Domain{}
+ 
+ 	c, err := l.generateConverterContext(vmi, allowEmulation, options, false)
+@@ -922,19 +929,94 @@ func (l *LibvirtDomainManager) SyncVMI(vmi *v1.VirtualMachineInstance, allowEmul
  		return nil, err
  	}
  
 +	// Get list of disks that should be detached
 +	detachedDisks := getDetachedDisks(vmi.Name, vmi.Namespace, oldSpec.Devices.Disks, domain.Spec.Devices.Disks)
++	logger.V(hotplugDetachmentVerbosity).Infof("Hotplug detached disks: %+v", len(detachedDisks))
 +
 +	// Check list of detached disks against the list of detachment goroutines.  Cancel the goroutines
 +	// that are no longer needed.
@@ -58,10 +72,7 @@ index 63d8d43d2..2115b7950 100644
  	// Look up all the disks to detach
 -	for _, detachDisk := range getDetachedDisks(oldSpec.Devices.Disks, domain.Spec.Devices.Disks) {
 -		logger.V(1).Infof("Detaching disk %s, target %s", detachDisk.Alias.GetName(), detachDisk.Target.Device)
-+	for namespacedDiskName, detachDisk := range detachedDisks {
-+		detachDiskName := detachDisk.Alias.GetName()
-+		detachDiskTargetDevice := detachDisk.Target.Device
-+		domainName := domain.Spec.Name
++	for detachDiskKey, detachDisk := range detachedDisks {
 +
  		detachBytes, err := xml.Marshal(detachDisk)
  		if err != nil {
@@ -75,47 +86,66 @@ index 63d8d43d2..2115b7950 100644
 -		}
 +
 +		// Create goroutine to do detachment so we can wait to see if the disk is reattached.
-+		go func() {
++		go func(namespacedDiskName, detachDiskName, detachDiskTargetDevice, domainName string, detachBytes []byte) {
 +			logger.V(hotplugDetachmentVerbosity).Infof("Potentially detaching hotplug disk %s", namespacedDiskName)
-+
++			// Claim mutex again to work on protected data like the channels map and the domain.
++			l.domainModifyLock.Lock()
 +			// If channel has already been created, a goroutine is already waiting for the disk to be detached.  Exit
 +			// so there aren't multiple goroutines waiting to detach the same disk.
 +			if _, ok := l.cancelDiskDetachChannels[namespacedDiskName]; ok {
 +				logger.V(hotplugDetachmentVerbosity).Infof("Potential hotplug disk detaching already handled: %s", namespacedDiskName)
++				// Unlock the mutex so protected data can be accessed
++				l.domainModifyLock.Unlock()
 +				return
 +			}
 +			// There are no other goroutines waiting to detach this disk, create a channel enable subsequent calls to
 +			// SyncVMI to cancel this detach (if attach is requested within the grace period: 5 seconds)
-+			l.cancelDiskDetachChannels[namespacedDiskName] = make(chan struct{})
++			cancelChannel := make(chan struct{})
++			l.cancelDiskDetachChannels[namespacedDiskName] = cancelChannel
++			// Unlock the mutex during the grace period wait so SyncVMI can continue to run
++			l.domainModifyLock.Unlock()
++
++			doDetach := false
 +			// Wait for either the grace period to expire (in which case: proceed to detach) or for the attach channel
 +			// to be triggered (in which case: cancel the detach)
 +			select {
-+			case <-l.cancelDiskDetachChannels[namespacedDiskName]:
++			case <-cancelChannel:
 +				// Disk attach has been requested within the grace period, cancel the detach
 +				logger.V(hotplugDetachmentVerbosity).Infof("Potential hotplug disk detaching was cancelled: %s", namespacedDiskName)
 +			case <-time.After(hotplugDetachmentGracePeriod):
-+				// Grace period has expired without an attache request, proceed to detach
++				// Grace period has expired without an attach request, proceed to detach
++				doDetach = true
++			}
++
++			// Claim mutex again to work on protected data like the channels map and the domain.
++			l.domainModifyLock.Lock()
++			// Ensure that the detach cancel channel is cleared and the mutex is unlocked before exiting
++			defer func() {
++				// Detach request has been handled, remove channel from map
++				delete(l.cancelDiskDetachChannels, namespacedDiskName)
++				// Unlock the mutex so protected data can be accessed
++				l.domainModifyLock.Unlock()
++			}()
++
++			if doDetach {
++				// Detach the volume
 +				logger.V(1).Infof("Detaching disk %s, target %s", detachDiskName, detachDiskTargetDevice)
 +				dom, err := l.virConn.LookupDomainByName(domainName)
 +				if err != nil {
 +					logger.Reason(err).Error("getting domain for device detach")
-+					break
++					return
 +				}
-+
 +				err = dom.DetachDeviceFlags(strings.ToLower(string(detachBytes)), affectLiveAndConfigLibvirtFlags)
 +				if err != nil {
 +					logger.Reason(err).Error("detaching device")
 +				}
-+
 +				dom.Free()
 +			}
-+			// Detach request has been handled, remove channel from map
-+			delete(l.cancelDiskDetachChannels, namespacedDiskName)
-+		}()
++		}(detachDiskKey, detachDisk.Alias.GetName(), detachDisk.Target.Device, domain.Spec.Name, detachBytes)
  	}
  	// Look up all the disks to attach
  	for _, attachDisk := range getAttachedDisks(oldSpec.Devices.Disks, domain.Spec.Devices.Disks) {
-@@ -945,7 +1010,18 @@ func (l *LibvirtDomainManager) SyncVMI(vmi *v1.VirtualMachineInstance, allowEmul
+@@ -945,7 +1027,18 @@ func (l *LibvirtDomainManager) SyncVMI(vmi *v1.VirtualMachineInstance, allowEmul
  		if !allowAttach {
  			continue
  		}
@@ -135,7 +165,7 @@ index 63d8d43d2..2115b7950 100644
  		// set drivers cache mode
  		err = converter.SetDriverCacheMode(&attachDisk, l.directIOChecker)
  		if err != nil {
-@@ -1032,7 +1108,7 @@ func isHotplugDisk(disk api.Disk) bool {
+@@ -1032,7 +1125,7 @@ func isHotplugDisk(disk api.Disk) bool {
  	return strings.HasPrefix(getSourceFile(disk), v1.HotplugDiskDir)
  }
  
@@ -144,7 +174,7 @@ index 63d8d43d2..2115b7950 100644
  	newDiskMap := make(map[string]api.Disk)
  	for _, disk := range newDisks {
  		file := getSourceFile(disk)
-@@ -1040,14 +1116,15 @@ func getDetachedDisks(oldDisks, newDisks []api.Disk) []api.Disk {
+@@ -1040,14 +1133,15 @@ func getDetachedDisks(oldDisks, newDisks []api.Disk) []api.Disk {
  			newDiskMap[file] = disk
  		}
  	}
@@ -162,97 +192,3 @@ index 63d8d43d2..2115b7950 100644
  		}
  	}
  	return res
-diff --git a/prototype.patch b/prototype.patch
-new file mode 100644
-index 000000000..6d4f0f1e3
---- /dev/null
-+++ b/prototype.patch
-@@ -0,0 +1,87 @@
-+diff --git a/pkg/virt-launcher/virtwrap/manager.go b/pkg/virt-launcher/virtwrap/manager.go
-+index 63d8d43d2..2115b7950 100644
-+--- a/pkg/virt-launcher/virtwrap/manager.go
-++++ b/pkg/virt-launcher/virtwrap/manager.go
-+@@ -97,6 +97,11 @@ const (
-+ const maxConcurrentHotplugHostDevices = 1
-+ const maxConcurrentMemoryDumps = 1
-+ 
-++// TODO: Make this configurable from the VMI object?
-++const hotplugDetachmentGracePeriod = 5 * time.Second
-++
-++const hotplugDetachmentVerbosity = 4
-++
-+ type contextStore struct {
-+ 	ctx    context.Context
-+ 	cancel context.CancelFunc
-+@@ -142,6 +147,7 @@ type LibvirtDomainManager struct {
-+ 
-+ 	hotplugHostDevicesInProgress chan struct{}
-+ 	memoryDumpInProgress         chan struct{}
-++	cancelDiskDetachChannels     map[string]chan struct{}
-+ 
-+ 	virtShareDir             string
-+ 	ephemeralDiskDir         string
-+@@ -204,6 +210,7 @@ func newLibvirtDomainManager(connection cli.Connection, virtShareDir, ephemeralD
-+ 		cancelSafetyUnfreezeChan: make(chan struct{}),
-+ 		migrateInfoStats:         &stats.DomainJobInfo{},
-+ 		metadataCache:            metadataCache,
-++		cancelDiskDetachChannels: make(map[string]chan struct{}),
-+ 	}
-+ 
-+ 	manager.hotplugHostDevicesInProgress = make(chan struct{}, maxConcurrentHotplugHostDevices)
-+@@ -922,19 +929,77 @@ func (l *LibvirtDomainManager) SyncVMI(vmi *v1.VirtualMachineInstance, allowEmul
-+ 		return nil, err
-+ 	}
-+ 
-++	// Get list of disks that should be detached
-++	detachedDisks := getDetachedDisks(vmi.Name, vmi.Namespace, oldSpec.Devices.Disks, domain.Spec.Devices.Disks)
-++
-++	// Check list of detached disks against the list of detachment goroutines.  Cancel the goroutines
-++	// that are no longer needed.
-++	for cancelDiskDetachChannelName, cancelDiskDetachChannel := range l.cancelDiskDetachChannels {
-++		if _, ok := detachedDisks[cancelDiskDetachChannelName]; ok {
-++			// If disk is already a detach goroutine and in the detachedDisk list, do not cancel
-++			// the goroutine.
-++			logger.V(hotplugDetachmentVerbosity).Infof("Hotplug detach stil requested, continue grace period = [%+v]", cancelDiskDetachChannelName)
-++		} else {
-++			// If disk is already a detach goroutine and is no longer in detachedDisk list, it no
-++			// longer needs to be detached.  Signal detach cancellation and remove from detachedDisks
-++			// list.
-++			logger.V(hotplugDetachmentVerbosity).Infof("Hotplug detach not longer needed, cancel it [%+v]", cancelDiskDetachChannelName)
-++			// Signal detach goutine to cancel
-++			cancelDiskDetachChannel <- struct{}{}
-++			// Remove from detachedDisks list so detach goutine is not recreated
-++			delete(detachedDisks, cancelDiskDetachChannelName)
-++		}
-++	}
-+ 	// Look up all the disks to detach
-+-	for _, detachDisk := range getDetachedDisks(oldSpec.Devices.Disks, domain.Spec.Devices.Disks) {
-+-		logger.V(1).Infof("Detaching disk %s, target %s", detachDisk.Alias.GetName(), detachDisk.Target.Device)
-++	for namespacedDiskName, detachDisk := range detachedDisks {
-++		detachDiskName := detachDisk.Alias.GetName()
-++		detachDiskTargetDevice := detachDisk.Target.Device
-++		domainName := domain.Spec.Name
-++
-+ 		detachBytes, err := xml.Marshal(detachDisk)
-+ 		if err != nil {
-+ 			logger.Reason(err).Error("marshalling detached disk failed")
-+ 			return nil, err
-+ 		}
-+-		err = dom.DetachDeviceFlags(strings.ToLower(string(detachBytes)), affectLiveAndConfigLibvirtFlags)
-+-		if err != nil {
-+-			logger.Reason(err).Error("detaching device")
-+-			return nil, err
-+-		}
-++
-++		// Create goroutine to do detachment so we can wait to see if the disk is reattached.
-++		go func() {
-++			logger.V(hotplugDetachmentVerbosity).Infof("Potentially detaching hotplug disk %s", namespacedDiskName)
-++
-++			// If channel has already been created, a goroutine is already waiting for the disk to be detached.  Exit
-++			// so there aren't multiple goroutines waiting to detach the same disk.
-++			if _, ok := l.cancelDiskDetachChannels[namespacedDiskName]; ok {
-++				logger.V(hotplugDetachmentVerbosity).Infof("Potential hotplug disk detaching already handled: %s", namespacedDiskName)
-++				return
-++			}
-++			// There are no other goroutines waiting to detach this disk, cr
-\ No newline at end of file

--- a/SPECS/kubevirt/Hotplug_detach_grace_period.patch
+++ b/SPECS/kubevirt/Hotplug_detach_grace_period.patch
@@ -1,5 +1,5 @@
 diff --git a/pkg/virt-launcher/virtwrap/manager.go b/pkg/virt-launcher/virtwrap/manager.go
-index 63d8d43d2..19719993a 100644
+index 63d8d43d2..2115b7950 100644
 --- a/pkg/virt-launcher/virtwrap/manager.go
 +++ b/pkg/virt-launcher/virtwrap/manager.go
 @@ -97,6 +97,11 @@ const (
@@ -30,7 +30,7 @@ index 63d8d43d2..19719993a 100644
  	}
  
  	manager.hotplugHostDevicesInProgress = make(chan struct{}, maxConcurrentHotplugHostDevices)
-@@ -922,19 +929,75 @@ func (l *LibvirtDomainManager) SyncVMI(vmi *v1.VirtualMachineInstance, allowEmul
+@@ -922,19 +929,77 @@ func (l *LibvirtDomainManager) SyncVMI(vmi *v1.VirtualMachineInstance, allowEmul
  		return nil, err
  	}
  
@@ -93,7 +93,7 @@ index 63d8d43d2..19719993a 100644
 +			case <-l.cancelDiskDetachChannels[namespacedDiskName]:
 +				// Disk attach has been requested within the grace period, cancel the detach
 +				logger.V(hotplugDetachmentVerbosity).Infof("Potential hotplug disk detaching was cancelled: %s", namespacedDiskName)
-+			case <-time.After(5 * time.Second):
++			case <-time.After(hotplugDetachmentGracePeriod):
 +				// Grace period has expired without an attache request, proceed to detach
 +				logger.V(1).Infof("Detaching disk %s, target %s", detachDiskName, detachDiskTargetDevice)
 +				dom, err := l.virConn.LookupDomainByName(domainName)
@@ -106,6 +106,8 @@ index 63d8d43d2..19719993a 100644
 +				if err != nil {
 +					logger.Reason(err).Error("detaching device")
 +				}
++
++				dom.Free()
 +			}
 +			// Detach request has been handled, remove channel from map
 +			delete(l.cancelDiskDetachChannels, namespacedDiskName)
@@ -113,7 +115,7 @@ index 63d8d43d2..19719993a 100644
  	}
  	// Look up all the disks to attach
  	for _, attachDisk := range getAttachedDisks(oldSpec.Devices.Disks, domain.Spec.Devices.Disks) {
-@@ -945,7 +1008,18 @@ func (l *LibvirtDomainManager) SyncVMI(vmi *v1.VirtualMachineInstance, allowEmul
+@@ -945,7 +1010,18 @@ func (l *LibvirtDomainManager) SyncVMI(vmi *v1.VirtualMachineInstance, allowEmul
  		if !allowAttach {
  			continue
  		}
@@ -133,7 +135,7 @@ index 63d8d43d2..19719993a 100644
  		// set drivers cache mode
  		err = converter.SetDriverCacheMode(&attachDisk, l.directIOChecker)
  		if err != nil {
-@@ -1032,7 +1106,7 @@ func isHotplugDisk(disk api.Disk) bool {
+@@ -1032,7 +1108,7 @@ func isHotplugDisk(disk api.Disk) bool {
  	return strings.HasPrefix(getSourceFile(disk), v1.HotplugDiskDir)
  }
  
@@ -142,7 +144,7 @@ index 63d8d43d2..19719993a 100644
  	newDiskMap := make(map[string]api.Disk)
  	for _, disk := range newDisks {
  		file := getSourceFile(disk)
-@@ -1040,14 +1114,15 @@ func getDetachedDisks(oldDisks, newDisks []api.Disk) []api.Disk {
+@@ -1040,14 +1116,15 @@ func getDetachedDisks(oldDisks, newDisks []api.Disk) []api.Disk {
  			newDiskMap[file] = disk
  		}
  	}
@@ -162,12 +164,12 @@ index 63d8d43d2..19719993a 100644
  	return res
 diff --git a/prototype.patch b/prototype.patch
 new file mode 100644
-index 000000000..a7d83eb93
+index 000000000..6d4f0f1e3
 --- /dev/null
 +++ b/prototype.patch
 @@ -0,0 +1,87 @@
 +diff --git a/pkg/virt-launcher/virtwrap/manager.go b/pkg/virt-launcher/virtwrap/manager.go
-+index 63d8d43d2..19719993a 100644
++index 63d8d43d2..2115b7950 100644
 +--- a/pkg/virt-launcher/virtwrap/manager.go
 ++++ b/pkg/virt-launcher/virtwrap/manager.go
 +@@ -97,6 +97,11 @@ const (
@@ -198,7 +200,7 @@ index 000000000..a7d83eb93
 + 	}
 + 
 + 	manager.hotplugHostDevicesInProgress = make(chan struct{}, maxConcurrentHotplugHostDevices)
-+@@ -922,19 +929,75 @@ func (l *LibvirtDomainManager) SyncVMI(vmi *v1.VirtualMachineInstance, allowEmul
++@@ -922,19 +929,77 @@ func (l *LibvirtDomainManager) SyncVMI(vmi *v1.VirtualMachineInstance, allowEmul
 + 		return nil, err
 + 	}
 + 

--- a/SPECS/kubevirt/kubevirt.spec
+++ b/SPECS/kubevirt/kubevirt.spec
@@ -20,7 +20,7 @@
 Summary:        Container native virtualization
 Name:           kubevirt
 Version:        0.59.0
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -210,6 +210,9 @@ install -p -m 0644 cmd/virt-handler/nsswitch.conf %{buildroot}%{_datadir}/kube-v
 %{_bindir}/virt-tests
 
 %changelog
+* Fri Jun 30 2023 Brian Fjeldstad <bfjelds@microsoft.com> - 0.59.0-4
+- Patch 0.59.0 with Operator Nexus patch for hotplug volume detachment IO errors
+
 * Thu Jun 15 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 0.59.0-3
 - Bump release to rebuild with go 1.19.10
 

--- a/SPECS/kubevirt/kubevirt.spec
+++ b/SPECS/kubevirt/kubevirt.spec
@@ -32,6 +32,7 @@ Source1:        disks-images-provider.yaml
 # correctly.
 Patch0:         Cleanup-housekeeping-cgroup-on-vm-del.patch
 Patch1:         Allocate-2-cpu-for-the-emulator-thread.patch
+Patch2:         Hotplug_detach_grace_period.patch
 BuildRequires:  glibc-devel
 BuildRequires:  glibc-static >= 2.35-3%{?dist}
 BuildRequires:  golang

--- a/SPECS/kubevirt/kubevirt.spec
+++ b/SPECS/kubevirt/kubevirt.spec
@@ -16,7 +16,6 @@
 #
 
 
-%global debug_package %{nil}
 Summary:        Container native virtualization
 Name:           kubevirt
 Version:        0.59.0
@@ -33,6 +32,7 @@ Source1:        disks-images-provider.yaml
 Patch0:         Cleanup-housekeeping-cgroup-on-vm-del.patch
 Patch1:         Allocate-2-cpu-for-the-emulator-thread.patch
 Patch2:         Hotplug_detach_grace_period.patch
+%global debug_package %{nil}
 BuildRequires:  glibc-devel
 BuildRequires:  glibc-static >= 2.35-3%{?dist}
 BuildRequires:  golang


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
Add patch for kubevirt related to hotplug volume pods being deleted.  Patched code introduces delay so that IO can continue through the time between when a hotplug volume pod gets deleted and when it is recreated.

###### Change Log  <!-- REQUIRED -->
KubeVirt changes introduce a grace period to allow IO to continue on a hotplug volume when the backing pod is deleted.  If the backing pod is recreated within the grace period (5 seconds), the /dev storage on the virt-launcher pod will not be removed/recreated.  If the backing pod is not recreated within the grace period, existing behavior will continue.

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Associated issues  <!-- optional -->
- #xxxx

###### Links to CVEs  <!-- optional -->

###### Test Methodology
- manual testing by creating kubevirt node, adding hotplug volume, and deleting the backing pod.