### PR TITLE
Re-enable tests for gnutls, jna, libsoup, strongswan

### DIFF
--- a/toolkit/resources/manifests/package/macros.override
+++ b/toolkit/resources/manifests/package/macros.override
@@ -8,7 +8,6 @@
 # This list of skip_check_%{name} entries will cause %check to return immediately
 # on the specified spec.
 
-%skip_check_libsoup 1
 %skip_check_ant 1
 %skip_check_python_lxml 1
 %skip_check_socat 1
@@ -19,16 +18,9 @@
 %skip_check_gtk_doc 1
 %skip_check_tdnf 1
 %skip_check_vim 1
-%skip_check_gnutls 1
-
-# JNA requires X11 dependencies which are only available in toolchain build environment
-%skip_check_jna 1
 
 # We are missing many of the dependency packages for the Dracut tests
 %skip_check_dracut 1
-
-# Strongswan's rsa testsuite occasionally hangs
-%skip_check_strongswan 1
 
 # asciidoc tests require the "source-highlight" package which is not available
 %skip_check_asciidoc 1


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Our test runner environment has changed drastically throughout the years and packages have been changed/upgraded, so we should re-evaluate tests that have been turned off in `macros.override` since the days of pre-1.0.

`gnutls`, `libsoup`: I can't track down the reason for these tests being disabled, but they seem to run without issues in our pipelines
`jna`: We no longer run tests for toolchain packages in the toolchain environment, so concerns over missing dependencies no longer apply.
`strongswan`: Test no longer hangs, most likely fixed by the solution to [this issue](https://github.com/strongswan/strongswan/issues/752)

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Remove `skip_check_*` macros from `macros.override` for `gnutls`, `jna`, `libsoup`, `strongswan`

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- [Tests for affected builds pass on both architectures](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=424138&view=ms.vss-test-web.build-test-results-tab)
