### PR TITLE
Add better backoff, semaphore to packer

### DIFF
--- a/toolkit/tools/internal/retry/retry.go
+++ b/toolkit/tools/internal/retry/retry.go
@@ -35,12 +35,12 @@ func calculateLinearDelay(failCount int, sleep time.Duration) time.Duration {
 	return sleep * time.Duration(failCount)
 }
 
-// backoffSleep sleeps for the given duration, unless the cancelSignal is triggered first. The cancelSignal may be nil
-// in which case the sleep will always complete.
-func backoffSleep(delay time.Duration, cancelSignal <-chan struct{}) (cancelled bool) {
+// backoffSleep sleeps for the given duration, unless the cancel channel is triggered or closed first. The cancel channel
+// may be nil in which case the sleep will always complete.
+func backoffSleep(delay time.Duration, cancel <-chan struct{}) (cancelled bool) {
 	select {
 	case <-time.After(delay):
-	case <-cancelSignal:
+	case <-cancel:
 		cancelled = true
 	}
 	return
@@ -48,10 +48,11 @@ func backoffSleep(delay time.Duration, cancelSignal <-chan struct{}) (cancelled 
 
 // runWithBackoffInternal runs function up to 'attempts' times, waiting delayCalc(failCount) before each i-th attempt.
 // delayCalc(0) is expected to return 0.
-func runWithBackoffInternal(function func() error, delayCalc func(failCount int) time.Duration, attempts int, cancelSignal <-chan struct{}) (err error) {
+// The function will return early if the cancel channel is closed.
+func runWithBackoffInternal(function func() error, delayCalc func(failCount int) time.Duration, attempts int, cancel <-chan struct{}) (err error) {
 	for failures := 0; failures < attempts; failures++ {
 		delayTime := delayCalc(failures)
-		cancelled := backoffSleep(delayTime, cancelSignal)
+		cancelled := backoffSleep(delayTime, cancel)
 		if cancelled {
 			err = fmt.Errorf("%w after %d tries", ErrRetryCancelled, failures)
 			break
@@ -69,17 +70,17 @@ func Run(function func() error, attempts int, sleep time.Duration) (err error) {
 }
 
 // RunWithLinearBackoff runs function up to 'attempts' times, waiting i * sleep duration before each i-th attempt. An
-// optional cancelSignal can be provided to cancel the retry loop immediately.
-func RunWithLinearBackoff(function func() error, attempts int, sleep time.Duration, cancelSignal <-chan struct{}) (err error) {
+// optional cancel channel can be provided to cancel the retry loop immediately by closing the channel.
+func RunWithLinearBackoff(function func() error, attempts int, sleep time.Duration, cancel <-chan struct{}) (err error) {
 	return runWithBackoffInternal(function, func(failCount int) time.Duration {
 		return calculateLinearDelay(failCount, sleep)
-	}, attempts, cancelSignal)
+	}, attempts, cancel)
 }
 
 // RunWithExpBackoff runs function up to 'attempts' times, waiting 'backoffExponentBase^(i-1) * sleep' duration before
-// each i-th attempt. An optional cancelSignal can be provided to cancel the retry loop immediately.
-func RunWithExpBackoff(function func() error, attempts int, sleep time.Duration, backoffExponentBase float64, cancelSignal <-chan struct{}) (err error) {
+// each i-th attempt. An optional cancel channel can be provided to cancel the retry loop immediately by closing the channel.
+func RunWithExpBackoff(function func() error, attempts int, sleep time.Duration, backoffExponentBase float64, cancel <-chan struct{}) (err error) {
 	return runWithBackoffInternal(function, func(failCount int) time.Duration {
 		return calculateExpDelay(failCount, sleep, backoffExponentBase)
-	}, attempts, cancelSignal)
+	}, attempts, cancel)
 }

--- a/toolkit/tools/internal/retry/retry.go
+++ b/toolkit/tools/internal/retry/retry.go
@@ -8,25 +8,35 @@ import (
 	"time"
 )
 
-func calculateDelay(retryCount int, sleep time.Duration, backoffExponent float64) time.Duration {
+// calculateDelay calculates the delay for the given failure count, sleep duration, and backoff exponent base.
+// If the base is negative, it will calculate a linear backoff.
+// If the base is positive, it will calculate an exponential backoff.
+func calculateDelay(failCount int, sleep time.Duration, backoffExponentBase float64) time.Duration {
+	if failCount == 0 {
+		return 0
+	}
+	// Treat negative values of base as linear backoff.
+	if backoffExponentBase < 0 {
+		return sleep * time.Duration(failCount)
+	}
 	// Calculate an exponential backoff.
-	// The formula is: sleep * (backoffExp ^ retryCount)
-	// For example, if sleep = 1 second, backoffExp = 2.0, retryCount = 3
+	// The formula is: sleep * (backoffExpBase ^ failCount)
+	// For example, if sleep = 1 second, backoffExp = 2.0, failCount = 3
 	// then the delay will be 1 * (2 ^ 3) = 8 seconds.
-	expRetry := math.Pow(backoffExp, float64(retryCount))
+	expRetry := math.Pow(backoffExponentBase, float64(failCount-1))
 	return time.Duration(expRetry * float64(sleep))
 }
 
 // Run runs function up to attempts times, waiting i * sleep duration before each i-th attempt.
 func Run(function func() error, attempts int, sleep time.Duration) (err error) {
-	return RunWithExpBackoff(function, attempts, sleep, 1.0)
+	return RunWithExpBackoff(function, attempts, sleep, -1)
 }
 
-// RunWithExpBackoff runs function up to 'attempts' times, waiting 'backoffExp^i * sleep' duration before each i-th attempt.
-func RunWithExpBackoff(function func() error, attempts int, sleep time.Duration, backoffExp float64) (err error) {
-	for i := 0; i < attempts; i++ {
+// RunWithExpBackoff runs function up to 'attempts' times, waiting 'backoffExponentBase^i * sleep' duration before each i-th attempt.
+func RunWithExpBackoff(function func() error, attempts int, sleep time.Duration, backoffExponentBase float64) (err error) {
+	for failures := 0; failures < attempts; failures++ {
 		// Calculate an exponential backoff. For i=0 we will calculate 0 delay and immediately call the function.
-		time.Sleep(calcDelay(i, sleep, backoffExp))
+		time.Sleep(calculateDelay(failures, sleep, backoffExponentBase))
 		if err = function(); err == nil {
 			break
 		}

--- a/toolkit/tools/internal/retry/retry.go
+++ b/toolkit/tools/internal/retry/retry.go
@@ -8,12 +8,12 @@ import (
 	"time"
 )
 
-func calcDelay(retryCount int, sleep time.Duration, backoffExp float64) time.Duration {
+func calculateDelay(retryCount int, sleep time.Duration, backoffExponent float64) time.Duration {
 	// Calculate an exponential backoff.
 	// The formula is: sleep * (backoffExp ^ retryCount)
 	// For example, if sleep = 1 second, backoffExp = 2.0, retryCount = 3
 	// then the delay will be 1 * (2 ^ 3) = 8 seconds.
-	expRetry := math.Pow(float64(retryCount), backoffExp)
+	expRetry := math.Pow(backoffExp, float64(retryCount))
 	return time.Duration(expRetry * float64(sleep))
 }
 
@@ -22,7 +22,7 @@ func Run(function func() error, attempts int, sleep time.Duration) (err error) {
 	return RunWithExpBackoff(function, attempts, sleep, 1.0)
 }
 
-// Run runs function up to attempts times, waiting i * backoffMult * sleep duration before each i-th attempt.
+// RunWithExpBackoff runs function up to 'attempts' times, waiting 'backoffExp^i * sleep' duration before each i-th attempt.
 func RunWithExpBackoff(function func() error, attempts int, sleep time.Duration, backoffExp float64) (err error) {
 	for i := 0; i < attempts; i++ {
 		// Calculate an exponential backoff.

--- a/toolkit/tools/internal/retry/retry.go
+++ b/toolkit/tools/internal/retry/retry.go
@@ -25,7 +25,7 @@ func Run(function func() error, attempts int, sleep time.Duration) (err error) {
 // RunWithExpBackoff runs function up to 'attempts' times, waiting 'backoffExp^i * sleep' duration before each i-th attempt.
 func RunWithExpBackoff(function func() error, attempts int, sleep time.Duration, backoffExp float64) (err error) {
 	for i := 0; i < attempts; i++ {
-		// Calculate an exponential backoff.
+		// Calculate an exponential backoff. For i=0 we will calculate 0 delay and immediately call the function.
 		time.Sleep(calcDelay(i, sleep, backoffExp))
 		if err = function(); err == nil {
 			break

--- a/toolkit/tools/internal/retry/retry.go
+++ b/toolkit/tools/internal/retry/retry.go
@@ -9,37 +9,52 @@ import (
 )
 
 // calculateDelay calculates the delay for the given failure count, sleep duration, and backoff exponent base.
-// If the base is negative, it will calculate a linear backoff.
 // If the base is positive, it will calculate an exponential backoff.
-func calculateDelay(failCount int, sleep time.Duration, backoffExponentBase float64) time.Duration {
-	if failCount == 0 {
+func calculateExpDelay(failCount int, sleep time.Duration, backoffExponentBase float64) time.Duration {
+	if failCount <= 0 {
 		return 0
 	}
-	// Treat negative values of base as linear backoff.
-	if backoffExponentBase < 0 {
-		return sleep * time.Duration(failCount)
-	}
-	// Calculate an exponential backoff.
-	// The formula is: sleep * (backoffExpBase ^ failCount)
+	// Calculate an exponential backoff. We calculate and sleep BEFORE we try to run the function, so we need to
+	// subtract 1 from the failCount to get the correct exponent.
+
+	// The formula is: sleep * (backoffExpBase ^ (failCount-1))
 	// For example, if sleep = 1 second, backoffExp = 2.0, failCount = 3
-	// then the delay will be 1 * (2 ^ 3) = 8 seconds.
+	// then the delay will be 1 * (2 ^ 2) = 4 seconds.
+	// (0 sec on the first call, 1 sec on the second call, 2 sec on the third call, etc.)
 	expRetry := math.Pow(backoffExponentBase, float64(failCount-1))
 	return time.Duration(expRetry * float64(sleep))
 }
 
-// Run runs function up to attempts times, waiting i * sleep duration before each i-th attempt.
-func Run(function func() error, attempts int, sleep time.Duration) (err error) {
-	return RunWithExpBackoff(function, attempts, sleep, -1)
+func calculateLinearDelay(failCount int, sleep time.Duration) time.Duration {
+	if failCount <= 0 {
+		return 0
+	}
+	return sleep * time.Duration(failCount)
 }
 
-// RunWithExpBackoff runs function up to 'attempts' times, waiting 'backoffExponentBase^i * sleep' duration before each i-th attempt.
-func RunWithExpBackoff(function func() error, attempts int, sleep time.Duration, backoffExponentBase float64) (err error) {
+// runWithBackoffInternal runs function up to 'attempts' times, waiting delayCalc(failCount) before each i-th attempt.
+// delayCalc(0) is expected to return 0.
+func runWithBackoffInternal(function func() error, delayCalc func(failCount int) time.Duration, attempts int) (err error) {
 	for failures := 0; failures < attempts; failures++ {
-		// Calculate an exponential backoff. For i=0 we will calculate 0 delay and immediately call the function.
-		time.Sleep(calculateDelay(failures, sleep, backoffExponentBase))
+		delayTime := delayCalc(failures)
+		time.Sleep(delayTime)
 		if err = function(); err == nil {
 			break
 		}
 	}
 	return err
+}
+
+// Run runs function up to 'attempts' times, waiting i * sleep duration before each i-th attempt.
+func Run(function func() error, attempts int, sleep time.Duration) (err error) {
+	return runWithBackoffInternal(function, func(failCount int) time.Duration {
+		return calculateLinearDelay(failCount, sleep)
+	}, attempts)
+}
+
+// RunWithExpBackoff runs function up to 'attempts' times, waiting 'backoffExponentBase^(i-1) * sleep' duration before each i-th attempt.
+func RunWithExpBackoff(function func() error, attempts int, sleep time.Duration, backoffExponentBase float64) (err error) {
+	return runWithBackoffInternal(function, func(failCount int) time.Duration {
+		return calculateExpDelay(failCount, sleep, backoffExponentBase)
+	}, attempts)
 }

--- a/toolkit/tools/internal/retry/retry.go
+++ b/toolkit/tools/internal/retry/retry.go
@@ -4,13 +4,29 @@
 package retry
 
 import (
+	"math"
 	"time"
 )
 
+func calcDelay(retryCount int, sleep time.Duration, backoffExp float64) time.Duration {
+	// Calculate an exponential backoff.
+	// The formula is: sleep * (backoffExp ^ retryCount)
+	// For example, if sleep = 1 second, backoffExp = 2.0, retryCount = 3
+	// then the delay will be 1 * (2 ^ 3) = 8 seconds.
+	expRetry := math.Pow(float64(retryCount), backoffExp)
+	return time.Duration((expRetry * float64(sleep)))
+}
+
 // Run runs function up to attempts times, waiting i * sleep duration before each i-th attempt.
 func Run(function func() error, attempts int, sleep time.Duration) (err error) {
+	return RunWithExpBackoff(function, attempts, sleep, 1.0)
+}
+
+// Run runs function up to attempts times, waiting i * backoffMult * sleep duration before each i-th attempt.
+func RunWithExpBackoff(function func() error, attempts int, sleep time.Duration, backoffExp float64) (err error) {
 	for i := 0; i < attempts; i++ {
-		time.Sleep(time.Duration(i) * sleep)
+		// Calculate an exponential backoff.
+		time.Sleep(calcDelay(i, sleep, backoffExp))
 		if err = function(); err == nil {
 			break
 		}

--- a/toolkit/tools/internal/retry/retry.go
+++ b/toolkit/tools/internal/retry/retry.go
@@ -14,7 +14,7 @@ func calcDelay(retryCount int, sleep time.Duration, backoffExp float64) time.Dur
 	// For example, if sleep = 1 second, backoffExp = 2.0, retryCount = 3
 	// then the delay will be 1 * (2 ^ 3) = 8 seconds.
 	expRetry := math.Pow(float64(retryCount), backoffExp)
-	return time.Duration((expRetry * float64(sleep)))
+	return time.Duration(expRetry * float64(sleep))
 }
 
 // Run runs function up to attempts times, waiting i * sleep duration before each i-th attempt.

--- a/toolkit/tools/internal/retry/retry_test.go
+++ b/toolkit/tools/internal/retry/retry_test.go
@@ -11,7 +11,7 @@ import (
 const (
 	defaultTestTime = time.Millisecond * 100
 
-// Tests won't run with perfect timing, so we need to allow for some fudge factor when we check maximum duration.
+	// Tests won't run with perfect timing, so we need to allow for some fudge factor when we check maximum duration.
 	timingFudgeFactor = time.Millisecond * 100
 )
 
@@ -23,31 +23,34 @@ func TestZeroBase(t *testing.T) {
 	assert.Equal(t, time.Duration(0), val)
 }
 
-func TestZeroI(t *testing.T) {
+func TestZeroFailuresTime(t *testing.T) {
 	// Zero failures, 1.0 base, should be 0 second delay
 	fails := 0
 	base := 1.0
 	val := calculateExpDelay(fails, defaultTestTime, base)
 	assert.Equal(t, time.Second*0, val)
+}
 
-	// Three failures, 1.0 base, should still be 0 second delay
-	fails = 3
-	base = 0.0
-	val = calculateExpDelay(fails, defaultTestTime, base)
+func TestZeroBaseTime(t *testing.T) {
+	// Three failures, 0.0 base, should be 0 second delay
+	fails := 3
+	base := 0.0
+	val := calculateExpDelay(fails, defaultTestTime, base)
 	assert.Equal(t, time.Second*0, val)
 }
 
-func TestNegativeI(t *testing.T) {
+func TestNegativeFailuresCountExp(t *testing.T) {
 	// Negative failures, 1.0 base, should be 0 second delay
 	fails := -1
 	base := 1.0
 	val := calculateExpDelay(fails, defaultTestTime, base)
 	assert.Equal(t, time.Second*0, val)
+}
 
+func TestNegativeFailuresCountLinear(t *testing.T) {
 	// Negative failures, should be 0 second delay
-	fails = -1
-	base = 1.0
-	val = calculateLinearDelay(fails, defaultTestTime)
+	fails := -1
+	val := calculateLinearDelay(fails, defaultTestTime)
 	assert.Equal(t, time.Second*0, val)
 }
 
@@ -62,7 +65,7 @@ func TestCalcDelayBaseLinear(t *testing.T) {
 	}
 }
 
-func TestCalcDelayBase2(t *testing.T) {
+func TestCalcDelayExpBase2(t *testing.T) {
 	// Delay vs. retry count for base = 2.0, delay = 0.1 seconds
 	var expectedValuesMillis2 = []int{0, 100, 200, 400, 800, 1600}
 
@@ -89,14 +92,22 @@ func TestTotalRunTimeWithFailuresLinear(t *testing.T) {
 	maxDelay := idealTime + timingFudgeFactor
 	assert.GreaterOrEqual(t, endTime.Sub(startTime), minDelay)
 	assert.LessOrEqual(t, endTime.Sub(startTime), maxDelay)
+}
 
+func TestTotalRunTimeWithFailuresDefaultRun(t *testing.T) {
+	attempts := 3
 	// Ensure the default Run() method works the same way
-	startTime = time.Now()
-	err = Run(func() error {
+	startTime := time.Now()
+	err := Run(func() error {
 		return fmt.Errorf("test error")
 	}, attempts, defaultTestTime)
-	endTime = time.Now()
+	endTime := time.Now()
 	assert.NotNil(t, err)
+	// Delays should be 0 seconds, <attempt>, .1 second, <attempt>, .2 seconds, <attempt>
+	// for a total of .3 seconds.
+	idealTime := time.Millisecond * 300
+	minDelay := idealTime
+	maxDelay := idealTime + timingFudgeFactor
 	assert.GreaterOrEqual(t, endTime.Sub(startTime), minDelay)
 	assert.LessOrEqual(t, endTime.Sub(startTime), maxDelay)
 }

--- a/toolkit/tools/internal/retry/retry_test.go
+++ b/toolkit/tools/internal/retry/retry_test.go
@@ -15,11 +15,11 @@ var expectedValuesMillis1 = []int{0, 100, 200, 300, 400, 500}
 var expectedValuesMillis2 = []int{0, 100, 400, 900, 1600, 2500}
 
 func TestCalcDelay1(t *testing.T) {
-	mult := 1.0
+	backoffExponentBase := 1.0
 	sleep := time.Millisecond * 100
 	for i, expected := range expectedValuesMillis1 {
 		expected := time.Duration(expected) * time.Millisecond
-		actual := calcDelay(i, sleep, mult)
+		actual := calcDelay(i, sleep, backoffExponentBase)
 		assert.Equal(t, expected, actual)
 	}
 }

--- a/toolkit/tools/internal/retry/retry_test.go
+++ b/toolkit/tools/internal/retry/retry_test.go
@@ -1,0 +1,83 @@
+package retry
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Delay vs. retry count for mult = 1.0, delay = .1 seconds
+var expectedValuesMillis1 = []int{0, 100, 200, 300, 400, 500}
+
+// Delay vs. retry count for exp = 2.0, delay = 0.1 seconds
+var expectedValuesMillis2 = []int{0, 100, 400, 900, 1600, 2500}
+
+func TestCalcDelay1(t *testing.T) {
+	mult := 1.0
+	sleep := time.Millisecond * 100
+	for i, expected := range expectedValuesMillis1 {
+		expected := time.Duration(expected) * time.Millisecond
+		actual := calcDelay(i, sleep, mult)
+		assert.Equal(t, expected, actual)
+	}
+}
+
+func TestCalcDelay2(t *testing.T) {
+	mult := 2.0
+	sleep := time.Millisecond * 100
+	for i, expected := range expectedValuesMillis2 {
+		expected := time.Duration(expected) * time.Millisecond
+		actual := calcDelay(i, sleep, mult)
+		assert.Equal(t, expected, actual)
+	}
+}
+
+func TestTotalRunTimeWithFailures1(t *testing.T) {
+	startTime := time.Now()
+	err := RunWithExpBackoff(func() error {
+		return fmt.Errorf("test error")
+	}, 3, time.Millisecond*100, 1.0)
+	endTime := time.Now()
+	assert.NotNil(t, err)
+	// Delays should be 0 seconds, <attempt>, .1 second, <attempt>, .2 seconds, <attempt>
+	// for a total of .3 seconds.
+	minDelay := time.Millisecond * 300
+	maxDelay := time.Millisecond * 500
+	assert.GreaterOrEqual(t, endTime.Sub(startTime), minDelay)
+	assert.LessOrEqual(t, endTime.Sub(startTime), maxDelay)
+}
+
+func TestTotalRunTimeWithFailures2(t *testing.T) {
+	startTime := time.Now()
+	err := RunWithExpBackoff(func() error {
+		return fmt.Errorf("test error")
+	}, 3, time.Millisecond*100, 2.0)
+	endTime := time.Now()
+	assert.NotNil(t, err)
+	// Delays should be 0 seconds, <attempt>, .1 second, <attempt>, .4 seconds, <attempt>
+	// for a total of .5 seconds.
+	minDelay := time.Millisecond * 500
+	maxDelay := time.Millisecond * 700
+	assert.GreaterOrEqual(t, endTime.Sub(startTime), minDelay)
+	assert.LessOrEqual(t, endTime.Sub(startTime), maxDelay)
+}
+
+func TestTotalRunTimeWithSuccess(t *testing.T) {
+	startTime := time.Now()
+	err := RunWithExpBackoff(func() error {
+		return nil
+	}, 3, time.Second, 1.0)
+	endTime := time.Now()
+	assert.Nil(t, err)
+	// Delays should be 0 seconds, <attempt>
+	// for a total of 0 seconds.
+	maxDelay := time.Millisecond * 100
+	assert.LessOrEqual(t, endTime.Sub(startTime), maxDelay)
+}
+
+func TestZeroMult(t *testing.T) {
+	val := calcDelay(2, time.Second, 0.0)
+	assert.LessOrEqual(t, val, time.Second*2)
+}

--- a/toolkit/tools/internal/retry/retry_test.go
+++ b/toolkit/tools/internal/retry/retry_test.go
@@ -8,10 +8,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var defaultTestTime = time.Millisecond * 100
+const (
+	defaultTestTime = time.Millisecond * 100
 
 // Tests won't run with perfect timing, so we need to allow for some fudge factor when we check maximum duration.
-var timingFudgeFactor = time.Millisecond * 100
+	timingFudgeFactor = time.Millisecond * 100
+)
 
 func TestZeroBase(t *testing.T) {
 	// Two failures, 0.0 multiplier, should be 0 second delay

--- a/toolkit/tools/internal/retry/retry_test.go
+++ b/toolkit/tools/internal/retry/retry_test.go
@@ -131,16 +131,3 @@ func TestTotalRunTimeWithSuccess(t *testing.T) {
 	maxDelay := timingFudgeFactor
 	assert.LessOrEqual(t, endTime.Sub(startTime), maxDelay)
 }
-
-// func TestFoo(t *testing.T) {
-// 	const (
-// 		downloadRetryAttempts  = 5
-// 		failureBackoffExponent = 2.0
-// 		downloadRetryDuration  = time.Second
-// 	)
-// 	totalDuration := time.Duration(0)
-// 	for i := 1; i <= downloadRetryAttempts; i++ {
-// 		totalDuration += calculateDelay(i, downloadRetryDuration, failureBackoffExponent)
-// 	}
-// 	assert.Equal(t, time.Duration(1023)*time.Millisecond, totalDuration)
-// }

--- a/toolkit/tools/srpmpacker/srpmpacker.go
+++ b/toolkit/tools/srpmpacker/srpmpacker.go
@@ -113,7 +113,7 @@ var (
 	runCheck     = app.Flag("run-check", "Whether or not to run the spec file's check section during package build.").Bool()
 
 	workers          = app.Flag("workers", "Number of concurrent goroutines to parse with.").Default(defaultWorkerCount).Int()
-	concurrentNetOps = app.Flag("concurrent-net-ops", "Number of concurrent network operations to perform.").Default(defaultWorkerCount).Int()
+	concurrentNetOps = app.Flag("concurrent-net-ops", "Number of concurrent network operations to perform.").Default(defaultNetOpsCount).Int()
 	repackAll        = app.Flag("repack", "Rebuild all SRPMs, even if already built.").Bool()
 	nestedSourcesDir = app.Flag("nested-sources", "Set if for a given SPEC, its sources are contained in a SOURCES directory next to the SPEC file.").Bool()
 

--- a/toolkit/tools/srpmpacker/srpmpacker.go
+++ b/toolkit/tools/srpmpacker/srpmpacker.go
@@ -233,7 +233,7 @@ func parsePackListFile(packListFile string) (packList map[string]bool, err error
 
 // createAllSRPMsWrapper wraps createAllSRPMs to conditionally run it inside a chroot.
 // If workerTar is non-empty, packing will occur inside a chroot, otherwise it will run on the host system.
-func createAllSRPMsWrapper(specsDir, distTag, buildDir, outDir, workerTar string, workers, concurrentNetOps int, nestedSourcesDir, repackAll, runCheck bool, packList map[string]bool, templateSrcConfig sourceRetrievalConfiguration) (err error) {
+func createAllSRPMsWrapper(specsDir, distTag, buildDir, outDir, workerTar string, workers int, concurrentNetOps uint, nestedSourcesDir, repackAll, runCheck bool, packList map[string]bool, templateSrcConfig sourceRetrievalConfiguration) (err error) {
 	var chroot *safechroot.Chroot
 	originalOutDir := outDir
 	if workerTar != "" {

--- a/toolkit/tools/srpmpacker/srpmpacker.go
+++ b/toolkit/tools/srpmpacker/srpmpacker.go
@@ -113,7 +113,7 @@ var (
 	runCheck     = app.Flag("run-check", "Whether or not to run the spec file's check section during package build.").Bool()
 
 	workers          = app.Flag("workers", "Number of concurrent goroutines to parse with.").Default(defaultWorkerCount).Int()
-	concurrentNetOps = app.Flag("concurrent-net-ops", "Number of concurrent network operations to perform.").Default(defaultNetOpsCount).Int()
+	concurrentNetOps = app.Flag("concurrent-net-ops", "Number of concurrent network operations to perform.").Default(defaultNetOpsCount).UInt()
 	repackAll        = app.Flag("repack", "Rebuild all SRPMs, even if already built.").Bool()
 	nestedSourcesDir = app.Flag("nested-sources", "Set if for a given SPEC, its sources are contained in a SOURCES directory next to the SPEC file.").Bool()
 
@@ -149,9 +149,6 @@ func main() {
 		logger.Log.Fatalf("Value in --workers must be greater than zero. Found %d", *workers)
 	}
 
-	if *concurrentNetOps <= 0 {
-		logger.Log.Fatalf("Value in --concurrent-net-ops must be greater than zero. Found %d", *concurrentNetOps)
-	}
 
 	// Create a template configuration that all packed SRPM will be based on.
 	var templateSrcConfig sourceRetrievalConfiguration

--- a/toolkit/tools/srpmpacker/srpmpacker.go
+++ b/toolkit/tools/srpmpacker/srpmpacker.go
@@ -976,7 +976,7 @@ func hydrateFromRemoteSource(fileHydrationState map[string]bool, newSourceDir st
 			}
 
 			return err
-		}, downloadRetryAttempts, downloadRetryDuration, failureBackoffBase)
+		}, downloadRetryAttempts, downloadRetryDuration, failureBackoffBase, cancel)
 
 		if netOpsSemaphore != nil {
 			// Clear the channel to allow another operation to start


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
During testing of the new parallel build PR gates, it was noticed that the build agents often dropped connections. We can run most of the packing step highly parallelized, but limiting the number of concurrent network operations significantly improves reliability.

Also adding a configurable exponent to the retry backoff logic allows us to be more accommodating by significantly slowing down network requests when things start to go wrong.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add retry.RunWithExpBackoff() which has a configurable backoff exponent (rather than the implicit `1.0` in `Run()`).
- Add a semaphore to limit concurrent network traffic in the packer

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local builds
