### PR TITLE
Clarified handling of rich dependencies and unified package string parsing.

### DIFF
--- a/toolkit/docs/how_it_works/3_package_building.md
+++ b/toolkit/docs/how_it_works/3_package_building.md
@@ -56,7 +56,7 @@ The single SPEC provides the base package `example`, but also provides a virtual
 All package dependency information is written to `./../build/pkg_artifacts/specs.json`.
 
 ### Rich dependencies
-Spec files can have `(a <condition> b)` style requirements. Depending on the condition the following will happen::
+Spec files can have `(a <condition> b)` style requirements. Depending on the condition the following will happen:
 - `and`, `or`, `with`: the build system will record both options into the graph so that all possible requirements will be made available to pick from during package install allowing for maximum flexibility. This means that the build system requires all optional RPMs to be available to build/download even if they will not be used for a specific configuration.
 - `if`: the build will record the requirement on the left side of the clause as a dependency. That means that the build system will require the package to be available to build/download even if it will not be used for a specific configuration.
 - `else`, `unless`, `without`, or multiple clauses of any kind: unsupported, the build will fail with an error.

--- a/toolkit/docs/how_it_works/3_package_building.md
+++ b/toolkit/docs/how_it_works/3_package_building.md
@@ -55,11 +55,14 @@ The single SPEC provides the base package `example`, but also provides a virtual
 
 All package dependency information is written to `./../build/pkg_artifacts/specs.json`.
 
-### Or Clauses
-Spec files can have `(a or b)` style requirements. When the build system encounters such a requirement it will record both options into the graph so that all possible requirements will be made available to pick from during package install allowing for maximum flexibility. This means that the build system requires all optional RPMs to be available to build/download even if they will not be used for a specific configuration.
+### Rich dependencies
+Spec files can have `(a <condition> b)` style requirements. Depending on the condition the following will happen::
+- `and`, `or`, `with`: the build system will record both options into the graph so that all possible requirements will be made available to pick from during package install allowing for maximum flexibility. This means that the build system requires all optional RPMs to be available to build/download even if they will not be used for a specific configuration.
+- `if`: the build will record the requirement on the left side of the clause as a dependency. That means that the build system will require the package to be available to build/download even if it will not be used for a specific configuration.
+- `else`, `unless`, `without`, or multiple boolean clauses of any kind: unsupported, the build will fail with an error.
 
 #### Warning:
-The build system will print a warning (`'OR' clause found (...), please refer to 'docs/how_it_works/3_package_building.md#or-clauses' for explanation of limitations.`) when it encounters an `or` clause. If be build fails make sure all conditional packages are available locally/online, or remove the unavailable conditional packages from the SPEC file.
+The build system will print a warning when it encounters a boolean clause. If the build fails make sure all conditional packages are following the guidelines from the message or remove the unavailable conditional packages from the SPEC file.
 
 ## Dependency Graphing
 

