### PR TITLE
Update ruby default uri to 0.12.2 and bundled uri to 0.10.3 and fix CVE-2023-36617

### DIFF
--- a/SPECS/ruby/CVE-2023-36617.patch
+++ b/SPECS/ruby/CVE-2023-36617.patch
@@ -4,6 +4,9 @@ Date: Wed, 21 Jun 2023 13:04:16 +0900
 Subject: [PATCH] [ruby/uri] Bump up v0.12.2
 
 https://github.com/ruby/uri/commit/e18e657ea8
+
+Updates ruby-uri from 0.12.1 to 0.12.2. Remove once ruby gets updated to a version that comes with ruby-uri 0.12.2
+
 ---
  lib/uri/version.rb | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)

--- a/SPECS/ruby/CVE-2023-36617.patch
+++ b/SPECS/ruby/CVE-2023-36617.patch
@@ -1,22 +1,50 @@
-From ab5421547c5546603c2383085005272ba7754fea Mon Sep 17 00:00:00 2001
+From c7af39ecd8d78d9ffc312dcde2af3466c7bbaf5f Mon Sep 17 00:00:00 2001
 From: Hiroshi SHIBATA <hsbt@ruby-lang.org>
-Date: Wed, 21 Jun 2023 13:04:16 +0900
-Subject: [PATCH] [ruby/uri] Bump up v0.12.2
-
-https://github.com/ruby/uri/commit/e18e657ea8
+Date: Wed, 21 Jun 2023 14:13:30 +0900
+Subject: [PATCH] Merge URI-0.12.2 for Bundler
 
 Updates ruby-uri from 0.12.1 to 0.12.2. Remove once ruby gets updated to a version that comes with ruby-uri 0.12.2
 
 ---
- lib/uri/version.rb | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
+ lib/bundler/vendor/uri/lib/uri/rfc2396_parser.rb | 4 ++--
+ lib/bundler/vendor/uri/lib/uri/rfc3986_parser.rb | 2 +-
+ lib/bundler/vendor/uri/lib/uri/version.rb        | 2 +-
+ 3 files changed, 4 insertions(+), 4 deletions(-)
 
-diff --git a/lib/uri/version.rb b/lib/uri/version.rb
-index 7497a7d31a5df..f0aca586acab4 100644
---- a/lib/uri/version.rb
-+++ b/lib/uri/version.rb
+diff --git a/lib/bundler/vendor/uri/lib/uri/rfc2396_parser.rb b/lib/bundler/vendor/uri/lib/uri/rfc2396_parser.rb
+index 2f8d55353bfbb..09c22c9906f8f 100644
+--- a/lib/bundler/vendor/uri/lib/uri/rfc2396_parser.rb
++++ b/lib/bundler/vendor/uri/lib/uri/rfc2396_parser.rb
+@@ -497,8 +497,8 @@ def initialize_regexp(pattern)
+       ret = {}
+ 
+       # for Bundler::URI::split
+-      ret[:ABS_URI] = Regexp.new('\A\s*' + pattern[:X_ABS_URI] + '\s*\z', Regexp::EXTENDED)
+-      ret[:REL_URI] = Regexp.new('\A\s*' + pattern[:X_REL_URI] + '\s*\z', Regexp::EXTENDED)
++      ret[:ABS_URI] = Regexp.new('\A\s*+' + pattern[:X_ABS_URI] + '\s*\z', Regexp::EXTENDED)
++      ret[:REL_URI] = Regexp.new('\A\s*+' + pattern[:X_REL_URI] + '\s*\z', Regexp::EXTENDED)
+ 
+       # for Bundler::URI::extract
+       ret[:URI_REF]     = Regexp.new(pattern[:URI_REF])
+diff --git a/lib/bundler/vendor/uri/lib/uri/rfc3986_parser.rb b/lib/bundler/vendor/uri/lib/uri/rfc3986_parser.rb
+index d527072db468e..a85511c146077 100644
+--- a/lib/bundler/vendor/uri/lib/uri/rfc3986_parser.rb
++++ b/lib/bundler/vendor/uri/lib/uri/rfc3986_parser.rb
+@@ -100,7 +100,7 @@ def default_regexp # :nodoc:
+         QUERY: /\A(?:%\h\h|[!$&-.0-;=@-Z_a-z~\/?])*\z/,
+         FRAGMENT: /\A(?:%\h\h|[!$&-.0-;=@-Z_a-z~\/?])*\z/,
+         OPAQUE: /\A(?:[^\/].*)?\z/,
+-        PORT: /\A[\x09\x0a\x0c\x0d ]*\d*[\x09\x0a\x0c\x0d ]*\z/,
++        PORT: /\A[\x09\x0a\x0c\x0d ]*+\d*[\x09\x0a\x0c\x0d ]*\z/,
+       }
+     end
+ 
+diff --git a/lib/bundler/vendor/uri/lib/uri/version.rb b/lib/bundler/vendor/uri/lib/uri/version.rb
+index 500fdb3f9923e..84b08eee309b1 100644
+--- a/lib/bundler/vendor/uri/lib/uri/version.rb
++++ b/lib/bundler/vendor/uri/lib/uri/version.rb
 @@ -1,6 +1,6 @@
