### PR TITLE
CVE-2022-36648: QEMU fix

### DIFF
--- a/SPECS/qemu/CVE-2022-36648.patch
+++ b/SPECS/qemu/CVE-2022-36648.patch
@@ -12,8 +12,7 @@ diff --git a/hw/net/rocker/rocker_of_dpa.c b/hw/net/rocker/rocker_of_dpa.c
 index b3b8c5bb6d..1611b79227 100644
 --- a/hw/net/rocker/rocker_of_dpa.c
 +++ b/hw/net/rocker/rocker_of_dpa.c
-@@ -2039,6 +2039,11 @@ static int of_dpa_cmd_add_l2_flood(OfDpa *of_dpa, 
-OfDpaGroup *group,
+@@ -2039,6 +2039,11 @@ static int of_dpa_cmd_add_l2_flood(OfDpa *of_dpa, OfDpaGroup *group,
      rocker_tlv_parse_nested(tlvs, group->l2_flood.group_count,
                              group_tlvs[ROCKER_TLV_OF_DPA_GROUP_IDS]);
  
@@ -25,5 +24,6 @@ OfDpaGroup *group,
      for (i = 0; i < group->l2_flood.group_count; i++) {
          group->l2_flood.group_ids[i] = rocker_tlv_get_le32(tlvs[i + 1]);
      }
+
 -- 
 2.35.3

--- a/SPECS/qemu/CVE-2022-36648.patch
+++ b/SPECS/qemu/CVE-2022-36648.patch
@@ -1,0 +1,29 @@
+rocker_tlv_parse_nested could return early because of no group ids in
+the group_tlvs. In such case tlvs is NULL; tlvs[i + 1] in the next
+for-loop will deref the NULL pointer.
+
+Signed-off-by: Mauro Matteo Cascella <mcascell@redhat.com>
+Reported-by: <arayz_w@icloud.com>
+---
+ hw/net/rocker/rocker_of_dpa.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/hw/net/rocker/rocker_of_dpa.c b/hw/net/rocker/rocker_of_dpa.c
+index b3b8c5bb6d..1611b79227 100644
+--- a/hw/net/rocker/rocker_of_dpa.c
++++ b/hw/net/rocker/rocker_of_dpa.c
+@@ -2039,6 +2039,11 @@ static int of_dpa_cmd_add_l2_flood(OfDpa *of_dpa, 
+OfDpaGroup *group,
+     rocker_tlv_parse_nested(tlvs, group->l2_flood.group_count,
+                             group_tlvs[ROCKER_TLV_OF_DPA_GROUP_IDS]);
+ 
++    if (!tlvs) {
++        err = -ROCKER_EINVAL;
++        goto err_out;
++    }
++
+     for (i = 0; i < group->l2_flood.group_count; i++) {
+         group->l2_flood.group_ids[i] = rocker_tlv_get_le32(tlvs[i + 1]);
+     }
+-- 
+2.35.3

--- a/SPECS/qemu/qemu.spec
+++ b/SPECS/qemu/qemu.spec
@@ -2333,7 +2333,7 @@ useradd -r -u 107 -g qemu -G kvm -d / -s %{_sbindir}/nologin \
 * Wed Oct 26 2022 Olivia Crain <oliviacrain@microsoft.com> - 6.2.0-10
 - Have virtiofsd subpackage obsolete qemu-common from 6.1.0 releases
 
-* Tue Sep 28 2022 Saul Paredes <saulparedes@microsoft.com> - 6.2.0-9
+* Wed Sep 28 2022 Saul Paredes <saulparedes@microsoft.com> - 6.2.0-9
 - Address CVE-2022-2962
 
 * Fri Sep 09 2022 Muhammad Falak <mwani@microsoft.com> - 6.2.0-8

--- a/SPECS/qemu/qemu.spec
+++ b/SPECS/qemu/qemu.spec
@@ -217,7 +217,7 @@ Obsoletes: %{name}-system-unicore32-core <= %{version}-%{release}
 Summary:        QEMU is a FAST! processor emulator
 Name:           qemu
 Version:        6.2.0
-Release:        16%{?dist}
+Release:        17%{?dist}
 License:        BSD AND CC-BY AND GPLv2+ AND LGPLv2+ AND MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -273,6 +273,7 @@ Patch1013:      CVE-2022-3165.patch
 # CVE-2021-3750 fix is not in a release yet
 # https://gitlab.com/qemu-project/qemu/-/issues/541
 Patch1014:      CVE-2021-3750.patch
+Patch1015:      CVE-2022-36648.patch
 
 # alsa audio output
 BuildRequires:  alsa-lib-devel
@@ -2307,6 +2308,9 @@ useradd -r -u 107 -g qemu -G kvm -d / -s %{_sbindir}/nologin \
 
 
 %changelog
+* Mon Aug 28 2023 Brian Fjeldstad <bfjelds@microsoft.com> - 6.2.0-17
+- Address CVE-2022-36648
+
 * Thu Jun 15 2023 Dylan Garrett <dylang@microsoft.com> - 6.2.0-16
 - Address CVE-2021-3750
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
CVE-2022-36648 Detail
Description
The hardware emulation in the of_dpa_cmd_add_l2_flood of rocker device model in QEMU, as used in 7.0.0 and earlier, allows remote attackers to crash the host qemu and potentially execute code on the host via execute a malformed program in the guest OS.

###### Change Log  <!-- REQUIRED -->
Added patch as described by https://lists.nongnu.org/archive/html/qemu-devel/2022-06/msg04469.html (which was referenced by https://nvd.nist.gov/vuln/detail/CVE-2022-36648).

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Associated issues  <!-- optional -->

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2022-36648

###### Test Methodology
- https://dev.azure.com/mariner-org/mariner/_build/results?buildId=414204&view=results
