### PR TITLE
Fix Bug 45595561: Remove .bazelversion file

### DIFF
--- a/SPECS/keras/keras.spec
+++ b/SPECS/keras/keras.spec
@@ -3,7 +3,7 @@
 Summary:        Keras is a high-level neural networks API.
 Name:           keras
 Version:        2.11.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -71,6 +71,9 @@ bazel --batch build  --verbose_explanations //keras/tools/pip_package:build_pip_
 
 
 %changelog
+* Tue Aug 01 2023 Riken Maharjan <rmaharjan@microsoft.com> - 2.11.0-2
+- remove .bazelversion file.
+
 * Mon Dec 12 2022 Riken Maharjan <rmaharjan@microsoft> - 2.11.0-1
 - License verified
 - Original version for CBL-Mariner

--- a/SPECS/keras/keras.spec
+++ b/SPECS/keras/keras.spec
@@ -11,7 +11,7 @@ Group:          Development/Languages/Python
 URL:            https://keras.io/
 Source0:        https://github.com/keras-team/keras/archive/refs/tags/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
 Source1:        %{name}-%{version}-cache.tar.gz
-BuildRequires:  bazel = 5.3.0
+BuildRequires:  bazel
 BuildRequires:  build-essential
 BuildRequires:  git
 BuildRequires:  libstdc++-devel
@@ -45,6 +45,8 @@ Python 3 version.
 tar -xf %{SOURCE1} -C /root/
 
 ln -s %{_bindir}/python3 %{_bindir}/python
+#remove .bazelversion file so that the latest bazel version available will be used to build Keras
+rm .bazelversion
 
 bazel --batch build  --verbose_explanations //keras/tools/pip_package:build_pip_package
 # ---------

--- a/SPECS/keras/keras.spec
+++ b/SPECS/keras/keras.spec
@@ -45,8 +45,6 @@ Python 3 version.
 tar -xf %{SOURCE1} -C /root/
 
 ln -s %{_bindir}/python3 %{_bindir}/python
-#remove .bazelversion file so that the latest bazel version available will be used to build Keras
-rm .bazelversion
 
 bazel --batch build  --verbose_explanations //keras/tools/pip_package:build_pip_package
 # ---------
@@ -72,7 +70,7 @@ bazel --batch build  --verbose_explanations //keras/tools/pip_package:build_pip_
 
 %changelog
 * Tue Aug 01 2023 Riken Maharjan <rmaharjan@microsoft.com> - 2.11.0-2
-- remove .bazelversion file.
+- remove bazel version.
 
 * Mon Dec 12 2022 Riken Maharjan <rmaharjan@microsoft> - 2.11.0-1
 - License verified

--- a/SPECS/keras/keras.spec
+++ b/SPECS/keras/keras.spec
@@ -70,7 +70,7 @@ bazel --batch build  --verbose_explanations //keras/tools/pip_package:build_pip_
 
 %changelog
 * Tue Aug 01 2023 Riken Maharjan <rmaharjan@microsoft.com> - 2.11.0-2
-- remove bazel version.
+- Remove bazel version.
 
 * Mon Dec 12 2022 Riken Maharjan <rmaharjan@microsoft> - 2.11.0-1
 - License verified

--- a/SPECS/python-tensorboard/python-tensorboard.spec
+++ b/SPECS/python-tensorboard/python-tensorboard.spec
@@ -7,7 +7,7 @@ TensorBoard is a suite of web applications for inspecting and understanding your
 Summary:        TensorBoard is a suite of web applications for inspecting and understanding your TensorFlow runs and graphs
 Name:           python-%{pypi_name}
 Version:        2.11.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -103,6 +103,9 @@ mv %{pypi_name}-%{version}-*.whl pyproject-wheeldir/
 %{python3_sitelib}/tensorboard_data_server*
 
 %changelog
+* Tue Aug 01 2023 Riken Maharjan <rmaharjan@microsoft.com> - 2.11.0-2
+- remove .bazelversion file.
+
 * Mon Dec 19 2022 Riken Maharjan <rmaharjan@microsoft.com> - 2.11.0-1
 - Original version for CBL-Mariner. License Verified.
 

--- a/SPECS/python-tensorboard/python-tensorboard.spec
+++ b/SPECS/python-tensorboard/python-tensorboard.spec
@@ -103,7 +103,7 @@ mv %{pypi_name}-%{version}-*.whl pyproject-wheeldir/
 
 %changelog
 * Tue Aug 01 2023 Riken Maharjan <rmaharjan@microsoft.com> - 2.11.0-2
-- remove bazel version.
+- Remove bazel version.
 
 * Mon Dec 19 2022 Riken Maharjan <rmaharjan@microsoft.com> - 2.11.0-1
 - Original version for CBL-Mariner. License Verified.

