### PR TITLE
Add explicit timeout to package builds

### DIFF
--- a/toolkit/scripts/incremental_building.mk
+++ b/toolkit/scripts/incremental_building.mk
@@ -78,6 +78,7 @@ REBUILD_TOOLS                   ?= n
 DELTA_BUILD                     ?= n
 CLEAN_TOOLCHAIN_CONTAINERS      ?= y
 MAX_CPU                         ?=
+PACKAGE_BUILD_TIMEOUT           ?= 4h
 DELTA_FETCH                     ?= n
 PRECACHE                        ?= n
 MAX_CASCADING_REBUILDS          ?=

--- a/toolkit/scripts/pkggen.mk
+++ b/toolkit/scripts/pkggen.mk
@@ -312,6 +312,7 @@ $(STATUS_FLAGS_DIR)/build-rpms.flag: $(no_repo_acl) $(preprocessed_file) $(chroo
 		$(if $(filter y,$(USE_CCACHE)),--use-ccache) \
 		$(if $(filter y,$(ALLOW_TOOLCHAIN_REBUILDS)),--allow-toolchain-rebuilds) \
 		--max-cpu="$(MAX_CPU)" \
+		$(if $(PACKAGE_BUILD_TIMEOUT),--timeout="$(PACKAGE_BUILD_TIMEOUT)") \
 		$(logging_command) && \
 	touch $@
 

--- a/toolkit/tools/pkgworker/pkgworker.go
+++ b/toolkit/tools/pkgworker/pkgworker.go
@@ -22,6 +22,7 @@ import (
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/shell"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/sliceutils"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/tdnf"
+	"golang.org/x/sys/unix"
 
 	"gopkg.in/alecthomas/kingpin.v2"
 )
@@ -54,6 +55,7 @@ var (
 	outArch              = app.Flag("out-arch", "Architecture of resulting package").String()
 	useCcache            = app.Flag("use-ccache", "Automatically install and use ccache during package builds").Bool()
 	maxCPU               = app.Flag("max-cpu", "Max number of CPUs used for package building").Default("").String()
+	timeout              = app.Flag("timeout", "Timeout for package building").Required().Duration()
 
 	logFile  = exe.LogFileFlag(app)
 	logLevel = exe.LogLevelFlag(app)
@@ -90,7 +92,7 @@ func main() {
 		defines[rpm.MaxCPUDefine] = *maxCPU
 	}
 
-	builtRPMs, err := buildSRPMInChroot(chrootDir, rpmsDirAbsPath, toolchainDirAbsPath, *workerTar, *srpmFile, *repoFile, *rpmmacrosFile, *outArch, defines, *noCleanup, *runCheck, *packagesToInstall, *useCcache)
+	builtRPMs, err := buildSRPMInChroot(chrootDir, rpmsDirAbsPath, toolchainDirAbsPath, *workerTar, *srpmFile, *repoFile, *rpmmacrosFile, *outArch, defines, *noCleanup, *runCheck, *packagesToInstall, *useCcache, *timeout)
 	logger.PanicOnError(err, "Failed to build SRPM '%s'. For details see log file: %s .", *srpmFile, *logFile)
 
 	err = copySRPMToOutput(*srpmFile, srpmsDirAbsPath)
@@ -121,7 +123,7 @@ func buildChrootDirPath(workDir, srpmFilePath string, runCheck bool) (chrootDirP
 	return filepath.Join(workDir, buildDirName)
 }
 
-func buildSRPMInChroot(chrootDir, rpmDirPath, toolchainDirPath, workerTar, srpmFile, repoFile, rpmmacrosFile, outArch string, defines map[string]string, noCleanup, runCheck bool, packagesToInstall []string, useCcache bool) (builtRPMs []string, err error) {
+func buildSRPMInChroot(chrootDir, rpmDirPath, toolchainDirPath, workerTar, srpmFile, repoFile, rpmmacrosFile, outArch string, defines map[string]string, noCleanup, runCheck bool, packagesToInstall []string, useCcache bool, timeout time.Duration) (builtRPMs []string, err error) {
 	const (
 		buildHeartbeatTimeout = 30 * time.Minute
 
@@ -177,9 +179,23 @@ func buildSRPMInChroot(chrootDir, rpmDirPath, toolchainDirPath, workerTar, srpmF
 		return
 	}
 
-	err = chroot.Run(func() (err error) {
-		return buildRPMFromSRPMInChroot(srpmFileInChroot, outArch, runCheck, defines, packagesToInstall, useCcache)
-	})
+	// Run the build in a go routine so we can monitor and kill it if it takes too long.
+	results := make(chan error)
+	go func() {
+		buildErr := chroot.Run(func() (err error) {
+			return buildRPMFromSRPMInChroot(srpmFileInChroot, outArch, runCheck, defines, packagesToInstall, useCcache)
+		})
+		results <- buildErr
+	}()
+
+	select {
+	case err = <-results:
+	case <-time.After(timeout):
+		shell.PermanentlyStopAllProcesses(unix.SIGKILL)
+		logger.Log.Errorf("Timeout after %v: killing all processes in chroot...", timeout)
+		err = fmt.Errorf("build timed out after %s", timeout)
+	}
+
 	if err != nil {
 		return
 	}

--- a/toolkit/tools/scheduler/buildagents/chrootagent.go
+++ b/toolkit/tools/scheduler/buildagents/chrootagent.go
@@ -93,6 +93,7 @@ func serializeChrootBuildAgentConfig(config *BuildAgentConfig, inputFile, logFil
 		fmt.Sprintf("--log-level=%s", config.LogLevel),
 		fmt.Sprintf("--out-arch=%s", outArch),
 		fmt.Sprintf("--max-cpu=%s", config.MaxCpu),
+		fmt.Sprintf("--timeout=%s", config.Timeout.String()),
 	}
 
 	if config.RpmmacrosFile != "" {

--- a/toolkit/tools/scheduler/buildagents/definition.go
+++ b/toolkit/tools/scheduler/buildagents/definition.go
@@ -3,7 +3,10 @@
 
 package buildagents
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 // BuildAgentConfig represents configuration options a BuildAgent would need to successfully build a given package.
 type BuildAgentConfig struct {
@@ -26,6 +29,7 @@ type BuildAgentConfig struct {
 	NoCleanup bool
 	UseCcache bool
 	MaxCpu    string
+	Timeout   time.Duration
 
 	LogDir   string
 	LogLevel string

--- a/toolkit/tools/scheduler/scheduler.go
+++ b/toolkit/tools/scheduler/scheduler.go
@@ -33,7 +33,10 @@ const (
 	defaultMaxCascadingRebuilds = "-1"
 )
 
-var defaultFreshness = fmt.Sprintf("%d", schedulerutils.NodeFreshnessAbsoluteMax)
+var (
+	defaultFreshness = fmt.Sprintf("%d", schedulerutils.NodeFreshnessAbsoluteMax)
+	defaultTimeout   = "3h"
+)
 
 // schedulerChannels represents the communication channels used by a build agent.
 // Unlike BuildChannels, schedulerChannels holds bidirectional channels that
@@ -81,6 +84,7 @@ var (
 	useCcache                  = app.Flag("use-ccache", "Automatically install and use ccache during package builds").Bool()
 	allowToolchainRebuilds     = app.Flag("allow-toolchain-rebuilds", "Allow toolchain packages to rebuild without causing an error.").Bool()
 	maxCPU                     = app.Flag("max-cpu", "Max number of CPUs used for package building").Default("").String()
+	timeout                    = app.Flag("max-timeout", "Max duration for any individual package build/test").Default(defaultTimeout).Duration()
 
 	validBuildAgentFlags = []string{buildagents.TestAgentFlag, buildagents.ChrootAgentFlag}
 	buildAgent           = app.Flag("build-agent", "Type of build agent to build packages with.").PlaceHolder(exe.PlaceHolderize(validBuildAgentFlags)).Required().Enum(validBuildAgentFlags...)
@@ -162,6 +166,7 @@ func main() {
 		NoCleanup: *noCleanup,
 		UseCcache: *useCcache,
 		MaxCpu:    *maxCPU,
+		Timeout:   *timeout,
 
 		LogDir:   *buildLogsDir,
 		LogLevel: *logLevel,

--- a/toolkit/tools/scheduler/scheduler.go
+++ b/toolkit/tools/scheduler/scheduler.go
@@ -35,7 +35,7 @@ const (
 
 var (
 	defaultFreshness = fmt.Sprintf("%d", schedulerutils.NodeFreshnessAbsoluteMax)
-	defaultTimeout   = "3h"
+	defaultTimeout   = "99h"
 )
 
 // schedulerChannels represents the communication channels used by a build agent.

--- a/toolkit/tools/scheduler/scheduler.go
+++ b/toolkit/tools/scheduler/scheduler.go
@@ -84,7 +84,7 @@ var (
 	useCcache                  = app.Flag("use-ccache", "Automatically install and use ccache during package builds").Bool()
 	allowToolchainRebuilds     = app.Flag("allow-toolchain-rebuilds", "Allow toolchain packages to rebuild without causing an error.").Bool()
 	maxCPU                     = app.Flag("max-cpu", "Max number of CPUs used for package building").Default("").String()
-	timeout                    = app.Flag("max-timeout", "Max duration for any individual package build/test").Default(defaultTimeout).Duration()
+	timeout                    = app.Flag("timeout", "Max duration for any individual package build/test").Default(defaultTimeout).Duration()
 
 	validBuildAgentFlags = []string{buildagents.TestAgentFlag, buildagents.ChrootAgentFlag}
 	buildAgent           = app.Flag("build-agent", "Type of build agent to build packages with.").PlaceHolder(exe.PlaceHolderize(validBuildAgentFlags)).Required().Enum(validBuildAgentFlags...)


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Sometimes package builds (or more often tests) get stuck. Generally, pipeline builds will timeout and kill the task, but we don't get our log output etc. in this case. We should instead gracefully monitor package builds and fail them if they take too long (say `4h`).

If the call to `rpmbuild` in the worker does not complete within that timeframe the worker will kill the `rpmbuild` process and return an error to the scheduler. The scheduler will be able to continue running as normal and will report this failure as normal at the end.

This can be configured by setting `PACKAGE_BUILD_TIMEOUT=10h` for 10 hours, `30m` for 30 minutes, etc.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add `--timeout` to scheduler and workers which kills a build if it runs too long
- Add `PACKAGE_BUILD_TIMEOUT=4h` to Makefile to control timeout

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**


###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local
