### PR TITLE
Fix strace's sockopt-sol_netlink test for kernel >= 5.15.116.1

### DIFF
--- a/SPECS/strace/strace.spec
+++ b/SPECS/strace/strace.spec
@@ -2,7 +2,7 @@
 Summary:        Tracks system calls that are made by a running process
 Name:           strace
 Version:        5.16
-Release:        1%{?dist}
+Release:        3%{?dist}
 License:        GPL-2.0-or-later AND LGPL-2.1-or-later
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -11,6 +11,8 @@ URL:            https://strace.io/
 Source0:        https://strace.io/files/%{version}/%{name}-%{version}.tar.xz
 # Released upstream in v5.18
 Patch0:         testfix-landlock-brackets.patch
+# Both patches released upstream in v6.4
+Patch1:         testfix-netlink-list-memberships.patch
 BuildRequires:  libacl-devel
 BuildRequires:  libaio-devel
 
@@ -41,11 +43,16 @@ all the arugments and return values from the system calls. This is useful in deb
 
 %files
 %defattr(-,root,root)
-%license COPYING
+%license COPYING LGPL-2.1-or-later bundled/linux/GPL-2.0
 %{_bindir}/*
 %{_mandir}/man1/*
 
 %changelog
+* Mon Jun 10 2023 Olivia Crain <oliviacrain@microsoft.com> - 5.16-3
+- Add upstream patch to fix sockopt-sol_netlink test with kernel >= 5.15.116.1
+- Modify landlock test patch to properly apply with `git am`
+- Package full license texts
+
 * Wed Jun 07 2023 Olivia Crain <oliviacrain@microsoft.com> - 5.16-2
 - Add upstream patch to fix landlock_create_ruleset-y test
 - Modernize calls to make by using macros

--- a/SPECS/strace/testfix-landlock-brackets.patch
+++ b/SPECS/strace/testfix-landlock-brackets.patch
@@ -1,6 +1,3 @@
-Maintainer note: Kernel patch mentioned below was backported to 5.15, is present in kernel>=5.15.33.1
-https://github.com/microsoft/CBL-Mariner-Linux-Kernel/commit/3d4b396a616d0d67bf95d6823ad1197f6247292e
-
 From 22cf83f78c12fe8afdd0b2d8029a037b6084edf2 Mon Sep 17 00:00:00 2001
 From: Eugene Syromyatnikov <evgsyr@gmail.com>
 Date: Fri, 27 May 2022 16:17:21 +0200
@@ -20,7 +17,11 @@ in the test instead.
 by the landlock_create_ruleset call and set it to fd_str, which
 is then printed.
 
-Signed-off-by: Olivia Crain <olivia@olivia.dev>
+Maintainer note: Kernel commit mentioned above was backported to 5.15,
+is present in kernel>=5.15.33.1
+https://github.com/microsoft/CBL-Mariner-Linux-Kernel/commit/3d4b396a616d0d67bf95d6823ad1197f6247292e
+
+Signed-off-by: Olivia Crain <oliviacrain@microsoft.com>
 ---
  tests/landlock_create_ruleset-y.c |  2 +-
  tests/landlock_create_ruleset.c   | 33 ++++++++++++++++++++++++++++++-

--- a/SPECS/strace/testfix-netlink-list-memberships.patch
+++ b/SPECS/strace/testfix-netlink-list-memberships.patch
@@ -1,0 +1,108 @@
+From 3bbfb541b258baec9eba674b5d8dc30007a61542 Mon Sep 17 00:00:00 2001
+From: "Dmitry V. Levin" <ldv@strace.io>
+Date: Wed, 21 Jun 2023 08:00:00 +0000
+Subject: [PATCH] net: enhance getsockopt decoding
+
+When getsockopt syscall fails the kernel sometimes updates the optlen
+argument, for example, NETLINK_LIST_MEMBERSHIPS updates it even if
+optval is not writable.
+
+* src/net.c (SYS_FUNC(getsockopt)): Try to fetch and print optlen
+argument on exiting syscall regardless of getsockopt exit status.
+
+Maintainer note: This small feature patch is required to apply the
+second patch in this series to fix the test failure.
+
+Signed-off-by: Olivia Crain <oliviacrain@microsoft.com>
+---
+ src/net.c | 15 ++++++++++++++-
+ 1 file changed, 14 insertions(+), 1 deletion(-)
+
+diff --git a/src/net.c b/src/net.c
+index f68ccb947..7244b5e57 100644
+--- a/src/net.c
++++ b/src/net.c
+@@ -1038,7 +1038,7 @@ SYS_FUNC(getsockopt)
+ 	} else {
+ 		ulen = get_tcb_priv_ulong(tcp);
+ 
+-		if (syserror(tcp) || umove(tcp, tcp->u_arg[4], &rlen) < 0) {
++		if (umove(tcp, tcp->u_arg[4], &rlen) < 0) {
+ 			/* optval */
+ 			printaddr(tcp->u_arg[3]);
+ 			tprint_arg_next();
+@@ -1047,6 +1047,19 @@ SYS_FUNC(getsockopt)
+ 			tprint_indirect_begin();
+ 			PRINT_VAL_D(ulen);
+ 			tprint_indirect_end();
++		} else if (syserror(tcp)) {
++			/* optval */
++			printaddr(tcp->u_arg[3]);
++			tprint_arg_next();
++
++			/* optlen */
++			tprint_indirect_begin();
++			if (ulen != rlen) {
++				PRINT_VAL_D(ulen);
++				tprint_value_changed();
++			}
++			PRINT_VAL_D(rlen);
++			tprint_indirect_end();
+ 		} else {
+ 			/* optval */
+ 			print_getsockopt(tcp, tcp->u_arg[1], tcp->u_arg[2],
+
+
+From f31c2f4494779e5c5f170ad10539bfc2dfafe967 Mon Sep 17 00:00:00 2001
+From: "Dmitry V. Levin" <ldv@strace.io>
+Date: Sat, 24 Jun 2023 08:00:00 +0000
+Subject: [PATCH] tests: update sockopt-sol_netlink test
+
+Update sockopt-sol_netlink test that started to fail, likely
+due to recent linux kernel commit f4e4534850a9 ("net/netlink: fix
+NETLINK_LIST_MEMBERSHIPS length report").
+
+* tests/sockopt-sol_netlink.c (main): Always print changing optlen value
+on exiting syscall.
+
+Maintainer note: Kernel commit mentioned above was backported to 5.15,
+is present in kernel>=5.15.116.1
+https://github.com/microsoft/CBL-Mariner-Linux-Kernel/commit/7dc379f8856bd334582c35c7fe28952e8bd8fb5d
+
+Reported-by: Alexander Gordeev <agordeev@linux.ibm.com>
+Signed-off-by: Olivia Crain <oliviacrain@microsoft.com>
+---
+ tests/sockopt-sol_netlink.c | 13 ++++++++++---
+ 1 file changed, 10 insertions(+), 3 deletions(-)
+
+diff --git a/tests/sockopt-sol_netlink.c b/tests/sockopt-sol_netlink.c
+index 82b98adc23..1c33219ac5 100644
+--- a/tests/sockopt-sol_netlink.c
++++ b/tests/sockopt-sol_netlink.c
+@@ -94,7 +94,10 @@ main(void)
+ 			printf("%p", val);
+ 		else
+ 			printf("[%d]", *val);
+-		printf(", [%d]) = %s\n", *len, errstr);
++		printf(", [%d", (int) sizeof(*val));
++		if ((int) sizeof(*val) != *len)
++			printf(" => %d", *len);
++		printf("]) = %s\n", errstr);
+ 
+ 		/* optlen larger than necessary - shortened */
+ 		*len = sizeof(*val) + 1;
+@@ -150,8 +153,12 @@ main(void)
+ 		/* optval EFAULT - print address */
+ 		*len = sizeof(*val);
+ 		get_sockopt(fd, names[i].val, efault, len);
+-		printf("getsockopt(%d, SOL_NETLINK, %s, %p, [%d]) = %s\n",
+-		       fd, names[i].str, efault, *len, errstr);
++		printf("getsockopt(%d, SOL_NETLINK, %s, %p",
++		       fd, names[i].str, efault);
++		printf(", [%d", (int) sizeof(*val));
++		if ((int) sizeof(*val) != *len)
++			printf(" => %d", *len);
++		printf("]) = %s\n", errstr);
+ 
+ 		/* optlen EFAULT - print address */
+ 		get_sockopt(fd, names[i].val, val, len + 1);


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Recent `strace` package test runs have been failing on the `sockopt-sol_netlink` test. This test fails due to a kernel commit (backported to our kernel in 5.15.116.1) that changes the expected output for a syscall. The test 

Kernel change: microsoft/CBL-Mariner-Linux-Kernel@7dc379f8856bd334582c35c7fe28952e8bd8fb5d
Upstream bug: strace/strace#257.
Upstream fix: strace/strace@f31c2f4494779e5c5f170ad10539bfc2dfafe967
Fix requires following patch be applied first: strace/strace@3bbfb541b258baec9eba674b5d8dc30007a61542

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add upstream patch to fix sockopt-sol_netlink test with kernel >= 5.15.116.1
- Modify landlock test patch to properly apply with `git am`
- Package full license texts

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- [Buddy build 391130](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=391130)
