### PR TITLE
revert: Remove umask handling from bash.spec and change it in filesytem.spec

### DIFF
--- a/SPECS/bash/bash.spec
+++ b/SPECS/bash/bash.spec
@@ -1,7 +1,7 @@
 Summary:        Bourne-Again SHell
 Name:           bash
 Version:        5.1.8
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        GPLv3
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -16,7 +16,6 @@ Requires(post): /bin/cp
 Requires(post): /bin/grep
 Requires(postun): /bin/grep
 Requires(postun): /bin/mv
-Requires:       filesystem
 Provides:       /bin/sh
 Provides:       /bin/bash
 Provides:       %{_bindir}/sh
@@ -97,6 +96,15 @@ if [ -z "$INPUTRC" -a ! -f "$HOME/.inputrc" ] ; then
         INPUTRC=%{_sysconfdir}/inputrc
 fi
 export INPUTRC
+EOF
+
+cat > %{buildroot}%{_sysconfdir}/profile.d/umask.sh << "EOF"
+# By default, the umask should be set.
+if [ "$(id -gn)" = "$(id -un)" -a $EUID -gt 99 ] ; then
+  umask 002
+else
+  umask 022
+fi
 EOF
 
 cat > %{buildroot}%{_sysconfdir}/profile.d/i18n.sh << "EOF"
@@ -320,6 +328,10 @@ fi
 %defattr(-,root,root)
 
 %changelog
+* Thu July 29 2023 Tobias Brick <tobiasb@microsoft.com> - 5.1.8-3
+- Revert: Add dependency on filesystem
+- Revert: Remove umask.sh, which will be provided by filesystem
+
 * Thu May 18 2023 Tobias Brick <tobiasb@microsoft.com> - 5.1.8-2
 - Add dependency on filesystem
 - Remove umask.sh, which will be provided by filesystem

--- a/SPECS/filesystem/filesystem.spec
+++ b/SPECS/filesystem/filesystem.spec
@@ -1,7 +1,7 @@
 Summary:      Default file system
 Name:         filesystem
 Version:      1.1
-Release:      14%{?dist}
+Release:      15%{?dist}
 License:      GPLv3
 Group:        System Environment/Base
 Vendor:       Microsoft Corporation
