### PR TITLE
Strip epoch on packages that use it in pre-cache

### DIFF
--- a/toolkit/scripts/precache.mk
+++ b/toolkit/scripts/precache.mk
@@ -8,6 +8,7 @@
 
 precache_state_dir = $(CACHED_RPMS_DIR)/precache
 precache_downloaded_files = $(precache_state_dir)/downloaded_files.txt
+repo_summary_file = $(precache_state_dir)/repo_summary.txt
 precache_chroot_dir = $(precache_state_dir)/chroot
 
 $(call create_folder,$(precache_state_dir))
@@ -34,6 +35,7 @@ $(STATUS_FLAGS_DIR)/precache.flag: $(go-precacher) $(chroot_worker) $(rpms_snaps
 		--snapshot "$(rpms_snapshot)" \
 		--output-dir "$(remote_rpms_cache_dir)" \
 		--output-summary-file "$(precache_downloaded_files)" \
+		--repo-summary-file "$(repo_summary_file)" \
 		$(foreach url,$(PACKAGE_URL_LIST), --repo-url "$(url)") \
 		--worker-tar $(chroot_worker) \
 		--worker-dir $(precache_chroot_dir) \


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Based on the contents of rpms-snapshot the pre-cache tool was calculating versions of the form `1:2.3.4-5`, of note is the epoch value `1`. The tool uses these values to compute the expected .rpm filepaths, but these paths do not contain the epoch number. Now we try to patch an rpm both with and without the epoch. We try both so we can explicitly warn the user we will not download the version with epoch (since `:` is a special character in `Make` and we use the contents of the rpm cache as an input into the rest of the tools).

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- String `<epoch>:` from the version of packages being checked by the pre-cache tool.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local