### PR TITLE
Add kernel conflicts and produce specialized versions of bpftool and python3-perf

### DIFF
--- a/SPECS-EXTENDED/kernel-rt/kernel-rt.spec
+++ b/SPECS-EXTENDED/kernel-rt/kernel-rt.spec
@@ -3,6 +3,7 @@
 %global rt_version rt48
 %define uname_r %{version}-%{rt_version}-%{release}
 %define version_upstream %(echo %{version} | rev | cut -d'.' -f2- | rev)
+%define short_name rt
 
 # find_debuginfo.sh arguments are set by default in rpm's macros.
 # The default arguments regenerate the build-id for vmlinux in the 
@@ -136,13 +137,13 @@ Requires:       audit
 %description tools
 This package contains the 'perf' performance analysis tools for Linux kernel.
 
-%package -n     python3-perf-rt
+%package        python3-perf
 Summary:        Python 3 extension for perf tools
 Requires:       python3
 Requires:       %{name} = %{version}-%{release}
-Provides:       python3-perf
+Provides:       python3-perf-%{short_name}
 
-%description -n python3-perf-rt
+%description    python3-perf
 This package contains the Python 3 extension for the 'perf' performance analysis tools for Linux kernel.
 
 %package dtb
@@ -152,12 +153,12 @@ Group:          System Environment/Kernel
 %description dtb
 This package contains common device tree blobs (dtb)
 
-%package -n     bpftool-rt
+%package        bpftool
 Summary:        Inspection and simple manipulation of eBPF programs and maps
 Requires:       %{name} = %{version}-%{release}
-Provides:       bpftool
+Provides:       bpftool-%{short_name}
 
-%description -n  bpftool-rt
+%description    bpftool
 This package contains the bpftool, which allows inspection and simple
 manipulation of eBPF programs and maps.
 
