### PR TITLE
Fixed image build issues with packages lacking tests.

### DIFF
--- a/toolkit/tools/scheduler/schedulerutils/buildlist.go
+++ b/toolkit/tools/scheduler/schedulerutils/buildlist.go
@@ -26,7 +26,6 @@ import (
 // - imageConfig: the path to the image config file. Used to extract additional packages to build.
 // - baseDirPath: the path to the base directory for the image. Used to resolve relative paths in the image config.
 func ParseAndGeneratePackageBuildList(dependencyGraph *pkggraph.PkgGraph, pkgsToBuild, pkgsToRebuild, pkgsToIgnore []string, imageConfig, baseDirPath string) (finalPackagesToBuild, packagesToRebuild, packagesToIgnore []*pkgjson.PackageVer, err error) {
-	isBuildList := true
 	logger.Log.Debug("Generating a package list for build nodes.")
 
 	buildNodeGetter := func(node *pkggraph.LookupNode) *pkggraph.PkgNode {
@@ -35,7 +34,7 @@ func ParseAndGeneratePackageBuildList(dependencyGraph *pkggraph.PkgGraph, pkgsTo
 		}
 		return nil
 	}
-	return parseAndGeneratePackageList(dependencyGraph, pkgsToBuild, pkgsToRebuild, pkgsToIgnore, imageConfig, baseDirPath, dependencyGraph.AllBuildNodes(), buildNodeGetter, isBuildList)
+	return parseAndGeneratePackageList(dependencyGraph, pkgsToBuild, pkgsToRebuild, pkgsToIgnore, imageConfig, baseDirPath, dependencyGraph.AllBuildNodes(), buildNodeGetter)
 }
 
 // ParseAndGeneratePackageTestList parses the common package request arguments and generates a list of packages to test based on the given dependency graph.
@@ -48,14 +47,13 @@ func ParseAndGeneratePackageBuildList(dependencyGraph *pkggraph.PkgGraph, pkgsTo
 func ParseAndGeneratePackageTestList(dependencyGraph *pkggraph.PkgGraph, testsToRun, testsToRerun, testsToIgnore []string, imageConfig, baseDirPath string) (finalPackagesToBuild, packagesToRebuild, packagesToIgnore []*pkgjson.PackageVer, err error) {
 	logger.Log.Debug("Generating a package list for test nodes.")
 
-	isBuildList := false
 	testNodeGetter := func(node *pkggraph.LookupNode) *pkggraph.PkgNode {
 		if node != nil {
 			return node.TestNode
 		}
 		return nil
 	}
-	return parseAndGeneratePackageList(dependencyGraph, testsToRun, testsToRerun, testsToIgnore, imageConfig, baseDirPath, dependencyGraph.AllTestNodes(), testNodeGetter, isBuildList)
+	return parseAndGeneratePackageList(dependencyGraph, testsToRun, testsToRerun, testsToIgnore, imageConfig, baseDirPath, dependencyGraph.AllTestNodes(), testNodeGetter)
 }
 
 // ReadReservedFilesList reads the list of reserved files (such as toolchain RPMs) from the manifest file passed in.
@@ -109,24 +107,22 @@ func IsReservedFile(rpmPath string, reservedRPMs []string) bool {
 //   - packagesNamesToRebuild,
 //   - local packages listed in the image config, and
 //   - kernels in the image config (if built locally).
-func calculatePackagesToBuild(packagesNamesToBuild, packagesNamesToRebuild []*pkgjson.PackageVer, imageConfig, baseDirPath string, dependencyGraph *pkggraph.PkgGraph, isBuildList bool) (packageVersToBuild []*pkgjson.PackageVer, err error) {
+func calculatePackagesToBuild(packagesNamesToBuild, packagesNamesToRebuild []*pkgjson.PackageVer, imageConfig, baseDirPath string, dependencyGraph *pkggraph.PkgGraph, nodeGetter func(*pkggraph.LookupNode) *pkggraph.PkgNode) (packageVersToBuild []*pkgjson.PackageVer, err error) {
 	packageVersToBuild = append(packagesNamesToBuild, packagesNamesToRebuild...)
 
-	packageVersFromConfig := []*pkgjson.PackageVer{}
-	err = nil
-	if isBuildList {
-		packageVersFromConfig, err = extractPackagesFromConfig(imageConfig, baseDirPath)
-		if err != nil {
-			err = fmt.Errorf("failed to extract packages from the image config, error:\n%w", err)
-			return
-		}
-		packageVersFromConfig, err = filterLocalPackagesOnly(packageVersFromConfig, dependencyGraph)
-		if err != nil {
-			err = fmt.Errorf("failed to filter local packages from the image config, error:\n%w", err)
-			return
-		}
-		packageVersToBuild = append(packageVersToBuild, packageVersFromConfig...)
+	packageVersFromConfig, err := extractPackagesFromConfig(imageConfig, baseDirPath)
+	if err != nil {
+		err = fmt.Errorf("failed to extract packages from the image config, error:\n%w", err)
+		return
 	}
+
+	packageVersFromConfig, err = filterLocalPackagesOnly(packageVersFromConfig, dependencyGraph, nodeGetter)
+	if err != nil {
+		err = fmt.Errorf("failed to filter local packages from the image config, error:\n%w", err)
+		return
+	}
+
+	packageVersToBuild = append(packageVersToBuild, packageVersFromConfig...)
 	packageVersToBuild = removePackageVersDuplicates(packageVersToBuild)
 
 	return
@@ -157,7 +153,7 @@ func extractPackagesFromConfig(configFile, baseDirPath string) (packageList []*p
 }
 
 // filterLocalPackagesOnly returns the subset of packageVersionsInConfig that only contains local packages.
-func filterLocalPackagesOnly(packageVersionsInConfig []*pkgjson.PackageVer, dependencyGraph *pkggraph.PkgGraph) (filteredPackages []*pkgjson.PackageVer, err error) {
+func filterLocalPackagesOnly(packageVersionsInConfig []*pkgjson.PackageVer, dependencyGraph *pkggraph.PkgGraph, nodeGetter func(*pkggraph.LookupNode) *pkggraph.PkgNode) (filteredPackages []*pkgjson.PackageVer, err error) {
 	logger.Log.Debug("Filtering out external packages from list of packages extracted from the image config file.")
 
 	for _, pkgVer := range packageVersionsInConfig {
@@ -166,7 +162,8 @@ func filterLocalPackagesOnly(packageVersionsInConfig []*pkgjson.PackageVer, depe
 		// A pkgNode for a local package has the following characteristics:
 		// 1) The pkgNode exists in the graph (is not nil).
 		// 2) The pkgNode has a build node. External packages will only have a run node.
-		if pkgNode != nil && pkgNode.BuildNode != nil {
+		filteredNode := nodeGetter(pkgNode)
+		if filteredNode != nil {
 			filteredPackages = append(filteredPackages, pkgVer)
 		} else {
 			logger.Log.Debugf("Found external package to filter out: %v.", pkgVer)
@@ -244,7 +241,7 @@ func packageNamesToPackages(packageOrSpecNames []string, analyzedNodes []*pkggra
 // - ignoreList: a list of package/spec names to ignore.
 // - imageConfig: the path to the image config file. Used to extract additional packages to build.
 // - baseDirPath: the path to the base directory for the image. Used to resolve relative paths in the image config.
-func parseAndGeneratePackageList(dependencyGraph *pkggraph.PkgGraph, buildList, rebuiltList, ignoreList []string, imageConfig, baseDirPath string, analyzedNodes []*pkggraph.PkgNode, nodeGetter func(*pkggraph.LookupNode) *pkggraph.PkgNode, isBuildList bool) (finalPackagesToBuild, packagesToRebuild, packagesToIgnore []*pkgjson.PackageVer, err error) {
+func parseAndGeneratePackageList(dependencyGraph *pkggraph.PkgGraph, buildList, rebuiltList, ignoreList []string, imageConfig, baseDirPath string, analyzedNodes []*pkggraph.PkgNode, nodeGetter func(*pkggraph.LookupNode) *pkggraph.PkgNode) (finalPackagesToBuild, packagesToRebuild, packagesToIgnore []*pkgjson.PackageVer, err error) {
 	packagesToBuild, err := packageNamesToPackages(buildList, analyzedNodes, nodeGetter, dependencyGraph)
 	if err != nil {
 		err = fmt.Errorf("unable to find nodes for the packages from the build list, error:\n%s", err)
@@ -279,7 +276,7 @@ func parseAndGeneratePackageList(dependencyGraph *pkggraph.PkgGraph, buildList, 
 		return
 	}
 
-	finalPackagesToBuild, err = calculatePackagesToBuild(packagesToBuild, packagesToRebuild, imageConfig, baseDirPath, dependencyGraph, isBuildList)
+	finalPackagesToBuild, err = calculatePackagesToBuild(packagesToBuild, packagesToRebuild, imageConfig, baseDirPath, dependencyGraph, nodeGetter)
 	if err != nil {
 		err = fmt.Errorf("unable to generate the final package build list, error:\n%s", err)
 		return


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
This is a fix to PR#5863.
ISO build fails with above PR because scheduler wrongly adds packages from image config to test list along with build list.
This is causing the ISO build to fail since there are not test nodes in the lookup Table.
Test list is getting added even though run_check is not enabled.
To summarize, scheduler wrongly considers packages in imageconfig that are to be built as packages to run tests.

Fix ensures local packages from imageconfig are considered as packages to be built but not be considered as packages to be tesed (since run_check is not enabled when building iso)


###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Passing a flag isBuildList from ParseAndGeneratePackage**Test**List with isBuildList set to false. The flag is set to true for ParseAndGeneratePackage**Build**List
- Packages to be built will get added to BuildList since flag is set when generating package build list.
- The packages will not get added to TestList since flag is not set when generating Package Test list.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #5863

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local iso build successful
- Triggered full build: Pipeline build id: 413975
