### PR TITLE
Upgrade libmicrohttpd 0.9.71 -> 0.9.76 to address CVE-2023-27371

### DIFF
--- a/SPECS-EXTENDED/libmicrohttpd/libmicrohttpd.signatures.json
+++ b/SPECS-EXTENDED/libmicrohttpd/libmicrohttpd.signatures.json
@@ -1,5 +1,5 @@
 {
- "Signatures": {
-  "libmicrohttpd-0.9.71.tar.gz": "e8f445e85faf727b89e9f9590daea4473ae00ead38b237cf1eda55172b89b182"
- }
+  "Signatures": {
+    "libmicrohttpd-0.9.76.tar.gz": "f0b1547b5a42a6c0f724e8e1c1cb5ce9c4c35fb495e7d780b9930d35011ceb4c"
+  }
 }

--- a/SPECS-EXTENDED/libmicrohttpd/libmicrohttpd.spec
+++ b/SPECS-EXTENDED/libmicrohttpd/libmicrohttpd.spec
@@ -113,6 +113,7 @@ fi
 * Thu Sep 05 2023 Muhammad Falak R Wani <mwani@microsoft.com> - 0.9.76-1
 - Upgrade to 0.9.76 to address CVE-2023-27371
 - Lint spec
+- License verified
 
 * Mon Nov 01 2021 Muhammad Falak <mwani@microsft.com> - 0.9.71-3
 - Remove epoch

--- a/SPECS-EXTENDED/libmicrohttpd/libmicrohttpd.spec
+++ b/SPECS-EXTENDED/libmicrohttpd/libmicrohttpd.spec
@@ -1,6 +1,6 @@
 Name:           libmicrohttpd
-Version:        0.9.71
-Release:        3%{?dist}
+Version:        0.9.76
+Release:        1%{?dist}
 Summary:        Lightweight library for embedding a webserver in applications
 License:        LGPLv2+
 Vendor:         Microsoft Corporation
@@ -107,6 +107,9 @@ fi
 %doc html
 
 %changelog
+* Thu Sep 05 2023 Muhammad Falak R Wani <mwani@microsoft.com> - 0.9.76-1
+- Upgrade to 0.9.76 to address CVE-2023-27371
+
 * Mon Nov 01 2021 Muhammad Falak <mwani@microsft.com> - 0.9.71-3
 - Remove epoch
 

--- a/SPECS-EXTENDED/libmicrohttpd/libmicrohttpd.spec
+++ b/SPECS-EXTENDED/libmicrohttpd/libmicrohttpd.spec
@@ -1,18 +1,21 @@
+Summary:        Lightweight library for embedding a webserver in applications
 Name:           libmicrohttpd
 Version:        0.9.76
 Release:        1%{?dist}
-Summary:        Lightweight library for embedding a webserver in applications
 License:        LGPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
-URL:            http://www.gnu.org/software/libmicrohttpd/
+URL:            https://www.gnu.org/software/libmicrohttpd/
 Source0:        https://ftp.gnu.org/gnu/libmicrohttpd/%{name}-%{version}.tar.gz
 Patch0:         gnutls-utilize-system-crypto-policy.patch
-
-BuildRequires:  autoconf, automake, libtool, gettext-devel
-BuildRequires:  texinfo
+BuildRequires:  autoconf
+BuildRequires:  automake
+BuildRequires:  doxygen
+BuildRequires:  gettext-devel
 BuildRequires:  gnutls-devel
-BuildRequires:  doxygen graphviz
+BuildRequires:  graphviz
+BuildRequires:  libtool
+BuildRequires:  texinfo
 Requires(post): info
 Requires(preun): info
 
@@ -66,7 +69,7 @@ make -C doc/doxygen full
 %install
 %make_install
 
-rm -f %{buildroot}%{_libdir}/*.la
+find %{buildroot} -type f -name "*.la" -delete -print
 rm -f %{buildroot}%{_infodir}/dir
 rm -f %{buildroot}%{_bindir}/demo
 
@@ -78,13 +81,13 @@ install -m 644 doc/examples/*.c examples
 cp -R doc/doxygen/html html
 
 %post doc
-/usr/bin/install-info %{_infodir}/libmicrohttpd.info.gz %{_infodir}/dir || :
-/usr/bin/install-info %{_infodir}/libmicrohttpd-tutorial.info.gz %{_infodir}/dir || :
+%{_bindir}/install-info %{_infodir}/libmicrohttpd.info.gz %{_infodir}/dir || :
+%{_bindir}/install-info %{_infodir}/libmicrohttpd-tutorial.info.gz %{_infodir}/dir || :
 
 %preun doc
 if [ $1 = 0 ] ; then
-/usr/bin/install-info --delete %{_infodir}/libmicrohttpd.info.gz %{_infodir}/dir || :
-/usr/bin/install-info --delete %{_infodir}/libmicrohttpd-tutorial.info.gz %{_infodir}/dir || :
+%{_bindir}/install-info --delete %{_infodir}/libmicrohttpd.info.gz %{_infodir}/dir || :
+%{_bindir}/install-info --delete %{_infodir}/libmicrohttpd-tutorial.info.gz %{_infodir}/dir || :
 fi
 
 %files
@@ -109,6 +112,7 @@ fi
 %changelog
 * Thu Sep 05 2023 Muhammad Falak R Wani <mwani@microsoft.com> - 0.9.76-1
 - Upgrade to 0.9.76 to address CVE-2023-27371
+- Lint spec
 
 * Mon Nov 01 2021 Muhammad Falak <mwani@microsft.com> - 0.9.71-3
 - Remove epoch
@@ -362,4 +366,3 @@ fi
 
 * Tue Aug 5 2008 Erik van Pienbroek <info@nntpgrab.nl> - 0.3.1-1
 - Initial release
-

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -10031,8 +10031,8 @@
         "type": "other",
         "other": {
           "name": "libmicrohttpd",
-          "version": "0.9.71",
-          "downloadUrl": "https://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.71.tar.gz"
+          "version": "0.9.76",
+          "downloadUrl": "https://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.76.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Upgrade libmicrohttpd 0.9.71 -> 0.9.76 to address CVE-2023-27371

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Upgrade libmicrohttpd 0.9.71 -> 0.9.76 to address CVE-2023-27371
- libmicrohttpd: lint spec

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- NA

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2023-27371

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: [PR-6161](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=417589&view=results)
- Local Build w/ & w/o `RUN_CHECK=y`
