### PR TITLE
Bump nodejs to 16.20.1

### DIFF
--- a/SPECS/nodejs/nodejs.signatures.json
+++ b/SPECS/nodejs/nodejs.signatures.json
@@ -1,5 +1,5 @@
 {
   "Signatures": {
-    "node-v16.19.1.tar.xz": "6cea9e7c99e79864fb7c5140c2830225e15b62e836c8d57e217992431b63d2cc"
+    "node-v16.20.1.tar.xz": "3b7d5a3b11e122da9f084448ce7723d3f8c92cd0e36100b6a22c66111d643d19"
   }
 }

--- a/SPECS/nodejs/nodejs.spec
+++ b/SPECS/nodejs/nodejs.spec
@@ -1,5 +1,4 @@
 # Retrieved from 'deps/npm/package.json' inside the sources tarball.
-%define npm_version 8.19.4
 
 Summary:        A JavaScript runtime built on Chrome's V8 JavaScript engine.
 Name:           nodejs
@@ -8,9 +7,9 @@ Name:           nodejs
 Version:        16.20.1
 Release:        1%{?dist}
 License:        BSD and MIT and Public Domain and NAIST-2003 and Artistic-2.0
-Group:          Applications/System
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
+Group:          Applications/System
 URL:            https://github.com/nodejs/node
 # !!!! Nodejs code has a vendored version of OpenSSL code that must be removed from source tarball
 # !!!! because it contains patented algorithms.
@@ -18,7 +17,9 @@ URL:            https://github.com/nodejs/node
 Source0:        https://nodejs.org/download/release/v%{version}/node-v%{version}.tar.xz
 Patch0:         disable-tlsv1-tlsv1-1.patch
 
+%define npm_version 8.19.4
 BuildRequires:  brotli-devel
+BuildRequires:  c-ares-devel
 BuildRequires:  coreutils >= 8.22
 BuildRequires:  gcc
 BuildRequires:  make
@@ -27,12 +28,9 @@ BuildRequires:  openssl-devel >= 1.1.1
 BuildRequires:  python3
 BuildRequires:  which
 BuildRequires:  zlib-devel
-BuildRequires:  c-ares-devel
-
 Requires:       brotli
 Requires:       coreutils >= 8.22
 Requires:       openssl >= 1.1.1
-
 Provides:       npm = %{npm_version}.%{version}-%{release}
 
 %description
@@ -86,7 +84,7 @@ JOBS=4 make %{?_smp_mflags} V=0
 
 %install
 
-make %{?_smp_mflags} install DESTDIR=$RPM_BUILD_ROOT
+make %{?_smp_mflags} install DESTDIR=%{buildroot}
 install -m 755 -d %{buildroot}%{_libdir}/node_modules/
 install -m 755 -d %{buildroot}%{_datadir}/%{name}
 
@@ -107,7 +105,8 @@ make cctest
 %{_bindir}/*
 %{_libdir}/node_modules/*
 %{_mandir}/man*/*
-%doc CHANGELOG.md LICENSE README.md
+%license LICENSE
+%doc CHANGELOG.md README.md
 
 %files devel
 %defattr(-,root,root)

--- a/SPECS/nodejs/nodejs.spec
+++ b/SPECS/nodejs/nodejs.spec
@@ -6,7 +6,7 @@ Name:           nodejs
 #           The version of NPM can be found inside the sources under 'deps/npm/package.json'.
 Version:        16.20.1
 Release:        1%{?dist}
-License:        BSD and MIT and Public Domain and NAIST-2003 and Artistic-2.0
+License:        BSD AND MIT AND Public Domain AND NAIST-2003 AND Artistic-2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Group:          Applications/System
@@ -16,7 +16,6 @@ URL:            https://github.com/nodejs/node
 # !!!  => use clean-source-tarball.sh script to create a clean and reproducible source tarball.
 Source0:        https://nodejs.org/download/release/v%{version}/node-v%{version}.tar.xz
 Patch0:         disable-tlsv1-tlsv1-1.patch
-
 %define npm_version 8.19.4
 BuildRequires:  brotli-devel
 BuildRequires:  c-ares-devel

