### PR TITLE
Running `PipAuthenticate@1` in each template separately.

### DIFF
--- a/.pipelines/templates/PackageBuild.yml
+++ b/.pipelines/templates/PackageBuild.yml
@@ -224,4 +224,5 @@ steps:
           buildRepoRoot: ${{ parameters.buildRepoRoot }}
           failOnTestFailures: ${{ parameters.failOnTestFailures }}
           outputArtifactsFolder: ${{ parameters.outputArtifactsFolder }}
+          pipArtifactFeeds: ${{ parameters.pipArtifactFeeds }}
           testSuiteName: ${{ parameters.testSuiteName }}

--- a/.pipelines/templates/PackageTestResultsAnalysis.yml
+++ b/.pipelines/templates/PackageTestResultsAnalysis.yml
@@ -14,6 +14,10 @@ parameters:
     type: string
     default: "$(Build.ArtifactStagingDirectory)"
 
+  - name: pipArtifactFeeds
+    type: string
+    default: ""
+
   - name: testSuiteName
     type: string
     default: "Package test"
@@ -28,8 +32,13 @@ parameters:
     default: "$(Agent.TempDirectory)"
 
 steps:
-  - bash: |
-      pip3 install junit_xml
+  - ${{ if parameters.pipArtifactFeeds }}:
+      - task: PipAuthenticate@1
+        inputs:
+          artifactFeeds: "${{ parameters.pipArtifactFeeds }}"
+        displayName: "Authenticate to custom pip artifact feeds"
+
+  - bash: pip3 install junit_xml
     displayName: "Install Python dependencies"
 
   - task: PythonScript@0


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

We've been having issues installing Python modules through `pip` in our PR check pipelines. It looks like package builds were interfering with the configuration set by the `PipAuthenticate@1` task, so we're now making sure we call it every time we need `pip`, regardless if it's been called before.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Adding `PipAuthenticate@1` to the ptest analysis templates.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- [Sample PR check run.](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=432694&view=results)