### PR TITLE
containerized-rpmbuild: use folder definitions from Makefile

### DIFF
--- a/toolkit/scripts/containerized-build.mk
+++ b/toolkit/scripts/containerized-build.mk
@@ -34,9 +34,6 @@ ifeq ($(ENABLE_REPO),y)
 containerized_build_args += -r
 endif
 
-# SPECS_DIR is always set
-containerized_build_args += -s ${SPECS_DIR}
-
 containerized-rpmbuild: no_repo_acl
 	$(SCRIPTS_DIR)/containerized-build/create_container_build.sh $(containerized_build_args)
 

--- a/toolkit/scripts/containerized-build/create_container_build.sh
+++ b/toolkit/scripts/containerized-build/create_container_build.sh
@@ -23,14 +23,12 @@ print_error() {
 help() {
 echo "
 Usage:
-sudo make containerized-rpmbuild [REPO_PATH=/path/to/CBL-Mariner] [MODE=test|build] [VERSION=1.0|2.0] [MOUNTS=/path/in/host:/path/in/container ...] [ENABLE_REPO=y] [SPECS_DIR=/path/to/SPECS_DIR/to/use] [BUILD_MOUNT=/path/to/build/chroot/mount]
+sudo make containerized-rpmbuild [REPO_PATH=/path/to/CBL-Mariner] [MODE=test|build] [VERSION=1.0|2.0] [MOUNTS=/path/in/host:/path/in/container ...] [ENABLE_REPO=y] [BUILD_MOUNT=/path/to/build/chroot/mount]
 
 Starts a docker container with the specified version of mariner.
 
 Optional arguments:
     REPO_PATH:      path to the CBL-Mariner repo root directory. default: "current directory"
-    SPECS_DIR:      The SPECS_DIR variable is reused from base Makefile. By Default it points to 'CBL-Mariner/SPECS'
-                    We can override the SPECS_DIR to extended e.g by appeneding: SPECS_DIR=path/to/SPECS-EXTENDED
     MODE            build or test. default:"build"
                         In 'test' mode it will use a pre-built mariner chroot image.
                         In 'build' mode it will use the latest published container.
@@ -41,26 +39,31 @@ Optional arguments:
                         Mountpoints will be ${BUILD_MOUNT}/container-build and ${BUILD_MOUNT}/container-buildroot. default: $REPO_PATH/build
     ENABLE_REPO:    Set to 'y' to use local RPMs to satisfy package dependencies. default: n
 
+    * User can override Mariner make definitions. Some useful overrides could be
+                    SPECS_DIR: build specs from another directory like SPECS-EXTENDED by providing SPECS_DIR=path/to/SPECS-EXTENDED. default: $REPO_PATH/SPECS
+                    SRPM_PACK_LIST: provide a list of SRPMS to build by providing SRPM_PACK_LIST="srpm1 srpm2 ...". default: builds all SRPMS from $SPECS_DIR
+                    RPMS_DIR: choose which built RPMs to mount into container by providing RPMS_DIR=path/to/custom/out/RPMS. default: $REPO_PATH/out/RPMS
+                    Refer to toolkit/Makefile for default definitions.
 To see help, run 'sudo make containerized-rpmbuild-help'
 "
 }
 
 build_worker_chroot() {
-    pushd "${repo_path}/toolkit"
+    pushd $toolkit_root
     echo "Building worker chroot..."
     make chroot-tools REBUILD_TOOLS=y > /dev/null
     popd
 }
 
 build_tools() {
-    pushd "${repo_path}/toolkit"
+    pushd $toolkit_root
     echo "Building required tools..."
     make go-srpmpacker go-depsearch go-grapher go-specreader REBUILD_TOOLS=y > /dev/null
     popd
 }
 
 build_graph() {
-    pushd "${repo_path}/toolkit"
+    pushd $toolkit_root
     echo "Building dependency graph..."
     make workplan > /dev/null
     popd
@@ -73,11 +76,8 @@ if [ "$EUID" -ne 0 ]; then
 fi
 
 script_dir=$(realpath $(dirname "${BASH_SOURCE[0]}"))
-tmp_dir=${script_dir%'/toolkit'*}/build/containerized-rpmbuild/tmp
-mkdir -p ${tmp_dir}
 topdir=/usr/src/mariner
 enable_local_repo=false
-specs_dir=""
 
 while (( "$#")); do
   case "$1" in
@@ -87,7 +87,6 @@ while (( "$#")); do
     -mo ) extra_mounts="$2"; shift 2 ;;
     -b ) build_mount_dir="$(realpath $2)"; shift 2;;
     -r ) enable_local_repo=true; shift ;;
-    -s ) specs_dir="$(realpath $2)"; shift 2;;
     -h ) help; exit 1 ;;
     ? ) echo -e "ERROR: INVALID OPTION.\n\n"; help; exit 1 ;;
   esac
