### PR TITLE
Extend `AdditionalFiles` config

### DIFF
--- a/toolkit/docs/formats/imageconfig.md
+++ b/toolkit/docs/formats/imageconfig.md
@@ -230,16 +230,41 @@ FinalizeImageScripts provide the opportunity to run shell scripts to customize t
 
 ### AdditionalFiles
 
-The `AdditionalFiles` list provides a mechanism to add arbitrary files to the image. The elemments are are `"src": "dst"` pairs. `src` is relative to the image config `.json` file, while `dst` is an absolute path on the installed system.
+The `AdditionalFiles` list provides a mechanism to add arbitrary files to the image. The elements are are `"src": "dst"` pairs. `src` is relative to the image config `.json` file, while `dst` is an absolute path on the installed system.
 
-ISO installers will include the files on the installation media and will place them  into the final installed image.
+The `dst` can be one of:
+
+- A string representing the destination absolute path, OR
+- A object (`FileConfig`) containing the destination absolute path and other file options, OR
+- An array containing a mixture of strings and objects, which allows a single source file to be copied to multiple destination paths.
+
+ISO installers will include the files on the installation media and will place them into the final installed image.
 
 ```json
     "AdditionalFiles": [
         "../../out/tools/imager": "/installer/imager",
-        "additionalconfigs": "/etc/my/config.conf"
+        "additionalconfigs": [
+            "/etc/my/config.conf",
+            {
+                "Path": "/etc/yours/config.conf",
+                "Permissions": "664"
+            }
+        ]
     ]
 ```
+
+#### FileConfig
+
+`FileConfig` provides options to modify metadata of files copied using `AdditionalFiles`.
+
+Fields:
+
+- `Path`: The destination absolute path.
+- `Permissions`: The file permissions to apply to the file.
+
+  Supported value formats:
+
+  - Octal string: A JSON string containing an octal number. e.g. `"664"`
 
 ### Networks
 

--- a/toolkit/docs/formats/imageconfig.md
+++ b/toolkit/docs/formats/imageconfig.md
@@ -230,12 +230,14 @@ FinalizeImageScripts provide the opportunity to run shell scripts to customize t
 
 ### AdditionalFiles
 
-The `AdditionalFiles` list provides a mechanism to add arbitrary files to the image. The elements are are `"src": "dst"` pairs. `src` is relative to the image config `.json` file, while `dst` is an absolute path on the installed system.
+The `AdditionalFiles` list provides a mechanism to add arbitrary files to the image. The elements are are `"src": "dst"` pairs.
+
+`src` is relative to the image config `.json` file.
 
 The `dst` can be one of:
 
 - A string representing the destination absolute path, OR
-- A object (`FileConfig`) containing the destination absolute path and other file options, OR
+- An object (`FileConfig`) containing the destination absolute path and other file options, OR
 - An array containing a mixture of strings and objects, which allows a single source file to be copied to multiple destination paths.
 
 ISO installers will include the files on the installation media and will place them into the final installed image.