@@ -284,20 +284,9 @@ for script in /etc/profile.d/*.sh ; do
 done
 
 unset script RED GREEN NORMAL
+umask 027
 # End /etc/profile
 EOF
-
-#
-#   profile.d drop-in file that sets up a restrictive umask for all users.
-#   Note that this comes very late in lexigraphical order, so it will override
-#   other umask settings.
-#
-cat > %{buildroot}/etc/profile.d/99-umask.sh <<- "EOF"
-# Begin /etc/profile.d/99-umask.sh
-umask 027
-# End /etc/profile.d/99-umask.sh
-EOF
-
 #
 #   The Proxy Bash Shell Startup File
 #
@@ -608,7 +597,6 @@ return 0
 %config(noreplace) /etc/sysconfig/proxy
 %dir /etc/profile.d
 %config(noreplace) /etc/profile.d/proxy.sh
-%config(noreplace) /etc/profile.d/99-umask.sh
 #	media filesystem
 %dir /run/media/cdrom
 %dir /run/media/floppy
@@ -721,6 +709,9 @@ return 0
 %config(noreplace) /etc/modprobe.d/tipc.conf
 
 %changelog
+* Thu July 29 2023 Tobias Brick <tobiasb@microsoft.com> - 1.1-15
+- Revert: Remove setting umask from /etc/profile and add it to a separate file in /etc/profile.d
+
 * Tue Jun 13 2023 Andy Zaugg <azaugg@linkedin.com> - 1.1-14
 - Adding /usr/local/sbin as per FHS
 

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -1,4 +1,4 @@
-filesystem-1.1-14.cm2.aarch64.rpm
+filesystem-1.1-15.cm2.aarch64.rpm
 kernel-headers-5.15.116.1-2.cm2.noarch.rpm
 glibc-2.35-3.cm2.aarch64.rpm
 glibc-devel-2.35-3.cm2.aarch64.rpm
@@ -42,9 +42,9 @@ readline-8.1-1.cm2.aarch64.rpm
 readline-devel-8.1-1.cm2.aarch64.rpm
 coreutils-8.32-6.cm2.aarch64.rpm
 coreutils-lang-8.32-6.cm2.aarch64.rpm
-bash-5.1.8-2.cm2.aarch64.rpm
-bash-devel-5.1.8-2.cm2.aarch64.rpm
-bash-lang-5.1.8-2.cm2.aarch64.rpm
+bash-5.1.8-3.cm2.aarch64.rpm
+bash-devel-5.1.8-3.cm2.aarch64.rpm
+bash-lang-5.1.8-3.cm2.aarch64.rpm
 bzip2-1.0.8-1.cm2.aarch64.rpm
 bzip2-devel-1.0.8-1.cm2.aarch64.rpm
 bzip2-libs-1.0.8-1.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -1,4 +1,4 @@
-filesystem-1.1-14.cm2.x86_64.rpm
+filesystem-1.1-15.cm2.x86_64.rpm
 kernel-headers-5.15.116.1-2.cm2.noarch.rpm
 glibc-2.35-3.cm2.x86_64.rpm
 glibc-devel-2.35-3.cm2.x86_64.rpm
@@ -42,9 +42,9 @@ readline-8.1-1.cm2.x86_64.rpm
 readline-devel-8.1-1.cm2.x86_64.rpm
 coreutils-8.32-6.cm2.x86_64.rpm
 coreutils-lang-8.32-6.cm2.x86_64.rpm
-bash-5.1.8-2.cm2.x86_64.rpm
-bash-devel-5.1.8-2.cm2.x86_64.rpm
-bash-lang-5.1.8-2.cm2.x86_64.rpm
+bash-5.1.8-3.cm2.x86_64.rpm
+bash-devel-5.1.8-3.cm2.x86_64.rpm
+bash-lang-5.1.8-3.cm2.x86_64.rpm
 bzip2-1.0.8-1.cm2.x86_64.rpm
 bzip2-devel-1.0.8-1.cm2.x86_64.rpm
 bzip2-libs-1.0.8-1.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -5,10 +5,10 @@ audit-devel-3.0.6-7.cm2.aarch64.rpm
 audit-libs-3.0.6-7.cm2.aarch64.rpm
 autoconf-2.71-3.cm2.noarch.rpm
 automake-1.16.5-1.cm2.noarch.rpm
-bash-5.1.8-2.cm2.aarch64.rpm
-bash-debuginfo-5.1.8-2.cm2.aarch64.rpm
-bash-devel-5.1.8-2.cm2.aarch64.rpm
-bash-lang-5.1.8-2.cm2.aarch64.rpm
+bash-5.1.8-3.cm2.aarch64.rpm
+bash-debuginfo-5.1.8-3.cm2.aarch64.rpm
+bash-devel-5.1.8-3.cm2.aarch64.rpm
+bash-lang-5.1.8-3.cm2.aarch64.rpm
 binutils-2.37-5.cm2.aarch64.rpm
 binutils-debuginfo-2.37-5.cm2.aarch64.rpm
 binutils-devel-2.37-5.cm2.aarch64.rpm
@@ -81,8 +81,8 @@ file-5.40-2.cm2.aarch64.rpm
 file-debuginfo-5.40-2.cm2.aarch64.rpm
 file-devel-5.40-2.cm2.aarch64.rpm
 file-libs-5.40-2.cm2.aarch64.rpm
-filesystem-1.1-14.cm2.aarch64.rpm
-filesystem-asc-1.1-14.cm2.aarch64.rpm
+filesystem-1.1-15.cm2.aarch64.rpm
+filesystem-asc-1.1-15.cm2.aarch64.rpm
 findutils-4.8.0-4.cm2.aarch64.rpm
 findutils-debuginfo-4.8.0-4.cm2.aarch64.rpm
 findutils-lang-4.8.0-4.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -5,10 +5,10 @@ audit-devel-3.0.6-7.cm2.x86_64.rpm
 audit-libs-3.0.6-7.cm2.x86_64.rpm
 autoconf-2.71-3.cm2.noarch.rpm
 automake-1.16.5-1.cm2.noarch.rpm
-bash-5.1.8-2.cm2.x86_64.rpm
-bash-debuginfo-5.1.8-2.cm2.x86_64.rpm
-bash-devel-5.1.8-2.cm2.x86_64.rpm
-bash-lang-5.1.8-2.cm2.x86_64.rpm
+bash-5.1.8-3.cm2.x86_64.rpm
+bash-debuginfo-5.1.8-3.cm2.x86_64.rpm
+bash-devel-5.1.8-3.cm2.x86_64.rpm
+bash-lang-5.1.8-3.cm2.x86_64.rpm
 binutils-2.37-5.cm2.x86_64.rpm
 binutils-debuginfo-2.37-5.cm2.x86_64.rpm
 binutils-devel-2.37-5.cm2.x86_64.rpm
@@ -81,8 +81,8 @@ file-5.40-2.cm2.x86_64.rpm
 file-debuginfo-5.40-2.cm2.x86_64.rpm
 file-devel-5.40-2.cm2.x86_64.rpm
 file-libs-5.40-2.cm2.x86_64.rpm
-filesystem-1.1-14.cm2.x86_64.rpm
-filesystem-asc-1.1-14.cm2.x86_64.rpm
+filesystem-1.1-15.cm2.x86_64.rpm
+filesystem-asc-1.1-15.cm2.x86_64.rpm
 findutils-4.8.0-4.cm2.x86_64.rpm
 findutils-debuginfo-4.8.0-4.cm2.x86_64.rpm
 findutils-lang-4.8.0-4.cm2.x86_64.rpm


### PR DESCRIPTION
Revert pull request #5528, which refactored how we configure `umask` in profile.

###### Merge Checklist  <!-- REQUIRED -->
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary
Change #5528 refactored how `umask` is set during profile load. However, this broke certain customers who had modified/replaced `/etc/profile`. This pull reverts those changes.

###### Change Log
- Reverted the actual changes in the bash and filesystem specs.
- Updated versions (rather than reverting versions) and change log.
- Updated package manifests

###### Does this affect the toolchain?
YES -- both bash and filesystem are in the toolchain.

###### Test Methodology
- Manually upgraded packages in a VM, in both possible orders.
- [BuddyBuild](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=386662&view=results)
- [ToolChain](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=386180&view=results)
