### PR TITLE
Only query precacher repos if one is passed in

### DIFF
--- a/toolkit/scripts/precache.mk
+++ b/toolkit/scripts/precache.mk
@@ -10,6 +10,7 @@ precache_state_dir = $(CACHED_RPMS_DIR)/precache
 precache_downloaded_files = $(precache_state_dir)/downloaded_files.txt
 repo_urls_file = $(precache_state_dir)/repo_urls.txt
 precache_chroot_dir = $(precache_state_dir)/chroot
+precache_logs_path = $(LOGS_DIR)/precache/precache.log
 
 $(call create_folder,$(precache_state_dir))
 $(call create_folder,$(remote_rpms_cache_dir))
@@ -39,7 +40,7 @@ $(STATUS_FLAGS_DIR)/precache.flag: $(go-precacher) $(chroot_worker) $(rpms_snaps
 		$(foreach repofile,$(REPO_LIST), --repo-file "$(repofile)") \
 		--worker-tar $(chroot_worker) \
 		--worker-dir $(precache_chroot_dir) \
-		--log-file=$(SRPM_BUILD_LOGS_DIR)/precacher.log \
+		--log-file=$(precache_logs_path) \
 		--log-level=$(LOG_LEVEL) \
 		--cpu-prof-file=$(PROFILE_DIR)/precacher.cpu.pprof \
 		--mem-prof-file=$(PROFILE_DIR)/precacher.mem.pprof \

--- a/toolkit/tools/precacher/precacher.go
+++ b/toolkit/tools/precacher/precacher.go
@@ -174,12 +174,16 @@ func getAllRepoData(repoURLs, repoFiles []string, workerTar, buildDir, repoUrlsF
 	}
 
 	var packageRepoUrls []string
-	err = queryChroot.Run(func() (chrootErr error) {
-		packageRepoUrls, chrootErr = getPackageRepoUrlsFromRepoFiles()
-		return chrootErr
-	})
-	if err != nil {
-		return nil, err
+	// Only run repoquery if we have repo files to query. --enablerepo=* will not work if there are no repo files
+	// and will return "Error: Unknown repo: '*'"
+	if len(repoFiles) > 0 {
+		err = queryChroot.Run(func() (chrootErr error) {
+			packageRepoUrls, chrootErr = getPackageRepoUrlsFromRepoFiles()
+			return chrootErr
+		})
+		if err != nil {
+			return nil, err
+		}
 	}
 	allPackageURLs = append(allPackageURLs, packageRepoUrls...)
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
If there are no repo files present, `repoquery` treats `--enablerepo=*` as a repo with the literal name `*`, and returns `Error: Unknown repo: '*'`.

In the `precacher` tool don't even run `repoquery` if the user passes no repo files to query (it will still query each repo URL given though).

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Skip running `repoquery` in the precacher if the user passes no repo files.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local testing against main and 2.0-stable
