### PR TITLE
Fix systemd/systemd-bootstrap confusion by adding explicit requires

### DIFF
--- a/SPECS-EXTENDED/gnome-desktop-testing/gnome-desktop-testing.spec
+++ b/SPECS-EXTENDED/gnome-desktop-testing/gnome-desktop-testing.spec
@@ -41,6 +41,7 @@ make install DESTDIR=$RPM_BUILD_ROOT
 %changelog
 * Tue Sep 19 2023 Jon Slobodzian <joslobo@microsoft.com> - 2018.1-4
 - Fix build issue for systemd/systemd-bootstrap confusion
+- License verified
 
 * Fri Oct 15 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 2018.1-3
 - Initial CBL-Mariner import from Fedora 32 (license: MIT).

--- a/SPECS-EXTENDED/gnome-desktop-testing/gnome-desktop-testing.spec
+++ b/SPECS-EXTENDED/gnome-desktop-testing/gnome-desktop-testing.spec
@@ -2,7 +2,7 @@ Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Name:           gnome-desktop-testing
 Version:        2018.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        GNOME test runner for installed tests
 
 License:        LGPLv2+
@@ -10,7 +10,7 @@ URL:            https://live.gnome.org/Initiatives/GnomeGoals/InstalledTests
 Source0:        https://gitlab.gnome.org/GNOME/%{name}/-/archive/v%{version}/%{name}-v%{version}.tar.gz
 
 BuildRequires:  pkgconfig(gio-unix-2.0)
-BuildRequires:  pkgconfig(libsystemd)
+BuildRequires:  systemd-devel
 BuildRequires:  pkgconfig(libgsystem)
 BuildRequires:  git automake autoconf libtool
 
@@ -39,6 +39,9 @@ make install DESTDIR=$RPM_BUILD_ROOT
 %{_bindir}/ginsttest-runner
 
 %changelog
+* Tue Sep 19 2023 Jon Slobodzian <joslobo@microsoft.com> - 2018.1-4
+- Fix build issue for systemd/systemd-bootstrap confusion
+
 * Fri Oct 15 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 2018.1-3
 - Initial CBL-Mariner import from Fedora 32 (license: MIT).
 

--- a/SPECS-EXTENDED/iio-sensor-proxy/iio-sensor-proxy.spec
+++ b/SPECS-EXTENDED/iio-sensor-proxy/iio-sensor-proxy.spec
@@ -12,7 +12,6 @@ Source0:        https://gitlab.freedesktop.org/hadess/%{name}/uploads/de965bcb44
 BuildRequires:  %{_bindir}/xsltproc
 BuildRequires:  make
 BuildRequires:  gcc
-BuildRequires:  pkgconfig(udev)
 BuildRequires:  pkgconfig(gio-2.0)
 BuildRequires:  pkgconfig(gudev-1.0)
 BuildRequires:  systemd

--- a/SPECS-EXTENDED/iio-sensor-proxy/iio-sensor-proxy.spec
+++ b/SPECS-EXTENDED/iio-sensor-proxy/iio-sensor-proxy.spec
@@ -2,7 +2,7 @@ Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Name:           iio-sensor-proxy
 Version:        3.0
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        IIO accelerometer sensor to input device proxy
 
 License:        GPLv3+
@@ -13,7 +13,6 @@ BuildRequires:  %{_bindir}/xsltproc
 BuildRequires:  make
 BuildRequires:  gcc
 BuildRequires:  pkgconfig(udev)
-BuildRequires:  pkgconfig(systemd)
 BuildRequires:  pkgconfig(gio-2.0)
 BuildRequires:  pkgconfig(gudev-1.0)
 BuildRequires:  systemd
@@ -66,6 +65,9 @@ This package contains the documentation for %{name}.
 %{_datadir}/gtk-doc/html/%{name}/
 
 %changelog
+* Tue Sep 19 2023 Jon Slobodzian <joslobo@microsoft.com> - 3.0-5
+- Fix build issue for systemd/systemd-bootstrap confusion
+
 * Tue Mar 22 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 3.0-4
 - Fixing configuration step in %%build.
 

