### PR TITLE
Tweak behavior of kernel-mshv initrd; let it remain in /boot.

### DIFF
--- a/SPECS/initramfs/initramfs.spec
+++ b/SPECS/initramfs/initramfs.spec
@@ -83,7 +83,9 @@ echo "initramfs (re)generation" %* >&2
 # So in order to be compatible with kdump, we need to make sure to add the -k
 # option when invoking mkinitrd with an explicit <image> and <kernel version>
 #
-# Copy initrd generated for kernel-mshv to /boot/efi, where linuxloader expects to find it
+# The old linuxloader runs entirely in the ESP (efi) partition and has no 
+# access to the ext4 /boot directory where the initramfs is installed by default.
+# Copy initrd generated for kernel-mshv to /boot/efi, where linuxloader expects to find it.
 %define file_trigger_action() \
 cat > /dev/null \
 if [ -f %{_localstatedir}/lib/rpm-state/initramfs/regenerate ]; then \

--- a/SPECS/initramfs/initramfs.spec
+++ b/SPECS/initramfs/initramfs.spec
@@ -96,7 +96,7 @@ elif [ -d %{_localstatedir}/lib/rpm-state/initramfs/pending ]; then \
         mkinitrd -q /boot/initrd.img-$k $k -k \
         if [[ $k == *mshv* ]]; then \
             cp /boot/initrd.img-$k /boot/efi/initrd.img-$k \
-        fi \ 
+        fi \
     done; \
 fi \
 %removal_action


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
In order to align our kernel-mshv boot path with Mariner, stop treating the kernel-mshv initrd differently and leave it in /boot. 

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Instead of putting *mshv* initrds in /boot/efi (required for old linuxloader), leave it in boot. Conditionally copy it to /boot/efi to maintain compatibility with old loader. 

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
NO

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://microsoft.visualstudio.com/OS/_workitems/edit/45235152


###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: xxxx