- module URI
+ module Bundler::URI
    # :stopdoc:
 -  VERSION_CODE = '001201'.freeze
 +  VERSION_CODE = '001202'.freeze

--- a/SPECS/ruby/CVE-2023-36617.patch
+++ b/SPECS/ruby/CVE-2023-36617.patch
@@ -1,0 +1,22 @@
+From ab5421547c5546603c2383085005272ba7754fea Mon Sep 17 00:00:00 2001
+From: Hiroshi SHIBATA <hsbt@ruby-lang.org>
+Date: Wed, 21 Jun 2023 13:04:16 +0900
+Subject: [PATCH] [ruby/uri] Bump up v0.12.2
+
+https://github.com/ruby/uri/commit/e18e657ea8
+---
+ lib/uri/version.rb | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/uri/version.rb b/lib/uri/version.rb
+index 7497a7d31a5df..f0aca586acab4 100644
+--- a/lib/uri/version.rb
++++ b/lib/uri/version.rb
+@@ -1,6 +1,6 @@
+ module URI
+   # :stopdoc:
+-  VERSION_CODE = '001201'.freeze
++  VERSION_CODE = '001202'.freeze
+   VERSION = VERSION_CODE.scan(/../).collect{|n| n.to_i}.join('.').freeze
+   # :startdoc:
+ end

--- a/SPECS/ruby/CVE-2023-36617.patch
+++ b/SPECS/ruby/CVE-2023-36617.patch
@@ -4,6 +4,8 @@ Date: Tue, 15 Aug 2023 13:49:55 -0700
 Subject: [PATCH] Update default uri to 0.12.2, patch bundled uri and fix
  CVE-2023-36617
 
+Remove once ruby gets updated to a version that comes with ruby-uri 0.12.2
+
 ---
  lib/bundler/vendor/uri/lib/uri/rfc2396_parser.rb | 4 ++--
  lib/bundler/vendor/uri/lib/uri/rfc3986_parser.rb | 2 +-

--- a/SPECS/ruby/CVE-2023-36617.patch
+++ b/SPECS/ruby/CVE-2023-36617.patch
@@ -1,21 +1,22 @@
-From c7af39ecd8d78d9ffc312dcde2af3466c7bbaf5f Mon Sep 17 00:00:00 2001
-From: Hiroshi SHIBATA <hsbt@ruby-lang.org>
-Date: Wed, 21 Jun 2023 14:13:30 +0900
-Subject: [PATCH] Merge URI-0.12.2 for Bundler
-
-Updates ruby-uri from 0.12.1 to 0.12.2. Remove once ruby gets updated to a version that comes with ruby-uri 0.12.2
+From d18e96b33436fc49c8709c7fbc8a7bb4f82cb8a9 Mon Sep 17 00:00:00 2001
+From: Saul Paredes <saulparedes@microsoft.com>
+Date: Tue, 15 Aug 2023 13:49:55 -0700
+Subject: [PATCH] Update default uri to 0.12.2, patch bundled uri and fix
+ CVE-2023-36617
 
 ---
  lib/bundler/vendor/uri/lib/uri/rfc2396_parser.rb | 4 ++--
  lib/bundler/vendor/uri/lib/uri/rfc3986_parser.rb | 2 +-
