### PR TITLE
Image customizer: Implement `PostInstallScripts` and `FinalizeImageScripts`.

### DIFF
--- a/toolkit/tools/imagecustomizerapi/script.go
+++ b/toolkit/tools/imagecustomizerapi/script.go
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package imagecustomizerapi
+
+import (
+	"fmt"
+)
+
+type Script struct {
+	Path string `yaml:"Path"`
+	Args string `yaml:"Args"`
+}
+
+func (s *Script) IsValid() error {
+	if s.Path == "" {
+		return fmt.Errorf("value of Path may not be empty")
+	}
+
+	return nil
+}

--- a/toolkit/tools/imagecustomizerapi/systemconfig.go
+++ b/toolkit/tools/imagecustomizerapi/systemconfig.go
@@ -9,7 +9,9 @@ import (
 
 // SystemConfig defines how each system present on the image is supposed to be configured.
 type SystemConfig struct {
-	AdditionalFiles map[string]FileConfigList `yaml:"AdditionalFiles"`
+	AdditionalFiles      map[string]FileConfigList `yaml:"AdditionalFiles"`
+	PostInstallScripts   []Script                  `yaml:"PostInstallScripts"`
+	FinalizeImageScripts []Script                  `yaml:"FinalizeImageScripts"`
 }
 
 func (s *SystemConfig) IsValid() error {
@@ -19,6 +21,20 @@ func (s *SystemConfig) IsValid() error {
 		err = fileConfigList.IsValid()
 		if err != nil {
 			return fmt.Errorf("invalid file configs for (%s):\n%w", sourcePath, err)
+		}
+	}
+
+	for i, script := range s.PostInstallScripts {
+		err = script.IsValid()
+		if err != nil {
+			return fmt.Errorf("invalid PostInstallScripts item at index %d: %w", i, err)
+		}
+	}
+
+	for i, script := range s.FinalizeImageScripts {
+		err = script.IsValid()
+		if err != nil {
+			return fmt.Errorf("invalid FinalizeImageScripts item at index %d: %w", i, err)
 		}
 	}
 

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeutils.go
@@ -22,6 +22,9 @@ const (
 func doCustomizations(baseConfigPath string, config *imagecustomizerapi.SystemConfig, imageChroot *safechroot.Chroot) error {
 	var err error
 
+	// Note: The ordering of the customization steps here should try to mirror the order of the equivalent steps in imager
+	// tool as closely as possible.
+
 	err = copyAdditionalFiles(baseConfigPath, config.AdditionalFiles, imageChroot)
 	if err != nil {
 		return err

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -150,6 +150,19 @@ func validateScript(baseConfigPath string, script *imagecustomizerapi.Script) er
 		return fmt.Errorf("install script (%s) is not under config directory (%s)", script.Path, baseConfigPath)
 	}
 
+	// Verify that the file exists.
+	fullPath := filepath.Join(baseConfigPath, script.Path)
+
+	scriptStat, err := os.Stat(fullPath)
+	if err != nil {
+		return fmt.Errorf("couldn't read install script (%s):\n%w", script.Path, err)
+	}
+
+	// Verify that the file has an executable bit set.
+	if scriptStat.Mode()&0111 == 0 {
+		return fmt.Errorf("install script (%s) does not have executable bit set", script.Path)
+	}
+
 	return nil
 }
 

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -112,6 +112,8 @@ func toQemuImageFormat(imageFormat string) (string, error) {
 }
 
 func validateConfig(baseConfigPath string, config *imagecustomizerapi.SystemConfig) error {
+	var err error
+
 	for sourceFile := range config.AdditionalFiles {
 		sourceFileFullPath := filepath.Join(baseConfigPath, sourceFile)
 		isFile, err := file.IsFile(sourceFileFullPath)
@@ -122,6 +124,30 @@ func validateConfig(baseConfigPath string, config *imagecustomizerapi.SystemConf
 		if !isFile {
 			return fmt.Errorf("invalid AdditionalFiles source file (%s): not a file", sourceFile)
 		}
+	}
+
+	for i, script := range config.PostInstallScripts {
+		err = validateScript(baseConfigPath, &script)
+		if err != nil {
+			return fmt.Errorf("invalid PostInstallScripts item at index %d: %w", i, err)
+		}
+	}
+
+	for i, script := range config.FinalizeImageScripts {
+		err = validateScript(baseConfigPath, &script)
+		if err != nil {
+			return fmt.Errorf("invalid FinalizeImageScripts item at index %d: %w", i, err)
+		}
+	}
+
+	return nil
+}
+
+func validateScript(baseConfigPath string, script *imagecustomizerapi.Script) error {
+	// Ensure that install scripts sit under the config file's parent directory.
+	// This allows the install script to be run in the chroot environment by bind mounting the config directory.
+	if !filepath.IsLocal(script.Path) {
+		return fmt.Errorf("install script (%s) is not under config directory (%s)", script.Path, baseConfigPath)
 	}
 
 	return nil

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
@@ -129,6 +129,44 @@ func TestValidateConfigdditionalFilesIsDir(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestValidateConfigScript(t *testing.T) {
+	err := validateConfig(testDir, &imagecustomizerapi.SystemConfig{
+		PostInstallScripts: []imagecustomizerapi.Script{
+			{
+				Path: "scripts/postinstallscript.sh",
+			},
+		},
+		FinalizeImageScripts: []imagecustomizerapi.Script{
+			{
+				Path: "scripts/finalizeimagescript.sh",
+			},
+		},
+	})
+	assert.NoError(t, err)
+}
+
+func TestValidateConfigScriptNonLocalFile(t *testing.T) {
+	err := validateConfig(testDir, &imagecustomizerapi.SystemConfig{
+		PostInstallScripts: []imagecustomizerapi.Script{
+			{
+				Path: "../a.sh",
+			},
+		},
+	})
+	assert.Error(t, err)
+}
+
+func TestValidateConfigScriptNonExecutable(t *testing.T) {
+	err := validateConfig(testDir, &imagecustomizerapi.SystemConfig{
+		FinalizeImageScripts: []imagecustomizerapi.Script{
+			{
+				Path: "files/a.txt",
+			},
+		},
+	})
+	assert.Error(t, err)
+}
+
 func createFakeEfiImage(buildDir string) (string, []string, []*safechroot.MountPoint, error) {
 	var err error
 

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/runscripts-config.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/runscripts-config.yaml
@@ -1,0 +1,5 @@
+PostInstallScripts:
+- Path: scripts/postinstallscript.sh
+
+FinalizeImageScripts:
+- Path: scripts/finalizeimagescript.sh

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/scripts/finalizeimagescript.sh
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/scripts/finalizeimagescript.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo "A finalize image script"

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/scripts/postinstallscript.sh
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/scripts/postinstallscript.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo "A post install script"


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->

Add and implement the `PostInstallScripts` and `FinalizeImageScripts` config values in the image customizer.

###### Change Log  <!-- REQUIRED -->

- Image customizer: Implement `PostInstallScripts` and `FinalizeImageScripts`.

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Ran toolkit UTs.
- Manually run image customizer.

