### PR TITLE
misc containerized-rpmbuild improvements

### DIFF
--- a/toolkit/scripts/containerized-build.mk
+++ b/toolkit/scripts/containerized-build.mk
@@ -7,7 +7,7 @@
 ######## CONTAINER ENV ########
 
 # General targets
-.PHONY: containerized-rpmbuild containerized-rpmbuild-help
+.PHONY: containerized-rpmbuild containerized-rpmbuild-help clean-containerized-rpmbuild
 
 containerized_build_args :=
 ifneq ($(MODE),)
@@ -23,7 +23,11 @@ containerized_build_args += -v ${VERSION}
 endif
 
 ifneq ($(MOUNTS),)
-containerized_build_args += -mo ${MOUNTS}
+containerized_build_args += -mo "$(MOUNTS)"
+endif
+
+ifneq ($(BUILD_MOUNT),)
+containerized_build_args += -bm "$(BUILD_MOUNT)"
 endif
 
 ifeq ($(ENABLE_REPO),y)
@@ -35,3 +39,8 @@ containerized-rpmbuild:
 
 containerized-rpmbuild-help:
 	$(SCRIPTS_DIR)/containerized-build/create_container_build.sh -h
+
+clean: clean-containerized-rpmbuild
+
+clean-containerized-rpmbuild:
+	$(SCRIPTS_DIR)/containerized-build/containerized-build_clean.sh $(BUILD_DIR)

--- a/toolkit/scripts/containerized-build/containerized-build_clean.sh
+++ b/toolkit/scripts/containerized-build/containerized-build_clean.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# Clean up any containers used during Mariner containerized-rpmbuild. These containers will
+# be rooted in a container called 'mariner-container-build:*'
+# We use a tag 'containerized-rpmbuild'=MARINER_BUILD_DIR to identify containers, where
+# MARINER_BUILD_DIR is the absolute path to the Mariner build directory.
+
+set -e
+
+# Used to tag our container layers
+MARINER_BUILD_DIR=$1
+
+# Only remove our tagged containers, as we may have running containers in another build
+containers=$(docker ps -aq --filter label="containerized-rpmbuild"="${MARINER_BUILD_DIR}" | sort -u)
+if [ -n "${containers}" ]; then
+    echo "Removing containerized-rpmbuild containers: '${containers}'"
+    docker rm --force ${containers} 2>&1 || true
+else
+    echo "No containers found for 'containerized-rpmbuild=${MARINER_BUILD_DIR}'"
+fi
+
+images="$(docker images -aq --filter label="containerized-rpmbuild"="${MARINER_BUILD_DIR}" | sort -u)"
+if [ -n "${images}" ]; then
+    echo "Removing containerized-rpmbuild images: '${images}'"
+    docker image rm --force ${images} 2>&1 || true
+else
+    echo "No images found for 'containerized-rpmbuild=${MARINER_BUILD_DIR}'"
+fi

--- a/toolkit/scripts/containerized-build/resources/mariner.Dockerfile
+++ b/toolkit/scripts/containerized-build/resources/mariner.Dockerfile
@@ -3,6 +3,7 @@ FROM ${container_img}
 ARG version
 ARG enable_local_repo
 ARG mariner_repo
+ARG mode
 LABEL containerized-rpmbuild=$mariner_repo/build
 
 COPY resources/local_repo /etc/yum.repos.d/local_repo.disabled_repo
@@ -15,5 +16,6 @@ RUN echo "alias tdnf='tdnf --releasever=$version'"               >> /root/.bashr
 RUN if [[ "${enable_local_repo}" == "true" ]]; then echo "enable_local_repo" >> /root/.bashrc; fi
 
 RUN echo "cat /mariner_setup_dir/splash.txt"                     >> /root/.bashrc && \
