### PR TITLE
Add bootUUID variable to /boot/efi/boot/grub2/grub.cfg

### DIFF
--- a/toolkit/resources/assets/efi/grub/grub.cfg
+++ b/toolkit/resources/assets/efi/grub/grub.cfg
@@ -3,4 +3,5 @@ search -n -u {{.BootUUID}} -s
 # If '/boot' is a seperate partition, BootUUID will point directly to '/boot'.
 # In this case we should omit the '/boot' prefix from all paths.
 set bootprefix={{.BootPrefix}}
+set bootUUID={{.BootUUID}}
 configfile $bootprefix/grub2/grub.cfg

--- a/toolkit/resources/assets/grub2/grub.cfg
+++ b/toolkit/resources/assets/grub2/grub.cfg
@@ -2,6 +2,8 @@ set timeout=0
 set bootprefix={{.BootPrefix}}
 search -n -u {{.BootUUID}} -s
 
+echo $bootUUID
+
 load_env -f $bootprefix/mariner.cfg
 if [ -f  $bootprefix/systemd.cfg ]; then
 	load_env -f $bootprefix/systemd.cfg


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
We often modify our grub.cfg of an existing base image in order to create derivative builds of Mariner. In cases where we want to add a more complex boot path (e.g. kata scenario), we want access to .BootUUID after the imagegen tool has already long since ran. Store it in a variable so it is readily accessible to new grub menuentries. 

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- add $bootUUID

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
NO

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Full image build: 