### PR TITLE
Upgrade opencryptoki 3.13.0 -> 3.17.0 to address CVE-2021-3798

### DIFF
--- a/SPECS-EXTENDED/opencryptoki/opencryptoki.signatures.json
+++ b/SPECS-EXTENDED/opencryptoki/opencryptoki.signatures.json
@@ -1,6 +1,6 @@
 {
- "Signatures": {
-  "opencryptoki-3.13.0.tar.gz": "af2983bb9d8059bbad604c562cb7d78e59f999f597cff0a02ab7763064301f39",
-  "opencryptoki.module": "d335359abeb5d4d1e684841f055ac99b98e8fcc77578e480ef86ef2621ab363d"
- }
+  "Signatures": {
+    "opencryptoki.module": "d335359abeb5d4d1e684841f055ac99b98e8fcc77578e480ef86ef2621ab363d",
+    "opencryptoki-3.17.0.tar.gz": "785596925738855b33b29bdff2399f613b892e7c6000d9ffbf79fe32c2aeaeee"
+  }
 }

--- a/SPECS-EXTENDED/opencryptoki/opencryptoki.spec
+++ b/SPECS-EXTENDED/opencryptoki/opencryptoki.spec
@@ -2,8 +2,8 @@ Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Name:			opencryptoki
 Summary:		Implementation of the PKCS#11 (Cryptoki) specification v2.11
-Version:		3.13.0
-Release:		2%{?dist}
+Version:		3.17.0
+Release:		1%{?dist}
 License:		CPL
 URL:			https://github.com/opencryptoki/opencryptoki
 Source0:		https://github.com/opencryptoki/%{name}/archive/v%{version}/%{name}-%{version}.tar.gz
@@ -306,6 +306,9 @@ fi
 
 
 %changelog
+* Mon Sep 04 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 3.17.0-1
+- Auto-upgrade to 3.17.0 - to address CVE-2021-3798
+
 * Thu Mar 18 2021 Henry Li <lihl@microsoft.com> - 3.13.0-2
 - Initial CBL-Mariner import from Fedora 32 (license: MIT).
 - Remove libitm-devel from build requirement because gcc already includes the necessary binaries it covers

--- a/SPECS-EXTENDED/opencryptoki/opencryptoki.spec
+++ b/SPECS-EXTENDED/opencryptoki/opencryptoki.spec
@@ -304,6 +304,7 @@ fi
 * Mon Sep 04 2023 Muhammad Falak <mwani@microsoft.com> - 3.17.0-1
 - Upgrade version to address CVE-2021-3798
 - Lint spec
+- License verified
 
 * Thu Mar 18 2021 Henry Li <lihl@microsoft.com> - 3.13.0-2
 - Initial CBL-Mariner import from Fedora 32 (license: MIT).

--- a/SPECS-EXTENDED/opencryptoki/opencryptoki.spec
+++ b/SPECS-EXTENDED/opencryptoki/opencryptoki.spec
@@ -221,8 +221,13 @@ fi
 %{_unitdir}/pkcsslotd.service
 %{_sbindir}/pkcsconf
 %{_sbindir}/pkcsslotd
+%{_sbindir}/p11sak
+%{_sbindir}/pkcstok_migrate
 %{_mandir}/man1/pkcsconf.1*
+%{_mandir}/man1/p11sak.1*
+%{_mandir}/man1/pkcstok_migrate.1*
 %{_mandir}/man5/%{name}.conf.5*
+%{_mandir}/man5/p11sak_defined_attrs.conf.5*
 %{_mandir}/man7/%{name}.7*
 %{_mandir}/man8/pkcsslotd.8*
 %{_libdir}/opencryptoki/methods

