### PR TITLE
make cloud-init-output.log available to serial console

### DIFF
--- a/SPECS/cloud-init/cloud-init.spec
+++ b/SPECS/cloud-init/cloud-init.spec
@@ -1,7 +1,7 @@
 Summary:        Cloud instance init scripts
 Name:           cloud-init
 Version:        23.2
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        GPLv3
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -74,8 +74,6 @@ Cloud-init configuration for Hyper-V telemetry
 %prep
 %autosetup -p1 -n %{name}-%{version}
 
-find systemd -name "cloud*.service*" | xargs sed -i s/StandardOutput=journal+console/StandardOutput=journal/g
-
 %build
 python3 setup.py build
 
@@ -145,6 +143,9 @@ make check %{?_smp_mflags}
 %config(noreplace) %{_sysconfdir}/cloud/cloud.cfg.d/10-azure-kvp.cfg
 
 %changelog
+* Thu Aug 24 2023 Minghe Ren <mingheren@microsoft.com> - 23.2-3
+- Remove the line prohibits cloud-init log dumping to serial console 
+
 * Fri Aug 11 2023 Minghe Ren <mingheren@microsoft.com> - 23.2-2
 - Add patch for unit test failure
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
There is a customer request that asking content of cloud-init-output.log to be available on Azure diagnostics serial log for Mariner VM, same as Ubuntu. In cloud-init.spec file, there is a particular line that makes the StandardOutput logs from cloud-init systemd service only dump to journal but not system console, which causes the content of cloud-init-output.log missing on Azure diagnostics serial log. We need to remove this line to resolve this issue.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Remove the line that replaces "StandardOutput=journal+console" to "StandardOutput=journal" in cloud-init systemd service: "find systemd -name "cloud*.service*" | xargs sed -i s/StandardOutput=journal+console/StandardOutput=journal/g"
- This particular line makes the logs from cloud-init systemd service StandardOutput dump only to journal instead of system console and journal both. Journal+console option will first connect standard output with the journal, which is accessible via [journalctl(1)](https://www.freedesktop.org/software/systemd/man/journalctl.html#), and then copy the output to the system console as well. After removing this line, content of cloud-init-output.log is available on Azure diagnostics serial log.


###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
NO

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- [Bug 46024617](https://microsoft.visualstudio.com/OS/_workitems/edit/46024617): [2.0][cloud-init] Azure boot diagnostic logs missing from Mariner's /var/log/cloud-init-output.log


###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: [412772](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=412772&view=results)
- Azure VM deployment and verify that the cloud-init-ouput.log now pops up in serial console
- BuddyBuild: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=412773&view=results