### PR TITLE
Upgrade plexus archiever to 4.8.0 to fix CVE-2023-37460

### DIFF
--- a/SPECS/javapackages-bootstrap/0001-Remove-usage-of-ArchiveStreamFactory.patch
+++ b/SPECS/javapackages-bootstrap/0001-Remove-usage-of-ArchiveStreamFactory.patch
@@ -1,34 +1,35 @@
-From ebb8f31b84299d5564e26ecb22845133819c9aae Mon Sep 17 00:00:00 2001
-From: Marian Koncek <mkoncek@redhat.com>
-Date: Mon, 17 Aug 2020 13:39:11 +0200
-Subject: [PATCH] Remove usage of ArchiveStreamFactory
+From 0e4f8a7394a5a3bc2ddbc3e8876ea0175ec47cef Mon Sep 17 00:00:00 2001
+From: Saul Paredes <saulparedes@microsoft.com>
+Date: Thu, 10 Aug 2023 19:10:22 -0700
+Subject: [PATCH] remove usage of ArchiveStreamFactory
 
-Forwarded: not-needed
+original commit: ebb8f31b84299d5564e26ecb22845133819c9aae
 ---
- .../archivers/zip/ZipSplitReadOnlySeekableByteChannel.java     | 3 +--
- 1 file changed, 1 insertion(+), 2 deletions(-)
+ .../archivers/zip/ZipSplitReadOnlySeekableByteChannel.java    | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
 
 diff --git a/src/main/java/org/apache/commons/compress/archivers/zip/ZipSplitReadOnlySeekableByteChannel.java b/src/main/java/org/apache/commons/compress/archivers/zip/ZipSplitReadOnlySeekableByteChannel.java
-index b37daff0..a83a40a3 100644
+index 956887d..202bb07 100644
 --- a/src/main/java/org/apache/commons/compress/archivers/zip/ZipSplitReadOnlySeekableByteChannel.java
 +++ b/src/main/java/org/apache/commons/compress/archivers/zip/ZipSplitReadOnlySeekableByteChannel.java
-@@ -18,7 +18,6 @@
- 
- package org.apache.commons.compress.archivers.zip;
- 
+@@ -34,8 +34,6 @@
+ import java.util.regex.Pattern;
+ import java.util.stream.Collectors;
+ import java.util.stream.Stream;
+-
 -import org.apache.commons.compress.archivers.ArchiveStreamFactory;
  import org.apache.commons.compress.utils.FileNameUtils;
  import org.apache.commons.compress.utils.MultiReadOnlySeekableByteChannel;
  
