### PR TITLE
qt5-qtsvg: rebuild with qt5-qtbase fix for CVE-2023-37369

### DIFF
--- a/SPECS/qt5-qtsvg/qt5-qtsvg.spec
+++ b/SPECS/qt5-qtsvg/qt5-qtsvg.spec
@@ -1,11 +1,9 @@
-%define majmin %(echo %{version} | cut -d. -f1-2)
-
 Summary:        Qt5 - Support for rendering and displaying SVG
 Name:           qt5-qtsvg
 Version:        5.12.11
 Release:        6%{?dist}
 # See LICENSE.GPL3-EXCEPT.txt, for exception details
-License:        GFDL AND GPLv2+ with exceptions AND LGPLv2.1+
+License:        GFDL AND GPLv2+ WITH exceptions AND LGPLv2.1+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 URL:            https://www.qt.io
@@ -16,12 +14,11 @@ Patch101:       CVE-2018-21035.nopatch
 # Vulnerability is limited to the Windows OS.
 Patch102:       CVE-2022-25634.nopatch
 Patch103:       CVE-2023-32573.patch
-
+%define majmin %(echo %{version} | cut -d. -f1-2)
+%{?_qt5:Requires: %{_qt5}%{?_isa} = %{_qt5_version}}
 BuildRequires:  qt5-qtbase-devel >= %{version}
 BuildRequires:  qt5-qtbase-private-devel
 BuildRequires:  zlib-devel
-
-%{?_qt5:Requires: %{_qt5}%{?_isa} = %{_qt5_version}}
 
 %description
 Scalable Vector Graphics (SVG) is an XML-based language for describing

--- a/SPECS/qt5-qtsvg/qt5-qtsvg.spec
+++ b/SPECS/qt5-qtsvg/qt5-qtsvg.spec
@@ -1,3 +1,5 @@
+%define majmin %(echo %{version} | cut -d. -f1-2)
+
 Summary:        Qt5 - Support for rendering and displaying SVG
 Name:           qt5-qtsvg
 Version:        5.12.11
@@ -14,7 +16,6 @@ Patch101:       CVE-2018-21035.nopatch
 # Vulnerability is limited to the Windows OS.
 Patch102:       CVE-2022-25634.nopatch
 Patch103:       CVE-2023-32573.patch
-%define majmin %(echo %{version} | cut -d. -f1-2)
 %{?_qt5:Requires: %{_qt5}%{?_isa} = %{_qt5_version}}
 BuildRequires:  qt5-qtbase-devel >= %{version}
 BuildRequires:  qt5-qtbase-private-devel
@@ -85,6 +86,7 @@ popd
 %changelog
 * Mon Aug 28 2023 Andrew Phelps <anphel@microsoft.com> - 5.12.11-6
 - Bump release to rebuild with qt5-qtbase >= 5.12.11-9, which contains fix for CVE-2023-37369
+- Lint spec.
 
 * Fri May 26 2023 Thien Trung Vuong <tvuong@microsoft.com> - 5.12.11-5
 - Add patch for CVE-2023-32573

--- a/SPECS/qt5-qtsvg/qt5-qtsvg.spec
+++ b/SPECS/qt5-qtsvg/qt5-qtsvg.spec
@@ -3,7 +3,7 @@
 Summary:        Qt5 - Support for rendering and displaying SVG
 Name:           qt5-qtsvg
 Version:        5.12.11
-Release:        5%{?dist}
+Release:        6%{?dist}
 # See LICENSE.GPL3-EXCEPT.txt, for exception details
 License:        GFDL AND GPLv2+ with exceptions AND LGPLv2.1+
 Vendor:         Microsoft Corporation
@@ -86,6 +86,9 @@ popd
 %{_qt5_examplesdir}/
 
 %changelog
+* Mon Aug 28 2023 Andrew Phelps <anphel@microsoft.com> - 5.12.11-6
+- Bump release to rebuild with qt5-qtbase >= 5.12.11-9, which contains fix for CVE-2023-37369
+
 * Fri May 26 2023 Thien Trung Vuong <tvuong@microsoft.com> - 5.12.11-5
 - Add patch for CVE-2023-32573
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Rebuild qt5-qtsvg package to resolve vulnerability to CVE-2023-37369. While the [`CVE-2023-37369.patch`](https://github.com/microsoft/CBL-Mariner/blob/main/SPECS/qt5-qtbase/CVE-2023-37369.patch) does not apply to any source code used by qt5-qtsvg, this package compiles against potentially vulnerable code from qt5-qtbase via `BuildRequires: qt5-qtbase-private-devel`. I've bumped the release version of qt5-qtsvg so that it recompiles against the updated qt5-qtbase which contains the CVE fix.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change qt5-qtsvg release number

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2023-37369

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Buddy build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=414523&view=results
