### PR TITLE
Update delta paths prior to implicit handling

### DIFF
--- a/toolkit/tools/scheduler/scheduler.go
+++ b/toolkit/tools/scheduler/scheduler.go
@@ -351,9 +351,21 @@ func buildAllNodes(stopOnFailure, canUseCache bool, packagesToRebuild []*pkgjson
 
 		if !stopBuilding {
 			if res.Err == nil {
+				if res.Node.Type == pkggraph.TypeLocalBuild && res.WasDelta {
+					logger.Log.Tracef("This is a delta result, update the graph with the new delta files for '%v'.", res.Node)
+					// We will need to update the graph with paths to any delta files that were actually rebuilt.
+					err = setAssociatedDeltaPaths(res, pkgGraph, graphMutex)
+					if err != nil {
+						// Failures to manipulate the graph are fatal. The ancillary delta nodes may be in an invalid state
+						// and we won't be able to track which RPMs were built or used delta files.
+						err = fmt.Errorf("error setting delta paths for ancillary nodes:\n%w", err)
+						stopBuilding = true
+					}
+				}
+
 				// If the graph has already been optimized and is now solvable without any additional information
 				// then skip processing any new implicit provides.
-				if !isGraphOptimized {
+				if !stopBuilding && !isGraphOptimized {
 					var (
 						didOptimize bool
 						newGraph    *pkggraph.PkgGraph
@@ -374,18 +386,6 @@ func buildAllNodes(stopOnFailure, canUseCache bool, packagesToRebuild []*pkgjson
 					}
 				}
 
-				if res.Node.Type == pkggraph.TypeLocalBuild && res.WasDelta {
-					logger.Log.Tracef("This is a delta result, update the graph with the new delta files for '%v'.", res.Node)
-					// We will need to update the graph with paths to any delta files that were actually rebuilt.
-					err = setAssociatedDeltaPaths(res, pkgGraph, graphMutex)
-					if err != nil {
-						// Failures to manipulate the graph are fatal. The ancillary delta nodes may be in an invalid state
-						// and we won't be able to track which RPMs were built or used delta files.
-						err = fmt.Errorf("error setting delta paths for ancillary nodes:\n%w", err)
-						stopBuilding = true
-					}
-				}
-
 				nodesToBuild = schedulerutils.FindUnblockedNodesFromResult(res, pkgGraph, graphMutex, buildState)
 			} else if stopOnFailure {
 				stopBuilding = true
@@ -399,6 +399,8 @@ func buildAllNodes(stopOnFailure, canUseCache bool, packagesToRebuild []*pkgjson
 			// If the build has failed, stop all outstanding builds.
 			stopBuild(channels, buildState)
 			err = fmt.Errorf("fatal error building package graph:\n%w", err)
+			// Save out the current graph state for debugging
+			builtGraph = pkgGraph
 			return
 		}
 
@@ -490,9 +492,11 @@ func setAssociatedDeltaPaths(res *schedulerutils.BuildResult, pkgGraph *pkggraph
 			// We only care about nodes that are deltas
 			if node.State == pkggraph.StateDelta {
 				// Update the node to point at the actual RPM path from our map of built files
-				logger.Log.Tracef("Updating delta run node '%s' path from '%s' to '%s'", node, node.RpmPath, builtFile)
+				logger.Log.Debugf("Updating delta run node '%s' path from '%s' to '%s'", node, node.RpmPath, builtFile)
 				node.RpmPath = builtFile
-			} else if node.RpmPath != builtFile {
+			} else if !node.Implicit && node.RpmPath != builtFile {
+				// Implicit nodes will point to the cached RPM path, but we don't care about them and will update their
+				// paths to the actual RPM path in a later step so ignore them here.
 				// Sanity check that any non-delta node has an exact match to the real RPM path
 				err = fmt.Errorf("non-delta run node '%s' has unexpected path '%s' (expected non-delta path of '%s')", node, node.RpmPath, builtFile)
 				return


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?

Currently we fail to link `font(fontawesome)` to its associated delta node. The issue is that a delta node will point into the cache, but a newly build node will instead point into `out/RPMS`. The halding for linking an implicit node expects an exact match for the rpm path. Fix the delta path for nodes first, before trying to link implicit nodes. Since we won't have fixed the implict nodes yet, we will also need to allow the delta path update code to skip over implicit nodes (since they will be unexpectedly pointing into the cache rather than `out/RPMS`).

This command should now work: `sudo make build-packages CONFIG_FILE="" PACKAGE_REBUILD_LIST="fontawesome-fonts" PACKAGE_BUILD_LIST="python3-sphinx_rtd_theme" QUICK_REBUILD=y`

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Reorder delta node updates to be before implicit node updates when processing a build result
- Allow delta updates to ignore implicit nodes that will point into the cache

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**


###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local builds
