### PR TITLE
Cleaned-up invalid edges from duplicate nodes.

### DIFF
--- a/toolkit/scripts/tools.mk
+++ b/toolkit/scripts/tools.mk
@@ -56,10 +56,11 @@ go_tool_targets = $(foreach target,$(go_tool_list),$(TOOL_BINS_DIR)/$(target))
 # Common files to monitor for all go targets
 go_module_files = $(TOOLS_DIR)/go.mod $(TOOLS_DIR)/go.sum
 go_internal_files = $(shell find $(TOOLS_DIR)/internal/ -type f -name '*.go')
+go_grapher_files = $(shell find $(TOOLS_DIR)/grapher/ -type f -name '*.go')
 go_pkg_files = $(shell find $(TOOLS_DIR)/pkg/ -type f -name '*.go')
 go_imagegen_files = $(shell find $(TOOLS_DIR)/imagegen/ -type f -name '*.go')
 go_scheduler_files = $(shell find $(TOOLS_DIR)/scheduler -type f -name '*.go')
-go_common_files = $(go_module_files) $(go_internal_files) $(go_imagegen_files) $(go_pkg_files) $(go_scheduler_files) $(STATUS_FLAGS_DIR)/got_go_deps.flag $(BUILD_DIR)/tools/internal.test_coverage
+go_common_files = $(go_module_files) $(go_internal_files) $(go_grapher_files) $(go_imagegen_files) $(go_pkg_files) $(go_scheduler_files) $(STATUS_FLAGS_DIR)/got_go_deps.flag $(BUILD_DIR)/tools/internal.test_coverage
 # A report on test coverage for all the go tools
 test_coverage_report=$(TOOL_BINS_DIR)/test_coverage_report.html
 

--- a/toolkit/tools/grapher/grapher.go
+++ b/toolkit/tools/grapher/grapher.go
@@ -137,7 +137,7 @@ func addUnresolvedPackage(g *pkggraph.PkgGraph, pkgVer *pkgjson.PackageVer) (new
 		return
 	}
 
-	logger.Log.Infof("Adding unresolved node %s\n", newRunNode.FriendlyName())
+	logger.Log.Infof("Adding unresolved node %s.", newRunNode.FriendlyName())
 
 	return
 }