--- a/SPECS-EXTENDED/opencryptoki/opencryptoki.spec
+++ b/SPECS-EXTENDED/opencryptoki/opencryptoki.spec
@@ -1,41 +1,38 @@
+Summary:        Implementation of the PKCS#11 (Cryptoki) specification v2.11
+Name:           opencryptoki
+Version:        3.17.0
+Release:        1%{?dist}
+License:        CPL
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
-Name:			opencryptoki
-Summary:		Implementation of the PKCS#11 (Cryptoki) specification v2.11
-Version:		3.17.0
-Release:		1%{?dist}
-License:		CPL
-URL:			https://github.com/opencryptoki/opencryptoki
-Source0:		https://github.com/opencryptoki/%{name}/archive/v%{version}/%{name}-%{version}.tar.gz
-Source1:		opencryptoki.module
+URL:            https://github.com/opencryptoki/opencryptoki
+Source0:        https://github.com/opencryptoki/%{name}/archive/v%{version}/%{name}-%{version}.tar.gz
+Source1:        opencryptoki.module
 # https://bugzilla.redhat.com/show_bug.cgi?id=732756
-Patch0:			opencryptoki-3.11.0-group.patch
-
+Patch0:         opencryptoki-3.11.0-group.patch
 # bz#1373833, change tmpfiles snippets from /var/lock/* to /run/lock/*
-Patch1:			opencryptoki-3.11.0-lockdir.patch
-
-# Use --no-undefined to debug missing symbols
-#Patch100:			%%{name}-3.2-no-undefined.patch
-
-Requires(pre):		coreutils
-BuildRequires:		gcc
-BuildRequires:		openssl-devel
-BuildRequires:		trousers-devel
-BuildRequires:		openldap-devel
-BuildRequires:		autoconf automake libtool
-BuildRequires:		bison flex
-BuildRequires:		systemd
-BuildRequires:		expect
+Patch1:         opencryptoki-3.11.0-lockdir.patch
+BuildRequires:  autoconf
+BuildRequires:  automake
+BuildRequires:  bison
+BuildRequires:  expect
+BuildRequires:  flex
+BuildRequires:  gcc
+BuildRequires:  libtool
+BuildRequires:  openldap-devel
+BuildRequires:  openssl-devel
+BuildRequires:  systemd
+BuildRequires:  trousers-devel
+Requires:       %{name}(token)
+Requires:       %{name}-libs%{?_isa} = %{version}-%{release}
+Requires(post): systemd
+Requires(postun): systemd
+Requires(pre):  %{name}-libs%{?_isa} = %{version}-%{release}
+Requires(pre):  coreutils
+Requires(preun): systemd
 %ifarch s390 s390x
-BuildRequires:		libica-devel >= 2.3
+BuildRequires:  libica-devel >= 2.3
 %endif
-Requires(pre):		%{name}-libs%{?_isa} = %{version}-%{release}
-Requires:		%{name}-libs%{?_isa} = %{version}-%{release}
-Requires:		%{name}(token)
-Requires(post):		systemd
-Requires(preun):	systemd
-Requires(postun):	systemd
-
 
 %description
 Opencryptoki implements the PKCS#11 specification v2.11 for a set of
@@ -45,10 +42,9 @@ token implementation that can be used without any cryptographic
 hardware.
 This package contains the Slot Daemon (pkcsslotd) and general utilities.
 
-
 %package libs
-Summary:		The run-time libraries for opencryptoki package
-Requires(pre):	shadow-utils
+Summary:        The run-time libraries for opencryptoki package
+Requires(pre):  shadow-utils
 
 %description libs
 Opencryptoki implements the PKCS#11 specification v2.11 for a set of
@@ -60,21 +56,19 @@ This package contains the PKCS#11 library implementation, and requires
 at least one token implementation (packaged separately) to be fully
 functional.
 
-
 %package devel
-Summary:		Development files for openCryptoki
-Requires:		%{name}-libs%{?_isa} = %{version}-%{release}
+Summary:        Development files for openCryptoki
+Requires:       %{name}-libs%{?_isa} = %{version}-%{release}
 
 %description devel
 This package contains the development header files for building
 opencryptoki and PKCS#11 based applications
 
-
 %package swtok
