### PR TITLE
Imgcustomizer: Discover partitions using grub.cfg and fstab files

### DIFF
--- a/toolkit/tools/imagecustomizerapi/fileconfig.go
+++ b/toolkit/tools/imagecustomizerapi/fileconfig.go
@@ -39,7 +39,7 @@ func (l *FileConfigList) IsValid() (err error) {
 	for i, fileConfig := range *l {
 		err = fileConfig.IsValid()
 		if err != nil {
-			return fmt.Errorf("invalid FileConfig at index %d: %w", i, err)
+			return fmt.Errorf("invalid FileConfig at index %d:\n%w", i, err)
 		}
 	}
 
@@ -61,7 +61,7 @@ func (l *FileConfigList) UnmarshalYAML(value *yaml.Node) error {
 	type IntermediateTypeFileConfigList FileConfigList
 	err = value.Decode((*IntermediateTypeFileConfigList)(l))
 	if err != nil {
-		return fmt.Errorf("failed to parse FileConfigList: %w", err)
+		return fmt.Errorf("failed to parse FileConfigList:\n%w", err)
 	}
 
 	return nil
@@ -77,7 +77,7 @@ func (f *FileConfig) IsValid() (err error) {
 	if f.Permissions != nil {
 		err = f.Permissions.IsValid()
 		if err != nil {
-			return fmt.Errorf("invalid Permissions value: %w", err)
+			return fmt.Errorf("invalid Permissions value:\n%w", err)
 		}
 	}
 
@@ -102,7 +102,7 @@ func (f *FileConfig) UnmarshalYAML(value *yaml.Node) error {
 	type IntermediateTypeFileConfig FileConfig
 	err = value.Decode((*IntermediateTypeFileConfig)(f))
 	if err != nil {
-		return fmt.Errorf("failed to parse FileConfig: %w", err)
+		return fmt.Errorf("failed to parse FileConfig:\n%w", err)
 	}
 
 	return nil

--- a/toolkit/tools/imagecustomizerapi/filepermissions.go
+++ b/toolkit/tools/imagecustomizerapi/filepermissions.go
@@ -34,13 +34,13 @@ func (p *FilePermissions) UnmarshalYAML(value *yaml.Node) error {
 	var strValue string
 	err = value.Decode(&strValue)
 	if err != nil {
-		return fmt.Errorf("failed to parse FilePermissions: %w", err)
+		return fmt.Errorf("failed to parse FilePermissions:\n%w", err)
 	}
 
 	// Try to parse the string as an octal number.
 	fileModeUint, err := strconv.ParseUint(strValue, 8, 32)
 	if err != nil {
-		return fmt.Errorf("failed to parse FilePermissions: %w", err)
+		return fmt.Errorf("failed to parse FilePermissions:\n%w", err)
 	}
 
 	*p = (FilePermissions)(fileModeUint)

--- a/toolkit/tools/imagecustomizerapi/systemconfig.go
+++ b/toolkit/tools/imagecustomizerapi/systemconfig.go
@@ -18,7 +18,7 @@ func (s *SystemConfig) IsValid() error {
 	for sourcePath, fileConfigList := range s.AdditionalFiles {
 		err = fileConfigList.IsValid()
 		if err != nil {
-			return fmt.Errorf("invalid file configs for (%s): %w", sourcePath, err)
+			return fmt.Errorf("invalid file configs for (%s):\n%w", sourcePath, err)
 		}
 	}
 

--- a/toolkit/tools/imagegen/diskutils/diskutils.go
+++ b/toolkit/tools/imagegen/diskutils/diskutils.go
@@ -343,7 +343,7 @@ func WaitForDevicesToSettle() error {
 	logger.Log.Debugf("Waiting for devices to settle")
 	_, _, err := shell.Execute("udevadm", "settle")
 	if err != nil {
-		return fmt.Errorf("failed to wait for devices to settle: %w", err)
+		return fmt.Errorf("failed to wait for devices to settle:\n%w", err)
 	}
 	return nil
 }
@@ -694,19 +694,19 @@ func GetDiskPartitions(diskDevPath string) ([]PartitionInfo, error) {
 	// Just in case the disk was only recently connected, wait for the OS to finish processing it.
 	err := WaitForDevicesToSettle()
 	if err != nil {
-		return nil, fmt.Errorf("failed to list disk (%s) partitions: %w", diskDevPath, err)
+		return nil, fmt.Errorf("failed to list disk (%s) partitions:\n%w", diskDevPath, err)
 	}
 
 	// Read the disk's partitions.
 	jsonString, _, err := shell.Execute("lsblk", diskDevPath, "--output", "NAME,PATH,PARTTYPE,FSTYPE,UUID,MOUNTPOINT,PARTUUID", "--json", "--list")
 	if err != nil {
-		return nil, fmt.Errorf("failed to list disk (%s) partitions: %w", diskDevPath, err)
+		return nil, fmt.Errorf("failed to list disk (%s) partitions:\n%w", diskDevPath, err)
 	}
 
 	var output partitionInfoOutput
 	err = json.Unmarshal([]byte(jsonString), &output)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse disk (%s) partitions JSON: %w", diskDevPath, err)
+		return nil, fmt.Errorf("failed to parse disk (%s) partitions JSON:\n%w", diskDevPath, err)
 	}
 
 	return output.Devices, err

--- a/toolkit/tools/imagegen/diskutils/diskutils.go
+++ b/toolkit/tools/imagegen/diskutils/diskutils.go
@@ -56,6 +56,8 @@ type PartitionInfo struct {
 const (
 	// AutoEndSize is used as the disk's "End" value to indicate it should be picked automatically
 	AutoEndSize = 0
+
+	EfiSystemPartitionUuid = "c12a7328-f81f-11d2-ba4b-00a0c93ec93b"
 )
 
 const (

--- a/toolkit/tools/imagegen/diskutils/diskutils.go
+++ b/toolkit/tools/imagegen/diskutils/diskutils.go
@@ -690,9 +690,9 @@ func SystemBlockDevices() (systemDevices []SystemBlockDevice, err error) {
 
 func GetDiskPartitions(diskDevPath string) ([]PartitionInfo, error) {
 	// Just in case the disk was only recently connected, wait for the OS to finish processing it.
-	_, _, err := shell.Execute("udevadm", "settle")
+	err := WaitForDevicesToSettle()
 	if err != nil {
-		return nil, fmt.Errorf("failed to list disk (%s) partitions: udevadm settle: %w", diskDevPath, err)
+		return nil, fmt.Errorf("failed to list disk (%s) partitions: %w", diskDevPath, err)
 	}
 
 	// Read the disk's partitions.
@@ -704,7 +704,7 @@ func GetDiskPartitions(diskDevPath string) ([]PartitionInfo, error) {
 	var output partitionInfoOutput
 	err = json.Unmarshal([]byte(jsonString), &output)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list disk (%s) partitions: unexpected JSON format: %w", diskDevPath, err)
+		return nil, fmt.Errorf("failed to parse disk (%s) partitions JSON: %w", diskDevPath, err)
 	}
 
 	return output.Devices, err

--- a/toolkit/tools/imagegen/diskutils/fstab.go
+++ b/toolkit/tools/imagegen/diskutils/fstab.go
@@ -32,7 +32,7 @@ func (f *MountFlags) UnmarshalJSON(b []byte) (err error) {
 	var stringValue string
 	err = json.Unmarshal(b, &stringValue)
 	if err != nil {
-		return fmt.Errorf("failed to parse MountFlags: %w", err)
+		return fmt.Errorf("failed to parse MountFlags:\n%w", err)
 	}
 
 	var value MountFlags
@@ -134,13 +134,13 @@ func ReadFstabFile(fstabPath string) ([]FstabEntry, error) {
 	jsonString, _, err := shell.Execute("findmnt", "--fstab", "--tab-file", fstabPath,
 		"--json", "--output", "source,target,fstype,vfs-options,fs-options,freq,passno")
 	if err != nil {
-		return nil, fmt.Errorf("failed to read fstab file (%s): %w", fstabPath, err)
+		return nil, fmt.Errorf("failed to read fstab file (%s):\n%w", fstabPath, err)
 	}
 
 	var output findmntOutput
 	err = json.Unmarshal([]byte(jsonString), &output)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read fstab file (%s): json parse error: %w", fstabPath, err)
+		return nil, fmt.Errorf("failed to read fstab file (%s): json parse error:\n%w", fstabPath, err)
 	}
 
 	return output.FileSystems, nil

--- a/toolkit/tools/imagegen/diskutils/fstab.go
+++ b/toolkit/tools/imagegen/diskutils/fstab.go
@@ -1,0 +1,147 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package diskutils
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/shell"
+	"golang.org/x/sys/unix"
+)
+
+type MountFlags uintptr
+
+type FstabEntry struct {
+	Source    string     `json:"source"`
+	Target    string     `json:"target"`
+	FsType    string     `json:"fstype"`
+	Options   MountFlags `json:"vfs-options"`
+	FsOptions string     `json:"fs-options"`
+	Freq      int        `json:"freq"`
+	PassNo    int        `json:"passno"`
+}
+
+type findmntOutput struct {
+	FileSystems []FstabEntry `json:"filesystems"`
+}
+
+func (f *MountFlags) UnmarshalJSON(b []byte) (err error) {
+	var stringValue string
+	err = json.Unmarshal(b, &stringValue)
+	if err != nil {
+		return fmt.Errorf("failed to parse MountFlags: %w", err)
+	}
+
+	var value MountFlags
+	options := strings.Split(stringValue, ",")
+	for _, option := range options {
+		switch option {
+		case "async":
+			value |= unix.MS_ASYNC
+
+		case "atime":
+			value &= ^MountFlags(unix.MS_NOATIME)
+
+		case "noatime":
+			value |= unix.MS_NOATIME
+
+		case "dev":
+			value &= ^MountFlags(unix.MS_NODEV)
+
+		case "nodev":
+			value |= unix.MS_NODEV
+
+		case "diratime":
+			value &= ^MountFlags(unix.MS_NODIRATIME)
+
+		case "nodiratime":
+			value |= unix.MS_NODIRATIME
+
+		case "dirsync":
+			value |= unix.MS_DIRSYNC
+
+		case "exec":
+			value &= ^MountFlags(unix.MS_NOEXEC)
+
+		case "noexec":
+			value |= unix.MS_NOEXEC
+
+		case "iversion":
+			value |= unix.MS_I_VERSION
+
+		case "mand":
+			value |= unix.MS_MANDLOCK
+
+		case "nomand":
+			value &= ^MountFlags(unix.MS_MANDLOCK)
+
+		case "relatime":
+			value |= unix.MS_RELATIME
+
+		case "norelatime":
+			value &= ^MountFlags(unix.MS_RELATIME)
+
+		case "strictatime":
+			value |= unix.MS_STRICTATIME
+
+		case "nostrictatime":
+			value &= ^MountFlags(unix.MS_STRICTATIME)
+
+		case "suid":
+			value &= ^MountFlags(unix.MS_NOSUID)
+
+		case "nosuid":
+			value |= unix.MS_NOSUID
+
+		case "remount":
+			value |= unix.MS_REMOUNT
+
+		case "ro":
+			value |= unix.MS_RDONLY
+
+		case "rw":
+			value &= ^MountFlags(unix.MS_RDONLY)
+
+		case "sync":
+			value |= unix.MS_SYNC
+
+		// These options are only relevant for the fstab file.
+		case "owner", "user", "nouser", "users", "group", "auto", "noauto", "nofail", "_netdev", "_rnetdev":
+
+		// There isn't a fixed set of defaults. So, no easy way to support this.
+		case "defaults":
+			return fmt.Errorf("unsupported mount flag (%s)", option)
+
+		// Ignore empty options.
+		case "":
+
+		default:
+			return fmt.Errorf("unknown mount flag (%s)", option)
+		}
+	}
+
+	*f = value
+	return nil
+}
+
+func ReadFstabFile(fstabPath string) ([]FstabEntry, error) {
+	// Read the fstab file.
+	// The `findmnt` command provides a convenient JSON output. In addition, it helpfully splits the
+	// common vfs options from the filesystem specific options.
+	jsonString, _, err := shell.Execute("findmnt", "--fstab", "--tab-file", fstabPath,
+		"--json", "--output", "source,target,fstype,vfs-options,fs-options,freq,passno")
+	if err != nil {
+		return nil, fmt.Errorf("failed to read fstab file (%s): %w", fstabPath, err)
+	}
+
+	var output findmntOutput
+	err = json.Unmarshal([]byte(jsonString), &output)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read fstab file (%s): json parse error: %w", fstabPath, err)
+	}
+
+	return output.FileSystems, nil
+}

--- a/toolkit/tools/internal/safemount.go/safemount.go
+++ b/toolkit/tools/internal/safemount.go/safemount.go
@@ -50,7 +50,7 @@ func (m *Mount) newMountHelper(source, target, fstype string, flags uintptr, dat
 		// Create the mount target directory.
 		err = os.MkdirAll(target, os.ModePerm)
 		if err != nil {
-			return fmt.Errorf("failed to create mount directory (%s): %w", target, err)
+			return fmt.Errorf("failed to create mount directory (%s):\n%w", target, err)
 		}
 
 		m.dirCreated = true
@@ -59,7 +59,7 @@ func (m *Mount) newMountHelper(source, target, fstype string, flags uintptr, dat
 	// Create the mount.
 	err = unix.Mount(source, target, fstype, flags, data)
 	if err != nil {
-		return fmt.Errorf("failed to mount (%s) to (%s): %w", source, target, err)
+		return fmt.Errorf("failed to mount (%s) to (%s):\n%w", source, target, err)
 	}
 
 	m.isMounted = true
@@ -81,7 +81,7 @@ func (m *Mount) Close() error {
 	if m.isMounted {
 		err = unix.Unmount(m.target, 0)
 		if err != nil {
-			return fmt.Errorf("failed to unmount (%s): %w", m.target, err)
+			return fmt.Errorf("failed to unmount (%s):\n%w", m.target, err)
 		}
 
 		m.isMounted = false
@@ -92,7 +92,7 @@ func (m *Mount) Close() error {
 		// (This is unlikely. But "belt and braces".)
 		err = os.Remove(m.target)
 		if err != nil {
-			return fmt.Errorf("failed to delete source rpms mount directory (%s): %w", m.target, err)
+			return fmt.Errorf("failed to delete source rpms mount directory (%s):\n%w", m.target, err)
 		}
 
 		m.dirCreated = false

--- a/toolkit/tools/internal/safemount.go/safemount.go
+++ b/toolkit/tools/internal/safemount.go/safemount.go
@@ -1,0 +1,102 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Package that assists with mounting and unmounting cleanly.
+package safemount
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/logger"
+	"golang.org/x/sys/unix"
+)
+
+type Mount struct {
+	target     string
+	isMounted  bool
+	dirCreated bool
+}
+
+// Creates a new system mount.
+func NewMount(source, target, fstype string, flags uintptr, data string, makeAndDeleteDir bool) (*Mount, error) {
+	var err error
+
+	mount := &Mount{
+		target: target,
+	}
+
+	// Try to create the mount.
+	err = mount.newMountHelper(source, target, fstype, flags, data, makeAndDeleteDir)
+	if err != nil {
+		// Cleanup anything created during the failed mount.
+		cleanupErr := mount.Close()
+		if cleanupErr != nil {
+			logger.Log.Warnf("failed to cleanup failed mount: %s", cleanupErr)
+		}
+		return nil, err
+	}
+
+	return mount, nil
+}
+
+func (m *Mount) newMountHelper(source, target, fstype string, flags uintptr, data string, makeAndDeleteDir bool) error {
+	var err error
+
+	logger.Log.Debugf("Mounting: source: (%s), target: (%s), fstype: (%s), flags: (%#x), data: (%s)",
+		source, target, fstype, flags, data)
+
+	if makeAndDeleteDir {
+		// Create the mount target directory.
+		err = os.MkdirAll(target, os.ModePerm)
+		if err != nil {
+			return fmt.Errorf("failed to create mount directory (%s): %w", target, err)
+		}
+
+		m.dirCreated = true
+	}
+
+	// Create the mount.
+	err = unix.Mount(source, target, fstype, flags, data)
+	if err != nil {
+		return fmt.Errorf("failed to mount (%s) to (%s): %w", source, target, err)
+	}
+
+	m.isMounted = true
+	return nil
+}
+
+// Target returns the target directory of the mount.
+func (m *Mount) Target() string {
+	return m.target
+}
+
+// Close removes the system mount.
+// This function is safe to call multiple times.
+func (m *Mount) Close() error {
+	var err error
+
+	logger.Log.Debugf("Unmounting (%s)", m.target)
+
+	if m.isMounted {
+		err = unix.Unmount(m.target, 0)
+		if err != nil {
+			return fmt.Errorf("failed to unmount (%s): %w", m.target, err)
+		}
+
+		m.isMounted = false
+	}
+
+	if m.dirCreated {
+		// Note: Do not use `RemoveAll` here in case the unmount silently failed.
+		// (This is unlikely. But "belt and braces".)
+		err = os.Remove(m.target)
+		if err != nil {
+			return fmt.Errorf("failed to delete source rpms mount directory (%s): %w", m.target, err)
+		}
+
+		m.dirCreated = false
+	}
+
+	return nil
+}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeutils_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeutils_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestCopyAdditionalFiles(t *testing.T) {
-	proposedDir := filepath.Join(tmpDir, "chroot", "TestCopyAdditionalFiles")
+	proposedDir := filepath.Join(tmpDir, "TestCopyAdditionalFiles")
 	chroot := safechroot.NewChroot(proposedDir, false)
 	baseConfigPath := testDir
 

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -179,7 +179,7 @@ func findPartitions(buildDir string, diskDevice string) ([]string, []*safechroot
 	// Look for the boot partition (i.e. EFI system partition).
 	var efiSystemPartition *diskutils.PartitionInfo
 	for _, diskPartition := range diskPartitions {
-		if diskPartition.PartitionTypeUuid == "c12a7328-f81f-11d2-ba4b-00a0c93ec93b" {
+		if diskPartition.PartitionTypeUuid == diskutils.EfiSystemPartitionUuid {
 			efiSystemPartition = &diskPartition
 			break
 		}

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -7,12 +7,19 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strings"
 
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/imagecustomizerapi"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/imagegen/diskutils"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/file"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/safechroot"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/safemount.go"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/shell"
+)
+
+var (
+	rootfsPartitionRegex = regexp.MustCompile(`(?m)^search -n -u ([a-zA-Z0-9\-]+) -s$`)
 )
 
 func CustomizeImageWithConfigFile(buildDir string, configFile string, imageFile string,
@@ -47,6 +54,12 @@ func CustomizeImage(buildDir string, baseConfigPath string, config *imagecustomi
 		return err
 	}
 
+	// Validate config.
+	err = validateConfig(baseConfigPath, config)
+	if err != nil {
+		return fmt.Errorf("invalid image config: %w", err)
+	}
+
 	// Normalize 'buildDir' path.
 	buildDirAbs, err := filepath.Abs(buildDir)
 	if err != nil {
@@ -57,12 +70,6 @@ func CustomizeImage(buildDir string, baseConfigPath string, config *imagecustomi
 	err = os.MkdirAll(buildDirAbs, os.ModePerm)
 	if err != nil {
 		return err
-	}
-
-	// Validate config.
-	err = validateConfig(baseConfigPath, config)
-	if err != nil {
-		return fmt.Errorf("invalid image config: %w", err)
 	}
 
 	// Convert image file to raw format, so that a kernel loop device can be used to make changes to the image.
@@ -80,6 +87,9 @@ func CustomizeImage(buildDir string, baseConfigPath string, config *imagecustomi
 	}
 
 	// Create final output image file.
+	outDir := filepath.Dir(outputImageFile)
+	os.MkdirAll(outDir, os.ModePerm)
+
 	_, _, err = shell.Execute("qemu-img", "convert", "-O", qemuOutputImageFormat, buildImageFile, outputImageFile)
 	if err != nil {
 		return fmt.Errorf("failed to convert image file to format: %s: %w", outputImageFormat, err)
@@ -134,9 +144,9 @@ func customizeImageHelper(buildDir string, baseConfigPath string, config *imagec
 	}
 
 	// Look for all the partitions on the image.
-	newMountDirectories, mountPoints, err := findPartitions(diskDevPath)
+	newMountDirectories, mountPoints, err := findPartitions(buildDir, diskDevPath)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to find disk partitions: %w", err)
 	}
 
 	// Create chroot environment.
@@ -158,14 +168,134 @@ func customizeImageHelper(buildDir string, baseConfigPath string, config *imagec
 	return nil
 }
 
-func findPartitions(diskDevice string) ([]string, []*safechroot.MountPoint, error) {
-	newMountDirectories := []string{}
+func findPartitions(buildDir string, diskDevice string) ([]string, []*safechroot.MountPoint, error) {
+	var err error
 
-	// TODO: Dynamically find partitions instead of hardcoding the mappings.
-	mountPoints := []*safechroot.MountPoint{
-		safechroot.NewPreDefaultsMountPoint(fmt.Sprintf("%sp2", diskDevice), "/", "ext4", 0, ""),
-		safechroot.NewMountPoint(fmt.Sprintf("%sp1", diskDevice), "/boot", "vfat", 0, ""),
+	diskPartitions, err := diskutils.GetDiskPartitions(diskDevice)
+	if err != nil {
+		return nil, nil, err
 	}
 
-	return newMountDirectories, mountPoints, nil
+	// Look for the boot partition (i.e. EFI system partition).
+	var efiSystemPartition *diskutils.PartitionInfo
+	for _, diskPartition := range diskPartitions {
+		if diskPartition.PartitionTypeUuid == "c12a7328-f81f-11d2-ba4b-00a0c93ec93b" {
+			efiSystemPartition = &diskPartition
+			break
+		}
+	}
+
+	if efiSystemPartition == nil {
+		return nil, nil, fmt.Errorf("failed to find EFI system partition (%s)", diskDevice)
+	}
+
+	// Mount the boot partition.
+	tmpDir := filepath.Join(buildDir, "tmppartition")
+
+	efiSystemPartitionMount, err := safemount.NewMount(efiSystemPartition.Path, tmpDir, efiSystemPartition.FileSystemType, 0, "", true)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to mount EFI system partition: %w", err)
+	}
+	defer efiSystemPartitionMount.Close()
+
+	// Read the grub.cfg file.
+	grubConfigFilePath := filepath.Join(tmpDir, "boot/grub2/grub.cfg")
+	grubConfigFile, err := os.ReadFile(grubConfigFilePath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to read grub.cfg file: %w", err)
+	}
+
+	// Close the boot partition mount.
+	err = efiSystemPartitionMount.Close()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to close EFI system partition mount: %w", err)
+	}
+
+	// Look for the rootfs declaration line in the grub.cfg file.
+	match := rootfsPartitionRegex.FindStringSubmatch(string(grubConfigFile))
+	if match == nil {
+		return nil, nil, fmt.Errorf("failed to find rootfs partition in grub.cfg file")
+	}
+
+	rootfsUuid := match[1]
+
+	var rootfsPartition *diskutils.PartitionInfo
+	for _, diskPartition := range diskPartitions {
+		if diskPartition.Uuid == rootfsUuid {
+			rootfsPartition = &diskPartition
+			break
+		}
+	}
+
+	// Temporarily mount the rootfs partition so that the fstab file can be read.
+	rootfsPartitionMount, err := safemount.NewMount(rootfsPartition.Path, tmpDir, rootfsPartition.FileSystemType, 0, "", true)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to mount rootfs partition: %w", err)
+	}
+	defer rootfsPartitionMount.Close()
+
+	// Read the fstab file.
+	fstabPath := filepath.Join(tmpDir, "/etc/fstab")
+	fstabEntries, err := diskutils.ReadFstabFile(fstabPath)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Close the rootfs partition mount.
+	err = rootfsPartitionMount.Close()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to close rootfs partition mount: %w", err)
+	}
+
+	// Convert fstab entries into mount points.
+	var mountPoints []*safechroot.MountPoint
+	var foundRoot bool
+	for _, fstabEntry := range fstabEntries {
+		// Ignore special partitions.
+		switch fstabEntry.FsType {
+		case "devtmpfs", "proc", "sysfs", "devpts", "tmpfs":
+			continue
+		}
+
+		source, err := findSourcePartition(fstabEntry.Source, diskPartitions)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		var mountPoint *safechroot.MountPoint
+		if fstabEntry.Target == "/" {
+			mountPoint = safechroot.NewPreDefaultsMountPoint(
+				source, fstabEntry.Target, fstabEntry.FsType,
+				uintptr(fstabEntry.Options), fstabEntry.FsOptions)
+
+			foundRoot = true
+		} else {
+			mountPoint = safechroot.NewMountPoint(
+				source, fstabEntry.Target, fstabEntry.FsType,
+				uintptr(fstabEntry.Options), fstabEntry.FsOptions)
+		}
+
+		mountPoints = append(mountPoints, mountPoint)
+	}
+
+	if !foundRoot {
+		return nil, nil, fmt.Errorf("image has invalid fstab file: no root partition found")
+	}
+
+	return nil, mountPoints, nil
+}
+
+func findSourcePartition(source string, partitions []diskutils.PartitionInfo) (string, error) {
+	partUuid, isPartUuid := strings.CutPrefix(source, "PARTUUID=")
+	if isPartUuid {
+		for _, partition := range partitions {
+			if partition.PartUuid == partUuid {
+				return partition.Path, nil
+			}
+		}
+
+		return "", fmt.Errorf("partition not found: %s", source)
+	}
+
+	return "", fmt.Errorf("unknown fstab source type: %s", source)
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -57,7 +57,7 @@ func CustomizeImage(buildDir string, baseConfigPath string, config *imagecustomi
 	// Validate config.
 	err = validateConfig(baseConfigPath, config)
 	if err != nil {
-		return fmt.Errorf("invalid image config: %w", err)
+		return fmt.Errorf("invalid image config:\n%w", err)
 	}
 
 	// Normalize 'buildDir' path.
@@ -77,7 +77,7 @@ func CustomizeImage(buildDir string, baseConfigPath string, config *imagecustomi
 
 	_, _, err = shell.Execute("qemu-img", "convert", "-O", "raw", imageFile, buildImageFile)
 	if err != nil {
-		return fmt.Errorf("failed to convert image file to raw format: %w", err)
+		return fmt.Errorf("failed to convert image file to raw format:\n%w", err)
 	}
 
 	// Customize the raw image file.
@@ -92,7 +92,7 @@ func CustomizeImage(buildDir string, baseConfigPath string, config *imagecustomi
 
 	_, _, err = shell.Execute("qemu-img", "convert", "-O", qemuOutputImageFormat, buildImageFile, outputImageFile)
 	if err != nil {
-		return fmt.Errorf("failed to convert image file to format: %s: %w", outputImageFormat, err)
+		return fmt.Errorf("failed to convert image file to format: %s:\n%w", outputImageFormat, err)
 	}
 
 	return nil
@@ -116,7 +116,7 @@ func validateConfig(baseConfigPath string, config *imagecustomizerapi.SystemConf
 		sourceFileFullPath := filepath.Join(baseConfigPath, sourceFile)
 		isFile, err := file.IsFile(sourceFileFullPath)
 		if err != nil {
-			return fmt.Errorf("invalid AdditionalFiles source file (%s): %w", sourceFile, err)
+			return fmt.Errorf("invalid AdditionalFiles source file (%s):\n%w", sourceFile, err)
 		}
 
 		if !isFile {
@@ -133,7 +133,7 @@ func customizeImageHelper(buildDir string, baseConfigPath string, config *imagec
 	// Mount the raw disk image file.
 	diskDevPath, err := diskutils.SetupLoopbackDevice(buildImageFile)
 	if err != nil {
-		return fmt.Errorf("failed to mount raw disk (%s) as a loopback device: %w", buildImageFile, err)
+		return fmt.Errorf("failed to mount raw disk (%s) as a loopback device:\n%w", buildImageFile, err)
 	}
 	defer diskutils.DetachLoopbackDevice(diskDevPath)
 
@@ -146,7 +146,7 @@ func customizeImageHelper(buildDir string, baseConfigPath string, config *imagec
 	// Look for all the partitions on the image.
 	newMountDirectories, mountPoints, err := findPartitions(buildDir, diskDevPath)
 	if err != nil {
-		return fmt.Errorf("failed to find disk partitions: %w", err)
+		return fmt.Errorf("failed to find disk partitions:\n%w", err)
 	}
 
 	// Create chroot environment.
@@ -194,7 +194,7 @@ func findPartitions(buildDir string, diskDevice string) ([]string, []*safechroot
 
 	efiSystemPartitionMount, err := safemount.NewMount(efiSystemPartition.Path, tmpDir, efiSystemPartition.FileSystemType, 0, "", true)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to mount EFI system partition: %w", err)
+		return nil, nil, fmt.Errorf("failed to mount EFI system partition:\n%w", err)
 	}
 	defer efiSystemPartitionMount.Close()
 
@@ -202,13 +202,13 @@ func findPartitions(buildDir string, diskDevice string) ([]string, []*safechroot
 	grubConfigFilePath := filepath.Join(tmpDir, "boot/grub2/grub.cfg")
 	grubConfigFile, err := os.ReadFile(grubConfigFilePath)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to read grub.cfg file: %w", err)
+		return nil, nil, fmt.Errorf("failed to read grub.cfg file:\n%w", err)
 	}
 
 	// Close the boot partition mount.
 	err = efiSystemPartitionMount.Close()
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to close EFI system partition mount: %w", err)
+		return nil, nil, fmt.Errorf("failed to close EFI system partition mount:\n%w", err)
 	}
 
 	// Look for the rootfs declaration line in the grub.cfg file.
@@ -230,7 +230,7 @@ func findPartitions(buildDir string, diskDevice string) ([]string, []*safechroot
 	// Temporarily mount the rootfs partition so that the fstab file can be read.
 	rootfsPartitionMount, err := safemount.NewMount(rootfsPartition.Path, tmpDir, rootfsPartition.FileSystemType, 0, "", true)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to mount rootfs partition: %w", err)
+		return nil, nil, fmt.Errorf("failed to mount rootfs partition:\n%w", err)
 	}
 	defer rootfsPartitionMount.Close()
 
@@ -244,7 +244,7 @@ func findPartitions(buildDir string, diskDevice string) ([]string, []*safechroot
 	// Close the rootfs partition mount.
 	err = rootfsPartitionMount.Close()
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to close rootfs partition mount: %w", err)
+		return nil, nil, fmt.Errorf("failed to close rootfs partition mount:\n%w", err)
 	}
 
 	// Convert fstab entries into mount points.

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
@@ -80,6 +80,11 @@ func TestCustomizeImageCopyFiles(t *testing.T) {
 	}
 	defer diskutils.DetachLoopbackDevice(diskDevPath)
 
+	err = diskutils.WaitForDevicesToSettle()
+	if !assert.NoError(t, err) {
+		return
+	}
+
 	imageChroot := safechroot.NewChroot(filepath.Join(buildDir, "imageroot"), false)
 	err = imageChroot.Initialize("", newMountDirectories, mountPoints)
 	if !assert.NoError(t, err) {

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/imagecustomizerapi"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/imagegen/configuration"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/imagegen/diskutils"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/imagegen/installutils"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/buildpipeline"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/safechroot"
 	"github.com/stretchr/testify/assert"
@@ -28,8 +29,8 @@ func TestCustomizeImageEmptyConfig(t *testing.T) {
 	buildDir := filepath.Join(tmpDir, "TestCustomizeImageEmptyConfig")
 	outImageFilePath := filepath.Join(buildDir, "image.vhd")
 
-	// Create empty disk.
-	diskFilePath, err := createEmptyDisk(buildDir)
+	// Create fake disk.
+	diskFilePath, _, _, err := createFakeEfiImage(buildDir)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -57,8 +58,8 @@ func TestCustomizeImageCopyFiles(t *testing.T) {
 	configFile := filepath.Join(testDir, "addfiles-config.yaml")
 	outImageFilePath := filepath.Join(buildDir, "image.qcow2")
 
-	// Create empty disk.
-	diskFilePath, err := createEmptyDisk(buildDir)
+	// Create fake disk.
+	diskFilePath, newMountDirectories, mountPoints, err := createFakeEfiImage(buildDir)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -78,8 +79,6 @@ func TestCustomizeImageCopyFiles(t *testing.T) {
 		return
 	}
 	defer diskutils.DetachLoopbackDevice(diskDevPath)
-
-	newMountDirectories, mountPoints := emptyDiskPartitions(diskDevPath)
 
 	imageChroot := safechroot.NewChroot(filepath.Join(buildDir, "imageroot"), false)
 	err = imageChroot.Initialize("", newMountDirectories, mountPoints)
@@ -127,12 +126,12 @@ func TestValidateConfigdditionalFilesIsDir(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func createEmptyDisk(buildDir string) (string, error) {
+func createFakeEfiImage(buildDir string) (string, []string, []*safechroot.MountPoint, error) {
 	var err error
 
 	err = os.MkdirAll(buildDir, os.ModePerm)
 	if err != nil {
-		return "", fmt.Errorf("failed to make build directory (%s): %w", buildDir, err)
+		return "", nil, nil, fmt.Errorf("failed to make build directory (%s): %w", buildDir, err)
 	}
 
 	// Use a prototypical Mariner image partition config.
@@ -156,36 +155,105 @@ func createEmptyDisk(buildDir string) (string, error) {
 		},
 	}
 
+	partitionSettings := []configuration.PartitionSetting{
+		{
+			ID:              "boot",
+			MountPoint:      "/boot/efi",
+			MountOptions:    "umask=0077",
+			MountIdentifier: configuration.MountIdentifierDefault,
+		},
+		{
+			ID:              "rootfs",
+			MountPoint:      "/",
+			MountIdentifier: configuration.MountIdentifierDefault,
+		},
+	}
+
 	// Create raw disk image file.
 	rawDisk, err := diskutils.CreateEmptyDisk(buildDir, "disk.raw", diskConfig)
 	if err != nil {
-		return "", fmt.Errorf("failed to create empty disk file in (%s): %w", buildDir, err)
+		return "", nil, nil, fmt.Errorf("failed to create empty disk file in (%s): %w", buildDir, err)
 	}
 
-	// Mount raw disk image file.
+	// Connect raw disk image file.
 	diskDevPath, err := diskutils.SetupLoopbackDevice(rawDisk)
 	if err != nil {
-		return "", fmt.Errorf("failed to mount raw disk (%s) as a loopback device: %w", rawDisk, err)
+		return "", nil, nil, fmt.Errorf("failed to mount raw disk (%s) as a loopback device: %w", rawDisk, err)
 	}
 	defer diskutils.DetachLoopbackDevice(diskDevPath)
 
 	// Set up partitions.
-	_, _, _, _, err = diskutils.CreatePartitions(diskDevPath, diskConfig,
+	partIDToDevPathMap, partIDToFsTypeMap, _, _, err := diskutils.CreatePartitions(diskDevPath, diskConfig,
 		configuration.RootEncryption{}, configuration.ReadOnlyVerityRoot{})
 	if err != nil {
-		return "", fmt.Errorf("failed to create partitions on disk (%s): %w", diskDevPath, err)
+		return "", nil, nil, fmt.Errorf("failed to create partitions on disk (%s): %w", diskDevPath, err)
 	}
 
-	return rawDisk, nil
-}
+	// Create partition mount config.
+	bootPartitionDevPath := fmt.Sprintf("%sp1", diskDevPath)
+	osPartitionDevPath := fmt.Sprintf("%sp2", diskDevPath)
 
-func emptyDiskPartitions(diskDevPath string) ([]string, []*safechroot.MountPoint) {
 	newMountDirectories := []string{}
 	mountPoints := []*safechroot.MountPoint{
-		safechroot.NewPreDefaultsMountPoint(fmt.Sprintf("%sp2", diskDevPath), "/", "ext4", 0, ""),
-		safechroot.NewMountPoint(fmt.Sprintf("%sp1", diskDevPath), "/boot", "vfat", 0, ""),
+		safechroot.NewPreDefaultsMountPoint(osPartitionDevPath, "/", "ext4", 0, ""),
+		safechroot.NewMountPoint(bootPartitionDevPath, "/boot/efi", "vfat", 0, ""),
 	}
-	return newMountDirectories, mountPoints
+
+	// Mount the partitions.
+	imageChroot := safechroot.NewChroot(filepath.Join(buildDir, "imageroot"), false)
+	err = imageChroot.Initialize("", newMountDirectories, mountPoints)
+	if err != nil {
+		return "", nil, nil, err
+	}
+	defer imageChroot.Close(false)
+
+	// Write a fake grub.cfg file so that the partition discovery logic works.
+	bootPrefix := "/boot"
+
+	osUuid, err := installutils.GetUUID(osPartitionDevPath)
+	if err != nil {
+		return "", nil, nil, fmt.Errorf("failed get OS partition UUID: %w", err)
+	}
+
+	rootDevice, err := installutils.FormatMountIdentifier(configuration.MountIdentifierUuid, osPartitionDevPath)
+	if err != nil {
+		return "", nil, nil, fmt.Errorf("failed to format mount identifier: %w", err)
+	}
+
+	err = installutils.InstallBootloader(imageChroot, false, "efi", osUuid, bootPrefix, "", assetsDir)
+	if err != nil {
+		return "", nil, nil, fmt.Errorf("failed to install bootloader: %w", err)
+	}
+
+	err = installutils.InstallGrubCfg(imageChroot.RootDir(), rootDevice, osUuid, bootPrefix, assetsDir,
+		diskutils.EncryptedRootDevice{}, configuration.KernelCommandLine{}, diskutils.VerityDevice{}, false)
+	if err != nil {
+		return "", nil, nil, fmt.Errorf("failed to install main grub config file: %w", err)
+	}
+
+	err = installutils.InstallGrubEnv(imageChroot.RootDir(), assetsDir)
+	if err != nil {
+		return "", nil, nil, fmt.Errorf("failed to install grubenv file: %w", err)
+	}
+
+	// Write a fake fstab file so that the partition discovery logic works.
+	err = os.Mkdir(filepath.Join(imageChroot.RootDir(), "etc"), os.ModePerm)
+	if err != nil {
+		return "", nil, nil, fmt.Errorf("failed to add /etc dir: %w", err)
+	}
+
+	mountPointMap, mountPointToFsTypeMap, mountPointToMountArgsMap, _ := installutils.CreateMountPointPartitionMap(
+		partIDToDevPathMap, partIDToFsTypeMap, partitionSettings,
+	)
+
+	err = installutils.UpdateFstab(imageChroot.RootDir(), partitionSettings, mountPointMap, mountPointToFsTypeMap,
+		mountPointToMountArgsMap, partIDToDevPathMap, partIDToFsTypeMap, false, /*hidepidEnabled*/
+	)
+	if err != nil {
+		return "", nil, nil, fmt.Errorf("failed to install fstab file: %w", err)
+	}
+
+	return rawDisk, newMountDirectories, mountPoints, nil
 }
 
 func checkFileType(t *testing.T, filePath string, expectedFileType string) {
@@ -219,5 +287,5 @@ func getImageFileType(filePath string) (string, error) {
 		return "raw", nil
 	}
 
-	return "", fmt.Errorf("Unknown file type")
+	return "", fmt.Errorf("unknown file type: %s", filePath)
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
@@ -48,8 +48,6 @@ func TestCustomizeImageEmptyConfig(t *testing.T) {
 func TestCustomizeImageCopyFiles(t *testing.T) {
 	var err error
 
-	t.Skip("Unreliable test")
-
 	if !buildpipeline.IsRegularBuild() {
 		t.Skip("loopback block device not available")
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
@@ -240,11 +240,6 @@ func createFakeEfiImage(buildDir string) (string, []string, []*safechroot.MountP
 	}
 
 	// Write a fake fstab file so that the partition discovery logic works.
-	err = os.Mkdir(filepath.Join(imageChroot.RootDir(), "etc"), os.ModePerm)
-	if err != nil {
-		return "", nil, nil, fmt.Errorf("failed to add /etc dir: %w", err)
-	}
-
 	mountPointMap, mountPointToFsTypeMap, mountPointToMountArgsMap, _ := installutils.CreateMountPointPartitionMap(
 		partIDToDevPathMap, partIDToFsTypeMap, partitionSettings,
 	)

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
@@ -134,7 +134,7 @@ func createFakeEfiImage(buildDir string) (string, []string, []*safechroot.MountP
 
 	err = os.MkdirAll(buildDir, os.ModePerm)
 	if err != nil {
-		return "", nil, nil, fmt.Errorf("failed to make build directory (%s): %w", buildDir, err)
+		return "", nil, nil, fmt.Errorf("failed to make build directory (%s):\n%w", buildDir, err)
 	}
 
 	// Use a prototypical Mariner image partition config.
@@ -175,13 +175,13 @@ func createFakeEfiImage(buildDir string) (string, []string, []*safechroot.MountP
 	// Create raw disk image file.
 	rawDisk, err := diskutils.CreateEmptyDisk(buildDir, "disk.raw", diskConfig)
 	if err != nil {
-		return "", nil, nil, fmt.Errorf("failed to create empty disk file in (%s): %w", buildDir, err)
+		return "", nil, nil, fmt.Errorf("failed to create empty disk file in (%s):\n%w", buildDir, err)
 	}
 
 	// Connect raw disk image file.
 	diskDevPath, err := diskutils.SetupLoopbackDevice(rawDisk)
 	if err != nil {
-		return "", nil, nil, fmt.Errorf("failed to mount raw disk (%s) as a loopback device: %w", rawDisk, err)
+		return "", nil, nil, fmt.Errorf("failed to mount raw disk (%s) as a loopback device:\n%w", rawDisk, err)
 	}
 	defer diskutils.DetachLoopbackDevice(diskDevPath)
 
@@ -189,7 +189,7 @@ func createFakeEfiImage(buildDir string) (string, []string, []*safechroot.MountP
 	partIDToDevPathMap, partIDToFsTypeMap, _, _, err := diskutils.CreatePartitions(diskDevPath, diskConfig,
 		configuration.RootEncryption{}, configuration.ReadOnlyVerityRoot{})
 	if err != nil {
-		return "", nil, nil, fmt.Errorf("failed to create partitions on disk (%s): %w", diskDevPath, err)
+		return "", nil, nil, fmt.Errorf("failed to create partitions on disk (%s):\n%w", diskDevPath, err)
 	}
 
 	// Create partition mount config.
@@ -215,28 +215,28 @@ func createFakeEfiImage(buildDir string) (string, []string, []*safechroot.MountP
 
 	osUuid, err := installutils.GetUUID(osPartitionDevPath)
 	if err != nil {
-		return "", nil, nil, fmt.Errorf("failed get OS partition UUID: %w", err)
+		return "", nil, nil, fmt.Errorf("failed get OS partition UUID:\n%w", err)
 	}
 
 	rootDevice, err := installutils.FormatMountIdentifier(configuration.MountIdentifierUuid, osPartitionDevPath)
 	if err != nil {
-		return "", nil, nil, fmt.Errorf("failed to format mount identifier: %w", err)
+		return "", nil, nil, fmt.Errorf("failed to format mount identifier:\n%w", err)
 	}
 
 	err = installutils.InstallBootloader(imageChroot, false, "efi", osUuid, bootPrefix, "", assetsDir)
 	if err != nil {
-		return "", nil, nil, fmt.Errorf("failed to install bootloader: %w", err)
+		return "", nil, nil, fmt.Errorf("failed to install bootloader:\n%w", err)
 	}
 
 	err = installutils.InstallGrubCfg(imageChroot.RootDir(), rootDevice, osUuid, bootPrefix, assetsDir,
 		diskutils.EncryptedRootDevice{}, configuration.KernelCommandLine{}, diskutils.VerityDevice{}, false)
 	if err != nil {
-		return "", nil, nil, fmt.Errorf("failed to install main grub config file: %w", err)
+		return "", nil, nil, fmt.Errorf("failed to install main grub config file:\n%w", err)
 	}
 
 	err = installutils.InstallGrubEnv(imageChroot.RootDir(), assetsDir)
 	if err != nil {
-		return "", nil, nil, fmt.Errorf("failed to install grubenv file: %w", err)
+		return "", nil, nil, fmt.Errorf("failed to install grubenv file:\n%w", err)
 	}
 
 	// Write a fake fstab file so that the partition discovery logic works.
@@ -248,7 +248,7 @@ func createFakeEfiImage(buildDir string) (string, []string, []*safechroot.MountP
 		mountPointToMountArgsMap, partIDToDevPathMap, partIDToFsTypeMap, false, /*hidepidEnabled*/
 	)
 	if err != nil {
-		return "", nil, nil, fmt.Errorf("failed to install fstab file: %w", err)
+		return "", nil, nil, fmt.Errorf("failed to install fstab file:\n%w", err)
 	}
 
 	return rawDisk, newMountDirectories, mountPoints, nil

--- a/toolkit/tools/pkg/imagecustomizerlib/main_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/main_test.go
@@ -15,6 +15,7 @@ var (
 	testDir    string
 	tmpDir     string
 	workingDir string
+	assetsDir  string
 )
 
 func TestMain(m *testing.M) {
@@ -29,6 +30,7 @@ func TestMain(m *testing.M) {
 
 	testDir = filepath.Join(workingDir, "testdata")
 	tmpDir = filepath.Join(workingDir, "_tmp")
+	assetsDir = filepath.Join(workingDir, "../../../resources/assets")
 
 	err = os.MkdirAll(tmpDir, os.ModePerm)
 	if err != nil {


### PR DESCRIPTION
###### Merge Checklist 
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary

In the imgcustomizer tool, detect the partitions available on the disk and how they should be mounted by reading the `grub.cfg` file on the boot partition and the `/etc/fstab` file on the OS partition. This will allow the tool to work on a variety of images with custom partition layouts.

###### Change Log

- In imgcustomizer, detect partitions using `grub.cfg` and `fstab` files.
- Update some `installutils` functions so that they are usable by imgcustomizer.
- Ensure that the assets directory mount point is only specified once within the code.

###### Does this affect the toolchain?

NO

###### Test Methodology

- Updated the UTs for imgcustomizer.
