### PR TITLE
Disable unreliable test

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
@@ -42,6 +42,8 @@ func TestCustomizeImageEmptyConfig(t *testing.T) {
 func TestCustomizeImageCopyFiles(t *testing.T) {
 	var err error
 
+	t.Skip("Unreliable test")
+
 	buildDir := filepath.Join(tmpDir, "TestCustomizeImageCopyFiles")
 	configFile := filepath.Join(testDir, "addfiles-config.yaml")
 	outImageFilePath := filepath.Join(buildDir, "image.qcow2")


### PR DESCRIPTION
###### Merge Checklist 
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->

Disable the TestCustomizeImageCopyFiles test as it appears to be unreliable.

###### Change Log  <!-- REQUIRED -->

- Disable TestCustomizeImageCopyFiles test.

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Ran toolkit UTs.
