### PR TITLE
Address CVE-2023-29383 in shadow-utils

### DIFF
--- a/SPECS/shadow-utils/CVE-2023-29383.patch
+++ b/SPECS/shadow-utils/CVE-2023-29383.patch
@@ -1,0 +1,58 @@
+From d4f64afb7142dfec9dcc4409368175cdd170a672 Mon Sep 17 00:00:00 2001
+From: Christian Göettsche <cgzones@googlemail.com>
+Date: Fri, 31 Mar 2023 14:46:50 +0200
+Subject: [PATCH] Overhaul valid_field()
+
+e5905c4b ("Added control character check") introduced checking for
+control characters but had the logic inverted, so it rejects all
+characters that are not control ones.
+
+Cast the character to `unsigned char` before passing to the character
+checking functions to avoid UB.
+
+Use strpbrk(3) for the illegal character test and return early.
+---
+ lib/fields.c | 24 ++++++++++--------------
+ 1 file changed, 10 insertions(+), 14 deletions(-)
+
+diff --git a/lib/fields.c b/lib/fields.c
+index fb51b5829..539292485 100644
+--- a/lib/fields.c
++++ b/lib/fields.c
+@@ -37,26 +37,22 @@ int valid_field (const char *field, const char *illegal)
+ 
+ 	/* For each character of field, search if it appears in the list
+ 	 * of illegal characters. */
++	if (illegal && NULL != strpbrk (field, illegal)) {
++		return -1;
++	}
++
++	/* Search if there are non-printable or control characters */
+ 	for (cp = field; '\0' != *cp; cp++) {
+-		if (strchr (illegal, *cp) != NULL) {
++		unsigned char c = *cp;
++		if (!isprint (c)) {
++			err = 1;
++		}
++		if (iscntrl (c)) {
+ 			err = -1;
+ 			break;
+ 		}
+ 	}
+ 
+-	if (0 == err) {
+-		/* Search if there are non-printable or control characters */
+-		for (cp = field; '\0' != *cp; cp++) {
+-			if (!isprint (*cp)) {
+-				err = 1;
+-			}
+-			if (!iscntrl (*cp)) {
+-				err = -1;
+-				break;
+-			}
+-		}
+-	}
+-
+ 	return err;
+ }
+ 

--- a/SPECS/shadow-utils/CVE-2023-29383.patch
+++ b/SPECS/shadow-utils/CVE-2023-29383.patch
@@ -1,7 +1,53 @@
-From d4f64afb7142dfec9dcc4409368175cdd170a672 Mon Sep 17 00:00:00 2001
-From: Christian Göettsche <cgzones@googlemail.com>
+From 8c7d6c407fd544db2cefa93b9fc95beadc00e132 Mon Sep 17 00:00:00 2001
+From: tomspiderlabs <128755403+tomspiderlabs@users.noreply.github.com>
+Date: Thu, 23 Mar 2023 23:39:38 +0000
+Subject: [PATCH 1/2] Added control character check
+
+Added control character check, returning -1 (to "err") if control characters are present.
+---
+ lib/fields.c | 11 +++++++----
+ 1 file changed, 7 insertions(+), 4 deletions(-)
+
+diff --git a/lib/fields.c b/lib/fields.c
+index 649fae17..b8f13ba7 100644
+--- a/lib/fields.c
++++ b/lib/fields.c
+@@ -44,9 +44,9 @@
+  *
+  * The supplied field is scanned for non-printable and other illegal
+  * characters.
+- *  + -1 is returned if an illegal character is present.
+- *  +  1 is returned if no illegal characters are present, but the field
+- *       contains a non-printable character.
++ *  + -1 is returned if an illegal or control character is present.
++ *  +  1 is returned if no illegal or control characters are present,
++ *       but the field contains a non-printable character.
+  *  +  0 is returned otherwise.
+  */
+ int valid_field (const char *field, const char *illegal)
+@@ -68,10 +68,13 @@ int valid_field (const char *field, const char *illegal)
+ 	}
+ 
+ 	if (0 == err) {
+-		/* Search if there are some non-printable characters */
++		/* Search if there are non-printable or control characters */
+ 		for (cp = field; '\0' != *cp; cp++) {
+ 			if (!isprint (*cp)) {
+ 				err = 1;
++			}
++			if (!iscntrl (*cp)) {
++				err = -1;
+ 				break;
+ 			}
+ 		}
+-- 
+2.25.1
+
+
+From 332037afa44a6ed81b91394d89972d2da3b1577d Mon Sep 17 00:00:00 2001
+From: Christian Göttsche <cgzones@googlemail.com>
 Date: Fri, 31 Mar 2023 14:46:50 +0200
-Subject: [PATCH] Overhaul valid_field()
+Subject: [PATCH 2/2] Overhaul valid_field()
 
 e5905c4b ("Added control character check") introduced checking for
 control characters but had the logic inverted, so it rejects all
@@ -16,10 +62,10 @@ Use strpbrk(3) for the illegal character test and return early.
  1 file changed, 10 insertions(+), 14 deletions(-)
 
 diff --git a/lib/fields.c b/lib/fields.c
-index fb51b5829..539292485 100644
+index b8f13ba7..191257e8 100644
 --- a/lib/fields.c
 +++ b/lib/fields.c
-@@ -37,26 +37,22 @@ int valid_field (const char *field, const char *illegal)
+@@ -60,26 +60,22 @@ int valid_field (const char *field, const char *illegal)
  
  	/* For each character of field, search if it appears in the list
  	 * of illegal characters. */
@@ -56,3 +102,6 @@ index fb51b5829..539292485 100644
  	return err;
  }
  
