### PR TITLE
libguestfs: remove toolchain package requirements to fix build break

### DIFF
--- a/SPECS/libguestfs/libguestfs.spec
+++ b/SPECS/libguestfs/libguestfs.spec
@@ -61,37 +61,70 @@ BuildRequires:  acl
 BuildRequires:  attr
 BuildRequires:  augeas-devel >= 1.7.0
 BuildRequires:  augeas-libs
+BuildRequires:  bash
 BuildRequires:  bash-completion
+BuildRequires:  binutils
+BuildRequires:  bison
 BuildRequires:  btrfs-progs
+BuildRequires:  bzip2
+BuildRequires:  coreutils
+BuildRequires:  cpio
+BuildRequires:  createrepo_c
 BuildRequires:  cryptsetup
+BuildRequires:  curl
 BuildRequires:  dhclient
+BuildRequires:  diffutils
 BuildRequires:  dosfstools
+BuildRequires:  e2fsprogs
+BuildRequires:  file
+BuildRequires:  file-devel
+BuildRequires:  findutils
+BuildRequires:  flex
 BuildRequires:  fuse
 BuildRequires:  fuse-devel
+BuildRequires:  gawk
 # Basic build requirements for the library and virt tools.
+BuildRequires:  gcc
+BuildRequires:  gcc-c++
 BuildRequires:  gdisk
 BuildRequires:  genisoimage
 BuildRequires:  gfs2-utils
+BuildRequires:  glibc-static >= 2.35-4%{?dist}
 BuildRequires:  gobject-introspection-devel
+BuildRequires:  gperf
+BuildRequires:  grep
+BuildRequires:  gzip
 BuildRequires:  hivex
 BuildRequires:  hivex-devel >= 1.3.10
 BuildRequires:  iproute
 BuildRequires:  iputils
 BuildRequires:  jansson-devel
 BuildRequires:  kernel
+BuildRequires:  kmod
 BuildRequires:  kpartx
+BuildRequires:  less
 BuildRequires:  libacl-devel
+BuildRequires:  libcap
+BuildRequires:  libcap-devel
 BuildRequires:  libconfig-devel
 BuildRequires:  libdb-utils
 BuildRequires:  libldm
 BuildRequires:  libldm-devel
+BuildRequires:  libselinux
+BuildRequires:  libselinux-devel
+BuildRequires:  libselinux-utils
 BuildRequires:  libtirpc-devel
 BuildRequires:  libvirt-daemon-kvm >= 5.3.0
 BuildRequires:  libvirt-devel
+BuildRequires:  libxml2
+BuildRequires:  libxml2-devel
 BuildRequires:  lsof
 BuildRequires:  lsscsi
+BuildRequires:  lua
+BuildRequires:  lua-devel
 BuildRequires:  lvm2
 BuildRequires:  lzop
+BuildRequires:  make
 BuildRequires:  mdadm
 BuildRequires:  ntfs-3g
 BuildRequires:  ntfs-3g-system-compression
@@ -106,16 +139,26 @@ BuildRequires:  ocaml-ounit-devel
 BuildRequires:  openssh-clients
 BuildRequires:  parted
 BuildRequires:  pciutils
+BuildRequires:  pcre
+BuildRequires:  pcre-devel
+BuildRequires:  perl-devel
+BuildRequires:  perl-generators
+BuildRequires:  perl-libintl-perl
+BuildRequires:  perl-macros
 BuildRequires:  policycoreutils
+BuildRequires:  procps
 BuildRequires:  psmisc
+BuildRequires:  python3-devel
 BuildRequires:  python3-libvirt
 BuildRequires:  qemu-img
 BuildRequires:  qemu-kvm
+BuildRequires:  readline-devel
 BuildRequires:  rpcgen
 BuildRequires:  rsync
 BuildRequires:  ruby-devel
 BuildRequires:  rubygem-rake
 BuildRequires:  scrub
+BuildRequires:  sed
 BuildRequires:  sleuthkit
 BuildRequires:  squashfs-tools
 BuildRequires:  strace