- lib/bundler/vendor/uri/lib/uri/version.rb        | 2 +-
- 3 files changed, 4 insertions(+), 4 deletions(-)
+ lib/uri/rfc2396_parser.rb                        | 4 ++--
+ lib/uri/rfc3986_parser.rb                        | 2 +-
+ lib/uri/version.rb                               | 2 +-
+ 5 files changed, 7 insertions(+), 7 deletions(-)
 
 diff --git a/lib/bundler/vendor/uri/lib/uri/rfc2396_parser.rb b/lib/bundler/vendor/uri/lib/uri/rfc2396_parser.rb
-index 2f8d55353bfbb..09c22c9906f8f 100644
+index e48e164..09ed407 100644
 --- a/lib/bundler/vendor/uri/lib/uri/rfc2396_parser.rb
 +++ b/lib/bundler/vendor/uri/lib/uri/rfc2396_parser.rb
-@@ -497,8 +497,8 @@ def initialize_regexp(pattern)
+@@ -491,8 +491,8 @@ def initialize_regexp(pattern)
        ret = {}
  
        # for Bundler::URI::split
@@ -27,9 +28,37 @@ index 2f8d55353bfbb..09c22c9906f8f 100644
        # for Bundler::URI::extract
        ret[:URI_REF]     = Regexp.new(pattern[:URI_REF])
 diff --git a/lib/bundler/vendor/uri/lib/uri/rfc3986_parser.rb b/lib/bundler/vendor/uri/lib/uri/rfc3986_parser.rb
-index d527072db468e..a85511c146077 100644
+index cd4dd0c..870720e 100644
 --- a/lib/bundler/vendor/uri/lib/uri/rfc3986_parser.rb
 +++ b/lib/bundler/vendor/uri/lib/uri/rfc3986_parser.rb
+@@ -95,7 +95,7 @@ def default_regexp # :nodoc:
+         QUERY: /\A(?:%\h\h|[!$&-.0-;=@-Z_a-z~\/?])*\z/,
+         FRAGMENT: /\A(?:%\h\h|[!$&-.0-;=@-Z_a-z~\/?])*\z/,
+         OPAQUE: /\A(?:[^\/].*)?\z/,
+-        PORT: /\A[\x09\x0a\x0c\x0d ]*\d*[\x09\x0a\x0c\x0d ]*\z/,
++        PORT: /\A[\x09\x0a\x0c\x0d ]*+\d*[\x09\x0a\x0c\x0d ]*\z/,
+       }
+     end
+ 
+diff --git a/lib/uri/rfc2396_parser.rb b/lib/uri/rfc2396_parser.rb
+index 76a8f99..00c66cf 100644
+--- a/lib/uri/rfc2396_parser.rb
++++ b/lib/uri/rfc2396_parser.rb
+@@ -497,8 +497,8 @@ def initialize_regexp(pattern)
+       ret = {}
+ 
+       # for URI::split
+-      ret[:ABS_URI] = Regexp.new('\A\s*' + pattern[:X_ABS_URI] + '\s*\z', Regexp::EXTENDED)
+-      ret[:REL_URI] = Regexp.new('\A\s*' + pattern[:X_REL_URI] + '\s*\z', Regexp::EXTENDED)
++      ret[:ABS_URI] = Regexp.new('\A\s*+' + pattern[:X_ABS_URI] + '\s*\z', Regexp::EXTENDED)
++      ret[:REL_URI] = Regexp.new('\A\s*+' + pattern[:X_REL_URI] + '\s*\z', Regexp::EXTENDED)
+ 
+       # for URI::extract
+       ret[:URI_REF]     = Regexp.new(pattern[:URI_REF])
+diff --git a/lib/uri/rfc3986_parser.rb b/lib/uri/rfc3986_parser.rb
+index dd24a40..9b1663d 100644
+--- a/lib/uri/rfc3986_parser.rb
++++ b/lib/uri/rfc3986_parser.rb
 @@ -100,7 +100,7 @@ def default_regexp # :nodoc:
          QUERY: /\A(?:%\h\h|[!$&-.0-;=@-Z_a-z~\/?])*\z/,
          FRAGMENT: /\A(?:%\h\h|[!$&-.0-;=@-Z_a-z~\/?])*\z/,
@@ -39,15 +68,18 @@ index d527072db468e..a85511c146077 100644
        }
      end
  
