### PR TITLE
Add a fallback lazy mode to chroot unmount

### DIFF
--- a/toolkit/tools/go.mod
+++ b/toolkit/tools/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/jinzhu/copier v0.3.2
 	github.com/juliangruber/go-intersect v1.1.0
 	github.com/klauspost/pgzip v1.2.5
+	github.com/moby/sys/mountinfo v0.6.2
 	github.com/muesli/crunchy v0.4.0
 	github.com/rivo/tview v0.0.0-20200219135020-0ba8301b415c
 	github.com/sirupsen/logrus v1.9.3

--- a/toolkit/tools/go.sum
+++ b/toolkit/tools/go.sum
@@ -41,6 +41,8 @@ github.com/lucasb-eyer/go-colorful v1.0.3/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.7 h1:Ei8KR0497xHyKJPAv59M1dkC+rOZCMBJ+t3fZ+twI54=
 github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/moby/sys/mountinfo v0.6.2 h1:BzJjoreD5BMFNmD9Rus6gdd1pLuecOFPt8wC+Vygl78=
+github.com/moby/sys/mountinfo v0.6.2/go.mod h1:IJb6JQeOklcdMU9F5xQ8ZALD+CUr5VlGpwtX+VE0rpI=
 github.com/muesli/crunchy v0.4.0 h1:qdiml8gywULHBsztiSAf6rrE6EyuNasNKZ104mAaahM=
 github.com/muesli/crunchy v0.4.0/go.mod h1:9k4x6xdSbb7WwtAVy0iDjaiDjIk6Wa5AgUIqp+HqOpU=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
