### PR TITLE
Patch irqbalance to fix incorrect balancing behavior

### DIFF
--- a/SPECS/irqbalance/fix-load-unsigned-overflow.patch
+++ b/SPECS/irqbalance/fix-load-unsigned-overflow.patch
@@ -1,0 +1,25 @@
+From 2a66a666d3e202dec5b1a4309447e32d5f292871 Mon Sep 17 00:00:00 2001
+From: liuchao173 <55137861+liuchao173@users.noreply.github.com>
+Date: Tue, 24 Aug 2021 20:50:18 +0800
+Subject: [PATCH] fix unsigned integer subtraction sign overflow
+
+Min_load, adjustment_load  and load are unsigned integers, so it overflows when (lb_info->min_load + info->load) < (lb_info->adjustment_load - info->load). The result will be greater than zero. Therefore the irq cannot be selected to rebalanced.
+
+Signed-off-by: Henry Beberman <henry.beberman@microsoft.com>
+---
+ irqlist.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/irqlist.c b/irqlist.c
+index 9ab321a..4dd4a83 100644
+--- a/irqlist.c
++++ b/irqlist.c
+@@ -97,7 +97,7 @@ static void move_candidate_irqs(struct irq_info *info, void *data)
+ 	}
+ 
+ 	/* If we can migrate an irq without swapping the imbalance do it. */
+-	if ((lb_info->min_load + info->load) - (lb_info->adjustment_load - info->load) < delta_load) {
++	if ((lb_info->min_load + info->load) < delta_load + (lb_info->adjustment_load - info->load)) {
+ 		lb_info->adjustment_load -= info->load;
+ 		lb_info->min_load += info->load;
+ 		if (lb_info->min_load > lb_info->adjustment_load) {

--- a/SPECS/irqbalance/irqbalance.spec
+++ b/SPECS/irqbalance/irqbalance.spec
@@ -1,7 +1,7 @@
 Summary:        Irqbalance daemon
 Name:           irqbalance
 Version:        1.8.0
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        GPLv2
 URL:            https://github.com/Irqbalance/irqbalance
 Group:          System Environment/Services
@@ -9,6 +9,7 @@ Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Source0:        https://github.com/Irqbalance/%{name}/archive/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
 Patch0:         fix-format-security.patch
+Patch1:         fix-load-unsigned-overflow.patch
 BuildRequires:  systemd-devel
 BuildRequires:  glib-devel
 Requires:       systemd
@@ -57,6 +58,9 @@ make -k check |& tee %{_specdir}/%{name}-check-log || %{nocheck}
 %{_datadir}/*
 
 %changelog
+* Fri Oct 06 2023 Henry Beberman <henry.beberman@microsoft.com> - 1.8.0-4
+- Apply upstream fix for unsigned subtraction overflow in load calculation
+
 * Wed Sep 20 2023 Jon Slobodzian <joslobo@microsoft.com> - 1.8.0-3
 - Recompile with stack-protection fixed gcc version (CVE-2023-4039)
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Currently irqbalance has an unsigned subtraction overflow that can cause it to leave IRQs pinned to a core that should actually be rebalanced. This PR applies an upstream fix to that calculation to avoid the overflow.
https://github.com/Irqbalance/irqbalance/commit/2a66a666d3e202dec5b1a4309447e32d5f292871

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Patch unsigned subtraction overflow in irqbalance.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**


###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local package build succeeded. Tested binaries from local package build on a K8s cluster.
- Buddy build succeeded: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=432669&view=results

1) Start a Standard_D8ads_v5 Azure VM with current irqbalance binary (1.8.0-3)
2) Load the system with network interrupts using iperf and peer on the same vnet `iperf3 -s -i 5`+`iperf3 -c <ip> -t 6000 -P64`
3) Remove and re-add the mlx drivers `modprobe -r mlx5_ib mlx5_core` then `modprobe mlx5_ib mlx5_core`
4) Observe that irqbalance moves all IRQs to the same core and never moves them off of it
5) Switch to new irqbalance binary
6) Remove and re-add the mlx drivers `modprobe -r mlx5_ib mlx5_core` then `modprobe mlx5_ib mlx5_core`
7) Observe that after a few balances (once every 10 seconds) irqbalance correctly distributes the IRQs across multiple cores