-diff --git a/lib/bundler/vendor/uri/lib/uri/version.rb b/lib/bundler/vendor/uri/lib/uri/version.rb
-index 500fdb3f9923e..84b08eee309b1 100644
---- a/lib/bundler/vendor/uri/lib/uri/version.rb
-+++ b/lib/bundler/vendor/uri/lib/uri/version.rb
+diff --git a/lib/uri/version.rb b/lib/uri/version.rb
+index 7497a7d..f0aca58 100644
+--- a/lib/uri/version.rb
++++ b/lib/uri/version.rb
 @@ -1,6 +1,6 @@
- module Bundler::URI
+ module URI
    # :stopdoc:
 -  VERSION_CODE = '001201'.freeze
 +  VERSION_CODE = '001202'.freeze
    VERSION = VERSION_CODE.scan(/../).collect{|n| n.to_i}.join('.').freeze
    # :startdoc:
  end
+-- 
+2.25.1
+

--- a/SPECS/ruby/CVE-2023-36617.patch
+++ b/SPECS/ruby/CVE-2023-36617.patch
@@ -1,18 +1,18 @@
-From d18e96b33436fc49c8709c7fbc8a7bb4f82cb8a9 Mon Sep 17 00:00:00 2001
+From 2ecb898f8da5e275f97afbcf3dfabb72f43e4e1f Mon Sep 17 00:00:00 2001
 From: Saul Paredes <saulparedes@microsoft.com>
-Date: Tue, 15 Aug 2023 13:49:55 -0700
-Subject: [PATCH] Update default uri to 0.12.2, patch bundled uri and fix
+Date: Wed, 16 Aug 2023 13:34:27 -0700
+Subject: [PATCH] Update lib uri to 0.12.2, bundled uri to 0.10.3 and fix
  CVE-2023-36617
 
-Remove once ruby gets updated to a version that comes with ruby-uri 0.12.2
-
+Remove once ruby gets updated to a version that comes with both lib/uri/version.rb and lib/bundler/vendor/uri/lib/uri/version.rb versions >= 0.12.2 or == 0.10.3
 ---
  lib/bundler/vendor/uri/lib/uri/rfc2396_parser.rb | 4 ++--
  lib/bundler/vendor/uri/lib/uri/rfc3986_parser.rb | 2 +-
+ lib/bundler/vendor/uri/lib/uri/version.rb        | 2 +-
  lib/uri/rfc2396_parser.rb                        | 4 ++--
  lib/uri/rfc3986_parser.rb                        | 2 +-
  lib/uri/version.rb                               | 2 +-
- 5 files changed, 7 insertions(+), 7 deletions(-)
+ 6 files changed, 8 insertions(+), 8 deletions(-)
 
 diff --git a/lib/bundler/vendor/uri/lib/uri/rfc2396_parser.rb b/lib/bundler/vendor/uri/lib/uri/rfc2396_parser.rb
 index e48e164..09ed407 100644
@@ -42,6 +42,18 @@ index cd4dd0c..870720e 100644
        }
      end
  
+diff --git a/lib/bundler/vendor/uri/lib/uri/version.rb b/lib/bundler/vendor/uri/lib/uri/version.rb
+index 3895df0..d65b7e5 100644
+--- a/lib/bundler/vendor/uri/lib/uri/version.rb
++++ b/lib/bundler/vendor/uri/lib/uri/version.rb
+@@ -1,6 +1,6 @@
+ module Bundler::URI
+   # :stopdoc:
+-  VERSION_CODE = '001002'.freeze
++  VERSION_CODE = '001003'.freeze
+   VERSION = VERSION_CODE.scan(/../).collect{|n| n.to_i}.join('.').freeze
+   # :startdoc:
+ end
 diff --git a/lib/uri/rfc2396_parser.rb b/lib/uri/rfc2396_parser.rb
 index 76a8f99..00c66cf 100644
 --- a/lib/uri/rfc2396_parser.rb

--- a/SPECS/ruby/ruby.spec
+++ b/SPECS/ruby/ruby.spec
@@ -71,7 +71,7 @@
 %global tmpdir_version          0.1.2
 %global tsort_version           0.1.0
 %global un_version              0.2.0
-%global uri_version             0.11.1
+%global uri_version             0.12.2
 %global weakref_version         0.1.1
 %global win32ole_version        1.8.8
 %global yaml_version            0.2.0
