### PR TITLE
Add SPDX license guidance to spec guidelines check

### DIFF
--- a/toolkit/scripts/check_spec_guidelines.py
+++ b/toolkit/scripts/check_spec_guidelines.py
@@ -48,8 +48,8 @@ ERROR: license not verified.
     Make sure the package's license matches the information provided inside the 'License' tag.
     Once that's done, indicate that through a changelog entry "License verified" or "Verified license".
 
-    NOTE: for the 'License' tag please use the names from the "Short Name" column inside Fedora's licensing guidelines:
-          https://fedoraproject.org/wiki/Licensing:Main?rd=Licensing#Good_Licenses
+    NOTE: For the 'License' tag, please use SPDX license expressions:
+          https://spdx.dev/learn/handling-license-info/
 """)
         return False
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
The spec guidelines check script points to Fedora shortnames as the standard for license names in spec files. The new standard is using SPDX license expressions, so change the script's guidance to reflect that.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Link to SPDX license expression explainer in spec guidelines check script

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Ran script locally