@@ -390,10 +391,10 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %{_libdir}/perf/include/bpf/*
 %{_includedir}/perf/perf_dlfilter.h
 
-%files -n python3-perf-rt
+%files python3-perf
 %{python3_sitearch}/*
 
-%files -n bpftool-rt
+%files bpftool
 %{_sbindir}/bpftool
 %{_sysconfdir}/bash_completion.d/bpftool
 

--- a/SPECS-EXTENDED/kernel-rt/kernel-rt.spec
+++ b/SPECS-EXTENDED/kernel-rt/kernel-rt.spec
@@ -23,7 +23,7 @@
 Summary:        Realtime Linux Kernel
 Name:           kernel-rt
 Version:        5.15.55.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -70,6 +70,11 @@ ExclusiveArch:  x86_64
 %ifarch x86_64
 BuildRequires:  pciutils-devel
 %endif
+Conflicts:      kernel
+Conflicts:      kernel-azure
+Conflicts:      kernel-hci
+Conflicts:      kernel-mshv
+Conflicts:      kernel-uvm
 # When updating the config files it is important to sanitize them.
 # Steps for updating a config file:
 #  1. Extract the linux sources into a folder
@@ -131,11 +136,13 @@ Requires:       audit
 %description tools
 This package contains the 'perf' performance analysis tools for Linux kernel.
 
-%package -n     python3-perf
+%package -n     python3-perf-rt
 Summary:        Python 3 extension for perf tools
 Requires:       python3
+Requires:       %{name} = %{version}-%{release}
+Provides:       python3-perf
 
-%description -n python3-perf
+%description -n python3-perf-rt
 This package contains the Python 3 extension for the 'perf' performance analysis tools for Linux kernel.
 
 %package dtb
@@ -145,10 +152,12 @@ Group:          System Environment/Kernel
 %description dtb
 This package contains common device tree blobs (dtb)
 
-%package -n     bpftool
+%package -n     bpftool-rt
 Summary:        Inspection and simple manipulation of eBPF programs and maps
+Requires:       %{name} = %{version}-%{release}
+Provides:       bpftool
 
-%description -n bpftool
+%description -n  bpftool-rt
 This package contains the bpftool, which allows inspection and simple
 manipulation of eBPF programs and maps.
 
@@ -381,14 +390,19 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %{_libdir}/perf/include/bpf/*
 %{_includedir}/perf/perf_dlfilter.h
 
-%files -n python3-perf
+%files -n python3-perf-rt
 %{python3_sitearch}/*
 
-%files -n bpftool
+%files -n bpftool-rt
 %{_sbindir}/bpftool
 %{_sysconfdir}/bash_completion.d/bpftool
 
 %changelog
+* Mon Jul 31 2023 Rachel Menge <rachelmenge@microsoft.com> - 5.15.55.1-4
+- Rename bpftool and python3-perf to be kernel specific
+- Add new requires for bpftool and python3-perf for specfic kernel
+- Add kernel conflicts
+
 * Wed Apr 19 2023 Rachel Menge <rachelmenge@microsoft.com> - 5.15.55.1-3
 - Disable rpm's debuginfo defaults which regenerate build-ids
 

--- a/SPECS-EXTENDED/kernel-rt/kernel-rt.spec
+++ b/SPECS-EXTENDED/kernel-rt/kernel-rt.spec
@@ -71,11 +71,12 @@ ExclusiveArch:  x86_64
 %ifarch x86_64
 BuildRequires:  pciutils-devel
 %endif
+# Conflicts is not required for kernel-uvm or kernel-mshv
+# because they have specialized ".mshv" versions of the kernel
+# and do not produce generic subpackages python3-perf or bpftool
 Conflicts:      kernel
 Conflicts:      kernel-azure
 Conflicts:      kernel-hci
-Conflicts:      kernel-mshv
-Conflicts:      kernel-uvm
 # When updating the config files it is important to sanitize them.
 # Steps for updating a config file:
 #  1. Extract the linux sources into a folder

--- a/SPECS-SIGNED/kernel-azure-signed/kernel-azure-signed.spec
+++ b/SPECS-SIGNED/kernel-azure-signed/kernel-azure-signed.spec
@@ -10,7 +10,7 @@
 Summary:        Signed Linux Kernel for Azure
 Name:           kernel-azure-signed-%{buildarch}
 Version:        5.15.122.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -153,6 +153,9 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %exclude /module_info.ld
 
 %changelog
+* Mon Jul 31 2023 Rachel Menge <rachelmenge@microsoft.com> - 5.15.122.1-2
+- Bump release to match kernel-azure
+
 * Wed Jul 26 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 5.15.122.1-1
 - Auto-upgrade to 5.15.122.1
 

--- a/SPECS-SIGNED/kernel-hci-signed/kernel-hci-signed.spec
+++ b/SPECS-SIGNED/kernel-hci-signed/kernel-hci-signed.spec
@@ -5,7 +5,7 @@
 Summary:        Signed Linux Kernel for HCI
 Name:           kernel-hci-signed-%{buildarch}
 Version:        5.15.122.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -149,6 +149,9 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %exclude /module_info.ld
 
 %changelog
+* Mon Jul 31 2023 Rachel Menge <rachelmenge@microsoft.com> - 5.15.122.1-3
+- Bump release to match kernel-hci
+
 * Fri Jul 28 2023 Vince Perri <viperri@microsoft.com> - 5.15.122.1-2
 - Bump release number to match kernel release.
 

--- a/SPECS-SIGNED/kernel-signed/kernel-signed.spec
+++ b/SPECS-SIGNED/kernel-signed/kernel-signed.spec
@@ -10,7 +10,7 @@
 Summary:        Signed Linux Kernel for %{buildarch} systems
 Name:           kernel-signed-%{buildarch}
 Version:        5.15.122.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -153,6 +153,9 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %exclude /module_info.ld
 
 %changelog
+* Mon Jul 31 2023 Rachel Menge <rachelmenge@microsoft.com> - 5.15.122.1-2
+- Bump release to match kernel
+
 * Wed Jul 26 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 5.15.122.1-1
 - Auto-upgrade to 5.15.122.1
 

--- a/SPECS/kernel-azure/kernel-azure.spec
+++ b/SPECS/kernel-azure/kernel-azure.spec
@@ -64,11 +64,12 @@ Requires:       filesystem
 Requires:       kmod
 Requires(post): coreutils
 Requires(postun): coreutils
+# Conflicts is not required for kernel-uvm or kernel-mshv
+# because they have specialized ".mshv" versions of the kernel
+# and do not produce generic subpackages python3-perf or bpftool
 Conflicts:      kernel
 Conflicts:      kernel-hci
 Conflicts:      kernel-rt
-Conflicts:      kernel-mshv
-Conflicts:      kernel-uvm
 # When updating the config files it is important to sanitize them.
 # Steps for updating a config file:
 #  1. Extract the linux sources into a folder

--- a/SPECS/kernel-azure/kernel-azure.spec
+++ b/SPECS/kernel-azure/kernel-azure.spec
@@ -1,6 +1,7 @@
 %global security_hardening none
 %global sha512hmac bash %{_sourcedir}/sha512hmac-openssl.sh
 %define uname_r %{version}-%{release}
+%define short_name azure
 
 # find_debuginfo.sh arguments are set by default in rpm's macros.
 # The default arguments regenerate the build-id for vmlinux in the 
@@ -137,13 +138,13 @@ Requires:       audit
 %description tools
 This package contains the 'perf' performance analysis tools for Linux kernel.
 
-%package -n     python3-perf-azure
+%package        python3-perf
 Summary:        Python 3 extension for perf tools
 Requires:       python3
 Requires:       %{name} = %{version}-%{release}
-Provides:       python3-perf
+Provides:       python3-perf-%{short_name}
 
-%description -n python3-perf-azure
+%description    python3-perf
 This package contains the Python 3 extension for the 'perf' performance analysis tools for Linux kernel.
 
 %package dtb
@@ -153,12 +154,12 @@ Group:          System Environment/Kernel
 %description dtb
 This package contains common device tree blobs (dtb)
 
-%package -n     bpftool-azure
+%package        bpftool
 Summary:        Inspection and simple manipulation of eBPF programs and maps
 Requires:       %{name} = %{version}-%{release}
-Provides:       bpftool
+Provides:       bpftool-%{short_name}
 
-%description -n bpftool-azure
+%description    bpftool
 This package contains the bpftool, which allows inspection and simple
 manipulation of eBPF programs and maps.
 
@@ -412,7 +413,7 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %{_libdir}/perf/include/bpf/*
 %{_includedir}/perf/perf_dlfilter.h
 
-%files -n python3-perf-azure
+%files python3-perf
 %{python3_sitearch}/*
 
 %ifarch aarch64
@@ -420,7 +421,7 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 /boot/dtb/fsl-imx8mq-evk.dtb
 %endif
 
-%files -n bpftool-azure
+%files bpftool
 %{_sbindir}/bpftool
 %{_sysconfdir}/bash_completion.d/bpftool
 

--- a/SPECS/kernel-azure/kernel-azure.spec
+++ b/SPECS/kernel-azure/kernel-azure.spec
@@ -28,7 +28,7 @@
 Summary:        Linux Kernel
 Name:           kernel-azure
 Version:        5.15.122.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -63,6 +63,11 @@ Requires:       filesystem
 Requires:       kmod
 Requires(post): coreutils
 Requires(postun): coreutils
+Conflicts:      kernel
+Conflicts:      kernel-hci
+Conflicts:      kernel-rt
+Conflicts:      kernel-mshv
+Conflicts:      kernel-uvm
 # When updating the config files it is important to sanitize them.
 # Steps for updating a config file:
 #  1. Extract the linux sources into a folder
@@ -132,11 +137,13 @@ Requires:       audit
 %description tools
 This package contains the 'perf' performance analysis tools for Linux kernel.
 
-%package -n     python3-perf
+%package -n     python3-perf-azure
 Summary:        Python 3 extension for perf tools
 Requires:       python3
+Requires:       %{name} = %{version}-%{release}
+Provides:       python3-perf
 
-%description -n python3-perf
+%description -n python3-perf-azure
 This package contains the Python 3 extension for the 'perf' performance analysis tools for Linux kernel.
 
 %package dtb
@@ -146,10 +153,12 @@ Group:          System Environment/Kernel
 %description dtb
 This package contains common device tree blobs (dtb)
 
-%package -n     bpftool
+%package -n     bpftool-azure
 Summary:        Inspection and simple manipulation of eBPF programs and maps
+Requires:       %{name} = %{version}-%{release}
+Provides:       bpftool
 
-%description -n bpftool
+%description -n bpftool-azure
 This package contains the bpftool, which allows inspection and simple
 manipulation of eBPF programs and maps.
 
@@ -403,7 +412,7 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %{_libdir}/perf/include/bpf/*
 %{_includedir}/perf/perf_dlfilter.h
 
-%files -n python3-perf
+%files -n python3-perf-azure
 %{python3_sitearch}/*
 
 %ifarch aarch64
@@ -411,11 +420,16 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 /boot/dtb/fsl-imx8mq-evk.dtb
 %endif
 
-%files -n bpftool
+%files -n bpftool-azure
 %{_sbindir}/bpftool
 %{_sysconfdir}/bash_completion.d/bpftool
 
 %changelog
+* Mon Jul 31 2023 Rachel Menge <rachelmenge@microsoft.com> - 5.15.122.1-2
+- Rename bpftool and python3-perf to be kernel specific
+- Add new requires for bpftool and python3-perf for specfic kernel
+- Add kernel conflicts
+
 * Wed Jul 26 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 5.15.122.1-1
 - Auto-upgrade to 5.15.122.1
 

--- a/SPECS/kernel-hci/kernel-hci.spec
+++ b/SPECS/kernel-hci/kernel-hci.spec
@@ -78,11 +78,12 @@ Requires:       filesystem
 Requires:       kmod
 Requires(post): coreutils
 Requires(postun): coreutils
+# Conflicts is not required for kernel-uvm or kernel-mshv
+# because they have specialized ".mshv" versions of the kernel
+# and do not produce generic subpackages python3-perf or bpftool
 Conflicts:      kernel
 Conflicts:      kernel-azure
-Conflicts:      kernel-mshv
 Conflicts:      kernel-rt
-Conflicts:      kernel-uvm
 ExclusiveArch:  x86_64
 # When updating the config files it is important to sanitize them.
 # Steps for updating a config file:

--- a/SPECS/kernel-hci/kernel-hci.spec
+++ b/SPECS/kernel-hci/kernel-hci.spec
@@ -1,6 +1,7 @@
 %global security_hardening none
 %global sha512hmac bash %{_sourcedir}/sha512hmac-openssl.sh
 %define uname_r %{version}-%{release}
+%define short_name hci
 
 # find_debuginfo.sh arguments are set by default in rpm's macros.
 # The default arguments regenerate the build-id for vmlinux in the
@@ -152,13 +153,13 @@ Requires:       audit
 %description tools
 This package contains the 'perf' performance analysis tools for Linux kernel.
 
-%package -n     python3-perf-hci
+%package        python3-perf
 Summary:        Python 3 extension for perf tools
 Requires:       python3
 Requires:       %{name} = %{version}-%{release}
-Provides:       python3-perf
+Provides:       python3-perf-%{short_name}
 
-%description -n python3-perf-hci
+%description    python3-perf
 This package contains the Python 3 extension for the 'perf' performance analysis tools for Linux kernel.
 
 %package dtb
@@ -168,12 +169,12 @@ Group:          System Environment/Kernel
 %description dtb
 This package contains common device tree blobs (dtb)
 
-%package -n     bpftool-hci
+%package        bpftool
 Summary:        Inspection and simple manipulation of eBPF programs and maps
 Requires:       %{name} = %{version}-%{release}
-Provides:       bpftool
+Provides:       bpftool-%{short_name}
 
-%description -n bpftool-hci
+%description    bpftool
 This package contains the bpftool, which allows inspection and simple
 manipulation of eBPF programs and maps.
 
@@ -432,10 +433,10 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %{_libdir}/perf/include/bpf/*
 %{_includedir}/perf/perf_dlfilter.h
 
-%files -n python3-perf-hci
+%files python3-perf
 %{python3_sitearch}/*
 
-%files -n bpftool-hci
+%files bpftool
 %{_sbindir}/bpftool
 %{_sysconfdir}/bash_completion.d/bpftool
 

--- a/SPECS/kernel-hci/kernel-hci.spec
+++ b/SPECS/kernel-hci/kernel-hci.spec
@@ -18,7 +18,7 @@
 Summary:        Linux Kernel for HCI
 Name:           kernel-hci
 Version:        5.15.122.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -77,6 +77,11 @@ Requires:       filesystem
 Requires:       kmod
 Requires(post): coreutils
 Requires(postun): coreutils
+Conflicts:      kernel
+Conflicts:      kernel-azure
+Conflicts:      kernel-mshv
+Conflicts:      kernel-rt
+Conflicts:      kernel-uvm
 ExclusiveArch:  x86_64
 # When updating the config files it is important to sanitize them.
 # Steps for updating a config file:
@@ -147,11 +152,13 @@ Requires:       audit
 %description tools
 This package contains the 'perf' performance analysis tools for Linux kernel.
 
-%package -n     python3-perf
+%package -n     python3-perf-hci
 Summary:        Python 3 extension for perf tools
 Requires:       python3
+Requires:       %{name} = %{version}-%{release}
+Provides:       python3-perf
 
-%description -n python3-perf
+%description -n python3-perf-hci
 This package contains the Python 3 extension for the 'perf' performance analysis tools for Linux kernel.
 
 %package dtb
@@ -161,10 +168,12 @@ Group:          System Environment/Kernel
 %description dtb
 This package contains common device tree blobs (dtb)
 
-%package -n     bpftool
+%package -n     bpftool-hci
 Summary:        Inspection and simple manipulation of eBPF programs and maps
+Requires:       %{name} = %{version}-%{release}
+Provides:       bpftool
 
-%description -n bpftool
+%description -n bpftool-hci
 This package contains the bpftool, which allows inspection and simple
 manipulation of eBPF programs and maps.
 
@@ -423,14 +432,19 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %{_libdir}/perf/include/bpf/*
 %{_includedir}/perf/perf_dlfilter.h
 
-%files -n python3-perf
+%files -n python3-perf-hci
 %{python3_sitearch}/*
 
-%files -n bpftool
+%files -n bpftool-hci
 %{_sbindir}/bpftool
 %{_sysconfdir}/bash_completion.d/bpftool
 
 %changelog
+* Mon Jul 31 2023 Rachel Menge <rachelmenge@microsoft.com> - 5.15.122.1-3
+- Rename bpftool and python3-perf to be kernel specific
+- Add new requires for bpftool and python3-perf for specfic kernel
+- Add kernel conflicts
+
 * Fri Jul 28 2023 Vince Perri <viperri@microsoft.com> - 5.15.122.1-2
 - Add net/mlx5 patch (27) switching warn message to debug
 

--- a/SPECS/kernel-headers/kernel-headers.spec
+++ b/SPECS/kernel-headers/kernel-headers.spec
@@ -1,7 +1,7 @@
 Summary:        Linux API header files
 Name:           kernel-headers
 Version:        5.15.122.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -36,6 +36,9 @@ cp -rv usr/include/* /%{buildroot}%{_includedir}
 %{_includedir}/*
 
 %changelog
+* Mon Jul 31 2023 Rachel Menge <rachelmenge@microsoft.com> - 5.15.122.1-2
+- Bump release to match kernel
+
 * Wed Jul 26 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 5.15.122.1-1
 - Auto-upgrade to 5.15.122.1
 

--- a/SPECS/kernel/kernel.spec
+++ b/SPECS/kernel/kernel.spec
@@ -68,11 +68,12 @@ Requires:       filesystem
 Requires:       kmod
 Requires(post): coreutils
 Requires(postun): coreutils
+# Conflicts is not required for kernel-uvm or kernel-mshv
+# because they have specialized ".mshv" versions of the kernel
+# and do not produce generic subpackages python3-perf or bpftool
 Conflicts:      kernel-azure
 Conflicts:      kernel-hci
-Conflicts:      kernel-mshv
 Conflicts:      kernel-rt
-Conflicts:      kernel-uvm
 # When updating the config files it is important to sanitize them.
 # Steps for updating a config file:
 #  1. Extract the linux sources into a folder

--- a/SPECS/kernel/kernel.spec
+++ b/SPECS/kernel/kernel.spec
@@ -28,7 +28,7 @@
 Summary:        Linux Kernel
 Name:           kernel
 Version:        5.15.122.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -68,6 +68,11 @@ Requires:       filesystem
 Requires:       kmod
 Requires(post): coreutils
 Requires(postun): coreutils
+Conflicts:      kernel-azure
+Conflicts:      kernel-hci
+Conflicts:      kernel-mshv
+Conflicts:      kernel-rt
+Conflicts:      kernel-uvm
 # When updating the config files it is important to sanitize them.
 # Steps for updating a config file:
 #  1. Extract the linux sources into a folder
@@ -140,6 +145,8 @@ This package contains the 'perf' performance analysis tools for Linux kernel.
 %package -n     python3-perf
 Summary:        Python 3 extension for perf tools
 Requires:       python3
+Requires:       %{name} = %{version}-%{release}
+Provides:       python3-perf
 
 %description -n python3-perf
 This package contains the Python 3 extension for the 'perf' performance analysis tools for Linux kernel.
@@ -153,6 +160,8 @@ This package contains common device tree blobs (dtb)
 
 %package -n     bpftool
 Summary:        Inspection and simple manipulation of eBPF programs and maps
+Requires:       %{name} = %{version}-%{release}
+Provides:       bpftool
 
 %description -n bpftool
 This package contains the bpftool, which allows inspection and simple
@@ -422,6 +431,10 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %{_sysconfdir}/bash_completion.d/bpftool
 
 %changelog
+* Mon Jul 31 2023 Rachel Menge <rachelmenge@microsoft.com> - 5.15.122.1-2
+- Add new requires for bpftool and python3-perf for specfic kernel
+- Add kernel conflicts
+
 * Wed Jul 26 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 5.15.122.1-1
 - Auto-upgrade to 5.15.122.1
 

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -1,5 +1,5 @@
 filesystem-1.1-15.cm2.aarch64.rpm
-kernel-headers-5.15.122.1-1.cm2.noarch.rpm
+kernel-headers-5.15.122.1-2.cm2.noarch.rpm
 glibc-2.35-4.cm2.aarch64.rpm
 glibc-devel-2.35-4.cm2.aarch64.rpm
 glibc-i18n-2.35-4.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -1,5 +1,5 @@
 filesystem-1.1-15.cm2.x86_64.rpm
-kernel-headers-5.15.122.1-1.cm2.noarch.rpm
+kernel-headers-5.15.122.1-2.cm2.noarch.rpm
 glibc-2.35-4.cm2.x86_64.rpm
 glibc-devel-2.35-4.cm2.x86_64.rpm
 glibc-i18n-2.35-4.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -136,7 +136,7 @@ intltool-0.51.0-7.cm2.noarch.rpm
 itstool-2.0.6-4.cm2.noarch.rpm
 kbd-2.2.0-1.cm2.aarch64.rpm
 kbd-debuginfo-2.2.0-1.cm2.aarch64.rpm
-kernel-headers-5.15.122.1-1.cm2.noarch.rpm
+kernel-headers-5.15.122.1-2.cm2.noarch.rpm
 kmod-29-1.cm2.aarch64.rpm
 kmod-debuginfo-29-1.cm2.aarch64.rpm
 kmod-devel-29-1.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -136,7 +136,7 @@ intltool-0.51.0-7.cm2.noarch.rpm
 itstool-2.0.6-4.cm2.noarch.rpm
 kbd-2.2.0-1.cm2.x86_64.rpm
 kbd-debuginfo-2.2.0-1.cm2.x86_64.rpm
-kernel-headers-5.15.122.1-1.cm2.noarch.rpm
+kernel-headers-5.15.122.1-2.cm2.noarch.rpm
 kmod-29-1.cm2.x86_64.rpm
 kmod-debuginfo-29-1.cm2.x86_64.rpm
 kmod-devel-29-1.cm2.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
rework of #5131, #5305, #5459

There was a [bug ](https://microsoft.visualstudio.com/OS/_workitems/edit/43814917/?triage=true)where certain specialized kernels (`kernel-azure`, `kernel-hci`) would create subpackages of the same name (`bpftool`, `python3-perf`) as the generic kernel. This will cause packages to be published and overwritten. To prevent this, create specialized packages. The packages can be accessed using the following names

|kernel | bpftool | python3-perf|
|-----|----|-------|
|kernel| bpftool | python3-perf |
|kernel-azure| kernel-azure-bpftool, bpftool-azure| kernel-azure-python3-perf, python3-perf-azure |
|kernel-hci| kernel-hci-bpftool, bpftool-hci | kernel-hci-python3-perf, python3-perf-hci|
|kernel-rt| kernel-rt-bpftool, bpftool-rt| kernel-rt-python3-perf, python3-perf-rt|

This will affect building and installing of kernels. The following cases for example for kernel-azure and bpftool should behave in the following way in regards to how the bpftool package is named. 

This change would cause the following tasks to behave as follows when certain package names are used
|task| kernel used | "bpftool" | "kernel-azure-bpftool"| "bpftool-azure" |
|-----|------|----|-------|-----|
|image build w/ package| kernel| Success| Error|Error| 
|tdnf install| kernel| success|Error|Error|
|image build w/ package| kernel-azure| Error| Success|Success| 
|tdnf install| kernel-azure| Error| Success|Success| 

On systems which already have "kernel" installed and "bpftool"
|task| result| steps|
|-----|----|-------|
|upgrade bpftool| Success | n/a|
|upgrade kernel| Success| n/a|
|install kernel-azure | Error| conflicts requires uninstalling kernel|

On systems which already have "kernel-azure" installed and "bpftool"
|task| result | steps|
|-----|----|-------|
|upgrade bpftool| Error| requires using bpftool-azure|
|upgrade kernel-azure | Success| n/a - old bpftool does not require kernel-azure|
|install kernel | Error| conflicts requires uninstalling kernel-azure|

Notes:
-  these packages along with the tools subpackage may not be dependent on the configs and can therefore be produced from only the kernel.spec. This is an investigation that is happening [here](https://microsoft.visualstudio.com/OS/_workitems/edit/44120370). This would reduce overhead significantly. Until then, lean on the safer side.

- subpackages should be installed using `sudo tdnf install -y kernel-tools-$(uname -r)` (as stated in https://microsoft.visualstudio.com/OS/_workitems/edit/44344054) which should account for version issues

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Rename bpftool and python3-perf to be kernel specific
- Add new requires for bpftool and python3-perf for specfic kernel
- Add kernel conflicts

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://microsoft.visualstudio.com/OS/_workitems/edit/43814917/?triage=true

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
Built packages and image locally.
Validated above use cases in hyperv vm
Pipeline build id: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=399534&view=results (both ARM and AMD images succeeded)
After rebase: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=400737&view=results