### PR TITLE
Make safeunmount.sh run in parallel

### DIFF
--- a/toolkit/scripts/pkggen.mk
+++ b/toolkit/scripts/pkggen.mk
@@ -236,7 +236,6 @@ build-packages: $(RPMS_DIR)
 
 clean: clean-build-packages clean-compress-rpms clean-compress-srpms
 
-# Empty rule for clean-build-packages-workers, we will append more rules to this later via the $(eval) function below
 clean-build-packages-workers:
 	@echo Verifying no mountpoints present in $(CHROOT_DIR)
 	$(SCRIPTS_DIR)/safeunmount.sh "$(CHROOT_DIR)"/* && \

--- a/toolkit/scripts/pkggen.mk
+++ b/toolkit/scripts/pkggen.mk
@@ -229,20 +229,23 @@ $(preprocessed_file): $(cached_file) $(go-graphPreprocessor)
 pkggen_archive	= $(OUT_DIR)/rpms.tar.gz
 srpms_archive  	= $(OUT_DIR)/srpms.tar.gz
 
-.PHONY: build-packages clean-build-packages hydrate-rpms compress-rpms clean-compress-rpms compress-srpms clean-compress-srpms
+.PHONY: build-packages clean-build-packages hydrate-rpms compress-rpms clean-compress-rpms compress-srpms clean-compress-srpms clean-build-packages-workers
 
 # Execute the package build scheduler.
 build-packages: $(RPMS_DIR)
 
 clean: clean-build-packages clean-compress-rpms clean-compress-srpms
-clean-build-packages:
+
+# Empty rule for clean-build-packages-workers, we will append more rules to this later via the $(eval) function below
+clean-build-packages-workers:
+	@echo Verifying no mountpoints present in $(CHROOT_DIR)
+	$(SCRIPTS_DIR)/safeunmount.sh "$(CHROOT_DIR)"/* && \
+	rm -rf $(CHROOT_DIR)
+clean-build-packages: clean-build-packages-workers
 	rm -rf $(RPMS_DIR)
 	rm -rf $(LOGS_DIR)/pkggen/failures.txt
 	rm -rf $(rpmbuilding_logs_dir)
 	rm -rf $(STATUS_FLAGS_DIR)/build-rpms.flag
-	@echo Verifying no mountpoints present in $(CHROOT_DIR)
-	$(SCRIPTS_DIR)/safeunmount.sh "$(CHROOT_DIR)" && \
-	rm -rf $(CHROOT_DIR)
 clean-compress-rpms:
 	rm -rf $(pkggen_archive)
 clean-compress-srpms:

--- a/toolkit/scripts/pkggen.mk
+++ b/toolkit/scripts/pkggen.mk
@@ -235,7 +235,6 @@ srpms_archive  	= $(OUT_DIR)/srpms.tar.gz
 build-packages: $(RPMS_DIR)
 
 clean: clean-build-packages clean-compress-rpms clean-compress-srpms
-
 clean-build-packages-workers:
 	@echo Verifying no mountpoints present in $(CHROOT_DIR)
 	$(SCRIPTS_DIR)/safeunmount.sh "$(CHROOT_DIR)"/* && \

--- a/toolkit/scripts/safeunmount.sh
+++ b/toolkit/scripts/safeunmount.sh
@@ -2,23 +2,46 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-# $1 path to recursively scan for mount points which must be cleaned up
-dir=${1}
-for dir in $(find ${dir} -type d | sort) ; do
-    if [[ -d $dir ]]; then
-        if  mountpoint -q ${dir} ; then
-            echo "WARNING: Removing mountpoint at $dir"
-            umount -l ${dir}
-            sleep 0.5
+# Usage: safeunmount.sh <dir1> <dir2> ...
+# e.g.
+#   `safeunmount.sh /mnt/resource /mnt/scratch` will attempt to unmount all mount points under /mnt/resource and /mnt/scratch in parallel
+#   `safeunmount.sh "/mnt/"*` will use bash expansion to unmount all mount points under /mnt/ in parallel
+
+function clean_dir {
+    dir=${1}
+    for dir in $(find "${dir}" -type d | sort) ; do
+        if [[ -d $dir ]]; then
+            if  mountpoint -q "${dir}" ; then
+                echo "WARNING: Removing mountpoint at $dir"
+                umount -l "${dir}"
+                sleep 0.5
+            fi
+            retries=10
+            while mountpoint -q "${dir}" ; do
+                echo "ERROR: Mountpoint still present at $dir, retrying unmount ${retries} times"
+                umount -l "${dir}"
+                retries=$(( "${retries}" - 1))
+                sleep 1
+                if [ ${retries} -eq 0 ] ; then return 1 ; fi
+            done
         fi
-        retries=10
-        while mountpoint -q ${dir} ; do
-            echo "ERROR: Mountpoint still present at $dir, retrying unmount ${retries} times"
-            umount -l ${dir}
-            retries=$(( ${retries} - 1))
-            sleep 1
-            if [ ${retries} -eq 0 ] ; then exit 1 ; fi
-        done
+    done || return 1
+
+    return 0
+}
+
+# For each argument, pass it to clean_dir in parallel then wait for all to finish and return the exit code
+for dir in "$@" ; do
+    if [[ ! -d $dir ]]; then
+        echo "Warning: $dir is not a directory, skipping safe unmount"
+    else
+        echo "Cleaning $dir" 
+        (clean_dir "${dir}") & pids+=( $! )
     fi
 done
+
+for pid in "${pids[@]}" ; do
+    wait "${pid}" || exit 1
+done
+
 exit 0


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Make `safeunmount.sh` optionally run in parallel. It will now accept multiple arguments, and for each argument it will behave the same as before, but in parallel (i.e., for each directory under the path provided it will check if that is a mountpoint and unmount it).

It can still be called the same way as before, but it can also now be called like `safeunmount.sh /path/to/chroot_container/*`, and for each directory inside `chroot_container` it will invoke the unmount logic (i.e., it will check if `/path/to/chroot_container/actual_chroot/*` is mounted and unmount as needed).

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Make `safeunmount.sh` run in parallel.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**


###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local testing
- Pipelines will generally not exhibit orphaned chroots, not viable to test there.
