### PR TITLE
Update go-test-coverage.yml to verify go version.

### DIFF
--- a/.github/workflows/go-test-coverage.yml
+++ b/.github/workflows/go-test-coverage.yml
@@ -9,21 +9,38 @@ on:
   pull_request:
     branches: [main, dev, 1.0*, 2.0*, fasttrack/*]
 
-jobs:
+env:
+  EXPECTED_GO_VERSION: "1.20"
 
+jobs:
   build:
     name: Go Test Coverage
     runs-on: ubuntu-latest
     steps:
 
     - name: Set up Go 1.x
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v4
       with:
-        go-version: 1.19
+        go-version: '${{ env.EXPECTED_GO_VERSION }}'
       id: go
+
+    - name: Check active go version
+      run: |
+        go version && which go
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v4
+
+    - name: Check go.mod
+      run: |
+        if grep -q "go $EXPECTED_GO_VERSION" ./toolkit/tools/go.mod; then
+          echo "go.mod has correct version ($EXPECTED_GO_VERSION)"
+        else
+          actual_version="$(grep -E '^go [0-9]+\.[0-9]+' ./toolkit/tools/go.mod)"
+          echo "go.mod has bad version expected:$EXPECTED_GO_VERSION, found: $actual_version"
+          echo "UPDATE ./github/workflows/go-test-coverage.yml AND prerequisite documentation if minimum go version changed"
+          exit 1
+        fi
 
     - name: Install prerequisites
       run: |
@@ -33,7 +50,7 @@ jobs:
     - name: Check for bad go formatting
       run: |
         pushd toolkit
-        sudo make go-fmt-all
+        sudo env "PATH=$PATH" make go-fmt-all
         changes=$(git diff *.go)
         if [ -n "$changes" ]; then
           echo Unformatted go files!
@@ -44,7 +61,7 @@ jobs:
     - name: Check for out of date go modules
       run: |
         pushd toolkit
-        sudo make go-mod-tidy
+        sudo env "PATH=$PATH" make go-mod-tidy
         modchanges=$(git diff tools/go.mod)
         sumchanges=$(git diff tools/go.sum)
         if [ -n "$modchanges$sumchanges" ]; then
@@ -59,17 +76,22 @@ jobs:
         pushd toolkit
         noTestCount=$(sudo make go-test-coverage | grep "no test files" | wc -l)
         if [ "$noTestCount" -ne "0" ]; then
-          sudo make go-test-coverage | grep "no test files"
+          sudo env "PATH=$PATH" make go-test-coverage | grep "no test files"
           echo Missing $noTestCount Go Tests!
         fi
 
     - name: Evaluate test coverage
       run: |
         pushd toolkit
-        sudo make go-test-coverage
+        sudo env "PATH=$PATH" make go-test-coverage
 
     - name: Upload test coverage
       uses: actions/upload-artifact@v2.1.4
       with:
         name: TestCoverage
         path: toolkit/out/tools/test_coverage_report.html
+
+    - name: Ensure all tools build
+      run: |
+        pushd toolkit
+        sudo env "PATH=$PATH" make go-tools REBUILD_TOOLS=y


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
We were not correctly detecting build breaks in our go tools due to tooling version changes. The Github Action worker was always using a very recent version of the Go tools and this could mask breaking changes.

We use `sudo` to run out tools, which clears the environment of the calling user by default. The action used to install Go does so by modifying the user's PATH. We need to explicitly pass this updated PATH to the tools if we want them to use the correct go.

Also add a check that validates the workflow against the `go.mod` file and alert if they get out of sync.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add a step to run `sudo make go-tools REBUILD_TOOLS=y` to the `go-test-coverage.yml` tests.
- Use correct version of go tools
- Validate go.mod against workflow.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**
