### PR TITLE
Fix parsing of releases containing '_'

### DIFF
--- a/toolkit/tools/pkg/rpmssnapshot/rpmssnapshot.go
+++ b/toolkit/tools/pkg/rpmssnapshot/rpmssnapshot.go
@@ -39,12 +39,12 @@ const (
 //
 //	^(.*)			<-- [index 1] package name
 //	-				<-- second-to-last hyphen separating the package name from its version
-//	([^-]+-\d+)		<-- [index 2] package version and package release number connected by the last hyphen
+//	([^-]+-[^-]+)		<-- [index 2] package version and package release number connected by the last hyphen
 //	\.				<-- second-to-last period separating the package release number from the distribution tag
 //	([^.]+)			<-- [index 3] the distribution tag
 //	\.				<-- last period separating the distribution tag from the architecture string
 //	([^.]+)$		<-- [index 4] the architecture string
-var rpmSpecBuiltRPMRegex = regexp.MustCompile(`^(.*)-([^-]+-\d+)\.([^.]+)\.([^.]+)$`)
+var rpmSpecBuiltRPMRegex = regexp.MustCompile(`^(.*)-([^-]+-[^-]+)\.([^.]+)\.([^.]+)$`)
 
 const (
 	rpmSpecBuiltRPMRegexNameIndex = iota + 1

--- a/toolkit/tools/pkg/rpmssnapshot/rpmssnapshot_test.go
+++ b/toolkit/tools/pkg/rpmssnapshot/rpmssnapshot_test.go
@@ -1,0 +1,77 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// A tool for generating snapshots of built RPMs from local specs.
+
+package rpmssnapshot
+
+import (
+	"testing"
+
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/packagerepo/repocloner"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRegexBasic(t *testing.T) {
+	input := "pkg-1.2.3-1.cm2.x86_64"
+	expectedResults := []string{"pkg", "1.2.3-1", "cm2", "x86_64"}
+	expectedMatchNumber := 5
+
+	matches := rpmSpecBuiltRPMRegex.FindStringSubmatch(input)
+	assert.Equal(t, expectedMatchNumber, len(matches))
+
+	assert.Equal(t, expectedResults[0], matches[rpmSpecBuiltRPMRegexNameIndex])
+	assert.Equal(t, expectedResults[1], matches[rpmSpecBuiltRPMRegexVersionIndex])
+	assert.Equal(t, expectedResults[2], matches[rpmSpecBuiltRPMRegexDistributionIndex])
+	assert.Equal(t, expectedResults[3], matches[rpmSpecBuiltRPMRegexArchitectureIndex])
+}
+
+func TestRegexUnderscore(t *testing.T) {
+	input := "pkg-1.2.3-1_2.3.cm2.x86_64"
+	expectedResults := []string{"pkg", "1.2.3-1_2.3", "cm2", "x86_64"}
+	expectedMatchNumber := 5
+
+	matches := rpmSpecBuiltRPMRegex.FindStringSubmatch(input)
+	assert.Equal(t, expectedMatchNumber, len(matches))
+
+	assert.Equal(t, expectedResults[0], matches[rpmSpecBuiltRPMRegexNameIndex])
+	assert.Equal(t, expectedResults[1], matches[rpmSpecBuiltRPMRegexVersionIndex])
+	assert.Equal(t, expectedResults[2], matches[rpmSpecBuiltRPMRegexDistributionIndex])
+	assert.Equal(t, expectedResults[3], matches[rpmSpecBuiltRPMRegexArchitectureIndex])
+}
+
+func TestGenerateResults(t *testing.T) {
+	input := []string{
+		"pkg-1.2.3-1_2.3.cm2.x86_64",
+		"other-pkg-1.2.3-1_2.3.cm2.x86_64",
+	}
+	expectedResults := repocloner.RepoContents{
+		Repo: []*repocloner.RepoPackage{
+			{
+				Name:         "pkg",
+				Version:      "1.2.3-1_2.3",
+				Distribution: "cm2",
+				Architecture: "x86_64",
+			},
+			{
+				Name:         "other-pkg",
+				Version:      "1.2.3-1_2.3",
+				Distribution: "cm2",
+				Architecture: "x86_64",
+			},
+		},
+	}
+	emptySnapshotGenerator := SnapshotGenerator{}
+	generatedContents, err := emptySnapshotGenerator.convertResultsToRepoContents(input)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedResults, generatedContents)
+}
+
+func TestGenerateInvalidInput(t *testing.T) {
+	input := []string{
+		"pkg-no-version",
+	}
+	emptySnapshotGenerator := SnapshotGenerator{}
+	_, err := emptySnapshotGenerator.convertResultsToRepoContents(input)
+	assert.EqualError(t, err, "RPM package name (pkg-no-version) doesn't match the regular expression ("+rpmSpecBuiltRPMRegex.String()+")")
+}

--- a/toolkit/tools/pkg/rpmssnapshot/rpmssnapshot_test.go
+++ b/toolkit/tools/pkg/rpmssnapshot/rpmssnapshot_test.go
@@ -73,5 +73,5 @@ func TestGenerateInvalidInput(t *testing.T) {
 	}
 	emptySnapshotGenerator := SnapshotGenerator{}
 	_, err := emptySnapshotGenerator.convertResultsToRepoContents(input)
-	assert.EqualError(t, err, "RPM package name (pkg-no-version) doesn't match the regular expression ("+rpmSpecBuiltRPMRegex.String()+")")
+	assert.EqualError(t, err, "RPM package name ("+input[0]+") doesn't match the regular expression ("+rpmSpecBuiltRPMRegex.String()+")")
 }


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Some packages use uncommon release numbers which include '_'. Generally a release is expected to be a number only, but this is not required. Relax the regex used by the `rpmssnapshot` tool to calculate the version of a `.spec` file.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Allow `rpmssnapshot` to handle `.spec` files which contain '_' in their release.
- Add basic unit tests to the regex in `rpmssnapshot.go`

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local test via `jq -r '.Repo | sort_by(.Name)' ./out/rpms_snapshot.json > sort.json` to compare results before/after.
