### PR TITLE
Limited running `setfacl` to package builds

### DIFF
--- a/toolkit/scripts/containerized-build.mk
+++ b/toolkit/scripts/containerized-build.mk
@@ -33,7 +33,7 @@ endif
 # SPECS_DIR is always set
 containerized_build_args += -s ${SPECS_DIR}
 
-containerized-rpmbuild:
+containerized-rpmbuild: no_repo_acl
 	$(SCRIPTS_DIR)/containerized-build/create_container_build.sh $(containerized_build_args)
 
 containerized-rpmbuild-help:

--- a/toolkit/scripts/pkggen.mk
+++ b/toolkit/scripts/pkggen.mk
@@ -257,7 +257,7 @@ $(RPMS_DIR):
 	@touch $@
 endif
 
-$(STATUS_FLAGS_DIR)/build-rpms.flag: $(preprocessed_file) $(chroot_worker) $(go-scheduler) $(go-pkgworker) $(depend_STOP_ON_PKG_FAIL) $(CONFIG_FILE) $(depend_CONFIG_FILE) $(depend_PACKAGE_BUILD_LIST) $(depend_PACKAGE_REBUILD_LIST) $(depend_PACKAGE_IGNORE_LIST) $(depend_MAX_CASCADING_REBUILDS) $(depend_TEST_RUN_LIST) $(depend_TEST_RERUN_LIST) $(depend_TEST_IGNORE_LIST) $(pkggen_rpms) $(srpms) $(BUILD_SRPMS_DIR)
+$(STATUS_FLAGS_DIR)/build-rpms.flag: no_repo_acl $(preprocessed_file) $(chroot_worker) $(go-scheduler) $(go-pkgworker) $(depend_STOP_ON_PKG_FAIL) $(CONFIG_FILE) $(depend_CONFIG_FILE) $(depend_PACKAGE_BUILD_LIST) $(depend_PACKAGE_REBUILD_LIST) $(depend_PACKAGE_IGNORE_LIST) $(depend_MAX_CASCADING_REBUILDS) $(depend_TEST_RUN_LIST) $(depend_TEST_RERUN_LIST) $(depend_TEST_IGNORE_LIST) $(pkggen_rpms) $(srpms) $(BUILD_SRPMS_DIR)
 	$(go-scheduler) \
 		--input="$(preprocessed_file)" \
 		--output="$(built_file)" \

--- a/toolkit/scripts/utils.mk
+++ b/toolkit/scripts/utils.mk
@@ -92,6 +92,6 @@ endef
 $(foreach var,$(watch_vars),$(eval $(call depend_on_var,$(var))))
 
 # Host's ACLs influence the default permissions of the
-# files inside the built RPMs. Disabling them for the build directory.
+# files inside the built RPMs. Disabling them for the repository.
 no_repo_acl:
 	@setfacl -bnR $(PROJECT_ROOT)

--- a/toolkit/scripts/utils.mk
+++ b/toolkit/scripts/utils.mk
@@ -91,6 +91,6 @@ endef
 # Invoke the above rule for each tracked variable
 $(foreach var,$(watch_vars),$(eval $(call depend_on_var,$(var))))
 
-# Host's extended ACLs influence the default permissions of the
+# Host's ACLs influence the default permissions of the
 # files inside the built RPMs. Disabling them for the build directory.
-$(call shell_real_build_only, setfacl -bnR $(PROJECT_ROOT))
+$(call shell_real_build_only, if command -v setfacl &>/dev/null; then setfacl -bnR $(PROJECT_ROOT); fi)

--- a/toolkit/scripts/utils.mk
+++ b/toolkit/scripts/utils.mk
@@ -58,7 +58,7 @@ watch_vars=PACKAGE_BUILD_LIST PACKAGE_REBUILD_LIST PACKAGE_IGNORE_LIST REPO_LIST
 #					$(depend_TOOLCHAIN_ARCHIVE) $(depend_REBUILD_TOOLCHAIN) $(depend_SRPM_PACK_LIST) $(depend_SPECS_DIR) $(depend_MAX_CASCADING_REBUILDS) $(depend_RUN_CHECK) $(depend_TEST_RUN_LIST)
 #					$(depend_TEST_RERUN_LIST) $(depend_TEST_IGNORE_LIST)
 
-.PHONY: variable_depends_on_phony clean-variable_depends_on_phony
+.PHONY: variable_depends_on_phony clean-variable_depends_on_phony no_repo_acl
 clean: clean-variable_depends_on_phony
 
 $(call create_folder,$(STATUS_FLAGS_DIR))
@@ -93,4 +93,5 @@ $(foreach var,$(watch_vars),$(eval $(call depend_on_var,$(var))))
 
 # Host's ACLs influence the default permissions of the
 # files inside the built RPMs. Disabling them for the build directory.
-$(call shell_real_build_only, if command -v setfacl &>/dev/null; then setfacl -bnR $(PROJECT_ROOT); fi)
+no_repo_acl:
+	@setfacl -bnR $(PROJECT_ROOT)

--- a/toolkit/scripts/utils.mk
+++ b/toolkit/scripts/utils.mk
@@ -94,4 +94,4 @@ $(foreach var,$(watch_vars),$(eval $(call depend_on_var,$(var))))
 # Host's ACLs influence the default permissions of the
 # files inside the built RPMs. Disabling them for the repository.
 no_repo_acl:
-	@setfacl -bnR $(PROJECT_ROOT)
+	@setfacl -bnR $(PROJECT_ROOT) &>/dev/null


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

The `setfacl` command was ran every time we used the toolkit, even for cases where it wasn't needed. In some of these scenarios the environment was stripped down and did have (or need) the `acl` package, which cause the toolkit to complain about missing `setfacl`, even though it didn't need it.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Limited the runs of `setfacl` only to scenarios when we're building packages.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local tests.