### PR TITLE
Address nodejs CVEs 32002 32006 32559

### DIFF
--- a/SPECS/nodejs/CVE-2022-25883-v18.patch
+++ b/SPECS/nodejs/CVE-2022-25883-v18.patch
@@ -82,7 +82,7 @@ index a791d912..a8c9d591 100644
        .join('||')
        .trim()
      return this.range
-@@ -77,8 +82,6 @@ class Range {
+@@ -77,8 +77,6 @@ class Range {
    }
  
    parseRange (range) {
@@ -90,8 +90,8 @@ index a791d912..a8c9d591 100644
 -
      // memoize range parsing for performance.
      // this is a very hot path, and fully deterministic.
-     const memoOpts = Object.keys(this.options).join(',')
-@@ -103,9 +106,6 @@ class Range {
+     const memoOpts =
+@@ -105,9 +106,6 @@ class Range {
      // `^ 1.2.3` => `^1.2.3`
      range = range.replace(re[t.CARETTRIM], caretTrimReplace)
  
@@ -101,7 +101,7 @@ index a791d912..a8c9d591 100644
      // At this point, the range is completely trimmed and
      // ready to be split into comparators.
  
-@@ -200,7 +200,7 @@ const Comparator = require('./comparator')
+@@ -203,7 +200,7 @@ const Comparator = require('./comparator')
  const debug = require('../internal/debug')
  const SemVer = require('./semver')
  const {
@@ -110,7 +110,7 @@ index a791d912..a8c9d591 100644
    t,
    comparatorTrimReplace,
    tildeTrimReplace,
-@@ -253,10 +253,13 @@ const isX = id => !id || id.toLowerCase() === 'x' || id === '*'
+@@ -257,10 +253,13 @@ const isX = id => !id || id.toLowerCase() === 'x' || id === '*'
  // ~1.2.3, ~>1.2.3 --> >=1.2.3 <1.3.0-0
  // ~1.2.0, ~>1.2.0 --> >=1.2.0 <1.3.0-0
  // ~0.0.1 --> >=0.0.1 <0.1.0-0
@@ -128,7 +128,7 @@ index a791d912..a8c9d591 100644
  
  const replaceTilde = (comp, options) => {
    const r = options.loose ? re[t.TILDELOOSE] : re[t.TILDE]
-@@ -294,10 +297,13 @@ const replaceTilde = (comp, options) => {
+@@ -298,10 +297,13 @@ const replaceTilde = (comp, options) => {
  // ^1.2.0 --> >=1.2.0 <2.0.0-0
  // ^0.0.1 --> >=0.0.1 <0.0.2-0
  // ^0.1.0 --> >=0.1.0 <0.2.0-0
@@ -146,7 +146,7 @@ index a791d912..a8c9d591 100644
  
  const replaceCaret = (comp, options) => {
    debug('caret', comp, options)
-@@ -354,9 +360,10 @@ const replaceCaret = (comp, options) => {
+@@ -359,9 +360,10 @@ const replaceCaret = (comp, options) => {
  
  const replaceXRanges = (comp, options) => {
    debug('replaceXRanges', comp, options)
@@ -160,7 +160,7 @@ index a791d912..a8c9d591 100644
  }
  
  const replaceXRange = (comp, options) => {
-@@ -439,12 +446,15 @@ const replaceXRange = (comp, options) => {
+@@ -443,12 +446,15 @@ const replaceXRange = (comp, options) => {
  const replaceStars = (comp, options) => {
    debug('replaceStars', comp, options)
    // Looseness is ignored here.  star is always as loose as it gets!
@@ -178,7 +178,7 @@ index a791d912..a8c9d591 100644
      .replace(re[options.includePrerelease ? t.GTE0PRE : t.GTE0], '')
  }
  
-@@ -482,7 +492,7 @@ const hyphenReplace = incPr => ($0,
+@@ -486,7 +492,7 @@ const hyphenReplace = incPr => ($0,
      to = `<=${to}`
    }
  

--- a/SPECS/nodejs/nodejs.signatures.json
+++ b/SPECS/nodejs/nodejs.signatures.json
@@ -1,5 +1,5 @@
 {
   "Signatures": {
-    "node-v16.20.1.tar.xz": "3b7d5a3b11e122da9f084448ce7723d3f8c92cd0e36100b6a22c66111d643d19"
+    "node-v16.20.2.tar.xz": "576f1a03c455e491a8d132b587eb6b3b84651fc8974bb3638433dd44d22c8f49"
   }
 }

--- a/SPECS/nodejs/nodejs.spec
+++ b/SPECS/nodejs/nodejs.spec
@@ -4,8 +4,8 @@ Summary:        A JavaScript runtime built on Chrome's V8 JavaScript engine.
 Name:           nodejs
 # WARNINGS: MUST check and update the 'npm_version' macro for every version update of this package.
 #           The version of NPM can be found inside the sources under 'deps/npm/package.json'.
-Version:        16.20.1
-Release:        2%{?dist}
+Version:        16.20.2
+Release:        1%{?dist}
 License:        BSD AND MIT AND Public Domain AND NAIST-2003 AND Artistic-2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -114,6 +114,9 @@ make cctest
 %{_datadir}/systemtap/tapset/node.stp
 
 %changelog
+* Wed Sep 06 2023 Brian Fjeldstad <bfjelds@microsoft.com> - 16.20.2-1
+- Patch CVE-2023-32002 CVE-2023-32006 CVE-2023-32559
+
 * Wed Jul 12 2023 Olivia Crain <oliviacrain@microsoft.com> - 16.20.1-2
 - Backport upstream patches to fix CVE-2022-25883
 

--- a/SPECS/nodejs/nodejs18.signatures.json
+++ b/SPECS/nodejs/nodejs18.signatures.json
@@ -1,5 +1,5 @@
 {
   "Signatures": {
-    "node-v18.16.0.tar.xz": "5dac46d9618dbb15cc78c1f9aa1871fa68a7dd763f3d39ed3c2bd11ca794544d"
+    "node-v18.17.1.tar.xz": "f215cf03d0f00f07ac0b674c6819f804c1542e16f152da04980022aeccf5e65a"
   }
 }

--- a/SPECS/nodejs/nodejs18.spec
+++ b/SPECS/nodejs/nodejs18.spec
@@ -5,8 +5,8 @@ Summary:        A JavaScript runtime built on Chrome's V8 JavaScript engine.
 Name:           nodejs18
 # WARNINGS: MUST check and update the 'npm_version' macro for every version update of this package.
 #           The version of NPM can be found inside the sources under 'deps/npm/package.json'.
-Version:        18.16.0
-Release:        3%{?dist}
+Version:        18.17.1
+Release:        1%{?dist}
 License:        BSD and MIT and Public Domain and NAIST-2003 and Artistic-2.0
 Group:          Applications/System
 Vendor:         Microsoft Corporation
@@ -117,6 +117,9 @@ make cctest
 %{_datadir}/systemtap/tapset/node.stp
 
 %changelog
+* Wed Sep 06 2023 Brian Fjeldstad <bfjelds@microsoft.com> - 18.17.1-1
+- Patch CVE-2023-32002 CVE-2023-32006 CVE-2023-32559
+
 * Tue Jul 11 2023 Muhammad Falak <mwani@microsoft.com> - 18.16.0-3
 - Patch CVE-2022-25883
 

--- a/SPECS/nodejs/nodejs18.spec
+++ b/SPECS/nodejs/nodejs18.spec
@@ -119,6 +119,7 @@ make cctest
 %changelog
 * Wed Sep 06 2023 Brian Fjeldstad <bfjelds@microsoft.com> - 18.17.1-1
 - Patch CVE-2023-32002 CVE-2023-32006 CVE-2023-32559
+- Refresh patch CVE-2022-25883-v18
 
 * Tue Jul 11 2023 Muhammad Falak <mwani@microsoft.com> - 18.16.0-3
 - Patch CVE-2022-25883

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -14303,8 +14303,8 @@
         "type": "other",
         "other": {
           "name": "nodejs",
-          "version": "16.20.1",
-          "downloadUrl": "https://nodejs.org/download/release/v16.20.1/node-v16.20.1.tar.xz"
+          "version": "16.20.2",
+          "downloadUrl": "https://nodejs.org/download/release/v16.20.2/node-v16.20.2.tar.xz"
         }
       }
     },
@@ -14333,8 +14333,8 @@
         "type": "other",
         "other": {
           "name": "nodejs18",
-          "version": "18.16.0",
-          "downloadUrl": "https://nodejs.org/download/release/v18.16.0/node-v18.16.0.tar.xz"
+          "version": "18.17.1",
+          "downloadUrl": "https://nodejs.org/download/release/v18.17.1/node-v18.17.1.tar.xz"
         }
       }
     },


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
Bump nodejs from 16.20.1 to 16.20.2 and nodejs18 from 18.16.0 to 18.17.1 to address CVE-2023-32002 CVE-2023-32006 CVE-2023-32559

###### Change Log  <!-- REQUIRED -->
- https://nvd.nist.gov/vuln/detail/CVE-2023-32002
- https://nvd.nist.gov/vuln/detail/CVE-2023-32006
- https://nvd.nist.gov/vuln/detail/CVE-2023-32559

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Associated issues  <!-- optional -->

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2023-32002
- https://nvd.nist.gov/vuln/detail/CVE-2023-32006
- https://nvd.nist.gov/vuln/detail/CVE-2023-32559

###### Test Methodology
- [build nodejs and nodejs18](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=418417&view=logs&j=7909073b-e471-53c1-2c44-627e2efc0564&t=fbeef549-39ab-510c-faa3-78579a516b53)
- [build nodejs, nodejs18, reaper, prometheus](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=418553&view=logs&j=7909073b-e471-53c1-2c44-627e2efc0564&t=fbeef549-39ab-510c-faa3-78579a516b53)
