### PR TITLE
toolkit: containerized-build: honor $SPECS_DIR instead of hard-coding

### DIFF
--- a/toolkit/scripts/containerized-build.mk
+++ b/toolkit/scripts/containerized-build.mk
@@ -30,6 +30,9 @@ ifeq ($(ENABLE_REPO),y)
 containerized_build_args += -r
 endif
 
+# SPECS_DIR is always set
+containerized_build_args += -s ${SPECS_DIR}
+
 containerized-rpmbuild:
 	$(SCRIPTS_DIR)/containerized-build/create_container_build.sh $(containerized_build_args)
 

--- a/toolkit/scripts/containerized-build/create_container_build.sh
+++ b/toolkit/scripts/containerized-build/create_container_build.sh
@@ -23,12 +23,14 @@ print_error() {
 help() {
 echo "
 Usage:
-sudo make containerized-rpmbuild [REPO_PATH=/path/to/CBL-Mariner] [MODE=test|build] [VERSION=1.0|2.0] [MOUNTS= /src/path:/dst/path] [ENABLE_REPO=y]
+sudo make containerized-rpmbuild [REPO_PATH=/path/to/CBL-Mariner] [MODE=test|build] [VERSION=1.0|2.0] [MOUNTS= /src/path:/dst/path] [ENABLE_REPO=y] [SPECS_DIR=/path/to/SPECS_DIR/to/use]
 
 Starts a docker container with the specified version of mariner.
 
 Optional arguments:
     REPO_PATH:      path to the CBL-Mariner repo root directory. default: "current directory"
+    SPECS_DIR:      The SPECS_DIR variable is reused from base Makefile. By Default it points to 'CBL-Mariner/SPECS'
+                    We can override the SPECS_DIR to extended e.g by appeneding: SPECS_DIR=path/to/SPECS-EXTENDED
     MODE            build or test. default:"build"
                         In 'test' mode it will use a pre-built mariner chroot image.
                         In 'build' mode it will use the latest published container.

--- a/toolkit/scripts/containerized-build/create_container_build.sh
+++ b/toolkit/scripts/containerized-build/create_container_build.sh
@@ -76,6 +76,7 @@ tmp_dir=${script_dir%'/toolkit'*}/build/containerized-rpmbuild/tmp
 mkdir -p ${tmp_dir}
 topdir=/usr/src/mariner
 enable_local_repo=false
+specs_dir=""
 
 while (( "$#")); do
   case "$1" in
@@ -84,6 +85,7 @@ while (( "$#")); do
     -p ) repo_path="$(realpath $2)"; shift 2 ;;
     -mo ) extra_mounts="$2"; shift 2 ;;
     -r ) enable_local_repo=true; shift ;;
+    -s ) specs_dir="$(realpath $2)"; shift 2;;
     -h ) help; exit 1 ;;
     ? ) echo -e "ERROR: INVALID OPTION.\n\n"; help; exit 1 ;;
   esac
@@ -149,7 +151,7 @@ echo "Setting up mounts..."
 mounts="${mounts} ${repo_path}/out/RPMS:/mnt/RPMS ${tmp_dir}:/mariner_setup_dir"
 # Add extra 'build' mounts
 if [[ "${mode}" == "build" ]]; then
-    mounts="${mounts} ${repo_path}/build/INTERMEDIATE_SRPMS:/mnt/INTERMEDIATE_SRPMS ${repo_path}/SPECS:${topdir}/SPECS"
+    mounts="${mounts} ${repo_path}/build/INTERMEDIATE_SRPMS:/mnt/INTERMEDIATE_SRPMS $specs_dir:${topdir}/SPECS"
 fi
 
 # Replace comma with space as delimiter


### PR DESCRIPTION
Signed-off-by: Muhammad Falak R Wani <falakreyaz@gmail.com>

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Honor `$SPECS_DIR` instead of hardcoding the value.

### Test1: Nothing provided on the command line
```bash
sudo make containerized-rpmbuild SRPM_PACK_LIST=vim
# ... [snip] ...
* Mount points:
/home/mfrw/mariner-org/cve/cve-ext/build/container-build' -> '/usr/src/mariner/BUILD
/home/mfrw/mariner-org/cve/cve-ext/build/container-buildroot' -> '/usr/src/mariner/BUILDROOT
/home/mfrw/mariner-org/cve/cve-ext/out/RPMS' -> '/mnt/RPMS
/home/mfrw/mariner-org/cve/cve-ext/build/containerized-rpmbuild/tmp' -> '/mariner_setup_dir
/home/mfrw/mariner-org/cve/cve-ext/build/INTERMEDIATE_SRPMS' -> '/mnt/INTERMEDIATE_SRPMS
/home/mfrw/mariner-org/cve/cve-ext/SPECS' -> '/usr/src/mariner/SPECS

```