-Summary:		The software token implementation for opencryptoki
-Requires(pre):		%{name}-libs%{?_isa} = %{version}-%{release}
-Requires:		%{name}-libs%{?_isa} = %{version}-%{release}
-Provides:		%{name}(token)
+Summary:        The software token implementation for opencryptoki
+Requires:       %{name}-libs%{?_isa} = %{version}-%{release}
+Requires(pre):  %{name}-libs%{?_isa} = %{version}-%{release}
+Provides:       %{name}(token)
 
 %description swtok
 Opencryptoki implements the PKCS#11 specification v2.11 for a set of
@@ -85,12 +79,11 @@ hardware.
 This package brings the software token implementation to use opencryptoki
 without any specific cryptographic hardware.
 
-
 %package tpmtok
-Summary:		Trusted Platform Module (TPM) device support for opencryptoki
-Requires(pre):		%{name}-libs%{?_isa} = %{version}-%{release}
-Requires:		%{name}-libs%{?_isa} = %{version}-%{release}
-Provides:		%{name}(token)
+Summary:        Trusted Platform Module (TPM) device support for opencryptoki
+Requires:       %{name}-libs%{?_isa} = %{version}-%{release}
+Requires(pre):  %{name}-libs%{?_isa} = %{version}-%{release}
+Provides:       %{name}(token)
 
 %description tpmtok
 Opencryptoki implements the PKCS#11 specification v2.11 for a set of
@@ -101,12 +94,11 @@ hardware.
 This package brings the necessary libraries and files to support
 Trusted Platform Module (TPM) devices in the opencryptoki stack.
 
-
 %package icsftok
-Summary:		ICSF token support for opencryptoki
-Requires(pre):		%{name}-libs%{?_isa} = %{version}-%{release}
-Requires:		%{name}-libs%{?_isa} = %{version}-%{release}
-Provides:		%{name}(token)
+Summary:        ICSF token support for opencryptoki
+Requires:       %{name}-libs%{?_isa} = %{version}-%{release}
+Requires(pre):  %{name}-libs%{?_isa} = %{version}-%{release}
+Provides:       %{name}(token)
 
 %description icsftok
 Opencryptoki implements the PKCS#11 specification v2.11 for a set of
@@ -117,13 +109,12 @@ hardware.
 This package brings the necessary libraries and files to support
 ICSF token in the opencryptoki stack.
 
-
 %ifarch s390 s390x
 %package icatok
-Summary:		ICA cryptographic devices (clear-key) support for opencryptoki
-Requires(pre):		%{name}-libs%{?_isa} = %{version}-%{release}
-Requires:		%{name}-libs%{?_isa} = %{version}-%{release}
-Provides:		%{name}(token)
+Summary:        ICA cryptographic devices (clear-key) support for opencryptoki
+Requires:       %{name}-libs%{?_isa} = %{version}-%{release}
+Requires(pre):  %{name}-libs%{?_isa} = %{version}-%{release}
+Provides:       %{name}(token)
 
 %description icatok
 Opencryptoki implements the PKCS#11 specification v2.11 for a set of
@@ -137,10 +128,10 @@ cryptographic hardware such as IBM 4764 or 4765 that uses the
 "accelerator" or "clear-key" path.
 
 %package ccatok
-Summary:		CCA cryptographic devices (secure-key) support for opencryptoki
-Requires(pre):		%{name}-libs%{?_isa} = %{version}-%{release}
-Requires:		%{name}-libs%{?_isa} = %{version}-%{release}
-Provides:		%{name}(token)
+Summary:        CCA cryptographic devices (secure-key) support for opencryptoki
+Requires:       %{name}-libs%{?_isa} = %{version}-%{release}
+Requires(pre):  %{name}-libs%{?_isa} = %{version}-%{release}
+Provides:       %{name}(token)
 
 %description ccatok
 Opencryptoki implements the PKCS#11 specification v2.11 for a set of
@@ -154,10 +145,10 @@ cryptographic hardware such as IBM 4764 or 4765 that uses the
 "co-processor" or "secure-key" path.
 
 %package ep11tok
