### PR TITLE
Included `curl` and `grep` in all core packages.

### DIFF
--- a/SPECS/core-packages/core-packages.spec
+++ b/SPECS/core-packages/core-packages.spec
@@ -1,7 +1,7 @@
 Summary:        Metapackage with core sets of packages
 Name:           core-packages
 Version:        2.0
-Release:        7%{?dist}
+Release:        8%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -20,7 +20,6 @@ Requires:       chrony
 Requires:       cpio
 Requires:       cracklib-dicts
 Requires:       cryptsetup
-Requires:       curl
 Requires:       dbus
 Requires:       e2fsprogs
 Requires:       file
@@ -54,6 +53,7 @@ Summary:        Metapackage to install the basic set of packages used all image 
 Requires:       bash
 Requires:       bzip2
 Requires:       ca-certificates-base
+Requires:       curl
 Requires:       elfutils-libelf
 Requires:       expat
 Requires:       filesystem
@@ -87,6 +87,9 @@ Requires:       zlib
 %files container
 
 %changelog
+* Wed Jun 28 2023 Pawel Winogrodzki <pawelwi@microsoft.com> - 2.0-8
+- Moving 'curl' to the 'core-packages-container'.
+
 * Fri Jun 17 2022 Olivia Crain <oliviacrain@microsoft.com> - 2.0-7
 - Remove nspr, nss-libs from base container image
 

--- a/SPECS/core-packages/core-packages.spec
+++ b/SPECS/core-packages/core-packages.spec
@@ -24,7 +24,6 @@ Requires:       dbus
 Requires:       e2fsprogs
 Requires:       file
 Requires:       gdbm
-Requires:       grep
 Requires:       iana-etc
 Requires:       libtool
 Requires:       iproute
@@ -58,6 +57,7 @@ Requires:       elfutils-libelf
 Requires:       expat
 Requires:       filesystem
 Requires:       findutils
+Requires:       grep
 Requires:       gzip
 Requires:       mariner-release
 Requires:       mariner-repos
@@ -88,7 +88,7 @@ Requires:       zlib
 
 %changelog
 * Wed Jun 28 2023 Pawel Winogrodzki <pawelwi@microsoft.com> - 2.0-8
-- Moving 'curl' to the 'core-packages-container'.
+- Moving 'curl' and 'grep' to the 'core-packages-container' package.
 
 * Fri Jun 17 2022 Olivia Crain <oliviacrain@microsoft.com> - 2.0-7
 - Remove nspr, nss-libs from base container image


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

Moving `curl` out of `core-packages-base-image` and into `core-packages-container`. Recent TDNF upgrade removed the TDNF -> cURL dependency, which was pulling in cURL even for container builds. After the update the base container image lost cURL and that introduced a regression for our users. Since that's a basic tool for many users, we're moving it.

I'm also doing the same thing for `grep`, which already is part of our container images but was not mentioned explicitly and could have suffered the same fate as `curl`.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Moved `curl` and `grep` into the `core-packages-container` package.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local package build.