@@ -123,15 +166,25 @@ BuildRequires:  supermin-devel >= 5.1.18
 BuildRequires:  systemd
 BuildRequires:  systemd-devel
 BuildRequires:  systemd-units
+BuildRequires:  tar
+BuildRequires:  tdnf
 BuildRequires:  udev
+BuildRequires:  unzip
+BuildRequires:  util-linux
 BuildRequires:  vala
 BuildRequires:  vim
+BuildRequires:  which
 BuildRequires:  xfsprogs
+BuildRequires:  xz
+BuildRequires:  xz-devel
 BuildRequires:  yajl
 BuildRequires:  zerofree
+BuildRequires:  zip
 BuildRequires:  perl(Expect)
+BuildRequires:  perl(ExtUtils::CBuilder)
 BuildRequires:  perl(Module::Build)
 BuildRequires:  perl(Pod::Man)
+BuildRequires:  perl(Pod::Simple)
 BuildRequires:  perl(Sys::Virt)
 BuildRequires:  perl(Test::More)
 BuildRequires:  perl(Test::Pod) >= 1.00
@@ -145,6 +198,9 @@ BuildRequires:  rubygem(rdoc)
 BuildRequires:  rubygem(test-unit)
 
 %if 0%{patches_touch_autotools}
+BuildRequires:  autoconf
+BuildRequires:  automake
+BuildRequires:  gettext-devel
 BuildRequires:  libtool
 %endif
 
@@ -700,24 +756,44 @@ cp %{SOURCE9} %{_sysconfdir}/yum.repos.d/allrepos.repo
 # Download to
 mkdir -pv %{_var}/cache/tdnf
 tdnf install --downloadonly -y --disablerepo=* \
-  --enablerepo=local-repo --enablerepo=upstream-cache-repo \
+  --enablerepo=local-repo \
+  --enablerepo=upstream-cache-repo \
+  --enablerepo=toolchain-repo \
   --alldeps --downloaddir %{_var}/cache/tdnf \
     acl \
     attr \
     augeas-libs \
+    bash \
+    binutils \
     btrfs-progs \
+    bzip2 \
+    coreutils \
+    cpio \
     cryptsetup \
+    curl \
     dhclient \
+    diffutils \
     dosfstools \
+    e2fsprogs \
+    file \
+    findutils \
+    gawk \
     gdisk \
     genisoimage \
     gfs2-utils \
+    grep \
+    gzip \
     hivex \
     iproute \
     iputils \
     kernel \
+    kmod \
     kpartx \
+    less \
+    libcap \
     libldm \
+    libselinux \
+    libxml2 \
     lsof \
     lsscsi \
     lvm2 \
@@ -728,11 +804,14 @@ tdnf install --downloadonly -y --disablerepo=* \
     openssh-clients \
     parted \
     pciutils \
+    pcre \
     policycoreutils \
+    procps \
     psmisc \
     qemu-img \
     rsync \
     scrub \
+    sed \
     sleuthkit \
     squashfs-tools \
     strace \
@@ -741,9 +820,13 @@ tdnf install --downloadonly -y --disablerepo=* \
     syslinux-devel \
 %endif
     systemd \
+    tar \
     udev \
+    util-linux \
     vim \
+    which \
     xfsprogs \
+    xz \
     yajl \
     zerofree \
 %ifnarch aarch64
@@ -1153,8 +1236,8 @@ rm ocaml/html/.gitignore
 %endif
 
 %changelog
-* Fri Sep 15 2023 Andrew Phelps <anphel@microsoft.com> - 1.44.0-14
-- Remove toolchain packages from BR and tdnf install to fix build break
+* Fri Sep 15 2023 Andrew Phelps anphel@microsoft.com - 1.44.0-14
+- Enable toolchain-repo with tdnf download command to fix build break
 
 * Wed Jul 05 2023 Andrew Phelps <anphel@microsoft.com> - 1.44.0-13
 - Bump release to rebuild against glibc 2.35-4

