### PR TITLE
containerized-rpmbuild: add arch to welcome txt

### DIFF
--- a/toolkit/scripts/containerized-build/create_container_build.sh
+++ b/toolkit/scripts/containerized-build/create_container_build.sh
@@ -177,6 +177,7 @@ done
 cp resources/welcome.txt $tmp_dir
 sed -i "s~<REPO_PATH>~${repo_path}~" $tmp_dir/welcome.txt
 sed -i "s~<REPO_BRANCH>~${repo_branch}~" $tmp_dir/welcome.txt
+sed -i "s~<AARCH>~$(uname -m)~" $tmp_dir/welcome.txt
 cp resources/setup_functions.sh $tmp_dir/setup_functions.sh
 sed -i "s~<TOPDIR>~${topdir}~" $tmp_dir/setup_functions.sh
 

--- a/toolkit/scripts/containerized-build/resources/welcome.txt
+++ b/toolkit/scripts/containerized-build/resources/welcome.txt
@@ -25,7 +25,7 @@
 *     Changes to /usr/src/mariner/SOURCES will not be available on host machine
 *     RPMs built in the container are stored at /usr/src/mariner/RPMS, and will not be available on host machine
 *     RPMs from host's <CBL-Mariner>/out/RPMs will be available in /repo
-*     Individual packages may be installed directly via\e[32m tdnf install /repo/x86_64/pkg.rpm and /repo/noarch/pkg.rpm\e[0m
+*     Individual packages may be installed directly via\e[32m tdnf install /repo/<AARCH>/pkg.rpm and /repo/noarch/pkg.rpm\e[0m
 *
 * \e[31mDirectory information:\e[0m
 *     Mariner repo path:          <REPO_PATH>


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Add platform arch to welcome text, so we can show the correct folder for RPMs. It is currently hardcoded to x86

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add platform arch to welcome text, so we can show the correct folder for RPMs. It is currently hardcoded to x86

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES/NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build