@@ -79,6 +81,7 @@ golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190626150813-e07cf5db2756/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191018095205-727590c5006e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f h1:v4INt8xihDGvnrfjMDVXGxw9wrfxYyCjk0KbXjhR55s=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/toolkit/tools/internal/safechroot/safechroot.go
+++ b/toolkit/tools/internal/safechroot/safechroot.go
@@ -479,7 +479,7 @@ func cleanupAllChroots() {
 // This is to avoid leaving folders like /dev mounted when the chroot folder is forcefully deleted in cleanup.
 // Iff all mounts were successfully unmounted, the chroot's root directory will be removed if requested.
 // If doLazyUnmount is true, use the lazy unmount flag which will allow the unmount to succeed even if the mount point is busy.
-func (c *Chroot) unmountAndRemove(leaveOnDisk, doLazyUnmount bool) (err error) {
+func (c *Chroot) unmountAndRemove(leaveOnDisk, lazyUnmount bool) (err error) {
 	const (
 		retryDuration      = time.Second
 		totalAttempts      = 3
@@ -491,7 +491,7 @@ func (c *Chroot) unmountAndRemove(leaveOnDisk, doLazyUnmount bool) (err error) {
 		errMsg           = "Failed to unmount (%s). Error: %s"
 	)
 	unmountFlags := unmountFlagsNormal
-	if doLazyUnmount {
+	if lazyUnmount {
 		logger.Log.Warnf("Final attempt to unmount chroot (%s), using a lazy unmount", c.rootDir)
 		unmountFlags = unmountFlagsLazy
 	}

--- a/toolkit/tools/internal/safechroot/safechroot.go
+++ b/toolkit/tools/internal/safechroot/safechroot.go
@@ -463,7 +463,7 @@ func cleanupAllChroots() {
 	}
 
 	if failedToUnmount {
-		logger.Log.Fatalf("Failed to unmount a chroot, manual unmount required")
+		logger.Log.Fatalf("Failed to unmount a chroot, manual unmount required. See above errors for details on which mounts failed.")
 	} else {
 		logger.Log.Info("Cleanup finished")
 	}

--- a/toolkit/tools/internal/safechroot/safechroot.go
+++ b/toolkit/tools/internal/safechroot/safechroot.go
@@ -504,7 +504,7 @@ func (c *Chroot) unmountAndRemove(leaveOnDisk, isFinalAttempt bool) (err error) 
 		}
 
 		_, err = retry.RunWithExpBackoff(func() error {
-			logger.Log.Warnf("Calling unmount (%s, %v)", fullPath, unmountFlags)
+			logger.Log.Debugf("Calling unmount (%s, %v)", fullPath, unmountFlags)
 			umountErr := unix.Unmount(fullPath, unmountFlags)
 			if isFinalAttempt && umountErr != nil {
 				logger.Log.Warnf(errMsg, fullPath, err.Error())

--- a/toolkit/tools/internal/safechroot/safechroot.go
+++ b/toolkit/tools/internal/safechroot/safechroot.go
@@ -82,11 +82,6 @@ var defaultChrootEnv = []string{
 	"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 }
 
-const (
-	isNotFinalAttempt = false
-	isFinalAttempt    = true
-)
-
 // init will always be called if this package is loaded
 func init() {
 	registerSIGTERMCleanup()
@@ -201,7 +196,7 @@ func (c *Chroot) Initialize(tarPath string, extraDirectories []string, extraMoun
 			if buildpipeline.IsRegularBuild() {
 				// mount/unmount is only supported in regular pipeline
 				// Best effort cleanup in case mountpoint creation failed mid-way through. We will not try again so treat as final attempt.
-				cleanupErr := c.unmountAndRemove(leaveChrootOnDisk, isFinalAttempt)
+				cleanupErr := c.unmountAndRemove(leaveChrootOnDisk, true)
 				if cleanupErr != nil {
 					logger.Log.Warnf("Failed to cleanup chroot (%s) during failed initialization. Error: %s", c.rootDir, cleanupErr)
 				}
@@ -376,10 +371,10 @@ func (c *Chroot) Close(leaveOnDisk bool) (err error) {
 
 	if buildpipeline.IsRegularBuild() {
 		// mount is only supported in regular pipeline
-		err = c.unmountAndRemove(leaveOnDisk, isNotFinalAttempt)
+		err = c.unmountAndRemove(leaveOnDisk, false)
 		if err != nil {
 			logger.Log.Warnf("Chroot cleanup failed, will retry with lazy unmount. Error: %s", err)
-			err = c.unmountAndRemove(leaveOnDisk, isFinalAttempt)
+			err = c.unmountAndRemove(leaveOnDisk, true)
 		}
 		if err == nil {
 			const emptyLen = 0
@@ -457,7 +452,7 @@ func cleanupAllChroots() {
 		logger.Log.Info("Cleaning up all active chroots")
 		for i := len(activeChroots) - 1; i >= 0; i-- {
 			logger.Log.Infof("Cleaning up chroot (%s)", activeChroots[i].rootDir)
-			err := activeChroots[i].unmountAndRemove(leaveChrootOnDisk, isFinalAttempt)
+			err := activeChroots[i].unmountAndRemove(leaveChrootOnDisk, true)
 			// Perform best effort cleanup: unmount as many chroots as possible,
 			// even if one fails.
 			if err != nil {
@@ -480,21 +475,18 @@ func cleanupAllChroots() {
 // Iff all mounts were successfully unmounted, the chroot's root directory will be removed if requested.
 func (c *Chroot) unmountAndRemove(leaveOnDisk, isFinalAttempt bool) (err error) {
 	const (
-		retryDuration       = time.Second
-		totalAttemptsNormal = 3
-		totalAttemptsFinal  = 5
-		unmountFlagsNormal  = 0
+		retryDuration      = time.Second
+		totalAttempts      = 3
+		unmountFlagsNormal = 0
 		// Do a lazy unmount on the final attempt. This will allow the unmount to succeed even if the mount point is busy.
 		// This is to avoid leaving folders like /dev mounted if the chroot folder is forcefully deleted by the user. Even
 		// if the mount is busy at least it will be detached from the filesystem and will not damage the host.
 		unmountFlagsFinal = unix.MNT_DETACH
 		errMsg            = "Failed to unmount (%s). Error: %s"
 	)
-	totalAttempts := totalAttemptsNormal
 	unmountFlags := unmountFlagsNormal
 	if isFinalAttempt {
 		logger.Log.Warnf("Final attempt to unmount chroot (%s)", c.rootDir)
-		totalAttempts = totalAttemptsFinal
 		unmountFlags = unmountFlagsFinal
 	}
 

--- a/toolkit/tools/internal/safechroot/safechroot.go
+++ b/toolkit/tools/internal/safechroot/safechroot.go
@@ -514,9 +514,6 @@ func (c *Chroot) unmountAndRemove(leaveOnDisk, isFinalAttempt bool) (err error) 
 		_, err = retry.RunWithExpBackoff(func() error {
 			logger.Log.Debugf("Calling unmount (%s, %v)", fullPath, unmountFlags)
 			umountErr := unix.Unmount(fullPath, unmountFlags)
-			if isFinalAttempt && umountErr != nil {
-				logger.Log.Warnf(errMsg, fullPath, umountErr.Error())
-			}
 			return umountErr
 		}, totalAttempts, retryDuration, 2.0, nil)
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Sometimes the chroots we use do not unmount correctly. There seem to be many different reasons this can occur (but `/dev/hugepages` has been a recent culprit). Generally, we try to gracefully unmount them when we call `.Close()`, but the `safechroot` package tracks active chroots and calls `cleanupAllChroots()` when the tool exits. Currently we will make an attempt to clean, but if the unmount fails (often due to a busy mount) we give up and leave the mountpoint present. If the user isn't cautious and deletes this folder, it can mess up the host system until a reboot.

Linux offers a lazy unmount option. This will detatch the mountpoint from the fileystem even if it can't fully tear down the mount. This means that at least the user won't be able to damage the host system accidentily. If we use this lazy detach mode in our final cleanup in `cleanupAllChroots()` we have a better chance of leaving the system in a safe state.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Use `unix.MNT_DETACH` on last chroot unmount attempt
- Make failure on final unmount explicilty a failure via `Fatalf(...)`
- Use exponential backoff for unmount so we try longer

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**


###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local builds