--- a/toolkit/tools/imagegen/configuration/configuration.go
+++ b/toolkit/tools/imagegen/configuration/configuration.go
@@ -355,10 +355,10 @@ func convertRawBinariesPath(baseDirPath string, diskConfig *Disk) {
 }
 
 func convertAdditionalFilesPath(baseDirPath string, systemConfig *SystemConfig) {
-	absAdditionalFiles := make(map[string]string)
-	for localFilePath, targetFilePath := range systemConfig.AdditionalFiles {
+	absAdditionalFiles := make(map[string]FileConfigList)
+	for localFilePath, targetFileConfigs := range systemConfig.AdditionalFiles {
 		localFilePath = file.GetAbsPathWithBase(baseDirPath, localFilePath)
-		absAdditionalFiles[localFilePath] = targetFilePath
+		absAdditionalFiles[localFilePath] = targetFileConfigs
 	}
 	systemConfig.AdditionalFiles = absAdditionalFiles
 }

--- a/toolkit/tools/imagegen/configuration/configuration_test.go
+++ b/toolkit/tools/imagegen/configuration/configuration_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/logger"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/ptrutils"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -413,9 +414,13 @@ var expectedConfiguration Config = Config{
 			KernelOptions: map[string]string{
 				"default": "kernel",
 			},
-			AdditionalFiles: map[string]string{
-				"local/path/file1": "/final/system/path",
-				"local/path/file2": "/final/system/path/renamedfile2",
+			AdditionalFiles: map[string]FileConfigList{
+				"local/path/file1": {{Path: "/final/system/path"}},
+				"local/path/file2": {{Path: "/final/system/path/renamedfile2"}},
+				"local/path/file3": {{Path: "/final/system/path/file3"}},
+				"local/path/file4": {{Path: "/final/system/path/file4", Permissions: ptrutils.PtrTo(FilePermissions(0o664))}},
+				"local/path/file5": {{Path: "/final/system/path/file5"}},
+				"local/path/file6": {{Path: "/final/system/path/file6"}, {Path: "/final/system/path/file6_copy"}},
 			},
 			Hostname: "Mariner-Test",
 			BootType: "efi",

--- a/toolkit/tools/imagegen/configuration/fileconfig.go
+++ b/toolkit/tools/imagegen/configuration/fileconfig.go
@@ -1,0 +1,119 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//
+
+package configuration
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// DestinationFileConfigList is a list of destination files to copy.
+type FileConfigList []FileConfig
+
+// FileConfig specifies options for how a file is copied in the target OS.
+type FileConfig struct {
+	// The file path in the target OS that the file will be copied to.
+	Path string `json:"Path"`
+
+	// The file permissions to set on the file.
+	Permissions *FilePermissions `json:"Permissions"`
+}
+
+var (
+	DefaultFileConfig = FileConfig{
+		Path:        "",
+		Permissions: nil,
+	}
+)
+
+func (l *FileConfigList) IsValid() (err error) {
+	if len(*l) <= 0 {
+		return fmt.Errorf("list is empty")
+	}
+
+	return nil
+}
+
+func (l *FileConfigList) UnmarshalJSON(b []byte) error {
+	var err error
+
+	// Try to parse as a single value.
+	var fileConfig FileConfig
+	err = json.Unmarshal(b, &fileConfig)
+	if err == nil {
+		*l = FileConfigList{fileConfig}
+		return nil
+	}
+
+	// Try to parse as a list.
+	type IntermediateTypeFileConfigList FileConfigList
+	err = json.Unmarshal(b, (*IntermediateTypeFileConfigList)(l))
+	if err != nil {
+		return fmt.Errorf("failed to parse [FileConfigList]: %w", err)
+	}
+
+	// Validate the unmarshaled object.
+	err = l.IsValid()
+	if err != nil {
+		return fmt.Errorf("failed to parse [FileConfigList]: %w", err)
+	}
+
+	return nil
+}
+
+func (f *FileConfig) IsValid() (err error) {
+	// Path
+	if f.Path == "" {
+		return fmt.Errorf("invalid [Path] value: empty string")
+	}
+
+	// Permissions
+
+	return nil
+}
+
+func (f *FileConfig) UnmarshalJSON(b []byte) error {
+	var err error
+
+	err = f.unmarshalJSONHelper(b)
+	if err != nil {
+		return err
+	}
+
+	// Validate the unmarshaled object.
+	err = f.IsValid()
+	if err != nil {
+		return fmt.Errorf("failed to parse [FileConfig]: %w", err)
+	}
+
+	return nil
+}
+
+func (f *FileConfig) unmarshalJSONHelper(b []byte) error {
+	var err error
+
+	// Try to parse as a string.
+	var path string
+	err = json.Unmarshal(b, &path)
+	if err == nil {
+		*f = FileConfig{
+			Path:        path,
+			Permissions: nil,
+		}
+		return nil
+	}
+
+	// Try to parse as a struct.
+	*f = DefaultFileConfig
+
+	type IntermediateTypeFileConfig FileConfig
+	err = json.Unmarshal(b, (*IntermediateTypeFileConfig)(f))
+	if err != nil {
+		return fmt.Errorf("failed to parse [FileConfig]: %w", err)
+	}
+
+	return nil
+}

--- a/toolkit/tools/imagegen/configuration/fileconfig.go
+++ b/toolkit/tools/imagegen/configuration/fileconfig.go
@@ -10,7 +10,8 @@ import (
 	"fmt"
 )
 
-// DestinationFileConfigList is a list of destination files to copy.
+// DestinationFileConfigList is a list of destination files where the source file will be copied to in the final image.
+// This type exists to allow a custom marshaller to be attached to it.
 type FileConfigList []FileConfig
 
 // FileConfig specifies options for how a file is copied in the target OS.

--- a/toolkit/tools/imagegen/configuration/fileconfig.go
+++ b/toolkit/tools/imagegen/configuration/fileconfig.go
@@ -35,6 +35,13 @@ func (l *FileConfigList) IsValid() (err error) {
 		return fmt.Errorf("list is empty")
 	}
 
+	for i, fileConfig := range *l {
+		err = fileConfig.IsValid()
+		if err != nil {
+			return fmt.Errorf("invalid [FileConfig] at index %d: %w", i, err)
+		}
+	}
+
 	return nil
 }
 
@@ -83,6 +90,12 @@ func (f *FileConfig) IsValid() (err error) {
 	}
 
 	// Permissions
+	if f.Permissions != nil {
+		err = f.Permissions.IsValid()
+		if err != nil {
+			return fmt.Errorf("invalid [Permissions] value: %w", err)
+		}
+	}
 
 	return nil
 }

--- a/toolkit/tools/imagegen/configuration/fileconfig.go
+++ b/toolkit/tools/imagegen/configuration/fileconfig.go
@@ -41,6 +41,23 @@ func (l *FileConfigList) IsValid() (err error) {
 func (l *FileConfigList) UnmarshalJSON(b []byte) error {
 	var err error
 
+	err = l.unmarshalJSONHelper(b)
+	if err != nil {
+		return err
+	}
+
+	// Validate the unmarshaled object.
+	err = l.IsValid()
+	if err != nil {
+		return fmt.Errorf("failed to parse [FileConfigList]: %w", err)
+	}
+
+	return nil
+}
+
+func (l *FileConfigList) unmarshalJSONHelper(b []byte) error {
+	var err error
+
 	// Try to parse as a single value.
 	var fileConfig FileConfig
 	err = json.Unmarshal(b, &fileConfig)
@@ -52,12 +69,6 @@ func (l *FileConfigList) UnmarshalJSON(b []byte) error {
 	// Try to parse as a list.
 	type IntermediateTypeFileConfigList FileConfigList
 	err = json.Unmarshal(b, (*IntermediateTypeFileConfigList)(l))
-	if err != nil {
-		return fmt.Errorf("failed to parse [FileConfigList]: %w", err)
-	}
-
-	// Validate the unmarshaled object.
-	err = l.IsValid()
 	if err != nil {
 		return fmt.Errorf("failed to parse [FileConfigList]: %w", err)
 	}

--- a/toolkit/tools/imagegen/configuration/fileconfig_test.go
+++ b/toolkit/tools/imagegen/configuration/fileconfig_test.go
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//
+
+package configuration
+
+import (
+	"testing"
+
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/ptrutils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseFileConfigValid1(t *testing.T) {
+	// Simple string path
+	testValidFileConfigList(t, "\"/a.txt\"", FileConfigList{{Path: "/a.txt"}})
+}
+
+func TestParseFileConfigValid2(t *testing.T) {
+	// Simple string path in an array.
+	testValidFileConfigList(t, "[ \"/a.txt\" ]", FileConfigList{{Path: "/a.txt"}})
+}
+
+func TestParseFileConfigValid3(t *testing.T) {
+	// Simple struct.
+	testValidFileConfigList(t, "{ \"Path\": \"/b.txt\" }", FileConfigList{{Path: "/b.txt"}})
+}
+
+func TestParseFileConfigValid4(t *testing.T) {
+	// Full struct.
+	testValidFileConfigList(t, "{ \"Path\": \"/b.txt\", \"Permissions\": \"770\" }",
+		FileConfigList{{Path: "/b.txt", Permissions: ptrutils.PtrTo(FilePermissions(0o770))}},
+	)
+}
+
+func TestParseFileConfigValid5(t *testing.T) {
+	// Mixed struct and string array.
+	testValidFileConfigList(t, "[ { \"Path\": \"/b.txt\" }, \"/c.txt\" ]",
+		FileConfigList{
+			{Path: "/b.txt"},
+			{Path: "/c.txt"},
+		},
+	)
+}
+
+func TestParseFileConfigInvalid1(t *testing.T) {
+	// Empty array.
+	testInvalidFileConfigList(t, "[ ]")
+}
+
+func TestParseFileConfigInvalid2(t *testing.T) {
+	// Number.
+	testInvalidFileConfigList(t, "1.2")
+}
+
+func TestParseFileConfigInvalid3(t *testing.T) {
+	// Empty string.
+	testInvalidFileConfigList(t, "\"\"")
+}
+
+func testValidFileConfigList(t *testing.T, json string, expectedValue FileConfigList) {
+	var value FileConfigList
+	err := marshalJSONString(json, &value)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedValue, value)
+}
+
+func testInvalidFileConfigList(t *testing.T, json string) {
+	var value FileConfigList
+	err := marshalJSONString(json, &value)
+	assert.Error(t, err)
+}

--- a/toolkit/tools/imagegen/configuration/filepermissions.go
+++ b/toolkit/tools/imagegen/configuration/filepermissions.go
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//
+
+package configuration
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+)
+
+// The file permissions to set on the file.
+//
+// Accepted formats:
+//
+// - Octal string (e.g. "660")
+type FilePermissions os.FileMode
+
+func (p *FilePermissions) IsValid() (err error) {
+	// Check if there are set bits outside of the permissions bits.
+	if *p & ^FilePermissions(os.ModePerm) != 0 {
+		return fmt.Errorf("0o%o contains non-permission bits", *p)
+	}
+
+	return nil
+}
+
+func (p *FilePermissions) UnmarshalJSON(b []byte) error {
+	var err error
+
+	// Try to parse as a string.
+	var strValue string
+	err = json.Unmarshal(b, &strValue)
+	if err != nil {
+		return fmt.Errorf("failed to parse [FilePermissions]: %w", err)
+	}
+
+	// Try to parse the string as an octal number.
+	fileModeUint, err := strconv.ParseUint(strValue, 8, 32)
+	if err != nil {
+		return fmt.Errorf("failed to parse [FilePermissions]: %w", err)
+	}
+
+	*p = (FilePermissions)(fileModeUint)
+
+	// Validate the unmarshaled object.
+	err = p.IsValid()
+	if err != nil {
+		return fmt.Errorf("failed to parse [FilePermissions]: %w", err)
+	}
+
+	return nil
+}
+
+func (p FilePermissions) MarshalJSON() ([]byte, error) {
+	strValue := strconv.FormatUint(uint64(p), 8)
+	return json.Marshal(strValue)
+}

--- a/toolkit/tools/imagegen/configuration/filepermissions_test.go
+++ b/toolkit/tools/imagegen/configuration/filepermissions_test.go
@@ -1,0 +1,55 @@
+// Copyright Microsoft Corporation.
+// Licensed under the MIT License.
+
+package configuration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseFilePermissionsValid1(t *testing.T) {
+	testValidFilePermission(t, "\"777\"", FilePermissions(0o777))
+}
+
+func TestParseFilePermissionsValid2(t *testing.T) {
+	testValidFilePermission(t, "\"000\"", FilePermissions(0))
+}
+
+func TestParseFilePermissionsValid3(t *testing.T) {
+	testValidFilePermission(t, "\"0\"", FilePermissions(0))
+}
+
+func TestParseFilePermissionsInvalid1(t *testing.T) {
+	// Value out of range.
+	testInvalidFilePermission(t, "\"1000\"")
+}
+
+func TestParseFilePermissionsInvalid2(t *testing.T) {
+	// Decimal number.
+	testInvalidFilePermission(t, "0")
+}
+
+func TestParseFilePermissionsInvalid3(t *testing.T) {
+	// Array value.
+	testInvalidFilePermission(t, "[]")
+}
+
+func TestParseFilePermissionsInvalid4(t *testing.T) {
+	// Not an octal value.
+	testInvalidFilePermission(t, "\"999\"")
+}
+
+func testValidFilePermission(t *testing.T, json string, expectedValue FilePermissions) {
+	var value FilePermissions
+	err := marshalJSONString(json, &value)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedValue, value)
+}
+
+func testInvalidFilePermission(t *testing.T, json string) {
+	var value FilePermissions
+	err := marshalJSONString(json, &value)
+	assert.Error(t, err)
+}

--- a/toolkit/tools/imagegen/configuration/systemconfig.go
+++ b/toolkit/tools/imagegen/configuration/systemconfig.go
@@ -16,29 +16,29 @@ import (
 
 // SystemConfig defines how each system present on the image is supposed to be configured.
 type SystemConfig struct {
-	IsDefault            bool               `json:"IsDefault"`
-	IsKickStartBoot      bool               `json:"IsKickStartBoot"`
-	IsIsoInstall         bool               `json:"IsIsoInstall"`
-	BootType             string             `json:"BootType"`
-	Hostname             string             `json:"Hostname"`
-	Name                 string             `json:"Name"`
-	PackageLists         []string           `json:"PackageLists"`
-	Packages             []string           `json:"Packages"`
-	KernelOptions        map[string]string  `json:"KernelOptions"`
-	KernelCommandLine    KernelCommandLine  `json:"KernelCommandLine"`
-	AdditionalFiles      map[string]string  `json:"AdditionalFiles"`
-	PartitionSettings    []PartitionSetting `json:"PartitionSettings"`
-	PreInstallScripts    []InstallScript    `json:"PreInstallScripts"`
-	PostInstallScripts   []InstallScript    `json:"PostInstallScripts"`
-	FinalizeImageScripts []InstallScript    `json:"FinalizeImageScripts"`
-	Networks             []Network          `json:"Networks"`
-	PackageRepos         []PackageRepo      `json:"PackageRepos"`
-	Groups               []Group            `json:"Groups"`
-	Users                []User             `json:"Users"`
-	Encryption           RootEncryption     `json:"Encryption"`
-	RemoveRpmDb          bool               `json:"RemoveRpmDb"`
-	ReadOnlyVerityRoot   ReadOnlyVerityRoot `json:"ReadOnlyVerityRoot"`
-	HidepidDisabled      bool               `json:"HidepidDisabled"`
+	IsDefault            bool                      `json:"IsDefault"`
+	IsKickStartBoot      bool                      `json:"IsKickStartBoot"`
+	IsIsoInstall         bool                      `json:"IsIsoInstall"`
+	BootType             string                    `json:"BootType"`
+	Hostname             string                    `json:"Hostname"`
+	Name                 string                    `json:"Name"`
+	PackageLists         []string                  `json:"PackageLists"`
+	Packages             []string                  `json:"Packages"`
+	KernelOptions        map[string]string         `json:"KernelOptions"`
+	KernelCommandLine    KernelCommandLine         `json:"KernelCommandLine"`
+	AdditionalFiles      map[string]FileConfigList `json:"AdditionalFiles"`
+	PartitionSettings    []PartitionSetting        `json:"PartitionSettings"`
+	PreInstallScripts    []InstallScript           `json:"PreInstallScripts"`
+	PostInstallScripts   []InstallScript           `json:"PostInstallScripts"`
+	FinalizeImageScripts []InstallScript           `json:"FinalizeImageScripts"`
+	Networks             []Network                 `json:"Networks"`
+	PackageRepos         []PackageRepo             `json:"PackageRepos"`
+	Groups               []Group                   `json:"Groups"`
+	Users                []User                    `json:"Users"`
+	Encryption           RootEncryption            `json:"Encryption"`
+	RemoveRpmDb          bool                      `json:"RemoveRpmDb"`
+	ReadOnlyVerityRoot   ReadOnlyVerityRoot        `json:"ReadOnlyVerityRoot"`
+	HidepidDisabled      bool                      `json:"HidepidDisabled"`
 }
 
 // GetRootPartitionSetting returns a pointer to the partition setting describing the disk which

--- a/toolkit/tools/imagegen/configuration/systemconfig.go
+++ b/toolkit/tools/imagegen/configuration/systemconfig.go
@@ -149,6 +149,13 @@ func (s *SystemConfig) IsValid() (err error) {
 		return fmt.Errorf("invalid [KernelCommandLine]: %w", err)
 	}
 
+	for srcFile, fileConfigList := range s.AdditionalFiles {
+		err = fileConfigList.IsValid()
+		if err != nil {
+			return fmt.Errorf("invalid [AdditionalFiles]: (%s): %w", srcFile, err)
+		}
+	}
+
 	// Validate that PackageRepos do not contain duplicate package repo name
 	repoNames := make(map[string]bool)
 	for _, packageRepo := range s.PackageRepos {

--- a/toolkit/tools/imagegen/configuration/systemconfig_test.go
+++ b/toolkit/tools/imagegen/configuration/systemconfig_test.go
@@ -374,3 +374,12 @@ func TestShouldFailParsingUnexpectedBootType_SystemConfig(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, "invalid [BootType]: uefi. Expecting values of either 'efi', 'legacy', 'none' or empty string", err.Error())
 }
+
+func TestShouldFaiInvalidAdditionalFiles_SystemConfig(t *testing.T) {
+	systemConfig := validSystemConfig
+	systemConfig.AdditionalFiles = map[string]FileConfigList{"a.txt": {}}
+
+	err := systemConfig.IsValid()
+	assert.Error(t, err)
+	assert.Equal(t, "invalid [AdditionalFiles]: (a.txt): list is empty", err.Error())
+}

--- a/toolkit/tools/imagegen/configuration/testdata/test_configuration.json
+++ b/toolkit/tools/imagegen/configuration/testdata/test_configuration.json
@@ -133,7 +133,11 @@
             },
             "AdditionalFiles": {
                 "local/path/file1": "/final/system/path",
-                "local/path/file2": "/final/system/path/renamedfile2"
+                "local/path/file2": "/final/system/path/renamedfile2",
+                "local/path/file3": ["/final/system/path/file3"],
+                "local/path/file4": { "Path": "/final/system/path/file4", "Permissions": "664" },
+                "local/path/file5": [ { "Path": "/final/system/path/file5" }],
+                "local/path/file6": [ { "Path": "/final/system/path/file6" }, "/final/system/path/file6_copy" ]
             },
             "Hostname": "Mariner-Test",
             "BootType": "efi",

--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -1838,19 +1838,26 @@ func installEfiBootloader(encryptEnabled bool, installRoot, bootUUID, bootPrefix
 }
 
 func copyAdditionalFiles(installChroot *safechroot.Chroot, config configuration.SystemConfig) (err error) {
+	return copyAdditionalFilesHelper(installChroot, config.AdditionalFiles)
+}
+
+func copyAdditionalFilesHelper(installChroot *safechroot.Chroot, additionalFiles map[string]configuration.FileConfigList) (err error) {
 	ReportAction("Copying additional files")
 	timestamp.StartEvent("Copying additional files", nil)
 	defer timestamp.StopEvent(nil)
 
-	for srcFile, dstFile := range config.AdditionalFiles {
-		fileToCopy := safechroot.FileToCopy{
-			Src:  srcFile,
-			Dest: dstFile,
-		}
+	for srcFile, dstFileConfigs := range additionalFiles {
+		for _, dstFileConfig := range dstFileConfigs {
+			fileToCopy := safechroot.FileToCopy{
+				Src:         srcFile,
+				Dest:        dstFileConfig.Path,
+				Permissions: (*os.FileMode)(dstFileConfig.Permissions),
+			}
 
-		err = installChroot.AddFiles(fileToCopy)
-		if err != nil {
-			return
+			err = installChroot.AddFiles(fileToCopy)
+			if err != nil {
+				return
+			}
 		}
 	}
 

--- a/toolkit/tools/imagegen/installutils/installutils_test.go
+++ b/toolkit/tools/imagegen/installutils/installutils_test.go
@@ -4,13 +4,48 @@
 package installutils
 
 import (
+	"os"
+	"path/filepath"
 	"runtime"
 	"testing"
 
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/imagegen/configuration"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/logger"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/pkgjson"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/ptrutils"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/safechroot"
 
 	"github.com/stretchr/testify/assert"
 )
+
+var (
+	testDir    string
+	tmpDir     string
+	workingDir string
+)
+
+func TestMain(m *testing.M) {
+	var err error
+
+	logger.InitStderrLog()
+
+	workingDir, err = os.Getwd()
+	if err != nil {
+		logger.Log.Panicf("Failed to get working directory, error: %s", err)
+	}
+
+	testDir = filepath.Join(workingDir, "testdata")
+	tmpDir = filepath.Join(workingDir, "_tmp")
+
+	retVal := m.Run()
+
+	err = os.RemoveAll(tmpDir)
+	if err != nil {
+		logger.Log.Warnf("Failed to cleanup tmp dir (%s). Error: %s", tmpDir, err)
+	}
+
+	os.Exit(retVal)
+}
 
 func TestShouldReturnCorrectRequiredPackagesForArch(t *testing.T) {
 	arm64RequiredPackages := []*pkgjson.PackageVer{}
@@ -26,4 +61,56 @@ func TestShouldReturnCorrectRequiredPackagesForArch(t *testing.T) {
 	default:
 		assert.Fail(t, "unknown GOARCH detected: "+arch)
 	}
+}
+
+func TestCopyAdditionalFiles(t *testing.T) {
+	dir := filepath.Join(tmpDir, "TestCopyAdditionalFiles")
+	chroot := safechroot.NewChroot(dir, false)
+
+	err := chroot.Initialize("", []string{}, []*safechroot.MountPoint{})
+	assert.NoError(t, err)
+
+	defer chroot.Close(false)
+
+	orig_filemode := os.FileMode(0o664)
+	copy_2_filemode := os.FileMode(0o777)
+
+	err = copyAdditionalFilesHelper(chroot, map[string]configuration.FileConfigList{
+		"testdata/a.txt": {
+			{Path: "/a_copy_1.txt"},
+			{Path: "/a_copy_2.txt", Permissions: ptrutils.PtrTo(configuration.FilePermissions(copy_2_filemode))},
+		},
+	})
+	assert.NoError(t, err)
+
+	copy_1_path := filepath.Join(dir, "a_copy_1.txt")
+	copy_2_path := filepath.Join(dir, "a_copy_2.txt")
+
+	// Make sure the files exist.
+	orig_info, err := os.Stat("testdata/a.txt")
+	assert.NoError(t, err)
+
+	copy_1_info, err := os.Stat(copy_1_path)
+	assert.NoError(t, err)
+
+	copy_2_info, err := os.Stat(copy_2_path)
+	assert.NoError(t, err)
+
+	// Make sure the file permissions are the expected values.
+	assert.Equal(t, orig_filemode, orig_info.Mode()&os.ModePerm)
+	assert.Equal(t, orig_filemode, copy_1_info.Mode()&os.ModePerm)
+	assert.Equal(t, copy_2_filemode, copy_2_info.Mode()&os.ModePerm)
+
+	// Make sure the files' contents are correct.
+	orig_contents, err := os.ReadFile("testdata/a.txt")
+	assert.NoError(t, err)
+
+	copy_1_contents, err := os.ReadFile(copy_1_path)
+	assert.NoError(t, err)
+
+	copy_2_contents, err := os.ReadFile(copy_2_path)
+	assert.NoError(t, err)
+
+	assert.Equal(t, orig_contents, copy_1_contents)
+	assert.Equal(t, orig_contents, copy_2_contents)
 }

--- a/toolkit/tools/imagegen/installutils/installutils_test.go
+++ b/toolkit/tools/imagegen/installutils/installutils_test.go
@@ -72,7 +72,6 @@ func TestCopyAdditionalFiles(t *testing.T) {
 
 	defer chroot.Close(false)
 
-	orig_filemode := os.FileMode(0o644)
 	copy_2_filemode := os.FileMode(0o777)
 
 	err = copyAdditionalFilesHelper(chroot, map[string]configuration.FileConfigList{
@@ -87,19 +86,22 @@ func TestCopyAdditionalFiles(t *testing.T) {
 	copy_2_path := filepath.Join(dir, "a_copy_2.txt")
 
 	// Make sure the files exist.
-	orig_info, err := os.Stat("testdata/a.txt")
+	orig_stat, err := os.Stat("testdata/a.txt")
 	assert.NoError(t, err)
 
-	copy_1_info, err := os.Stat(copy_1_path)
+	copy_1_stat, err := os.Stat(copy_1_path)
 	assert.NoError(t, err)
 
-	copy_2_info, err := os.Stat(copy_2_path)
+	copy_2_stat, err := os.Stat(copy_2_path)
 	assert.NoError(t, err)
+
+	// Make sure the filemode of the original file is different from the target filemode,
+	// as otherwise it would defeat the purpose of the test.
+	assert.NotEqual(t, copy_2_filemode, orig_stat.Mode()&os.ModePerm)
 
 	// Make sure the file permissions are the expected values.
-	assert.Equal(t, orig_filemode, orig_info.Mode()&os.ModePerm)
-	assert.Equal(t, orig_filemode, copy_1_info.Mode()&os.ModePerm)
-	assert.Equal(t, copy_2_filemode, copy_2_info.Mode()&os.ModePerm)
+	assert.Equal(t, orig_stat.Mode()&os.ModePerm, copy_1_stat.Mode()&os.ModePerm)
+	assert.Equal(t, copy_2_filemode, copy_2_stat.Mode()&os.ModePerm)
 
 	// Make sure the files' contents are correct.
 	orig_contents, err := os.ReadFile("testdata/a.txt")

--- a/toolkit/tools/imagegen/installutils/installutils_test.go
+++ b/toolkit/tools/imagegen/installutils/installutils_test.go
@@ -72,7 +72,7 @@ func TestCopyAdditionalFiles(t *testing.T) {
 
 	defer chroot.Close(false)
 
-	orig_filemode := os.FileMode(0o664)
+	orig_filemode := os.FileMode(0o644)
 	copy_2_filemode := os.FileMode(0o777)
 
 	err = copyAdditionalFilesHelper(chroot, map[string]configuration.FileConfigList{

--- a/toolkit/tools/imagegen/installutils/installutils_test.go
+++ b/toolkit/tools/imagegen/installutils/installutils_test.go
@@ -64,8 +64,8 @@ func TestShouldReturnCorrectRequiredPackagesForArch(t *testing.T) {
 }
 
 func TestCopyAdditionalFiles(t *testing.T) {
-	dir := filepath.Join(tmpDir, "TestCopyAdditionalFiles")
-	chroot := safechroot.NewChroot(dir, false)
+	proposedDir := filepath.Join(tmpDir, "TestCopyAdditionalFiles")
+	chroot := safechroot.NewChroot(proposedDir, false)
 
 	err := chroot.Initialize("", []string{}, []*safechroot.MountPoint{})
 	assert.NoError(t, err)
@@ -82,8 +82,8 @@ func TestCopyAdditionalFiles(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	copy_1_path := filepath.Join(dir, "a_copy_1.txt")
-	copy_2_path := filepath.Join(dir, "a_copy_2.txt")
+	copy_1_path := filepath.Join(chroot.RootDir(), "a_copy_1.txt")
+	copy_2_path := filepath.Join(chroot.RootDir(), "a_copy_2.txt")
 
 	// Make sure the files exist.
 	orig_stat, err := os.Stat("testdata/a.txt")

--- a/toolkit/tools/imagegen/installutils/testdata/a.txt
+++ b/toolkit/tools/imagegen/installutils/testdata/a.txt
@@ -1,0 +1,1 @@
+abcdefg

--- a/toolkit/tools/imager/imager.go
+++ b/toolkit/tools/imager/imager.go
@@ -325,10 +325,10 @@ func setupDiskEncryption(systemConfig *configuration.SystemConfig, encryptedRoot
 
 		// Copy the default keyfile into the image
 		if len(systemConfig.AdditionalFiles) == 0 {
-			systemConfig.AdditionalFiles = make(map[string]string)
+			systemConfig.AdditionalFiles = make(map[string]configuration.FileConfigList)
 		}
 
-		systemConfig.AdditionalFiles[encryptedRoot.HostKeyFile] = diskutils.DefaultKeyFilePath
+		systemConfig.AdditionalFiles[encryptedRoot.HostKeyFile] = configuration.FileConfigList{{Path: diskutils.DefaultKeyFilePath}}
 		logger.Log.Infof("Adding default key file to systemConfig additional files")
 	}
 
@@ -455,8 +455,8 @@ func fixupExtraFilesIntoChroot(installChroot *safechroot.Chroot, config *configu
 		}
 	}
 
-	fixedUpAdditionalFiles := make(map[string]string)
-	for srcFile, dstFile := range config.AdditionalFiles {
+	fixedUpAdditionalFiles := make(map[string]configuration.FileConfigList)
+	for srcFile, dstFileConfigs := range config.AdditionalFiles {
 		newFilePath := filepath.Join(additionalFilesTempDirectory, srcFile)
 
 		fileToCopy := safechroot.FileToCopy{
@@ -464,7 +464,7 @@ func fixupExtraFilesIntoChroot(installChroot *safechroot.Chroot, config *configu
 			Dest: newFilePath,
 		}
 
-		fixedUpAdditionalFiles[newFilePath] = dstFile
+		fixedUpAdditionalFiles[newFilePath] = dstFileConfigs
 		filesToCopy = append(filesToCopy, fileToCopy)
 	}
 	config.AdditionalFiles = fixedUpAdditionalFiles

--- a/toolkit/tools/internal/ptrutils/ptrutils.go
+++ b/toolkit/tools/internal/ptrutils/ptrutils.go
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package ptrutils
+
+func PtrTo[Type any](value Type) *Type {
+	return &value
+}

--- a/toolkit/tools/isomaker/maker.go
+++ b/toolkit/tools/isomaker/maker.go
@@ -322,10 +322,10 @@ func (im *IsoMaker) copyAndRenameAdditionalFiles(configFilesAbsDirPath string) {
 	for i := range im.config.SystemConfigs {
 		systemConfig := &im.config.SystemConfigs[i]
 
-		absAdditionalFiles := make(map[string]string)
-		for localAbsFilePath, installedSystemAbsFilePath := range systemConfig.AdditionalFiles {
+		absAdditionalFiles := make(map[string]configuration.FileConfigList)
+		for localAbsFilePath, installedSystemFileConfigs := range systemConfig.AdditionalFiles {
 			isoRelativeFilePath := im.copyFileToConfigRoot(configFilesAbsDirPath, additionalFilesSubDirName, localAbsFilePath)
-			absAdditionalFiles[isoRelativeFilePath] = installedSystemAbsFilePath
+			absAdditionalFiles[isoRelativeFilePath] = installedSystemFileConfigs
 		}
 		systemConfig.AdditionalFiles = absAdditionalFiles
 	}


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary

This change extends the `AdditionalFiles` field of the image system config to support copying to multiple destination files and changing the file permissions of the destination files.

###### Change Log

- Change `AdditionalFiles` to an array of `FileConfig` structs and add support for changing the destination file permissions.
- Add a custom [un]marshaler for `AdditionalFiles` so that the existing schema is still supported.
- Extend and add new image configuration tests to cover the new options for `AdditionalFiles`.
- Add a test for `installutils` to verify file copying behavior during image builds.

###### Does this affect the toolchain?

NO

###### Test Methodology

- All existing toolkit tests pass.
- New toolkits tests were added to test the new features.
- Ran a local build of `marketplace-gen2.json` and manually ensured all the `AdditionalFiles` were present in the image,
