### PR TITLE
llvm: modify LLVM_PARALLEL_COMPILE_JOBS

### DIFF
--- a/SPECS/llvm/llvm.spec
+++ b/SPECS/llvm/llvm.spec
@@ -1,7 +1,7 @@
 Summary:        A collection of modular and reusable compiler and toolchain technologies.
 Name:           llvm
 Version:        12.0.1
-Release:        6%{?dist}
+Release:        7%{?dist}
 License:        NCSA
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -44,7 +44,6 @@ cmake -G Ninja                              \
       -DLLVM_ENABLE_RTTI=ON                 \
       -DCMAKE_BUILD_TYPE=Release            \
       -DLLVM_PARALLEL_LINK_JOBS=1           \
-      -DLLVM_PARALLEL_COMPILE_JOBS=2        \
       -DLLVM_BUILD_LLVM_DYLIB=ON            \
       -DLLVM_LINK_LLVM_DYLIB=ON             \
       -DLLVM_INCLUDE_TESTS=ON               \

--- a/SPECS/llvm/llvm.spec
+++ b/SPECS/llvm/llvm.spec
@@ -44,6 +44,7 @@ cmake -G Ninja                              \
       -DLLVM_ENABLE_RTTI=ON                 \
       -DCMAKE_BUILD_TYPE=Release            \
       -DLLVM_PARALLEL_LINK_JOBS=1           \
+      -DLLVM_PARALLEL_COMPILE_JOBS=%{?_smp_ncpus_max:%_smp_build_ncpus} \
       -DLLVM_BUILD_LLVM_DYLIB=ON            \
       -DLLVM_LINK_LLVM_DYLIB=ON             \
       -DLLVM_INCLUDE_TESTS=ON               \
@@ -88,6 +89,9 @@ ninja check-all
 %{_includedir}/*
 
 %changelog
+* Thu Jun 29 2023 Andrew Phelps <anphel@microsoft.com> - 12.0.1-7
+- Modify parallel compile jobs limit to _smp_ncpus_max if set, or _smp_build_ncpus
+
 * Thu Jun 01 2023 Andrew Phelps <anphel@microsoft.com> - 12.0.1-6
 - Limit to 2 parallel compile jobs to avoid running out of memory in build
 

--- a/SPECS/llvm/llvm16.spec
+++ b/SPECS/llvm/llvm16.spec
@@ -1,7 +1,7 @@
 Summary:        A collection of modular and reusable compiler and toolchain technologies.
 Name:           llvm16
 Version:        16.0.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        NCSA
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -44,7 +44,6 @@ cmake -G Ninja                              \
       -DLLVM_ENABLE_RTTI=ON                 \
       -DCMAKE_BUILD_TYPE=Release            \
       -DLLVM_PARALLEL_LINK_JOBS=1           \
-      -DLLVM_PARALLEL_COMPILE_JOBS=2        \
       -DLLVM_BUILD_LLVM_DYLIB=ON            \
       -DLLVM_LINK_LLVM_DYLIB=ON             \
       -DLLVM_INCLUDE_TESTS=ON               \

--- a/SPECS/llvm/llvm16.spec
+++ b/SPECS/llvm/llvm16.spec
@@ -44,6 +44,7 @@ cmake -G Ninja                              \
       -DLLVM_ENABLE_RTTI=ON                 \
       -DCMAKE_BUILD_TYPE=Release            \
       -DLLVM_PARALLEL_LINK_JOBS=1           \
+      -DLLVM_PARALLEL_COMPILE_JOBS=%{?_smp_ncpus_max:%_smp_build_ncpus} \
       -DLLVM_BUILD_LLVM_DYLIB=ON            \
       -DLLVM_LINK_LLVM_DYLIB=ON             \
       -DLLVM_INCLUDE_TESTS=ON               \
@@ -88,6 +89,9 @@ ninja check-all
 %{_includedir}/*
 
 %changelog
+* Thu Jun 29 2023 Andrew Phelps <anphel@microsoft.com> - 16.0.0-3
+- Modify parallel compile jobs limit to _smp_ncpus_max if set, or _smp_build_ncpus
+
 * Thu Jun 01 2023 Andrew Phelps <anphel@microsoft.com> - 16.0.0-2
 - Limit to 2 parallel compile jobs to avoid running out of memory in build
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Modify the value of LLVM_PARALLEL_COMPILE_JOBS for llvm and llvm16. These packages build with ninja, and we've run into out-of-memory errors when building on 32 core machines. This parameter was previously set to 2, which resolved the memory issues, but resulted in slow builds. This PR modifies the value to `_smp_ncpus_max` if it is set (this can be set with the MAX_CPU parameter; see #5677), and if not, will use `_smp_build_ncpus`. In our ARM64 pipeline builds, this change reduces the package build times from ~120min to ~25min, and I've run three full package builds without hitting the memory errors.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change llvm LLVM_PARALLEL_COMPILE_JOBS
- Change llvm16 LLVM_PARALLEL_COMPILE_JOBS

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: ARM64 RPM build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=387143&view=results
