### PR TITLE
Patch CVE-2023-31486 in perl

### DIFF
--- a/SPECS/perl/CVE-2023-31486.patch
+++ b/SPECS/perl/CVE-2023-31486.patch
@@ -1,0 +1,154 @@
+From 77f557ef84698efeb6eed04e4a9704eaf85b741d Mon Sep 17 00:00:00 2001
+From: Stig Palmquist <git@stig.io>
+Date: Mon, 5 Jun 2023 16:46:22 +0200
+Subject: [PATCH] Change verify_SSL default to 1, add ENV var to enable
+ insecure default
+
+- Changes the `verify_SSL` default parameter from `0` to `1`
+
+  Based on patch by Dominic Hargreaves:
+  https://salsa.debian.org/perl-team/interpreter/perl/-/commit/1490431e40e22052f75a0b3449f1f53cbd27ba92
+
+  Fixes CVE-2023-31486
+
+- Add check for `$ENV{PERL_HTTP_TINY_SSL_INSECURE_BY_DEFAULT}` that
+  enables the previous insecure default behaviour if set to `1`.
+
+  This provides a workaround for users who encounter problems with the
+  new `verify_SSL` default.
+
+  Example to disable certificate checks:
+  ```
+    $ PERL_HTTP_TINY_SSL_INSECURE_BY_DEFAULT=1 ./script.pl
+  ```
+
+- Updates to documentation:
+  - Describe changing the verify_SSL value
+  - Describe the escape-hatch environment variable
+  - Remove rationale for not enabling verify_SSL
+  - Add missing certificate search paths
+  - Replace "SSL" with "TLS/SSL" where appropriate
+  - Use "machine-in-the-middle" instead of "man-in-the-middle"
+
+- Update `210_live_ssl.t`
+  - Use github.com, cpan.org and badssl.com hosts for checking
+    certificates.
+  - Add self signed snake-oil certificate for checking failures rather
+    than bypassing the `SSL_verify_callback`
+  - Test `verify_SSL` parameter in addition to low level SSL_options
+  - Test that `PERL_HTTP_TINY_SSL_INSECURE_BY_DEFAULT=1` behaves as
+    expected against badssl.com
+
+- Added `180_verify_SSL.t`
+  - Test that `verify_SSL` default is `1`
+  - Test that `PERL_HTTP_TINY_SSL_INSECURE_BY_DEFAULT` behaves as expected
+  - Test that using different values for `verify_SSL` and legacy `verify_ssl`
+    doesn't disable cert checks
+
+Modified 77f557ef84698efeb6eed04e4a9704eaf85b741d to apply to CBL-Mariner:
+  - Remove changes to `t/210_live_ssl.t` as it is not included in HTTP-Tiny v0.076
+  - Remove changes to `t/180_verify_SSL.t` as it is not included HTTP-Tiny v0.076
+  - Remove most changes to documentation
+Modified by corvus-callidus <108946721+corvus-callidus@users.noreply.github.com>
+
+---
+ cpan/HTTP-Tiny/lib/HTTP/Tiny.pm   |  72 ++++++++++++++----------
+ 1 files changed, 277 insertions(+), 73 deletions(-)
+
+diff --git a/cpan/HTTP-Tiny/lib/HTTP/Tiny.pm b/cpan/HTTP-Tiny/lib/HTTP/Tiny.pm
+index 2ece5ca..58be640 100644
+--- a/cpan/HTTP-Tiny/lib/HTTP/Tiny.pm
++++ b/cpan/HTTP-Tiny/lib/HTTP/Tiny.pm
+@@ -39,10 +39,14 @@ #pod This constructor returns a new HTTP::Tiny object.  Valid attributes include:
+ #pod   C<$ENV{no_proxy}> —)
+ #pod * C<timeout> — Request timeout in seconds (default is 60) If a socket open,
+ #pod   read or write takes longer than the timeout, an exception is thrown.
+-#pod * C<verify_SSL> — A boolean that indicates whether to validate the SSL
+-#pod   certificate of an C<https> — connection (default is false)
++#pod * C<verify_SSL> — A boolean that indicates whether to validate the TLS/SSL
++#pod   certificate of an C<https> — connection (default is true). Changed from false
++#pod   to true in version 0.083.
+ #pod * C<SSL_options> — A hashref of C<SSL_*> — options to pass through to
+ #pod   L<IO::Socket::SSL>
++#pod * C<$ENV{PERL_HTTP_TINY_SSL_INSECURE_BY_DEFAULT}> - Changes the default
++#pod   certificate verification behavior to not check server identity if set to 1.
++#pod   Only effective if C<verify_SSL> is not set. Added in version 0.083.
+ #pod
+ #pod Passing an explicit C<undef> for C<proxy>, C<http_proxy> or C<https_proxy> will
+ #pod prevent getting the corresponding proxies from the environment.
+@@ -111,11 +116,17 @@ sub timeout {
+ sub new {
+     my($class, %args) = @_;
+ 
++    # Support lower case verify_ssl argument, but only if verify_SSL is not
++    # true.
++    if ( exists $args{verify_ssl} ) {
++        $args{verify_SSL}  ||= $args{verify_ssl};
++    }
++
+     my $self = {
+         max_redirect => 5,
+         timeout      => defined $args{timeout} ? $args{timeout} : 60,
+         keep_alive   => 1,
+-        verify_SSL   => $args{verify_SSL} || $args{verify_ssl} || 0, # no verification by default
++        verify_SSL   => defined $args{verify_SSL} ? $args{verify_SSL} : _verify_SSL_default(),
+         no_proxy     => $ENV{no_proxy},
+     };
+ 
+@@ -134,6 +145,13 @@ sub new {
+     return $self;
+ }
+ 
++sub _verify_SSL_default {
++    my ($self) = @_;
++    # Check if insecure default certificate verification behaviour has been
++    # changed by the user by setting PERL_HTTP_TINY_SSL_INSECURE_BY_DEFAULT=1
++    return (($ENV{PERL_HTTP_TINY_INSECURE_BY_DEFAULT} || '') eq '1') ? 0 : 1;
++}
++
+ sub _set_proxies {
+     my ($self) = @_;
+ 
+@@ -1060,7 +1078,7 @@ sub new {
+         timeout          => 60,
+         max_line_size    => 16384,
+         max_header_lines => 64,
+-        verify_SSL       => 0,
++        verify_SSL       => HTTP::Tiny::_verify_SSL_default(),
+         SSL_options      => {},
+         %args
+     }, $class;
+From a22785783b17cbaa28afaee4a024d81a1903701d Mon Sep 17 00:00:00 2001
+From: Stig Palmquist <git@stig.io>
+Date: Sun, 18 Jun 2023 11:36:05 +0200
+Subject: [PATCH] Fix incorrect env var name for verify_SSL default
+
+The variable to override the verify_SSL default differed slightly in the
+documentation from what was checked for in the code.
+
+This commit makes the code use `PERL_HTTP_TINY_SSL_INSECURE_BY_DEFAULT`
+as documented, instead of `PERL_HTTP_TINY_INSECURE_BY_DEFAULT` which was
+missing `SSL_`
+
+Modified a22785783b17cbaa28afaee4a024d81a1903701d to apply to CBL-Mariner:
+  - Removed changes to `t/180_verify_SSL.t` as it is not included in HTTP-Tiny v0.076
+  - Removed changes to `t/210_live_ssl.t` as it is not included in HTTP-Tiny v0.076
+Modified by corvus-callidus <108946721+corvus-callidus@users.noreply.github.com>
+
+---
+ cpan/HTTP-Tiny/lib/HTTP/Tiny.pm   |  2 +-
+ 1 files changed, 1 insertions(+), 1 deletions(-)
+
+diff --git a/cpan/HTTP-Tiny/lib/HTTP/Tiny.pm b/cpan/HTTP-Tiny/lib/HTTP/Tiny.pm
+index bf455b6..7240b65 100644
+--- a/cpan/HTTP-Tiny/lib/HTTP/Tiny.pm
++++ b/cpan/HTTP-Tiny/lib/HTTP/Tiny.pm
+@@ -149,7 +149,7 @@ sub _verify_SSL_default {
+     my ($self) = @_;
+     # Check if insecure default certificate verification behaviour has been
+     # changed by the user by setting PERL_HTTP_TINY_SSL_INSECURE_BY_DEFAULT=1
+-    return (($ENV{PERL_HTTP_TINY_INSECURE_BY_DEFAULT} || '') eq '1') ? 0 : 1;
++    return (($ENV{PERL_HTTP_TINY_SSL_INSECURE_BY_DEFAULT} || '') eq '1') ? 0 : 1;
+ }
+ 
+ sub _set_proxies {

--- a/SPECS/perl/perl.spec
+++ b/SPECS/perl/perl.spec
@@ -9,13 +9,14 @@
 Summary:        Practical Extraction and Report Language
 Name:           perl
 Version:        5.30.3
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        GPL+ or Artistic
 URL:            https://www.perl.org/
 Group:          Development/Languages
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Source0:        https://www.cpan.org/src/5.0/%{name}-%{version}.tar.gz
+Patch0:         CVE-2023-31486.patch
 Provides:       perl >= 0:5.003000
 Provides:       perl(getopts.pl)
 Provides:       perl(s)
@@ -34,6 +35,7 @@ The Perl package contains the Practical Extraction and
 Report Language.
 %prep
 %setup -q
+%patch0 -p1
 sed -i 's/-fstack-protector/&-all/' Configure
 
 %build
@@ -74,6 +76,10 @@ make test TEST_SKIP_VERSION_CHECK=1
 %{_mandir}/*/*
 
 %changelog
+* Fri Jun 30 2023 corvus-callidus <108946721+corvus-callidus@users.noreply.github.com> - 5.30.3-3
+- Add patch for CVE-2023-31486
+- Fix bogus date in changelog
+
 * Mon Apr 24 2023 Sam Meluch <sammeluch@microsoft.com> 5.30.3-2
 - Add -Dman3ext to Configure script in order to avoid manual page name conflicts on installs
 
@@ -83,7 +89,7 @@ make test TEST_SKIP_VERSION_CHECK=1
 -   Added %%license line automatically
 *   Fri May 8 2020 Nicolas Guibourge <nicolasg@microsoft.com> 5.28.1-3
 -   Undo caretx.c patch
-*   Thu Apr 29 2020 Nicolas Guibourge <nicolasg@microsoft.com> 5.28.1-2
+*   Thu Apr 30 2020 Nicolas Guibourge <nicolasg@microsoft.com> 5.28.1-2
 -   Patch caretx.c so perl works from chroot inside Doccker container
 *   Tue Apr 21 2020 Emre Girgin <mrgirgin@microsoft.com> 5.28.1-1
 -   Upgrade to 5.28.1.

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -101,7 +101,7 @@ libpipeline-devel-1.5.0-4.cm1.aarch64.rpm
 gdbm-1.18-3.cm1.aarch64.rpm
 gdbm-devel-1.18-3.cm1.aarch64.rpm
 gdbm-lang-1.18-3.cm1.aarch64.rpm
-perl-5.30.3-2.cm1.aarch64.rpm
+perl-5.30.3-3.cm1.aarch64.rpm
 texinfo-6.5-7.cm1.aarch64.rpm
 autoconf-2.69-10.cm1.noarch.rpm
 automake-1.16.1-3.cm1.noarch.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -101,7 +101,7 @@ libpipeline-devel-1.5.0-4.cm1.x86_64.rpm
 gdbm-1.18-3.cm1.x86_64.rpm
 gdbm-devel-1.18-3.cm1.x86_64.rpm
 gdbm-lang-1.18-3.cm1.x86_64.rpm
-perl-5.30.3-2.cm1.x86_64.rpm
+perl-5.30.3-3.cm1.x86_64.rpm
 texinfo-6.5-7.cm1.x86_64.rpm
 autoconf-2.69-10.cm1.noarch.rpm
 automake-1.16.1-3.cm1.noarch.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -321,7 +321,7 @@ pcre-8.44-2.cm1.aarch64.rpm
 pcre-debuginfo-8.44-2.cm1.aarch64.rpm
 pcre-devel-8.44-2.cm1.aarch64.rpm
 pcre-libs-8.44-2.cm1.aarch64.rpm
-perl-5.30.3-2.cm1.aarch64.rpm
+perl-5.30.3-3.cm1.aarch64.rpm
 perl-DBD-SQLite-1.62-3.cm1.aarch64.rpm
 perl-DBD-SQLite-debuginfo-1.62-3.cm1.aarch64.rpm
 perl-DBI-1.641-3.cm1.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -327,7 +327,7 @@ perl-DBD-SQLite-debuginfo-1.62-3.cm1.aarch64.rpm
 perl-DBI-1.641-3.cm1.aarch64.rpm
 perl-DBI-debuginfo-1.641-3.cm1.aarch64.rpm
 perl-DBIx-Simple-1.37-2.cm1.noarch.rpm
-perl-debuginfo-5.30.3-2.cm1.aarch64.rpm
+perl-debuginfo-5.30.3-3.cm1.aarch64.rpm
 perl-libintl-perl-1.29-4.cm1.aarch64.rpm
 perl-libintl-perl-debuginfo-1.29-4.cm1.aarch64.rpm
 perl-Object-Accessor-0.48-6.cm1.noarch.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -321,7 +321,7 @@ pcre-8.44-2.cm1.x86_64.rpm
 pcre-debuginfo-8.44-2.cm1.x86_64.rpm
 pcre-devel-8.44-2.cm1.x86_64.rpm
 pcre-libs-8.44-2.cm1.x86_64.rpm
-perl-5.30.3-2.cm1.x86_64.rpm
+perl-5.30.3-3.cm1.x86_64.rpm
 perl-DBD-SQLite-1.62-3.cm1.x86_64.rpm
 perl-DBD-SQLite-debuginfo-1.62-3.cm1.x86_64.rpm
 perl-DBI-1.641-3.cm1.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -327,7 +327,7 @@ perl-DBD-SQLite-debuginfo-1.62-3.cm1.x86_64.rpm
 perl-DBI-1.641-3.cm1.x86_64.rpm
 perl-DBI-debuginfo-1.641-3.cm1.x86_64.rpm
 perl-DBIx-Simple-1.37-2.cm1.noarch.rpm
-perl-debuginfo-5.30.3-2.cm1.x86_64.rpm
+perl-debuginfo-5.30.3-3.cm1.x86_64.rpm
 perl-libintl-perl-1.29-4.cm1.x86_64.rpm
 perl-libintl-perl-debuginfo-1.29-4.cm1.x86_64.rpm
 perl-Object-Accessor-0.48-6.cm1.noarch.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
This patches CVE-2023-31486 for perl. This patch changes the default behavior of the embedded HTTP-Tiny package to verify certificates by default and adds support for an environment variable to switch back to pre-patch behavior (don't verify by default). The patch for HTTP-Tiny was created for v0.0.86 and included extra tests and documentation changes. These extras were omitted from this patch. Additionally, a subsequent commit to HTTP-Tiny fixed a defect in the original patch. The relevent portion of that fix is also included here.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Patches CVE-2023-31486 for perl-5.30.3

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2023-31486

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline builds: 
  - [ARM64 BuildToolchain](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=387703&view=results) - PASSED
  - [ARM64 BuildRPMS](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=387744&view=results) - PASSED
  - [AMD64 BuildToolchain](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=388328&view=results) - PASSED
  - [AMD64 BuildRPMS](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=388363&view=results) - PASSED