### PR TITLE
Remove dst file on failed network download

### DIFF
--- a/toolkit/tools/graphpkgfetcher/graphpkgfetcher.go
+++ b/toolkit/tools/graphpkgfetcher/graphpkgfetcher.go
@@ -423,6 +423,8 @@ func downloadSingleDeltaRPM(realDependencyGraph *pkggraph.PkgGraph, buildNode *p
 			logger.Log.Warnf("Can't find delta RPM to download for %s: %s (local copy may be newer than published version)", fullyQualifiedRpmName, err)
 			return nil
 		}
+	} else {
+		logger.Log.Debugf("Found pre-cached delta RPM for %s, skipping download", fullyQualifiedRpmName)
 	}
 
 	foundCacheRPM, err = file.PathExists(cachedRPMPath)

--- a/toolkit/tools/internal/file/file.go
+++ b/toolkit/tools/internal/file/file.go
@@ -8,8 +8,10 @@ import (
 	"crypto/sha1"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 
@@ -157,6 +159,15 @@ func Append(data string, dst string) (err error) {
 	defer dstFile.Close()
 
 	_, err = dstFile.WriteString(data)
+	return
+}
+
+// RemoveFileIfExists will delete a file if it exists on disk.
+func RemoveFileIfExists(path string) (err error) {
+	removeErr := os.Remove(path)
+	if removeErr != nil && !errors.Is(removeErr, fs.ErrNotExist) {
+		err = fmt.Errorf("failed to remove file (%s):\n%w", path, err)
+	}
 	return
 }
 

--- a/toolkit/tools/internal/file/file_test.go
+++ b/toolkit/tools/internal/file/file_test.go
@@ -18,20 +18,28 @@ func TestMain(m *testing.M) {
 	os.Exit(retVal)
 }
 
+// testFileName returns a file name in a temporary directory. This path will
+// be different for EVERY call to this function.
 func testFileName(t *testing.T) string {
 	return filepath.Join(t.TempDir(), t.Name())
 }
 
 func TestRemoveFileIfExistsValid(t *testing.T) {
+	fileName := testFileName(t)
 	// Create a file to remove
-	err := Write("test", testFileName(t))
+	err := Write("test", fileName)
 	assert.NoError(t, err)
 
-	err = RemoveFileIfExists(testFileName(t))
+	err = RemoveFileIfExists(fileName)
 	assert.NoError(t, err)
+
+	exists, err := PathExists(fileName)
+	assert.NoError(t, err)
+	assert.False(t, exists)
 }
 
 func TestRemoveFileDoesNotExist(t *testing.T) {
-	err := RemoveFileIfExists(testFileName(t))
+	fileName := testFileName(t)
+	err := RemoveFileIfExists(fileName)
 	assert.NoError(t, err)
 }

--- a/toolkit/tools/internal/file/file_test.go
+++ b/toolkit/tools/internal/file/file_test.go
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package file
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/logger"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMain(m *testing.M) {
+	logger.InitStderrLog()
+	retVal := m.Run()
+	os.Exit(retVal)
+}
+
+func testFileName(t *testing.T) string {
+	return filepath.Join(t.TempDir(), t.Name())
+}
+
+func TestRemoveFileIfExistsValid(t *testing.T) {
+	// Create a file to remove
+	err := Write("test", testFileName(t))
+	assert.NoError(t, err)
+
+	err = RemoveFileIfExists(testFileName(t))
+	assert.NoError(t, err)
+}
+
+func TestRemoveFileDoesNotExist(t *testing.T) {
+	err := RemoveFileIfExists(testFileName(t))
+	assert.NoError(t, err)
+}

--- a/toolkit/tools/internal/network/network.go
+++ b/toolkit/tools/internal/network/network.go
@@ -42,13 +42,13 @@ func DownloadFile(url, dst string, caCerts *x509.CertPool, tlsCerts []tls.Certif
 	defer func() {
 		// If there was an error, ensure that the file is removed
 		if err != nil {
-			cleanupErr := removeFileIfExists(dst)
+			cleanupErr := file.RemoveFileIfExists(dst)
 			if cleanupErr != nil {
 				logger.Log.Errorf("Failed to remove failed network download file '%s': %s", dst, err)
 			}
 		}
+		dstFile.Close()
 	}()
-	defer dstFile.Close()
 
 	tlsConfig := &tls.Config{
 		RootCAs:      caCerts,
@@ -72,22 +72,6 @@ func DownloadFile(url, dst string, caCerts *x509.CertPool, tlsCerts []tls.Certif
 
 	_, err = io.Copy(dstFile, response.Body)
 
-	return
-}
-
-func removeFileIfExists(fullPath string) (err error) {
-	exists, err := file.PathExists(fullPath)
-	if err != nil {
-		err = fmt.Errorf("failed to check if file exists:\n%w", err)
-		return
-	}
-	if exists {
-		err = os.Remove(fullPath)
-		if err != nil {
-			err = fmt.Errorf("failed to remove file:\n%w", err)
-			return
-		}
-	}
 	return
 }
 

--- a/toolkit/tools/internal/network/network.go
+++ b/toolkit/tools/internal/network/network.go
@@ -39,7 +39,6 @@ func DownloadFile(url, dst string, caCerts *x509.CertPool, tlsCerts []tls.Certif
 	if err != nil {
 		return
 	}
-	defer dstFile.Close()
 	defer func() {
 		// If there was an error, ensure that the file is removed
 		if err != nil {
@@ -49,6 +48,7 @@ func DownloadFile(url, dst string, caCerts *x509.CertPool, tlsCerts []tls.Certif
 			}
 		}
 	}()
+	defer dstFile.Close()
 
 	tlsConfig := &tls.Config{
 		RootCAs:      caCerts,


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
When `network.DownloadFile()` it was leaving files on the disk. The pre-cacher tool would create empty `.rpm` files which would confuse the fetcher and scheduler further downstream.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- network.DownloadFile() will now clean up its dst file on error
- Added `file.RemoveFileIfExists()`
- Add file_test.go 

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local test