### PR TITLE
User/bfjelds/buildah CVE 2022 2990

### DIFF
--- a/SPECS-EXTENDED/buildah/CVE-2022-2990.patch
+++ b/SPECS-EXTENDED/buildah/CVE-2022-2990.patch
@@ -1,0 +1,90 @@
+From 9934b17365083ce966b44c5ce3c7e052f516e255 Mon Sep 17 00:00:00 2001
+From: Aditya R <arajan@redhat.com>
+Date: Wed, 24 Aug 2022 08:42:23 +0530
+Subject: [PATCH] run: add container gid to additional groups
+
+When container is created with specific uid and gid also add container
+gid to supplementary/additional group.
+
+Signed-off-by: Aditya R <arajan@redhat.com>
+---
+ run_common.go                            |  1 +
+ tests/bud.bats                           | 16 ++++++++++++++++
+ tests/bud/supplemental-groups/Dockerfile |  3 +++
+ tests/run.bats                           | 14 ++++++++++++++
+ 4 files changed, 34 insertions(+)
+ create mode 100644 tests/bud/supplemental-groups/Dockerfile
+
+diff --git a/run_common.go b/run_common.go
+index 2054c56527..f5a5ec8505 100644
+--- a/run_common.go
++++ b/run_common.go
+@@ -262,6 +262,7 @@ func (b *Builder) configureUIDGID(g *generate.Generator, mountPoint string, opti
+ 	}
+ 	g.SetProcessUID(user.UID)
+ 	g.SetProcessGID(user.GID)
++	g.AddProcessAdditionalGid(user.GID)
+ 	for _, gid := range user.AdditionalGids {
+ 		g.AddProcessAdditionalGid(gid)
+ 	}
+diff --git a/tests/bud.bats b/tests/bud.bats
+index a37e418b41..07bdf45cac 100644
+--- a/tests/bud.bats
++++ b/tests/bud.bats
+@@ -366,6 +366,22 @@ _EOF
+   expect_output --substring "invalid response status"
+ }
+ 
++@test "build test has gid in supplemental groups" {
++  _prefetch alpine
++  run_buildah build $WITH_POLICY_JSON -t source -f $BUDFILES/supplemental-groups/Dockerfile
++  # gid 1000 must be in supplemental groups
++  expect_output --substring "Groups:	1000"
++}
++
++@test "build test if supplemental groups has gid with --isolation chroot" {
++  test -z "${BUILDAH_ISOLATION}" || skip "BUILDAH_ISOLATION=${BUILDAH_ISOLATION} overrides --isolation"
++
++  _prefetch alpine
++  run_buildah build --isolation chroot $WITH_POLICY_JSON -t source -f $BUDFILES/supplemental-groups/Dockerfile
++  # gid 1000 must be in supplemental groups
++  expect_output --substring "Groups:	1000"
++}
++
+ # Test skipping images with FROM
+ @test "build-test skipping unwanted stages with FROM" {
+   mkdir -p ${TEST_SCRATCH_DIR}/bud/platform
+diff --git a/tests/bud/supplemental-groups/Dockerfile b/tests/bud/supplemental-groups/Dockerfile
+new file mode 100644
+index 0000000000..462d9ea7a4
+--- /dev/null
++++ b/tests/bud/supplemental-groups/Dockerfile
+@@ -0,0 +1,3 @@
++FROM alpine
++USER 1000:1000
++RUN cat /proc/$$/status
+diff --git a/tests/run.bats b/tests/run.bats
+index 2e8836c470..e34091fcbe 100644
+--- a/tests/run.bats
++++ b/tests/run.bats
+@@ -349,6 +349,20 @@ function configure_and_check_user() {
+   expect_output "888:888"
+ }
+ 
++@test "run --user and verify gid in supplemental groups" {
++  skip_if_no_runtime
++
++  # Create the container.
++  _prefetch alpine
++  run_buildah from $WITH_POLICY_JSON alpine
++  ctr="$output"
++
++  # Run with uid:gid 1000:1000 and verify if gid is present in additional groups
++  run_buildah run --user 1000:1000 "$ctr" cat /proc/self/status
++  # gid 1000 must be in additional/supplemental groups
++  expect_output --substring "Groups:	1000 "
++}
++
+ @test "run --workingdir" {
+ 	skip_if_no_runtime
+ 

--- a/SPECS-EXTENDED/buildah/CVE-2022-2990.patch
+++ b/SPECS-EXTENDED/buildah/CVE-2022-2990.patch
@@ -1,4 +1,4 @@
-From 9934b17365083ce966b44c5ce3c7e052f516e255 Mon Sep 17 00:00:00 2001
+From 7b961bf8391a7692468c46175ab30e03e8d777b5 Mon Sep 17 00:00:00 2001
 From: Aditya R <arajan@redhat.com>
 Date: Wed, 24 Aug 2022 08:42:23 +0530
 Subject: [PATCH] run: add container gid to additional groups
@@ -7,19 +7,20 @@ When container is created with specific uid and gid also add container
 gid to supplementary/additional group.
 
 Signed-off-by: Aditya R <arajan@redhat.com>
+Signed-off-by: Nalin Dahyabhai <nalin@redhat.com>
 ---
- run_common.go                            |  1 +
- tests/bud.bats                           | 16 ++++++++++++++++
+ run_linux.go                             |  1 +
+ tests/bud.bats                           | 16 ++++++++++++
  tests/bud/supplemental-groups/Dockerfile |  3 +++
- tests/run.bats                           | 14 ++++++++++++++
- 4 files changed, 34 insertions(+)
+ tests/run.bats                           | 33 ++++++++++++++++++++++++
+ 4 files changed, 53 insertions(+)
  create mode 100644 tests/bud/supplemental-groups/Dockerfile
 
-diff --git a/run_common.go b/run_common.go
-index 2054c56527..f5a5ec8505 100644
---- a/run_common.go
-+++ b/run_common.go
-@@ -262,6 +262,7 @@ func (b *Builder) configureUIDGID(g *generate.Generator, mountPoint string, opti
+diff --git a/run_linux.go b/run_linux.go
+index d907941ed..452d62a3c 100644
+--- a/run_linux.go
++++ b/run_linux.go
+@@ -1942,6 +1942,7 @@ func (b *Builder) configureUIDGID(g *generate.Generator, mountPoint string, opti
  	}
  	g.SetProcessUID(user.UID)
  	g.SetProcessGID(user.GID)
@@ -28,16 +29,16 @@ index 2054c56527..f5a5ec8505 100644
  		g.AddProcessAdditionalGid(gid)
  	}
 diff --git a/tests/bud.bats b/tests/bud.bats
-index a37e418b41..07bdf45cac 100644
+index ff9db0609..40b847e10 100644
 --- a/tests/bud.bats
 +++ b/tests/bud.bats
-@@ -366,6 +366,22 @@ _EOF
-   expect_output --substring "invalid response status"
+@@ -108,6 +108,22 @@ symlink(subdir)"
+   check_options_flag_err "--userns=cnt1"
  }
  
 +@test "build test has gid in supplemental groups" {
 +  _prefetch alpine
-+  run_buildah build $WITH_POLICY_JSON -t source -f $BUDFILES/supplemental-groups/Dockerfile
++  run_buildah build $WITH_POLICY_JSON -t source -f ${TESTSDIR}/bud/supplemental-groups/Dockerfile
 +  # gid 1000 must be in supplemental groups
 +  expect_output --substring "Groups:	1000"
 +}
@@ -46,17 +47,17 @@ index a37e418b41..07bdf45cac 100644
 +  test -z "${BUILDAH_ISOLATION}" || skip "BUILDAH_ISOLATION=${BUILDAH_ISOLATION} overrides --isolation"
 +
 +  _prefetch alpine
-+  run_buildah build --isolation chroot $WITH_POLICY_JSON -t source -f $BUDFILES/supplemental-groups/Dockerfile
++  run_buildah build --isolation chroot $WITH_POLICY_JSON -t source -f ${TESTSDIR}/bud/supplemental-groups/Dockerfile
 +  # gid 1000 must be in supplemental groups
 +  expect_output --substring "Groups:	1000"
 +}
 +