@@ -98,7 +97,25 @@ done
 [[ ! -d "${repo_path}" ]] && { print_error " Directory ${repo_path} does not exist"; exit 1; }
 [[ -z "${mode}" ]] && mode="build"
 [[ -z "${version}" ]] && version="2.0"
-[[ -z "${build_mount_dir}" ]] && build_mount_dir="${repo_path}/build"
+
+# Set relevant folder definitions using Mariner Makefile that can be overriden by user
+# Default values are populated from toolkit/Makefile
+PROJECT_ROOT=$repo_path
+toolkit_root="$PROJECT_ROOT/toolkit"
+pushd $toolkit_root
+BUILD_DIR=$(make -s printvar-BUILD_DIR  2> /dev/null)              # default: $repo_path/build
+OUT_DIR=$(make -s printvar-OUT_DIR 2> /dev/null)                   # default: $repo_path/out
+SPECS_DIR=$(make -s printvar-SPECS_DIR 2> /dev/null)               # default: $repo_path/SPECS
+BUILD_SRPMS_DIR=$(make -s printvar-BUILD_SRPMS_DIR 2> /dev/null)   # default: $repo_path/build/INTERMEDIATE_SRPMS
+RPMS_DIR=$(make -s printvar-RPMS_DIR 2> /dev/null)                 # default: $repo_path/out/RPMS
+TOOL_BINS_DIR=$(make -s printvar-TOOL_BINS_DIR 2> /dev/null)       # default: $repo_path/toolkit/out/tools
+PKGBUILD_DIR=$(make -s printvar-PKGBUILD_DIR 2> /dev/null)         # default: $repo_path/build/pkg_artifacts
+popd
+
+# Assign remaining default values based on folder definitions
+tmp_dir=${BUILD_DIR}/containerized-rpmbuild/tmp
+mkdir -p ${tmp_dir}
+[[ -z "${build_mount_dir}" ]] && build_mount_dir="$BUILD_DIR"
 [[ ! -d "${build_mount_dir}" ]] && { print_error " Directory ${build_mount_dir} does not exist"; exit 1; }
 
 cd "${script_dir}"  || { echo "ERROR: Could not change directory to ${script_dir}"; exit 1; }
@@ -122,9 +139,9 @@ fi
 # ============ Populate SRPMS ============
 # Populate ${repo_path}/build/INTERMEDIATE_SRPMS with SRPMs, that can be used to build RPMs in the container (only required in build mode)
 if [[ "${mode}" == "build" ]]; then
-    pushd "${repo_path}/toolkit"
+    pushd $toolkit_root
     echo "Populating Intermediate SRPMs..."
-    if [[ ( ! -f "${repo_path}/toolkit/out/tools/srpmpacker" ) ]]; then build_tools; fi
+    if [[ ( ! -f "$TOOL_BINS_DIR/srpmpacker" ) ]]; then build_tools; fi
     make input-srpms SRPM_FILE_SIGNATURE_HANDLING="update" > /dev/null
     popd
 fi
@@ -142,22 +159,22 @@ if [[ "${mode}" == "build" ]]; then
 fi
 
 # ============ Setup tools ============
-# Copy relavant build tool executables from ${repo_path}/tools/out
+# Copy relavant build tool executables from $TOOL_BINS_DIR
 echo "Setting up tools..."
-if [[ ( ! -f "${repo_path}/toolkit/out/tools/depsearch" ) || ( ! -f "${repo_path}/toolkit/out/tools/grapher" ) || ( ! -f "${repo_path}/toolkit/out/tools/specreader" ) ]]; then build_tools; fi
-if [[ ! -f "${repo_path}/build/pkg_artifacts/graph.dot" ]]; then build_graph; fi
-cp ${repo_path}/toolkit/out/tools/depsearch ${tmp_dir}/
-cp ${repo_path}/toolkit/out/tools/grapher ${tmp_dir}/
-cp ${repo_path}/toolkit/out/tools/specreader ${tmp_dir}/
-cp ${repo_path}/build/pkg_artifacts/graph.dot ${tmp_dir}/
+if [[ ( ! -f "$TOOL_BINS_DIR/depsearch" ) || ( ! -f "$TOOL_BINS_DIR/grapher" ) || ( ! -f "$TOOL_BINS_DIR/specreader" ) ]]; then build_tools; fi
+if [[ ! -f "$PKGBUILD_DIR/graph.dot" ]]; then build_graph; fi
+cp $TOOL_BINS_DIR/depsearch ${tmp_dir}/
+cp $TOOL_BINS_DIR/grapher ${tmp_dir}/
+cp $TOOL_BINS_DIR/specreader ${tmp_dir}/
+cp $PKGBUILD_DIR/graph.dot ${tmp_dir}/
 
 # ========= Setup mounts =========
 echo "Setting up mounts..."
 
