### PR TITLE
Get go tools unit tests to pass in VSCode

### DIFF
--- a/toolkit/tools/imagegen/configuration/networkconfig.go
+++ b/toolkit/tools/imagegen/configuration/networkconfig.go
@@ -76,7 +76,10 @@ func (n *Network) IsValid() (err error) {
 
 // ConfigureNetwork performs network configuration during the installation process
 func ConfigureNetwork(installChroot *safechroot.Chroot, systemConfig SystemConfig) (err error) {
-	const squashErrors = false
+	const (
+		squashErrors   = false
+		networkFileDir = "/etc/systemd/network"
+	)
 
 	for _, networkData := range systemConfig.Networks {
 		deviceName, err := checkNetworkDeviceAvailability(networkData)
@@ -87,7 +90,7 @@ func ConfigureNetwork(installChroot *safechroot.Chroot, systemConfig SystemConfi
 			return err
 		}
 
-		err = createNetworkConfigFile(installChroot, networkData, deviceName)
+		err = createNetworkConfigFile(installChroot, networkData, deviceName, networkFileDir)
 		if err != nil {
 			return err
 		}
@@ -236,18 +239,15 @@ func populateNetworkSection(networkData Network, fileName string) (err error) {
 	return
 }
 
-func createNetworkConfigFile(installChroot *safechroot.Chroot, networkData Network, deviceName string) (err error) {
-	const (
-		networkFileDir = "/etc/systemd/network"
-		filePrefix     = "10"
-	)
+func createNetworkConfigFile(installChroot *safechroot.Chroot, networkData Network, deviceName, networkFileDir string) (err error) {
+	const filePrefix = "10"
 
 	if exists, ferr := file.DirExists(networkFileDir); ferr != nil {
-		logger.Log.Errorf("Error accessing /etc/systemd/network/")
+		logger.Log.Errorf("Error accessing: %s", networkFileDir)
 		err = ferr
 		return
 	} else if !exists {
-		err = fmt.Errorf("/etc/systemd/network/: no such path or directory")
+		err = fmt.Errorf("%s: no such path or directory", networkFileDir)
 		return
 	}
 

--- a/toolkit/tools/imagegen/configuration/networkconfig_test.go
+++ b/toolkit/tools/imagegen/configuration/networkconfig_test.go
@@ -5,6 +5,7 @@ package configuration
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/file"
@@ -134,28 +135,12 @@ func TestShouldFailParsingInvalidDevice_Network(t *testing.T) {
 }
 
 func TestShouldPassCreatingNetworkFile_Network(t *testing.T) {
-	const (
-		networkFileDir  = "/etc/systemd/network"
-		testNetworkFile = "/etc/systemd/network/10-static-eth1.network"
-	)
-
-	// Some systems may not have systemd-networkd service configured, and thus
-	// /etc/systemd/network may not exist. For this test case, manually create this directory
-	// if it does not exist
-	exists, err := file.DirExists(networkFileDir)
-	assert.NoError(t, err)
-	if !exists {
-		err = os.Mkdir(networkFileDir, os.ModePerm)
-		assert.NoError(t, err)
-		t.Cleanup(func() {
-			err = os.RemoveAll(networkFileDir)
-			assert.NoError(t, err)
-		})
-	}
+	testNetworkFileDir := t.TempDir()
+	testNetworkFile := filepath.Join(testNetworkFileDir, "10-static-eth1.network")
 
 	testNetwork := validNetworks[0]
 
-	err = createNetworkConfigFile(nil, testNetwork, "eth1")
+	err := createNetworkConfigFile(nil, testNetwork, "eth1", testNetworkFileDir)
 	assert.NoError(t, err)
 	t.Cleanup(func() {
 		os.Remove(testNetworkFile)

--- a/toolkit/tools/imagegen/installutils/installutils_test.go
+++ b/toolkit/tools/imagegen/installutils/installutils_test.go
@@ -64,6 +64,10 @@ func TestShouldReturnCorrectRequiredPackagesForArch(t *testing.T) {
 }
 
 func TestCopyAdditionalFiles(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("Test must be run as root because it uses a chroot")
+	}
+
 	proposedDir := filepath.Join(tmpDir, "TestCopyAdditionalFiles")
 	chroot := safechroot.NewChroot(proposedDir, false)
 

--- a/toolkit/tools/internal/safechroot/safechroot_test.go
+++ b/toolkit/tools/internal/safechroot/safechroot_test.go
@@ -24,35 +24,26 @@ const (
 )
 
 var (
-	testDir    string
-	tmpDir     string
-	workingDir string
+	testDir string
 )
 
 func TestMain(m *testing.M) {
-	var err error
-
 	logger.InitStderrLog()
-
-	workingDir, err = os.Getwd()
-	if err != nil {
-		logger.Log.Panicf("Failed to get working directory, error: %s", err)
-	}
-
-	testDir = filepath.Join(workingDir, "testdata")
-	tmpDir = filepath.Join(workingDir, "_tmp")
 
 	var retVal int
 	if os.Geteuid() != 0 {
+		// We're not running as root; we need to skip all tests in this file.
 		logger.Log.Warn("safechroot tests must be run as root; skipping...")
 		retVal = 0
 	} else {
-		retVal = m.Run()
-	}
+		// We're running as root; let's proceed with test setup and testing.
+		var err error
+		testDir, err = filepath.Abs("testdata")
+		if err != nil {
+			logger.Log.Panicf("Failed to get path to test data, error: %s", err)
+		}
 
-	err = os.RemoveAll(tmpDir)
-	if err != nil {
-		logger.Log.Warnf("Failed to cleanup tmp dir (%s). Error: %s", tmpDir, err)
+		retVal = m.Run()
 	}
 
 	os.Exit(retVal)
@@ -62,7 +53,7 @@ func TestInitializeShouldCreateRoot(t *testing.T) {
 	extraMountPoints := []*MountPoint{}
 	extraDirectories := []string{}
 
-	dir := filepath.Join(tmpDir, "TestInitializeShouldCreateRoot")
+	dir := filepath.Join(t.TempDir(), "TestInitializeShouldCreateRoot")
 	chroot := NewChroot(dir, isExistingDir)
 
 	err := chroot.Initialize(emptyPath, extraDirectories, extraMountPoints)
@@ -78,7 +69,7 @@ func TestCloseShouldRemoveRoot(t *testing.T) {
 	extraMountPoints := []*MountPoint{}
 	extraDirectories := []string{}
 
-	dir := filepath.Join(tmpDir, "TestCloseShouldRemoveRoot")
+	dir := filepath.Join(t.TempDir(), "TestCloseShouldRemoveRoot")
 	chroot := NewChroot(dir, isExistingDir)
 
 	err := chroot.Initialize(emptyPath, extraDirectories, extraMountPoints)
@@ -108,7 +99,7 @@ func TestCloseShouldLeaveRootOnRequest(t *testing.T) {
 		extraMountPoints := []*MountPoint{}
 		extraDirectories := []string{}
 
-		dir := filepath.Join(tmpDir, "TestCloseShouldLeaveRootOnRequest")
+		dir := filepath.Join(t.TempDir(), "TestCloseShouldLeaveRootOnRequest")
 		chroot := NewChroot(dir, isExistingDir)
 
 		err := chroot.Initialize(emptyPath, extraDirectories, extraMountPoints)
@@ -130,7 +121,7 @@ func TestCloseShouldLeaveRootOnRequest(t *testing.T) {
 func TestRootDirShouldReturnRootDir(t *testing.T) {
 	if buildpipeline.IsRegularBuild() {
 		// this test only apply to "regular build" pipeline
-		dir := filepath.Join(tmpDir, "TestRootDirShouldReturnRootDir")
+		dir := filepath.Join(t.TempDir(), "TestRootDirShouldReturnRootDir")
 		chroot := NewChroot(dir, isExistingDir)
 		assert.Equal(t, dir, chroot.RootDir())
 	}
@@ -140,7 +131,7 @@ func TestRunShouldReturnCorrectError(t *testing.T) {
 	extraMountPoints := []*MountPoint{}
 	extraDirectories := []string{}
 
-	dir := filepath.Join(tmpDir, "TestRunShouldReturnCorrectError")
+	dir := filepath.Join(t.TempDir(), "TestRunShouldReturnCorrectError")
 	chroot := NewChroot(dir, isExistingDir)
 
 	err := chroot.Initialize(emptyPath, extraDirectories, extraMountPoints)
@@ -159,7 +150,7 @@ func TestRunShouldChangeCWD(t *testing.T) {
 	extraMountPoints := []*MountPoint{}
 	extraDirectories := []string{}
 
-	dir := filepath.Join(tmpDir, "TestRunShouldChangeCWD")
+	dir := filepath.Join(t.TempDir(), "TestRunShouldChangeCWD")
 	chroot := NewChroot(dir, isExistingDir)
 
 	err := chroot.Initialize(emptyPath, extraDirectories, extraMountPoints)
@@ -184,14 +175,14 @@ func TestShouldRestoreCWD(t *testing.T) {
 	extraMountPoints := []*MountPoint{}
 	extraDirectories := []string{}
 
-	dir := filepath.Join(tmpDir, "TestShouldRestoreCWD")
+	dir := filepath.Join(t.TempDir(), "TestShouldRestoreCWD")
 	chroot := NewChroot(dir, isExistingDir)
 
 	err := chroot.Initialize(emptyPath, extraDirectories, extraMountPoints)
 	assert.NoError(t, err)
 	defer chroot.Close(defaultLeaveOnDisk)
 
-	expectedWorkingDirectory := workingDir
+	expectedWorkingDirectory, err := os.Getwd()
 	assert.NoError(t, err)
 
 	err = chroot.Run(func() (err error) {
@@ -211,7 +202,7 @@ func TestInitializeShouldExtractTar(t *testing.T) {
 	extraMountPoints := []*MountPoint{}
 	extraDirectories := []string{}
 
-	dir := filepath.Join(tmpDir, "TestInitializeShouldExtractTar")
+	dir := filepath.Join(t.TempDir(), "TestInitializeShouldExtractTar")
 	chroot := NewChroot(dir, isExistingDir)
 
 	err := chroot.Initialize(tarPath, extraDirectories, extraMountPoints)
@@ -234,7 +225,7 @@ func TestInitializeShouldCreateCustomMountPoints(t *testing.T) {
 			NewMountPoint(srcMount, "custom-mount", "", BindMountPointFlags, emptyPath),
 		}
 
-		dir := filepath.Join(tmpDir, "TestInitializeShouldCreateCustomMountPoints")
+		dir := filepath.Join(t.TempDir(), "TestInitializeShouldCreateCustomMountPoints")
 		chroot := NewChroot(dir, isExistingDir)
 
 		err := chroot.Initialize(emptyPath, extraDirectories, extraMountPoints)
@@ -257,7 +248,7 @@ func TestInitializeShouldCleanupOnBadMountPoint(t *testing.T) {
 			NewMountPoint(invalidMountPointSource, "custom-mount", "", emptyFlags, emptyPath),
 		}
 
-		dir := filepath.Join(tmpDir, "TestInitializeShouldCleanupOnBadMountPoint")
+		dir := filepath.Join(t.TempDir(), "TestInitializeShouldCleanupOnBadMountPoint")
 		chroot := NewChroot(dir, isExistingDir)
 
 		err := chroot.Initialize(emptyPath, extraDirectories, extraMountPoints)
@@ -274,7 +265,7 @@ func TestInitializeShouldCreateExtraDirectories(t *testing.T) {
 	extraDirectories := []string{expectedExtraDirectory}
 	extraMountPoints := []*MountPoint{}
 
-	dir := filepath.Join(tmpDir, "TestInitializeShouldCreateExtraDirectories")
+	dir := filepath.Join(t.TempDir(), "TestInitializeShouldCreateExtraDirectories")
 	chroot := NewChroot(dir, isExistingDir)
 
 	err := chroot.Initialize(emptyPath, extraDirectories, extraMountPoints)

--- a/toolkit/tools/internal/safechroot/safechroot_test.go
+++ b/toolkit/tools/internal/safechroot/safechroot_test.go
@@ -42,7 +42,13 @@ func TestMain(m *testing.M) {
 	testDir = filepath.Join(workingDir, "testdata")
 	tmpDir = filepath.Join(workingDir, "_tmp")
 
-	retVal := m.Run()
+	var retVal int
+	if os.Geteuid() != 0 {
+		logger.Log.Warn("safechroot tests must be run as root; skipping...")
+		retVal = 0
+	} else {
+		retVal = m.Run()
+	}
 
 	err = os.RemoveAll(tmpDir)
 	if err != nil {

--- a/toolkit/tools/internal/timestamp/timestamp_test.go
+++ b/toolkit/tools/internal/timestamp/timestamp_test.go
@@ -15,45 +15,17 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const (
-	testDataDir   = "./testdata/"
-	testOutputDir = "./testout/"
-)
-
 var (
 	defaultStartTime = time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
 	defaultEndTime   = time.Date(2023, 1, 1, 1, 0, 0, 0, time.UTC)
 )
 
-func setUp() {
+func TestMain(m *testing.M) {
 	// init logger to be used by the timestamp tool
 	logger.InitStderrLog()
 
-	if _, err := os.Stat(testOutputDir); os.IsNotExist(err) {
-		err = os.Mkdir(testOutputDir, 0755)
-		if err != nil {
-			panic(err)
-		}
-	}
-}
-
-func tearDown() {
-	timestampRecordFiles, err := filepath.Glob(testOutputDir + "*.jsonl")
-	if err != nil {
-		panic(err)
-	}
-	for _, file := range timestampRecordFiles {
-		err = os.Remove(file)
-		if err != nil {
-			panic(err)
-		}
-	}
-}
-
-func TestMain(m *testing.M) {
-	setUp()
 	retVal := m.Run()
-	tearDown()
+
 	os.Exit(retVal)
 }
 
@@ -143,7 +115,7 @@ func TestTimeStampComplete(t *testing.T) {
 func TestCreateTimeStampFile(t *testing.T) {
 	assert := assert.New(t)
 
-	testFile := testOutputDir + "test_create_timestamp_file.jsonl"
+	testFile := filepath.Join(t.TempDir(), "test_create_timestamp_file.jsonl")
 	_, err := BeginTiming("test", testFile)
 	defer CompleteTiming()
 
@@ -154,7 +126,7 @@ func TestCreateTimeStampFile(t *testing.T) {
 func TestResumeAndAppend(t *testing.T) {
 	assert := assert.New(t)
 
-	testFile := testOutputDir + "test_resume_and_append.jsonl"
+	testFile := filepath.Join(t.TempDir(), "test_resume_and_append.jsonl")
 	_, err := BeginTiming("test", testFile)
 	FlushAndCleanUpResources()
 
@@ -187,7 +159,7 @@ func TestResumeAndAppend(t *testing.T) {
 func TestStartStopEvent(t *testing.T) {
 	assert := assert.New(t)
 
-	testFile := testOutputDir + "test_start_stop_event.jsonl"
+	testFile := filepath.Join(t.TempDir(), "test_start_stop_event.jsonl")
 	root, err := BeginTiming("test", testFile)
 
 	assert.NoError(err)
@@ -226,7 +198,7 @@ func TestStartStopEvent(t *testing.T) {
 func TestPauseResumeEvent(t *testing.T) {
 	assert := assert.New(t)
 
-	testFile := testOutputDir + "test_pause_resume_event.jsonl"
+	testFile := filepath.Join(t.TempDir(), "test_pause_resume_event.jsonl")
 	root, _ := BeginTiming("test", testFile)
 
 	ts, _ := StartEvent("A", root)


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary
The go tools' unit tests presently don't run cleanly in VSCode. The main blockers are tests that require running as `root` / under `sudo`. While triaging some of those failures, I also noticed a unit test that is writing to `/etc` on the host system--that should be remedied.

###### Change Log
- Fix the network config unit test so that it arranges to write to a test dir, not to real `/etc`. Actually makes the test simpler since we can leverage `t.TempDir()` and rely on it being existent (and empty) and cleaned up for us afterwards.
- Identify unit tests that require running in a chroot and arrange for them to be skipped when the effective UID isn't 0 (i.e., when we're running as non-root, and not under `sudo`).

###### Does this affect the toolchain?  
No.

###### Test Methodology
Local test run.