--- a/SPECS/libguestfs/libguestfs.spec
+++ b/SPECS/libguestfs/libguestfs.spec
@@ -1236,7 +1236,7 @@ rm ocaml/html/.gitignore
 %endif
 
 %changelog
-* Fri Sep 15 2023 Andrew Phelps anphel@microsoft.com - 1.44.0-14
+* Fri Sep 15 2023 Andrew Phelps <anphel@microsoft.com> - 1.44.0-14
 - Enable toolchain-repo with tdnf download command to fix build break
 
 * Wed Jul 05 2023 Andrew Phelps <anphel@microsoft.com> - 1.44.0-13

--- a/SPECS/libguestfs/libguestfs.spec
+++ b/SPECS/libguestfs/libguestfs.spec
@@ -107,7 +107,6 @@ BuildRequires:  openssh-clients
 BuildRequires:  parted
 BuildRequires:  pciutils
 BuildRequires:  policycoreutils
-BuildRequires:  procps
 BuildRequires:  psmisc
 BuildRequires:  python3-libvirt
 BuildRequires:  qemu-img
@@ -730,7 +729,6 @@ tdnf install --downloadonly -y --disablerepo=* \
     parted \
     pciutils \
     policycoreutils \
-    procps \
     psmisc \
     qemu-img \
     rsync \

--- a/SPECS/libguestfs/libguestfs.spec
+++ b/SPECS/libguestfs/libguestfs.spec
@@ -25,7 +25,7 @@
 Summary:        Access and modify virtual machine disk images
 Name:           libguestfs
 Version:        1.44.0
-Release:        13%{?dist}
+Release:        14%{?dist}
 License:        LGPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -63,7 +63,6 @@ BuildRequires:  augeas-devel >= 1.7.0
 BuildRequires:  augeas-libs
 BuildRequires:  bash
 BuildRequires:  bash-completion
-BuildRequires:  binutils
 BuildRequires:  bison
 BuildRequires:  btrfs-progs
 BuildRequires:  bzip2
@@ -1234,6 +1233,9 @@ rm ocaml/html/.gitignore
 %endif
 
 %changelog
+* Fri Sep 15 2023 Andrew Phelps <anphel@microsoft.com> - 1.44.0-14
+- Remove binutils from BR
+
 * Wed Jul 05 2023 Andrew Phelps <anphel@microsoft.com> - 1.44.0-13
 - Bump release to rebuild against glibc 2.35-4
 

--- a/SPECS/libguestfs/libguestfs.spec
+++ b/SPECS/libguestfs/libguestfs.spec
@@ -61,69 +61,37 @@ BuildRequires:  acl
 BuildRequires:  attr
 BuildRequires:  augeas-devel >= 1.7.0
 BuildRequires:  augeas-libs
-BuildRequires:  bash
 BuildRequires:  bash-completion
-BuildRequires:  bison
 BuildRequires:  btrfs-progs
-BuildRequires:  bzip2
-BuildRequires:  coreutils
-BuildRequires:  cpio
-BuildRequires:  createrepo_c
 BuildRequires:  cryptsetup
-BuildRequires:  curl
 BuildRequires:  dhclient
-BuildRequires:  diffutils
 BuildRequires:  dosfstools
-BuildRequires:  e2fsprogs
-BuildRequires:  file
-BuildRequires:  file-devel
-BuildRequires:  findutils
-BuildRequires:  flex
 BuildRequires:  fuse
 BuildRequires:  fuse-devel
-BuildRequires:  gawk
 # Basic build requirements for the library and virt tools.
-BuildRequires:  gcc
-BuildRequires:  gcc-c++
 BuildRequires:  gdisk
 BuildRequires:  genisoimage
 BuildRequires:  gfs2-utils
-BuildRequires:  glibc-static >= 2.35-4%{?dist}
 BuildRequires:  gobject-introspection-devel
-BuildRequires:  gperf
-BuildRequires:  grep
-BuildRequires:  gzip
 BuildRequires:  hivex
 BuildRequires:  hivex-devel >= 1.3.10
 BuildRequires:  iproute
 BuildRequires:  iputils
 BuildRequires:  jansson-devel
 BuildRequires:  kernel
