### PR TITLE
Filter implicit run nodes before passing to collapse.

### DIFF
--- a/toolkit/docs/how_it_works/3_package_building.md
+++ b/toolkit/docs/how_it_works/3_package_building.md
@@ -69,7 +69,7 @@ A critical component of package building is ensuring that the packages are built
 
 ### Types of Nodes
 The graph contains several types of nodes, with various states. As the graph is processed by each tool nodes are updated, pruned, or added as needed.
-#### TypeBuild
+#### TypeLocalBuild
 > This represents a local package which may be passed to the build worker to generate an RPM from.
 > It can be either:
 >
@@ -79,7 +79,7 @@ The graph contains several types of nodes, with various states. As the graph is 
 >
 > `StateUpToDate`: Package is already available locally
 
-#### TypeRun
+#### TypeLocalRun
 > This node represents a package which is may be installed or used as a dependency.
 > Run nodes are always:
 >
@@ -91,7 +91,7 @@ The graph contains several types of nodes, with various states. As the graph is 
 >
 > `StateMeta`: Organizational node used to impose ordering on other nodes
 
-#### TypeRemote
+#### TypeRemoteRun
 > This node represents a package which is unknown to the local build system, but has been requested as a dependency. It will need to be resolved from a remote source. `TypeRemote` nodes are considered equivalent to `TypeRun` nodes in most cases.
 > Remote nodes may be either:
 >

