### PR TITLE
Add additional functions to pkggraph.go

### DIFF
--- a/toolkit/tools/internal/pkggraph/pkggraph.go
+++ b/toolkit/tools/internal/pkggraph/pkggraph.go
@@ -1175,6 +1175,10 @@ func (g *PkgGraph) AddGoalNodeFromNodes(goalName string, existingNodes []*PkgNod
 	}
 
 	for _, node := range existingNodes {
+		if !g.HasNode(node) {
+			err = fmt.Errorf("can't add goal node '%s' from node '%s' which is not in the graph", goalName, node.FriendlyName())
+			return nil, err
+		}
 		err = g.AddEdge(goalNode, node)
 		if err != nil {
 			return nil, err

--- a/toolkit/tools/internal/pkggraph/pkggraph.go
+++ b/toolkit/tools/internal/pkggraph/pkggraph.go
@@ -1126,16 +1126,19 @@ func (g *PkgGraph) AddGoalNodeWithExtraLayers(goalName string, packages, tests [
 
 	err = g.safeAddNode(goalNode)
 	if err != nil {
+		err = fmt.Errorf("failed to add goal node '%s': %s", goalName, err.Error())
 		return
 	}
 
 	err = g.connectGoalEdges(goalNode, packagesGoalSet, strict, TypeLocalRun)
 	if err != nil {
+		err = fmt.Errorf("failed to connect goal node '%s' to packages: %s", goalName, err.Error())
 		return
 	}
 
 	err = g.connectGoalEdges(goalNode, testsGoalSet, strict, TypeTest)
 	if err != nil {
+		err = fmt.Errorf("failed to connect goal node '%s' to tests: %s", goalName, err.Error())
 		return
 	}
 
@@ -1171,6 +1174,7 @@ func (g *PkgGraph) AddGoalNodeToNodes(goalName string, existingNodes []*PkgNode,
 
 	err = g.safeAddNode(goalNode)
 	if err != nil {
+		err = fmt.Errorf("failed to add goal node '%s': %s", goalName, err.Error())
 		return
 	}
 
@@ -1181,6 +1185,7 @@ func (g *PkgGraph) AddGoalNodeToNodes(goalName string, existingNodes []*PkgNode,
 		}
 		err = g.AddEdge(goalNode, node)
 		if err != nil {
+			err = fmt.Errorf("failed to add edge from goal node '%s' to node '%s': %s", goalName, node.FriendlyName(), err.Error())
 			return nil, err
 		}
 	}

--- a/toolkit/tools/internal/pkggraph/pkggraph.go
+++ b/toolkit/tools/internal/pkggraph/pkggraph.go
@@ -1150,7 +1150,13 @@ func (g *PkgGraph) AddGoalNodeWithExtraLayers(goalName string, packages, tests [
 	return
 }
 
-// AddGoalNodeToNodes adds a goal node to the graph which links to a list of existing nodes.
+// AddGoalNodeToNodes behaves similarly to AddGoalNodeWithExtraLayers, but instead of using a list of package versions (via
+// graph lookup) to create the goal node, it uses a list of existing nodes in the graph.
+//   - goalName: The name of the goal node to add
+//   - existingNodes: A list of nodes to link the goal node to.
+//   - extraLayers: The number of levels to expand the goal node. Each level will add one more layer of packages beyond
+//     the goal node. For example, if the goal node is "x" and extraLevels is 1, the goal node will link to all nodes
+//     which depend on "x" as well as "x" itself (Specifically run nodes, all other nodes are stepped over)
 func (g *PkgGraph) AddGoalNodeToNodes(goalName string, existingNodes []*PkgNode, extraLayers int) (goalNode *PkgNode, err error) {
 	// Check if we already have a goal node with the requested name
 	if g.FindGoalNode(goalName) != nil {

--- a/toolkit/tools/internal/pkggraph/pkggraph.go
+++ b/toolkit/tools/internal/pkggraph/pkggraph.go
@@ -1147,8 +1147,8 @@ func (g *PkgGraph) AddGoalNodeWithExtraLayers(goalName string, packages, tests [
 	return
 }
 
-// AddGoalNodeFromNodes adds a goal node to the graph which links to a list of existing nodes.
-func (g *PkgGraph) AddGoalNodeFromNodes(goalName string, existingNodes []*PkgNode, extraLayers int) (goalNode *PkgNode, err error) {
+// AddGoalNodeToNodes adds a goal node to the graph which links to a list of existing nodes.
+func (g *PkgGraph) AddGoalNodeToNodes(goalName string, existingNodes []*PkgNode, extraLayers int) (goalNode *PkgNode, err error) {
 	// Check if we already have a goal node with the requested name
 	if g.FindGoalNode(goalName) != nil {
 		err = fmt.Errorf("can't have two goal nodes named %s", goalName)

--- a/toolkit/tools/internal/pkggraph/pkggraph_test.go
+++ b/toolkit/tools/internal/pkggraph/pkggraph_test.go
@@ -803,7 +803,7 @@ func TestStrictGoalNodes(t *testing.T) {
 	assert.Error(t, err)
 }
 
-// Search for packages to add to the goal node
+// Basic test of adding a goal node using two package node objects.
 func TestGoalWithNodes(t *testing.T) {
 	g := NewPkgGraph()
 	err := addNodesHelper(g, allNodes)
@@ -823,6 +823,7 @@ func TestGoalWithNodes(t *testing.T) {
 	assert.Equal(t, 2, len(goalNodes))
 }
 
+// Make sure we can't add a duplicate goal node with AddGoalNodeToNodes().
 func TestDuplicateGoalWithNodes(t *testing.T) {
 	g := NewPkgGraph()
 	goal, err := g.AddGoalNode("test", nil, nil, false)
@@ -834,6 +835,7 @@ func TestDuplicateGoalWithNodes(t *testing.T) {
 	assert.Error(t, err)
 }
 
+// Ensure nodes that are outside the graph can't be added to a goal
 func TestGoalWithNodeOutsideGraph(t *testing.T) {
 	g := NewPkgGraph()
 	err := addNodesHelper(g, allNodes)
@@ -934,6 +936,7 @@ func TestGoalWithLevelTwo(t *testing.T) {
 	checkEqualComponents(t, expectedGoalPackages, g.AllNodesFrom(goal))
 }
 
+// Check if AddGoalNodeToNodes() works with a levels
 func TestGoalWithNodesWithLevelTwo(t *testing.T) {
 	g, err := buildTestGraphHelper()
 	assert.NoError(t, err)
@@ -1354,6 +1357,8 @@ func TestHasNodeCopyNode(t *testing.T) {
 	assert.False(t, g.HasNode(nCopy))
 }
 
+// Ensure that HasNode functions as expected when we create a subgraph. The subgraph should only "have" the nodes
+// that make up the subgraph.
 func TestHasNodeSubgraph(t *testing.T) {
 	g, err := buildTestGraphHelper()
 	assert.NoError(t, err)

--- a/toolkit/tools/internal/pkggraph/pkggraph_test.go
+++ b/toolkit/tools/internal/pkggraph/pkggraph_test.go
@@ -310,6 +310,8 @@ func getRealNodeFromGraphHelper(t *testing.T, g *PkgGraph, n *PkgNode) (realN *P
 	case TypeTest:
 		realN = realNode.TestNode
 	case TypeLocalRun:
+		fallthrough
+	case TypeRemoteRun:
 		realN = realNode.RunNode
 	default:
 		assert.Fail(t, "Unknown node type")

--- a/toolkit/tools/internal/pkggraph/pkggraph_test.go
+++ b/toolkit/tools/internal/pkggraph/pkggraph_test.go
@@ -1336,7 +1336,7 @@ func TestHasNodeCopyGraph(t *testing.T) {
 	assert.NotNil(t, n)
 	assert.NoError(t, err)
 
-	// A deep copy should have different objects, and should returnf alse
+	// A deep copy should have different objects, and should return false
 	gCopy, err := g.DeepCopy()
 	assert.NoError(t, err)
 	assert.False(t, gCopy.HasNode(n))
@@ -1392,132 +1392,6 @@ func TestHasNodeSubgraph(t *testing.T) {
 	for _, n := range outsideSubgraph {
 		assert.False(t, subGraph.HasNode(getRealNodeFromGraphHelper(t, g, n)))
 	}
-}
-
-func TestAllNodes(t *testing.T) {
-	g := NewPkgGraph()
-	assert.NotNil(t, g)
-	n, err := addNodeToGraphHelper(g, pkgARun)
-	assert.NotNil(t, n)
-	assert.NoError(t, err)
-
-	checkEqualComponents(t, []*PkgNode{pkgARun}, g.AllNodes())
-
-	g, err = buildTestGraphHelper()
-	assert.NoError(t, err)
-	assert.NotNil(t, g)
-
-	checkEqualComponents(t, allNodes, g.AllNodes())
-
-}
-
-func TestAllRunNodes(t *testing.T) {
-	g := NewPkgGraph()
-	assert.NotNil(t, g)
-	n, err := addNodeToGraphHelper(g, pkgARun)
-	assert.NotNil(t, n)
-	assert.NoError(t, err)
-
-	checkEqualComponents(t, []*PkgNode{pkgARun}, g.AllRunNodes())
-
-	g, err = buildTestGraphHelper()
-	assert.NoError(t, err)
-	assert.NotNil(t, g)
-
-	checkEqualComponents(t, append(runNodes, unresolvedNodes...), g.AllRunNodes())
-}
-
-func TestAllPreferredRunNodes(t *testing.T) {
-	g := NewPkgGraph()
-	assert.NotNil(t, g)
-	n, err := addNodeToGraphHelper(g, pkgARun)
-	assert.NotNil(t, n)
-	assert.NoError(t, err)
-
-	checkEqualComponents(t, []*PkgNode{pkgARun}, g.AllRunNodes())
-	checkEqualComponents(t, []*PkgNode{pkgARun}, g.AllPreferredRunNodes())
-
-	duplicateRemote, err := addNodeToGraphHelper(g, buildUnresolvedNodeHelper(&pkgA))
-	assert.NotNil(t, duplicateRemote)
-	assert.NoError(t, err)
-
-	// Duplicate node should show here
-	checkEqualComponents(t, []*PkgNode{pkgARun, duplicateRemote}, g.AllRunNodes())
-	// But not here
-	checkEqualComponents(t, []*PkgNode{pkgARun}, g.AllPreferredRunNodes())
-}
-
-func TestAllBuildNodes(t *testing.T) {
-	g := NewPkgGraph()
-	assert.NotNil(t, g)
-	n, err := addNodeToGraphHelper(g, pkgARun)
-	assert.NotNil(t, n)
-	assert.NoError(t, err)
-	n, err = addNodeToGraphHelper(g, pkgABuild)
-	assert.NotNil(t, n)
-	assert.NoError(t, err)
-
-	checkEqualComponents(t, []*PkgNode{pkgABuild}, g.AllBuildNodes())
-
-	g, err = buildTestGraphHelper()
-	assert.NoError(t, err)
-	assert.NotNil(t, g)
-
-	checkEqualComponents(t, buildNodes, g.AllBuildNodes())
-}
-
-func TestAllTestNodes(t *testing.T) {
-	g := NewPkgGraph()
-	assert.NotNil(t, g)
-	n, err := addNodeToGraphHelper(g, pkgARun)
-	assert.NotNil(t, n)
-	assert.NoError(t, err)
-
-	testNode := buildTestNodeHelper(&pkgA)
-
-	n, err = addNodeToGraphHelper(g, testNode)
-	assert.NotNil(t, n)
-	assert.NoError(t, err)
-
-	checkEqualComponents(t, []*PkgNode{testNode}, g.AllTestNodes())
-
-	g, err = buildTestGraphHelper()
-	assert.NoError(t, err)
-	assert.NotNil(t, g)
-
-	n, err = addNodeToGraphHelper(g, testNode)
-	assert.NotNil(t, n)
-	assert.NoError(t, err)
-
-	checkEqualComponents(t, []*PkgNode{testNode}, g.AllTestNodes())
-}
-
-func TestAllImplicitNodes(t *testing.T) {
-	g := NewPkgGraph()
-	assert.NotNil(t, g)
-	n, err := addNodeToGraphHelper(g, pkgARun)
-	assert.NotNil(t, n)
-	assert.NoError(t, err)
-
-	implicitVersion := pkgjson.PackageVer{Name: "/path/to/implicit"}
-	implicitNode := buildUnresolvedNodeHelper(&implicitVersion)
-
-	actualImplicitNode, err := addNodeToGraphHelper(g, implicitNode)
-	assert.NotNil(t, actualImplicitNode)
-	assert.NoError(t, err)
-	assert.True(t, actualImplicitNode.Implicit)
-
-	checkEqualComponents(t, []*PkgNode{actualImplicitNode}, g.AllImplicitNodes())
-
-	g, err = buildTestGraphHelper()
-	assert.NoError(t, err)
-	assert.NotNil(t, g)
-
-	actualImplicitNode, err = addNodeToGraphHelper(g, implicitNode)
-	assert.NotNil(t, actualImplicitNode)
-	assert.NoError(t, err)
-
-	checkEqualComponents(t, []*PkgNode{actualImplicitNode}, g.AllImplicitNodes())
 }
 
 func TestShouldSucceedMakeDAGWithGoalNode(t *testing.T) {
@@ -1583,6 +1457,25 @@ func TestShouldGetSRPMNameFromEmptySRPMPath(t *testing.T) {
 	assert.Equal(t, ".", node.SRPMFileName())
 }
 
+func TestAllBuildNodes(t *testing.T) {
+	g := NewPkgGraph()
+	assert.NotNil(t, g)
+	n, err := addNodeToGraphHelper(g, pkgARun)
+	assert.NotNil(t, n)
+	assert.NoError(t, err)
+	n, err = addNodeToGraphHelper(g, pkgABuild)
+	assert.NotNil(t, n)
+	assert.NoError(t, err)
+
+	checkEqualComponents(t, []*PkgNode{pkgABuild}, g.AllBuildNodes())
+
+	g, err = buildTestGraphHelper()
+	assert.NoError(t, err)
+	assert.NotNil(t, g)
+
+	checkEqualComponents(t, buildNodes, g.AllBuildNodes())
+}
+
 func TestShouldGetAllBuildNodesWithFilter(t *testing.T) {
 	gOut, err := buildTestGraphHelper()
 	assert.NoError(t, err)
@@ -1594,6 +1487,22 @@ func TestShouldGetAllBuildNodesWithFilter(t *testing.T) {
 	checkEqualComponents(t, buildNodes, foundNodes)
 }
 
+func TestAllNodes(t *testing.T) {
+	g := NewPkgGraph()
+	assert.NotNil(t, g)
+	n, err := addNodeToGraphHelper(g, pkgARun)
+	assert.NotNil(t, n)
+	assert.NoError(t, err)
+
+	checkEqualComponents(t, []*PkgNode{pkgARun}, g.AllNodes())
+
+	g, err = buildTestGraphHelper()
+	assert.NoError(t, err)
+	assert.NotNil(t, g)
+
+	checkEqualComponents(t, allNodes, g.AllNodes())
+}
+
 func TestShouldGetAllNodesWithFilter(t *testing.T) {
 	gOut, err := buildTestGraphHelper()
 	assert.NoError(t, err)
@@ -1603,6 +1512,42 @@ func TestShouldGetAllNodesWithFilter(t *testing.T) {
 		return true
 	})
 	checkEqualComponents(t, allNodes, foundNodes)
+}
+
+func TestAllRunNodes(t *testing.T) {
+	g := NewPkgGraph()
+	assert.NotNil(t, g)
+	n, err := addNodeToGraphHelper(g, pkgARun)
+	assert.NotNil(t, n)
+	assert.NoError(t, err)
+
+	checkEqualComponents(t, []*PkgNode{pkgARun}, g.AllRunNodes())
+
+	g, err = buildTestGraphHelper()
+	assert.NoError(t, err)
+	assert.NotNil(t, g)
+
+	checkEqualComponents(t, append(runNodes, unresolvedNodes...), g.AllRunNodes())
+}
+
+func TestAllPreferredRunNodes(t *testing.T) {
+	g := NewPkgGraph()
+	assert.NotNil(t, g)
+	n, err := addNodeToGraphHelper(g, pkgARun)
+	assert.NotNil(t, n)
+	assert.NoError(t, err)
+
+	checkEqualComponents(t, []*PkgNode{pkgARun}, g.AllRunNodes())
+	checkEqualComponents(t, []*PkgNode{pkgARun}, g.AllPreferredRunNodes())
+
+	duplicateRemote, err := addNodeToGraphHelper(g, buildUnresolvedNodeHelper(&pkgA))
+	assert.NotNil(t, duplicateRemote)
+	assert.NoError(t, err)
+
+	// Duplicate node should show here
+	checkEqualComponents(t, []*PkgNode{pkgARun, duplicateRemote}, g.AllRunNodes())
+	// But not here
+	checkEqualComponents(t, []*PkgNode{pkgARun}, g.AllPreferredRunNodes())
 }
 
 func TestShouldGetAllRunNodesWithFilter(t *testing.T) {
@@ -1625,4 +1570,58 @@ func TestShouldGetAllUnresolvedNodesWithFilter(t *testing.T) {
 		return node.State == StateUnresolved
 	})
 	checkEqualComponents(t, unresolvedNodes, foundNodes)
+}
+
+func TestAllTestNodes(t *testing.T) {
+	g := NewPkgGraph()
+	assert.NotNil(t, g)
+	n, err := addNodeToGraphHelper(g, pkgARun)
+	assert.NotNil(t, n)
+	assert.NoError(t, err)
+
+	testNode := buildTestNodeHelper(&pkgA)
+
+	n, err = addNodeToGraphHelper(g, testNode)
+	assert.NotNil(t, n)
+	assert.NoError(t, err)
+
+	checkEqualComponents(t, []*PkgNode{testNode}, g.AllTestNodes())
+
+	g, err = buildTestGraphHelper()
+	assert.NoError(t, err)
+	assert.NotNil(t, g)
+
+	n, err = addNodeToGraphHelper(g, testNode)
+	assert.NotNil(t, n)
+	assert.NoError(t, err)
+
+	checkEqualComponents(t, []*PkgNode{testNode}, g.AllTestNodes())
+}
+
+func TestAllImplicitNodes(t *testing.T) {
+	g := NewPkgGraph()
+	assert.NotNil(t, g)
+	n, err := addNodeToGraphHelper(g, pkgARun)
+	assert.NotNil(t, n)
+	assert.NoError(t, err)
+
+	implicitVersion := pkgjson.PackageVer{Name: "/path/to/implicit"}
+	implicitNode := buildUnresolvedNodeHelper(&implicitVersion)
+
+	actualImplicitNode, err := addNodeToGraphHelper(g, implicitNode)
+	assert.NotNil(t, actualImplicitNode)
+	assert.NoError(t, err)
+	assert.True(t, actualImplicitNode.Implicit)
+
+	checkEqualComponents(t, []*PkgNode{actualImplicitNode}, g.AllImplicitNodes())
+
+	g, err = buildTestGraphHelper()
+	assert.NoError(t, err)
+	assert.NotNil(t, g)
+
+	actualImplicitNode, err = addNodeToGraphHelper(g, implicitNode)
+	assert.NotNil(t, actualImplicitNode)
+	assert.NoError(t, err)
+
+	checkEqualComponents(t, []*PkgNode{actualImplicitNode}, g.AllImplicitNodes())
 }

--- a/toolkit/tools/internal/pkggraph/pkggraph_test.go
+++ b/toolkit/tools/internal/pkggraph/pkggraph_test.go
@@ -815,7 +815,7 @@ func TestGoalWithNodes(t *testing.T) {
 		getRealNodeFromGraphHelper(t, g, pkgBRun),
 	}
 
-	goal, err := g.AddGoalNodeFromNodes("test", nodeList, 0)
+	goal, err := g.AddGoalNodeToNodes("test", nodeList, 0)
 	assert.NoError(t, err)
 	assert.NotNil(t, goal)
 	assert.Equal(t, len(allNodes)+1, len(g.AllNodes()))
@@ -830,7 +830,7 @@ func TestDuplicateGoalWithNodes(t *testing.T) {
 	assert.NotNil(t, goal)
 	assert.Equal(t, "test", goal.GoalName)
 
-	_, err = g.AddGoalNodeFromNodes("test", nil, 0)
+	_, err = g.AddGoalNodeToNodes("test", nil, 0)
 	assert.Error(t, err)
 }
 
@@ -842,7 +842,7 @@ func TestGoalWithNodeOutsideGraph(t *testing.T) {
 
 	nodeList := []*PkgNode{pkgARun, pkgBRun}
 
-	goal, err := g.AddGoalNodeFromNodes("test", nodeList, 0)
+	goal, err := g.AddGoalNodeToNodes("test", nodeList, 0)
 	assert.Error(t, err)
 	assert.Nil(t, goal)
 }
@@ -940,7 +940,7 @@ func TestGoalWithNodesWithLevelTwo(t *testing.T) {
 	assert.NotNil(t, g)
 
 	goalNode := getRealNodeFromGraphHelper(t, g, pkgCRun)
-	goal, err := g.AddGoalNodeFromNodes("test_2", []*PkgNode{goalNode}, 2)
+	goal, err := g.AddGoalNodeToNodes("test_2", []*PkgNode{goalNode}, 2)
 	assert.NoError(t, err)
 	assert.NotNil(t, goal)
 	nodesInGoal := []*PkgNode{}

--- a/toolkit/tools/internal/pkggraph/pkggraph_test.go
+++ b/toolkit/tools/internal/pkggraph/pkggraph_test.go
@@ -821,7 +821,7 @@ func TestGoalWithNodes(t *testing.T) {
 	assert.Equal(t, 2, len(goalNodes))
 }
 
-func TestDuplicateGoalWitNodes(t *testing.T) {
+func TestDuplicateGoalWithNodes(t *testing.T) {
 	g := NewPkgGraph()
 	goal, err := g.AddGoalNode("test", nil, nil, false)
 	assert.NoError(t, err)
@@ -830,6 +830,19 @@ func TestDuplicateGoalWitNodes(t *testing.T) {
 
 	_, err = g.AddGoalNodeFromNodes("test", nil, 0)
 	assert.Error(t, err)
+}
+
+func TestGoalWithNodeOutsideGraph(t *testing.T) {
+	g := NewPkgGraph()
+	err := addNodesHelper(g, allNodes)
+	assert.NoError(t, err)
+	assert.NotNil(t, g)
+
+	nodeList := []*PkgNode{pkgARun, pkgBRun}
+
+	goal, err := g.AddGoalNodeFromNodes("test", nodeList, 0)
+	assert.Error(t, err)
+	assert.Nil(t, goal)
 }
 
 func TestGoalWithLevelZero(t *testing.T) {


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
In preparation for an implicit provides optimization PR (RFC/PoC: https://github.com/microsoft/CBL-Mariner/pull/6298), add a couple of functions to pkgraph:
- HasNode(): Returns true if a specific node object is present in a graph, the node must point to the same underlying object, equivalence is not sufficient.
- AllImplicitNodes(): Like the other `All*Nodes():` returns a list of all run/remote nodes in the graph that have `n.Implicit == true`
- AddGoalNodeToNodes(): Creates a goal node that links to arbitrary node objects in the graph rather than package versions.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add `HasNode()` `AllImplicitNodes()`  `AddGoalNodeToNodes()`

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local