-BuildRequires:  kmod
 BuildRequires:  kpartx
-BuildRequires:  less
 BuildRequires:  libacl-devel
-BuildRequires:  libcap
-BuildRequires:  libcap-devel
 BuildRequires:  libconfig-devel
 BuildRequires:  libdb-utils
 BuildRequires:  libldm
 BuildRequires:  libldm-devel
-BuildRequires:  libselinux
-BuildRequires:  libselinux-devel
-BuildRequires:  libselinux-utils
 BuildRequires:  libtirpc-devel
 BuildRequires:  libvirt-daemon-kvm >= 5.3.0
 BuildRequires:  libvirt-devel
-BuildRequires:  libxml2
-BuildRequires:  libxml2-devel
 BuildRequires:  lsof
 BuildRequires:  lsscsi
-BuildRequires:  lua
-BuildRequires:  lua-devel
 BuildRequires:  lvm2
 BuildRequires:  lzop
-BuildRequires:  make
 BuildRequires:  mdadm
 BuildRequires:  ntfs-3g
 BuildRequires:  ntfs-3g-system-compression
@@ -138,26 +106,17 @@ BuildRequires:  ocaml-ounit-devel
 BuildRequires:  openssh-clients
 BuildRequires:  parted
 BuildRequires:  pciutils
-BuildRequires:  pcre
-BuildRequires:  pcre-devel
-BuildRequires:  perl-devel
-BuildRequires:  perl-generators
-BuildRequires:  perl-libintl-perl
-BuildRequires:  perl-macros
 BuildRequires:  policycoreutils
 BuildRequires:  procps
 BuildRequires:  psmisc
-BuildRequires:  python3-devel
 BuildRequires:  python3-libvirt
 BuildRequires:  qemu-img
 BuildRequires:  qemu-kvm
-BuildRequires:  readline-devel
 BuildRequires:  rpcgen
 BuildRequires:  rsync
 BuildRequires:  ruby-devel
 BuildRequires:  rubygem-rake
 BuildRequires:  scrub
-BuildRequires:  sed
 BuildRequires:  sleuthkit
 BuildRequires:  squashfs-tools
 BuildRequires:  strace
@@ -165,25 +124,15 @@ BuildRequires:  supermin-devel >= 5.1.18
 BuildRequires:  systemd
 BuildRequires:  systemd-devel
 BuildRequires:  systemd-units
-BuildRequires:  tar
-BuildRequires:  tdnf
 BuildRequires:  udev
-BuildRequires:  unzip
-BuildRequires:  util-linux
 BuildRequires:  vala
 BuildRequires:  vim
-BuildRequires:  which
 BuildRequires:  xfsprogs
-BuildRequires:  xz
-BuildRequires:  xz-devel
 BuildRequires:  yajl
 BuildRequires:  zerofree
-BuildRequires:  zip
 BuildRequires:  perl(Expect)
-BuildRequires:  perl(ExtUtils::CBuilder)
 BuildRequires:  perl(Module::Build)
 BuildRequires:  perl(Pod::Man)
-BuildRequires:  perl(Pod::Simple)
 BuildRequires:  perl(Sys::Virt)
 BuildRequires:  perl(Test::More)
 BuildRequires:  perl(Test::Pod) >= 1.00
@@ -197,9 +146,6 @@ BuildRequires:  rubygem(rdoc)
 BuildRequires:  rubygem(test-unit)
 
 %if 0%{patches_touch_autotools}
-BuildRequires:  autoconf
-BuildRequires:  automake
-BuildRequires:  gettext-devel
 BuildRequires:  libtool
 %endif
 
@@ -760,36 +706,19 @@ tdnf install --downloadonly -y --disablerepo=* \
     acl \
     attr \
     augeas-libs \
-    bash \
     btrfs-progs \
-    bzip2 \
-    coreutils \
-    cpio \
     cryptsetup \
-    curl \
     dhclient \
-    diffutils \
     dosfstools \
-    e2fsprogs \
-    file \
-    findutils \
-    gawk \
     gdisk \
     genisoimage \
     gfs2-utils \
