### PR TITLE
Made `python-certifi` stop using its bundled certificates to fix CVE-2023-37920.

### DIFF
--- a/SPECS/python-certifi/certifi-2022.12.07-use-system-cert.patch
+++ b/SPECS/python-certifi/certifi-2022.12.07-use-system-cert.patch
@@ -1,0 +1,128 @@
+From c8704810b3e82a7d38bc0de7dd007b8755b83e39 Mon Sep 17 00:00:00 2001
+From: Karolina Surma <ksurma@redhat.com>
+Date: Mon, 14 Nov 2022 13:30:48 +0100
+Subject: [PATCH] certifi-2022.9.24-use-system-cert
+
+---
+ certifi/core.py | 105 +++---------------------------------------------
+ 1 file changed, 6 insertions(+), 99 deletions(-)
+
+diff --git a/certifi/core.py b/certifi/core.py
+index de02898..207116f 100644
+--- a/certifi/core.py
++++ b/certifi/core.py
+@@ -4,105 +4,12 @@ certifi.py
+ 
+ This module returns the installation location of cacert.pem or its contents.
+ """
+-import sys
+ 
++# The RPM-packaged certifi always uses the system certificates
++def where() -> str:
++    return '/etc/pki/tls/certs/ca-bundle.crt'
+ 
+-if sys.version_info >= (3, 11):
++def contents() -> str:
++    with open(where(), encoding='utf=8') as data:
++        return data.read()
+ 
+-    from importlib.resources import as_file, files
+-
+-    _CACERT_CTX = None
+-    _CACERT_PATH = None
+-
+-    def where() -> str:
+-        # This is slightly terrible, but we want to delay extracting the file
+-        # in cases where we're inside of a zipimport situation until someone
+-        # actually calls where(), but we don't want to re-extract the file
+-        # on every call of where(), so we'll do it once then store it in a
+-        # global variable.
+-        global _CACERT_CTX
+-        global _CACERT_PATH
+-        if _CACERT_PATH is None:
+-            # This is slightly janky, the importlib.resources API wants you to
+-            # manage the cleanup of this file, so it doesn't actually return a
+-            # path, it returns a context manager that will give you the path
+-            # when you enter it and will do any cleanup when you leave it. In
+-            # the common case of not needing a temporary file, it will just
+-            # return the file system location and the __exit__() is a no-op.
+-            #
+-            # We also have to hold onto the actual context manager, because
+-            # it will do the cleanup whenever it gets garbage collected, so
+-            # we will also store that at the global level as well.
+-            _CACERT_CTX = as_file(files("certifi").joinpath("cacert.pem"))
+-            _CACERT_PATH = str(_CACERT_CTX.__enter__())
+-
+-        return _CACERT_PATH
+-
+-    def contents() -> str:
+-        return files("certifi").joinpath("cacert.pem").read_text(encoding="ascii")
+-
+-elif sys.version_info >= (3, 7):
+-
+-    from importlib.resources import path as get_path, read_text
+-
+-    _CACERT_CTX = None
+-    _CACERT_PATH = None
+-
+-    def where() -> str:
+-        # This is slightly terrible, but we want to delay extracting the
+-        # file in cases where we're inside of a zipimport situation until
+-        # someone actually calls where(), but we don't want to re-extract
+-        # the file on every call of where(), so we'll do it once then store
+-        # it in a global variable.
+-        global _CACERT_CTX
+-        global _CACERT_PATH
+-        if _CACERT_PATH is None:
+-            # This is slightly janky, the importlib.resources API wants you
+-            # to manage the cleanup of this file, so it doesn't actually
+-            # return a path, it returns a context manager that will give
+-            # you the path when you enter it and will do any cleanup when
+-            # you leave it. In the common case of not needing a temporary
+-            # file, it will just return the file system location and the
+-            # __exit__() is a no-op.
+-            #
+-            # We also have to hold onto the actual context manager, because
+-            # it will do the cleanup whenever it gets garbage collected, so
+-            # we will also store that at the global level as well.
+-            _CACERT_CTX = get_path("certifi", "cacert.pem")
+-            _CACERT_PATH = str(_CACERT_CTX.__enter__())
+-
+-        return _CACERT_PATH
+-
+-    def contents() -> str:
+-        return read_text("certifi", "cacert.pem", encoding="ascii")
+-
+-else:
+-    import os
+-    import types
+-    from typing import Union
+-
+-    Package = Union[types.ModuleType, str]
+-    Resource = Union[str, "os.PathLike"]
+-
+-    # This fallback will work for Python versions prior to 3.7 that lack the
+-    # importlib.resources module but relies on the existing `where` function
+-    # so won't address issues with environments like PyOxidizer that don't set
+-    # __file__ on modules.
+-    def read_text(
+-        package: Package,
+-        resource: Resource,
+-        encoding: str = 'utf-8',
+-        errors: str = 'strict'
+-    ) -> str:
+-        with open(where(), encoding=encoding) as data:
+-            return data.read()
+-
+-    # If we don't have importlib.resources, then we will just do the old logic
+-    # of assuming we're on the filesystem and munge the path directly.
+-    def where() -> str:
+-        f = os.path.dirname(__file__)
+-
+-        return os.path.join(f, "cacert.pem")
+-
+-    def contents() -> str:
+-        return read_text("certifi", "cacert.pem", encoding="ascii")
+-- 
+2.37.3
+

--- a/SPECS/python-certifi/python-certifi.signatures.json
+++ b/SPECS/python-certifi/python-certifi.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "certifi-2022.12.07.tar.gz": "48d30258d28d0d04b9220492bca614cc596be8f14c94b96ea8298d9284a5e3dd"
+  "python-certifi-2023.05.07.tar.gz": "3ee59191c133d4c3c921c075fe4e8bec7c25a16d02143f0ee7de47f7f22cfd0f"
  }
 }

--- a/SPECS/python-certifi/python-certifi.spec
+++ b/SPECS/python-certifi/python-certifi.spec
@@ -1,4 +1,5 @@
 %global certs_bundle_path %{_sysconfdir}/pki/tls/certs/ca-bundle.crt
+
 Summary:        Python package for providing Mozilla's CA Bundle
 Name:           python-certifi
 Version:        2023.05.07
@@ -9,8 +10,12 @@ Distribution:   Mariner
 URL:            https://certifi.io/
 Source:         https://github.com/certifi/%{name}/archive/%{version}/%{name}-%{version}.tar.gz
 Patch0:         certifi-2022.12.07-use-system-cert.patch
-BuildRequires:  python3-devel
+
 BuildArch:      noarch
+
+BuildRequires:  python3-devel
+BuildRequires:  python3-wheel
+
 %if %{with_check}
 BuildRequires:  ca-certificates-base
 BuildRequires:  python3-pytest
@@ -23,7 +28,6 @@ instead. For more details on this system, see the 'ca-certificates' package.
 
 %package -n python3-certifi
 Summary:        %{summary}
-Requires:       ca-certificates
 
 %description -n python3-certifi
 This Azure Linux package does not include its own certificate

--- a/SPECS/python-certifi/python-certifi.spec
+++ b/SPECS/python-certifi/python-certifi.spec
@@ -42,14 +42,14 @@ This package provides the Python 3 certifi library.
 # Remove bundled root certificates collection
 rm -rf certifi/*.pem
 
-%{generate_buildrequires}
-%{pyproject_buildrequires}
+%generate_buildrequires
+%pyproject_buildrequires
 
 %build
-%{pyproject_wheel}
+%pyproject_wheel
 
 %install
-%{pyproject_install}
+%pyproject_install
 %pyproject_save_files certifi
 
 %check

--- a/SPECS/python-certifi/python-certifi.spec
+++ b/SPECS/python-certifi/python-certifi.spec
@@ -28,6 +28,8 @@ instead. For more details on this system, see the 'ca-certificates' package.
 %package -n python3-certifi
 Summary:        %{summary}
 
+Requires:       ca-certificates-base
+
 %description -n python3-certifi
 This Azure Linux package does not include its own certificate
 collection. It reads the system shared certificate trust collection

--- a/SPECS/python-certifi/python-certifi.spec
+++ b/SPECS/python-certifi/python-certifi.spec
@@ -28,7 +28,7 @@ instead. For more details on this system, see the 'ca-certificates' package.
 %package -n python3-certifi
 Summary:        %{summary}
 
-Requires:       ca-certificates-base
+Requires:       %{_sysconfdir}/pki/tls/certs/ca-bundle.crt
 
 %description -n python3-certifi
 This Azure Linux package does not include its own certificate

--- a/SPECS/python-certifi/python-certifi.spec
+++ b/SPECS/python-certifi/python-certifi.spec
@@ -1,5 +1,3 @@
-%global certs_bundle_path %{_sysconfdir}/pki/tls/certs/ca-bundle.crt
-
 Summary:        Python package for providing Mozilla's CA Bundle
 Name:           python-certifi
 Version:        2023.05.07
@@ -14,6 +12,7 @@ Patch0:         certifi-2022.12.07-use-system-cert.patch
 BuildArch:      noarch
 
 BuildRequires:  python3-devel
+BuildRequires:  python3-pip
 BuildRequires:  python3-wheel
 
 %if %{with_check}
@@ -53,13 +52,6 @@ rm -rf certifi/*.pem
 %pyproject_save_files certifi
 
 %check
-# sanity check
-export PYTHONPATH=%{buildroot}%{python3_sitelib}
-test $(python3 -m certifi) == %{certs_bundle_path}
-test $(python3 -c 'import certifi; print(certifi.where())') == %{certs_bundle_path}
-python3 -c 'import certifi; print(certifi.contents())' > contents
-diff --ignore-blank-lines %{certs_bundle_path} contents
-# upstream tests
 %pytest -v
 
 %files -n python3-certifi -f %{pyproject_files}
@@ -67,6 +59,7 @@ diff --ignore-blank-lines %{certs_bundle_path} contents
 
 %changelog
 * Fri Aug 04 2023 Pawel Winogrodzki <pawelwi@microsoft.com> - 2023.05.07-1
+- Removing bundled certificates.
 - Switching to Fedora 39 implementation of the spec (license: MIT).
 
 * Tue Jan 24 2023 Muhammad Falak <mwani@microsoft.com> - 2022.12.07-1

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -21864,8 +21864,8 @@
         "type": "other",
         "other": {
           "name": "python-certifi",
-          "version": "2022.12.07",
-          "downloadUrl": "https://github.com/certifi/python-certifi/archive/refs/tags/2022.12.07.tar.gz"
+          "version": "2023.05.07",
+          "downloadUrl": "https://github.com/certifi/python-certifi/archive/2023.05.07/python-certifi-2023.05.07.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

Fixing CVE-2023-37920. The CVE is about removing a CA from the bundled list of trusted anchors inside `python-certifi`. Since we don't want to use any other bundles except for the ones provided by `ca-certificates`, the change is about switching `python-certifi` to use the system certificates instead of its own bundle.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Switched `python-certifi` to use the system trusted CAs instead of its own bundle.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2023-37920

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local package build and test.