### PR TITLE
Add custom build mount

### DIFF
--- a/toolkit/scripts/containerized-build.mk
+++ b/toolkit/scripts/containerized-build.mk
@@ -26,6 +26,10 @@ ifneq ($(MOUNTS),)
 containerized_build_args += -mo ${MOUNTS}
 endif
 
+ifneq ($(BUILD_MOUNT),)
+containerized_build_args += -b ${BUILD_MOUNT}
+endif
+
 ifeq ($(ENABLE_REPO),y)
 containerized_build_args += -r
 endif

--- a/toolkit/scripts/containerized-build/create_container_build.sh
+++ b/toolkit/scripts/containerized-build/create_container_build.sh
@@ -23,7 +23,7 @@ print_error() {
 help() {
 echo "
 Usage:
-sudo make containerized-rpmbuild [REPO_PATH=/path/to/CBL-Mariner] [MODE=test|build] [VERSION=1.0|2.0] [MOUNTS= /src/path:/dst/path] [ENABLE_REPO=y] [SPECS_DIR=/path/to/SPECS_DIR/to/use]
+sudo make containerized-rpmbuild [REPO_PATH=/path/to/CBL-Mariner] [MODE=test|build] [VERSION=1.0|2.0] [MOUNTS= /src/path:/dst/path] [ENABLE_REPO=y] [SPECS_DIR=/path/to/SPECS_DIR/to/use] [BUILD_MOUNT=/path/to/build/chroot/mount]
 
 Starts a docker container with the specified version of mariner.
 
@@ -37,7 +37,9 @@ Optional arguments:
     VERISION        1.0 or 2.0. default: "2.0"
     MOUNTS          mount a directory into the container. Should be of the form '/src/dir:/dest/dir'. For multiple mounts, please use ',' as delimiter
                         e.g. MOUNTS=/src/dir1:/dest/dir1,/src/dir2:/dest/dir2
-    ENABLE_REPO:    Set to 'y' to use local RPMs to satisfy package dependencies. default: "n"
+    BUILD_MOUNT     path to folder to create mountpoints for container's BUILD and BUILDROOT directories.
+                        Mountpoints will be ${BUILD_MOUNT}/container-build and ${BUILD_MOUNT}/container-buildroot. default: $REPO_PATH/build
+    ENABLE_REPO:    Set to 'y' to use local RPMs to satisfy package dependencies. default: n
 
 To see help, run 'sudo make containerized-rpmbuild-help'
 "
@@ -86,6 +88,7 @@ while (( "$#")); do
     -v ) version="$2"; shift 2 ;;
     -p ) repo_path="$(realpath $2)"; shift 2 ;;
     -mo ) extra_mounts="$2"; shift 2 ;;
+    -b ) build_mount_dir="$(realpath $2)"; shift 2;;
     -r ) enable_local_repo=true; shift ;;
     -s ) specs_dir="$(realpath $2)"; shift 2;;
     -h ) help; exit 1 ;;
@@ -98,6 +101,8 @@ done
 [[ ! -d "${repo_path}" ]] && { print_error " Directory ${repo_path} does not exist"; exit 1; }
 [[ -z "${mode}" ]] && mode="build"
 [[ -z "${version}" ]] && version="2.0"
+[[ -z "${build_mount_dir}" ]] && build_mount_dir="${repo_path}/build"
+[[ ! -d "${build_mount_dir}" ]] && { print_error " Directory ${build_mount_dir} does not exist"; exit 1; }
 
 cd "${script_dir}"  || { echo "ERROR: Could not change directory to ${script_dir}"; exit 1; }
 
@@ -128,8 +133,8 @@ popd
 # ============ Map chroot mount ============
 if [[ "${mode}" == "build" ]]; then
     # Create a new directory and map it to chroot directory in container
-    build_mount="${repo_path}/build/container-build"
-    buildroot_mount="${repo_path}/build/container-buildroot"
+    build_mount="${build_mount_dir}/container-build"
+    buildroot_mount="${build_mount_dir}/container-buildroot"
     if [ -d "${build_mount}" ]; then rm -Rf ${build_mount}; fi
     if [ -d "${buildroot_mount}" ]; then rm -Rf ${buildroot_mount}; fi
     mkdir ${build_mount}


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Add custom build mount

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Give optional argument to specify a directory to create mountpoints for build chroot in the container
- The build/ from container will be mounted at $BUILD_MOUNT/container-build
- The buildroot/ from container will be mounted at $BUILD_MOUNT/container-buildroot

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build: tested by providing path to a new directory. The script created container-build and container-buildroot folders in the directory, and mounted the build and buildroot folders from container.