--- a/SPECS/nodejs/nodejs.spec
+++ b/SPECS/nodejs/nodejs.spec
@@ -1,18 +1,18 @@
 # Retrieved from 'deps/npm/package.json' inside the sources tarball.
-%define npm_version 8.19.3
+%define npm_version 8.19.4
 
 Summary:        A JavaScript runtime built on Chrome's V8 JavaScript engine.
 Name:           nodejs
 # WARNINGS: MUST check and update the 'npm_version' macro for every version update of this package.
 #           The version of NPM can be found inside the sources under 'deps/npm/package.json'.
-Version:        16.19.1
-Release:        2%{?dist}
+Version:        16.20.1
+Release:        1%{?dist}
 License:        BSD and MIT and Public Domain and NAIST-2003 and Artistic-2.0
 Group:          Applications/System
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 URL:            https://github.com/nodejs/node
-# !!!! Nodejs code has a vendored version of OpenSSL code that must be removed from source tarball 
+# !!!! Nodejs code has a vendored version of OpenSSL code that must be removed from source tarball
 # !!!! because it contains patented algorithms.
 # !!!  => use clean-source-tarball.sh script to create a clean and reproducible source tarball.
 Source0:        https://nodejs.org/download/release/v%{version}/node-v%{version}.tar.xz
@@ -116,6 +116,9 @@ make cctest
 %{_datadir}/systemtap/tapset/node.stp
 
 %changelog
+* Wed Jun 28 2023 David Steele <davidsteele@microsoft.com> - 16.20.1-1
+- Upgrade to nodejs to 16.20.1 and npm to 8.19.4
+
 * Tue May 30 2023 Dallas Delaney <dadelan@microsoft.com> - 16.19.1-2
 - Fix CVE-2023-32067, CVE-2023-31130, CVE-2023-31147 by using system c-ares
 

--- a/SPECS/nodejs/nodejs.spec
+++ b/SPECS/nodejs/nodejs.spec
@@ -1,5 +1,5 @@
 # Retrieved from 'deps/npm/package.json' inside the sources tarball.
-
+%define npm_version 8.19.4
 Summary:        A JavaScript runtime built on Chrome's V8 JavaScript engine.
 Name:           nodejs
 # WARNINGS: MUST check and update the 'npm_version' macro for every version update of this package.
@@ -16,7 +16,6 @@ URL:            https://github.com/nodejs/node
 # !!!  => use clean-source-tarball.sh script to create a clean and reproducible source tarball.
 Source0:        https://nodejs.org/download/release/v%{version}/node-v%{version}.tar.xz
 Patch0:         disable-tlsv1-tlsv1-1.patch
-%define npm_version 8.19.4
 BuildRequires:  brotli-devel
 BuildRequires:  c-ares-devel
 BuildRequires:  coreutils >= 8.22
@@ -101,11 +100,11 @@ make cctest
 %files
 %defattr(-,root,root)
 %license LICENSE
+%doc CHANGELOG.md README.md
 %{_bindir}/*
 %{_libdir}/node_modules/*
 %{_mandir}/man*/*
-%license LICENSE
-%doc CHANGELOG.md README.md
+
 
 %files devel
 %defattr(-,root,root)

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -14173,8 +14173,8 @@
         "type": "other",
         "other": {
           "name": "nodejs",
-          "version": "16.19.1",
-          "downloadUrl": "https://nodejs.org/download/release/v16.19.1/node-v16.19.1.tar.xz"
+          "version": "16.20.1",
+          "downloadUrl": "https://nodejs.org/download/release/v16.20.1/node-v16.20.1.tar.xz"
         }
       }
     },


### PR DESCRIPTION

###### Merge Checklist  
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary
Bump nodejs (16) to 16.20.1 to resolve CVE-2022-25881 in http-cache-semantics depended on by npm. 


###### Change Log 
- bump nodejs to 16.20.1


###### Does this affect the toolchain?  
NO

###### Links to CVEs 
- https://nvd.nist.gov/vuln/detail/CVE-2022-25881

@reviewer please could you run the pipeline to add nodejs16.20.1, https://github.com/nodejs/node/releases/tag/v16.20.1 the  script SPECS/nodejs/generate_source_tarball.sh will need to be run to create a "clean" tar. 