--- a/SPECS-EXTENDED/iwd/iwd.spec
+++ b/SPECS-EXTENDED/iwd/iwd.spec
@@ -1,7 +1,7 @@
 Summary:        Wireless daemon for Linux
 Name:           iwd
 Version:        1.22
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        LGPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -15,7 +15,7 @@ BuildRequires:  python3-docutils
 BuildRequires:  readline-devel
 BuildRequires:  pkgconfig(dbus-1)
 BuildRequires:  pkgconfig(ell) >= 0.27
-BuildRequires:  pkgconfig(libsystemd)
+BuildRequires:  systemd-devel
 Requires:       dbus
 Requires:       systemd
 
@@ -71,6 +71,9 @@ mkdir -p %{buildroot}%{_sharedstatedir}/ead
 
 
 %changelog
+* Tue Sep 19 2023 Jon Slobodzian <joslobo@microsoft.com> - 1.22-2
+- Fix build issue for systemd/systemd-bootstrap confusion
+
 * Thu Dec 15 2022 Muhammad Falak <mwani@microsoft.com> - 1.22-1
 - License verified
 

--- a/SPECS-EXTENDED/pacemaker/pacemaker.spec
+++ b/SPECS-EXTENDED/pacemaker/pacemaker.spec
@@ -92,7 +92,7 @@
 Summary:        Scalable High-Availability cluster resource manager
 Name:           pacemaker
 Version:        2.1.5
-Release:        4%{?dist}
+Release:        5%{?dist}
 License:        GPLv2+ and LGPLv2+
 Url:            https://www.clusterlabs.org/
 Source0:        https://github.com/ClusterLabs/pacemaker/archive/refs/tags/Pacemaker-2.1.5.tar.gz#/%{name}-%{version}.tar.gz
@@ -148,7 +148,7 @@ BuildRequires:  asciidoc
 BuildRequires:  inkscape
 BuildRequires:  %{python_name}-sphinx
 %endif
-BuildRequires:  pkgconfig(systemd)
+BuildRequires:  systemd
 Requires:       corosync >= 2.0.0
 # Booth requires this
 Provides:       pacemaker-ticket-support = 2.0
@@ -602,6 +602,9 @@ exit 0
 %{_datadir}/pkgconfig/pacemaker-schemas.pc
 
 %changelog
+* Tue Sep 19 2023 Jon Slobodzian <joslobo@microsoft.com> - 2.1.5-5
+- Fix build issue for systemd/systemd-bootstrap confusion
+
 * Wed Mar 08 2023 Sumedh Sharma <sumsharma@microsoft.com> - 2.1.5-4
 - Initial CBL-Mariner import from Fedora 37 (license: MIT)
 - Disable nagios-plugins-metadata

--- a/SPECS-EXTENDED/samba/samba.spec
+++ b/SPECS-EXTENDED/samba/samba.spec
@@ -3438,6 +3438,7 @@ fi
 %changelog
 * Tue Sep 19 2023 Jon Slobodzian <joslobo@microsoft.com> - 4.12.5-5
 - Fix build issue for systemd/systemd-bootstrap confusion
+- License verified
 
 * Mon Nov 01 2021 Muhammad Falak <mwani@microsft.com> - 4.12.5-4
 - Remove epoch

--- a/SPECS-EXTENDED/samba/samba.spec
+++ b/SPECS-EXTENDED/samba/samba.spec
@@ -85,7 +85,7 @@
 
 Name:           samba
 Version:        4.12.5
-Release:        4%{?dist}
+Release:        5%{?dist}
 
 
 %define samba_depver %{version}-%{release}
@@ -193,7 +193,7 @@ BuildRequires: xfsprogs-devel
 BuildRequires: xz
 BuildRequires: zlib-devel >= 1.2.3
 
-BuildRequires: pkgconfig(libsystemd)
+BuildRequires: systemd-devel
 
 %if %{with_vfs_glusterfs}
 BuildRequires: glusterfs-api-devel >= 3.4.0.16
@@ -3436,6 +3436,9 @@ fi
 %endif
 
 %changelog
+* Tue Sep 19 2023 Jon Slobodzian <joslobo@microsoft.com> - 4.12.5-5
+- Fix build issue for systemd/systemd-bootstrap confusion
+
 * Mon Nov 01 2021 Muhammad Falak <mwani@microsft.com> - 4.12.5-4
 - Remove epoch
 