-    grep \
-    gzip \
     hivex \
     iproute \
     iputils \
     kernel \
-    kmod \
     kpartx \
-    less \
-    libcap \
     libldm \
-    libselinux \
-    libxml2 \
     lsof \
     lsscsi \
     lvm2 \
@@ -800,14 +729,12 @@ tdnf install --downloadonly -y --disablerepo=* \
     openssh-clients \
     parted \
     pciutils \
-    pcre \
     policycoreutils \
     procps \
     psmisc \
     qemu-img \
     rsync \
     scrub \
-    sed \
     sleuthkit \
     squashfs-tools \
     strace \
@@ -816,13 +743,9 @@ tdnf install --downloadonly -y --disablerepo=* \
     syslinux-devel \
 %endif
     systemd \
-    tar \
     udev \
-    util-linux \
     vim \
-    which \
     xfsprogs \
-    xz \
     yajl \
     zerofree \
 %ifnarch aarch64
@@ -1233,7 +1156,7 @@ rm ocaml/html/.gitignore
 
 %changelog
 * Fri Sep 15 2023 Andrew Phelps <anphel@microsoft.com> - 1.44.0-14
-- Remove binutils from BR to fix build break
+- Remove toolchain packages from BR and tdnf install to fix build break
 
 * Wed Jul 05 2023 Andrew Phelps <anphel@microsoft.com> - 1.44.0-13
 - Bump release to rebuild against glibc 2.35-4

--- a/SPECS/libguestfs/libguestfs.spec
+++ b/SPECS/libguestfs/libguestfs.spec
@@ -761,7 +761,6 @@ tdnf install --downloadonly -y --disablerepo=* \
     attr \
     augeas-libs \
     bash \
-    binutils \
     btrfs-progs \
     bzip2 \
     coreutils \
@@ -1234,7 +1233,7 @@ rm ocaml/html/.gitignore
 
 %changelog
 * Fri Sep 15 2023 Andrew Phelps <anphel@microsoft.com> - 1.44.0-14
-- Remove binutils from BR
+- Remove binutils from BR to fix build break
 
 * Wed Jul 05 2023 Andrew Phelps <anphel@microsoft.com> - 1.44.0-13
 - Bump release to rebuild against glibc 2.35-4


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Fix [build break](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=421960&view=results) from libguestfs seen below. Enable the `toolchain-repo` so that the `binutils` package, and all other toolchain packages, are 
 available.

`
"+ cp /usr/src/mariner/SOURCES/tdnf-build-cache.repo /etc/yum.repos.d/allrepos.repo"
"+ mkdir -pv /var/cache/tdnf"
`
`
"+ tdnf install --downloadonly -y '--disablerepo=*' --enablerepo=local-repo --enablerepo=upstream-cache-repo --alldeps --downloaddir /var/cache/tdnf acl attr augeas-libs bash binutils btrfs-progs bzip2 coreutils cpio cryptsetup curl dhclient diffutils dosfstools e2fsprogs file findutils gawk gdisk genisoimage gfs2-utils grep gzip hivex iproute iputils kernel kmod kpartx less libcap libldm libselinux libxml2 lsof lsscsi lvm2 lzop mdadm ntfs-3g ntfsprogs ntfs-3g-system-compression openssh-clients parted pciutils pcre policycoreutils procps psmisc qemu-img rsync scrub sed sleuthkit squashfs-tools strace syslinux syslinux-devel systemd tar udev util-linux vim which xfsprogs xz yajl zerofree zfs-fuse"
`
`
"Loaded plugin: tdnfrepogpgcheck"
`
`
"binutils package not found or not installed"
`
`
"Error(1011) : No matching packages"
`
`
"error: Bad exit status from /var/tmp/rpm-tmp.LtIWiN (%prep)"
`

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change libguestfs to enable the toolchain-repo

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Reseeded x86_64 main build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=422444&view=logs&j=75cba72d-09cb-503a-3927-4ab61ac4a179&t=96d12790-e2a0-56cb-1f4c-4eb56738aded
