### PR TITLE
Nopatch kernel for CVE-2023-38426, CVE-2023-38427, CVE-2023-38428, CVE-2023-38429, CVE-2023-38430, CVE-2023-38431, CVE-2023-38432

### DIFF
--- a/SPECS/kernel/CVE-2023-38426.nopatch
+++ b/SPECS/kernel/CVE-2023-38426.nopatch
@@ -1,0 +1,2 @@
+CVE-2023-38426 - CBL-Mariner does not enable ksmbd at this time (5.10.187.1-1)
+upstream: 02f76c401d17e409ed45bf7887148fcc22c93c85 

--- a/SPECS/kernel/CVE-2023-38427.nopatch
+++ b/SPECS/kernel/CVE-2023-38427.nopatch
@@ -1,0 +1,2 @@
+CVE-2023-38427 - CBL-Mariner does not enable ksmbd at this time (5.10.187.1-1)
+upstream: f1a411873c85b642f13b01f21b534c2bab81fc1b 

--- a/SPECS/kernel/CVE-2023-38428.nopatch
+++ b/SPECS/kernel/CVE-2023-38428.nopatch
@@ -1,0 +1,2 @@
+CVE-2023-38428 - CBL-Mariner does not enable ksmbd at this time (5.10.187.1-1)
+upstream: f0a96d1aafd8964e1f9955c830a3e5cb3c60a90f

--- a/SPECS/kernel/CVE-2023-38429.nopatch
+++ b/SPECS/kernel/CVE-2023-38429.nopatch
@@ -1,0 +1,2 @@
+CVE-2023-38429 - CBL-Mariner does not enable ksmbd at this time (5.10.187.1-1)
+upstream: 443d61d1fa9faa60ef925513d83742902390100f 

--- a/SPECS/kernel/CVE-2023-38430.nopatch
+++ b/SPECS/kernel/CVE-2023-38430.nopatch
@@ -1,0 +1,2 @@
+CVE-2023-38430 - CBL-Mariner does not enable ksmbd at this time (5.10.187.1-1)
+upstream: 1c1bcf2d3ea061613119b534f57507c377df20f9

--- a/SPECS/kernel/CVE-2023-38431.nopatch
+++ b/SPECS/kernel/CVE-2023-38431.nopatch
@@ -1,0 +1,2 @@
+CVE-2023-38431 - CBL-Mariner does not enable ksmbd at this time (5.10.187.1-1)
+upstream: 368ba06881c395f1c9a7ba22203cf8d78b4addc0

--- a/SPECS/kernel/CVE-2023-38432.nopatch
+++ b/SPECS/kernel/CVE-2023-38432.nopatch
@@ -1,0 +1,2 @@
+CVE-2023-38432 - CBL-Mariner does not enable ksmbd at this time (5.10.187.1-1)
+upstream: 2b9b8f3b68edb3d67d79962f02e26dbb5ae3808d


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
CBL-Mariner does not enable ksmbd (CONFIG_SMB_SERVER not present) and therefore the following CVEs do not apply. 
 Address CVE-2023-38426, CVE-2023-38427, CVE-2023-38428, CVE-2023-38429, CVE-2023-38430, CVE-2023-38431, CVE-2023-38432

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Address CVE-2023-38426, CVE-2023-38427, CVE-2023-38428, CVE-2023-38429, CVE-2023-38430, CVE-2023-38431, CVE-2023-38432

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2023-38426
- https://nvd.nist.gov/vuln/detail/CVE-2023-38427
- https://nvd.nist.gov/vuln/detail/CVE-2023-38428
- https://nvd.nist.gov/vuln/detail/CVE-2023-38429
- https://nvd.nist.gov/vuln/detail/CVE-2023-38430
- https://nvd.nist.gov/vuln/detail/CVE-2023-38431
- https://nvd.nist.gov/vuln/detail/CVE-2023-38432