+-- 
+2.25.1
+

--- a/SPECS/shadow-utils/shadow-utils.spec
+++ b/SPECS/shadow-utils/shadow-utils.spec
@@ -71,6 +71,7 @@ Libraries and headers for libsubid
 %setup -q -n shadow-%{version}
 %patch0 -p1
 %patch1 -p1
+%patch2 -p1
 
 autoreconf -fiv
 
@@ -177,7 +178,7 @@ chmod 000 %{_sysconfdir}/shadow
 %{_libdir}/libsubid.so
 
 %changelog
-* Wed Sept 20 2023 Kanika Nema <kanikanema@microsoft.com> - 4.9-13
+* Wed Sep 20 2023 Kanika Nema <kanikanema@microsoft.com> - 4.9-13
 - Address CVE-2023-29383
 
 * Wed May 24 2023 Tobias Brick <tobiasb@microsoft.com> - 4.9-12

--- a/SPECS/shadow-utils/shadow-utils.spec
+++ b/SPECS/shadow-utils/shadow-utils.spec
@@ -1,7 +1,7 @@
 Summary:        Programs for handling passwords in a secure way
 Name:           shadow-utils
 Version:        4.9
-Release:        12%{?dist}
+Release:        13%{?dist}
 License:        BSD
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -22,6 +22,7 @@ Source12:       useradd-default
 Source13:       login-defs
 Patch0:         chkname-allowcase.patch
 Patch1:         libsubid-pam-link.patch
+Patch2:         CVE-2023-29383.patch
 BuildRequires:  autoconf
 BuildRequires:  audit-devel
 BuildRequires:  automake
@@ -176,6 +177,9 @@ chmod 000 %{_sysconfdir}/shadow
 %{_libdir}/libsubid.so
 
 %changelog
+* Wed Sept 20 2023 Kanika Nema <kanikanema@microsoft.com> - 4.9-13
+- Address CVE-2023-29383
+
 * Wed May 24 2023 Tobias Brick <tobiasb@microsoft.com> - 4.9-12
 - Add SETUID bit to passwd binary
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Fixes CVE-2023-29383

###### Change Log  <!-- REQUIRED -->
This fix is based on https://github.com/NixOS/nixpkgs/pull/233924. An earlier attempt that included just the first patch caused a build break.

###### Does this affect the toolchain?  <!-- REQUIRED -->
No

###### Associated issues  <!-- optional -->

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2023-29383

###### Test Methodology
- Buddy Build: 424052. (Please note the tdnf install step fails due to a bug in InstallPackagesTdnf.sh)
- Full Pipeline build id: 424088