### PR TITLE
Patch reaper for CVE-2018-11694 in libsass module

### DIFF
--- a/SPECS/reaper/CVE-2018-11694.patch
+++ b/SPECS/reaper/CVE-2018-11694.patch
@@ -1,0 +1,185 @@
+Fixes CVE-2018-11694: https://nvd.nist.gov/vuln/detail/CVE-2018-11694,
+which is a vulnerability in libsass module version 3.5.5
+[Even though NVD lists CPE upto including 3.5.4, 3.5.5 also contains the
+vulnerable code.]
+
+This patch adpats fixes in libsass sources for the mentioned CVE:
+Patch: https://github.com/sass/libsass/pull/2760
+Patch: https://github.com/sass/libsass/pull/2762
+Issue: https://github.com/sass/libsass/issues/2663
+
+From 2214ae16d9d9ec4c102c56a53ff5fb8d25217dd4 Mon Sep 17 00:00:00 2001
+From: <redacted>
+Date: Fri, 4 Aug 2023 15:04:06 +0530
+Subject: [PATCH] Disallow parent selectors in selector-append.
+                 Fix crash in selector-append('.x~~', 'a')
+
+---
+ .../node-sass/src/libsass/src/functions.cpp   | 26 +++++++++++--------
+ .../node-sass/src/libsass/src/parser.cpp      | 14 +++++-----
+ .../node-sass/src/libsass/src/parser.hpp      | 13 +++++-----
+ 3 files changed, 29 insertions(+), 24 deletions(-)
+
+diff --git a/node_modules/node-sass/src/libsass/src/functions.cpp b/node_modules/node-sass/src/libsass/src/functions.cpp
+index c9999fc3..4227d4de 100644
+--- a/node_modules/node-sass/src/libsass/src/functions.cpp
++++ b/node_modules/node-sass/src/libsass/src/functions.cpp
+@@ -240,13 +240,13 @@ namespace Sass {
+         std::stringstream msg;
+         msg << argname << ": null is not a valid selector: it must be a string,\n";
+         msg << "a list of strings, or a list of lists of strings for `" << function_name(sig) << "'";
+-        error(msg.str(), pstate, traces);
++        error(msg.str(), exp->pstate(), traces);
+       }
+       if (String_Constant_Ptr str = Cast<String_Constant>(exp)) {
+         str->quote_mark(0);
+       }
+       std::string exp_src = exp->to_string(ctx.c_options);
+-      return Parser::parse_selector(exp_src.c_str(), ctx, traces);
++      return Parser::parse_selector(exp_src.c_str(), ctx, traces, exp->pstate(), pstate.src);
+     }
+ 
+     template <>
+@@ -255,13 +255,13 @@ namespace Sass {
+       if (exp->concrete_type() == Expression::NULL_VAL) {
+         std::stringstream msg;
+         msg << argname << ": null is not a string for `" << function_name(sig) << "'";
+-        error(msg.str(), pstate, traces);
++        error(msg.str(), exp->pstate(), traces);
+       }
+       if (String_Constant_Ptr str = Cast<String_Constant>(exp)) {
+         str->quote_mark(0);
+       }
+       std::string exp_src = exp->to_string(ctx.c_options);
+-      Selector_List_Obj sel_list = Parser::parse_selector(exp_src.c_str(), ctx, traces);
++      Selector_List_Obj sel_list = Parser::parse_selector(exp_src.c_str(), ctx, traces, exp->pstate(), pstate.src);
+       if (sel_list->length() == 0) return NULL;
+       Complex_Selector_Obj first = sel_list->first();
+       if (!first->tail()) return first->head();
+@@ -1970,7 +1970,7 @@ namespace Sass {
+           str->quote_mark(0);
+         }
+         std::string exp_src = exp->to_string(ctx.c_options);
+-        Selector_List_Obj sel = Parser::parse_selector(exp_src.c_str(), ctx, traces);
++        Selector_List_Obj sel = Parser::parse_selector(exp_src.c_str(), ctx, traces, exp->pstate(), pstate.src);
+         parsedSelectors.push_back(sel);
+       }
+ 
+@@ -2023,7 +2023,9 @@ namespace Sass {
+           str->quote_mark(0);
+         }
+         std::string exp_src = exp->to_string();
+-        Selector_List_Obj sel = Parser::parse_selector(exp_src.c_str(), ctx, traces);
++        Selector_List_Obj sel = Parser::parse_selector(exp_src.c_str(), ctx, traces,
++                                                       exp->pstate(), pstate.src,
++                                                       /*allow_parent=*/false);
+         parsedSelectors.push_back(sel);
+       }
+ 
+@@ -2077,11 +2079,13 @@ namespace Sass {
+ 
+             // TODO: Add check for namespace stuff
+ 
+-            // append any selectors in childSeq's head
+-            parentSeqClone->innermost()->head()->concat(base->head());
+-
+-            // Set parentSeqClone new tail
+-            parentSeqClone->innermost()->tail( base->tail() );
++            Complex_Selector_Ptr lastComponent = parentSeqClone->mutable_last();
++            if (lastComponent->head() == nullptr) {
++              std::string msg = "Parent \"" + parentSeqClone->to_string() + "\" is incompatible with \"" + base->to_string() + "\"";
++              error(msg, pstate, traces);
++            }
++            lastComponent->head()->concat(base->head());
++            lastComponent->tail(base->tail());
+ 
+             newElements.push_back(parentSeqClone);
+           }
+diff --git a/node_modules/node-sass/src/libsass/src/parser.cpp b/node_modules/node-sass/src/libsass/src/parser.cpp
+index 28fe0224..8d916269 100644
+--- a/node_modules/node-sass/src/libsass/src/parser.cpp
++++ b/node_modules/node-sass/src/libsass/src/parser.cpp
+@@ -30,11 +30,11 @@ namespace Sass {
+   using namespace Constants;
+   using namespace Prelexer;
+ 
+-  Parser Parser::from_c_str(const char* beg, Context& ctx, Backtraces traces, ParserState pstate, const char* source)
++  Parser Parser::from_c_str(const char* beg, Context& ctx, Backtraces traces, ParserState pstate, const char* source, bool allow_parent)
+   {
+     pstate.offset.column = 0;
+     pstate.offset.line = 0;
+-    Parser p(ctx, pstate, traces);
++    Parser p(ctx, pstate, traces, allow_parent);
+     p.source   = source ? source : beg;
+     p.position = beg ? beg : p.source;
+     p.end      = p.position + strlen(p.position);
+@@ -44,11 +44,11 @@ namespace Sass {
+     return p;
+   }
+ 
+-  Parser Parser::from_c_str(const char* beg, const char* end, Context& ctx, Backtraces traces, ParserState pstate, const char* source)
++  Parser Parser::from_c_str(const char* beg, const char* end, Context& ctx, Backtraces traces, ParserState pstate, const char* source, bool allow_parent)
+   {
+     pstate.offset.column = 0;
+     pstate.offset.line = 0;
+-    Parser p(ctx, pstate, traces);
++    Parser p(ctx, pstate, traces, allow_parent);
+     p.source   = source ? source : beg;
+     p.position = beg ? beg : p.source;
+     p.end      = end ? end : p.position + strlen(p.position);
+@@ -66,10 +66,9 @@ namespace Sass {
+       pstate.offset.line = 0;
+     }
+ 
+-  Selector_List_Obj Parser::parse_selector(const char* beg, Context& ctx, Backtraces traces, ParserState pstate, const char* source)
++  Selector_List_Obj Parser::parse_selector(const char* beg, Context& ctx, Backtraces traces, ParserState pstate, const char* source, bool allow_parent)
+   {
+-    Parser p = Parser::from_c_str(beg, ctx, traces, pstate, source);
+-    // ToDo: ruby sass errors on parent references
++    Parser p = Parser::from_c_str(beg, ctx, traces, pstate, source, allow_parent);
+     // ToDo: remap the source-map entries somehow
+     return p.parse_selector_list(false);
+   }
+@@ -818,6 +817,7 @@ namespace Sass {
+       // parse parent selector
+       else if (lex< exactly<'&'> >(false))
+       {
++        if (!allow_parent) error("Parent selectors aren't allowed here.");
+         // this produces a linefeed!?
+         seq->has_parent_reference(true);
+         seq->append(SASS_MEMORY_NEW(Parent_Selector, pstate));
+diff --git a/node_modules/node-sass/src/libsass/src/parser.hpp b/node_modules/node-sass/src/libsass/src/parser.hpp
+index d2a6ddc1..2371dfca 100644
+--- a/node_modules/node-sass/src/libsass/src/parser.hpp
++++ b/node_modules/node-sass/src/libsass/src/parser.hpp
+@@ -48,23 +48,24 @@ namespace Sass {
+     Backtraces traces;
+     size_t indentation;
+     size_t nestings;
++    bool allow_parent;
+ 
+     Token lexed;
+ 
+-    Parser(Context& ctx, const ParserState& pstate, Backtraces traces)
++    Parser(Context& ctx, const ParserState& pstate, Backtraces traces, bool allow_parent = true)
+     : ParserState(pstate), ctx(ctx), block_stack(), stack(0), last_media_block(),
+       source(0), position(0), end(0), before_token(pstate), after_token(pstate),
+-      pstate(pstate), traces(traces), indentation(0), nestings(0)
++      pstate(pstate), traces(traces), indentation(0), nestings(0), allow_parent(allow_parent)
+     { 
+       stack.push_back(Scope::Root);
+     }
+ 
+     // static Parser from_string(const std::string& src, Context& ctx, ParserState pstate = ParserState("[STRING]"));
+-    static Parser from_c_str(const char* src, Context& ctx, Backtraces, ParserState pstate = ParserState("[CSTRING]"), const char* source = 0);
+-    static Parser from_c_str(const char* beg, const char* end, Context& ctx, Backtraces, ParserState pstate = ParserState("[CSTRING]"), const char* source = 0);
+-    static Parser from_token(Token t, Context& ctx, Backtraces, ParserState pstate = ParserState("[TOKEN]"), const char* source = 0);
++    static Parser from_c_str(const char* src, Context& ctx, Backtraces, ParserState pstate = ParserState("[CSTRING]"), const char* source = nullptr, bool allow_parent = true);
++    static Parser from_c_str(const char* beg, const char* end, Context& ctx, Backtraces, ParserState pstate = ParserState("[CSTRING]"), const char* source = nullptr, bool allow_parent = true);
++    static Parser from_token(Token t, Context& ctx, Backtraces, ParserState pstate = ParserState("[TOKEN]"), const char* source = nullptr);
+     // special static parsers to convert strings into certain selectors
+-    static Selector_List_Obj parse_selector(const char* src, Context& ctx, Backtraces, ParserState pstate = ParserState("[SELECTOR]"), const char* source = 0);
++    static Selector_List_Obj parse_selector(const char* src, Context& ctx, Backtraces, ParserState pstate = ParserState("[SELECTOR]"), const char* source = nullptr, bool allow_parent = true);
+ 
+ #ifdef __clang__
+

--- a/SPECS/reaper/reaper.spec
+++ b/SPECS/reaper/reaper.spec
@@ -1,7 +1,5 @@
 %global debug_package %{nil}
-
 %define srcdir cassandra-%{name}-%{version}
-
 %define bower_components reaper-bower-components-%{version}.tar.gz
 %define srcui_node_modules reaper-srcui-node-modules-%{version}.tar.gz
 %define bower_cache reaper-bower-cache-%{version}.tar.gz
@@ -10,19 +8,16 @@
 %define local_lib_node_modules reaper-local-lib-node-modules-%{version}.tar.gz
 %define local_n reaper-local-n-%{version}.tar.gz
 
+Summary:        Reaper for cassandra is a tool for running Apache Cassandra repairs against single or multi-site clusters.
 Name:           reaper
 Version:        3.1.1
-Release:        5%{?dist}
-Summary:        Reaper for cassandra is a tool for running Apache Cassandra repairs against single or multi-site clusters.
+Release:        6%{?dist}
 License:        ASL 2.0
-Distribution:   Mariner
 Vendor:         Microsoft Corporation
+Distribution:   Mariner
 Group:          Applications/System
 URL:            https://cassandra-reaper.io/
 Source0:        https://github.com/thelastpickle/cassandra-reaper/archive/refs/tags/%{version}.tar.gz#/cassandra-reaper-%{version}.tar.gz
-# Building reaper only for x86_64 architecture for now, as build caches are x86_64 specific.
-ExclusiveArch:  x86_64
-
 # Building reaper from sources downloads artifacts related to maven/node/etc. These artifacts need to be downloaded as caches in order to build reaper using maven in offline mode.
 # Below is the list of cached sources.
 # bower-components downloaded under src/ui
@@ -42,7 +37,7 @@ Source6:        %{local_lib_node_modules}
 Source7:        %{local_n}
 Patch0:         CVE-2022-37601.patch
 Patch1:         CVE-2023-28155.patch
-
+Patch2:         CVE-2018-11694.patch
 BuildRequires:  git
 BuildRequires:  javapackages-tools
 BuildRequires:  maven
@@ -54,12 +49,14 @@ Requires:       msopenjdk-11
 Requires(pre):  %{_sbindir}/groupadd
 Requires(pre):  %{_sbindir}/useradd
 Provides:       reaper = %{version}-%{release}
+# Building reaper only for x86_64 architecture for now, as build caches are x86_64 specific.
+ExclusiveArch:  x86_64
 
 %description
 Cassandra reaper is an open source tool that aims to schedule and orchestrate repairs of Apache Cassandra clusters.
 
 %prep
-%setup -n %{srcdir}
+%setup -q -n %{srcdir}
 
 %build
 export JAVA_HOME="%{_libdir}/jvm/msopenjdk-11"
@@ -111,6 +108,7 @@ echo "Installing npm_modules"
 tar fx %{SOURCE2}
 patch -p1 --input %{PATCH0}
 patch -p1 --input %{PATCH1}
+patch -p1 --input %{PATCH2}
 popd
 
 # Building using maven in offline mode.
@@ -181,6 +179,9 @@ fi
 %{_unitdir}/cassandra-%{name}.service
 
 %changelog
+* Fri Aug 04 2023 Sumedh Sharma <sumsharma@microsoft.com> - 3.1.1-6
+- Patch CVE-2018-11694 in libsass module
+
 * Thu May 25 2023 Tobias Brick <tobiasb@microsoft.com> - 3.1.1-5
 - Patch CVE-2023-28155 for request npm module
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
Add patch for CVE-2018-11694

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
- Add patch for CVE-2018-11694
- Update spec file

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Associated issues  <!-- optional -->


###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2018-11694

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: Buddy Build
                              https://dev.azure.com/mariner-org/mariner/_build/results?buildId=402680