@@ -145,7 +145,7 @@ func addUnresolvedPackage(g *pkggraph.PkgGraph, pkgVer *pkgjson.PackageVer) (new
 // addNodesForPackage creates a "Run", "Build", and "Test" node for the package described
 // in the Package structure. Returns pointers to the build and run Nodes
 // created, or an error if one of the nodes could not be created.
-func addNodesForPackage(g *pkggraph.PkgGraph, pkg *pkgjson.Package) (err error) {
+func addNodesForPackage(g *pkggraph.PkgGraph, pkg *pkgjson.Package) (foundDuplicate bool, err error) {
 	var (
 		newRunNode   *pkggraph.PkgNode
 		newBuildNode *pkggraph.PkgNode
@@ -157,34 +157,23 @@ func addNodesForPackage(g *pkggraph.PkgGraph, pkg *pkgjson.Package) (err error) 
 		return
 	}
 
-	skipNewTestNode := false
 	if nodes != nil {
-		logger.Log.Warnf(`Duplicate package name for package %+v read from SRPM "%s" (Previous: %+v)`, pkg.Provides, pkg.SrpmPath, nodes.RunNode)
-		newRunNode = nodes.RunNode
-		newBuildNode = nodes.BuildNode
-		newTestNode = nodes.TestNode
-
-		// Test nodes must be assigned to the build nodes of their true origin and not a duplicate from a potentially different SRPM.
-		skipNewTestNode = true
+		logger.Log.Warnf(`Skipping duplicate package name for package %+v read from SRPM "%s". Original: %+v.`, pkg.Provides, pkg.SrpmPath, nodes.RunNode)
+		foundDuplicate = true
+		return
 	}
 
-	if newRunNode == nil {
-		// Add "Run" node
-		newRunNode, err = g.AddPkgNode(pkg.Provides, pkggraph.StateMeta, pkggraph.TypeLocalRun, pkg.SrpmPath, pkg.RpmPath, pkg.SpecPath, pkg.SourceDir, pkg.Architecture, pkggraph.LocalRepo)
-		if err != nil {
-			return
-		}
-		logger.Log.Debugf("Adding run node %s with id %d\n", newRunNode.FriendlyName(), newRunNode.ID())
+	newRunNode, err = g.AddPkgNode(pkg.Provides, pkggraph.StateMeta, pkggraph.TypeLocalRun, pkg.SrpmPath, pkg.RpmPath, pkg.SpecPath, pkg.SourceDir, pkg.Architecture, pkggraph.LocalRepo)
+	if err != nil {
+		return
 	}
+	logger.Log.Debugf("Adding run node %s with id %d.", newRunNode.FriendlyName(), newRunNode.ID())
 
-	if newBuildNode == nil {
-		// Add "Build" node
-		newBuildNode, err = g.AddPkgNode(pkg.Provides, pkggraph.StateBuild, pkggraph.TypeLocalBuild, pkg.SrpmPath, pkg.RpmPath, pkg.SpecPath, pkg.SourceDir, pkg.Architecture, pkggraph.LocalRepo)
-		if err != nil {
-			return
-		}
-		logger.Log.Debugf("Adding build node %s with id %d\n", newBuildNode.FriendlyName(), newBuildNode.ID())
+	newBuildNode, err = g.AddPkgNode(pkg.Provides, pkggraph.StateBuild, pkggraph.TypeLocalBuild, pkg.SrpmPath, pkg.RpmPath, pkg.SpecPath, pkg.SourceDir, pkg.Architecture, pkggraph.LocalRepo)
+	if err != nil {
+		return
 	}
+	logger.Log.Debugf("Adding build node %s with id %d.", newBuildNode.FriendlyName(), newBuildNode.ID())
 
 	// A "run" node has an implicit dependency on its corresponding "build" node, encode that here.
 	err = g.AddEdge(newRunNode, newBuildNode)
@@ -193,19 +182,16 @@ func addNodesForPackage(g *pkggraph.PkgGraph, pkg *pkgjson.Package) (err error) 
 		return
 	}
 
-	if skipNewTestNode || !pkg.RunTests {
+	if !pkg.RunTests {
 		logger.Log.Debugf("Skipping adding a test node for package %+v", pkg)
 		return
 	}
 
-	if newTestNode == nil {
-		// Add "Test" node
-		newTestNode, err = g.AddPkgNode(pkg.Provides, pkggraph.StateBuild, pkggraph.TypeTest, pkg.SrpmPath, pkggraph.NoRPMPath, pkg.SpecPath, pkg.SourceDir, pkg.Architecture, pkggraph.LocalRepo)
-		if err != nil {
-			return
-		}
-		logger.Log.Debugf("Adding test node %s with id %d\n", newTestNode.FriendlyName(), newTestNode.ID())
+	newTestNode, err = g.AddPkgNode(pkg.Provides, pkggraph.StateBuild, pkggraph.TypeTest, pkg.SrpmPath, pkggraph.NoRPMPath, pkg.SpecPath, pkg.SourceDir, pkg.Architecture, pkggraph.LocalRepo)
+	if err != nil {
+		return
 	}
+	logger.Log.Debugf("Adding test node %s with id %d.", newTestNode.FriendlyName(), newTestNode.ID())
 
 	// A "test" node has a dependency on its corresponding "build" node. This dependency is required
 	// to guarantee we will first check if the build node needs to be built or not before we make
@@ -332,11 +318,16 @@ func populateGraph(graph *pkggraph.PkgGraph, repo *pkgjson.PackageRepo) (err err
 
 	// Scan and add each package we know about
 	logger.Log.Infof("Adding all packages from %s", *input)
+	uniquePackages := make(map[*pkgjson.Package]bool)
 	for _, pkg := range packages {
-		err = addNodesForPackage(graph, pkg)
+		foundDuplicate, err := addNodesForPackage(graph, pkg)
 		if err != nil {
 			logger.Log.Errorf("Failed to add local package %+v", pkg)
 			return err
+		}
+
+		if !foundDuplicate {
+			uniquePackages[pkg] = true
 		}
 	}
 	logger.Log.Infof("\tAdded %d packages", len(packages))
@@ -347,8 +338,7 @@ func populateGraph(graph *pkggraph.PkgGraph, repo *pkgjson.PackageRepo) (err err
 	// Rescan and add all the dependencies
 	logger.Log.Infof("Adding all dependencies from %s", *input)
 	dependenciesAdded := 0
-	for idx := range packages {
-		pkg := packages[idx]
+	for pkg := range uniquePackages {
 		num, err := addPkgDependencies(graph, pkg)
 		if err != nil {
 			logger.Log.Errorf("Failed to add dependency %+v", pkg)

--- a/toolkit/tools/grapher/grapher.go
+++ b/toolkit/tools/grapher/grapher.go
@@ -137,7 +137,7 @@ func addUnresolvedPackage(g *pkggraph.PkgGraph, pkgVer *pkgjson.PackageVer) (new
 		return
 	}
 
-	logger.Log.Infof("Adding unresolved node %s.", newRunNode.FriendlyName())
+	logger.Log.Infof("Adding unresolved node '%s'.", newRunNode.FriendlyName())
 
 	return
 }
@@ -167,13 +167,13 @@ func addNodesForPackage(g *pkggraph.PkgGraph, pkg *pkgjson.Package) (foundDuplic
 	if err != nil {
 		return
 	}
-	logger.Log.Debugf("Adding run node %s with id %d.", newRunNode.FriendlyName(), newRunNode.ID())
+	logger.Log.Debugf("Adding run node '%s' with id %d.", newRunNode.FriendlyName(), newRunNode.ID())
 
 	newBuildNode, err = g.AddPkgNode(pkg.Provides, pkggraph.StateBuild, pkggraph.TypeLocalBuild, pkg.SrpmPath, pkg.RpmPath, pkg.SpecPath, pkg.SourceDir, pkg.Architecture, pkggraph.LocalRepo)
 	if err != nil {
 		return
 	}
-	logger.Log.Debugf("Adding build node %s with id %d.", newBuildNode.FriendlyName(), newBuildNode.ID())
+	logger.Log.Debugf("Adding build node '%s' with id %d.", newBuildNode.FriendlyName(), newBuildNode.ID())
 
 	// A "run" node has an implicit dependency on its corresponding "build" node, encode that here.
 	err = g.AddEdge(newRunNode, newBuildNode)
@@ -191,7 +191,7 @@ func addNodesForPackage(g *pkggraph.PkgGraph, pkg *pkgjson.Package) (foundDuplic
 	if err != nil {
 		return
 	}
-	logger.Log.Debugf("Adding test node %s with id %d.", newTestNode.FriendlyName(), newTestNode.ID())
+	logger.Log.Debugf("Adding test node '%s' with id %d.", newTestNode.FriendlyName(), newTestNode.ID())
 
 	// A "test" node has a dependency on its corresponding "build" node. This dependency is required
 	// to guarantee we will first check if the build node needs to be built or not before we make

--- a/toolkit/tools/grapher/grapher.go
+++ b/toolkit/tools/grapher/grapher.go
@@ -338,10 +338,10 @@ func populateGraph(graph *pkggraph.PkgGraph, repo *pkgjson.PackageRepo) (err err
 	// Rescan and add all the dependencies
 	logger.Log.Infof("Adding all dependencies from %s", *input)
 	dependenciesAdded := 0
-	for pkg := range uniquePackages {
-		num, err := addPkgDependencies(graph, pkg)
+	for uniquePkg := range uniquePackages {
+		num, err := addPkgDependencies(graph, uniquePkg)
 		if err != nil {
-			logger.Log.Errorf("Failed to add dependency %+v", pkg)
+			logger.Log.Errorf("Failed to add dependency %+v", uniquePkg)
 			return err
 		}
 		dependenciesAdded += num


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

Whenever we found multiple packages providing the same capability (for instance `bundled(gnulib)`), we would only add a run-build(-test) set of nodes for it once. Every other package providing the same capability would generate a warning but not a new node. However, when we later generated graph edges to indicate node dependencies, we would read the dependencies for all the packages providing the duplicate capability and attach them to the original node. This caused some packages to be unnecessarily re-built.

Example: `augeas` and `libguestfs` provide `bundled(gnulib)`. We only add a node for the run and build nodes of the `augeas` version of `bundled(gnulib)`. However, later we read the dependencies of the `libguestfs` version of it and connect them with the `augeas` version. If we then built `vim`, we would end up with a rebuild of `libguestfs` (correct, it `BuildRequires` `vim`) and `augeas` (incorrect, the `bundled(gnulib)` node depended on the `BuildRequires` from `libguestfs` despite coming from the SRPM for `augeas`). To add to the confusion, `augeas` would be shown to be built twice: first when nodes belonging to its SRPM were unblocked and later, when all the `BuildRequires` for the remaining `bundled(gnulib)` nodes were satisfied.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Stop adding dependency edges for duplicate package capabilities.
- Removed unnecessary new lines from debug logs.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local package builds.