### PR TITLE
Patch CVE-2023-2650 and CVE-2023-0465 in cloud-hypervisor

### DIFF
--- a/SPECS/cloud-hypervisor/CVE-2023-0465.patch
+++ b/SPECS/cloud-hypervisor/CVE-2023-0465.patch
@@ -1,0 +1,1 @@
+The CVE-2023-2650.patch also fixes CVE-2023-0465

--- a/SPECS/cloud-hypervisor/CVE-2023-2650.patch
+++ b/SPECS/cloud-hypervisor/CVE-2023-2650.patch
@@ -1,0 +1,40 @@
+From 724eeff414725dd8b6be8429f3acd316b92f7a56 Mon Sep 17 00:00:00 2001
+From: Suresh Thelkar <sthelkar@microsoft.com>
+Date: Fri, 30 Jun 2023 09:49:24 +0530
+Subject: [PATCH] Patch for CVE-2023-2650 and CVE-2023-0465
+
+---
+ Cargo.lock | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/Cargo.lock b/Cargo.lock
+index f99b516..99af0b2 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -119,9 +119,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+ 
+ [[package]]
+ name = "cc"
+-version = "1.0.73"
++version = "1.0.79"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
++checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+ 
+ [[package]]
+ name = "cfg-if"
+@@ -574,9 +574,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "openssl-src"
+-version = "111.17.0+1.1.1m"
++version = "111.26.0+1.1.1u"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "05d6a336abd10814198f66e2a91ccd7336611f30334119ca8ce300536666fcf4"
++checksum = "efc62c9f12b22b8f5208c23a7200a442b2e5999f8bdf80233852122b5a4f6f37"
+ dependencies = [
+  "cc",
+ ]
+-- 
+2.38.1
+

--- a/SPECS/cloud-hypervisor/cloud-hypervisor.signatures.json
+++ b/SPECS/cloud-hypervisor/cloud-hypervisor.signatures.json
@@ -1,6 +1,7 @@
 {
  "Signatures": {
-  "cloud-hypervisor-22.0-cargo.tar.gz": "550e2e2ad6c64ae7fa4786582c2357993cfad1f205566f6c80bcef7888cbd702",
-  "cloud-hypervisor-22.0.tar.gz": "5c5440435f78d4acdbb3ea91abe17d6704da6c18b6f52fe77f15835cfc60d17a"
+  "cloud-hypervisor-22.0-cargo-3.cm1.tar.gz": "c54238aa053bfcba7b507982a1e8583bd6885dddf261e1a908977dcc84434214",
+  "cloud-hypervisor-22.0.tar.gz": "5c5440435f78d4acdbb3ea91abe17d6704da6c18b6f52fe77f15835cfc60d17a",
+  "cloud-hypervisor-22.0-vendor-3.cm1.tar.gz": "61721dce31d7a5c5c55347ecef6f0752d0d28a1b48f5e03b8e4cbb07b2eb2e6a"
  }
 }

--- a/SPECS/cloud-hypervisor/cloud-hypervisor.spec
+++ b/SPECS/cloud-hypervisor/cloud-hypervisor.spec
@@ -8,7 +8,9 @@ Group:          Development/Tools
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Source0:        %{url}/archive/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
+# Note: the %%{name}-%%{version}-cargo-%%{release}.tar.gz file contains a cache created by capturing the contents downloaded into $CARGO_HOME.
 Source1:        %{name}-%{version}-cargo-%{release}.tar.gz
+# Note: the %%{name}-%%{version}-vendor-%%{release}.tar.gz file contains vendor sources by capturing the contents downloaded into "vendor" folder when "cargo vendor" is run.
 Source2:        %{name}-%{version}-vendor-%{release}.tar.gz
 Patch0:         CVE-2023-28448.patch
 Patch1:         CVE-2023-2650.patch

--- a/SPECS/cloud-hypervisor/cloud-hypervisor.spec
+++ b/SPECS/cloud-hypervisor/cloud-hypervisor.spec
@@ -1,18 +1,17 @@
 Summary:        A Rust-VMM based cloud hypervisor from Intel
 Name:           cloud-hypervisor
 Version:        22.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        ASL 2.0 or BSD
 URL:            https://github.com/cloud-hypervisor/cloud-hypervisor
 Group:          Development/Tools
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
-Source0:       %{url}/archive/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
-# Note: the %%{name}-%%{version}-cargo.tar.gz file contains a cache created by capturing the contents downloaded into $CARGO_HOME.
-# To update the cache run:
-#   [repo_root]/toolkit/scripts/build_cargo_cache.sh %%{name}-%%{version}.tar.gz
-Source1:        %{name}-%{version}-cargo.tar.gz
+Source0:        %{url}/archive/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
+Source1:        %{name}-%{version}-cargo-%{release}.tar.gz
+Source2:        %{name}-%{version}-vendor-%{release}.tar.gz
 Patch0:         CVE-2023-28448.patch
+Patch1:         CVE-2023-2650.patch
 ExclusiveArch:  x86_64
 
 BuildRequires:  gcc
@@ -26,15 +25,14 @@ A Rust-VMM based cloud hypervisor from Intel.
 
 %prep
 # Setup .cargo directory
-mkdir -p $HOME
-pushd $HOME
 tar xf %{SOURCE1} --no-same-owner
 %patch0 -p1
-popd
 %setup -q
+%patch1 -p1
+tar xf %{SOURCE2} -C ../ --no-same-owner
 
 %build
-cargo build --release
+CARGO_HOME=$(pwd)/../.cargo cargo build --release --offline
 
 %install
 install -d %{buildroot}%{_bindir}
@@ -51,6 +49,9 @@ install -d %{buildroot}%{_libdir}/cloud-hypervisor
 %exclude %{_libdir}/debug
 
 %changelog
+* Tue Jul 04 2023 Suresh Thelkar <sthelkar@microsoft.com> - 22.0-3
+- Patch CVE-2023-0465 and CVE-2023-2650
+
 * Wed Apr 05 2023 Henry Beberman <henry.beberman@microsoft.com> - 22.0-2
 - Patch CVE-2023-28448 in vendored versionize crate
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Patch CVE-2023-2650 and CVE-2023-0465 in cloud-hypervisor

My analysis has reveled that the solution for these CVEs is to have openssl-src crate with the version "111.26.0+1.1.1u". Hence added a patch CVE-2023-2650.patch which takes care of this and all other dependencies.

If we take care of applying this patch in the spec file then cloud-hypervisor build goes smoothly when Network is enabled.. But the offline Buddy Build was failing. 

In the recent versions of Rust, “cargo vendor” option is officially supported which will vendor all crates.io and git dependencies into a specified directory by default "vendor". Making use of this option which will solve the problem in hand. 

- After extracting the source tar, we run "cargo vendor". This creates a vendor folder which consists of vendored crates. We can create a compressed archive file out of it. 
- The above command also lists few instructions that needs to be gone to ".cargo/config.toml"
- Also create a compressed archive file out of ".cargo" directory. 
- All of the above can be used appropriately while doing a cargo offline build. 
- Modified spec file accordingly.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- CVE-2023-2650
- CVE-2023-0465

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2023-2650
- https://nvd.nist.gov/vuln/detail/CVE-2023-0465

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Buddy build with Network Access disabled is [here](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=388890&view=results)
- Buddy build with Network Access enabled is [here](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=388891&view=results)
