### PR TITLE
Patch etcd and bump fuzzing for CVE-2023-32082

### DIFF
--- a/SPECS/etcd/CVE-2023-32082-v3.5.0.patch
+++ b/SPECS/etcd/CVE-2023-32082-v3.5.0.patch
@@ -1,0 +1,272 @@
+From 3e6c1e3207e421584525994a08ae16f01f200ac6 Mon Sep 17 00:00:00 2001
+From: Rachel Menge <rachelmenge@microsoft.com>
+Date: Wed, 23 Aug 2023 13:22:19 -0700
+Subject: [PATCH] Patch CVE-2023-32082
+
+---
+ server/etcdserver/v3_server.go    | 52 +++++++++++++++++-
+ tests/e2e/ctl_v3_auth_test.go     | 49 +++++++++++++++++
+ tests/e2e/ctl_v3_lease_test.go    |  8 +++
+ tests/integration/v3_auth_test.go | 91 +++++++++++++++++++++++++++++--
+ 4 files changed, 194 insertions(+), 6 deletions(-)
+
+diff --git a/server/etcdserver/v3_server.go b/server/etcdserver/v3_server.go
+index c4e9397..e94853a 100644
+--- a/server/etcdserver/v3_server.go
++++ b/server/etcdserver/v3_server.go
+@@ -314,7 +314,32 @@ func (s *EtcdServer) LeaseRenew(ctx context.Context, id lease.LeaseID) (int64, e
+ 	return -1, ErrCanceled
+ }
+ 
+-func (s *EtcdServer) LeaseTimeToLive(ctx context.Context, r *pb.LeaseTimeToLiveRequest) (*pb.LeaseTimeToLiveResponse, error) {
++func (s *EtcdServer) checkLeaseTimeToLive(ctx context.Context, leaseID lease.LeaseID) (uint64, error) {
++	rev := s.AuthStore().Revision()
++	if !s.AuthStore().IsAuthEnabled() {
++		return rev, nil
++	}
++	authInfo, err := s.AuthInfoFromCtx(ctx)
++	if err != nil {
++		return rev, err
++	}
++	if authInfo == nil {
++		return rev, auth.ErrUserEmpty
++	}
++
++	l := s.lessor.Lookup(leaseID)
++	if l != nil {
++		for _, key := range l.Keys() {
++			if err := s.AuthStore().IsRangePermitted(authInfo, []byte(key), []byte{}); err != nil {
++				return 0, err
++			}
++		}
++	}
++
++	return rev, nil
++}
++
++func (s *EtcdServer) leaseTimeToLive(ctx context.Context, r *pb.LeaseTimeToLiveRequest) (*pb.LeaseTimeToLiveResponse, error) {
+ 	if s.Leader() == s.ID() {
+ 		// primary; timetolive directly from leader
+ 		le := s.lessor.Lookup(lease.LeaseID(r.ID))
+@@ -361,6 +386,31 @@ func (s *EtcdServer) LeaseTimeToLive(ctx context.Context, r *pb.LeaseTimeToLiveR
+ 	return nil, ErrCanceled
+ }
+ 
++func (s *EtcdServer) LeaseTimeToLive(ctx context.Context, r *pb.LeaseTimeToLiveRequest) (*pb.LeaseTimeToLiveResponse, error) {
++	var rev uint64
++	var err error
++	if r.Keys {
++		// check RBAC permission only if Keys is true
++		rev, err = s.checkLeaseTimeToLive(ctx, lease.LeaseID(r.ID))
++		if err != nil {
++			return nil, err
++		}
++	}
++
++	resp, err := s.leaseTimeToLive(ctx, r)
++	if err != nil {
++		return nil, err
++	}
++
++	if r.Keys {
++		if s.AuthStore().IsAuthEnabled() && rev != s.AuthStore().Revision() {
++			return nil, auth.ErrAuthOldRevision
++		}
++	}
++	return resp, nil
++}
++
++// LeaseLeases is really ListLeases !???
+ func (s *EtcdServer) LeaseLeases(ctx context.Context, r *pb.LeaseLeasesRequest) (*pb.LeaseLeasesResponse, error) {
+ 	ls := s.lessor.Leases()
+ 	lss := make([]*pb.LeaseStatus, len(ls))
+diff --git a/tests/e2e/ctl_v3_auth_test.go b/tests/e2e/ctl_v3_auth_test.go
+index 58a3b61..090c4ab 100644
+--- a/tests/e2e/ctl_v3_auth_test.go
++++ b/tests/e2e/ctl_v3_auth_test.go
+@@ -70,6 +70,7 @@ func TestCtlV3AuthSnapshot(t *testing.T)            { testCtl(t, authTestSnapsho
+ func TestCtlV3AuthSnapshotJWT(t *testing.T)         { testCtl(t, authTestSnapshot, withCfg(*newConfigJWT())) }
+ func TestCtlV3AuthJWTExpire(t *testing.T)           { testCtl(t, authTestJWTExpire, withCfg(*newConfigJWT())) }
+ func TestCtlV3AuthRevisionConsistency(t *testing.T) { testCtl(t, authTestRevisionConsistency) }
++func TestCtlV3AuthLeaseTimeToLive(t *testing.T)     { testCtl(t, authTestLeaseTimeToLive) }
+ 
+ func authEnableTest(cx ctlCtx) {
+ 	if err := authEnable(cx); err != nil {
+@@ -1206,3 +1207,51 @@ func authTestRevisionConsistency(cx ctlCtx) {
+ 		cx.t.Fatalf("auth revison shouldn't change when restarting etcd, expected: %d, got: %d", oldAuthRevision, newAuthRevision)
+ 	}
+ }
++
++func authTestLeaseTimeToLive(cx ctlCtx) {
++	if err := authEnable(cx); err != nil {
++		cx.t.Fatal(err)
++	}
++	cx.user, cx.pass = "root", "root"
++
++	authSetupTestUser(cx)
++
++	cx.user = "test-user"
++	cx.pass = "pass"
++
++	leaseID, err := ctlV3LeaseGrant(cx, 10)
++	if err != nil {
++		cx.t.Fatal(err)
++	}
++
++	err = ctlV3Put(cx, "foo", "val", leaseID)
++	if err != nil {
++		cx.t.Fatal(err)
++	}
++
++	err = ctlV3LeaseTimeToLive(cx, leaseID, true)
++	if err != nil {
++		cx.t.Fatal(err)
++	}
++
++	cx.user = "root"
++	cx.pass = "root"
++	err = ctlV3Put(cx, "bar", "val", leaseID)
++	if err != nil {
++		cx.t.Fatal(err)
++	}
++
++	cx.user = "test-user"
++	cx.pass = "pass"
++	// the lease is attached to bar, which test-user cannot access
++	err = ctlV3LeaseTimeToLive(cx, leaseID, true)
++	if err == nil {
++		cx.t.Fatal("test-user must not be able to access to the lease, because it's attached to the key bar")
++	}
++
++	// without --keys, access should be allowed
++	err = ctlV3LeaseTimeToLive(cx, leaseID, false)
++	if err != nil {
++		cx.t.Fatal(err)
++	}
++}
+diff --git a/tests/e2e/ctl_v3_lease_test.go b/tests/e2e/ctl_v3_lease_test.go
+index 59e47bc..fffcdf6 100644
+--- a/tests/e2e/ctl_v3_lease_test.go
++++ b/tests/e2e/ctl_v3_lease_test.go
+@@ -300,3 +300,11 @@ func ctlV3LeaseRevoke(cx ctlCtx, leaseID string) error {
+ 	cmdArgs := append(cx.PrefixArgs(), "lease", "revoke", leaseID)
+ 	return spawnWithExpect(cmdArgs, fmt.Sprintf("lease %s revoked", leaseID))
+ }
++
++func ctlV3LeaseTimeToLive(cx ctlCtx, leaseID string, withKeys bool) error {
++	cmdArgs := append(cx.PrefixArgs(), "lease", "timetolive", leaseID)
++	if withKeys {
++		cmdArgs = append(cmdArgs, "--keys")
++	}
++	return spawnWithExpectWithEnv(cmdArgs, cx.envMap, fmt.Sprintf("lease %s granted with", leaseID))
++}
+diff --git a/tests/integration/v3_auth_test.go b/tests/integration/v3_auth_test.go
+index 286f2db..95272ad 100644
+--- a/tests/integration/v3_auth_test.go
++++ b/tests/integration/v3_auth_test.go
+@@ -150,12 +150,10 @@ func testV3AuthWithLeaseRevokeWithRoot(t *testing.T, ccfg ClusterConfig) {
+ 	// wait for lease expire
+ 	time.Sleep(3 * time.Second)
+ 
+-	tresp, terr := api.Lease.LeaseTimeToLive(
++	tresp, terr := rootc.TimeToLive(
+ 		context.TODO(),
+-		&pb.LeaseTimeToLiveRequest{
+-			ID:   int64(leaseID),
+-			Keys: true,
+-		},
++		leaseID,
++		clientv3.WithAttachedKeys(),
+ 	)
+ 	if terr != nil {
+ 		t.Error(terr)
+@@ -394,3 +392,86 @@ func TestV3AuthOldRevConcurrent(t *testing.T) {
+ 	}
+ 	wg.Wait()
+ }
++
++func TestV3AuthWithLeaseTimeToLive(t *testing.T) {
++	BeforeTest(t)
++	clus := NewClusterV3(t, &ClusterConfig{Size: 1})
++	defer clus.Terminate(t)
++
++	users := []user{
++		{
++			name:     "user1",
++			password: "user1-123",
++			role:     "role1",
++			key:      "k1",
++			end:      "k3",
++		},
++		{
++			name:     "user2",
++			password: "user2-123",
++			role:     "role2",
++			key:      "k2",
++			end:      "k4",
++		},
++	}
++	authSetupUsers(t, toGRPC(clus.Client(0)).Auth, users)
++
++	authSetupRoot(t, toGRPC(clus.Client(0)).Auth)
++
++	user1c, cerr := NewClient(t, clientv3.Config{Endpoints: clus.Client(0).Endpoints(), Username: "user1", Password: "user1-123"})
++	if cerr != nil {
++		t.Fatal(cerr)
++	}
++	defer user1c.Close()
++
++	user2c, cerr := NewClient(t, clientv3.Config{Endpoints: clus.Client(0).Endpoints(), Username: "user2", Password: "user2-123"})
++	if cerr != nil {
++		t.Fatal(cerr)
++	}
++	defer user2c.Close()
++
++	leaseResp, err := user1c.Grant(context.TODO(), 90)
++	if err != nil {
++		t.Fatal(err)
++	}
++	leaseID := leaseResp.ID
++	_, err = user1c.Put(context.TODO(), "k1", "val", clientv3.WithLease(leaseID))
++	if err != nil {
++		t.Fatal(err)
++	}
++	// k2 can be accessed from both user1 and user2
++	_, err = user1c.Put(context.TODO(), "k2", "val", clientv3.WithLease(leaseID))
++	if err != nil {
++		t.Fatal(err)
++	}
++
++	_, err = user1c.TimeToLive(context.TODO(), leaseID)
++	if err != nil {
++		t.Fatal(err)
++	}
++
++	_, err = user2c.TimeToLive(context.TODO(), leaseID)
++	if err != nil {
++		t.Fatal(err)
++	}
++
++	_, err = user2c.TimeToLive(context.TODO(), leaseID, clientv3.WithAttachedKeys())
++	if err == nil {
++		t.Fatal("timetolive from user2 should be failed with permission denied")
++	}
++
++	rootc, cerr := NewClient(t, clientv3.Config{Endpoints: clus.Client(0).Endpoints(), Username: "root", Password: "123"})
++	if cerr != nil {
++		t.Fatal(cerr)
++	}
++	defer rootc.Close()
++
++	if _, err := rootc.RoleRevokePermission(context.TODO(), "role1", "k1", "k3"); err != nil {
++		t.Fatal(err)
++	}
++
++	_, err = user1c.TimeToLive(context.TODO(), leaseID, clientv3.WithAttachedKeys())
++	if err == nil {
++		t.Fatal("timetolive from user2 should be failed with permission denied")
++	}
++}
+-- 
+2.17.1
+

--- a/SPECS/etcd/CVE-2023-32082-v3.5.3.patch
+++ b/SPECS/etcd/CVE-2023-32082-v3.5.3.patch
@@ -1,0 +1,272 @@
+From 3dee04d0c96383dc95b453ed1c6b3e12eeea2103 Mon Sep 17 00:00:00 2001
+From: Rachel Menge <rachelmenge@microsoft.com>
+Date: Wed, 23 Aug 2023 13:31:30 -0700
+Subject: [PATCH] Patch CVE-2023-32082
+
+---
+ server/etcdserver/v3_server.go    | 52 +++++++++++++++++-
+ tests/e2e/ctl_v3_auth_test.go     | 49 +++++++++++++++++
+ tests/e2e/ctl_v3_lease_test.go    |  8 +++
+ tests/integration/v3_auth_test.go | 91 +++++++++++++++++++++++++++++--
+ 4 files changed, 194 insertions(+), 6 deletions(-)
+
+diff --git a/server/etcdserver/v3_server.go b/server/etcdserver/v3_server.go
+index 960a7b1..9f69b86 100644
+--- a/server/etcdserver/v3_server.go
++++ b/server/etcdserver/v3_server.go
+@@ -336,7 +336,32 @@ func (s *EtcdServer) LeaseRenew(ctx context.Context, id lease.LeaseID) (int64, e
+ 	return -1, ErrCanceled
+ }
+ 
+-func (s *EtcdServer) LeaseTimeToLive(ctx context.Context, r *pb.LeaseTimeToLiveRequest) (*pb.LeaseTimeToLiveResponse, error) {
++func (s *EtcdServer) checkLeaseTimeToLive(ctx context.Context, leaseID lease.LeaseID) (uint64, error) {
++	rev := s.AuthStore().Revision()
++	if !s.AuthStore().IsAuthEnabled() {
++		return rev, nil
++	}
++	authInfo, err := s.AuthInfoFromCtx(ctx)
++	if err != nil {
++		return rev, err
++	}
++	if authInfo == nil {
++		return rev, auth.ErrUserEmpty
++	}
++
++	l := s.lessor.Lookup(leaseID)
++	if l != nil {
++		for _, key := range l.Keys() {
++			if err := s.AuthStore().IsRangePermitted(authInfo, []byte(key), []byte{}); err != nil {
++				return 0, err
++			}
++		}
++	}
++
++	return rev, nil
++}
++
++func (s *EtcdServer) leaseTimeToLive(ctx context.Context, r *pb.LeaseTimeToLiveRequest) (*pb.LeaseTimeToLiveResponse, error) {
+ 	if s.isLeader() {
+ 		if err := s.waitAppliedIndex(); err != nil {
+ 			return nil, err
+@@ -386,6 +411,31 @@ func (s *EtcdServer) LeaseTimeToLive(ctx context.Context, r *pb.LeaseTimeToLiveR
+ 	return nil, ErrCanceled
+ }
+ 
++func (s *EtcdServer) LeaseTimeToLive(ctx context.Context, r *pb.LeaseTimeToLiveRequest) (*pb.LeaseTimeToLiveResponse, error) {
++	var rev uint64
++	var err error
++	if r.Keys {
++		// check RBAC permission only if Keys is true
++		rev, err = s.checkLeaseTimeToLive(ctx, lease.LeaseID(r.ID))
++		if err != nil {
++			return nil, err
++		}
++	}
++
++	resp, err := s.leaseTimeToLive(ctx, r)
++	if err != nil {
++		return nil, err
++	}
++
++	if r.Keys {
++		if s.AuthStore().IsAuthEnabled() && rev != s.AuthStore().Revision() {
++			return nil, auth.ErrAuthOldRevision
++		}
++	}
++	return resp, nil
++}
++
++// LeaseLeases is really ListLeases !???
+ func (s *EtcdServer) LeaseLeases(ctx context.Context, r *pb.LeaseLeasesRequest) (*pb.LeaseLeasesResponse, error) {
+ 	ls := s.lessor.Leases()
+ 	lss := make([]*pb.LeaseStatus, len(ls))
+diff --git a/tests/e2e/ctl_v3_auth_test.go b/tests/e2e/ctl_v3_auth_test.go
+index 11db1b3..79af238 100644
+--- a/tests/e2e/ctl_v3_auth_test.go
++++ b/tests/e2e/ctl_v3_auth_test.go
+@@ -70,6 +70,7 @@ func TestCtlV3AuthSnapshot(t *testing.T)            { testCtl(t, authTestSnapsho
+ func TestCtlV3AuthSnapshotJWT(t *testing.T)         { testCtl(t, authTestSnapshot, withCfg(*newConfigJWT())) }
+ func TestCtlV3AuthJWTExpire(t *testing.T)           { testCtl(t, authTestJWTExpire, withCfg(*newConfigJWT())) }
+ func TestCtlV3AuthRevisionConsistency(t *testing.T) { testCtl(t, authTestRevisionConsistency) }
++func TestCtlV3AuthLeaseTimeToLive(t *testing.T)     { testCtl(t, authTestLeaseTimeToLive) }
+ 
+ func authEnableTest(cx ctlCtx) {
+ 	if err := authEnable(cx); err != nil {
+@@ -1206,3 +1207,51 @@ func authTestRevisionConsistency(cx ctlCtx) {
+ 		cx.t.Fatalf("auth revison shouldn't change when restarting etcd, expected: %d, got: %d", oldAuthRevision, newAuthRevision)
+ 	}
+ }
++
++func authTestLeaseTimeToLive(cx ctlCtx) {
++	if err := authEnable(cx); err != nil {
++		cx.t.Fatal(err)
++	}
++	cx.user, cx.pass = "root", "root"
++
++	authSetupTestUser(cx)
++
++	cx.user = "test-user"
++	cx.pass = "pass"
++
++	leaseID, err := ctlV3LeaseGrant(cx, 10)
++	if err != nil {
++		cx.t.Fatal(err)
++	}
++
++	err = ctlV3Put(cx, "foo", "val", leaseID)
++	if err != nil {
++		cx.t.Fatal(err)
++	}
++
++	err = ctlV3LeaseTimeToLive(cx, leaseID, true)
++	if err != nil {
++		cx.t.Fatal(err)
++	}
++
++	cx.user = "root"
++	cx.pass = "root"
++	err = ctlV3Put(cx, "bar", "val", leaseID)
++	if err != nil {
++		cx.t.Fatal(err)
++	}
++
++	cx.user = "test-user"
++	cx.pass = "pass"
++	// the lease is attached to bar, which test-user cannot access
++	err = ctlV3LeaseTimeToLive(cx, leaseID, true)
++	if err == nil {
++		cx.t.Fatal("test-user must not be able to access to the lease, because it's attached to the key bar")
++	}
++
++	// without --keys, access should be allowed
++	err = ctlV3LeaseTimeToLive(cx, leaseID, false)
++	if err != nil {
++		cx.t.Fatal(err)
++	}
++}
+diff --git a/tests/e2e/ctl_v3_lease_test.go b/tests/e2e/ctl_v3_lease_test.go
+index 0dc4452..e4e15d9 100644
+--- a/tests/e2e/ctl_v3_lease_test.go
++++ b/tests/e2e/ctl_v3_lease_test.go
+@@ -300,3 +300,11 @@ func ctlV3LeaseRevoke(cx ctlCtx, leaseID string) error {
+ 	cmdArgs := append(cx.PrefixArgs(), "lease", "revoke", leaseID)
+ 	return spawnWithExpectWithEnv(cmdArgs, cx.envMap, fmt.Sprintf("lease %s revoked", leaseID))
+ }
++
++func ctlV3LeaseTimeToLive(cx ctlCtx, leaseID string, withKeys bool) error {
++	cmdArgs := append(cx.PrefixArgs(), "lease", "timetolive", leaseID)
++	if withKeys {
++		cmdArgs = append(cmdArgs, "--keys")
++	}
++	return spawnWithExpectWithEnv(cmdArgs, cx.envMap, fmt.Sprintf("lease %s granted with", leaseID))
++}
+diff --git a/tests/integration/v3_auth_test.go b/tests/integration/v3_auth_test.go
+index 286f2db..95272ad 100644
+--- a/tests/integration/v3_auth_test.go
++++ b/tests/integration/v3_auth_test.go
+@@ -150,12 +150,10 @@ func testV3AuthWithLeaseRevokeWithRoot(t *testing.T, ccfg ClusterConfig) {
+ 	// wait for lease expire
+ 	time.Sleep(3 * time.Second)
+ 
+-	tresp, terr := api.Lease.LeaseTimeToLive(
++	tresp, terr := rootc.TimeToLive(
+ 		context.TODO(),
+-		&pb.LeaseTimeToLiveRequest{
+-			ID:   int64(leaseID),
+-			Keys: true,
+-		},
++		leaseID,
++		clientv3.WithAttachedKeys(),
+ 	)
+ 	if terr != nil {
+ 		t.Error(terr)
+@@ -394,3 +392,86 @@ func TestV3AuthOldRevConcurrent(t *testing.T) {
+ 	}
+ 	wg.Wait()
+ }
++
++func TestV3AuthWithLeaseTimeToLive(t *testing.T) {
++	BeforeTest(t)
++	clus := NewClusterV3(t, &ClusterConfig{Size: 1})
++	defer clus.Terminate(t)
++
++	users := []user{
++		{
++			name:     "user1",
++			password: "user1-123",
++			role:     "role1",
++			key:      "k1",
++			end:      "k3",
++		},
++		{
++			name:     "user2",
++			password: "user2-123",
++			role:     "role2",
++			key:      "k2",
++			end:      "k4",
++		},
++	}
++	authSetupUsers(t, toGRPC(clus.Client(0)).Auth, users)
++
++	authSetupRoot(t, toGRPC(clus.Client(0)).Auth)
++
++	user1c, cerr := NewClient(t, clientv3.Config{Endpoints: clus.Client(0).Endpoints(), Username: "user1", Password: "user1-123"})
++	if cerr != nil {
++		t.Fatal(cerr)
++	}
++	defer user1c.Close()
++
++	user2c, cerr := NewClient(t, clientv3.Config{Endpoints: clus.Client(0).Endpoints(), Username: "user2", Password: "user2-123"})
++	if cerr != nil {
++		t.Fatal(cerr)
++	}
++	defer user2c.Close()
++
++	leaseResp, err := user1c.Grant(context.TODO(), 90)
++	if err != nil {
++		t.Fatal(err)
++	}
++	leaseID := leaseResp.ID
++	_, err = user1c.Put(context.TODO(), "k1", "val", clientv3.WithLease(leaseID))
++	if err != nil {
++		t.Fatal(err)
++	}
++	// k2 can be accessed from both user1 and user2
++	_, err = user1c.Put(context.TODO(), "k2", "val", clientv3.WithLease(leaseID))
++	if err != nil {
++		t.Fatal(err)
++	}
++
++	_, err = user1c.TimeToLive(context.TODO(), leaseID)
++	if err != nil {
++		t.Fatal(err)
++	}
++
++	_, err = user2c.TimeToLive(context.TODO(), leaseID)
++	if err != nil {
++		t.Fatal(err)
++	}
++
++	_, err = user2c.TimeToLive(context.TODO(), leaseID, clientv3.WithAttachedKeys())
++	if err == nil {
++		t.Fatal("timetolive from user2 should be failed with permission denied")
++	}
++
++	rootc, cerr := NewClient(t, clientv3.Config{Endpoints: clus.Client(0).Endpoints(), Username: "root", Password: "123"})
++	if cerr != nil {
++		t.Fatal(cerr)
++	}
++	defer rootc.Close()
++
++	if _, err := rootc.RoleRevokePermission(context.TODO(), "role1", "k1", "k3"); err != nil {
++		t.Fatal(err)
++	}
++
++	_, err = user1c.TimeToLive(context.TODO(), leaseID, clientv3.WithAttachedKeys())
++	if err == nil {
++		t.Fatal("timetolive from user2 should be failed with permission denied")
++	}
++}
+-- 
+2.17.1
+

--- a/SPECS/etcd/CVE-2023-32082.patch
+++ b/SPECS/etcd/CVE-2023-32082.patch
@@ -1,0 +1,282 @@
+From d1b1aa9dbe8065fb2cb36fe035daf701ccabc4e0 Mon Sep 17 00:00:00 2001
+From: Hitoshi Mitake <h.mitake@gmail.com>
+Date: Wed, 29 Mar 2023 20:46:32 +0900
+Subject: [PATCH 1/2] etcdserver: protect lease timetilive with auth
+
+Signed-off-by: Hitoshi Mitake <h.mitake@gmail.com>
+Co-authored-by: Benjamin Wang <wachao@vmware.com>
+---
+ server/etcdserver/v3_server.go | 52 +++++++++++++++++++++++++++++++++-
+ 1 file changed, 51 insertions(+), 1 deletion(-)
+
+diff --git a/server/etcdserver/v3_server.go b/server/etcdserver/v3_server.go
+index 960a7b11f4b..9f69b86b9b1 100644
+--- a/server/etcdserver/v3_server.go
++++ b/server/etcdserver/v3_server.go
+@@ -336,7 +336,32 @@ func (s *EtcdServer) LeaseRenew(ctx context.Context, id lease.LeaseID) (int64, e
+ 	return -1, ErrCanceled
+ }
+ 
+-func (s *EtcdServer) LeaseTimeToLive(ctx context.Context, r *pb.LeaseTimeToLiveRequest) (*pb.LeaseTimeToLiveResponse, error) {
++func (s *EtcdServer) checkLeaseTimeToLive(ctx context.Context, leaseID lease.LeaseID) (uint64, error) {
++	rev := s.AuthStore().Revision()
++	if !s.AuthStore().IsAuthEnabled() {
++		return rev, nil
++	}
++	authInfo, err := s.AuthInfoFromCtx(ctx)
++	if err != nil {
++		return rev, err
++	}
++	if authInfo == nil {
++		return rev, auth.ErrUserEmpty
++	}
++
++	l := s.lessor.Lookup(leaseID)
++	if l != nil {
++		for _, key := range l.Keys() {
++			if err := s.AuthStore().IsRangePermitted(authInfo, []byte(key), []byte{}); err != nil {
++				return 0, err
++			}
++		}
++	}
++
++	return rev, nil
++}
++
++func (s *EtcdServer) leaseTimeToLive(ctx context.Context, r *pb.LeaseTimeToLiveRequest) (*pb.LeaseTimeToLiveResponse, error) {
+ 	if s.isLeader() {
+ 		if err := s.waitAppliedIndex(); err != nil {
+ 			return nil, err
+@@ -386,6 +411,31 @@ func (s *EtcdServer) LeaseTimeToLive(ctx context.Context, r *pb.LeaseTimeToLiveR
+ 	return nil, ErrCanceled
+ }
+ 
++func (s *EtcdServer) LeaseTimeToLive(ctx context.Context, r *pb.LeaseTimeToLiveRequest) (*pb.LeaseTimeToLiveResponse, error) {
++	var rev uint64
++	var err error
++	if r.Keys {
++		// check RBAC permission only if Keys is true
++		rev, err = s.checkLeaseTimeToLive(ctx, lease.LeaseID(r.ID))
++		if err != nil {
++			return nil, err
++		}
++	}
++
++	resp, err := s.leaseTimeToLive(ctx, r)
++	if err != nil {
++		return nil, err
++	}
++
++	if r.Keys {
++		if s.AuthStore().IsAuthEnabled() && rev != s.AuthStore().Revision() {
++			return nil, auth.ErrAuthOldRevision
++		}
++	}
++	return resp, nil
++}
++
++// LeaseLeases is really ListLeases !???
+ func (s *EtcdServer) LeaseLeases(ctx context.Context, r *pb.LeaseLeasesRequest) (*pb.LeaseLeasesResponse, error) {
+ 	ls := s.lessor.Leases()
+ 	lss := make([]*pb.LeaseStatus, len(ls))
+
+From e38eb678bbecdbe35391fa518b44c1ac14a9e322 Mon Sep 17 00:00:00 2001
+From: Hitoshi Mitake <h.mitake@gmail.com>
+Date: Fri, 31 Mar 2023 23:07:23 +0900
+Subject: [PATCH 2/2] tests: e2e and integration test for timetolive
+
+Signed-off-by: Hitoshi Mitake <h.mitake@gmail.com>
+Co-authored-by: Benjamin Wang <wachao@vmware.com>
+---
+ tests/e2e/ctl_v3_auth_test.go     | 49 +++++++++++++++++
+ tests/e2e/ctl_v3_lease_test.go    |  8 +++
+ tests/integration/v3_auth_test.go | 91 +++++++++++++++++++++++++++++--
+ 3 files changed, 143 insertions(+), 5 deletions(-)
+
+diff --git a/tests/e2e/ctl_v3_auth_test.go b/tests/e2e/ctl_v3_auth_test.go
+index 0792087e062..ac7e90e0437 100644
+--- a/tests/e2e/ctl_v3_auth_test.go
++++ b/tests/e2e/ctl_v3_auth_test.go
+@@ -76,6 +76,7 @@ func TestCtlV3AuthSnapshotJWT(t *testing.T)         { testCtl(t, authTestSnapsho
+ func TestCtlV3AuthJWTExpire(t *testing.T)           { testCtl(t, authTestJWTExpire, withCfg(*newConfigJWT())) }
+ func TestCtlV3AuthRevisionConsistency(t *testing.T) { testCtl(t, authTestRevisionConsistency) }
+ func TestCtlV3AuthTestCacheReload(t *testing.T)     { testCtl(t, authTestCacheReload) }
++func TestCtlV3AuthLeaseTimeToLive(t *testing.T)     { testCtl(t, authTestLeaseTimeToLive) }
+ 
+ func TestCtlV3AuthRecoverFromSnapshot(t *testing.T) {
+ 	testCtl(t, authTestRecoverSnapshot, withCfg(*newConfigNoTLS()), withQuorum(), withSnapshotCount(5))
+@@ -1509,3 +1510,51 @@ func hashKVs(endpoints []string, cli *clientv3.Client) ([]*clientv3.HashKVRespon
+ 	}
+ 	return retHashKVs, nil
+ }
++
++func authTestLeaseTimeToLive(cx ctlCtx) {
++	if err := authEnable(cx); err != nil {
++		cx.t.Fatal(err)
++	}
++	cx.user, cx.pass = "root", "root"
++
++	authSetupTestUser(cx)
++
++	cx.user = "test-user"
++	cx.pass = "pass"
++
++	leaseID, err := ctlV3LeaseGrant(cx, 10)
++	if err != nil {
++		cx.t.Fatal(err)
++	}
++
++	err = ctlV3Put(cx, "foo", "val", leaseID)
++	if err != nil {
++		cx.t.Fatal(err)
++	}
++
++	err = ctlV3LeaseTimeToLive(cx, leaseID, true)
++	if err != nil {
++		cx.t.Fatal(err)
++	}
++
++	cx.user = "root"
++	cx.pass = "root"
++	err = ctlV3Put(cx, "bar", "val", leaseID)
++	if err != nil {
++		cx.t.Fatal(err)
++	}
++
++	cx.user = "test-user"
++	cx.pass = "pass"
++	// the lease is attached to bar, which test-user cannot access
++	err = ctlV3LeaseTimeToLive(cx, leaseID, true)
++	if err == nil {
++		cx.t.Fatal("test-user must not be able to access to the lease, because it's attached to the key bar")
++	}
++
++	// without --keys, access should be allowed
++	err = ctlV3LeaseTimeToLive(cx, leaseID, false)
++	if err != nil {
++		cx.t.Fatal(err)
++	}
++}
+diff --git a/tests/e2e/ctl_v3_lease_test.go b/tests/e2e/ctl_v3_lease_test.go
+index 0dc4452026f..e4e15d90547 100644
+--- a/tests/e2e/ctl_v3_lease_test.go
++++ b/tests/e2e/ctl_v3_lease_test.go
+@@ -300,3 +300,11 @@ func ctlV3LeaseRevoke(cx ctlCtx, leaseID string) error {
+ 	cmdArgs := append(cx.PrefixArgs(), "lease", "revoke", leaseID)
+ 	return spawnWithExpectWithEnv(cmdArgs, cx.envMap, fmt.Sprintf("lease %s revoked", leaseID))
+ }
++
++func ctlV3LeaseTimeToLive(cx ctlCtx, leaseID string, withKeys bool) error {
++	cmdArgs := append(cx.PrefixArgs(), "lease", "timetolive", leaseID)
++	if withKeys {
++		cmdArgs = append(cmdArgs, "--keys")
++	}
++	return spawnWithExpectWithEnv(cmdArgs, cx.envMap, fmt.Sprintf("lease %s granted with", leaseID))
++}
+diff --git a/tests/integration/v3_auth_test.go b/tests/integration/v3_auth_test.go
+index 9a60ab02953..f030c4e164d 100644
+--- a/tests/integration/v3_auth_test.go
++++ b/tests/integration/v3_auth_test.go
+@@ -177,12 +177,10 @@ func testV3AuthWithLeaseRevokeWithRoot(t *testing.T, ccfg ClusterConfig) {
+ 	// wait for lease expire
+ 	time.Sleep(3 * time.Second)
+ 
+-	tresp, terr := api.Lease.LeaseTimeToLive(
++	tresp, terr := rootc.TimeToLive(
+ 		context.TODO(),
+-		&pb.LeaseTimeToLiveRequest{
+-			ID:   int64(leaseID),
+-			Keys: true,
+-		},
++		leaseID,
++		clientv3.WithAttachedKeys(),
+ 	)
+ 	if terr != nil {
+ 		t.Error(terr)
+@@ -553,3 +551,86 @@ func TestV3AuthWatchErrorAndWatchId0(t *testing.T) {
+ 
+ 	<-watchEndCh
+ }
++
++func TestV3AuthWithLeaseTimeToLive(t *testing.T) {
++	BeforeTest(t)
++	clus := NewClusterV3(t, &ClusterConfig{Size: 1})
++	defer clus.Terminate(t)
++
++	users := []user{
++		{
++			name:     "user1",
++			password: "user1-123",
++			role:     "role1",
++			key:      "k1",
++			end:      "k3",
++		},
++		{
++			name:     "user2",
++			password: "user2-123",
++			role:     "role2",
++			key:      "k2",
++			end:      "k4",
++		},
++	}
++	authSetupUsers(t, toGRPC(clus.Client(0)).Auth, users)
++
++	authSetupRoot(t, toGRPC(clus.Client(0)).Auth)
++
++	user1c, cerr := NewClient(t, clientv3.Config{Endpoints: clus.Client(0).Endpoints(), Username: "user1", Password: "user1-123"})
++	if cerr != nil {
++		t.Fatal(cerr)
++	}
++	defer user1c.Close()
++
++	user2c, cerr := NewClient(t, clientv3.Config{Endpoints: clus.Client(0).Endpoints(), Username: "user2", Password: "user2-123"})
++	if cerr != nil {
++		t.Fatal(cerr)
++	}
++	defer user2c.Close()
++
++	leaseResp, err := user1c.Grant(context.TODO(), 90)
++	if err != nil {
++		t.Fatal(err)
++	}
++	leaseID := leaseResp.ID
++	_, err = user1c.Put(context.TODO(), "k1", "val", clientv3.WithLease(leaseID))
++	if err != nil {
++		t.Fatal(err)
++	}
++	// k2 can be accessed from both user1 and user2
++	_, err = user1c.Put(context.TODO(), "k2", "val", clientv3.WithLease(leaseID))
++	if err != nil {
++		t.Fatal(err)
++	}
++
++	_, err = user1c.TimeToLive(context.TODO(), leaseID)
++	if err != nil {
++		t.Fatal(err)
++	}
++
++	_, err = user2c.TimeToLive(context.TODO(), leaseID)
++	if err != nil {
++		t.Fatal(err)
++	}
++
++	_, err = user2c.TimeToLive(context.TODO(), leaseID, clientv3.WithAttachedKeys())
++	if err == nil {
++		t.Fatal("timetolive from user2 should be failed with permission denied")
++	}
++
++	rootc, cerr := NewClient(t, clientv3.Config{Endpoints: clus.Client(0).Endpoints(), Username: "root", Password: "123"})
++	if cerr != nil {
++		t.Fatal(cerr)
++	}
++	defer rootc.Close()
++
++	if _, err := rootc.RoleRevokePermission(context.TODO(), "role1", "k1", "k3"); err != nil {
++		t.Fatal(err)
++	}
++
++	_, err = user1c.TimeToLive(context.TODO(), leaseID, clientv3.WithAttachedKeys())
++	if err == nil {
++		t.Fatal("timetolive from user2 should be failed with permission denied")
++	}
++}

--- a/SPECS/etcd/etcd-3.5.0.spec
+++ b/SPECS/etcd/etcd-3.5.0.spec
@@ -40,7 +40,7 @@ Source1:        etcd.service
 #       - For the value of "--mtime" use the date "2021-04-26 00:00Z" to simplify future updates.
 Source2:        %{name}-%{version}-vendor.tar.gz
 Patch0:         CVE-2021-28235.patch
-Patch1:         CVE-2023-32082-v3.5.0.patch 
+Patch1:         CVE-2023-32082-v3.5.0.patch
 BuildRequires:  golang >= 1.16
 
 %description

--- a/SPECS/etcd/etcd-3.5.0.spec
+++ b/SPECS/etcd/etcd-3.5.0.spec
@@ -3,7 +3,7 @@
 Summary:        A highly-available key value store for shared configuration
 Name:           etcd
 Version:        3.5.0
-Release:        16%{?dist}
+Release:        17%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -40,6 +40,7 @@ Source1:        etcd.service
 #       - For the value of "--mtime" use the date "2021-04-26 00:00Z" to simplify future updates.
 Source2:        %{name}-%{version}-vendor.tar.gz
 Patch0:         CVE-2021-28235.patch
+Patch1:         CVE-2023-32082-v3.5.0.patch 
 BuildRequires:  golang >= 1.16
 
 %description
@@ -141,6 +142,9 @@ install -vdm755 %{buildroot}%{_sharedstatedir}/etcd
 /%{_docdir}/%{name}-%{version}-tools/*
 
 %changelog
+* Wed Aug 23 2023 Rachel Menge <rachelmenge@microsoft.com> - 3.5.0-17
+- Backport patch for CVE-2023-32082
+
 * Mon Aug 07 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 3.5.0-16
 - Bump release to rebuild with go 1.19.12
 

--- a/SPECS/etcd/etcd-3.5.0.spec
+++ b/SPECS/etcd/etcd-3.5.0.spec
@@ -1,4 +1,4 @@
-%global _default_patch_fuzz 1
+%global _default_patch_fuzz 2
 
 Summary:        A highly-available key value store for shared configuration
 Name:           etcd
@@ -144,6 +144,7 @@ install -vdm755 %{buildroot}%{_sharedstatedir}/etcd
 %changelog
 * Wed Aug 23 2023 Rachel Menge <rachelmenge@microsoft.com> - 3.5.0-17
 - Backport patch for CVE-2023-32082
+- Update patch fuzz to 2 for backporting patch
 
 * Mon Aug 07 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 3.5.0-16
 - Bump release to rebuild with go 1.19.12

--- a/SPECS/etcd/etcd-3.5.1.spec
+++ b/SPECS/etcd/etcd-3.5.1.spec
@@ -1,4 +1,4 @@
-%global _default_patch_fuzz 1
+%global _default_patch_fuzz 2
 
 Summary:        A highly-available key value store for shared configuration
 Name:           etcd
@@ -149,6 +149,7 @@ install -vdm755 %{buildroot}%{_sharedstatedir}/etcd
 %changelog
 * Wed Aug 23 2023 Rachel Menge <rachelmenge@microsoft.com> - 3.5.1-15
 - Backport patch for CVE-2023-32082
+- Update patch fuzz to 2 for backporting patch
 
 * Mon Aug 07 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 3.5.1-14
 - Bump release to rebuild with go 1.19.12

--- a/SPECS/etcd/etcd-3.5.1.spec
+++ b/SPECS/etcd/etcd-3.5.1.spec
@@ -3,7 +3,7 @@
 Summary:        A highly-available key value store for shared configuration
 Name:           etcd
 Version:        3.5.1
-Release:        14%{?dist}
+Release:        15%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -45,6 +45,7 @@ Source1:        etcd.service
 #             -cJf [tarball name] [folder to tar]
 Source2:        %{name}-%{version}-vendor.tar.gz
 Patch0:         CVE-2021-28235.patch
+Patch1:         CVE-2023-32082-v3.5.0.patch
 BuildRequires:  golang >= 1.16
 
 %description
@@ -146,6 +147,9 @@ install -vdm755 %{buildroot}%{_sharedstatedir}/etcd
 /%{_docdir}/%{name}-%{version}-tools/*
 
 %changelog
+* Wed Aug 23 2023 Rachel Menge <rachelmenge@microsoft.com> - 3.5.1-15
+- Backport patch for CVE-2023-32082
+
 * Mon Aug 07 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 3.5.1-14
 - Bump release to rebuild with go 1.19.12
 

--- a/SPECS/etcd/etcd-3.5.3.spec
+++ b/SPECS/etcd/etcd-3.5.3.spec
@@ -3,7 +3,7 @@
 Summary:        A highly-available key value store for shared configuration
 Name:           etcd
 Version:        3.5.3
-Release:        9%{?dist}
+Release:        10%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -45,6 +45,7 @@ Source1:        etcd.service
 #             -cJf [tarball name] [folder to tar]
 Source2:        %{name}-%{version}-vendor.tar.gz
 Patch0:         CVE-2021-28235.patch
+Patch1:         CVE-2023-32082-v3.5.3.patch
 BuildRequires:  golang >= 1.16
 
 %description
@@ -146,6 +147,9 @@ install -vdm755 %{buildroot}%{_sharedstatedir}/etcd
 /%{_docdir}/%{name}-%{version}-tools/*
 
 %changelog
+* Wed Aug 23 2023 Rachel Menge <rachelmenge@microsoft.com> - 3.5.3-10
+- Backport patch for CVE-2023-32082
+
 * Mon Aug 07 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 3.5.3-9
 - Bump release to rebuild with go 1.19.12
 

--- a/SPECS/etcd/etcd-3.5.3.spec
+++ b/SPECS/etcd/etcd-3.5.3.spec
@@ -1,4 +1,4 @@
-%global _default_patch_fuzz 1
+%global _default_patch_fuzz 2
 
 Summary:        A highly-available key value store for shared configuration
 Name:           etcd
@@ -149,6 +149,7 @@ install -vdm755 %{buildroot}%{_sharedstatedir}/etcd
 %changelog
 * Wed Aug 23 2023 Rachel Menge <rachelmenge@microsoft.com> - 3.5.3-10
 - Backport patch for CVE-2023-32082
+- Update patch fuzz to 2 for backporting patch
 
 * Mon Aug 07 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 3.5.3-9
 - Bump release to rebuild with go 1.19.12

--- a/SPECS/etcd/etcd-3.5.4.spec
+++ b/SPECS/etcd/etcd-3.5.4.spec
@@ -1,4 +1,4 @@
-%global _default_patch_fuzz 1
+%global _default_patch_fuzz 2
 
 Summary:        A highly-available key value store for shared configuration
 Name:           etcd
@@ -149,6 +149,7 @@ install -vdm755 %{buildroot}%{_sharedstatedir}/etcd
 %changelog
 * Wed Aug 23 2023 Rachel Menge <rachelmenge@microsoft.com> - 3.5.4-10
 - Backport patch for CVE-2023-32082
+- Update patch fuzz to 2 for backporting patch
 
 * Mon Aug 07 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 3.5.4-9
 - Bump release to rebuild with go 1.19.12

--- a/SPECS/etcd/etcd-3.5.4.spec
+++ b/SPECS/etcd/etcd-3.5.4.spec
@@ -3,7 +3,7 @@
 Summary:        A highly-available key value store for shared configuration
 Name:           etcd
 Version:        3.5.4
-Release:        9%{?dist}
+Release:        10%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -45,6 +45,7 @@ Source1:        etcd.service
 #             -cJf [tarball name] [folder to tar]
 Source2:        %{name}-%{version}-vendor.tar.gz
 Patch0:         CVE-2021-28235.patch
+Patch1:         CVE-2023-32082-v3.5.3.patch
 BuildRequires:  golang >= 1.16
 
 %description
@@ -146,6 +147,9 @@ install -vdm755 %{buildroot}%{_sharedstatedir}/etcd
 /%{_docdir}/%{name}-%{version}-tools/*
 
 %changelog
+* Wed Aug 23 2023 Rachel Menge <rachelmenge@microsoft.com> - 3.5.4-10
+- Backport patch for CVE-2023-32082
+
 * Mon Aug 07 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 3.5.4-9
 - Bump release to rebuild with go 1.19.12
 

--- a/SPECS/etcd/etcd-3.5.5.spec
+++ b/SPECS/etcd/etcd-3.5.5.spec
@@ -3,7 +3,7 @@
 Summary:        A highly-available key value store for shared configuration
 Name:           etcd
 Version:        3.5.5
-Release:        9%{?dist}
+Release:        10%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -45,6 +45,7 @@ Source1:        etcd.service
 #             -cJf [tarball name] [folder to tar]
 Source2:        %{name}-%{version}-vendor.tar.gz
 Patch0:         CVE-2021-28235.patch
+Patch1:         CVE-2023-32082.patch
 BuildRequires:  golang >= 1.16
 
 %description
@@ -146,6 +147,9 @@ install -vdm755 %{buildroot}%{_sharedstatedir}/etcd
 /%{_docdir}/%{name}-%{version}-tools/*
 
 %changelog
+* Wed Aug 23 2023 Rachel Menge <rachelmenge@microsoft.com> - 3.5.5-10
+- Patch CVE-2023-32082
+
 * Mon Aug 07 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 3.5.5-9
 - Bump release to rebuild with go 1.19.12
 

--- a/SPECS/etcd/etcd-3.5.5.spec
+++ b/SPECS/etcd/etcd-3.5.5.spec
@@ -1,4 +1,4 @@
-%global _default_patch_fuzz 1
+%global _default_patch_fuzz 2
 
 Summary:        A highly-available key value store for shared configuration
 Name:           etcd
@@ -149,6 +149,7 @@ install -vdm755 %{buildroot}%{_sharedstatedir}/etcd
 %changelog
 * Wed Aug 23 2023 Rachel Menge <rachelmenge@microsoft.com> - 3.5.5-10
 - Patch CVE-2023-32082
+- Update patch fuzz to 2 for backporting patch
 
 * Mon Aug 07 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 3.5.5-9
 - Bump release to rebuild with go 1.19.12

--- a/SPECS/etcd/etcd-3.5.6.spec
+++ b/SPECS/etcd/etcd-3.5.6.spec
@@ -3,7 +3,7 @@
 Summary:        A highly-available key value store for shared configuration
 Name:           etcd
 Version:        3.5.6
-Release:        9%{?dist}
+Release:        10%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -45,6 +45,7 @@ Source1:        etcd.service
 #             -cJf [tarball name] [folder to tar]
 Source2:        %{name}-%{version}-vendor.tar.gz
 Patch0:         CVE-2021-28235.patch
+Patch1:         CVE-2023-32082.patch
 BuildRequires:  golang >= 1.16
 
 %description
@@ -146,6 +147,9 @@ install -vdm755 %{buildroot}%{_sharedstatedir}/etcd
 /%{_docdir}/%{name}-%{version}-tools/*
 
 %changelog
+* Wed Aug 23 2023 Rachel Menge <rachelmenge@microsoft.com> - 3.5.6-10
+- Patch CVE-2023-32082
+
 * Mon Aug 07 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 3.5.6-9
 - Bump release to rebuild with go 1.19.12
 

--- a/SPECS/etcd/etcd-3.5.6.spec
+++ b/SPECS/etcd/etcd-3.5.6.spec
@@ -1,4 +1,4 @@
-%global _default_patch_fuzz 1
+%global _default_patch_fuzz 2
 
 Summary:        A highly-available key value store for shared configuration
 Name:           etcd
@@ -149,6 +149,7 @@ install -vdm755 %{buildroot}%{_sharedstatedir}/etcd
 %changelog
 * Wed Aug 23 2023 Rachel Menge <rachelmenge@microsoft.com> - 3.5.6-10
 - Patch CVE-2023-32082
+- Update patch fuzz to 2 for backporting patch
 
 * Mon Aug 07 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 3.5.6-9
 - Bump release to rebuild with go 1.19.12


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Patch etcd and bump fuzzing for CVE-2023-32082

Versions 3.5.0 and 3.5.1 use a backport of the patch upstream (CVE-2023-32082-v3.5.0.patch)
Versions 3.5.3 and 3.5.4 use a backport of the patch upstream (CVE-2023-32082-v3.5.3.patch)
Versions 3.5.5 and 3.5.6 use the original patch upstream (CVE-2023-32082.patch)

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Patch etcd 
- Bump default fuzzing value to 2

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2023-32082

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- https://dev.azure.com/mariner-org/mariner/_build/results?buildId=412407&view=results