-mounts="${mounts} ${repo_path}/out/RPMS:/mnt/RPMS ${tmp_dir}:/mariner_setup_dir"
+mounts="${mounts} $RPMS_DIR:/mnt/RPMS ${tmp_dir}:/mariner_setup_dir"
 # Add extra 'build' mounts
 if [[ "${mode}" == "build" ]]; then
-    mounts="${mounts} ${repo_path}/build/INTERMEDIATE_SRPMS:/mnt/INTERMEDIATE_SRPMS $specs_dir:${topdir}/SPECS"
+    mounts="${mounts} $BUILD_SRPMS_DIR:/mnt/INTERMEDIATE_SRPMS $SPECS_DIR:${topdir}/SPECS"
 fi
 
 rm -f ${tmp_dir}/mounts.txt
@@ -185,7 +202,7 @@ dockerfile="${script_dir}/resources/mariner.Dockerfile"
 
 if [[ "${mode}" == "build" ]]; then # Configure base image
     echo "Importing chroot into docker..."
-    chroot_file="${repo_path}/build/worker/worker_chroot.tar.gz"
+    chroot_file="$BUILD_DIR/worker/worker_chroot.tar.gz"
     if [[ ! -f "${chroot_file}" ]]; then build_worker_chroot; fi
     chroot_hash=$(sha256sum "${chroot_file}" | cut -d' ' -f1)
     # Check if the chroot file's hash has changed since the last build
@@ -218,5 +235,5 @@ echo "docker_image_tag is ${docker_image_tag}"
 bash -c "docker run --rm \
     ${mount_arg} \
     -it ${docker_image_tag} /bin/bash; \
-    if [[ -d ${repo_path}/out/RPMS/repodata ]]; then { rm -r ${repo_path}/out/RPMS/repodata; echo 'Clearing repodata' ; }; fi
+    if [[ -d $RPMS_DIR/repodata ]]; then { rm -r $RPMS_DIR/repodata; echo 'Clearing repodata' ; }; fi
     "

--- a/toolkit/scripts/containerized-build/create_container_build.sh
+++ b/toolkit/scripts/containerized-build/create_container_build.sh
@@ -41,7 +41,7 @@ Optional arguments:
 
     * User can override Mariner make definitions. Some useful overrides could be
                     SPECS_DIR: build specs from another directory like SPECS-EXTENDED by providing SPECS_DIR=path/to/SPECS-EXTENDED. default: $REPO_PATH/SPECS
-                    SRPM_PACK_LIST: provide a list of SRPMS to build by providing SRPM_PACK_LIST="srpm1 srpm2 ...". default: builds all SRPMS from $SPECS_DIR
+                    SRPM_PACK_LIST: provide a list of SRPMS to build by providing SRPM_PACK_LIST=\"srpm1 srpm2 ...\". default: builds all SRPMS from $SPECS_DIR
                     RPMS_DIR: choose which built RPMs to mount into container by providing RPMS_DIR=path/to/custom/out/RPMS. default: $REPO_PATH/out/RPMS
                     Refer to toolkit/Makefile for default definitions.
 To see help, run 'sudo make containerized-rpmbuild-help'


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
use folder definitions from Makefile, and allow user to override the default definitions

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- use folder definitions from Makefile, and allow user to override the default definitions
- this makes the tool more usable by giving the user the freedom to choose any folder location as one of the Mariner folders
- draft PR: https://github.com/microsoft/CBL-Mariner/pull/6114

Below figures show example usages. Some have errors intentionally, so one can see how the tool overrides default Mariner directory structure and instead, uses the user provided directory.

Using another directory as build directory. The mount points show the user defined directory being used for storing build artifacts
![build-1](https://github.com/microsoft/CBL-Mariner/assets/58672330/cffa67c3-cef4-4a12-a985-92ba1a553b7e)

![build-2](https://github.com/microsoft/CBL-Mariner/assets/58672330/cf4c0db1-d70e-4292-840d-6336b6987af2)

Using SPECS-EXTENDED as the specs directory. The specs provided in the SRPM_PACK_LIST are from SPECS/ and hence, are not found in SPECS-EXTENDED
![specs-extended](https://github.com/microsoft/CBL-Mariner/assets/58672330/2745533f-026e-414c-ba66-d8266612e003)

Using a custom directory as the specs folder. The tool was successfully able to use a custom directory as the specs directory. The tool didn't launch because the custom directory didn't have all the specs specified in the SRPM_PACK_LIST.
![custom-spec](https://github.com/microsoft/CBL-Mariner/assets/58672330/347b0336-3f50-4f2a-a109-711c8ab6c3e8)


###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build