### PR TITLE
Damcilva/2.0/tools/add scheduler stuck debug code

### DIFF
--- a/toolkit/tools/scheduler/scheduler.go
+++ b/toolkit/tools/scheduler/scheduler.go
@@ -279,21 +279,18 @@ func startWorkerPool(agent buildagents.BuildAgent, workers, buildAttempts, check
 
 // debugStuckNode is a debugging function that will print out the stuck node and all nodes that are blocking it.
 func debugStuckNode(buildState *schedulerutils.GraphBuildState, pkgGraph *pkggraph.PkgGraph, stuckNode *pkggraph.PkgNode, indent int) {
-	isStuck := !buildState.IsNodeAvailable(stuckNode)
-	indentSpaces := ""
-	for i := 0; i < indent; i++ {
-		indentSpaces += "  "
+	if buildState.IsNodeAvailable(stuckNode) {
+		return
 	}
-	if isStuck {
-		logger.Log.Debugf("DEBUG: %s**STUCK** (%s)", indentSpaces, stuckNode.FriendlyName())
 
-		// Iterate over all the nodes that are blocking the stuck node.
-		dependency := pkgGraph.From(stuckNode.ID())
-		for dependency.Next() {
-			dependent := dependency.Node().(*pkggraph.PkgNode)
-			debugStuckNode(buildState, pkgGraph, dependent, indent+1)
-		}
+	nodeName := fmt.Sprintf("(%s)", stuckNode.FriendlyName())
+	logger.Log.Debugf("%*s", indent, nodeName)
 
+	// Iterate over all the nodes that are blocking the stuck node.
+	dependency := pkgGraph.From(stuckNode.ID())
+	for dependency.Next() {
+		dependent := dependency.Node().(*pkggraph.PkgNode)
+		debugStuckNode(buildState, pkgGraph, dependent, indent+1)
 	}
 }
 

--- a/toolkit/tools/scheduler/scheduler.go
+++ b/toolkit/tools/scheduler/scheduler.go
@@ -422,8 +422,6 @@ func buildAllNodes(stopOnFailure, canUseCache bool, packagesToRebuild, testsToRe
 						// When querying their edges, the graph library will return an empty iterator (graph.Empty).
 						pkgGraph = newGraph
 						goalNode = newGoalNode
-						// Temporarily print debug information about the stuck nodes.
-						logger.Log.Debugf("DEBUG: Updated goal node!")
 					}
 				}
 

--- a/toolkit/tools/scheduler/scheduler.go
+++ b/toolkit/tools/scheduler/scheduler.go
@@ -277,6 +277,7 @@ func startWorkerPool(agent buildagents.BuildAgent, workers, buildAttempts, check
 	return
 }
 
+// debugStuckNode is a debugging function that will print out the stuck node and all nodes that are blocking it.
 func debugStuckNode(buildState *schedulerutils.GraphBuildState, pkgGraph *pkggraph.PkgGraph, stuckNode *pkggraph.PkgNode, indent int) {
 	isStuck := !buildState.IsNodeAvailable(stuckNode)
 	indentSpaces := ""
@@ -284,7 +285,7 @@ func debugStuckNode(buildState *schedulerutils.GraphBuildState, pkgGraph *pkggra
 		indentSpaces += "  "
 	}
 	if isStuck {
-		logger.Log.Errorf("DEBUG: %s**STUCK** (%s)", indentSpaces, stuckNode.FriendlyName())
+		logger.Log.Debugf("DEBUG: %s**STUCK** (%s)", indentSpaces, stuckNode.FriendlyName())
 
 		// Iterate over all the nodes that are blocking the stuck node.
 		dependency := pkgGraph.From(stuckNode.ID())
@@ -365,6 +366,7 @@ func buildAllNodes(stopOnFailure, canUseCache bool, packagesToRebuild, testsToRe
 		if len(buildState.ActiveBuilds()) == 0 && len(channels.Results) == 0 {
 			if useCachedImplicit {
 				err = fmt.Errorf("could not build all packages")
+				// Temporarily print debug information about the stuck node.
 				debugStuckNode(buildState, pkgGraph, goalNode, 0)
 				break
 			} else {

--- a/toolkit/tools/scheduler/scheduler.go
+++ b/toolkit/tools/scheduler/scheduler.go
@@ -422,7 +422,8 @@ func buildAllNodes(stopOnFailure, canUseCache bool, packagesToRebuild, testsToRe
 						// When querying their edges, the graph library will return an empty iterator (graph.Empty).
 						pkgGraph = newGraph
 						goalNode = newGoalNode
-						logger.Log.Errorf("DEBUG: Updated goal node!")
+						// Temporarily print debug information about the stuck nodes.
+						logger.Log.Debugf("DEBUG: Updated goal node!")
 					}
 				}
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
We are seeing some builds getting stuck while still reporting all packages were built. This should only happen if there is node stuck that isn't getting queued to build somehow. If the build fails, dump the state of the available nodes via `IsNodeAvailable()` recursively starting at the goal node. This is a similar mechanism as is used to queue nodes so we should see why the goal node isn't available (which is the "success" state for the scheduler).

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add  temporary `debugStuckNode()` function to help diagnose scheduler issues.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**


###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local
