### PR TITLE
Use sparse raw image file

### DIFF
--- a/toolkit/tools/imagegen/diskutils/diskutils.go
+++ b/toolkit/tools/imagegen/diskutils/diskutils.go
@@ -196,17 +196,18 @@ func CreateEmptyDisk(workDirPath, diskName string, disk configuration.Disk) (dis
 
 	// Assume that Disk.MaxSize is given
 	maxSize := disk.MaxSize
-	err = ZeroDisk(diskFilePath, defautBlockSize, maxSize)
+	err = sparseDisk(diskFilePath, defautBlockSize, maxSize)
 	return
 }
 
-// ZeroDisk applies zeroes to the disk specified by diskpath
-func ZeroDisk(diskPath string, blockSize, size uint64) (err error) {
+// sparseDisk creates an empty sparse disk file.
+func sparseDisk(diskPath string, blockSize, size uint64) (err error) {
 	ddArgs := []string{
 		"if=/dev/zero",                  // Input file.
 		fmt.Sprintf("of=%s", diskPath),  // Output file.
 		fmt.Sprintf("bs=%d", blockSize), // Size of one copied block.
-		fmt.Sprintf("count=%d", size),   // Number of blocks to copy to the output file.
+		fmt.Sprintf("seek=%d", size),    // Size of the image.
+		"count=0",                       // Number of blocks to copy to the output file.
 	}
 
 	_, stderr, err := shell.Execute("dd", ddArgs...)


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->

Use a sparse raw image file for the intermediate build image file. This will allow images to be built that have a larger capacity than the free disk space available on the build machine (so long as the committed size is within the free disk space). This will also speed up the build a little bit since it will no longer be pointlessly writing zeros to disk.

###### Change Log  <!-- REQUIRED -->

- Use sparse image file in imager utility.

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Manually run image builds on dev box.
