### PR TITLE
kernel-hci: Add net/mlx5 patch (27) switching warn message to debug

### DIFF
--- a/SPECS-SIGNED/kernel-hci-signed/kernel-hci-signed.spec
+++ b/SPECS-SIGNED/kernel-hci-signed/kernel-hci-signed.spec
@@ -5,7 +5,7 @@
 Summary:        Signed Linux Kernel for HCI
 Name:           kernel-hci-signed-%{buildarch}
 Version:        5.15.122.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -149,6 +149,9 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %exclude /module_info.ld
 
 %changelog
+* Fri Jul 28 2023 Vince Perri <viperri@microsoft.com> - 5.15.122.1-2
+- Bump release number to match kernel release.
+
 * Wed Jul 26 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 5.15.122.1-1
 - Auto-upgrade to 5.15.122.1
 

--- a/SPECS/kernel-hci/0028-net-mlx5-Bridge-use-debug-not-warn-if-entry-not-found.patch
+++ b/SPECS/kernel-hci/0028-net-mlx5-Bridge-use-debug-not-warn-if-entry-not-found.patch
@@ -1,0 +1,42 @@
+From: Roi Dayan <roid@xxxxxxxxxx>
+
+There is no need for the warn if entry already removed.
+Use debug print like in the update flow.
+Also update the messages so user can identify if the it's
+from the update flow or remove flow.
+
+Signed-off-by: Roi Dayan <roid@xxxxxxxxxx>
+Reviewed-by: Vlad Buslov <vladbu@xxxxxxxxxx>
+Signed-off-by: Saeed Mahameed <saeedm@xxxxxxxxxx>
+---
+ drivers/net/ethernet/mellanox/mlx5/core/esw/bridge.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/net/ethernet/mellanox/mlx5/core/esw/bridge.c b/drivers/net/ethernet/mellanox/mlx5/core/esw/bridge.c
+index 4fbff7bcc155..b176648d1343 100644
+--- a/drivers/net/ethernet/mellanox/mlx5/core/esw/bridge.c
++++ b/drivers/net/ethernet/mellanox/mlx5/core/esw/bridge.c
+@@ -1722,7 +1722,7 @@ void mlx5_esw_bridge_fdb_update_used(struct net_device *dev, u16 vport_num, u16
+ 	entry = mlx5_esw_bridge_fdb_lookup(bridge, fdb_info->addr, fdb_info->vid);
+ 	if (!entry) {
+ 		esw_debug(br_offloads->esw->dev,
+-			  "FDB entry with specified key not found (MAC=%pM,vid=%u,vport=%u)\n",
++			  "FDB update entry with specified key not found (MAC=%pM,vid=%u,vport=%u)\n",
+ 			  fdb_info->addr, fdb_info->vid, vport_num);
+ 		return;
+ 	}
+@@ -1775,9 +1775,9 @@ void mlx5_esw_bridge_fdb_remove(struct net_device *dev, u16 vport_num, u16 esw_o
+ 	bridge = port->bridge;
+ 	entry = mlx5_esw_bridge_fdb_lookup(bridge, fdb_info->addr, fdb_info->vid);
+ 	if (!entry) {
+-		esw_warn(esw->dev,
+-			 "FDB entry with specified key not found (MAC=%pM,vid=%u,vport=%u)\n",
+-			 fdb_info->addr, fdb_info->vid, vport_num);
++		esw_debug(esw->dev,
++			  "FDB remove entry with specified key not found (MAC=%pM,vid=%u,vport=%u)\n",
++			  fdb_info->addr, fdb_info->vid, vport_num);
+ 		return;
+ 	}
+ 
+-- 
+2.38.1

--- a/SPECS/kernel-hci/kernel-hci.spec
+++ b/SPECS/kernel-hci/kernel-hci.spec
@@ -432,7 +432,7 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 
 %changelog
 * Fri Jul 28 2023 Vince Perri <viperri@microsoft.com> - 5.15.122.1-2
-- Add net/mlx5 patches (patch 28) switching warn message to debug
+- Add net/mlx5 patch (27) switching warn message to debug
 
 * Wed Jul 26 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 5.15.122.1-1
 - Auto-upgrade to 5.15.122.1

--- a/SPECS/kernel-hci/kernel-hci.spec
+++ b/SPECS/kernel-hci/kernel-hci.spec
@@ -18,7 +18,7 @@
 Summary:        Linux Kernel for HCI
 Name:           kernel-hci
 Version:        5.15.122.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -431,6 +431,9 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %{_sysconfdir}/bash_completion.d/bpftool
 
 %changelog
+* Fri Jul 28 2023 Vince Perri <viperri@microsoft.com> - 5.15.122.1-2
+- Add net/mlx5 patches (patch 28) switching warn message to debug
+
 * Wed Jul 26 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 5.15.122.1-1
 - Auto-upgrade to 5.15.122.1
 

--- a/SPECS/kernel-hci/kernel-hci.spec
+++ b/SPECS/kernel-hci/kernel-hci.spec
@@ -54,6 +54,7 @@ Patch23:        0024-net-mlx5-Bridge-extract-VLAN-push-pop-actions-creati.patch
 Patch24:        0025-net-mlx5-Bridge-implement-infrastructure-for-VLAN-pr.patch
 Patch25:        0026-net-mlx5-Bridge-implement-QinQ-support.patch
 Patch26:        0027-mstflint-This-driver-enables-under-the-secure-boot.patch
+Patch27:        0028-net-mlx5-Bridge-use-debug-not-warn-if-entry-not-found.patch
 BuildRequires:  audit-devel
 BuildRequires:  bash
 BuildRequires:  bc
@@ -196,6 +197,7 @@ manipulation of eBPF programs and maps.
 %patch24 -p1
 %patch25 -p1
 %patch26 -p1
+%patch27 -p1
 
 make mrproper
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Prevents a debug message in net/mlx5 driver from flooding the log by switching it to warn.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add 0028-net-mlx5-Bridge-use-debug-not-warn-if-entry-not-found.patch to kernel-hci

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Official pipeline build id: 398165
- HCI pipeline build id: 399404