- # Test skipping images with FROM
- @test "build-test skipping unwanted stages with FROM" {
-   mkdir -p ${TEST_SCRATCH_DIR}/bud/platform
+ @test "bud with --layers and --no-cache flags" {
+   _prefetch alpine
+   cp -a ${TESTSDIR}/bud/use-layers ${TESTDIR}/use-layers
 diff --git a/tests/bud/supplemental-groups/Dockerfile b/tests/bud/supplemental-groups/Dockerfile
 new file mode 100644
-index 0000000000..462d9ea7a4
+index 000000000..462d9ea7a
 --- /dev/null
 +++ b/tests/bud/supplemental-groups/Dockerfile
 @@ -0,0 +1,3 @@
@@ -64,13 +65,32 @@ index 0000000000..462d9ea7a4
 +USER 1000:1000
 +RUN cat /proc/$$/status
 diff --git a/tests/run.bats b/tests/run.bats
-index 2e8836c470..e34091fcbe 100644
+index c22a671dc..ba26c350f 100644
 --- a/tests/run.bats
 +++ b/tests/run.bats
-@@ -349,6 +349,20 @@ function configure_and_check_user() {
-   expect_output "888:888"
+@@ -252,6 +252,39 @@ function configure_and_check_user() {
+ 	run_buildah run -v ${TESTDIR}/was-empty/testfile:/var/different-multi-level/subdirectory/testfile        $cid touch /var/different-multi-level/subdirectory/testfile
  }
  
++@test "run --volume with U flag" {
++  skip_if_no_runtime
++
++  # Create source volume.
++  mkdir ${TESTDIR}/testdata
++
++  # Create the container.
++  _prefetch alpine
++  run_buildah from --signature-policy ${TESTSDIR}/policy.json alpine
++  ctr="$output"
++
++  # Test user can create file in the mounted volume.
++  run_buildah run --user 888:888 --volume ${TESTDIR}/testdata:/mnt:z,U "$ctr" touch /mnt/testfile1.txt
++
++  # Test created file has correct UID and GID ownership.
++  run_buildah run --user 888:888 --volume ${TESTDIR}/testdata:/mnt:z,U "$ctr" stat -c "%u:%g" /mnt/testfile1.txt
++  expect_output "888:888"
++}
++
 +@test "run --user and verify gid in supplemental groups" {
 +  skip_if_no_runtime
 +
@@ -85,6 +105,9 @@ index 2e8836c470..e34091fcbe 100644
 +  expect_output --substring "Groups:	1000 "
 +}
 +
- @test "run --workingdir" {
+ @test "run --mount" {
  	skip_if_no_runtime
  
+-- 
+2.17.1
+

--- a/SPECS-EXTENDED/buildah/buildah.spec
+++ b/SPECS-EXTENDED/buildah/buildah.spec
@@ -21,7 +21,7 @@
 Summary:        A command line tool used for creating OCI Images
 Name:           buildah
 Version:        1.18.0
-Release:        16%{?dist}
+Release:        17%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner

--- a/SPECS-EXTENDED/buildah/buildah.spec
+++ b/SPECS-EXTENDED/buildah/buildah.spec
@@ -123,10 +123,13 @@ cp imgtype %{buildroot}/%{_bindir}/%{name}-imgtype
 %{_datadir}/%{name}/test
 
 %changelog
+* Tue Sep 05 2023 Brian Fjeldstad <bfjelds@microsoft.com> - 1.18.0-17
+- Address CVE-2022-2990
+
 * Mon Aug 07 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 1.18.0-16
 - Bump release to rebuild with go 1.19.12
 
-* Wed Jul 14 2023 Andrew Phelps <anphel@microsoft.com> - 1.18.0-15
+* Fri Jul 14 2023 Andrew Phelps <anphel@microsoft.com> - 1.18.0-15
 - Bump release to rebuild against glibc 2.35-4
 
 * Thu Jul 13 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 1.18.0-14

--- a/SPECS-EXTENDED/buildah/buildah.spec
+++ b/SPECS-EXTENDED/buildah/buildah.spec
@@ -27,6 +27,7 @@ Vendor:         Microsoft Corporation
 Distribution:   Mariner
 URL:            https://%{name}.io
 Source:         %{download_url}#/%{name}-%{version}.tar.gz
+Patch0:         CVE-2022-2990.patch
 BuildRequires:  btrfs-progs-devel
 BuildRequires:  device-mapper-devel
 BuildRequires:  git
@@ -73,7 +74,7 @@ Requires:       podman
 This package contains system tests for %{name}
 
 %prep
-%autosetup -Sgit -n %{name}-%{built_tag_strip}
+%autosetup -Sgit -n %{name}-%{built_tag_strip} -p1
 sed -i 's/GOMD2MAN =/GOMD2MAN ?=/' docs/Makefile
 sed -i '/docs install/d' Makefile
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
CVE-2022-2990 Detail
 
An incorrect handling of the supplementary groups in the Buildah container engine might lead to the sensitive information disclosure or possible data modification if an attacker has direct access to the affected container where supplementary groups are used to set access permissions and is able to execute a binary code in that container.

###### Change Log  <!-- REQUIRED -->
- https://nvd.nist.gov/vuln/detail/CVE-2022-2990

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Associated issues  <!-- optional -->

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2022-2990

###### Test Methodology
- https://dev.azure.com/mariner-org/mariner/_build/results?buildId=417914&view=logs&j=7909073b-e471-53c1-2c44-627e2efc0564&t=7909073b-e471-53c1-2c44-627e2efc0564