### Test2: Relative PATHS
```bash
sudo make containerized-rpmbuild SRPM_PACK_LIST=vim SPECS_DIR=../SPECS
# ... [snip] ...
* Mount points:
/home/mfrw/mariner-org/cve/cve-ext/build/container-build' -> '/usr/src/mariner/BUILD
/home/mfrw/mariner-org/cve/cve-ext/build/container-buildroot' -> '/usr/src/mariner/BUILDROOT
/home/mfrw/mariner-org/cve/cve-ext/out/RPMS' -> '/mnt/RPMS
/home/mfrw/mariner-org/cve/cve-ext/build/containerized-rpmbuild/tmp' -> '/mariner_setup_dir
/home/mfrw/mariner-org/cve/cve-ext/build/INTERMEDIATE_SRPMS' -> '/mnt/INTERMEDIATE_SRPMS
/home/mfrw/mariner-org/cve/cve-ext/SPECS' -> '/usr/src/mariner/SPECS
```

### Test3: Absolute PATHS
```bash
sudo make containerized-rpmbuild SRPM_PACK_LIST=vim SPECS_DIR=/home/mfrw/mariner-org/CBL-Mariner/SPECS
# ... [snip] ...
* Mount points:
/home/mfrw/mariner-org/cve/cve-ext/build/container-build' -> '/usr/src/mariner/BUILD
/home/mfrw/mariner-org/cve/cve-ext/build/container-buildroot' -> '/usr/src/mariner/BUILDROOT
/home/mfrw/mariner-org/cve/cve-ext/out/RPMS' -> '/mnt/RPMS
/home/mfrw/mariner-org/cve/cve-ext/build/containerized-rpmbuild/tmp' -> '/mariner_setup_dir
/home/mfrw/mariner-org/cve/cve-ext/build/INTERMEDIATE_SRPMS' -> '/mnt/INTERMEDIATE_SRPMS
/home/mfrw/mariner-org/cve/cve-ext/SPECS' -> '/usr/src/mariner/SPECS
```

### Test4: EXTENDED Relative
```bash
sudo make containerized-rpmbuild SRPM_PACK_LIST=wireshark SPECS_DIR=../SPECS-EXTENDED/
# ... [snip] ...
* Mount points:
* Mount points:
/home/mfrw/mariner-org/cve/cve-ext/build/container-build' -> '/usr/src/mariner/BUILD
/home/mfrw/mariner-org/cve/cve-ext/build/container-buildroot' -> '/usr/src/mariner/BUILDROOT
/home/mfrw/mariner-org/cve/cve-ext/out/RPMS' -> '/mnt/RPMS
/home/mfrw/mariner-org/cve/cve-ext/build/containerized-rpmbuild/tmp' -> '/mariner_setup_dir
/home/mfrw/mariner-org/cve/cve-ext/build/INTERMEDIATE_SRPMS' -> '/mnt/INTERMEDIATE_SRPMS
/home/mfrw/mariner-org/cve/cve-ext/SPECS-EXTENDED' -> '/usr/src/mariner/SPECS
```

### Test4: EXTENDED Absolute PATHS
```bash
sudo make containerized-rpmbuild SRPM_PACK_LIST=wireshark SPECS_DIR=/home/mfrw/mariner-org/CBL-Mariner/SPECS-EXTENDED
# ... [snip] ...
* Mount points:
* Mount points:
/home/mfrw/mariner-org/cve/cve-ext/build/container-build' -> '/usr/src/mariner/BUILD
/home/mfrw/mariner-org/cve/cve-ext/build/container-buildroot' -> '/usr/src/mariner/BUILDROOT
/home/mfrw/mariner-org/cve/cve-ext/out/RPMS' -> '/mnt/RPMS
/home/mfrw/mariner-org/cve/cve-ext/build/containerized-rpmbuild/tmp' -> '/mariner_setup_dir
/home/mfrw/mariner-org/cve/cve-ext/build/INTERMEDIATE_SRPMS' -> '/mnt/INTERMEDIATE_SRPMS
/home/mfrw/mariner-org/cve/cve-ext/SPECS-EXTENDED' -> '/usr/src/mariner/SPECS
```

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Honor value of `$SPECS_DIR` instead of only mounting `SPECS`

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- NA

###### Links to CVEs  <!-- optional -->
- NA

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local Build and test
