### PR TITLE
cloud-init modify running order of modules 

### DIFF
--- a/toolkit/imageconfigs/additionalconfigs/cloud-init.cfg
+++ b/toolkit/imageconfigs/additionalconfigs/cloud-init.cfg
@@ -54,12 +54,12 @@ cloud_config_modules:
 # this can be used by upstart jobs for 'start on cloud-config'.
  - ssh-import-id
  - set-passwords
- - package-update-upgrade-install
- - runcmd
  - yum-add-repo
+ - runcmd
 
 # The modules that run in the 'final' stage
 cloud_final_modules:
+ - package-update-upgrade-install
  - scripts-vendor
  - scripts-per-once
  - scripts-per-boot


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Change cloud-int modules running order to make sure yum_add_repo running before package-update-upgrade-install otherwise it will cause issues when user want to add new package repos and install packages using cloud-init customize script.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- move yum_add_repo module to run earlier stage
- move package-update-upgrade-install back to cloud_final_modules following upstream pattern in [cloud.cfg](https://github.com/canonical/cloud-init/blob/main/config/cloud.cfg.tmpl)


###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
NO

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- [Bug 46139895](https://microsoft.visualstudio.com/OS/_workitems/edit/46139895): Observed issue while deploying packages in Mariner 2.0 VM with cloud-init script.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: [428908](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=428908&view=results)
- Azure VMSS deployment and test it out packages can be installed successfully after the change. 
