### PR TITLE
libsprio: upgrade version 20190731 -> 20221101 to address CVE-2019-19847

### DIFF
--- a/SPECS-EXTENDED/libspiro/libspiro.signatures.json
+++ b/SPECS-EXTENDED/libspiro/libspiro.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "libspiro-20190731.tar.gz": "24c7d1ccc7c7fe44ff10c376aa9f96e20e505f417ee72b63dc91a9b34eeac354"
+  "libspiro-20221101.tar.gz": "5984fb5af3e4e1f927f3a74850b705a711fb86284802a5e6170b09786440e8be"
  }
 }

--- a/SPECS-EXTENDED/libspiro/libspiro.spec
+++ b/SPECS-EXTENDED/libspiro/libspiro.spec
@@ -1,20 +1,19 @@
-Vendor:         Microsoft Corporation
-Distribution:   Mariner
+Summary:        Library to simplify the drawing of beautiful curves
 Name:           libspiro
 Version:        20221101
 Release:        1%{?dist}
-Summary:        Library to simplify the drawing of beautiful curves
-
 License:        GPL-3.0-or-later
+Vendor:         Microsoft Corporation
+Distribution:   Mariner
 URL:            https://github.com/fontforge/libspiro/
 Source0:        https://github.com/fontforge/libspiro/releases/download/%{version}/libspiro-dist-%{version}.tar.gz#/%{name}-%{version}.tar.gz
 BuildRequires:  gcc
 BuildRequires:  make
 
 %description
-This library will take an array of spiro control points and 
-convert them into a series of bézier splines which can then 
-be used in the myriad of ways the world has come to use béziers. 
+This library will take an array of spiro control points and
+convert them into a series of bézier splines which can then
+be used in the myriad of ways the world has come to use béziers.
 
 %package        devel
 Summary:        Development files for %{name}
@@ -33,7 +32,7 @@ developing applications that use %{name}.
 
 %install
 %make_install
-find $RPM_BUILD_ROOT -name '*.la' -exec rm -f {} ';'
+find %{buildroot} -type f -name "*.la" -delete -print
 
 %files
 %doc README* ChangeLog AUTHORS
@@ -49,6 +48,7 @@ find $RPM_BUILD_ROOT -name '*.la' -exec rm -f {} ';'
 %changelog
 * Fri Oct 15 2021 Muhammad Falak <mwani@microsoft.com> - 20221101-1
 - Bump version to address CVE-2019-19847
+- Lint spec
 
 * Fri Oct 15 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 20190731-3
 - Initial CBL-Mariner import from Fedora 32 (license: MIT).

--- a/SPECS-EXTENDED/libspiro/libspiro.spec
+++ b/SPECS-EXTENDED/libspiro/libspiro.spec
@@ -1,16 +1,15 @@
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Name:           libspiro
-Version:        20190731
-Release:        3%{?dist}
+Version:        20221101
+Release:        1%{?dist}
 Summary:        Library to simplify the drawing of beautiful curves
 
-# The files that are used to compile this library are all in GPLv3+
-# https://github.com/fontforge/libspiro/issues/8
-License:        GPLv3+
+License:        GPL-3.0-or-later
 URL:            https://github.com/fontforge/libspiro/
-Source0:        https://github.com/fontforge/libspiro/releases/download/%{version}/libspiro-%{version}.tar.gz
-BuildRequires: automake autoconf libtool
+Source0:        https://github.com/fontforge/libspiro/releases/download/%{version}/libspiro-dist-%{version}.tar.gz#/%{name}-%{version}.tar.gz
+BuildRequires:  gcc
+BuildRequires:  make
 
 %description
 This library will take an array of spiro control points and 
@@ -29,13 +28,11 @@ developing applications that use %{name}.
 %autosetup -n libspiro-%{version}
 
 %build
-autoreconf -i
-automake --foreign -Wall
 %configure --disable-static
-make %{?_smp_mflags}
+%make_build
 
 %install
-make install DESTDIR=$RPM_BUILD_ROOT INSTALL="install -p"
+%make_install
 find $RPM_BUILD_ROOT -name '*.la' -exec rm -f {} ';'
 
 %files
@@ -47,8 +44,12 @@ find $RPM_BUILD_ROOT -name '*.la' -exec rm -f {} ';'
 %{_includedir}/*
 %{_libdir}/*.so
 %{_libdir}/pkgconfig/libspiro.pc
+%{_mandir}/man3/libspiro.3.gz
 
 %changelog
+* Fri Oct 15 2021 Muhammad Falak <mwani@microsoft.com> - 20221101-1
+- Bump version to address CVE-2019-19847
+
 * Fri Oct 15 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 20190731-3
 - Initial CBL-Mariner import from Fedora 32 (license: MIT).
 

--- a/SPECS-EXTENDED/libspiro/libspiro.spec
+++ b/SPECS-EXTENDED/libspiro/libspiro.spec
@@ -49,6 +49,7 @@ find %{buildroot} -type f -name "*.la" -delete -print
 * Fri Oct 15 2021 Muhammad Falak <mwani@microsoft.com> - 20221101-1
 - Bump version to address CVE-2019-19847
 - Lint spec
+- License verified
 
 * Fri Oct 15 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 20190731-3
 - Initial CBL-Mariner import from Fedora 32 (license: MIT).

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -11051,8 +11051,8 @@
         "type": "other",
         "other": {
           "name": "libspiro",
-          "version": "20190731",
-          "downloadUrl": "https://github.com/fontforge/libspiro/releases/download/20190731/libspiro-20190731.tar.gz"
+          "version": "20221101",
+          "downloadUrl": "https://github.com/fontforge/libspiro/releases/download/20221101/libspiro-dist-20221101.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Bump version 20190731 -> 20221101 to address CVE-2019-19847

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- libsprio: upgrade version 20190731 -> 20221101 to address CVE-2019-19847
- libsprio: lint spec
- libsprio: verify license
- libsprio: cgmanifest: update entry

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- NA

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2019-19847

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: [PR-6267](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=425378&view=results)
