### PR TITLE
Add hard check on go version

### DIFF
--- a/toolkit/scripts/tools.mk
+++ b/toolkit/scripts/tools.mk
@@ -16,6 +16,7 @@ $(call create_folder,$(BUILD_DIR)/tools)
 # The version as held in the go.mod file (a line like 'go 1.19'). Add "go" to the front of the version number
 # so that it matches the output of 'go version' (e.g. 'go1.19').
 go_min_version = go$(shell grep -E '^go [0-9]+\.[0-9]+' $(TOOLS_DIR)/go.mod | awk '{print $$2}')
+
 # Check if the go version is high enough to build the tools. The 'sort' command is used to compare the versions
 # (with -V which sorts by version number). If the lowest version in the sort is the same as the minimum version, then
 # the installed version must be greater than or equal to the minimum version and we are fine.

--- a/toolkit/scripts/tools.mk
+++ b/toolkit/scripts/tools.mk
@@ -13,16 +13,16 @@ $(call create_folder,$(BUILD_DIR)/tools)
 
 ######## GO TOOLS ########
 
-# The version as reported by 'go version'
-go_min_version = go1.19.0
-
+# The version as held in the go.mod file (a line like 'go 1.19'). Add "go" to the front of the version number
+# so that it matches the output of 'go version' (e.g. 'go1.19').
+go_min_version = go$(shell grep -E '^go [0-9]+\.[0-9]+' $(TOOLS_DIR)/go.mod | awk '{print $$2}')
 # Check if the go version is high enough to build the tools. The 'sort' command is used to compare the versions
-# (with -V which sorts by version number). If the lowest version in the sort is the same as the minimum version, then the installed
-# version must be greater than or equal to the minimum version and we are fine.
+# (with -V which sorts by version number). If the lowest version in the sort is the same as the minimum version, then
+# the installed version must be greater than or equal to the minimum version and we are fine.
 ifeq ($(REBUILD_TOOLS),y)
 go_current_version = $(shell go version | awk '{print $$3}')
-go_version_check = $(shell printf '%s\n' "$(go_min_version)" "$(go_current_version)" | sort -V -r | head -n1)
-ifeq ($(go_version_check),$(go_min_version))
+go_version_check = $(shell printf '%s\n%s\n' "$(go_min_version)" "$(go_current_version)" | sort -V | head -n1)
+ifneq ($(go_version_check),$(go_min_version))
 $(error Go version '$(go_current_version)' is less than minimum required version '$(go_min_version)')
 endif
 endif

--- a/toolkit/scripts/tools.mk
+++ b/toolkit/scripts/tools.mk
@@ -13,6 +13,20 @@ $(call create_folder,$(BUILD_DIR)/tools)
 
 ######## GO TOOLS ########
 
+# The version as reported by 'go version'
+go_min_version = go1.19.0
+
+# Check if the go version is high enough to build the tools. The 'sort' command is used to compare the versions
+# (with -V which sorts by version number). If the lowest version in the sort is the same as the minimum version, then the installed
+# version must be greater than or equal to the minimum version and we are fine.
+ifeq ($(REBUILD_TOOLS),y)
+go_current_version = $(shell go version | awk '{print $$3}')
+go_version_check = $(shell printf '%s\n' "$(go_min_version)" "$(go_current_version)" | sort -V -r | head -n1)
+ifeq ($(go_version_check),$(go_min_version))
+$(error Go version '$(go_current_version)' is less than minimum required version '$(go_min_version)')
+endif
+endif
+
 # List of go utilities in tools/ directory
 go_tool_list = \
 	boilerplate \


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Add a hard error condition if you try to rebuild the tools with a version of go that is too old. The go compiler itself will report this error, but it is easy to lose that message in the output. Now we will immediately stop parsing the makefile if the version is wrong. We only check if `REBUILD_TOOLS=y` is set to 'y'.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add check for go compiler version if `REBUILD_TOOLS=y`

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: local test
- Needs full pipeline run