@@ -83,7 +83,7 @@ Name:           ruby
 # provides should be versioned according to the ruby version.
 # More info: https://stdgems.org/
 Version:        3.1.4
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        (Ruby OR BSD) AND Public Domain AND MIT AND CC0 AND zlib AND UCD
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -97,6 +97,7 @@ Source4:        rubygems.con
 Source5:        rubygems.prov
 Source6:        rubygems.req
 Source7:        macros.rubygems
+Patch0:         CVE-2023-36617.patch
 BuildRequires:  openssl-devel
 BuildRequires:  readline
 BuildRequires:  readline-devel
@@ -399,6 +400,9 @@ sudo -u test make test TESTS="-v"
 %{_rpmconfigdir}/rubygems.con
 
 %changelog
+* Mon Aug 14 2023 Saul Paredes <saulparedes@microsoft.com> - 3.1.4-2
+- Patch CVE-2023-36617
+
 * Wed May 03 2023 Rakshaa Viswanathan <rviswanathan@microsoft.com> - 3.1.4-1
 - Upgrade ruby to 3.1.4
 - Update time_version to v0.2.2 to resolve CVE-2023-28756

--- a/SPECS/ruby/ruby.spec
+++ b/SPECS/ruby/ruby.spec
@@ -97,7 +97,7 @@ Source4:        rubygems.con
 Source5:        rubygems.prov
 Source6:        rubygems.req
 Source7:        macros.rubygems
-# Updates ruby-uri from 0.12.1 to 0.12.2. Remove once ruby gets updated to a version that comes with ruby-uri 0.12.2
+# Updates default ruby-uri from 0.12.1 to 0.12.2 and patches vendored one. Remove once ruby gets updated to a version that comes with ruby-uri 0.12.2
 Patch0:         CVE-2023-36617.patch
 BuildRequires:  openssl-devel
 BuildRequires:  readline

--- a/SPECS/ruby/ruby.spec
+++ b/SPECS/ruby/ruby.spec
@@ -97,7 +97,7 @@ Source4:        rubygems.con
 Source5:        rubygems.prov
 Source6:        rubygems.req
 Source7:        macros.rubygems
-Patch0:         CVE-2023-36617.patch
+Patch0:         CVE-2023-36617.patch # Updates ruby-uri from 0.12.1 to 0.12.2. Remove once ruby gets updated to a version that comes with ruby-uri 0.12.2
 BuildRequires:  openssl-devel
 BuildRequires:  readline
 BuildRequires:  readline-devel

--- a/SPECS/ruby/ruby.spec
+++ b/SPECS/ruby/ruby.spec
@@ -97,7 +97,7 @@ Source4:        rubygems.con
 Source5:        rubygems.prov
 Source6:        rubygems.req
 Source7:        macros.rubygems
-# Updates default ruby-uri from 0.12.1 to 0.12.2 and patches vendored one. Remove once ruby gets updated to a version that comes with ruby-uri 0.12.2
+# Updates default ruby-uri to 0.12.2 and vendored one to 0.10.3. Remove once ruby gets updated to a version that comes with both lib/uri/version.rb and lib/bundler/vendor/uri/lib/uri/version.rb versions >= 0.12.2 or == 0.10.3
 Patch0:         CVE-2023-36617.patch
 BuildRequires:  openssl-devel
 BuildRequires:  readline

--- a/SPECS/ruby/ruby.spec
+++ b/SPECS/ruby/ruby.spec
@@ -97,7 +97,8 @@ Source4:        rubygems.con
 Source5:        rubygems.prov
 Source6:        rubygems.req
 Source7:        macros.rubygems
-Patch0:         CVE-2023-36617.patch # Updates ruby-uri from 0.12.1 to 0.12.2. Remove once ruby gets updated to a version that comes with ruby-uri 0.12.2
+# Updates ruby-uri from 0.12.1 to 0.12.2. Remove once ruby gets updated to a version that comes with ruby-uri 0.12.2
+Patch0:         CVE-2023-36617.patch
 BuildRequires:  openssl-devel
 BuildRequires:  readline
 BuildRequires:  readline-devel


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Patch ruby-uri version and fix CVE-2023-36617 (vulnerability not present in rub uri 12.2) https://github.com/hsbt/ruby/commit/ab5421547c5546603c2383085005272ba7754fea

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- CVE-2023-36617

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**


###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2023-36617

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Unified build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=408103&view=results
