### PR TITLE
patch libtommath for CVE-2023-36328

### DIFF
--- a/SPECS-EXTENDED/libtommath/CVE-2023-36328.patch
+++ b/SPECS-EXTENDED/libtommath/CVE-2023-36328.patch
@@ -1,0 +1,136 @@
+From beba892bc0d4e4ded4d667ab1d2a94f4d75109a9 Mon Sep 17 00:00:00 2001
+From: czurnieden <czurnieden@gmx.de>
+Date: Tue, 9 May 2023 17:17:12 +0200
+Subject: [PATCH] Fix possible integer overflow
+
+---
+ bn_mp_2expt.c                | 4 ++++
+ bn_mp_grow.c                 | 4 ++++
+ bn_mp_init_size.c            | 5 +++++
+ bn_mp_mul_2d.c               | 4 ++++
+ bn_s_mp_mul_digs.c           | 4 ++++
+ bn_s_mp_mul_digs_fast.c      | 4 ++++
+ bn_s_mp_mul_high_digs.c      | 4 ++++
+ bn_s_mp_mul_high_digs_fast.c | 4 ++++
+ 8 files changed, 33 insertions(+)
+
+diff --git a/bn_mp_2expt.c b/bn_mp_2expt.c
+index 0ae3df1bf..23de0c3c5 100644
+--- a/bn_mp_2expt.c
++++ b/bn_mp_2expt.c
+@@ -21,6 +21,10 @@ int mp_2expt(mp_int *a, int b)
+ {
+    int     res;
+ 
++   if (b < 0) {
++      return MP_VAL;
++   }
++
+    /* zero a as per default */
+    mp_zero(a);
+ 
+diff --git a/bn_mp_grow.c b/bn_mp_grow.c
+index 9e904c547..2b1682651 100644
+--- a/bn_mp_grow.c
++++ b/bn_mp_grow.c
+@@ -18,6 +18,10 @@ int mp_grow(mp_int *a, int size)
+    int     i;
+    mp_digit *tmp;
+ 
++   if (size < 0) {
++      return MP_VAL;
++   }
++
+    /* if the alloc size is smaller alloc more ram */
+    if (a->alloc < size) {
+       /* ensure there are always at least MP_PREC digits extra on top */
+diff --git a/bn_mp_init_size.c b/bn_mp_init_size.c
+index d62268721..99573833f 100644
+--- a/bn_mp_init_size.c
++++ b/bn_mp_init_size.c
+@@ -17,6 +17,10 @@ int mp_init_size(mp_int *a, int size)
+ {
+    int x;
+ 
++   if (size < 0) {
++      return MP_VAL;
++   }
++
+    /* pad size so there are always extra digits */
+    size += (MP_PREC * 2) - (size % MP_PREC);
+ 
+diff --git a/bn_mp_mul_2d.c b/bn_mp_mul_2d.c
+index 87354de20..bfeaf2eb2 100644
+--- a/bn_mp_mul_2d.c
++++ b/bn_mp_mul_2d.c
+@@ -18,6 +18,10 @@ int mp_mul_2d(const mp_int *a, int b, mp_int *c)
+    mp_digit d;
+    int      res;
+ 
++   if (b < 0) {
++      return MP_VAL;
++   }
++
+    /* copy */
+    if (a != c) {
+       if ((res = mp_copy(a, c)) != MP_OKAY) {
+diff --git a/bn_s_mp_mul_digs.c b/bn_s_mp_mul_digs.c
+index 64509d4cb..3682b4980 100644
+--- a/bn_s_mp_mul_digs.c
++++ b/bn_s_mp_mul_digs.c
+@@ -24,6 +24,10 @@ int s_mp_mul_digs(const mp_int *a, const mp_int *b, mp_int *c, int digs)
+    mp_word r;
+    mp_digit tmpx, *tmpt, *tmpy;
+ 
++   if (digs < 0) {
++      return MP_VAL;
++   }
++
+    /* can we use the fast multiplier? */
+    if ((digs < (int)MP_WARRAY) &&
+        (MIN(a->used, b->used) <
+# diff --git a/bn_s_mp_mul_digs_fast.c b/bn_s_mp_mul_digs_fast.c
+# index b2a287b02..3c4176a87 100644
+# --- a/bn_s_mp_mul_digs_fast.c
+# +++ b/bn_s_mp_mul_digs_fast.c
+# @@ -26,6 +26,10 @@ mp_err s_mp_mul_digs_fast(const mp_int *a, const mp_int *b, mp_int *c, int digs)
+#     mp_digit W[MP_WARRAY];
+#     mp_word  _W;
+ 
+# +   if (digs < 0) {
+# +      return MP_VAL;
+# +   }
+# +
+#     /* grow the destination as required */
+#     if (c->alloc < digs) {
+#        if ((err = mp_grow(c, digs)) != MP_OKAY) {
+diff --git a/bn_s_mp_mul_high_digs.c b/bn_s_mp_mul_high_digs.c
+index 2bb2a5098..c9dd355f8 100644
+--- a/bn_s_mp_mul_high_digs.c
++++ b/bn_s_mp_mul_high_digs.c
+@@ -23,6 +23,10 @@ int s_mp_mul_high_digs(const mp_int *a, const mp_int *b, mp_int *c, int digs)
+    mp_word r;
+    mp_digit tmpx, *tmpt, *tmpy;
+ 
++   if (digs < 0) {
++      return MP_VAL;
++   }
++
+    /* can we use the fast multiplier? */
+ #ifdef BN_FAST_S_MP_MUL_HIGH_DIGS_C
+    if (((a->used + b->used + 1) < (int)MP_WARRAY)
+# diff --git a/bn_s_mp_mul_high_digs_fast.c b/bn_s_mp_mul_high_digs_fast.c
+# index a2c4fb692..4ce7f590c 100644
+# --- a/bn_s_mp_mul_high_digs_fast.c
+# +++ b/bn_s_mp_mul_high_digs_fast.c
+# @@ -19,6 +19,10 @@ mp_err s_mp_mul_high_digs_fast(const mp_int *a, const mp_int *b, mp_int *c, int
+#     mp_digit W[MP_WARRAY];
+#     mp_word  _W;
+ 
+# +   if (digs < 0) {
+# +      return MP_VAL;
+# +   }
+# +
+#     /* grow the destination as required */
+#     pa = a->used + b->used;
+#     if (c->alloc < pa) {

--- a/SPECS-EXTENDED/libtommath/libtommath.spec
+++ b/SPECS-EXTENDED/libtommath/libtommath.spec
@@ -7,6 +7,7 @@ Vendor:         Microsoft Corporation
 Distribution:   Mariner
 URL:            https://www.libtom.net/
 Source0:        https://github.com/libtom/%{name}/archive/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
+Patch0:         CVE-2023-36328.patch
 
 BuildRequires:  libtool
 
@@ -26,6 +27,7 @@ applications that use %{name}.
 
 %prep
 %setup -q
+%patch0 -p1
 # Fix permissions on installed library
 sed -i -e 's/644 $(LIBNAME)/755 $(LIBNAME)/g' makefile.shared
 # Fix pkgconfig path

--- a/SPECS-EXTENDED/libtommath/libtommath.spec
+++ b/SPECS-EXTENDED/libtommath/libtommath.spec
@@ -1,7 +1,7 @@
 Summary:        A portable number theoretic multiple-precision integer library
 Name:           libtommath
 Version:        1.1.0
-Release:        4%{?dist}
+Release:        5%{?dist}
 License:        Public Domain
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -58,6 +58,9 @@ find %{buildroot} -name '*.a' -delete
 %{_libdir}/pkgconfig/*.pc
 
 %changelog
+* Thu Sep 07 2023 Brian Fjeldstad <bfjelds@microsoft.com> - 1.1.0-5
+- Fix CVE-2023-36328
+
 * Fri Feb 04 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.1.0-4
 - Removing docs to drop dependency on 'ghostscript'.
 - License verified.

--- a/SPECS-EXTENDED/libtommath/libtommath.spec
+++ b/SPECS-EXTENDED/libtommath/libtommath.spec
@@ -26,8 +26,7 @@ The %{name}-devel package contains libraries and header files for developing
 applications that use %{name}.
 
 %prep
-%setup -q
-%patch0 -p1
+%autosetup -p1
 # Fix permissions on installed library
 sed -i -e 's/644 $(LIBNAME)/755 $(LIBNAME)/g' makefile.shared
 # Fix pkgconfig path


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
Adapt nist linked patch to libtommath 1.1.0 to address CVE-2023-36328

###### Change Log  <!-- REQUIRED -->
- CVE-2023-36328

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Associated issues  <!-- optional -->

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2023-36328

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- https://dev.azure.com/mariner-org/mariner/_build/results?buildId=418762&view=results