--- a/toolkit/tools/depsearch/depsearch.go
+++ b/toolkit/tools/depsearch/depsearch.go
@@ -352,7 +352,7 @@ func (t *treeSearch) treeNodeToString(n *pkggraph.PkgNode, depth, maxDepth int, 
 		if generateStrings {
 			lines = append(lines, "__"+colorRed+thisNode+colorReset)
 		}
-		if n.Type == pkggraph.TypeRun {
+		if n.Type == pkggraph.TypeLocalRun {
 			// We only want to record run nodes for the purposes of listing packages in non-tree mode
 			t.filteredNodes[n] = true
 		}
@@ -361,7 +361,7 @@ func (t *treeSearch) treeNodeToString(n *pkggraph.PkgNode, depth, maxDepth int, 
 		if generateStrings {
 			lines = append(lines, "__"+thisNode)
 		}
-		if n.Type == pkggraph.TypeRun {
+		if n.Type == pkggraph.TypeLocalRun {
 			// We only want to record run nodes for the purposes of listing packages in non-tree mode
 			t.normalNodes[n] = true
 		}

--- a/toolkit/tools/depsearch/depsearch.go
+++ b/toolkit/tools/depsearch/depsearch.go
@@ -338,7 +338,7 @@ func (t *treeSearch) printProgress() {
 func (t *treeSearch) treeNodeToString(n *pkggraph.PkgNode, depth, maxDepth int, filter bool, filterFile string, verbosity int, generateStrings, printDuplicates bool) (lines []string, hasNonToolchain bool) {
 	t.printProgress()
 	// We only care about run nodes for the purposes of detecting toolchain files
-	hasNonToolchain = n.Type == pkggraph.TypeBuild && !isFilteredFile(n.RpmPath, filterFile)
+	hasNonToolchain = n.Type == pkggraph.TypeLocalBuild && !isFilteredFile(n.RpmPath, filterFile)
 
 	if !printDuplicates && t.alreadyAdded[n] {
 		return []string{}, false

--- a/toolkit/tools/graphPreprocessor/graphPreprocessor.go
+++ b/toolkit/tools/graphPreprocessor/graphPreprocessor.go
@@ -26,7 +26,7 @@ var (
 func replaceRunNodesWithPrebuiltNodes(pkgGraph *pkggraph.PkgGraph) (err error) {
 	for _, node := range pkgGraph.AllNodes() {
 
-		if node.Type != pkggraph.TypeRun {
+		if node.Type != pkggraph.TypeLocalRun {
 			continue
 		}
 

--- a/toolkit/tools/graphanalytics/graphanalytics.go
+++ b/toolkit/tools/graphanalytics/graphanalytics.go
@@ -73,7 +73,7 @@ func printIndirectlyMostUnresolved(pkgGraph *pkggraph.PkgGraph, maxResults int) 
 	unresolvedPackageDependents := make(map[string][]string)
 
 	for _, node := range pkgGraph.AllNodes() {
-		if node.Type != pkggraph.TypeLocalRun && node.Type != pkggraph.TypeBuild {
+		if node.Type != pkggraph.TypeLocalRun && node.Type != pkggraph.TypeLocalBuild {
 			continue
 		}
 
@@ -135,7 +135,7 @@ func printDirectlyClosestToBeingUnblocked(pkgGraph *pkggraph.PkgGraph, maxResult
 	srpmsBlockedBy := make(map[string][]string)
 
 	for _, node := range pkgGraph.AllNodes() {
-		if node.Type != pkggraph.TypeBuild {
+		if node.Type != pkggraph.TypeLocalBuild {
 			continue
 		}
 
@@ -176,7 +176,7 @@ func printIndirectlyClosestToBeingUnblocked(pkgGraph *pkggraph.PkgGraph, maxResu
 	srpmsBlockedByPaths := make(map[string][][]graph.Node)
 
 	for _, node := range pkgGraph.AllNodes() {
-		if node.Type != pkggraph.TypeBuild {
+		if node.Type != pkggraph.TypeLocalBuild {
 			continue
 		}
 

--- a/toolkit/tools/graphanalytics/graphanalytics.go
+++ b/toolkit/tools/graphanalytics/graphanalytics.go
@@ -73,7 +73,7 @@ func printIndirectlyMostUnresolved(pkgGraph *pkggraph.PkgGraph, maxResults int) 
 	unresolvedPackageDependents := make(map[string][]string)
 
 	for _, node := range pkgGraph.AllNodes() {
-		if node.Type != pkggraph.TypeRun && node.Type != pkggraph.TypeBuild {
+		if node.Type != pkggraph.TypeLocalRun && node.Type != pkggraph.TypeBuild {
 			continue
 		}
 

--- a/toolkit/tools/grapher/grapher.go
+++ b/toolkit/tools/grapher/grapher.go
@@ -100,7 +100,7 @@ func addUnresolvedPackage(g *pkggraph.PkgGraph, pkgVer *pkgjson.PackageVer) (new
 	}
 
 	// Create a new node
-	newRunNode, err = g.AddPkgNode(pkgVer, pkggraph.StateUnresolved, pkggraph.TypeRemote, "<NO_SRPM_PATH>", "<NO_RPM_PATH>", "<NO_SPEC_PATH>", "<NO_SOURCE_PATH>", "<NO_ARCHITECTURE>", "<NO_REPO>")
+	newRunNode, err = g.AddPkgNode(pkgVer, pkggraph.StateUnresolved, pkggraph.TypeRemoteRun, "<NO_SRPM_PATH>", "<NO_RPM_PATH>", "<NO_SPEC_PATH>", "<NO_SOURCE_PATH>", "<NO_ARCHITECTURE>", "<NO_REPO>")
 	if err != nil {
 		return
 	}
@@ -131,7 +131,7 @@ func addNodesForPackage(g *pkggraph.PkgGraph, pkgVer *pkgjson.PackageVer, pkg *p
 
 	if newRunNode == nil {
 		// Add "Run" node
-		newRunNode, err = g.AddPkgNode(pkgVer, pkggraph.StateMeta, pkggraph.TypeRun, pkg.SrpmPath, pkg.RpmPath, pkg.SpecPath, pkg.SourceDir, pkg.Architecture, "<LOCAL>")
+		newRunNode, err = g.AddPkgNode(pkgVer, pkggraph.StateMeta, pkggraph.TypeLocalRun, pkg.SrpmPath, pkg.RpmPath, pkg.SpecPath, pkg.SourceDir, pkg.Architecture, "<LOCAL>")
 		logger.Log.Debugf("Adding run node %s with id %d\n", newRunNode.FriendlyName(), newRunNode.ID())
 		if err != nil {
 			return
@@ -188,8 +188,8 @@ func addSingleDependency(g *pkggraph.PkgGraph, packageNode *pkggraph.PkgNode, de
 	// Creating these edges may cause non-problematic cycles that can significantly increase memory usage and runtime during cycle resolution.
 	// If there are enough of these cycles it can exhaust the system's memory when resolving them.
 	// - Only check run nodes. If a build node has a reflexive cycle then it cannot be built without a bootstrap version.
-	if packageNode.Type == pkggraph.TypeRun &&
-		dependentNode.Type == pkggraph.TypeRun &&
+	if packageNode.Type == pkggraph.TypeLocalRun &&
+		dependentNode.Type == pkggraph.TypeLocalRun &&
 		packageNode.RpmPath == dependentNode.RpmPath {
 
 		logger.Log.Debugf("%+v requires %+v which is provided by the same RPM.", packageNode, dependentNode)

--- a/toolkit/tools/grapher/grapher.go
+++ b/toolkit/tools/grapher/grapher.go
@@ -140,7 +140,7 @@ func addNodesForPackage(g *pkggraph.PkgGraph, pkgVer *pkgjson.PackageVer, pkg *p
 
 	if newBuildNode == nil {
 		// Add "Build" node
-		newBuildNode, err = g.AddPkgNode(pkgVer, pkggraph.StateBuild, pkggraph.TypeBuild, pkg.SrpmPath, pkg.RpmPath, pkg.SpecPath, pkg.SourceDir, pkg.Architecture, "<LOCAL>")
+		newBuildNode, err = g.AddPkgNode(pkgVer, pkggraph.StateBuild, pkggraph.TypeLocalBuild, pkg.SrpmPath, pkg.RpmPath, pkg.SpecPath, pkg.SourceDir, pkg.Architecture, "<LOCAL>")
 		logger.Log.Debugf("Adding build node %s with id %d\n", newBuildNode.FriendlyName(), newBuildNode.ID())
 		if err != nil {
 			return

--- a/toolkit/tools/internal/pkggraph/pkggraph.go
+++ b/toolkit/tools/internal/pkggraph/pkggraph.go
@@ -51,14 +51,14 @@ type NodeType int
 
 // Valid values for NodeType type
 const (
-	TypeUnknown  NodeType = iota         // Unknown type
-	TypeBuild    NodeType = iota         // Package can be build if all dependency edges are satisfied
-	TypeRun      NodeType = iota         // Package can be run if all dependency edges are satisfied. Will be associated with a partner build node
-	TypeGoal     NodeType = iota         // Meta node which depends on a user selected subset of packages to be built.
-	TypeRemote   NodeType = iota         // A non-local node which may have a cache entry
-	TypePureMeta NodeType = iota         // An arbitrary meta node with no other meaning
-	TypePreBuilt NodeType = iota         // A node indicating a pre-built SRPM used in breaking cyclic build dependencies
-	TypeMAX      NodeType = TypePureMeta // Max allowable type
+	TypeUnknown    NodeType = iota         // Unknown type
+	TypeLocalBuild NodeType = iota         // Package can be build if all dependency edges are satisfied
+	TypeLocalRun   NodeType = iota         // Package can be run if all dependency edges are satisfied. Will be associated with a partner build node
+	TypeGoal       NodeType = iota         // Meta node which depends on a user selected subset of packages to be built.
+	TypeRemoteRun  NodeType = iota         // A non-local node which may have a cache entry
+	TypePureMeta   NodeType = iota         // An arbitrary meta node with no other meaning
+	TypePreBuilt   NodeType = iota         // A node indicating a pre-built SRPM used in breaking cyclic build dependencies
+	TypeMAX        NodeType = TypePureMeta // Max allowable type
 )
 
 // Dot encoding/decoding keys
@@ -131,13 +131,13 @@ func (n NodeState) String() string {
 
 func (n NodeType) String() string {
 	switch n {
-	case TypeBuild:
+	case TypeLocalBuild:
 		return "Build"
-	case TypeRun:
+	case TypeLocalRun:
 		return "Run"
 	case TypeGoal:
 		return "Goal"
-	case TypeRemote:
+	case TypeRemoteRun:
 		return "Remote"
 	case TypePureMeta:
 		return "PureMeta"
@@ -195,7 +195,7 @@ func (g *PkgGraph) initLookup() {
 	// (they always expect a run node to be present)
 	for _, n := range graph.NodesOf(g.Nodes()) {
 		pkgNode := n.(*PkgNode)
-		if pkgNode.Type == TypeRun || pkgNode.Type == TypeRemote {
+		if pkgNode.Type == TypeLocalRun || pkgNode.Type == TypeRemoteRun {
 			g.addToLookup(pkgNode, true)
 		}
 	}
@@ -203,7 +203,7 @@ func (g *PkgGraph) initLookup() {
 	// Now run again for any build nodes, or other nodes we want to track
 	for _, n := range graph.NodesOf(g.Nodes()) {
 		pkgNode := n.(*PkgNode)
-		if pkgNode.Type != TypeRun && pkgNode.Type != TypeRemote {
+		if pkgNode.Type != TypeLocalRun && pkgNode.Type != TypeRemoteRun {
 			g.addToLookup(pkgNode, true)
 		}
 	}
@@ -250,7 +250,7 @@ func (g *PkgGraph) validateNodeForLookup(pkgNode *PkgNode) (valid bool, err erro
 	)
 
 	// Only add run, remote, or build nodes to lookup
-	if pkgNode.Type != TypeBuild && pkgNode.Type != TypeRun && pkgNode.Type != TypeRemote {
+	if pkgNode.Type != TypeLocalBuild && pkgNode.Type != TypeLocalRun && pkgNode.Type != TypeRemoteRun {
 		err = fmt.Errorf("%s has invalid type for lookup", pkgNode)
 		return
 	}
@@ -262,12 +262,12 @@ func (g *PkgGraph) validateNodeForLookup(pkgNode *PkgNode) (valid bool, err erro
 	}
 	if existingLookup != nil {
 		switch pkgNode.Type {
-		case TypeBuild:
+		case TypeLocalBuild:
 			haveDuplicateNode = existingLookup.BuildNode != nil
-		case TypeRemote:
+		case TypeRemoteRun:
 			// For the purposes of lookup, a "Remote" node provides the same utility as a "Run" node
 			fallthrough
-		case TypeRun:
+		case TypeLocalRun:
 			haveDuplicateNode = existingLookup.RunNode != nil
 		}
 		if haveDuplicateNode {
@@ -284,7 +284,7 @@ func (g *PkgGraph) validateNodeForLookup(pkgNode *PkgNode) (valid bool, err erro
 	}
 
 	// Basic run nodes can only provide basic conditional versions
-	if pkgNode.Type != TypeRemote {
+	if pkgNode.Type != TypeRemoteRun {
 		// We only support a single conditional (ie ver >= 1), or (ver = 1)
 		if versionInterval.UpperBound.Compare(versioncompare.NewMax()) != 0 && versionInterval.UpperBound.Compare(versionInterval.LowerBound) != 0 {
 			err = fmt.Errorf("%s is a run node and can't have double conditionals", pkgNode)
@@ -307,7 +307,7 @@ func (g *PkgGraph) addToLookup(pkgNode *PkgNode, deferSort bool) (err error) {
 	)
 
 	// We only care about run/build nodes or remote dependencies
-	if pkgNode.Type != TypeBuild && pkgNode.Type != TypeRun && pkgNode.Type != TypeRemote {
+	if pkgNode.Type != TypeLocalBuild && pkgNode.Type != TypeLocalRun && pkgNode.Type != TypeRemoteRun {
 		logger.Log.Tracef("Skipping %+v, not valid for lookup", pkgNode)
 		return
 	}
@@ -327,7 +327,7 @@ func (g *PkgGraph) addToLookup(pkgNode *PkgNode, deferSort bool) (err error) {
 		return err
 	}
 	if existingLookup == nil {
-		if (!deferSort) && pkgNode.Type == TypeBuild {
+		if (!deferSort) && pkgNode.Type == TypeLocalBuild {
 			err = fmt.Errorf("can't add %s, no corresponding run node found and not defering sort", pkgNode)
 			return
 		}
@@ -336,17 +336,17 @@ func (g *PkgGraph) addToLookup(pkgNode *PkgNode, deferSort bool) (err error) {
 	}
 
 	switch pkgNode.Type {
-	case TypeBuild:
+	case TypeLocalBuild:
 		if existingLookup.BuildNode == nil {
 			existingLookup.BuildNode = pkgNode.This
 		} else {
 			err = duplicateError
 			return
 		}
-	case TypeRemote:
+	case TypeRemoteRun:
 		// For the purposes of lookup, a "Remote" node provides the same utility as a "Run" node
 		fallthrough
-	case TypeRun:
+	case TypeLocalRun:
 		if existingLookup.RunNode == nil {
 			existingLookup.RunNode = pkgNode.This
 		} else {
@@ -395,7 +395,7 @@ func (g *PkgGraph) NewNode() graph.Node {
 // - The collapsed node will inherit all attributes of the parent node minus the versionedPkg.
 func (g *PkgGraph) CreateCollapsedNode(versionedPkg *pkgjson.PackageVer, parentNode *PkgNode, nodesToCollapse []*PkgNode) (newNode *PkgNode, err error) {
 	// enforce parent is run node
-	if parentNode.Type != TypeRun {
+	if parentNode.Type != TypeLocalRun {
 		err = fmt.Errorf("cannot collapse nodes to a non run node (%s)", parentNode.FriendlyName())
 		return
 	}
@@ -662,11 +662,11 @@ func (n PkgNode) SetDOTID(id string) {
 // FriendlyName formats a summary of a node into a string.
 func (n *PkgNode) FriendlyName() string {
 	switch n.Type {
-	case TypeBuild:
+	case TypeLocalBuild:
 		return fmt.Sprintf("%s-%s-BUILD<%s>", n.VersionedPkg.Name, n.VersionedPkg.Version, n.State.String())
-	case TypeRun:
+	case TypeLocalRun:
 		return fmt.Sprintf("%s-%s-RUN<%s>", n.VersionedPkg.Name, n.VersionedPkg.Version, n.State.String())
-	case TypeRemote:
+	case TypeRemoteRun:
 		ver1 := fmt.Sprintf("%s%s", n.VersionedPkg.Condition, n.VersionedPkg.Version)
 		ver2 := ""
 		if len(n.VersionedPkg.SCondition) > 0 || len(n.VersionedPkg.SVersion) > 0 {
@@ -1273,7 +1273,7 @@ func (g *PkgGraph) fixIntraSpecCycle(trimmedCycle []*PkgNode) (err error) {
 	logger.Log.Debug("Checking if cycle contains build nodes.")
 
 	for _, currentNode := range trimmedCycle {
-		if currentNode.Type == TypeBuild {
+		if currentNode.Type == TypeLocalBuild {
 			logger.Log.Debug("Cycle contains build dependencies, cannot be solved this way.")
 			return fmt.Errorf("cycle contains build dependencies, unresolvable")
 		}
@@ -1344,7 +1344,7 @@ func (g *PkgGraph) fixPrebuiltSRPMsCycle(trimmedCycle []*PkgNode) (err error) {
 		//    Considering that, we avoid accidentally skipping a rebuild by only removing edges between a build and a run node.
 		// 2. Every build cycle must contain at least one edge between a build node and a run node from different SRPMs.
 		//    These edges represent the 'BuildRequires' from the .spec file. If the cycle is breakable, the run node comes from a pre-built SRPM.
-		buildToRunEdge := previousNode.Type == TypeBuild && currentNode.Type == TypeRun
+		buildToRunEdge := previousNode.Type == TypeLocalBuild && currentNode.Type == TypeLocalRun
 		if isPrebuilt, _, _ := IsSRPMPrebuilt(currentNode.SrpmPath, g, nil); buildToRunEdge && isPrebuilt {
 			logger.Log.Debugf("Cycle contains pre-built SRPM '%s'. Replacing edges from build nodes associated with '%s' with an edge to a new 'PreBuilt' node.",
 				currentNode.SrpmPath, previousNode.SrpmPath)
@@ -1358,7 +1358,7 @@ func (g *PkgGraph) fixPrebuiltSRPMsCycle(trimmedCycle []*PkgNode) (err error) {
 			parentNodes := g.To(currentNode.ID())
 			for parentNodes.Next() {
 				parentNode := parentNodes.Node().(*PkgNode)
-				if parentNode.Type == TypeBuild && parentNode.SrpmPath == previousNode.SrpmPath {
+				if parentNode.Type == TypeLocalBuild && parentNode.SrpmPath == previousNode.SrpmPath {
 					g.RemoveEdge(parentNode.ID(), currentNode.ID())
 
 					err = g.AddEdge(parentNode, preBuiltNode)

--- a/toolkit/tools/internal/pkggraph/pkggraph_test.go
+++ b/toolkit/tools/internal/pkggraph/pkggraph_test.go
@@ -122,7 +122,7 @@ func buildBuildNodeHelper(pkg *pkgjson.PackageVer) (node *PkgNode) {
 	node = &PkgNode{
 		VersionedPkg: &pkgCopy,
 		State:        StateBuild,
-		Type:         TypeBuild,
+		Type:         TypeLocalBuild,
 		SrpmPath:     pkgCopy.Name + ".src.rpm",
 		RpmPath:      pkgCopy.Name + ".rpm",
 		SpecPath:     pkgCopy.Name + ".spec",
@@ -197,13 +197,13 @@ func addEdgeHelper(g *PkgGraph, pkg1 PkgNode, pkg2 PkgNode) (err error) {
 		return fmt.Errorf("couldn't find %s (%v)", pkg2.String(), lu2)
 	}
 
-	if pkg1.Type == TypeBuild {
+	if pkg1.Type == TypeLocalBuild {
 		n1 = lu1.BuildNode
 	} else {
 		n1 = lu1.RunNode
 	}
 
-	if pkg2.Type == TypeBuild {
+	if pkg2.Type == TypeLocalBuild {
 		n2 = lu2.BuildNode
 	} else {
 		n2 = lu2.RunNode
@@ -304,7 +304,7 @@ func TestNodeStateString(t *testing.T) {
 
 // TestNodeTypeString checks the NodeType -> string functionality
 func TestNodeTypeString(t *testing.T) {
-	assert.Equal(t, "Build", TypeBuild.String())
+	assert.Equal(t, "Build", TypeLocalBuild.String())
 	assert.Equal(t, "Run", TypeLocalRun.String())
 	assert.Equal(t, "Goal", TypeGoal.String())
 	assert.Equal(t, "Remote", TypeRemoteRun.String())

--- a/toolkit/tools/internal/pkggraph/pkggraph_test.go
+++ b/toolkit/tools/internal/pkggraph/pkggraph_test.go
@@ -103,7 +103,7 @@ func buildRunNodeHelper(pkg *pkgjson.PackageVer) (node *PkgNode) {
 	node = &PkgNode{
 		VersionedPkg: &pkgCopy,
 		State:        StateMeta,
-		Type:         TypeRun,
+		Type:         TypeLocalRun,
 		SrpmPath:     pkgCopy.Name + ".src.rpm",
 		RpmPath:      pkgCopy.Name + ".rpm",
 		SpecPath:     pkgCopy.Name + ".spec",
@@ -141,7 +141,7 @@ func buildUnresolvedNodeHelper(pkg *pkgjson.PackageVer) (node *PkgNode) {
 	node = &PkgNode{
 		VersionedPkg: &pkgCopy,
 		State:        StateUnresolved,
-		Type:         TypeRemote,
+		Type:         TypeRemoteRun,
 		SrpmPath:     "url://" + pkgCopy.Name + ".src.rpm",
 		RpmPath:      "url://" + pkgCopy.Name + ".rpm",
 		SpecPath:     "url://" + pkgCopy.Name + ".spec",
@@ -305,9 +305,9 @@ func TestNodeStateString(t *testing.T) {
 // TestNodeTypeString checks the NodeType -> string functionality
 func TestNodeTypeString(t *testing.T) {
 	assert.Equal(t, "Build", TypeBuild.String())
-	assert.Equal(t, "Run", TypeRun.String())
+	assert.Equal(t, "Run", TypeLocalRun.String())
 	assert.Equal(t, "Goal", TypeGoal.String())
-	assert.Equal(t, "Remote", TypeRemote.String())
+	assert.Equal(t, "Remote", TypeRemoteRun.String())
 	assert.Equal(t, "PureMeta", TypePureMeta.String())
 	assert.Equal(t, "PreBuilt", TypePreBuilt.String())
 	var tp NodeType

--- a/toolkit/tools/scheduler/scheduler.go
+++ b/toolkit/tools/scheduler/scheduler.go
@@ -321,7 +321,7 @@ func buildAllNodes(stopOnFailure, canUseCache bool, packagesToRebuild []*pkgjson
 				fallthrough
 			case pkggraph.TypeRemoteRun:
 				fallthrough
-			case pkggraph.TypeBuild:
+			case pkggraph.TypeLocalBuild:
 				fallthrough
 			default:
 				channels.Requests <- req
@@ -374,7 +374,7 @@ func buildAllNodes(stopOnFailure, canUseCache bool, packagesToRebuild []*pkgjson
 					}
 				}
 
-				if res.Node.Type == pkggraph.TypeBuild && res.WasDelta {
+				if res.Node.Type == pkggraph.TypeLocalBuild && res.WasDelta {
 					logger.Log.Tracef("This is a delta result, update the graph with the new delta files for '%v'.", res.Node)
 					// We will need to update the graph with paths to any delta files that were actually rebuilt.
 					err = setAssociatedDeltaPaths(res, pkgGraph, graphMutex)
@@ -419,7 +419,7 @@ func buildAllNodes(stopOnFailure, canUseCache bool, packagesToRebuild []*pkgjson
 			}
 		}
 
-		if res.Node.Type == pkggraph.TypeBuild {
+		if res.Node.Type == pkggraph.TypeLocalBuild {
 			logger.Log.Infof("%d currently active build(s): %v.", activeSRPMsCount, activeSRPMs)
 		}
 

--- a/toolkit/tools/scheduler/scheduler.go
+++ b/toolkit/tools/scheduler/scheduler.go
@@ -317,9 +317,9 @@ func buildAllNodes(stopOnFailure, canUseCache bool, packagesToRebuild []*pkgjson
 				fallthrough
 			case pkggraph.TypePureMeta:
 				fallthrough
-			case pkggraph.TypeRun:
+			case pkggraph.TypeLocalRun:
 				fallthrough
-			case pkggraph.TypeRemote:
+			case pkggraph.TypeRemoteRun:
 				fallthrough
 			case pkggraph.TypeBuild:
 				fallthrough

--- a/toolkit/tools/scheduler/schedulerutils/buildworker.go
+++ b/toolkit/tools/scheduler/schedulerutils/buildworker.go
@@ -105,7 +105,7 @@ func BuildNodeWorker(channels *BuildChannels, agent buildagents.BuildAgent, grap
 		}
 
 		switch req.Node.Type {
-		case pkggraph.TypeBuild:
+		case pkggraph.TypeLocalBuild:
 			res.UsedCache, res.Skipped, res.BuiltFiles, res.LogFile, res.Err = buildBuildNode(req.Node, req.PkgGraph, graphMutex, agent, req.CanUseCache, buildAttempts, checkAttempts, ignoredPackages)
 			if res.Err == nil {
 				setAncillaryBuildNodesStatus(req, pkggraph.StateUpToDate)
@@ -173,7 +173,7 @@ func getBuildDependencies(node *pkggraph.PkgNode, pkgGraph *pkggraph.PkgGraph, g
 	// Skip traversing any build nodes to avoid other package's buildrequires.
 	search.Traverse = func(e graph.Edge) bool {
 		toNode := e.To().(*pkggraph.PkgNode)
-		return toNode.Type != pkggraph.TypeBuild
+		return toNode.Type != pkggraph.TypeLocalBuild
 	}
 
 	search.Walk(pkgGraph, node, func(n graph.Node, d int) (stopSearch bool) {
@@ -265,7 +265,7 @@ func buildSRPMFile(agent buildagents.BuildAgent, buildAttempts int, checkAttempt
 // setAncillaryBuildNodesStatus sets the NodeState for all of the request's ancillary nodes.
 func setAncillaryBuildNodesStatus(req *BuildRequest, nodeState pkggraph.NodeState) {
 	for _, node := range req.AncillaryNodes {
-		if node.Type == pkggraph.TypeBuild {
+		if node.Type == pkggraph.TypeLocalBuild {
 			node.State = nodeState
 		}
 	}

--- a/toolkit/tools/scheduler/schedulerutils/buildworker.go
+++ b/toolkit/tools/scheduler/schedulerutils/buildworker.go
@@ -112,7 +112,7 @@ func BuildNodeWorker(channels *BuildChannels, agent buildagents.BuildAgent, grap
 			} else {
 				setAncillaryBuildNodesStatus(req, pkggraph.StateBuildError)
 			}
-		case pkggraph.TypeRun, pkggraph.TypeGoal, pkggraph.TypeRemote, pkggraph.TypePureMeta, pkggraph.TypePreBuilt:
+		case pkggraph.TypeLocalRun, pkggraph.TypeGoal, pkggraph.TypeRemoteRun, pkggraph.TypePureMeta, pkggraph.TypePreBuilt:
 			res.UsedCache = req.CanUseCache
 
 		case pkggraph.TypeUnknown:

--- a/toolkit/tools/scheduler/schedulerutils/graphbuildstate.go
+++ b/toolkit/tools/scheduler/schedulerutils/graphbuildstate.go
@@ -82,7 +82,7 @@ func (g *GraphBuildState) ActiveBuilds() map[int64]*BuildRequest {
 // ActiveSRPMs returns a list of all SRPMs, which are currently being built.
 func (g *GraphBuildState) ActiveSRPMs() (builtSRPMs []string) {
 	for _, buildRequest := range g.activeBuilds {
-		if buildRequest.Node.Type == pkggraph.TypeBuild {
+		if buildRequest.Node.Type == pkggraph.TypeLocalBuild {
 			builtSRPMs = append(builtSRPMs, buildRequest.Node.SRPMFileName())
 		}
 	}

--- a/toolkit/tools/scheduler/schedulerutils/implicitprovides.go
+++ b/toolkit/tools/scheduler/schedulerutils/implicitprovides.go
@@ -56,12 +56,12 @@ func InjectMissingImplicitProvides(res *BuildResult, pkgGraph *pkggraph.PkgGraph
 func replaceNodesWithProvides(res *BuildResult, pkgGraph *pkggraph.PkgGraph, provides *pkgjson.PackageVer, nodes []*pkggraph.PkgNode, rpmFileProviding string) (err error) {
 	var parentNode *pkggraph.PkgNode
 
-	// Find a run node that is backed by the same rpm as the one providing the implicit provide.
+	// Find a local run node that is backed by the same rpm as the one providing the implicit provide.
 	// Make this node the parent node for the new implicit provide node.
 	// - By making a run node the parent node, it will inherit the identical runtime dependencies of the already setup node.
 	for _, node := range pkgGraph.AllRunNodes() {
-		// We need to filter out any non-run nodes since cached remote nodes are considered "Run" nodes for the graph.
-		if node.Type == pkggraph.TypeRun && rpmFileProviding == node.RpmPath {
+		// We need to filter out any non-local run nodes since cached remote nodes are not acceptable parent nodes for collapsed nodes.
+		if node.Type == pkggraph.TypeLocalRun && rpmFileProviding == node.RpmPath {
 			logger.Log.Debugf("Linked implicit provide (%s) to run node (%s)", provides, node.FriendlyName())
 			parentNode = node
 			break

--- a/toolkit/tools/scheduler/schedulerutils/implicitprovides.go
+++ b/toolkit/tools/scheduler/schedulerutils/implicitprovides.go
@@ -60,7 +60,8 @@ func replaceNodesWithProvides(res *BuildResult, pkgGraph *pkggraph.PkgGraph, pro
 	// Make this node the parent node for the new implicit provide node.
 	// - By making a run node the parent node, it will inherit the identical runtime dependencies of the already setup node.
 	for _, node := range pkgGraph.AllRunNodes() {
-		if rpmFileProviding == node.RpmPath {
+		// We need to filter out any non-run nodes since cached remote nodes are considered "Run" nodes for the graph.
+		if node.Type == pkggraph.TypeRun && rpmFileProviding == node.RpmPath {
 			logger.Log.Debugf("Linked implicit provide (%s) to run node (%s)", provides, node.FriendlyName())
 			parentNode = node
 			break

--- a/toolkit/tools/scheduler/schedulerutils/preparerequest.go
+++ b/toolkit/tools/scheduler/schedulerutils/preparerequest.go
@@ -28,7 +28,7 @@ func ConvertNodesToRequests(pkgGraph *pkggraph.PkgGraph, graphMutex *sync.RWMute
 	buildNodes := make(map[string][]*pkggraph.PkgNode)
 
 	for _, node := range nodesToBuild {
-		if node.Type == pkggraph.TypeBuild {
+		if node.Type == pkggraph.TypeLocalBuild {
 			buildNodes[node.SrpmPath] = append(buildNodes[node.SrpmPath], node)
 			continue
 		}

--- a/toolkit/tools/scheduler/schedulerutils/printresults.go
+++ b/toolkit/tools/scheduler/schedulerutils/printresults.go
@@ -22,7 +22,7 @@ func PrintBuildResult(res *BuildResult) {
 		return
 	}
 
-	if res.Node.Type == pkggraph.TypeBuild {
+	if res.Node.Type == pkggraph.TypeLocalBuild {
 		if res.Skipped {
 			logger.Log.Warnf("Skipped build for '%s' per user request. RPMs expected to be present: %v", baseSRPMName, res.BuiltFiles)
 		} else if res.UsedCache {


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Filter implicit run nodes before passing to `pkgGraph.CreateCollapsedNode()`. The new delta fetcher will create build nodes that point into the cache (prebuilt nodes). When we parse these prebuilt nodes to see if we can resolve any implicit nodes we match based on `node.RpmPath`. Previously those paths would always point into `out/RPMS`, and cache nodes will never point into that directory. With the new delta nodes some build nodes will now point into the cache. These can now match against remote cache nodes, which are not a valid node to squash implicit provides into.

Filter to only real run nodes and discard cache nodes.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- In `replaceNodesWithProvides()` filter out cach nodes before passing them to `CreateCollapsedNode()`.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build