### PR TITLE
Allow scheduler to update cached implicit nodes

### DIFF
--- a/toolkit/tools/scheduler/schedulerutils/implicitprovides.go
+++ b/toolkit/tools/scheduler/schedulerutils/implicitprovides.go
@@ -111,7 +111,7 @@ func implicitPackagesToUnresolvedNodesInGraph(pkgGraph *pkggraph.PkgGraph, useCa
 		// Only consider these as resolved if useCachedImplicit is set.
 		if n.State == pkggraph.StateCached {
 			if useCachedImplicit {
-				logger.Log.Warnf("Implicit node (%s) was already cached and may have been used to satisfy another node (useCachedImplicit=%v). Updating implicit path regardless!", n.FriendlyName(), useCachedImplicit)
+				logger.Log.Warnf("Implicit node (%s) was already cached and may have been used to satisfy another node (useCachedImplicit=true). Updating implicit path regardless!", n.FriendlyName())
 			}
 		} else if n.State != pkggraph.StateUnresolved {
 			continue

--- a/toolkit/tools/scheduler/schedulerutils/implicitprovides.go
+++ b/toolkit/tools/scheduler/schedulerutils/implicitprovides.go
@@ -111,7 +111,7 @@ func implicitPackagesToUnresolvedNodesInGraph(pkgGraph *pkggraph.PkgGraph, useCa
 		// Only consider these as resolved if useCachedImplicit is set.
 		if n.State == pkggraph.StateCached {
 			if useCachedImplicit {
-				continue
+				logger.Log.Warnf("Implicit node (%s) was already cached and may have been used to satisfy another node (useCachedImplicit=%v). Updating regardless implicit path anyways!", n.FriendlyName(), useCachedImplicit)
 			}
 		} else if n.State != pkggraph.StateUnresolved {
 			continue

--- a/toolkit/tools/scheduler/schedulerutils/implicitprovides.go
+++ b/toolkit/tools/scheduler/schedulerutils/implicitprovides.go
@@ -79,8 +79,9 @@ func replaceNodesWithProvides(res *BuildResult, pkgGraph *pkggraph.PkgGraph, pro
 	return
 }
 
-// implicitPackagesToUnresolvedNodesInGraph returns a map of package names to implicit nodes.
-func implicitPackagesToUnresolvedNodesInGraph(pkgGraph *pkggraph.PkgGraph, useCachedImplicit bool) (nameToNodes map[string][]*pkggraph.PkgNode) {
+// implicitPackageNamesToNodesInGraph returns a map of package names to implicit nodes. These nodes will either be unresolved,
+// or in the cache.
+func implicitPackageNamesToNodesInGraph(pkgGraph *pkggraph.PkgGraph, useCachedImplicit bool) (nameToNodes map[string][]*pkggraph.PkgNode) {
 	nameToNodes = make(map[string][]*pkggraph.PkgNode)
 
 	// Depending on the node order that the graph was created, there may be multiple unresolved nodes for a single package.
@@ -128,7 +129,7 @@ func implicitPackagesToUnresolvedNodesInGraph(pkgGraph *pkggraph.PkgGraph, useCa
 // matchProvidesToUnresolvedNodes matches a list of provides to unresolved nodes that they satisfy in the graph.
 func matchProvidesToUnresolvedNodes(provides []*pkgjson.PackageVer, pkgGraph *pkggraph.PkgGraph, useCachedImplicit bool) (matches map[*pkgjson.PackageVer][]*pkggraph.PkgNode, err error) {
 	matches = make(map[*pkgjson.PackageVer][]*pkggraph.PkgNode)
-	implicitPackagesToUnresolvedNodes := implicitPackagesToUnresolvedNodesInGraph(pkgGraph, useCachedImplicit)
+	implicitPackagesToUnresolvedNodes := implicitPackageNamesToNodesInGraph(pkgGraph, useCachedImplicit)
 
 	// An unresolved node can only be satisfied by a single provide, prevent duplicate matching
 	nodeToSatisfier := make(map[*pkggraph.PkgNode]*pkgjson.PackageVer)

--- a/toolkit/tools/scheduler/schedulerutils/implicitprovides.go
+++ b/toolkit/tools/scheduler/schedulerutils/implicitprovides.go
@@ -79,7 +79,7 @@ func replaceNodesWithProvides(res *BuildResult, pkgGraph *pkggraph.PkgGraph, pro
 	return
 }
 
-// implicitPackagesToUnresolvedNodesInGraph returns a map of package names to unresolved implicit nodes.
+// implicitPackagesToUnresolvedNodesInGraph returns a map of package names to implicit nodes.
 func implicitPackagesToUnresolvedNodesInGraph(pkgGraph *pkggraph.PkgGraph, useCachedImplicit bool) (nameToNodes map[string][]*pkggraph.PkgNode) {
 	nameToNodes = make(map[string][]*pkggraph.PkgNode)
 
@@ -107,8 +107,10 @@ func implicitPackagesToUnresolvedNodesInGraph(pkgGraph *pkggraph.PkgGraph, useCa
 		}
 
 		// When graphpkgfetcher runs, it will attempt to resolve all unresolved nodes.
-		// Some of these may be implicit and it may find an upstream package that satisfies it.
-		// Only consider these as resolved if useCachedImplicit is set.
+		// Some of these may be implicit and it may find an upstream package that satisfies it. The scheduler will have
+		// done its best to avoid using these nodes, but may eventually have to use them if there are no other options.
+		// We will allow these nodes to be switched even after the scheduler starts to use them since some packages may
+		// end up needing to install multiple versions of the same package if we don't unify them.
 		if n.State == pkggraph.StateCached {
 			if useCachedImplicit {
 				logger.Log.Warnf("Implicit node (%s) was already cached and may have been used to satisfy another node (useCachedImplicit=true). Updating implicit path regardless!", n.FriendlyName())

--- a/toolkit/tools/scheduler/schedulerutils/implicitprovides.go
+++ b/toolkit/tools/scheduler/schedulerutils/implicitprovides.go
@@ -111,7 +111,7 @@ func implicitPackagesToUnresolvedNodesInGraph(pkgGraph *pkggraph.PkgGraph, useCa
 		// Only consider these as resolved if useCachedImplicit is set.
 		if n.State == pkggraph.StateCached {
 			if useCachedImplicit {
-				logger.Log.Warnf("Implicit node (%s) was already cached and may have been used to satisfy another node (useCachedImplicit=%v). Updating regardless implicit path anyways!", n.FriendlyName(), useCachedImplicit)
+				logger.Log.Warnf("Implicit node (%s) was already cached and may have been used to satisfy another node (useCachedImplicit=%v). Updating implicit path regardless!", n.FriendlyName(), useCachedImplicit)
 			}
 		} else if n.State != pkggraph.StateUnresolved {
 			continue


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
There is an edge case that may break builds using implicit provides. The symptoms are: `pkgA` queues for build, the scheduler calculates its build-time dependencies: `pkgB-1, pkgB-2, pkgC, ...`. When the packages are installed into the build environment, `pkgB-1` conflicts with `pkgB-2` and the build fails.

The scheduler calculates the build-time dependencies by doing a walk of the build graph starting from the node to be built (`pkgA_build`). In this example, lets say we have a newly updated `pkgB` with `version:2`. Our package also relies on `pkgC`. Both `pkgB` and `pkgC` have a dependency on the implicit package `/usr/bin/tool_b` (which by observation we know will come from `pkgB`).
```mermaid
flowchart TB
    classDef a fill:#F7DC6F,color:#000000
    classDef b fill:#85C1E9,color:#000000
    classDef b_imp fill:#A569BD,color:#000000
    classDef c fill:#F5B7B1,color:#000000

    pkgA_run:::a --> pkgA_build:::a --> pkgB-2_run:::b --> pkgB-2_build:::b
    pkgB-2_run:::b --> /usr/bin/tool_b:::b_imp
    pkgA_build:::a --> pkgC_run:::c --> /usr/bin/tool_b:::b_imp
    
```
During the fetch stage, we defensively query our repo servers to see where we might expect to find `/usr/bin/tool_b` incase we don't have a package that will provide it locally. In this case we find out that it comes from `pkgB`, but the version in the repo is `version:1`, so the fetcher grabs version 1.
```mermaid
flowchart TB
    classDef a fill:#F7DC6F,color:#000000
    classDef b fill:#85C1E9,color:#000000
    classDef b_imp fill:#A569BD,color:#000000
    classDef c fill:#F5B7B1,color:#000000
    
    pkgA_run:::a --> pkgA_build:::a --> pkgB-2_run:::b --> pkgB-2_build:::b
    pkgB-2_run:::b --> /usr/bin/tool_b:::b_imp
    pkgA_build:::a --> pkgC_run:::c --> /usr/bin/tool_b(/usr/bin/tool_b - *version 1*):::b_imp
```
The scheduler will attempt to avoid using "implicit" nodes that have no local backing as long as possible (e.g., `/usr/bin/tool_b`), but eventually the build can be stuck. Lets assume the build has reached that point, and enables implicit cached nodes (e.g., `/usr/bin/tool_b`). We now unblock the graph and eventually build `pkgB-2_build`. Currently we don't update implicit cached nodes once we enter the global implicit cache allow state (more on why later).

Packages `b`, and `c` will build fine, resulting in something that looks like:
```mermaid
flowchart TB
    classDef a fill:#F7DC6F,color:#000000
    classDef b fill:#85C1E9,color:#000000,stroke-dasharray: 5 5,stroke:#00AF00,stroke-width:4px
    classDef b_imp fill:#A569BD,color:#000000,stroke-dasharray: 5 5,stroke:#00AF00,stroke-width:4px
     classDef c fill:#F5B7B1,color:#000000,stroke-dasharray: 5 5,stroke:#00AF00,stroke-width:4px
    
    pkgA_run:::a --> pkgA_build:::a --> pkgB-2_run:::b --> pkgB-2_build:::b
    pkgB-2_run:::b --> /usr/bin/tool_b:::b_imp
    pkgB-2_run:::b ~~~ /usr/bin/tool_b2(/usr/bin/tool_b - *version 2*):::b -.-> pkgB-2_build
    pkgA_build:::a --> pkgC_run:::c --> /usr/bin/tool_b(/usr/bin/tool_b - *version 1*):::b_imp
```

Notice we found a new copy of `/usr/bin/tool_b`, but didn't update any nodes to  use it. The scheduler will now build `pkgA_build`, using a walk of the graph to determine the packages to install into the worker (Yellow).
```mermaid
flowchart TB
    classDef a fill:#F7DC6F,color:#000000
    classDef b fill:#85C1E9,color:#000000,stroke-dasharray: 5 5,stroke:#00AF00,stroke-width:4px
    classDef b_imp fill:#A569BD,color:#000000,stroke-dasharray: 5 5,stroke:#00AF00,stroke-width:4px
     classDef c fill:#F5B7B1,color:#000000,stroke-dasharray: 5 5,stroke:#00AF00,stroke-width:4px
    classDef install fill:#Bda233,color:#000000
    
    pkgA_run:::a --> pkgA_build:::a --> pkgB-2_run:::install --> pkgB-2_build:::install
    pkgB-2_run:::install --> /usr/bin/tool_b:::install
    pkgB-2_run:::install ~~~ /usr/bin/tool_b2(/usr/bin/tool_b - *version 2*):::b -.-> pkgB-2_build
    pkgA_build:::a --> pkgC_run:::install --> /usr/bin/tool_b(/usr/bin/tool_b - *version 1*):::b_imp
```

Notice we install both version 1 and version 2 of `pkgB`. Generally this will not work and the build will fail.

This change alters the behavior of the scheduler. We will now always allow the implicit cached nodes to be updated, even after the global implicit cache mode is enabled. In this world, we would see:

```mermaid
flowchart TB
    classDef a fill:#F7DC6F,color:#000000
    classDef b fill:#85C1E9,color:#000000
    classDef b_imp fill:#A569BD,color:#000000
    classDef c fill:#F5B7B1,color:#000000
    
    pkgA_run:::a --> pkgA_build:::a --> pkgB-2_run:::b --> pkgB-2_build:::b
    pkgB-2_run:::b ~~~ /usr/bin/tool_b:::b_imp
    pkgB-2_run:::b --> /usr/bin/tool_b2(/usr/bin/tool_b - *version 2*):::b -.-> pkgB-2_build
    pkgA_build:::a --> pkgC_run:::c ~~~ /usr/bin/tool_b(/usr/bin/tool_b - *version 1*):::b_imp
    pkgC_run:::c --> /usr/bin/tool_b2(/usr/bin/tool_b - *version 2*):::b
```

### Implications:
Unfortunately, there is a downside to this change. Previously the scheduler's output could generally be considered deterministic, even if the internal flow to reach the end state was not. With this change, we can no longer guarantee that if we enable the global cached implicit mode.

Consider some package `pkgX`, that has two build dependencies: `/usr/bin/tool_b`, `pkgY`. It is otherwise not influenced by the other packages, it just needs `tool_b` and `pkgY` to build. As soon as we enable the cached implicit mode `pkgX` will start to build since the `/usr/bin/tool_b` (version 1) we have in the cache is sufficient (assume he `pkgY` built already). Jump forward a while, and we now rebuild `pkgB`. What should happen to `pkgX`?

In the old system it would always build with the older version of `pkgB`, no matter what. But now we have a new version. Depending on how long `pkgY` takes to build we might see either the new or old version of `/usr/bin/tool_b`.

Depending on how serious this is we may need to add a meachanism to invalidate an already building/built package and tell the scheduler to re-queue it (and anything downstream of it).

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Update cached implicit packages in the scheduler ever after we enter global implicit mode

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://microsoft.visualstudio.com/DefaultCollection/OS/_workitems/edit/45502828/

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local testing