--- a/toolkit/docs/how_it_works/3_package_building.md
+++ b/toolkit/docs/how_it_works/3_package_building.md
@@ -59,10 +59,10 @@ All package dependency information is written to `./../build/pkg_artifacts/specs
 Spec files can have `(a <condition> b)` style requirements. Depending on the condition the following will happen::
 - `and`, `or`, `with`: the build system will record both options into the graph so that all possible requirements will be made available to pick from during package install allowing for maximum flexibility. This means that the build system requires all optional RPMs to be available to build/download even if they will not be used for a specific configuration.
 - `if`: the build will record the requirement on the left side of the clause as a dependency. That means that the build system will require the package to be available to build/download even if it will not be used for a specific configuration.
-- `else`, `unless`, `without`, or multiple boolean clauses of any kind: unsupported, the build will fail with an error.
+- `else`, `unless`, `without`, or multiple clauses of any kind: unsupported, the build will fail with an error.
 
 #### Warning:
-The build system will print a warning when it encounters a boolean clause. If the build fails make sure all conditional packages are following the guidelines from the message or remove the unavailable conditional packages from the SPEC file.
+The build system will print a warning when it encounters a rich dependency. If the build fails, make sure all conditional packages are following the guidelines from the message or remove the unavailable conditional packages from the SPEC file.
 
 ## Dependency Graphing
 

--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -352,7 +352,7 @@ func PackageNamesFromConfig(config configuration.Config) (packageList []*pkgjson
 		for _, pkg := range packagesToInstall {
 			var packageVer *pkgjson.PackageVer
 
-			packageVer, err = pkgjson.PackagesListEntryToPackageVer(pkg)
+			packageVer, err = pkgjson.PackageStringToPackageVer(pkg)
 			if err != nil {
 				logger.Log.Errorf("Failed to parse packages list from system config \"%s\".", systemCfg.Name)
 				return

--- a/toolkit/tools/internal/pkgjson/pkgjson.go
+++ b/toolkit/tools/internal/pkgjson/pkgjson.go
@@ -249,12 +249,13 @@ func (pkgVer *PackageVer) String() string {
 	return fmt.Sprintf("%s:C:'%s'V:'%s',C2:'%s'V2:'%s'", pkgVer.Name, pkgVer.Condition, pkgVer.Version, pkgVer.SCondition, pkgVer.SVersion)
 }
 
-// PackagesListEntryToPackageVer converts an entry from the packages list JSON into an instance of PackageVer.
-// The entries may contain only the name of the package or also include a single package version constraint.
+// PackageStringToPackageVer converts a package string into an instance of PackageVer.
+// The string may contain only the name of the package or also include a single package version constraint.
 // Examples:
 //   - "gcc"
 //   - "gcc=9.1.0"
-func PackagesListEntryToPackageVer(packageString string) (pkgVer *PackageVer, err error) {
+//   - "gcc < 9.1.0"
+func PackageStringToPackageVer(packageString string) (pkgVer *PackageVer, err error) {
 	matches := packageWithVersionRegex.FindStringSubmatch(packageString)
 	if len(matches) != packageWithVersionExpectedMatches {
 		err = fmt.Errorf("packages list entry \"%s\" does not match the '[name][optional_condition][optional_version]' format", packageString)

--- a/toolkit/tools/internal/pkgjson/pkgjson_test.go
+++ b/toolkit/tools/internal/pkgjson/pkgjson_test.go
@@ -746,7 +746,7 @@ func TestShouldFailIntervalCreationUnkownFirstCondition(t *testing.T) {
 }
 
 func TestShouldCorrectlyConvertPackageNameWithoutVersionConstraints(t *testing.T) {
-	packageVer, err := PackagesListEntryToPackageVer("gcc-devel")
+	packageVer, err := PackageStringToPackageVer("gcc-devel")
 
 	assert.NoError(t, err)
 	assert.Equal(t, "gcc-devel", packageVer.Name)
@@ -757,7 +757,7 @@ func TestShouldCorrectlyConvertPackageNameWithoutVersionConstraints(t *testing.T
 }
 
 func TestShouldCorrectlyConvertPackageNameWithEqualsVersionConstraint(t *testing.T) {
-	packageVer, err := PackagesListEntryToPackageVer("gcc-devel=9.1.0")
+	packageVer, err := PackageStringToPackageVer("gcc-devel=9.1.0")
 
 	assert.NoError(t, err)
 	assert.Equal(t, "gcc-devel", packageVer.Name)
@@ -768,7 +768,7 @@ func TestShouldCorrectlyConvertPackageNameWithEqualsVersionConstraint(t *testing
 }
 
 func TestShouldCorrectlyConvertPackageNameWithGreaterEqualsVersionConstraint(t *testing.T) {
-	packageVer, err := PackagesListEntryToPackageVer("gcc-devel>=9.1.0")
+	packageVer, err := PackageStringToPackageVer("gcc-devel>=9.1.0")
 
 	assert.NoError(t, err)
 	assert.Equal(t, "gcc-devel", packageVer.Name)
@@ -779,7 +779,7 @@ func TestShouldCorrectlyConvertPackageNameWithGreaterEqualsVersionConstraint(t *
 }
 
 func TestShouldCorrectlyConvertPackageNameWithGreaterVersionConstraint(t *testing.T) {
-	packageVer, err := PackagesListEntryToPackageVer("gcc-devel>9.1.0")
+	packageVer, err := PackageStringToPackageVer("gcc-devel>9.1.0")
 
 	assert.NoError(t, err)
 	assert.Equal(t, "gcc-devel", packageVer.Name)
@@ -790,7 +790,7 @@ func TestShouldCorrectlyConvertPackageNameWithGreaterVersionConstraint(t *testin
 }
 
 func TestShouldCorrectlyConvertPackageNameWithLesserEqualsVersionConstraint(t *testing.T) {
-	packageVer, err := PackagesListEntryToPackageVer("gcc-devel<=9.1.0")
+	packageVer, err := PackageStringToPackageVer("gcc-devel<=9.1.0")
 
 	assert.NoError(t, err)
 	assert.Equal(t, "gcc-devel", packageVer.Name)
@@ -801,7 +801,7 @@ func TestShouldCorrectlyConvertPackageNameWithLesserEqualsVersionConstraint(t *t
 }
 
 func TestShouldCorrectlyConvertPackageNameWithLesserVersionConstraint(t *testing.T) {
-	packageVer, err := PackagesListEntryToPackageVer("gcc-devel<9.1.0")
+	packageVer, err := PackageStringToPackageVer("gcc-devel<9.1.0")
 
 	assert.NoError(t, err)
 	assert.Equal(t, "gcc-devel", packageVer.Name)
@@ -812,7 +812,7 @@ func TestShouldCorrectlyConvertPackageNameWithLesserVersionConstraint(t *testing
 }
 
 func TestShouldCorrectlyConvertPackageNameWithAllowedWhitespaces(t *testing.T) {
-	packageVer, err := PackagesListEntryToPackageVer("  gcc-devel\t\t< 9.1.0    ")
+	packageVer, err := PackageStringToPackageVer("  gcc-devel\t\t< 9.1.0    ")
 
 	assert.NoError(t, err)
 	assert.Equal(t, "gcc-devel", packageVer.Name)
@@ -823,7 +823,7 @@ func TestShouldCorrectlyConvertPackageNameWithAllowedWhitespaces(t *testing.T) {
 }
 
 func TestShouldFailToConvertPackageListEntryStartingWithInvalidCharacter(t *testing.T) {
-	_, err := PackagesListEntryToPackageVer("=gcc-devel")
+	_, err := PackageStringToPackageVer("=gcc-devel")
 
 	assert.Error(t, err)
 }
@@ -835,7 +835,7 @@ func TestShouldFailIntervalCreationUnkownSecondCondition(t *testing.T) {
 	assert.Error(t, err)
 }
 func TestShouldFailToConvertPackageListEntryWithIncompleteComparison(t *testing.T) {
-	_, err := PackagesListEntryToPackageVer("gcc-devel=")
+	_, err := PackageStringToPackageVer("gcc-devel=")
 
 	assert.Error(t, err)
 }
@@ -847,7 +847,7 @@ func TestShouldFailIntervalCreationFirstConditionWithoutVersion(t *testing.T) {
 	assert.Error(t, err)
 }
 func TestShouldFailToConvertPackageListEntryWithInvalidComparison(t *testing.T) {
-	_, err := PackagesListEntryToPackageVer("gcc-devel=>9.1.0")
+	_, err := PackageStringToPackageVer("gcc-devel=>9.1.0")
 
 	assert.Error(t, err)
 }
@@ -859,7 +859,7 @@ func TestShouldFailIntervalCreationSecondConditionWithoutVersion(t *testing.T) {
 	assert.Error(t, err)
 }
 func TestShouldFailToConvertPackageListEntryWithWhitespacesInComparison(t *testing.T) {
-	_, err := PackagesListEntryToPackageVer("gcc-devel< =9.1.0")
+	_, err := PackageStringToPackageVer("gcc-devel< =9.1.0")
 
 	assert.Error(t, err)
 }
@@ -871,7 +871,7 @@ func TestShouldFailIntervalCreationFirstConditionEmptySecondConditionWithoutVers
 	assert.Error(t, err)
 }
 func TestShouldFailToConvertPackageListEntryWithWhitespacesInName(t *testing.T) {
-	_, err := PackagesListEntryToPackageVer("gcc devel")
+	_, err := PackageStringToPackageVer("gcc devel")
 
 	assert.Error(t, err)
 }
@@ -883,7 +883,7 @@ func TestShouldFailIntervalCreationFirstConditionWithoutVersionSecondConditionEm
 	assert.Error(t, err)
 }
 func TestShouldFailToConvertPackageListEntryWithWhitespacesInVersion(t *testing.T) {
-	_, err := PackagesListEntryToPackageVer("gcc-devel<9 1.0")
+	_, err := PackageStringToPackageVer("gcc-devel<9 1.0")
 
 	assert.Error(t, err)
 }

--- a/toolkit/tools/specreader/specreader.go
+++ b/toolkit/tools/specreader/specreader.go
@@ -526,6 +526,8 @@ func parseProvides(rpmsDir, toolchainDir string, toolchainRPMs []string, srpmPat
 // Normally a list of length 1 is returned, however parsePackageVersions is also responsible for
 // identifying if the package name is an "or" condition and returning all options.
 func parsePackageVersions(packageString string) (newPackages []*pkgjson.PackageVer, err error) {
+	packageString = strings.TrimSpace(packageString)
+
 	// If the first character of the packageString is a "(" then it's an "or" condition.
 	if packageString[0] == '(' {
 		return parseRichDependency(packageString)
@@ -596,6 +598,7 @@ func condensePackageVersionArray(packagelist []*pkgjson.PackageVer, specfile str
 func parseRichDependency(richDependency string) (versions []*pkgjson.PackageVer, err error) {
 	const documentationHint = "Please refer to 'docs/how_it_works/3_package_building.md#rich-dependencies' for explanation of limitations"
 
+	// All single condition strings are surrounded by spaces to match full words.
 	for _, singleCondition := range unsupportedBooleanConditions {
 		if strings.Contains(richDependency, singleCondition) {
 			err = fmt.Errorf("found unsupported boolean condition '%s' inside '%s'. %s", singleCondition, richDependency, documentationHint)
@@ -604,6 +607,7 @@ func parseRichDependency(richDependency string) (versions []*pkgjson.PackageVer,
 	}
 
 	conditionsCount := 0
+	// All single condition strings are surrounded by spaces to match full words.
 	for _, singleCondition := range supportedBooleanConditions {
 		conditionsCount += strings.Count(richDependency, singleCondition)
 	}
@@ -616,6 +620,7 @@ func parseRichDependency(richDependency string) (versions []*pkgjson.PackageVer,
 	richDependency = strings.ReplaceAll(richDependency, ")", "")
 
 	packageStrings := []string{}
+	// All single condition strings are surrounded by spaces to match full words.
 	for _, singleCondition := range supportedBooleanConditions {
 		if strings.Contains(richDependency, singleCondition) {
 			packageStrings = strings.Split(richDependency, singleCondition)

--- a/toolkit/tools/specreader/specreader.go
+++ b/toolkit/tools/specreader/specreader.go
@@ -502,7 +502,7 @@ func parseProvides(rpmsDir, toolchainDir string, toolchainRPMs []string, srpmPat
 // Normally a list of length 1 is returned, however parsePackageVersions is also responsible for
 // identifying if the package name is an "or" condition and returning all options.
 func parsePackageVersions(packageString string) (newPackages []*pkgjson.PackageVer, err error) {
-	// If first character of the packageString is a "(" then its an "or" condition
+	// If the first character of the packageString is a "(" then it's an "or" condition.
 	if packageString[0] == '(' {
 		return parseOrCondition(packageString)
 	}

--- a/toolkit/tools/specreader/specreader.go
+++ b/toolkit/tools/specreader/specreader.go
@@ -606,10 +606,10 @@ func parseRichDependency(richDependency string) (versions []*pkgjson.PackageVer,
 	conditionsCount := 0
 	for _, singleCondition := range supportedBooleanConditions {
 		conditionsCount += strings.Count(richDependency, singleCondition)
-		if conditionsCount > 1 {
-			err = fmt.Errorf("found more than one boolean condition inside '%s'. %s", richDependency, documentationHint)
-			return
-		}
+	}
+	if conditionsCount > 1 {
+		err = fmt.Errorf("found more than one boolean condition inside '%s'. %s", richDependency, documentationHint)
+		return
 	}
 
 	richDependency = strings.ReplaceAll(richDependency, "(", "")

--- a/toolkit/tools/specreader/specreader.go
+++ b/toolkit/tools/specreader/specreader.go
@@ -570,12 +570,12 @@ func condensePackageVersionArray(packagelist []*pkgjson.PackageVer, specfile str
 
 // parseOrCondition splits a package name like (foo or bar) and returns both foo and bar as separate requirements.
 func parseOrCondition(orCondition string) (versions []*pkgjson.PackageVer, err error) {
-	logger.Log.Warnf("'OR' clause found (%s), make sure both packages are available. Please refer to 'docs/how_it_works/3_package_building.md#or-clauses' for explanation of limitations.", orCondition)
+	logger.Log.Warnf("'OR' clause found '%s', make sure both packages are available. Please refer to 'docs/how_it_works/3_package_building.md#or-clauses' for explanation of limitations.", orCondition)
 	orCondition = strings.ReplaceAll(orCondition, "(", "")
 	orCondition = strings.ReplaceAll(orCondition, ")", "")
 
 	packageStrings := strings.Split(orCondition, " or ")
-	err = minSliceLength(packageStrings, 2)
+	err = minSliceLength(packageStrings, 1)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

We've been parsing package strings with version like `gcc >= 1.2.3` with different logic inside `specreader.go` and `pkgjson.go`. The version from `specreader.go` failed to properly handle cases with missing spaces like `gcc>=1.2.3`. Since these instances are not consider erroneous by `rpmbuild` and we handle them correctly with the `PackagesListEntryToPackageVer` function from `pkgjson.go`, I've made `specreader.go` call into `PackagesListEntryToPackageVer` as well.

### Why the change
The unhandled `gcc>=1.2.3` cases in `specreader.go` made us create `PkgVer` structs with their `Name` fields set to `gcc>=1.2.3` and so far we only lucked out that this didn't cause any issues, as only one spec seems to be defining dependencies this way and it's not depending on another local spec.

### Updated handling of rich dependencies
The old way of splitting the dependencies by looking only for the ` or ` string was erroneous where it would attempt to create a `PackageVer` with a `Condition` field equal to `if` and `Version` field equal to `python3` for dependencies like `(python3-importlib-metadata if python3 < 3.8)` (taken from `python-tox.spec`).

So far, we ended having to handle rich dependencies from only two specs: `maven-surefire.spec` and `annobin.spec`. By accident we've managed to avoid build breaks in these cases.

The change from this PR makes the parsing logic and logging more robust.

I used the ["Boolean dependencies" paragraph](https://weldr.io/RPM-Dependencies/#boolean-dependencies) from an article by David Shea for guidance. Thank you, @dashea!

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Switched package strings parsing logic from `specreader.go` to use `PackagesListEntryToPackageVer` from `pkgjson.go`.
- Renamed `PackagesListEntryToPackageVer` to `PackageStringToPackageVer`.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- [Full pipeline build](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=406301&view=results).
- Local tests.
- Tooling unit tests.