### PR TITLE
Resolve Golang warnings, fix text output in depsearch.

### DIFF
--- a/toolkit/tools/depsearch/depsearch.go
+++ b/toolkit/tools/depsearch/depsearch.go
@@ -242,7 +242,7 @@ func formatNode(n *pkggraph.PkgNode, verbosity int) string {
 	case 3:
 		return fmt.Sprintf("'%s' from node '%s'", filepath.Base(n.RpmPath), n.FriendlyName())
 	case 4:
-		return fmt.Sprintf("'%s'", n)
+		return fmt.Sprintf("(%v)'%#v'", n.VersionedPkg, *n)
 	default:
 		logger.Log.Fatalf("Invalid verbosity level %v", verbosity)
 	}

--- a/toolkit/tools/internal/pkggraph/pkggraph_test.go
+++ b/toolkit/tools/internal/pkggraph/pkggraph_test.go
@@ -6,7 +6,7 @@ package pkggraph
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"testing"
 
@@ -98,8 +98,7 @@ func TestMain(m *testing.M) {
 
 // buildRunNode creates a new 'Run' PkgNode based on a PackageVer struct
 func buildRunNodeHelper(pkg *pkgjson.PackageVer) (node *PkgNode) {
-	var pkgCopy pkgjson.PackageVer
-	pkgCopy = *pkg
+	pkgCopy := *pkg
 	node = &PkgNode{
 		VersionedPkg: &pkgCopy,
 		State:        StateMeta,
@@ -117,8 +116,7 @@ func buildRunNodeHelper(pkg *pkgjson.PackageVer) (node *PkgNode) {
 
 // buildBuildNode creates a new 'Build' PkgNode based on a PackageVer struct
 func buildBuildNodeHelper(pkg *pkgjson.PackageVer) (node *PkgNode) {
-	var pkgCopy pkgjson.PackageVer
-	pkgCopy = *pkg
+	pkgCopy := *pkg
 	node = &PkgNode{
 		VersionedPkg: &pkgCopy,
 		State:        StateBuild,
@@ -136,8 +134,7 @@ func buildBuildNodeHelper(pkg *pkgjson.PackageVer) (node *PkgNode) {
 
 // buildBuildNode creates a new 'Unresolved' PkgNode based on a PackageVer struct
 func buildUnresolvedNodeHelper(pkg *pkgjson.PackageVer) (node *PkgNode) {
-	var pkgCopy pkgjson.PackageVer
-	pkgCopy = *pkg
+	pkgCopy := *pkg
 	node = &PkgNode{
 		VersionedPkg: &pkgCopy,
 		State:        StateUnresolved,
@@ -723,8 +720,8 @@ func TestGoalWithPackages(t *testing.T) {
 	assert.Equal(t, len(runNodes)+len(unresolvedNodes), len(goalNodes))
 
 	goal, err = g.AddGoalNode("test2", []*pkgjson.PackageVer{
-		&pkgjson.PackageVer{Name: "A"},
-		&pkgjson.PackageVer{Name: "B"},
+		{Name: "A"},
+		{Name: "B"},
 	}, nil, false)
 	assert.NoError(t, err)
 	assert.NotNil(t, goal)
@@ -740,7 +737,7 @@ func TestStrictGoalNodes(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, g)
 
-	_, err = g.AddGoalNode("test", []*pkgjson.PackageVer{&pkgjson.PackageVer{Name: "Not a package"}}, nil, true)
+	_, err = g.AddGoalNode("test", []*pkgjson.PackageVer{{Name: "Not a package"}}, nil, true)
 	assert.Error(t, err)
 }
 
@@ -891,6 +888,7 @@ func TestEncodeDecodeMultiDOT(t *testing.T) {
 
 	gFinal := NewPkgGraph()
 	err = ReadDOTGraph(gFinal, &buf2)
+	assert.NoError(t, err)
 
 	checkTestGraph(t, gFinal)
 }
@@ -932,13 +930,15 @@ func TestReferenceDOTFile(t *testing.T) {
 	assert.NoError(t, err)
 
 	f, err := os.Open("test_graph_reference.dot")
-	defer f.Close()
+	if err == nil {
+		defer f.Close()
+	}
 	assert.NoError(t, err)
 
 	// Compare the bytes from the reference file against a fresh encoding
-	bytesFromCode, err := ioutil.ReadAll(&buf)
+	bytesFromCode, err := io.ReadAll(&buf)
 	assert.NoError(t, err)
-	bytesFromFile, err := ioutil.ReadAll(f)
+	bytesFromFile, err := io.ReadAll(f)
 	assert.NoError(t, err)
 	assert.True(t, len(bytesFromCode) > 0)
 	assert.True(t, len(bytesFromFile) > 0)
@@ -990,6 +990,7 @@ func TestEncodingSubGraph(t *testing.T) {
 
 	// Copy uses the encode/decode flow
 	gCopy, err := subGraph.DeepCopy()
+	assert.NoError(t, err)
 
 	component := []*PkgNode{
 		pkgCRun,


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Fix some go warnings, formatting issues, fix bug in depsearch.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Fix go warnings.
- Fix bug with depsearch verbosity 4

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local