### PR TITLE
Enable dbus audit logs.

### DIFF
--- a/SPECS/dbus/dbus.spec
+++ b/SPECS/dbus/dbus.spec
@@ -2,13 +2,14 @@
 Summary:        DBus for systemd
 Name:           dbus
 Version:        1.15.2
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        GPLv2+ OR AFL
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Group:          Applications/File
 URL:            https://www.freedesktop.org/wiki/Software/dbus
 Source0:        https://%{name}.freedesktop.org/releases/%{name}/%{name}-%{version}.tar.xz
+BuildRequires:  audit-devel
 BuildRequires:  expat-devel
 BuildRequires:  systemd-bootstrap-devel
 BuildRequires:  xz-devel
@@ -42,7 +43,7 @@ It contains the libraries and header files to create applications
 %build
 %configure \
     --docdir=%{_versioneddocdir}  \
-    --enable-libaudit=no \
+    --enable-libaudit=yes \
     --enable-selinux=yes \
     --with-console-auth-dir=/run/console
 
@@ -86,6 +87,9 @@ make %{?_smp_mflags} check
 %{_libdir}/*.so
 
 %changelog
+* Tue Jun 27 2023 Chris Gunn <chrisgun@microsoft.com> - 1.15.2-3
+- Enable audit integration
+
 * Fri Oct 14 2022 Muhammad Falak <mwani@microsoft.com> - 1.15.2-2
 - Add an explicit provides `dbus-x11`
 

--- a/SPECS/dbus/dbus.spec
+++ b/SPECS/dbus/dbus.spec
@@ -11,9 +11,9 @@ URL:            https://www.freedesktop.org/wiki/Software/dbus
 Source0:        https://%{name}.freedesktop.org/releases/%{name}/%{name}-%{version}.tar.xz
 BuildRequires:  audit-devel
 BuildRequires:  expat-devel
+BuildRequires:  libselinux-devel
 BuildRequires:  systemd-bootstrap-devel
 BuildRequires:  xz-devel
-BuildRequires:  libselinux-devel
 Requires:       expat
 Requires:       xz
 # Using the weak dependency 'Recommends' to break a circular dependency during
@@ -21,7 +21,6 @@ Requires:       xz
 # In real-life situations systemd will always be present and thus installed.
 Recommends:     systemd
 Provides:       dbus-libs = %{version}-%{release}
-
 # NOTE: We currently do not build with X11 support.
 # build with X11 support in the future.
 Provides:       %{name}-x11


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->

dbus has implemented its own SELinux rules. When dbus blocks an operation based on SELinux, it has logic to log the violation to the security audit logs (as it should). Unfortunatley, this logic is currently incorrectly disabled by a build flag. This changes fixes this problem.

Note: The audit client lib supports and actively encourages clients to not fail when the audit service is not available on the system. So, this does not add a dependency on the audit package.

###### Change Log  <!-- REQUIRED -->

- Enable dbus audit logs.

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

Ran a command that was known to trigger dbus SELinux violation (while using an SELinux enable image) and ensured that the correct log showed up in the audit logs.