--- a/SPECS/python-tensorboard/python-tensorboard.spec
+++ b/SPECS/python-tensorboard/python-tensorboard.spec
@@ -67,8 +67,7 @@ pushd tensorboard/data/server/pip_package
 python3 setup.py -q bdist_wheel 
 popd
 mkdir -p pyproject-wheeldir/ && cp tensorboard/data/server/pip_package/dist/*.whl pyproject-wheeldir/
-#remove .bazelversion file so that latest bazel version available will be used to build tensorboard
-rm .bazelversion
+
 #tensorboard built using bazel
 bazel --batch build //tensorboard/pip_package:build_pip_package
 #cache 
@@ -104,7 +103,7 @@ mv %{pypi_name}-%{version}-*.whl pyproject-wheeldir/
 
 %changelog
 * Tue Aug 01 2023 Riken Maharjan <rmaharjan@microsoft.com> - 2.11.0-2
-- remove .bazelversion file.
+- remove bazel version.
 
 * Mon Dec 19 2022 Riken Maharjan <rmaharjan@microsoft.com> - 2.11.0-1
 - Original version for CBL-Mariner. License Verified.

--- a/SPECS/python-tensorboard/python-tensorboard.spec
+++ b/SPECS/python-tensorboard/python-tensorboard.spec
@@ -18,7 +18,7 @@ BuildRequires:  python3-setuptools
 BuildRequires:  python3-pip
 BuildRequires:  python3-wheel
 BuildRequires:  python3-six
-BuildRequires:  bazel = 5.3.0
+BuildRequires:  bazel
 BuildRequires:  python3-tf-nightly = 2.11.0
 BuildRequires:  gcc
 BuildRequires:  build-essential
@@ -67,7 +67,8 @@ pushd tensorboard/data/server/pip_package
 python3 setup.py -q bdist_wheel 
 popd
 mkdir -p pyproject-wheeldir/ && cp tensorboard/data/server/pip_package/dist/*.whl pyproject-wheeldir/
-
+#remove .bazelversion file so that latest bazel version available will be used to build tensorboard
+rm .bazelversion
 #tensorboard built using bazel
 bazel --batch build //tensorboard/pip_package:build_pip_package
 #cache 

--- a/SPECS/tensorflow/tensorflow.spec
+++ b/SPECS/tensorflow/tensorflow.spec
@@ -110,7 +110,7 @@ Python 3 version.
 tar -xf %{SOURCE1} -C /root/
 
 ln -s %{_bindir}/python3 %{_bindir}/python
-#remove .bazelversion file so that latest bazel version available will be used to build TensorFlow
+# Remove the .bazelversion file so that latest bazel version available will be used to build TensorFlow.
 rm .bazelversion
 bazel --batch build  --verbose_explanations //tensorflow/tools/pip_package:build_pip_package
 # ---------

--- a/SPECS/tensorflow/tensorflow.spec
+++ b/SPECS/tensorflow/tensorflow.spec
@@ -148,16 +148,16 @@ bazel --batch build  --verbose_explanations //tensorflow/tools/pip_package:build
 
 %changelog
 * Tue Aug 01 2023 Riken Maharjan <rmaharjan@microsoft.com> - 2.11.0-4
-- remove .bazelversion file.
+- Remove .bazelversion file.
 
 * Thu Jan 03 2022 Riken Maharjan <rmaharjan@microsoft> - 2.11.0-3
-- add tf-nightly subpackage. 
+- Add tf-nightly subpackage. 
 
 * Thu Dec 08 2022 Riken Maharjan <rmaharjan@microsoft> - 2.11.0-2
-- correct markupsafe package name. 
+- Correct markupsafe package name. 
 
 * Sun Dec 04 2022 Riken Maharjan <rmaharjan@microsoft> - 2.11.0-1
-- update to 2.11.0
+- Update to 2.11.0
 
 * Thu Sep 22 2022 Riken Maharjan <rmaharjan@microsoft> - 2.8.3-1
 - License verified

--- a/SPECS/tensorflow/tensorflow.spec
+++ b/SPECS/tensorflow/tensorflow.spec
@@ -1,7 +1,7 @@
 Summary:        TensorFlow is an open source machine learning framework for everyone.
 Name:           tensorflow
 Version:        2.11.0
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -147,6 +147,9 @@ bazel --batch build  --verbose_explanations //tensorflow/tools/pip_package:build
 
 
 %changelog
+* Tue Aug 01 2023 Riken Maharjan <rmaharjan@microsoft.com> - 2.11.0-4
+- remove .bazelversion file.
+
 * Thu Jan 03 2022 Riken Maharjan <rmaharjan@microsoft> - 2.11.0-3
 - add tf-nightly subpackage. 
 

--- a/SPECS/tensorflow/tensorflow.spec
+++ b/SPECS/tensorflow/tensorflow.spec
@@ -9,7 +9,7 @@ Group:          Development/Languages/Python
 URL:            https://www.tensorflow.org/
 Source0:        https://github.com/tensorflow/tensorflow/archive/refs/tags/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
 Source1:        %{name}-%{version}-cache.tar.gz
-BuildRequires:  bazel = 5.3.0
+BuildRequires:  bazel
 BuildRequires:  binutils
 BuildRequires:  build-essential
 BuildRequires:  git
@@ -110,7 +110,7 @@ Python 3 version.
 tar -xf %{SOURCE1} -C /root/
 
 ln -s %{_bindir}/python3 %{_bindir}/python
-
+echo 5.3.2 > .bazelversion
 bazel --batch build  --verbose_explanations //tensorflow/tools/pip_package:build_pip_package
 # ---------
 # steps to create the cache tar. network connection is required to create the cache.

--- a/SPECS/tensorflow/tensorflow.spec
+++ b/SPECS/tensorflow/tensorflow.spec
@@ -110,7 +110,8 @@ Python 3 version.
 tar -xf %{SOURCE1} -C /root/
 
 ln -s %{_bindir}/python3 %{_bindir}/python
-echo 5.3.2 > .bazelversion
+#remove .bazelversion file so that latest bazel version available will be used to build TensorFlow
+rm .bazelversion
 bazel --batch build  --verbose_explanations //tensorflow/tools/pip_package:build_pip_package
 # ---------
 # steps to create the cache tar. network connection is required to create the cache.


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
=> tensorflow, keras and python3-tensorboard could be build with our latest Bazel. i.e 5.3.2. 

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change: 
Remove tightly coupled dependency on a particular bazel version while building bazel packages by removing the .bazelversion file as well as removing the version provided in the buildRequires. 


###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES/NO**
NO

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- Fixes #45595561



###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id (AMD64) :  [401515](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=401515&view=results)
- Pipeline build id (ARM64) : [401275](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=401275&view=results)