### PR TITLE
moby-engine: introduce patch to fix `http: invalid Host header`

### DIFF
--- a/SPECS/moby-engine/fix-invalid-host-header.patch
+++ b/SPECS/moby-engine/fix-invalid-host-header.patch
@@ -1,0 +1,336 @@
+From 09fa77b952c9f959b41bf3794b8225564f24937d Mon Sep 17 00:00:00 2001
+From: Sebastiaan van Stijn <github@gone.nl>
+Date: Fri, 14 Jul 2023 18:56:47 +0200
+Subject: [PATCH 1/4] client: TestSetHostHeader: don't use un-keyed literals
+
+Backported by @mfrw for 20.10.24 on 2023-08-04
+
+Signed-off-by: Sebastiaan van Stijn <github@gone.nl>
+Signed-off-by: Muhammad Falak R Wani <falakreyaz@gmail.com>
+---
+ client/request_test.go | 24 ++++++++++++------------
+ 1 file changed, 12 insertions(+), 12 deletions(-)
+
+diff --git a/client/request_test.go b/client/request_test.go
+index b93b546..a3be507 100644
+--- a/client/request_test.go
++++ b/client/request_test.go
+@@ -26,24 +26,24 @@ func TestSetHostHeader(t *testing.T) {
+ 		expectedURLHost string
+ 	}{
+ 		{
+-			"unix:///var/run/docker.sock",
+-			"docker",
+-			"/var/run/docker.sock",
++			host:            "unix:///var/run/docker.sock",
++			expectedHost:    "docker",
++			expectedURLHost: "/var/run/docker.sock",
+ 		},
+ 		{
+-			"npipe:////./pipe/docker_engine",
+-			"docker",
+-			"//./pipe/docker_engine",
++			host:            "npipe:////./pipe/docker_engine",
++			expectedHost:    "docker",
++			expectedURLHost: "//./pipe/docker_engine",
+ 		},
+ 		{
+-			"tcp://0.0.0.0:4243",
+-			"",
+-			"0.0.0.0:4243",
++			host:            "tcp://0.0.0.0:4243",
++			expectedHost:    "",
++			expectedURLHost: "0.0.0.0:4243",
+ 		},
+ 		{
+-			"tcp://localhost:4243",
+-			"",
+-			"localhost:4243",
++			host:            "tcp://localhost:4243",
++			expectedHost:    "",
++			expectedURLHost: "localhost:4243",
+ 		},
+ 	}
+ 
+-- 
+2.40.1
+
+From a3f86aa8dbaa37f1c1abceb88e055c462e2baa85 Mon Sep 17 00:00:00 2001
+From: Sebastiaan van Stijn <github@gone.nl>
+Date: Wed, 12 Jul 2023 14:15:38 +0200
+Subject: [PATCH 2/4] client: define a "dummy" hostname to use for local
+ connections
+
+Backported by @mfrw for 20.10.24 on 2023-08-04
+
+For local communications (npipe://, unix://), the hostname is not used,
+but we need valid and meaningful hostname.
+
+The current code used the client's `addr` as hostname in some cases, which
+could contain the path for the unix-socket (`/var/run/docker.sock`), which
+gets rejected by go1.20.6 and go1.19.11 because of a security fix for
+[CVE-2023-29406 ][1], which was implemented in  https://go.dev/issue/60374.
+
+Prior versions go Go would clean the host header, and strip slashes in the
+process, but go1.20.6 and go1.19.11 no longer do, and reject the host
+header.
+
+This patch introduces a `DummyHost` const, and uses this dummy host for
+cases where we don't need an actual hostname.
+
+Before this patch (using go1.20.6):
+
+    make GO_VERSION=1.20.6 TEST_FILTER=TestAttach test-integration
+    === RUN   TestAttachWithTTY
+        attach_test.go:46: assertion failed: error is not nil: http: invalid Host header
+    --- FAIL: TestAttachWithTTY (0.11s)
+    === RUN   TestAttachWithoutTTy
+        attach_test.go:46: assertion failed: error is not nil: http: invalid Host header
+    --- FAIL: TestAttachWithoutTTy (0.02s)
+    FAIL
+
+With this patch applied:
+
+    make GO_VERSION=1.20.6 TEST_FILTER=TestAttach test-integration
+    INFO: Testing against a local daemon
+    === RUN   TestAttachWithTTY
+    --- PASS: TestAttachWithTTY (0.12s)
+    === RUN   TestAttachWithoutTTy
+    --- PASS: TestAttachWithoutTTy (0.02s)
+    PASS
+
+[1]: https://github.com/advisories/GHSA-f8f7-69v5-w4vx
+
+Signed-off-by: Sebastiaan van Stijn <github@gone.nl>
+Signed-off-by: Muhammad Falak R Wani <falakreyaz@gmail.com>
+---
+ client/client.go       | 30 ++++++++++++++++++++++++++++++
+ client/hijack.go       |  6 +++++-
+ client/request.go      | 10 ++++------
+ client/request_test.go |  4 ++--
+ 4 files changed, 41 insertions(+), 9 deletions(-)
+
+diff --git a/client/client.go b/client/client.go
+index 0d3614d..d0ce09a 100644
+--- a/client/client.go
++++ b/client/client.go
+@@ -56,6 +56,36 @@ import (
+ 	"github.com/pkg/errors"
+ )
+ 
++// DummyHost is a hostname used for local communication.
++//
++// It acts as a valid formatted hostname for local connections (such as "unix://"
++// or "npipe://") which do not require a hostname. It should never be resolved,
++// but uses the special-purpose ".localhost" TLD (as defined in [RFC 2606, Section 2]
++// and [RFC 6761, Section 6.3]).
++//
++// [RFC 7230, Section 5.4] defines that an empty header must be used for such
++// cases:
++//
++//	If the authority component is missing or undefined for the target URI,
++//	then a client MUST send a Host header field with an empty field-value.
++//
++// However, [Go stdlib] enforces the semantics of HTTP(S) over TCP, does not
++// allow an empty header to be used, and requires req.URL.Scheme to be either
++// "http" or "https".
++//
++// For further details, refer to:
++//
++//   - https://github.com/docker/engine-api/issues/189
++//   - https://github.com/golang/go/issues/13624
++//   - https://github.com/golang/go/issues/61076
++//   - https://github.com/moby/moby/issues/45935
++//
++// [RFC 2606, Section 2]: https://www.rfc-editor.org/rfc/rfc2606.html#section-2
++// [RFC 6761, Section 6.3]: https://www.rfc-editor.org/rfc/rfc6761#section-6.3
++// [RFC 7230, Section 5.4]: https://datatracker.ietf.org/doc/html/rfc7230#section-5.4
++// [Go stdlib]: https://github.com/golang/go/blob/6244b1946bc2101b01955468f1be502dbadd6807/src/net/http/transport.go#L558-L569
++const DummyHost = "api.moby.localhost"
++
+ // ErrRedirect is the error returned by checkRedirect when the request is non-GET.
+ var ErrRedirect = errors.New("unexpected redirect in response")
+ 
+diff --git a/client/hijack.go b/client/hijack.go
+index e1dc49e..b8fac0b 100644
+--- a/client/hijack.go
++++ b/client/hijack.go
+@@ -62,7 +62,11 @@ func fallbackDial(proto, addr string, tlsConfig *tls.Config) (net.Conn, error) {
+ }
+ 
+ func (cli *Client) setupHijackConn(ctx context.Context, req *http.Request, proto string) (net.Conn, error) {
+-	req.Host = cli.addr
++	req.URL.Host = cli.addr
++	if cli.proto == "unix" || cli.proto == "npipe" {
++		// Override host header for non-tcp connections.
++		req.Host = DummyHost
++	}
+ 	req.Header.Set("Connection", "Upgrade")
+ 	req.Header.Set("Upgrade", proto)
+ 
+diff --git a/client/request.go b/client/request.go
+index d3d9a3f..22e59d1 100644
+--- a/client/request.go
++++ b/client/request.go
+@@ -88,16 +88,14 @@ func (cli *Client) buildRequest(method, path string, body io.Reader, headers hea
+ 		return nil, err
+ 	}
+ 	req = cli.addHeaders(req, headers)
++	req.URL.Host = cli.addr
++	req.URL.Scheme = cli.scheme
+ 
+ 	if cli.proto == "unix" || cli.proto == "npipe" {
+-		// For local communications, it doesn't matter what the host is. We just
+-		// need a valid and meaningful host name. (See #189)
+-		req.Host = "docker"
++		// Override host header for non-tcp connections.
++		req.Host = DummyHost
+ 	}
+ 
+-	req.URL.Host = cli.addr
+-	req.URL.Scheme = cli.scheme
+-
+ 	if expectedPayload && req.Header.Get("Content-Type") == "" {
+ 		req.Header.Set("Content-Type", "text/plain")
+ 	}
+diff --git a/client/request_test.go b/client/request_test.go
+index a3be507..c1a1092 100644
+--- a/client/request_test.go
++++ b/client/request_test.go
+@@ -27,12 +27,12 @@ func TestSetHostHeader(t *testing.T) {
+ 	}{
+ 		{
+ 			host:            "unix:///var/run/docker.sock",
+-			expectedHost:    "docker",
++			expectedHost:    DummyHost,
+ 			expectedURLHost: "/var/run/docker.sock",
+ 		},
+ 		{
+ 			host:            "npipe:////./pipe/docker_engine",
+-			expectedHost:    "docker",
++			expectedHost:    DummyHost,
+ 			expectedURLHost: "//./pipe/docker_engine",
+ 		},
+ 		{
+-- 
+2.40.1
+
+From 37ca6df4494752bb8a3d1f7000c0411380786365 Mon Sep 17 00:00:00 2001
+From: Sebastiaan van Stijn <github@gone.nl>
+Date: Wed, 12 Jul 2023 15:07:59 +0200
+Subject: [PATCH 3/4] pkg/plugins: use a dummy hostname for local connections
+
+Backported by @mfrw for 20.10.24 on 2023-08-04
+
+For local communications (npipe://, unix://), the hostname is not used,
+but we need valid and meaningful hostname.
+
+The current code used the socket path as hostname, which gets rejected by
+go1.20.6 and go1.19.11 because of a security fix for [CVE-2023-29406 ][1],
+which was implemented in  https://go.dev/issue/60374.
+
+Prior versions go Go would clean the host header, and strip slashes in the
+process, but go1.20.6 and go1.19.11 no longer do, and reject the host
+header.
+
+Before this patch, tests would fail on go1.20.6:
+
+    === FAIL: pkg/authorization TestAuthZRequestPlugin (15.01s)
+    time="2023-07-12T12:53:45Z" level=warning msg="Unable to connect to plugin: //tmp/authz2422457390/authz-test-plugin.sock/AuthZPlugin.AuthZReq: Post \"http://%2F%2Ftmp%2Fauthz2422457390%2Fauthz-test-plugin.sock/AuthZPlugin.AuthZReq\": http: invalid Host header, retrying in 1s"
+    time="2023-07-12T12:53:46Z" level=warning msg="Unable to connect to plugin: //tmp/authz2422457390/authz-test-plugin.sock/AuthZPlugin.AuthZReq: Post \"http://%2F%2Ftmp%2Fauthz2422457390%2Fauthz-test-plugin.sock/AuthZPlugin.AuthZReq\": http: invalid Host header, retrying in 2s"
+    time="2023-07-12T12:53:48Z" level=warning msg="Unable to connect to plugin: //tmp/authz2422457390/authz-test-plugin.sock/AuthZPlugin.AuthZReq: Post \"http://%2F%2Ftmp%2Fauthz2422457390%2Fauthz-test-plugin.sock/AuthZPlugin.AuthZReq\": http: invalid Host header, retrying in 4s"
+    time="2023-07-12T12:53:52Z" level=warning msg="Unable to connect to plugin: //tmp/authz2422457390/authz-test-plugin.sock/AuthZPlugin.AuthZReq: Post \"http://%2F%2Ftmp%2Fauthz2422457390%2Fauthz-test-plugin.sock/AuthZPlugin.AuthZReq\": http: invalid Host header, retrying in 8s"
+        authz_unix_test.go:82: Failed to authorize request Post "http://%2F%2Ftmp%2Fauthz2422457390%2Fauthz-test-plugin.sock/AuthZPlugin.AuthZReq": http: invalid Host header
+
+[1]: https://github.com/advisories/GHSA-f8f7-69v5-w4vx
+
+Signed-off-by: Sebastiaan van Stijn <github@gone.nl>
+Signed-off-by: Muhammad Falak R Wani <falakreyaz@gmail.com>
+---
+ pkg/plugins/client.go | 14 ++++++++++++--
+ 1 file changed, 12 insertions(+), 2 deletions(-)
+
+diff --git a/pkg/plugins/client.go b/pkg/plugins/client.go
+index 752fecd..e683eb7 100644
+--- a/pkg/plugins/client.go
++++ b/pkg/plugins/client.go
+@@ -18,6 +18,12 @@ import (
+ 
+ const (
+ 	defaultTimeOut = 30
++
++	// dummyHost is a hostname used for local communication.
++	//
++	// For local communications (npipe://, unix://), the hostname is not used,
++	// but we need valid and meaningful hostname.
++	dummyHost = "plugin.moby.localhost"
+ )
+ 
+ func newTransport(addr string, tlsConfig *tlsconfig.Options) (transport.Transport, error) {
+@@ -44,8 +50,12 @@ func newTransport(addr string, tlsConfig *tlsconfig.Options) (transport.Transpor
+ 		return nil, err
+ 	}
+ 	scheme := httpScheme(u)
+-
+-	return transport.NewHTTPTransport(tr, scheme, socket), nil
++	hostName := u.Host
++	if hostName == "" || u.Scheme == "unix" || u.Scheme == "npipe" {
++		// Override host header for non-tcp connections.
++		hostName = dummyHost
++	}
++	return transport.NewHTTPTransport(tr, scheme, hostName), nil
+ }
+ 
+ // NewClient creates a new plugin client (http).
+-- 
+2.40.1
+
+From b9bf2e4eb5aa9399fda8c7848bbfef7a995f9381 Mon Sep 17 00:00:00 2001
+From: Sebastiaan van Stijn <github@gone.nl>
+Date: Wed, 12 Jul 2023 17:37:01 +0200
+Subject: [PATCH 4/4] testutil: use dummyhost for non-tcp connections
+
+Backported by @mfrw for 20.10.24 on 2023-08-04
+
+Signed-off-by: Sebastiaan van Stijn <github@gone.nl>
+Signed-off-by: Muhammad Falak R Wani <falakreyaz@gmail.com>
+---
+ integration-cli/docker_api_attach_test.go | 5 +++++
+ testutil/request/request.go               | 5 +++++
+ 2 files changed, 10 insertions(+)
+
+diff --git a/integration-cli/docker_api_attach_test.go b/integration-cli/docker_api_attach_test.go
+index 48bf47e..7664883 100644
+--- a/integration-cli/docker_api_attach_test.go
++++ b/integration-cli/docker_api_attach_test.go
+@@ -235,6 +235,11 @@ func requestHijack(method, endpoint string, data io.Reader, ct, daemon string, m
+ 	req.URL.Scheme = "http"
+ 	req.URL.Host = hostURL.Host
+ 
++	if hostURL.Scheme == "unix" || hostURL.Scheme == "npipe" {
++		// Override host header for non-tcp connections.
++		req.Host = client.DummyHost
++	}
++
+ 	for _, opt := range modifiers {
+ 		opt(req)
+ 	}
+diff --git a/testutil/request/request.go b/testutil/request/request.go
+index 4f82012..fab0a84 100644
+--- a/testutil/request/request.go
++++ b/testutil/request/request.go
+@@ -126,6 +126,11 @@ func newRequest(endpoint string, opts *Options) (*http.Request, error) {
+ 	}
+ 	req.URL.Host = hostURL.Host
+ 
++	if hostURL.Scheme == "unix" || hostURL.Scheme == "npipe" {
++		// Override host header for non-tcp connections.
++		req.Host = client.DummyHost
++	}
++
+ 	for _, config := range opts.requestModifiers {
+ 		if err := config(req); err != nil {
+ 			return nil, err
+-- 
+2.40.1
+

--- a/SPECS/moby-engine/moby-engine.spec
+++ b/SPECS/moby-engine/moby-engine.spec
@@ -4,7 +4,7 @@
 Summary: The open-source application container engine
 Name:    %{upstream_name}-engine
 Version: 20.10.24
-Release: 3%{?dist}
+Release: 4%{?dist}
 License: ASL 2.0
 Group:   Tools/Container
 URL: https://mobyproject.org
@@ -20,6 +20,7 @@ Source1: https://github.com/moby/libnetwork/archive/master.tar.gz/#/%{upstream_n
 Source3: docker.service
 Source4: docker.socket
 Patch0:  CVE-2023-25153.patch
+Patch1:  fix-invalid-host-header.patch
 
 %{?systemd_requires}
 
@@ -126,6 +127,9 @@ fi
 %{_unitdir}/*
 
 %changelog
+* Fri Aug 04 2023 Muhammad Falak <mwani@microsoft.com> - 20.10.24-4
+- Introduce patch to fix 'http: invalid Host header'
+
 * Thu Jul 13 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 20.10.24-3
 - Bump release to rebuild with go 1.19.11
 


### PR DESCRIPTION
Signed-off-by: Muhammad Falak R Wani <falakreyaz@gmail.com>

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
With the upgrade to go1.19.11 the moby client starts failing with
`http: invalid Host header` errors when used against the default
unix socket.

Fixes Bug: https://microsoft.visualstudio.com/OS/_workitems/edit/45821789

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Introduce patch to fix `http: invalid Host header`

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://github.com/moby/moby/issues/45935
- https://github.com/moby/moby/pull/45942

###### Links to CVEs  <!-- optional -->
- NA

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build with RUN_CHECK=y/n
- BuddyBuild: [PR-5936](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=402641&view=results)
- Validation in a Mariner VM [WIP]
