### PR TITLE
Image Customizer: Support Hostname

### DIFF
--- a/toolkit/tools/imagecustomizerapi/systemconfig.go
+++ b/toolkit/tools/imagecustomizerapi/systemconfig.go
@@ -5,10 +5,14 @@ package imagecustomizerapi
 
 import (
 	"fmt"
+	"strings"
+
+	"github.com/asaskevich/govalidator"
 )
 
 // SystemConfig defines how each system present on the image is supposed to be configured.
 type SystemConfig struct {
+	Hostname             string                    `yaml:"Hostname"`
 	AdditionalFiles      map[string]FileConfigList `yaml:"AdditionalFiles"`
 	PostInstallScripts   []Script                  `yaml:"PostInstallScripts"`
 	FinalizeImageScripts []Script                  `yaml:"FinalizeImageScripts"`
@@ -16,6 +20,12 @@ type SystemConfig struct {
 
 func (s *SystemConfig) IsValid() error {
 	var err error
+
+	if s.Hostname != "" {
+		if !govalidator.IsDNSName(s.Hostname) || strings.Contains(s.Hostname, "_") {
+			return fmt.Errorf("invalid hostname: %s", s.Hostname)
+		}
+	}
 
 	for sourcePath, fileConfigList := range s.AdditionalFiles {
 		err = fileConfigList.IsValid()

--- a/toolkit/tools/imagecustomizerapi/systemconfig_test.go
+++ b/toolkit/tools/imagecustomizerapi/systemconfig_test.go
@@ -11,6 +11,14 @@ func TestSystemConfigValidEmpty(t *testing.T) {
 	testValidYamlValue[*SystemConfig](t, "{ }", &SystemConfig{})
 }
 
+func TestSystemConfigValidHostname(t *testing.T) {
+	testValidYamlValue[*SystemConfig](t, "{ \"Hostname\": \"validhostname\" }", &SystemConfig{Hostname: "validhostname"})
+}
+
+func TestSystemConfigInvalidHostname(t *testing.T) {
+	testInvalidYamlValue[*SystemConfig](t, "{ \"Hostname\": \"invalid_hostname\" }")
+}
+
 func TestSystemConfigInvalidAdditionalFiles(t *testing.T) {
 	testInvalidYamlValue[*SystemConfig](t, "{ \"AdditionalFiles\": { \"a.txt\": [] } }")
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeutils_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeutils_test.go
@@ -14,6 +14,28 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestUpdateHostname(t *testing.T) {
+	// Setup environment.
+	proposedDir := filepath.Join(tmpDir, "TestUpdateHostname")
+	chroot := safechroot.NewChroot(proposedDir, false)
+	err := chroot.Initialize("", []string{}, []*safechroot.MountPoint{})
+	assert.NoError(t, err)
+	defer chroot.Close(false)
+
+	err = os.MkdirAll(filepath.Join(chroot.RootDir(), "etc"), os.ModePerm)
+	assert.NoError(t, err)
+
+	// Set hostname.
+	expectedHostname := "testhostname"
+	err = updateHostname(expectedHostname, chroot)
+	assert.NoError(t, err)
+
+	// Ensure hostname was correctly set.
+	actualHostname, err := os.ReadFile(filepath.Join(chroot.RootDir(), "etc/hostname"))
+	assert.NoError(t, err)
+	assert.Equal(t, expectedHostname, string(actualHostname))
+}
+
 func TestCopyAdditionalFiles(t *testing.T) {
 	proposedDir := filepath.Join(tmpDir, "TestCopyAdditionalFiles")
 	chroot := safechroot.NewChroot(proposedDir, false)


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->

In the Image Customizer, add support for setting the hostname.

###### Change Log  <!-- REQUIRED -->

- Image Customizer: Support Hostname

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Added UTs.
- Ran toolkit UTs.
- Manually run image customizer.