-Summary:		CCA cryptographic devices (secure-key) support for opencryptoki
-Requires(pre):		%{name}-libs%{?_isa} = %{version}-%{release}
-Requires:		%{name}-libs%{?_isa} = %{version}-%{release}
-Provides:		%{name}(token)
+Summary:        CCA cryptographic devices (secure-key) support for opencryptoki
+Requires:       %{name}-libs%{?_isa} = %{version}-%{release}
+Requires(pre):  %{name}-libs%{?_isa} = %{version}-%{release}
+Provides:       %{name}(token)
 
 %description ep11tok
 Opencryptoki implements the PKCS#11 specification v2.11 for a set of
@@ -190,8 +181,8 @@ make %{?_smp_mflags} CHGRP=/bin/true
 
 
 %install
-make install DESTDIR=$RPM_BUILD_ROOT CHGRP=/bin/true
-install -Dpm 644 %{SOURCE1} $RPM_BUILD_ROOT%{_datadir}/p11-kit/modules/opencryptoki.module
+make install DESTDIR=%{buildroot} CHGRP=/bin/true
+install -Dpm 644 %{SOURCE1} %{buildroot}%{_datadir}/p11-kit/modules/opencryptoki.module
 
 
 %pre libs
@@ -209,7 +200,6 @@ fi
 
 %postun
 %systemd_postun_with_restart pkcsslotd.service
-
 
 %files
 %doc ChangeLog FAQ README.md
@@ -242,7 +232,7 @@ fi
 %{_sysconfdir}/ld.so.conf.d/*
 # Unversioned .so symlinks usually belong to -devel packages, but opencryptoki
 # needs them in the main package, because:
-#   documentation suggests that programs should dlopen "PKCS11_API.so".
+# documentation suggests that programs should dlopen "PKCS11_API.so".
 %dir %{_libdir}/opencryptoki
 %{_libdir}/opencryptoki/libopencryptoki.*
 %{_libdir}/opencryptoki/PKCS11_API.so
@@ -313,6 +303,7 @@ fi
 %changelog
 * Mon Sep 04 2023 Muhammad Falak <mwani@microsoft.com> - 3.17.0-1
 - Upgrade version to address CVE-2021-3798
+- Lint spec
 
 * Thu Mar 18 2021 Henry Li <lihl@microsoft.com> - 3.13.0-2
 - Initial CBL-Mariner import from Fedora 32 (license: MIT).

--- a/SPECS-EXTENDED/opencryptoki/opencryptoki.spec
+++ b/SPECS-EXTENDED/opencryptoki/opencryptoki.spec
@@ -311,8 +311,8 @@ fi
 
 
 %changelog
-* Mon Sep 04 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 3.17.0-1
-- Auto-upgrade to 3.17.0 - to address CVE-2021-3798
+* Mon Sep 04 2023 Muhammad Falak <mwani@microsoft.com> - 3.17.0-1
+- Upgrade version to address CVE-2021-3798
 
 * Thu Mar 18 2021 Henry Li <lihl@microsoft.com> - 3.13.0-2
 - Initial CBL-Mariner import from Fedora 32 (license: MIT).

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -15244,8 +15244,8 @@
         "type": "other",
         "other": {
           "name": "opencryptoki",
-          "version": "3.13.0",
-          "downloadUrl": "https://github.com/opencryptoki/opencryptoki/archive/v3.13.0/opencryptoki-3.13.0.tar.gz"
+          "version": "3.17.0",
+          "downloadUrl": "https://github.com/opencryptoki/opencryptoki/archive/v3.17.0/opencryptoki-3.17.0.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Upgrade opencryptoki 3.13.0 -> 3.17.0 to address CVE-2021-3798

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- opencryptoki: lint spec

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- NA

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2021-3798

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: [PR-6163](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=417649&view=results)
- Local build with Dependents: `opencryptoki opendnssec openssl-ibmpkcs11 tpm-tools`
