### PR TITLE
set starting directory based on mode

### DIFF
--- a/toolkit/scripts/containerized-build/create_container_build.sh
+++ b/toolkit/scripts/containerized-build/create_container_build.sh
@@ -208,6 +208,7 @@ docker build -q \
                 --build-arg version="$version" \
                 --build-arg enable_local_repo="$enable_local_repo" \
                 --build-arg mariner_repo="$repo_path" \
+                --build-arg mode="$mode" \
                 .
 
 echo "docker_image_tag is ${docker_image_tag}"

--- a/toolkit/scripts/containerized-build/resources/mariner.Dockerfile
+++ b/toolkit/scripts/containerized-build/resources/mariner.Dockerfile
@@ -3,6 +3,7 @@ FROM ${container_img}
 ARG version
 ARG enable_local_repo
 ARG mariner_repo
+ARG mode
 LABEL containerized-rpmbuild=$mariner_repo/build
 
 COPY resources/local_repo /etc/yum.repos.d/local_repo.disabled_repo
@@ -15,8 +16,10 @@ RUN echo "alias tdnf='tdnf --releasever=$version'"               >> /root/.bashr
 RUN if [[ "${enable_local_repo}" == "true" ]]; then echo "enable_local_repo" >> /root/.bashrc; fi
 
 RUN echo "cat /mariner_setup_dir/splash.txt"                     >> /root/.bashrc && \
-    echo "show_help"                                             >> /root/.bashrc && \
-    echo "cd /usr/src/mariner/ || { echo \"ERROR: Could not change directory to /usr/src/mariner/ \"; exit 1; }"  >> /root/.bashrc
+    echo "show_help"                                             >> /root/.bashrc
+
+RUN if [[ "${mode}" == "build" ]]; then echo "cd /usr/src/mariner || { echo \"ERROR: Could not change directory to /usr/src/mariner \"; exit 1; }"  >> /root/.bashrc; fi
+RUN if [[ "${mode}" == "test" ]]; then echo "cd /mnt || { echo \"ERROR: Could not change directory to /mnt \"; exit 1; }"  >> /root/.bashrc; fi
 
 # Install vim & git in the build env
 RUN tdnf --releasever=$version install -y vim git


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
set starting directory based on mode

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Earlier we were starting at the same directory, /usr/src/mariner inside the container, but this directory is not created in the 'test ' mode
- Now, we set the starting directory based on the mode (build v/s test)

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local test