--- a/SPECS-EXTENDED/samba/samba.spec
+++ b/SPECS-EXTENDED/samba/samba.spec
@@ -97,8 +97,8 @@ Distribution:   Mariner
 URL:            https://www.samba.org
 
 # This is a xz recompressed file of https://ftp.samba.org/pub/samba/samba-%%{version}%%{pre_release}.tar.gz
-Source0:        https://ftp.samba.org/pub/samba/samba-%{version}%{pre_release}.tar.gz#/samba-%{version}%{pre_release}.tar.xz
-Source1:        https://ftp.samba.org/pub/samba/samba-%{version}%{pre_release}.tar.asc
+Source0:        https://ftp.samba.org/pub/samba/stable/samba-%{version}%{pre_release}.tar.gz#/samba-%{version}%{pre_release}.tar.xz
+Source1:        https://ftp.samba.org/pub/samba/stable/samba-%{version}%{pre_release}.tar.asc
 Source2:        gpgkey-52FBC0B86D954B0843324CDC6F33915B6568B7EA.gpg
 
 # Red Hat specific replacement-files

--- a/SPECS-EXTENDED/systemd-bootchart/systemd-bootchart.spec
+++ b/SPECS-EXTENDED/systemd-bootchart/systemd-bootchart.spec
@@ -56,6 +56,7 @@ are displayed separately.
 %changelog
 * Tue Sep 19 2023 Jon Slobodzian <joslobo@microsoft.com> - 233-8
 - Fix build issue for systemd/systemd-bootstrap confusion
+- License verified
 
 * Fri Oct 15 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 233-7
 - Initial CBL-Mariner import from Fedora 32 (license: MIT).

--- a/SPECS-EXTENDED/systemd-bootchart/systemd-bootchart.spec
+++ b/SPECS-EXTENDED/systemd-bootchart/systemd-bootchart.spec
@@ -2,7 +2,7 @@ Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Name:           systemd-bootchart
 Version:        233
-Release:        8{?dist}
+Release:        8%{?dist}
 Summary:        Boot performance graphing tool
 
 License:        GPLv2+ and LGPLv2+

--- a/SPECS-EXTENDED/systemd-bootchart/systemd-bootchart.spec
+++ b/SPECS-EXTENDED/systemd-bootchart/systemd-bootchart.spec
@@ -2,7 +2,7 @@ Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Name:           systemd-bootchart
 Version:        233
-Release:        7%{?dist}
+Release:        8{?dist}
 Summary:        Boot performance graphing tool
 
 License:        GPLv2+ and LGPLv2+
@@ -11,7 +11,7 @@ Source0:        https://github.com/systemd/%{name}/releases/download/v%{version}
 
 BuildRequires:  gcc
 BuildRequires:  systemd
-BuildRequires:  pkgconfig(libsystemd) >= 221
+BuildRequires:  systemd-devel
 BuildRequires:  %{_bindir}/xsltproc
 BuildRequires:  docbook-style-xsl
 %{?systemd_requires}
@@ -54,6 +54,9 @@ are displayed separately.
 %{_mandir}/man5/bootchart.conf.d.5*
 
 %changelog
+* Tue Sep 19 2023 Jon Slobodzian <joslobo@microsoft.com> - 233-8
+- Fix build issue for systemd/systemd-bootstrap confusion
+
 * Fri Oct 15 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 233-7
 - Initial CBL-Mariner import from Fedora 32 (license: MIT).
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -27146,7 +27146,7 @@
         "other": {
           "name": "samba",
           "version": "4.12.5",
-          "downloadUrl": "https://ftp.samba.org/pub/samba/samba-4.12.5.tar.gz"
+          "downloadUrl": "https://ftp.samba.org/pub/samba/stable/samba-4.12.5.tar.gz"
         }
       }
     },


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
Full builds of the extended packages have been broken for an unknown amount of time.  The build was incorrectly trying to use systemd-bootstrap or systemd-bootstrap-devel as a build time dependency.  This change fixes sevearl SPEC files by explicitly requiring systemd or systemd-devel for the build time dependencies.