-@@ -156,7 +155,7 @@ public static SeekableByteChannel forOrderedSeekableByteChannels(final SeekableB
+@@ -98,7 +96,7 @@ public static SeekableByteChannel buildFromLastSplitSegment(final File lastSegme
       */
-     public static SeekableByteChannel buildFromLastSplitSegment(final File lastSegmentFile) throws IOException {
-         final String extension = FileNameUtils.getExtension(lastSegmentFile.getCanonicalPath());
+     public static SeekableByteChannel buildFromLastSplitSegment(final Path lastSegmentPath) throws IOException {
+         final String extension = FileNameUtils.getExtension(lastSegmentPath);
 -        if (!extension.equalsIgnoreCase(ArchiveStreamFactory.ZIP)) {
 +        if (!extension.equalsIgnoreCase("zip")) {
-             throw new IllegalArgumentException("The extension of last zip split segment should be .zip");
+             throw new IllegalArgumentException("The extension of last ZIP split segment should be .zip");
          }
  
 -- 
-2.35.1
+2.25.1
 

--- a/SPECS/javapackages-bootstrap/ignore.upstream.patch.txt
+++ b/SPECS/javapackages-bootstrap/ignore.upstream.patch.txt
@@ -1,1 +1,2 @@
 patches/commons-compress/0001-Remove-usage-of-ArchiveStreamFactory.patch
+patches/plexus-archiver/0001-Remove-support-for-snappy.patch

--- a/SPECS/javapackages-bootstrap/javapackages-bootstrap.signatures.json
+++ b/SPECS/javapackages-bootstrap/javapackages-bootstrap.signatures.json
@@ -103,7 +103,7 @@
         "sisu-inject.tar.xz": "c01068336a14c2f13d6b8be98ba4cd65bb78858023789bac844170814b11116c",
         "sisu-mojos.tar.xz": "5abb82f48fc52039bd72a953aaf19454cdfdaf268f8c65301965377946b26108",
         "sisu-plexus.tar.xz": "d1ef48ada2b8124838e69a2e03a1f0a55f238c15d820726f51c65877aed295ee",
-        "slf4j.tar.xz": "5b9269e08c6182b01fffb0c5b1c93537e5e591854a5ffc77d272f7a83decc61e",
+        "slf4j-1.7.36-test.tar.xz": "adcb1a120be7ee0bbc7ace5ff28cb218f05fd702ca416fae944df0db7078c2fd",
         "testng.tar.xz": "73e026f729c9bec84dec3d272a07b887cdd908ea71db31b6ed3480515305d1e2",
         "univocity-parsers.tar.xz": "2451cddf9aaa102979bb1e1f626140b17904fd90eb6049bdb9f960c5ae178378",
         "velocity-engine.tar.xz": "c5835596688fb9ed0a6306ab172675655aa03cf9e9d741f4d018e0105688774f",

--- a/SPECS/javapackages-bootstrap/javapackages-bootstrap.signatures.json
+++ b/SPECS/javapackages-bootstrap/javapackages-bootstrap.signatures.json
@@ -18,7 +18,7 @@
         "commons-cli.tar.xz": "d3df2a5de3bf57d5c53fc4bc199e7c45a3436f10b76481cf88a51cefbbf7be7c",
         "commons-codec.tar.xz": "a9cc38b23b583ab9a277845a57ef2f2b0ef8cb0f41a2c8dc9110f1eeff7ea22c",
         "commons-collections.tar.xz": "0a28fe4702eb1ae471d47f0219a1b18863c0019673baa08330c4370ece7518f8",
-        "commons-compress-1.21.tar.xz": "c35662f60b14b194f379dbbf6eaffaab1d9dfc568e4a8435aef28db52fda8d11",
+        "commons-compress-1.23.0.tar.xz": "b83f8b56c745722372c71292ddc48b89200b06b6440753ae85587acc1a09408b",
         "commons-io.tar.xz": "bc1821e063263ce6aac33f669e49a86dc4681dbe15d3d6d968402b52009132e8",
         "commons-jxpath.tar.xz": "9b25bffed85891c1331d951ce47bcef9db1b3d6a6fbd8decf45e623d406452db",
         "commons-lang.tar.xz": "0c4f449791a506f0765239df53d5c2f8b8504a2eb268e0f9f154bb7852baf827",

--- a/SPECS/javapackages-bootstrap/javapackages-bootstrap.signatures.json
+++ b/SPECS/javapackages-bootstrap/javapackages-bootstrap.signatures.json
@@ -2,7 +2,7 @@
     "Signatures": {
         "javapackages-bootstrap-1.5.0.tar.xz": "37518e10d629f6d7115bd78bed85977c7294f871c2438a57f7857f2c0e065c7c",
         "javapackages-bootstrap-PACKAGE-LICENSING": "3f440662012f41be31be13fb764c1f6a21d51f2efdcabf85ed35e9eb8c3b5714",
-        "ignore.upstream.patch.txt": "441bb5697fc5fb4089b1d43479dd443a8ce4405bec4d6b92c4152d4320ad3a80",
+        "ignore.upstream.patch.txt": "44d2daaf7bc6906603521b4585b1a693a773ce0a4cae6afebb0904a21edc9e64",
         "apache-pom.tar.xz": "cedc788ca41b99d04a6b058b1689e6eda8f33b9afd642e526a0998d7741f7614",
         "ant.tar.xz": "230ad9d99c5adfffd14abc3e094e8b7331cef0c061282ce0f13245a02458b604",
         "apiguardian.tar.xz": "2637e3d7ba392f36d2bd6faa792385bc33ec195e18215b7efa7f4c580cd3ab8b",
@@ -84,7 +84,7 @@
         "osgi-cmpn.tar.xz": "78344be15a3ac9b94ac94768493d402ee18c4f595ebb8b2b6471be839e597f57",
         "osgi-core.tar.xz": "faa87a67045f6db6d2623d3772f7034b8dadb12e832c38e94f9aa51f32bc9ae7",
         "oss-parent-pom.tar.xz": "7a0b3ba7507e99224d96d0bbc5ddc56a58b59999318cd52507b3ce3e2d79b3b7",
-        "plexus-archiver.tar.xz": "c444101f1ac55dddf2a9798c10074d8a0615902a0b8fdd09fa76da526be9c386",
+        "plexus-archiver-4.8.0.tar.xz": "1a089b453aadf56c32fc590adc2b44103fdf56d7e0defc32ee399fa5bd95caf9",
         "plexus-cipher.tar.xz": "7da516bba3704ef175ce4a5e6fcab7f78e72ed8104601f59d319409ed95cd189",
         "plexus-classworlds.tar.xz": "f92ba7722caa11a67d8f3d4ed86219c3eb20bba7708cff06dfc0690c7e857138",
         "plexus-compiler.tar.xz": "fc03377057331a19c3814a97992b94eed97c94cb86e12d1e0234cfac0fa7c298",

--- a/SPECS/javapackages-bootstrap/javapackages-bootstrap.spec
+++ b/SPECS/javapackages-bootstrap/javapackages-bootstrap.spec
@@ -310,6 +310,7 @@ done
 
 # removing harmony files from the source as it causes build time error
 sed  -i "/<excludeSourceMatching>/a\ \t<excludeSourceMatching>/org/apache/commons/compress/harmony/(pack200|unpack200)/.*</excludeSourceMatching>" project/commons-compress.xml
+sed -i 's/zstandard|//g' project/commons-compress.xml
 sed -i '13i\<dependency>slf4j</dependency>' project/plexus-archiver.xml
 
 %build

--- a/SPECS/javapackages-bootstrap/javapackages-bootstrap.spec
+++ b/SPECS/javapackages-bootstrap/javapackages-bootstrap.spec
@@ -309,7 +309,7 @@ do
 done
 
 # removing harmony files from the source as it causes build time error
-sed  -i "/<excludeSourceMatching>/a\ \t<excludeSourceMatching>/org/apache/commons/compress/harmony/(pack200|unpack200)/.*</excludeSourceMatching>" project/commons-compress.xml
+# sed  -i "/<excludeSourceMatching>/a\ \t<excludeSourceMatching>/org/apache/commons/compress/harmony/(pack200|unpack200)/.*</excludeSourceMatching>" project/commons-compress.xml
 
 
 %build

--- a/SPECS/javapackages-bootstrap/javapackages-bootstrap.spec
+++ b/SPECS/javapackages-bootstrap/javapackages-bootstrap.spec
@@ -136,7 +136,7 @@ Source1107:     xmvn.tar.xz
 Source1108:     xz-java.tar.xz
 
 Patch0:         0001-Bind-to-OpenJDK-11-for-runtime.patch
-Patch1:         0001-Remove-usage-of-ArchiveStreamFactory.patch
+# Patch1:         0001-Remove-usage-of-ArchiveStreamFactory.patch
 
 Provides:       bundled(ant) = 1.10.9
 Provides:       bundled(apache-parent) = 23
@@ -289,7 +289,7 @@ done
 
 %patch0 -p1
 pushd "downstream/commons-compress"
-%patch1 -p1 
+# %patch1 -p1 
 popd
 
 for patch_path in patches/*/*
@@ -310,7 +310,6 @@ done
 
 # removing harmony files from the source as it causes build time error
 sed  -i "/<excludeSourceMatching>/a\ \t<excludeSourceMatching>/org/apache/commons/compress/harmony/(pack200|unpack200)/.*</excludeSourceMatching>" project/commons-compress.xml
-sed -i '13i\<dependency>slf4j</dependency>' project/plexus-archiver.xml
 sed -i '13i\<dependency>slf4j</dependency>' project/plexus-archiver.xml
 
 %build

--- a/SPECS/javapackages-bootstrap/javapackages-bootstrap.spec
+++ b/SPECS/javapackages-bootstrap/javapackages-bootstrap.spec
@@ -309,11 +309,11 @@ do
 done
 
 # removing harmony files from the source as it causes build time error
-# sed  -i "/<excludeSourceMatching>/a\ \t<excludeSourceMatching>/org/apache/commons/compress/harmony/(pack200|unpack200)/.*</excludeSourceMatching>" project/commons-compress.xml
+sed  -i "/<excludeSourceMatching>/a\ \t<excludeSourceMatching>/org/apache/commons/compress/harmony/(pack200|unpack200)/.*</excludeSourceMatching>" project/commons-compress.xml
 
 
 %build
-export LC_ALL=en_US.UTF-8 
+# export LC_ALL=en_US.UTF-8 
 export JAVA_HOME=$(find /usr/lib/jvm -name "*openjdk*")
 ./mbi.sh build -parallel
 

--- a/SPECS/javapackages-bootstrap/javapackages-bootstrap.spec
+++ b/SPECS/javapackages-bootstrap/javapackages-bootstrap.spec
@@ -126,7 +126,7 @@ Source1097:     sisu-build-api.tar.xz
 Source1098:     sisu-inject.tar.xz
 Source1099:     sisu-mojos.tar.xz
 Source1100:     sisu-plexus.tar.xz
-Source1101:     slf4j.tar.xz
+Source1101:     slf4j-1.7.36-test.tar.xz
 Source1102:     testng.tar.xz
 Source1103:     univocity-parsers.tar.xz
 Source1104:     velocity-engine.tar.xz
@@ -238,7 +238,7 @@ Provides:       bundled(plexus-build-api) = 0.0.7
 Provides:       bundled(sisu) = 0.3.4
 Provides:       bundled(sisu-mojos) = 0.3.4
 Provides:       bundled(sisu-plexus) = 0.3.4
-Provides:       bundled(slf4j) = 1.7.30
+Provides:       bundled(slf4j) = 1.7.36
 Provides:       bundled(testng) = 7.3.0
 Provides:       bundled(univocity-parsers) = 2.9.1
 Provides:       bundled(velocity) = 1.7

--- a/SPECS/javapackages-bootstrap/javapackages-bootstrap.spec
+++ b/SPECS/javapackages-bootstrap/javapackages-bootstrap.spec
@@ -41,7 +41,7 @@ Source1012:     commons-beanutils.tar.xz
 Source1013:     commons-cli.tar.xz
 Source1014:     commons-codec.tar.xz
 Source1015:     commons-collections.tar.xz
-Source1016:     commons-compress-1.21.tar.xz
+Source1016:     commons-compress-1.23.0.tar.xz
 Source1017:     commons-io.tar.xz
 Source1018:     commons-jxpath.tar.xz
 Source1019:     commons-lang.tar.xz
@@ -153,7 +153,7 @@ Provides:       bundled(apache-commons-beanutils) = 1.9.4
 Provides:       bundled(apache-commons-cli) = 1.4
 Provides:       bundled(apache-commons-codec) = 1.15
 Provides:       bundled(apache-commons-collections) = 3.2.2
-Provides:       bundled(apache-commons-compress) = 1.21
+Provides:       bundled(apache-commons-compress) = 1.23.0
 Provides:       bundled(apache-commons-io) = 2.8.0
 Provides:       bundled(apache-commons-jxpath) = 1.3
 Provides:       bundled(apache-commons-lang3) = 3.11
@@ -311,7 +311,7 @@ done
 # removing harmony files from the source as it causes build time error
 sed  -i "/<excludeSourceMatching>/a\ \t<excludeSourceMatching>/org/apache/commons/compress/harmony/(pack200|unpack200)/.*</excludeSourceMatching>" project/commons-compress.xml
 sed -i '13i\<dependency>slf4j</dependency>' project/plexus-archiver.xml
-
+sed -i '13i\<dependency>slf4j</dependency>' project/plexus-archiver.xml
 
 %build
 export LC_ALL=en_US.UTF-8 

--- a/SPECS/javapackages-bootstrap/javapackages-bootstrap.spec
+++ b/SPECS/javapackages-bootstrap/javapackages-bootstrap.spec
@@ -310,10 +310,11 @@ done
 
 # removing harmony files from the source as it causes build time error
 sed  -i "/<excludeSourceMatching>/a\ \t<excludeSourceMatching>/org/apache/commons/compress/harmony/(pack200|unpack200)/.*</excludeSourceMatching>" project/commons-compress.xml
+sed -i '13i\<dependency>slf4j</dependency>' project/plexus-archiver.xml
 
 
 %build
-# export LC_ALL=en_US.UTF-8 
+export LC_ALL=en_US.UTF-8 
 export JAVA_HOME=$(find /usr/lib/jvm -name "*openjdk*")
 ./mbi.sh build -parallel
 

--- a/SPECS/javapackages-bootstrap/javapackages-bootstrap.spec
+++ b/SPECS/javapackages-bootstrap/javapackages-bootstrap.spec
@@ -136,7 +136,7 @@ Source1107:     xmvn.tar.xz
 Source1108:     xz-java.tar.xz
 
 Patch0:         0001-Bind-to-OpenJDK-11-for-runtime.patch
-# Patch1:         0001-Remove-usage-of-ArchiveStreamFactory.patch
+Patch1:         0001-Remove-usage-of-ArchiveStreamFactory.patch
 
 Provides:       bundled(ant) = 1.10.9
 Provides:       bundled(apache-parent) = 23
@@ -289,7 +289,7 @@ done
 
 %patch0 -p1
 pushd "downstream/commons-compress"
-# %patch1 -p1 
+%patch1 -p1 
 popd
 
 for patch_path in patches/*/*

--- a/SPECS/javapackages-bootstrap/javapackages-bootstrap.spec
+++ b/SPECS/javapackages-bootstrap/javapackages-bootstrap.spec
@@ -13,7 +13,7 @@
 
 Name:           javapackages-bootstrap
 Version:        1.5.0
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        A means of bootstrapping Java Packages Tools
 # For detailed info see the file javapackages-bootstrap-PACKAGE-LICENSING
 License:        ASL 2.0 and ASL 1.1 and (ASL 2.0 or EPL-2.0) and (EPL-2.0 or GPLv2 with exceptions) and MIT and (BSD with advertising) and BSD-3-Clause and EPL-1.0 and EPL-2.0 and CDDL-1.0 and xpp and CC0 and Public Domain
@@ -107,7 +107,7 @@ Source1078:     osgi-annotation.tar.xz
 Source1079:     osgi-cmpn.tar.xz
 Source1080:     osgi-core.tar.xz
 Source1081:     oss-parent-pom.tar.xz
-Source1082:     plexus-archiver.tar.xz
+Source1082:     plexus-archiver-4.8.0.tar.xz
 Source1083:     plexus-cipher.tar.xz
 Source1084:     plexus-classworlds.tar.xz
 Source1085:     plexus-compiler.tar.xz
@@ -219,7 +219,7 @@ Provides:       bundled(osgi-annotation) = 8.0.0
 Provides:       bundled(osgi-compendium) = 7.0.0
 Provides:       bundled(osgi-core) = 8.0.0
 Provides:       bundled(sonatype-oss-parent) = 7
-Provides:       bundled(plexus-archiver) = 4.2.2
+Provides:       bundled(plexus-archiver) = 4.8.0
 Provides:       bundled(plexus-cipher) = 1.7
 Provides:       bundled(plexus-classworlds) = 2.6.0
 Provides:       bundled(plexus-compiler) = 2.8.8
@@ -359,6 +359,9 @@ sed -i 's|/usr/lib/jvm/java-11-openjdk|%{java_home}|' %{buildroot}%{launchersPat
 %doc AUTHORS
 
 %changelog
+* Tue Aug 08 2023 Saul Paredes <saulparedes@microsoft.com> - 1.5.0-4
+- Update plexus-archiever to 4.8.0
+
 * Wed Apr 05 2023 Riken Maharjan <rmaharjan@microsoft.com> - 1.5.0-3
 - Update commons-compress to 1.21 
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Fix CVE-2023-37460 by upgrading plexus archiever to 4.8.0. Removed patch that doesn't apply based on https://github.com/microsoft/CBL-Mariner/commit/95cc1fc5f17e19cef25f00e0c9f98638a506ed12


###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- javapackages-bootstrap

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2023-37460

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=405008&view=results
