### PR TITLE
toolkit: generate image_pkg_manifest.json with image builds

### DIFF
--- a/toolkit/scripts/imggen.mk
+++ b/toolkit/scripts/imggen.mk
@@ -43,6 +43,7 @@ validate-config                      = $(STATUS_FLAGS_DIR)/validate-image-config
 meta_user_data_tmp_dir               = $(IMAGEGEN_DIR)/meta-user-data_tmp
 image_package_cache_summary          = $(imggen_config_dir)/image_deps.json
 image_external_package_cache_summary = $(imggen_config_dir)/image_external_deps.json
+image_package_manifest               = $(imggen_config_dir)/image_pkg_manifest.json
 
 # Outputs
 artifact_dir             = $(IMAGES_DIR)/$(config_name)
@@ -151,6 +152,7 @@ $(STATUS_FLAGS_DIR)/imager_disk_output.flag: $(go-imager) $(image_package_cache_
 		--local-repo $(local_and_external_rpm_cache) \
 		--tdnf-worker $(chroot_worker) \
 		--repo-file=$(imggen_local_repo) \
+		--output-image-contents=$(image_package_manifest) \
 		--assets $(assets_dir) \
 		--output-dir $(imager_disk_output_dir) \
 		--cpu-prof-file=$(PROFILE_DIR)/imager.cpu.pprof \

--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -656,6 +656,9 @@ func configureSystemFiles(installChroot *safechroot.Chroot, hostname string, con
 	return
 }
 
+// calculateTotalPackages() will simulate installing the provided list of packages in the installRoot.
+// all packages that will be installed are returned in installedPackages, and a manifest with these packages
+// is generated under build/imagegen/$config_name/image_pkg_manifest.json
 func calculateTotalPackages(packages []string, installRoot string) (installedPackages *repocloner.RepoContents, err error) {
 	var (
 		releaseverCliArg string
@@ -723,7 +726,7 @@ func calculateTotalPackages(packages []string, installRoot string) (installedPac
 	logger.Log.Debugf("Total number of packages to be installed: %d", len(installedPackages.Repo))
 
 	// Write out JSON file with list of packages included in the image
-	err = jsonutils.WriteJSONFile("/installroot/image_pkg_manifest_temp1.json", installedPackages)
+	err = jsonutils.WriteJSONFile("/installroot/image_pkg_manifest_installroot.json", installedPackages)
 
 	return
 }

--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -642,7 +642,7 @@ func configureSystemFiles(installChroot *safechroot.Chroot, hostname string, con
 	return
 }
 
-// calculateTotalPackages() will simulate installing the provided list of packages in the installRoot.
+// calculateTotalPackages will simulate installing the provided list of packages in the installRoot.
 // all packages that will be installed are returned in installedPackages, and a manifest with these packages
 // is generated under build/imagegen/$config_name/image_pkg_manifest.json
 func calculateTotalPackages(packages []string, installRoot string) (installedPackages *repocloner.RepoContents, err error) {

--- a/toolkit/tools/imager/imager.go
+++ b/toolkit/tools/imager/imager.go
@@ -33,6 +33,7 @@ var (
 	assets          = app.Flag("assets", "Path to assets directory.").ExistingDir()
 	baseDirPath     = app.Flag("base-dir", "Base directory for relative file paths from the config. Defaults to config's directory.").ExistingDir()
 	outputDir       = app.Flag("output-dir", "Path to directory to place final image.").ExistingDir()
+	imgContentFile  = app.Flag("output-image-contents", "File that stores list of packages used to compose the image.").String()
 	liveInstallFlag = app.Flag("live-install", "Enable to perform a live install to the disk specified in config file.").Bool()
 	emitProgress    = app.Flag("emit-progress", "Write progress updates to stdout, such as percent complete and current action.").Bool()
 	timestampFile   = app.Flag("timestamp-file", "File that stores timestamps for this program.").String()
@@ -108,11 +109,11 @@ func main() {
 		timestamp.StopEvent(nil) // applying kickstart
 	}
 
-	err = buildSystemConfig(systemConfig, config.Disks, *outputDir, *buildDir)
+	err = buildSystemConfig(systemConfig, config.Disks, *outputDir, *buildDir, *imgContentFile)
 	logger.PanicOnError(err, "Failed to build system configuration")
 }
 
-func buildSystemConfig(systemConfig configuration.SystemConfig, disks []configuration.Disk, outputDir, buildDir string) (err error) {
+func buildSystemConfig(systemConfig configuration.SystemConfig, disks []configuration.Disk, outputDir, buildDir string, imgContentFile string) (err error) {
 	logger.Log.Infof("Building system configuration (%s)", systemConfig.Name)
 	timestamp.StartEvent("building system config", nil)
 	defer timestamp.StopEvent(nil)
@@ -263,12 +264,15 @@ func buildSystemConfig(systemConfig configuration.SystemConfig, disks []configur
 		timestamp.StopEvent(nil) // create offline install env
 
 		err = setupChroot.Run(func() error {
-			return buildImage(mountPointMap, mountPointToFsTypeMap, mountPointToMountArgsMap, partIDToDevPathMap, partIDToFsTypeMap, mountPointToOverlayMap, packagesToInstall, systemConfig, diskDevPath, isRootFS, encryptedRoot, readOnlyRoot, diffDiskBuild)
+			return buildImage(mountPointMap, mountPointToFsTypeMap, mountPointToMountArgsMap, partIDToDevPathMap, partIDToFsTypeMap, mountPointToOverlayMap, packagesToInstall, systemConfig, diskDevPath, isRootFS, encryptedRoot, readOnlyRoot, diffDiskBuild, imgContentFile)
 		})
 		if err != nil {
 			logger.Log.Error("Failed to build image")
 			return
 		}
+
+		// Extract image package manifest from the 'setuproot' chroot
+		setupChroot.ExtractFile("image_pkg_manifest_temp2.json", imgContentFile)
 
 		err = cleanupExtraFilesInChroot(setupChroot)
 		if err != nil {
@@ -295,7 +299,7 @@ func buildSystemConfig(systemConfig configuration.SystemConfig, disks []configur
 			}
 		}
 	} else {
-		err = buildImage(mountPointMap, mountPointToFsTypeMap, mountPointToMountArgsMap, partIDToDevPathMap, partIDToFsTypeMap, mountPointToOverlayMap, packagesToInstall, systemConfig, diskDevPath, isRootFS, encryptedRoot, readOnlyRoot, diffDiskBuild)
+		err = buildImage(mountPointMap, mountPointToFsTypeMap, mountPointToMountArgsMap, partIDToDevPathMap, partIDToFsTypeMap, mountPointToOverlayMap, packagesToInstall, systemConfig, diskDevPath, isRootFS, encryptedRoot, readOnlyRoot, diffDiskBuild, imgContentFile)
 		if err != nil {
 			logger.Log.Error("Failed to build image")
 			return
@@ -518,7 +522,8 @@ func cleanupExtraFilesInChroot(chroot *safechroot.Chroot) (err error) {
 	})
 	return
 }
-func buildImage(mountPointMap, mountPointToFsTypeMap, mountPointToMountArgsMap, partIDToDevPathMap, partIDToFsTypeMap map[string]string, mountPointToOverlayMap map[string]*installutils.Overlay, packagesToInstall []string, systemConfig configuration.SystemConfig, diskDevPath string, isRootFS bool, encryptedRoot diskutils.EncryptedRootDevice, readOnlyRoot diskutils.VerityDevice, diffDiskBuild bool) (err error) {
+
+func buildImage(mountPointMap, mountPointToFsTypeMap, mountPointToMountArgsMap, partIDToDevPathMap, partIDToFsTypeMap map[string]string, mountPointToOverlayMap map[string]*installutils.Overlay, packagesToInstall []string, systemConfig configuration.SystemConfig, diskDevPath string, isRootFS bool, encryptedRoot diskutils.EncryptedRootDevice, readOnlyRoot diskutils.VerityDevice, diffDiskBuild bool, imgContentFile string) (err error) {
 	timestamp.StartEvent("building image", nil)
 	defer timestamp.StopEvent(nil)
 	const (
@@ -599,6 +604,9 @@ func buildImage(mountPointMap, mountPointToFsTypeMap, mountPointToMountArgsMap, 
 		err = fmt.Errorf("failed to populate image contents: %s", err)
 		return
 	}
+
+	// Copy image package manifest from 'installroot' chroot to 'setuproot' chroot
+	installChroot.ExtractFile("image_pkg_manifest_temp1.json", "/image_pkg_manifest_temp2.json")
 
 	// Only configure the bootloader or read only partitions for actual disks, a rootfs does not need these
 	if !isRootFS {

--- a/toolkit/tools/imager/imager.go
+++ b/toolkit/tools/imager/imager.go
@@ -272,7 +272,7 @@ func buildSystemConfig(systemConfig configuration.SystemConfig, disks []configur
 		}
 
 		// Extract image package manifest from the 'setuproot' chroot
-		setupChroot.MoveOutFile("image_pkg_manifest_setuproot.json", imgContentFile)
+		setupChroot.MoveOutFile(installutils.PackageManifestRelativePath, imgContentFile)
 
 		err = cleanupExtraFilesInChroot(setupChroot)
 		if err != nil {
@@ -604,9 +604,6 @@ func buildImage(mountPointMap, mountPointToFsTypeMap, mountPointToMountArgsMap, 
 		err = fmt.Errorf("failed to populate image contents: %s", err)
 		return
 	}
-
-	// Copy image package manifest from 'installroot' chroot to 'setuproot' chroot
-	installChroot.MoveOutFile("image_pkg_manifest_installroot.json", "/image_pkg_manifest_setuproot.json")
 
 	// Only configure the bootloader or read only partitions for actual disks, a rootfs does not need these
 	if !isRootFS {

--- a/toolkit/tools/imager/imager.go
+++ b/toolkit/tools/imager/imager.go
@@ -272,7 +272,7 @@ func buildSystemConfig(systemConfig configuration.SystemConfig, disks []configur
 		}
 
 		// Extract image package manifest from the 'setuproot' chroot
-		setupChroot.ExtractFile("image_pkg_manifest_temp2.json", imgContentFile)
+		setupChroot.MoveOutFile("image_pkg_manifest_setuproot.json", imgContentFile)
 
 		err = cleanupExtraFilesInChroot(setupChroot)
 		if err != nil {
@@ -606,7 +606,7 @@ func buildImage(mountPointMap, mountPointToFsTypeMap, mountPointToMountArgsMap, 
 	}
 
 	// Copy image package manifest from 'installroot' chroot to 'setuproot' chroot
-	installChroot.ExtractFile("image_pkg_manifest_temp1.json", "/image_pkg_manifest_temp2.json")
+	installChroot.MoveOutFile("image_pkg_manifest_installroot.json", "/image_pkg_manifest_setuproot.json")
 
 	// Only configure the bootloader or read only partitions for actual disks, a rootfs does not need these
 	if !isRootFS {

--- a/toolkit/tools/internal/safechroot/safechroot.go
+++ b/toolkit/tools/internal/safechroot/safechroot.go
@@ -277,12 +277,23 @@ func (c *Chroot) AddFiles(filesToCopy ...FileToCopy) (err error) {
 	return
 }
 
-// ExtractFile copies file 'srcPath' in the chroot to the host at 'destPath'
-func (c *Chroot) ExtractFile(srcPath string, destPath string) (err error) {
+// CopyOutFile copies file 'srcPath' in the chroot to the host at 'destPath'
+func (c *Chroot) CopyOutFile(srcPath string, destPath string) (err error) {
 	srcPathFull := filepath.Join(c.rootDir, srcPath)
 	err = file.Copy(srcPathFull, destPath)
 	if err != nil {
 		logger.Log.Errorf("Error copying file '%s'", err)
+		return
+	}
+	return
+}
+
+// MoveOutFile moves file 'srcPath' in the chroot to the host at 'destPath', deleting the 'srcPath' file.
+func (c *Chroot) MoveOutFile(srcPath string, destPath string) (err error) {
+	srcPathFull := filepath.Join(c.rootDir, srcPath)
+	err = file.Move(srcPathFull, destPath)
+	if err != nil {
+		logger.Log.Errorf("Error moving file '%s'", err)
 		return
 	}
 	return

--- a/toolkit/tools/internal/safechroot/safechroot.go
+++ b/toolkit/tools/internal/safechroot/safechroot.go
@@ -277,6 +277,17 @@ func (c *Chroot) AddFiles(filesToCopy ...FileToCopy) (err error) {
 	return
 }
 
+// ExtractFile copies file 'srcPath' in the chroot to the host at 'destPath'
+func (c *Chroot) ExtractFile(srcPath string, destPath string) (err error) {
+	srcPathFull := filepath.Join(c.rootDir, srcPath)
+	err = file.Copy(srcPathFull, destPath)
+	if err != nil {
+		logger.Log.Errorf("Error copying file '%s'", err)
+		return
+	}
+	return
+}
+
 // Run runs a given function inside the Chroot. This function will synchronize
 // with all other Chroots to ensure only one Chroot command is executed at a given time.
 func (c *Chroot) Run(toRun func() error) (err error) {

--- a/toolkit/tools/internal/tdnf/tdnf.go
+++ b/toolkit/tools/internal/tdnf/tdnf.go
@@ -22,6 +22,39 @@ var (
 	//   - version:         1.1b.8_X-22~rc1
 	//   - dist:            cm2
 	InstallPackageRegex = regexp.MustCompile(`^\s*([[:alnum:]_.+-]+)\s+([[:alnum:]_+-]+)\s+([[:alnum:]._+~-]+)\.([[:alpha:]]+[[:digit:]]+)`)
+
+	// Every valid line pair will be of the form:
+	//		<package>-<version>.<arch> : <Description>
+	//		Repo	: [repo_name]
+	//
+	// NOTE: we ignore packages installed in the build environment denoted by "Repo	: @System".
+	PackageLookupNameMatchRegex = regexp.MustCompile(`([^:\s]+(x86_64|aarch64|noarch))\s*:[^\n]*\nRepo\s+:\s+[^@]`)
+	PackageNameIndex            = 1
+
+	// Every line containing a repo ID will be of the form:
+	//		[<repo_name>]
+	// For:
+	//
+	//		[fetcher-cloned-repo]
+	//
+	// We'd get:
+	//   - repo_name:    fetcher-cloned-repo
+	//
+	// The non-capturing groups are used to ignore the brackets.
+	RepoIDRegex = regexp.MustCompile(`(?:\[)([^]]+)(?:\])`)
+	RepoIDIndex = 1
+
+	// Every valid line will be of the form: <package_name>.<architecture> <version>.<dist> <repo_id>
+	// For:
+	//
+	//		COOL_package2-extended++.aarch64	1.1b.8_X-22~rc1.cm1		fetcher-cloned-repo
+	//
+	// We'd get:
+	//   - package_name:    COOL_package2-extended++
+	//   - architecture:    aarch64
+	//   - version:         1.1b.8_X-22~rc1
+	//   - dist:            cm1
+	ListedPackageRegex = regexp.MustCompile(`^\s*([[:alnum:]_.+-]+)\.([[:alnum:]_+-]+)\s+([[:alnum:]._+~-]+)\.([[:alpha:]]+[[:digit:]]+)`)
 )
 
 const (
@@ -31,6 +64,15 @@ const (
 	InstallPackageVersion = iota
 	InstallPackageDist    = iota
 	InstallMaxMatchLen    = iota
+)
+
+const (
+	ListMatchSubString = iota
+	ListPackageName    = iota
+	ListPackageArch    = iota
+	ListPackageVersion = iota
+	ListPackageDist    = iota
+	ListMaxMatchLen    = iota
 )
 
 const (

--- a/toolkit/tools/internal/tdnf/tdnf.go
+++ b/toolkit/tools/internal/tdnf/tdnf.go
@@ -11,6 +11,28 @@ import (
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/exe"
 )
 
+var (
+	// Every valid line will be of the form: <package_name> <architecture> <version>.<dist> <repo_id>
+	// For:
+	//     X aarch64	1.1b.8_X-22~rc1.cm2		fetcher-cloned-repo
+	//
+	// We'd get:
+	//   - package_name:    X
+	//   - architecture:    aarch64
+	//   - version:         1.1b.8_X-22~rc1
+	//   - dist:            cm2
+	InstallPackageRegex = regexp.MustCompile(`^\s*([[:alnum:]_.+-]+)\s+([[:alnum:]_+-]+)\s+([[:alnum:]._+~-]+)\.([[:alpha:]]+[[:digit:]]+)`)
+)
+
+const (
+	InstallMatchSubString = iota
+	InstallPackageName    = iota
+	InstallPackageArch    = iota
+	InstallPackageVersion = iota
+	InstallPackageDist    = iota
+	InstallMaxMatchLen    = iota
+)
+
 const (
 	// ReleaseverArgument specifies the release version argument to be used with tdnf
 	releaseverArgument = "--releasever"


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Generate a new output file `image_pkg_manifest.json` when creating images. This contains all packages used to compose the image, as well as version, architecture and distribution information for each package.
The new file will be generated in the following location:
`build/imagegen/$(config_name)/image_pkg_manifest.json`
The current use case for this file is to server as an input to assist in generating an SBOM for each image.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change image generation to create a `image_pkg_manifest.json` file for each image type

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id x64: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=414169&view=results
- Pipeline build id arm64: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=413311&view=results
