### PR TITLE
Disabled extended ACLs for the `build` directory.

### DIFF
--- a/toolkit/scripts/srpm_pack.mk
+++ b/toolkit/scripts/srpm_pack.mk
@@ -39,6 +39,10 @@ $(call create_folder,$(BUILD_DIR))
 $(call create_folder,$(BUILD_SRPMS_DIR))
 $(call create_folder,$(SRPM_BUILD_CHROOT_DIR))
 
+# Host's extended ACLs influence the default permissions of the
+# files inside the built RPMs. Disabling them for the build directory.
+$(call shell_real_build_only, setfacl -bn $(BUILD_DIR))
+
 # General targets
 .PHONY: toolchain-input-srpms input-srpms clean-input-srpms
 input-srpms: $(BUILD_SRPMS_DIR)

--- a/toolkit/scripts/srpm_pack.mk
+++ b/toolkit/scripts/srpm_pack.mk
@@ -39,10 +39,6 @@ $(call create_folder,$(BUILD_DIR))
 $(call create_folder,$(BUILD_SRPMS_DIR))
 $(call create_folder,$(SRPM_BUILD_CHROOT_DIR))
 
-# Host's extended ACLs influence the default permissions of the
-# files inside the built RPMs. Disabling them for the build directory.
-$(call shell_real_build_only, setfacl -bn $(BUILD_DIR))
-
 # General targets
 .PHONY: toolchain-input-srpms input-srpms clean-input-srpms
 input-srpms: $(BUILD_SRPMS_DIR)

--- a/toolkit/scripts/tools.mk
+++ b/toolkit/scripts/tools.mk
@@ -11,6 +11,10 @@ $(call create_folder,$(CCACHE_DIR))
 $(call create_folder,$(TOOL_BINS_DIR))
 $(call create_folder,$(BUILD_DIR)/tools)
 
+# Host's extended ACLs influence the default permissions of the
+# files inside the built RPMs. Disabling them for the build directory.
+$(call shell_real_build_only, setfacl -bn $(BUILD_DIR))
+
 ######## GO TOOLS ########
 
 # List of go utilities in tools/ directory


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

We've been having build issues depending on the configuration of the host we've been building on. Since [`rpmbuild` sets `umask` to 022 by default in the `%prep` section](http://ftp.rpm.org/max-rpm/ch-rpm-b-command.html#S2-RPM-B-COMMAND-BP-OPTION), it seems that the host's extended ACLs are the source of issue, which manifested in the following way:
```
(...)
WARN[0067] Installing:                                  
WARN[0067] systemd-rpm-macros noarch       250.3-17.cm2     local-repo     6.01k    22.85k 
WARN[0067]                                              
WARN[0067] Total installed size:   6.01k                
WARN[0067] Total download size:  22.85k                 
WARN[0067] Testing transaction                          
WARN[0067] Found 1 problems                             
WARN[0067] file /usr/lib/rpm/macros.d from install of systemd-rpm-macros-250.3-17.cm2.noarch conflicts with file from package rpm-build-4.18.0-3.cm2.x86_64  
...
```

This is an output from the build of `mdadm`, which `BuildRequires: systemd-rpm-macros` and `systemd-rpm-macros` was built earlier on the host machine, while the `rpm-build` package was pre-populated from PMC. Comparing the PMC and built versions of `systemd-rpm-macros` for `/usr/lib/rpm/macros.d`:

```
rpm -qp --dump built/systemd-rpm-macros-250.3-17.cm2.noarch.rpm
(...)
/usr/lib/rpm/macros.d 0 1690576370 0000000000000000000000000000000000000000000000000000000000000000 040775 root root 0 0 0 X
(...)

rpm -qp --dump pmc/systemd-rpm-macros-250.3-16.cm2.noarch.rpm
(...)
/usr/lib/rpm/macros.d 0 1690528863 0000000000000000000000000000000000000000000000000000000000000000 040755 root root 0 0 0 X
...
```

Notice the difference between `040775` and `040755`.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Removed extended ACLs for the `build` directory.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
Yes.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- [Full pipeline build.](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=399568&view=results)