### PR TITLE
Fix CVE-2023-36617 by patching plexus-archiver

### DIFF
--- a/SPECS/javapackages-bootstrap/CVE-2023-37460.patch
+++ b/SPECS/javapackages-bootstrap/CVE-2023-37460.patch
@@ -1,0 +1,60 @@
+From ac60706ff2e9c4241f792b5f2fea6d1197b6dc70 Mon Sep 17 00:00:00 2001
+From: Saul Paredes <saulparedes@microsoft.com>
+Date: Fri, 11 Aug 2023 12:00:58 -0700
+Subject: [PATCH] Avoid override target symlink by standard file in
+ AbstractUnArchiver
+
+---
+ .../plexus/archiver/AbstractUnArchiver.java        | 14 ++++++++------
+ 1 file changed, 8 insertions(+), 6 deletions(-)
+
+diff --git a/src/main/java/org/codehaus/plexus/archiver/AbstractUnArchiver.java b/src/main/java/org/codehaus/plexus/archiver/AbstractUnArchiver.java
+index 41f6c8c..f40aab9 100644
+--- a/src/main/java/org/codehaus/plexus/archiver/AbstractUnArchiver.java
++++ b/src/main/java/org/codehaus/plexus/archiver/AbstractUnArchiver.java
+@@ -21,7 +21,6 @@
+ import java.io.FileOutputStream;
+ import java.io.IOException;
+ import java.io.InputStream;
+-import java.io.OutputStream;
+ import java.util.ArrayList;
+ import java.util.Date;
+ import java.util.List;
+@@ -32,8 +31,9 @@
+ import org.codehaus.plexus.components.io.resources.PlexusIoResource;
+ import org.codehaus.plexus.logging.AbstractLogEnabled;
+ import org.codehaus.plexus.util.FileUtils;
+-import org.codehaus.plexus.util.IOUtil;
+ import org.codehaus.plexus.util.StringUtils;
++import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
++import java.nio.file.Files;
+ 
+ // TODO there should really be constructors which take the source file.
+ 
+@@ -336,6 +336,11 @@ protected void extractFile( final File srcF, final File dir, final InputStream c
+         String canonicalDirPath = dir.getCanonicalPath();
+         String canonicalDestPath = f.getCanonicalPath();
+ 
++        // don't allow override target symlink by standard file
++        if (StringUtils.isEmpty(symlinkDestination) && Files.isSymbolicLink(f.getCanonicalFile().toPath())) {
++            throw new ArchiverException("Entry is outside of the target directory (" + entryName + ")");
++        }
++
+         if ( !canonicalDestPath.startsWith( canonicalDirPath ) )
+         {
+             throw new ArchiverException( "Entry is outside of the target directory (" + entryName + ")" );
+@@ -365,10 +370,7 @@ else if ( isDirectory )
+             }
+             else
+             {
+-                try ( OutputStream out = new FileOutputStream( f ) )
+-                {
+-                    IOUtil.copy( compressedInputStream, out );
+-                }
++                Files.copy(compressedInputStream, f.toPath(), REPLACE_EXISTING);
+             }
+ 
+             f.setLastModified( entryDate.getTime() );
+-- 
+2.25.1
+

--- a/SPECS/javapackages-bootstrap/javapackages-bootstrap.spec
+++ b/SPECS/javapackages-bootstrap/javapackages-bootstrap.spec
@@ -13,7 +13,7 @@
 
 Name:           javapackages-bootstrap
 Version:        1.5.0
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        A means of bootstrapping Java Packages Tools
 # For detailed info see the file javapackages-bootstrap-PACKAGE-LICENSING
 License:        ASL 2.0 and ASL 1.1 and (ASL 2.0 or EPL-2.0) and (EPL-2.0 or GPLv2 with exceptions) and MIT and (BSD with advertising) and BSD-3-Clause and EPL-1.0 and EPL-2.0 and CDDL-1.0 and xpp and CC0 and Public Domain
@@ -137,6 +137,7 @@ Source1108:     xz-java.tar.xz
 
 Patch0:         0001-Bind-to-OpenJDK-11-for-runtime.patch
 Patch1:         0001-Remove-usage-of-ArchiveStreamFactory.patch
+Patch2:         CVE-2023-37460.patch
 
 Provides:       bundled(ant) = 1.10.9
 Provides:       bundled(apache-parent) = 23
@@ -292,6 +293,10 @@ pushd "downstream/commons-compress"
 %patch1 -p1 
 popd
 
+pushd "downstream/plexus-archiver"
+%patch2 -p1 
+popd
+
 for patch_path in patches/*/*
 do
   package_name="$(echo ${patch_path} | cut -f2 -d/)"
@@ -359,6 +364,9 @@ sed -i 's|/usr/lib/jvm/java-11-openjdk|%{java_home}|' %{buildroot}%{launchersPat
 %doc AUTHORS
 
 %changelog
+* Fri Aug 11 2023 Saul Paredes <saulparedes@microsoft.com> - 1.5.0-4
+- Patch plexus-archiver to fix CVE-2023-37460
+
 * Wed Apr 05 2023 Riken Maharjan <rmaharjan@microsoft.com> - 1.5.0-3
 - Update commons-compress to 1.21 
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Fix CVE-2023-37460 by patching plexus-archiver. Patch has been adapted from https://github.com/codehaus-plexus/plexus-archiver/commit/54759839fbdf85caf8442076f001d5fd64e0dcb2 (Omitted parts of the patch that update testing since it causes compile issues. E.g a part of the patch adds a new junit test, but they didn't switch to junit until 4.5.0, currently using 4.2.2)

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- javapackages-bootstrap

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2023-37460

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- https://dev.azure.com/mariner-org/mariner/_build/results?buildId=407028&view=results: using new unified pipeline buddy builds. Failed `build-arm64-check` but passed `build-arm64` Not sure if this is a no-go