-    echo "show_help"                                             >> /root/.bashrc && \
-    echo "cd /usr/src/mariner/ || { echo \"ERROR: Could not change directory to /usr/src/mariner/ \"; exit 1; }"  >> /root/.bashrc
+    echo "show_help"                                             >> /root/.bashrc
+RUN if [[ "${mode}" == "build" ]]; then echo "cd /usr/src/mariner || { echo \"ERROR: Could not change directory to /usr/src/mariner \"; exit 1; }"  >> /root/.bashrc; fi
+RUN if [[ "${mode}" == "test" ]]; then echo "cd /mnt || { echo \"ERROR: Could not change directory to /mnt \"; exit 1; }"  >> /root/.bashrc; fi

--- a/toolkit/scripts/containerized-build/resources/setup_functions.sh
+++ b/toolkit/scripts/containerized-build/resources/setup_functions.sh
@@ -18,6 +18,7 @@ do
   MACROS+=("--load=$macro_file")
 done
 
+# Enhance rpm() with ability to
 # Create symlink from SPECS/ to SOURCES/ when rpm is called
 rpm() {
     local args=("$@")
@@ -62,9 +63,11 @@ show_help() {
     echo "******************************************************************************************"
 }
 
+# Enhance rpmbuild() with ability to
 # Refresh repo cache with newly built RPM, use Mariner specific DEFINES
 rpmbuild() {
     local args=("$@")
+    mkdir -p $SOURCES_DIR
     command "$FUNCNAME" "${DEFINES[@]}" "${args[@]}"
     if [[ ${IS_REPO_ENABLED} = true ]] ; then
         refresh_local_repo
@@ -139,6 +142,7 @@ install_dependencies() {
     done
 }
 
+# Enhance rpmspec() with ability to
 # use Mariner specific DEFINES
 rpmspec() {
     local args=("$@")

--- a/toolkit/scripts/containerized-build/resources/setup_functions.sh
+++ b/toolkit/scripts/containerized-build/resources/setup_functions.sh
@@ -10,13 +10,17 @@ RPMS_DIR=$TOPDIR/RPMS
 SRPMS_DIR=$TOPDIR/SRPMS
 IS_REPO_ENABLED=false
 
-# Mariner macro files used during spec parsing (as defined in toolkit/scripts/rpmops.sh)
+# General setup
+## Mariner macro files used during spec parsing (as defined in toolkit/scripts/rpmops.sh)
 DEFINES=(-D "with_check 1")
 MACROS=()
 for macro_file in "$SPECS_DIR"/mariner-rpm-macros/macros* "$SPECS_DIR"/pyproject-rpm-macros/macros.pyproject "$SPECS_DIR"/perl/macros.perl
 do
   MACROS+=("--load=$macro_file")
 done
+
+## Create SOURCES_DIR
+mkdir -p SOURCES_DIR
 
 # Enhance rpm() with ability to
 # Create symlink from SPECS/ to SOURCES/ when rpm is called
@@ -31,7 +35,6 @@ rpm() {
                 SPEC=${SPEC%-*} #remove last suffix of type -*
                 SPEC=${SPEC%-*} #remove last suffix of type -*
                 SPEC=${SPEC%\**}
-                mkdir -p $SOURCES_DIR
                 ln -sf $SPECS_DIR/$SPEC/* $SOURCES_DIR/
             fi
         done
@@ -67,7 +70,6 @@ show_help() {
 # Refresh repo cache with newly built RPM, use Mariner specific DEFINES
 rpmbuild() {
     local args=("$@")
-    mkdir -p $SOURCES_DIR
     command "$FUNCNAME" "${DEFINES[@]}" "${args[@]}"
     if [[ ${IS_REPO_ENABLED} = true ]] ; then
         refresh_local_repo

--- a/toolkit/scripts/containerized-build/resources/welcome.txt
+++ b/toolkit/scripts/containerized-build/resources/welcome.txt
@@ -9,12 +9,11 @@
 *     For more build options, see https://linux.die.net/man/8/rpmbuild
 *     Auto install dependencies:                    there are 3 ways to auto install a package's build dependencies
                                                         1) run 'install_dependencies pkg' to install
-                                                            dependencies listed as 'BuildRequires' from spec
+                                                            'BuildRequires' dependencies from spec
                                                         2) run 'install_dependencies_depsearch pkg' to install
-                                                            dependencies using mariner depsearch tool
-                                                        3) use dnf repoquery:
-                                                            run 'tdnf install -y dnf dnf-plugins-core'
-                                                            followed by 'dnf builddep -y my-pkg.spec'
+                                                            dependencies using Mariner depsearch tool
+                                                        3) use dnf repoquery: run 'tdnf install -y dnf dnf-plugins-core',
+                                                            'dnf builddep -y my-pkg.spec'
 *     Show package dependencies:                    run 'tdnf install -y dnf', 'dnf repoquery --deplist my-pkg'
 *     Build a package:                              run 'build_pkg my-pkg' This will install my-pkg.src.rpm,
                                                         install package dependencies and build it
@@ -24,8 +23,8 @@
 *     Changes to /usr/src/mariner/SPECS will be available on host machine at <CBL-Mariner>/SPECS
 *     Changes to /usr/src/mariner/SOURCES will not be available on host machine
 *     RPMs built in the container are stored at /usr/src/mariner/RPMS, and will not be available on host machine
-*     RPMs from host's out/RPMs will be available in /repo
-*     Individual packages may be installed directly via 'tdnf install /repo/x86_64/pkg.rpm'
+*     RPMs from host's <CBL-Mariner>/out/RPMs will be available in /repo
+*     Individual packages may be installed directly via 'tdnf install /repo/<AARCH>/pkg.rpm and /repo/noarch/pkg.rpm'
 *
 * Directory information:
 *     Mariner repo path:          <REPO_PATH>

--- a/toolkit/scripts/toolchain/toolchain_clean.sh
+++ b/toolkit/scripts/toolchain/toolchain_clean.sh
@@ -22,26 +22,10 @@ else
     echo "No containers found for 'marinertoolchain=${MARINER_BUILD_DIR}'"
 fi
 
-containers=$(docker ps -aq --filter label="containerized-rpmbuild"="${MARINER_BUILD_DIR}" | sort -u)
-if [ -n "${containers}" ]; then
-    echo "Removing containerized-rpmbuild containers: '${containers}'"
-    docker rm --force ${containers} 2>&1 || true
-else
-    echo "No containers found for 'containerized-rpmbuild=${MARINER_BUILD_DIR}'"
-fi
-
 images="$(docker images -aq --filter label="marinertoolchain"="${MARINER_BUILD_DIR}" | sort -u)"
 if [ -n "${images}" ]; then
     echo "Removing toolchain images: '${images}'"
     docker image rm --force ${images} 2>&1 || true
 else
     echo "No images found for 'marinertoolchain=${MARINER_BUILD_DIR}'"
-fi
-
-images="$(docker images -aq --filter label="containerized-rpmbuild"="${MARINER_BUILD_DIR}" | sort -u)"
-if [ -n "${images}" ]; then
-    echo "Removing containerized-rpmbuild images: '${images}'"
-    docker image rm --force ${images} 2>&1 || true
-else
-    echo "No images found for 'containerized-rpmbuild=${MARINER_BUILD_DIR}'"
 fi


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
miscellaneous containerized-rpmbuild improvements as suggested in developer feedback and https://github.com/microsoft/CBL-Mariner/pull/5855

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add BUILD_MOUNT optional argument to use as mountpoint for BUILD and BUILDCHROOT from container, instead of default REPO_PATH/build
- Add separate target for cleaning up container and image
- Use " " as delimiter instead of "," for multiple extra_mounts (in accordance with Mariner standard)
- Use different start directory for container in 'test' mode
- Run make commands in parallel wherever possible
- Use correct make command for building worker-chroot
- Populate INTERMEDIATE_SRPMS only in 'build' mode
- Use realpath for extra_mounts
- Improve welcome text
- Improve readability

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local test