### PR TITLE
golang: bump golang 1.19.12 -> 1.20.7

### DIFF
--- a/SPECS/golang/golang.signatures.json
+++ b/SPECS/golang/golang.signatures.json
@@ -1,5 +1,6 @@
 {
  "Signatures": {
+  "go1.19.12.src.tar.gz": "ee5d50e0a7fd74ba1b137cb879609aaaef9880bf72b5d1742100e38ae72bb557",
   "go1.20.7.src.tar.gz": "2c5ee9c9ec1e733b0dbbc2bdfed3f62306e51d8172bf38f4f4e542b27520f597",
   "go1.4-bootstrap-20171003.tar.gz": "f4ff5b5eb3a3cae1c993723f3eab519c5bae18866b5e5f96fe1102f0cb5c3e52"
  }

--- a/SPECS/golang/golang.signatures.json
+++ b/SPECS/golang/golang.signatures.json
@@ -1,6 +1,6 @@
 {
-  "Signatures": {
-    "go1.4-bootstrap-20171003.tar.gz": "f4ff5b5eb3a3cae1c993723f3eab519c5bae18866b5e5f96fe1102f0cb5c3e52",
-    "go1.19.12.src.tar.gz": "ee5d50e0a7fd74ba1b137cb879609aaaef9880bf72b5d1742100e38ae72bb557"
-  }
+ "Signatures": {
+  "go1.20.7.src.tar.gz": "2c5ee9c9ec1e733b0dbbc2bdfed3f62306e51d8172bf38f4f4e542b27520f597",
+  "go1.4-bootstrap-20171003.tar.gz": "f4ff5b5eb3a3cae1c993723f3eab519c5bae18866b5e5f96fe1102f0cb5c3e52"
+ }
 }

--- a/SPECS/golang/golang.spec
+++ b/SPECS/golang/golang.spec
@@ -12,7 +12,7 @@
 %define __find_requires %{nil}
 Summary:        Go
 Name:           golang
-Version:        1.19.12
+Version:        1.20.7
 Release:        1%{?dist}
 License:        BSD-3-Clause
 Vendor:         Microsoft Corporation
@@ -119,6 +119,10 @@ fi
 %{_bindir}/*
 
 %changelog
+* Tue Aug 15 2023 Muhammad Falak <mwani@microsoft.com> - 1.20.7-1
+- Bump version to 1.20.7
+- Introduce patch to permit requests with invalid host header
+
 * Tue Aug 15 2023 Muhammad Falak <mwani@microsoft.com> - 1.19.12-1
 - Auto-upgrade to 1.19.12 to address CVE-2023-29409
 - Introduce patch to permit requests with invalid header

--- a/SPECS/golang/golang.spec
+++ b/SPECS/golang/golang.spec
@@ -21,6 +21,7 @@ Group:          System Environment/Security
 URL:            https://golang.org
 Source0:        https://golang.org/dl/go%{version}.src.tar.gz
 Source1:        https://dl.google.com/go/go1.4-bootstrap-20171003.tar.gz
+Source2:        https://dl.google.com/go/go1.19.12.src.tar.gz
 Patch0:         go14_bootstrap_aarch64.patch
 Patch1:         permit-requests-with-invalid-header.patch
 Obsoletes:      %{name} < %{version}
@@ -47,6 +48,19 @@ CGO_ENABLED=0 ./make.bash
 popd
 mv -v %{_topdir}/BUILD/go-bootstrap %{_libdir}/golang
 export GOROOT=%{_libdir}/golang
+
+# Use go1.4 bootstrap to compile go1.19.12 (bootstrap)
+export GOROOT_BOOTSTRAP=%{_libdir}/golang
+mkdir -p %{_topdir}/BUILD/go1.19.12
+tar xf %{SOURCE2} -C %{_topdir}/BUILD/go1.19.12 --strip-components=1
+pushd %{_topdir}/BUILD/go1.19.12/src
+CGO_ENABLED=0 ./make.bash
+popd
+
+# Nuke the older go1.4 bootstrap
+rm -rf %{_libdir}/golang
+# Make go1.19.12 as the new bootstrapper
+mv -v %{_topdir}/BUILD/go1.19.12 %{_libdir}/golang
 
 # Build current go version
 export GOHOSTOS=linux

--- a/SPECS/golang/golang.spec
+++ b/SPECS/golang/golang.spec
@@ -1,3 +1,4 @@
+%global bootstrap_compiler_version 1.19.12
 %global goroot          %{_libdir}/golang
 %global gopath          %{_datadir}/gocode
 %ifarch aarch64
@@ -21,7 +22,7 @@ Group:          System Environment/Security
 URL:            https://golang.org
 Source0:        https://golang.org/dl/go%{version}.src.tar.gz
 Source1:        https://dl.google.com/go/go1.4-bootstrap-20171003.tar.gz
-Source2:        https://dl.google.com/go/go1.19.12.src.tar.gz
+Source2:        https://dl.google.com/go/go%{bootstrap_compiler_version}.src.tar.gz
 Patch0:         go14_bootstrap_aarch64.patch
 Patch1:         permit-requests-with-invalid-header.patch
 Obsoletes:      %{name} < %{version}
@@ -42,6 +43,14 @@ mv -v go go-bootstrap
 %patch1 -p1
 
 %build
+# (go >= 1.20 bootstraps with go >= 1.17)
+# This condition makes go compiler >= 1.20 build a 3 step process:
+# - Build the bootstrap compiler 1.4 (bootstrap bits in c)
+# - Use the 1.4 compiler to build %{bootstrap_compiler_version}
+# - Use the %{bootstrap_compiler_version} compiler to build go >= 1.20 compiler
+# PS: Since go compiles fairly quickly, the extra overhead is arounnd 2-3 minutes
+#     on a reasonable machine.
+
 # Build go 1.4 bootstrap
 pushd %{_topdir}/BUILD/go-bootstrap/src
 CGO_ENABLED=0 ./make.bash
@@ -49,17 +58,18 @@ popd
 mv -v %{_topdir}/BUILD/go-bootstrap %{_libdir}/golang
 export GOROOT=%{_libdir}/golang
 
-# Use go1.4 bootstrap to compile go1.19.12 (bootstrap)
+# Use go1.4 bootstrap to compile go%{bootstrap_compiler_version} (bootstrap)
 export GOROOT_BOOTSTRAP=%{_libdir}/golang
-mkdir -p %{_topdir}/BUILD/go1.19.12
-tar xf %{SOURCE2} -C %{_topdir}/BUILD/go1.19.12 --strip-components=1
-pushd %{_topdir}/BUILD/go1.19.12/src
+mkdir -p %{_topdir}/BUILD/go%{bootstrap_compiler_version}
+tar xf %{SOURCE2} -C %{_topdir}/BUILD/go%{bootstrap_compiler_version} --strip-components=1
+pushd %{_topdir}/BUILD/go%{bootstrap_compiler_version}/src
 CGO_ENABLED=0 ./make.bash
 popd
 
 # Nuke the older go1.4 bootstrap
 rm -rf %{_libdir}/golang
-# Make go1.19.12 as the new bootstrapper
+
+# Make go%{bootstrap_compiler_version} as the new bootstrapper
 mv -v %{_topdir}/BUILD/go1.19.12 %{_libdir}/golang
 
 # Build current go version

--- a/SPECS/golang/permit-requests-with-invalid-header.patch
+++ b/SPECS/golang/permit-requests-with-invalid-header.patch
@@ -1,7 +1,7 @@
-From c08a5fa413a34111c9a37fd9e545de27ab0978b1 Mon Sep 17 00:00:00 2001
+From ede3e278ae8df8ce1beec4b251dbaa68b8d2ad48 Mon Sep 17 00:00:00 2001
 From: Damien Neil <dneil@google.com>
 Date: Wed, 19 Jul 2023 10:30:46 -0700
-Subject: [PATCH] [release-branch.go1.19] net/http: permit requests with
+Subject: [PATCH] [release-branch.go1.20] net/http: permit requests with
  invalid Host headers
 
 Historically, the Transport has silently truncated invalid
@@ -20,7 +20,7 @@ without a Host.
 
 For #60374
 Fixes #61431
-Fixes #61825
+Fixes #61826
 
 Change-Id: If170c7dd860aa20eb58fe32990fc93af832742b6
 Reviewed-on: https://go-review.googlesource.com/c/go/+/511155
@@ -28,10 +28,10 @@ TryBot-Result: Gopher Robot <gobot@golang.org>
 Reviewed-by: Roland Shoemaker <roland@golang.org>
 Run-TryBot: Damien Neil <dneil@google.com>
 (cherry picked from commit b9153f6ef338baee5fe02a867c8fbc83a8b29dd1)
-Reviewed-on: https://go-review.googlesource.com/c/go/+/518855
+Reviewed-on: https://go-review.googlesource.com/c/go/+/518756
 Auto-Submit: Dmitri Shuralyov <dmitshur@google.com>
-Run-TryBot: Roland Shoemaker <roland@golang.org>
 Reviewed-by: Russ Cox <rsc@golang.org>
+Run-TryBot: Roland Shoemaker <roland@golang.org>
 Signed-off-by: Muhammad Falak R Wani <falakreyaz@gmail.com>
 ---
  src/net/http/request.go      | 23 ++++++++++++++++++++++-
@@ -39,10 +39,10 @@ Signed-off-by: Muhammad Falak R Wani <falakreyaz@gmail.com>
  2 files changed, 34 insertions(+), 6 deletions(-)
 
 diff --git a/src/net/http/request.go b/src/net/http/request.go
-index 3100037386..91cb8a66b9 100644
+index 9c888b3768..2cf96b4417 100644
 --- a/src/net/http/request.go
 +++ b/src/net/http/request.go
-@@ -582,8 +582,29 @@ func (r *Request) write(w io.Writer, usingProxy bool, extraHeaders Header, waitF
+@@ -586,8 +586,29 @@ func (r *Request) write(w io.Writer, usingProxy bool, extraHeaders Header, waitF
  	if err != nil {
  		return err
  	}
@@ -74,10 +74,10 @@ index 3100037386..91cb8a66b9 100644
  
  	// According to RFC 6874, an HTTP client, proxy, or other
 diff --git a/src/net/http/request_test.go b/src/net/http/request_test.go
-index fddc85d6a9..dd1e2dc2a1 100644
+index 86c68e470e..a9343cd935 100644
 --- a/src/net/http/request_test.go
 +++ b/src/net/http/request_test.go
-@@ -770,16 +770,23 @@ func TestRequestWriteBufferedWriter(t *testing.T) {
+@@ -766,16 +766,23 @@ func TestRequestWriteBufferedWriter(t *testing.T) {
  	}
  }
  
@@ -108,3 +108,4 @@ index fddc85d6a9..dd1e2dc2a1 100644
  
 -- 
 2.41.0
+

--- a/SPECS/moby-cli/moby-cli.signatures.json
+++ b/SPECS/moby-cli/moby-cli.signatures.json
@@ -1,5 +1,5 @@
 {
-  "Signatures": {
-    "moby-cli-20.10.24.tar.gz": "3ffc8924756da21b0fd2b735540003fb3e3ba8602ceffeba40010b34aec22b5b"
-  }
+ "Signatures": {
+  "moby-cli-20.10.25.tar.gz": "fc80d99f6c929d3d3f7b5322063e1a5236623341a0b671c70cfa15854cadbc18"
+ }
 }

--- a/SPECS/moby-cli/moby-cli.spec
+++ b/SPECS/moby-cli/moby-cli.spec
@@ -80,7 +80,7 @@ install -p -m 644 contrib/completion/fish/docker.fish %{buildroot}%{_datadir}/fi
 %{_datadir}/fish/vendor_completions.d/docker.fish
 
 %changelog
-* Sat Aug 08 2023 Muhammad Falak <mwani@microsoft.com> - 20.10.25-1
+* Thu Aug 17 2023 Muhammad Falak <mwani@microsoft.com> - 20.10.25-1
 - Bump version to 20.10.25
 
 * Mon Aug 07 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 20.10.24-4

--- a/SPECS/moby-cli/moby-cli.spec
+++ b/SPECS/moby-cli/moby-cli.spec
@@ -1,10 +1,10 @@
 %define upstream_name cli
-%define commit_hash e91ed5707e038b02af3b5120fa0835c5bedfd42e
+%define commit_hash b82b9f3a0e763304a250531cb9350aa6d93723c9
 
 Summary: The open-source application container engine client.
 Name: moby-%{upstream_name}
-Version: 20.10.24
-Release: 4%{?dist}
+Version: 20.10.25
+Release: 1%{?dist}
 License: ASL 2.0
 Group: Tools/Container
 URL: https://github.com/docker/cli
@@ -80,6 +80,9 @@ install -p -m 644 contrib/completion/fish/docker.fish %{buildroot}%{_datadir}/fi
 %{_datadir}/fish/vendor_completions.d/docker.fish
 
 %changelog
+* Sat Aug 08 2023 Muhammad Falak <mwani@microsoft.com> - 20.10.25-1
+- Bump version to 20.10.25
+
 * Mon Aug 07 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 20.10.24-4
 - Bump release to rebuild with go 1.19.12
 

--- a/SPECS/moby-containerd/moby-containerd.signatures.json
+++ b/SPECS/moby-containerd/moby-containerd.signatures.json
@@ -1,7 +1,7 @@
 {
-  "Signatures": {
-    "containerd.service": "b7908653ff8298fc8c1c21854a6e338f40c607ec40d177269615a8f3448c5153",
-    "containerd.toml": "793d4f11a4e69bdb3b1903da2cdf76b7f32dbc97197b12d295a05ecc284e230e",
-    "moby-containerd-1.6.18.tar.gz": "e9b84d52da7743000c1e8dae0175dda16d558a44cf80a5ae2556862205361a64"
-  }
+ "Signatures": {
+  "containerd.service": "b7908653ff8298fc8c1c21854a6e338f40c607ec40d177269615a8f3448c5153",
+  "containerd.toml": "793d4f11a4e69bdb3b1903da2cdf76b7f32dbc97197b12d295a05ecc284e230e",
+  "moby-containerd-1.6.22.tar.gz": "b109aceacc814d7a637ed94ba5ade829cd2642841d03e06971ef124fa3b86899"
+ }
 }

--- a/SPECS/moby-containerd/moby-containerd.spec
+++ b/SPECS/moby-containerd/moby-containerd.spec
@@ -1,11 +1,11 @@
 %global debug_package %{nil}
 %define upstream_name containerd
-%define commit_hash 2456e983eb9e37e47538f59ea18f2043c9a73640
+%define commit_hash 8165feabfdfe38c65b599c4993d227328c231fca
 
 Summary: Industry-standard container runtime
 Name: moby-%{upstream_name}
-Version: 1.6.18
-Release: 7%{?dist}
+Version: 1.6.22
+Release: 1%{?dist}
 License: ASL 2.0
 Group: Tools/Container
 URL: https://www.containerd.io
@@ -86,6 +86,9 @@ fi
 %config(noreplace) %{_sysconfdir}/containerd/config.toml
 
 %changelog
+* Wed Aug 16 2023 Muhammad Falak <mwani@microsoft.com> - 1.6.22-1
+- Bump version to 1.6.22
+
 * Mon Aug 07 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 1.6.18-7
 - Bump release to rebuild with go 1.19.12
 

--- a/SPECS/moby-engine/moby-engine.signatures.json
+++ b/SPECS/moby-engine/moby-engine.signatures.json
@@ -1,8 +1,8 @@
 {
-  "Signatures": {
-    "docker.service": "b150b3ce0947a65c655ed09dfe4e48b7464c60542f9f9902330288bbf87af38e",
-    "docker.socket": "51a06786cae46bc63b7314c25d0bd5bb2e676120d80874b99e35bf60d0b0ffa8",
-    "moby-engine-20.10.24.tar.gz": "5c586d9f352bbe3a16bce27dd4856baa0ef02de58433bb3e1af9976c04c7eaae",
-    "moby-libnetwork-20.10.24.tar.gz": "669cf428b381dfd8e774890c908773d4f843f695cdc6f07c2711c9bec369ad4f"
-  }
+ "Signatures": {
+  "docker.service": "b150b3ce0947a65c655ed09dfe4e48b7464c60542f9f9902330288bbf87af38e",
+  "docker.socket": "51a06786cae46bc63b7314c25d0bd5bb2e676120d80874b99e35bf60d0b0ffa8",
+  "moby-engine-20.10.25.tar.gz": "dbd19da08d716cf17866d77ad5022d8b1288cf6ba498fdf67895b1abf1719916",
+  "moby-libnetwork-20.10.25.tar.gz": "3d76ad1fd3a29b34c86501ceb3e43f2e74dc4cd16a61a9a1eff2df0a7adfc0ec"
+ }
 }

--- a/SPECS/moby-engine/moby-engine.spec
+++ b/SPECS/moby-engine/moby-engine.spec
@@ -1,10 +1,10 @@
 %define upstream_name moby
-%define commit_hash 87a90dc786bda134c9eb02adbae2c6a7342fb7f6
+%define commit_hash 5df983c7dbe2f8914e6efd4dd6e0083a20c41ce1
 
 Summary: The open-source application container engine
 Name:    %{upstream_name}-engine
-Version: 20.10.24
-Release: 4%{?dist}
+Version: 20.10.25
+Release: 1%{?dist}
 License: ASL 2.0
 Group:   Tools/Container
 URL: https://mobyproject.org
@@ -126,6 +126,9 @@ fi
 %{_unitdir}/*
 
 %changelog
+* Sat Aug 08 2023 Muhammad Falak <mwani@microsoft.com> - 20.10.25-1
+- Bump version to 20.10.25
+
 * Mon Aug 07 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 20.10.24-4
 - Bump release to rebuild with go 1.19.12
 

--- a/SPECS/moby-engine/moby-engine.spec
+++ b/SPECS/moby-engine/moby-engine.spec
@@ -126,7 +126,7 @@ fi
 %{_unitdir}/*
 
 %changelog
-* Sat Aug 08 2023 Muhammad Falak <mwani@microsoft.com> - 20.10.25-1
+* Thu Aug 17 2023 Muhammad Falak <mwani@microsoft.com> - 20.10.25-1
 - Bump version to 20.10.25
 
 * Mon Aug 07 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 20.10.24-4

--- a/SPECS/moby-runc/moby-runc.signatures.json
+++ b/SPECS/moby-runc/moby-runc.signatures.json
@@ -1,5 +1,5 @@
 {
-  "Signatures": {
-    "moby-runc-1.1.5.tar.gz": "76cbf30637cbb828794d72d32fb3fd6ff3139cd9743b8b44790fd110f43d96b2"
-  }
+ "Signatures": {
+  "moby-runc-1.1.9.tar.gz": "509993674481aad7e14aedfb280e0eb160f3a34c0b77e2e98c4b3c0b1df76894"
+ }
 }

--- a/SPECS/moby-runc/moby-runc.spec
+++ b/SPECS/moby-runc/moby-runc.spec
@@ -1,11 +1,11 @@
 %define         upstream_name runc
-%define         commit_hash a916309fff0f838eb94e928713dbc3c0d0ac7aa4
+%define         commit_hash ccaecfcbc907d70a7aa870a6650887b901b25b82
 
 Summary:        CLI tool for spawning and running containers per OCI spec.
 Name:           moby-%{upstream_name}
 # update "commit_hash" above when upgrading version
-Version:        1.1.5
-Release:        4%{?dist}
+Version:        1.1.9
+Release:        1%{?dist}
 License:        ASL 2.0
 URL:            https://github.com/opencontainers/runc
 Group:          Virtualization/Libraries
@@ -13,7 +13,6 @@ Vendor:         Microsoft Corporation
 Distribution:   Mariner
 
 Source0:        https://github.com/opencontainers/runc/archive/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
-Patch0:         0001-cgroups-cpuset-fix-byte-order-while-parsing-cpuset-r.patch
 
 BuildRequires:  git
 BuildRequires:  golang => 1.16
@@ -37,7 +36,6 @@ runC is a CLI tool for spawning and running containers according to the OCI spec
 
 %prep
 %setup -q -n %{upstream_name}-%{version}
-%patch0 -p1
 
 %build
 export CGO_ENABLED=1
@@ -59,6 +57,9 @@ make install-man DESTDIR="%{buildroot}" PREFIX="%{_prefix}"
 %{_mandir}/*
 
 %changelog
+* Tue Aug 15 2023 Muhammad Falak <mwani@microsoft.com> - 1.1.9-1
+- Bump version to 1.1.9
+
 * Mon Aug 07 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 1.1.5-4
 - Bump release to rebuild with go 1.19.12
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -13283,8 +13283,8 @@
         "type": "other",
         "other": {
           "name": "moby-runc",
-          "version": "1.1.5",
-          "downloadUrl": "https://github.com/opencontainers/runc/archive/v1.1.5.tar.gz"
+          "version": "1.1.9",
+          "downloadUrl": "https://github.com/opencontainers/runc/archive/v1.1.9.tar.gz"
         }
       }
     },

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -13233,8 +13233,8 @@
         "type": "other",
         "other": {
           "name": "moby-cli",
-          "version": "20.10.24",
-          "downloadUrl": "https://github.com/docker/cli/archive/v20.10.24.tar.gz"
+          "version": "20.10.25",
+          "downloadUrl": "https://github.com/docker/cli/archive/v20.10.25.tar.gz"
         }
       }
     },

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -13273,8 +13273,8 @@
         "type": "other",
         "other": {
           "name": "moby-engine",
-          "version": "20.10.24",
-          "downloadUrl": "https://github.com/moby/moby/archive/v20.10.24.tar.gz"
+          "version": "20.10.25",
+          "downloadUrl": "https://github.com/moby/moby/archive/v20.10.25.tar.gz"
         }
       }
     },

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -13253,8 +13253,8 @@
         "type": "other",
         "other": {
           "name": "moby-containerd",
-          "version": "1.6.18",
-          "downloadUrl": "https://github.com/containerd/containerd/archive/v1.6.18.tar.gz"
+          "version": "1.6.22",
+          "downloadUrl": "https://github.com/containerd/containerd/archive/v1.6.22.tar.gz"
         }
       }
     },

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -4630,6 +4630,16 @@
         "type": "other",
         "other": {
           "name": "golang",
+          "version": "1.19.12",
+          "downloadUrl": "https://golang.org/dl/go1.19.12.src.tar.gz"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "other",
+        "other": {
+          "name": "golang",
           "version": "1.20.7",
           "downloadUrl": "https://golang.org/dl/go1.20.7.src.tar.gz"
         }

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -4630,8 +4630,8 @@
         "type": "other",
         "other": {
           "name": "golang",
-          "version": "1.19.12",
-          "downloadUrl": "https://golang.org/dl/go1.19.12.src.tar.gz"
+          "version": "1.20.7",
+          "downloadUrl": "https://golang.org/dl/go1.20.7.src.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
This touches moby-* and golang:
- Golang bumped to 1.20.7. Note that for go versions >= 1.20, the minimum compiler required is 1.17.
First the go1.4 bootstrap compiler is built.
The result of 1.4 compiler is used to build a 1.19.12 compiler.
The 1.19.12 compiler is used to build the actual 1.20.7 compiler.
Since go builds fairly quickly, the overhead of this is ~2-3 minutes on a reasonable machine.

- moby-engine & moby-cli -> bumped to 20.10.25 (which contain the fix `http: invalid host header`.
If we build moby-enginne & moby-cli with 1.19.12 compiler, it still does not work.

- moby-runc bumped to 1.1.9
- moby-containerd bumped to 1.6.22

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- golang: bump version 1.19.12 -> 1.20.7
- golang: fix compile process for go >= 1.20
- golang: add comment on how the compiler builds post go >= 1.20
- golang: cgmanifest: update entry
- moby-engine: bump version 20.10.24 -> 20.10.25
- moby-engine: cgmanifest: update entry
- moby-cli: bump version 20.10.24 -> 20.10.25
- moby-cli: cgmanifest: update entry
- moby-containerd: bump version 1.6.18 -> 1.6.22
- moby-containerd: cgmanifest: add entry
- moby-runc: bump version 1.1.5 -> 1.1.9
- moby-runc: cgmanifest: update entry

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
Fixes:
- #5980
- Related Workitem/Bug: [45821789](https://microsoft.visualstudio.com/OS/_workitems/edit/45821789/)
- Closes: https://github.com/microsoft/CBL-Mariner/pull/5936
- Supersedes: https://github.com/microsoft/CBL-Mariner/pull/5946

###### Links to CVEs  <!-- optional -->
- NA

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local Build and verification

Pipeline Build: 
- ARM: [FullBuild](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=409256&view=logs&j=75cba72d-09cb-503a-3927-4ab61ac4a179&t=266a177c-c74b-572c-2e05-3a6c5cd5b38a&l=28004)
- AMD: [FullBuild](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=409244&view=logs&j=75cba72d-09cb-503a-3927-4ab61ac4a179&t=266a177c-c74b-572c-2e05-3a6c5cd5b38a)



PS: I used the new `containerized-build` feature for this and a big kudos to @neha170 for this feature
/cc @christopherco