### PR TITLE
Nopatch kernel and hyperv-daemons for CVE-2023-3439 as mctp is not enabled in CBL-Mariner

### DIFF
--- a/SPECS/hyperv-daemons/CVE-2023-3439.nopatch
+++ b/SPECS/hyperv-daemons/CVE-2023-3439.nopatch
@@ -1,0 +1,2 @@
+CVE-2023-3439 - not applicable to CBL_Mariner because CONFIG_MCTP is not enabled
+Upstream fix: b561275d633bcd8e0e8055ab86f1a13df75a0269

--- a/SPECS/kernel/CVE-2023-3439.nopatch
+++ b/SPECS/kernel/CVE-2023-3439.nopatch
@@ -1,0 +1,2 @@
+CVE-2023-3439 - not applicable to CBL_Mariner because CONFIG_MCTP is not enabled
+Upstream fix: b561275d633bcd8e0e8055ab86f1a13df75a0269

--- a/toolkit/scripts/mariner-required-configs.json
+++ b/toolkit/scripts/mariner-required-configs.json
@@ -1101,6 +1101,19 @@
                 "PR": [
                     "https://github.com/microsoft/CBL-Mariner/pull/5972"
                 ]
+            },
+            "CONFIG_MCTP": {
+                "value": [
+                    "is not set"
+                ],
+                "arch": [
+                    "AMD64",
+                    "ARM64"
+                ],
+                "comment": "Do not enable mctp unless fix for CVE-2023-3439 is present",
+                "PR": [
+                    "https://github.com/torvalds/linux/commit/b561275d633bcd8e0e8055ab86f1a13df75a0269"
+                ]
             }
         }
     }


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Nopatch CVE-2023-3439 as mctp is not enabled in CBL-Mariner 
Update required configs to reflect the need for the fix if mctp is enabled

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Nopatch CVE-2023-3439 as mctp is not enabled in CBL-Mariner

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2023-3439 

