### PR TITLE
Switched the PR check pipeline to grab agent pools from a shared group.

### DIFF
--- a/.pipelines/prchecks/PackageBuildPRCheck.yml
+++ b/.pipelines/prchecks/PackageBuildPRCheck.yml
@@ -13,11 +13,11 @@ parameters:
     type: object
     default:
       - name: "AMD64"
-        agentPool: "$(DEV_AMD64_Managed)"
+        agentPool: "$(DEV_AMD64_Managed)" # Pool defined inside the "Agent pools (DEV)" variable group.
         rawToolchainCacheURL: "$(rawToolchainCacheURL_AMD64)"
         rawToolchainExpectedHash: "f56df34b90915c93f772d3961bf5e9eeb8c1233db43dd92070214e4ce6b72894"
       - name: "ARM64"
-        agentPool: "$(DEV_ARM64_Managed)"
+        agentPool: "$(DEV_ARM64_Managed)" # Pool defined inside the "Agent pools (DEV)" variable group.
         rawToolchainCacheURL: "$(rawToolchainCacheURL_ARM64)"
         rawToolchainExpectedHash: "65de43b3bdcfdaac71df1f11fd1f830a8109b1eb9d7cb6cbc2e2d0e929d0ef76"
 

--- a/.pipelines/prchecks/PackageBuildPRCheck.yml
+++ b/.pipelines/prchecks/PackageBuildPRCheck.yml
@@ -5,8 +5,6 @@
 # the pipeline requires defining the following variables outside of the YAML:
 # - rawToolchainCacheURL_AMD64
 # - rawToolchainCacheURL_ARM64
-# - agentPool_AMD64
-# - agentPool_ARM64
 
 trigger: none
 
@@ -15,11 +13,11 @@ parameters:
     type: object
     default:
       - name: "AMD64"
-        agentPool: "$(agentPool_AMD64)"
+        agentPool: "$(DEV_AMD64_Managed)"
         rawToolchainCacheURL: "$(rawToolchainCacheURL_AMD64)"
         rawToolchainExpectedHash: "f56df34b90915c93f772d3961bf5e9eeb8c1233db43dd92070214e4ce6b72894"
       - name: "ARM64"
-        agentPool: "$(agentPool_ARM64)"
+        agentPool: "$(DEV_ARM64_Managed)"
         rawToolchainCacheURL: "$(rawToolchainCacheURL_ARM64)"
         rawToolchainExpectedHash: "65de43b3bdcfdaac71df1f11fd1f830a8109b1eb9d7cb6cbc2e2d0e929d0ef76"
 
@@ -31,8 +29,11 @@ resources:
       ref: refs/heads/main
 
 variables:
-  rpmsArtifactNameBase: RPMs
-  toolchainArtifactNameBase: Toolchain
+  - group: "Agent pools"
+  - name: rpmsArtifactNameBase
+    value: RPMs
+  - name: toolchainArtifactNameBase
+    value: Toolchain
 
 extends:
   template: v2/OneBranch.NonOfficial.CrossPlat.yml@templates

--- a/.pipelines/prchecks/PackageBuildPRCheck.yml
+++ b/.pipelines/prchecks/PackageBuildPRCheck.yml
@@ -29,7 +29,7 @@ resources:
       ref: refs/heads/main
 
 variables:
-  - group: "Agent pools"
+  - group: "Agent pools (DEV)"
   - name: rpmsArtifactNameBase
     value: RPMs
   - name: toolchainArtifactNameBase


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

Moving the agent definitions to a shared variable group. This way we can update the pools across our pipelines globally instead of keeping them defined per-pipeline.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Switched to grabbing the agent pool names from the `Agent pools (DEV)` variable group.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #6026

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- PR check for a test PR #6026