### PR TITLE
Image Customizer: Add `Config` struct.

### DIFF
--- a/toolkit/tools/imagecustomizerapi/config.go
+++ b/toolkit/tools/imagecustomizerapi/config.go
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package imagecustomizerapi
+
+type Config struct {
+	SystemConfig SystemConfig `yaml:"SystemConfig"`
+}
+
+func (c *Config) IsValid() error {
+	err := c.SystemConfig.IsValid()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeutils.go
@@ -26,7 +26,7 @@ const (
 	resolveConfPath            = "/etc/resolv.conf"
 )
 
-func doCustomizations(buildDir string, baseConfigPath string, config *imagecustomizerapi.SystemConfig,
+func doCustomizations(buildDir string, baseConfigPath string, config *imagecustomizerapi.Config,
 	imageChroot *safechroot.Chroot, rpmsSources []string, useBaseImageRpmRepos bool,
 ) error {
 	var err error
@@ -39,37 +39,37 @@ func doCustomizations(buildDir string, baseConfigPath string, config *imagecusto
 		return err
 	}
 
-	err = addRemoveAndUpdatePackages(buildDir, baseConfigPath, config, imageChroot, rpmsSources, useBaseImageRpmRepos)
+	err = addRemoveAndUpdatePackages(buildDir, baseConfigPath, &config.SystemConfig, imageChroot, rpmsSources, useBaseImageRpmRepos)
 	if err != nil {
 		return err
 	}
 
-	err = updateHostname(config.Hostname, imageChroot)
+	err = updateHostname(config.SystemConfig.Hostname, imageChroot)
 	if err != nil {
 		return err
 	}
 
-	err = copyAdditionalFiles(baseConfigPath, config.AdditionalFiles, imageChroot)
+	err = copyAdditionalFiles(baseConfigPath, config.SystemConfig.AdditionalFiles, imageChroot)
 	if err != nil {
 		return err
 	}
 
-	err = addOrUpdateUsers(config.Users, baseConfigPath, imageChroot)
+	err = addOrUpdateUsers(config.SystemConfig.Users, baseConfigPath, imageChroot)
 	if err != nil {
 		return err
 	}
 
-	err = enableOrDisableServices(config.Services, baseConfigPath, imageChroot)
+	err = enableOrDisableServices(config.SystemConfig.Services, baseConfigPath, imageChroot)
 	if err != nil {
 		return err
 	}
 
-	err = runScripts(baseConfigPath, config.PostInstallScripts, imageChroot)
+	err = runScripts(baseConfigPath, config.SystemConfig.PostInstallScripts, imageChroot)
 	if err != nil {
 		return err
 	}
 
-	err = runScripts(baseConfigPath, config.FinalizeImageScripts, imageChroot)
+	err = runScripts(baseConfigPath, config.SystemConfig.FinalizeImageScripts, imageChroot)
 	if err != nil {
 		return err
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -28,7 +28,7 @@ func CustomizeImageWithConfigFile(buildDir string, configFile string, imageFile 
 ) error {
 	var err error
 
-	var config imagecustomizerapi.SystemConfig
+	var config imagecustomizerapi.Config
 	err = imagecustomizerapi.UnmarshalYamlFile(configFile, &config)
 	if err != nil {
 		return err
@@ -45,7 +45,7 @@ func CustomizeImageWithConfigFile(buildDir string, configFile string, imageFile 
 	return nil
 }
 
-func CustomizeImage(buildDir string, baseConfigPath string, config *imagecustomizerapi.SystemConfig, imageFile string,
+func CustomizeImage(buildDir string, baseConfigPath string, config *imagecustomizerapi.Config, imageFile string,
 	rpmsSources []string, outputImageFile string, outputImageFormat string, useBaseImageRpmRepos bool,
 ) error {
 	var err error
@@ -113,7 +113,18 @@ func toQemuImageFormat(imageFormat string) (string, error) {
 	}
 }
 
-func validateConfig(baseConfigPath string, config *imagecustomizerapi.SystemConfig) error {
+func validateConfig(baseConfigPath string, config *imagecustomizerapi.Config) error {
+	var err error
+
+	err = validateSystemConfig(baseConfigPath, &config.SystemConfig)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func validateSystemConfig(baseConfigPath string, config *imagecustomizerapi.SystemConfig) error {
 	var err error
 
 	for sourceFile := range config.AdditionalFiles {
@@ -168,7 +179,7 @@ func validateScript(baseConfigPath string, script *imagecustomizerapi.Script) er
 	return nil
 }
 
-func customizeImageHelper(buildDir string, baseConfigPath string, config *imagecustomizerapi.SystemConfig,
+func customizeImageHelper(buildDir string, baseConfigPath string, config *imagecustomizerapi.Config,
 	buildImageFile string, rpmsSources []string, useBaseImageRpmRepos bool,
 ) error {
 	// Mount the raw disk image file.

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
@@ -36,7 +36,7 @@ func TestCustomizeImageEmptyConfig(t *testing.T) {
 	}
 
 	// Customize image.
-	err = CustomizeImage(buildDir, buildDir, &imagecustomizerapi.SystemConfig{}, diskFilePath, nil, outImageFilePath,
+	err = CustomizeImage(buildDir, buildDir, &imagecustomizerapi.Config{}, diskFilePath, nil, outImageFilePath,
 		"vhd", false)
 	if !assert.NoError(t, err) {
 		return
@@ -100,71 +100,77 @@ func TestCustomizeImageCopyFiles(t *testing.T) {
 func TestValidateConfigValidAdditionalFiles(t *testing.T) {
 	var err error
 
-	err = validateConfig(testDir, &imagecustomizerapi.SystemConfig{
-		AdditionalFiles: map[string]imagecustomizerapi.FileConfigList{
-			"files/a.txt": {{Path: "/a.txt"}},
-		},
-	})
+	err = validateConfig(testDir, &imagecustomizerapi.Config{
+		SystemConfig: imagecustomizerapi.SystemConfig{
+			AdditionalFiles: map[string]imagecustomizerapi.FileConfigList{
+				"files/a.txt": {{Path: "/a.txt"}},
+			},
+		}})
 	assert.NoError(t, err)
 }
 
 func TestValidateConfigMissingAdditionalFiles(t *testing.T) {
 	var err error
 
-	err = validateConfig(testDir, &imagecustomizerapi.SystemConfig{
-		AdditionalFiles: map[string]imagecustomizerapi.FileConfigList{
-			"files/missing_a.txt": {{Path: "/a.txt"}},
-		},
-	})
+	err = validateConfig(testDir, &imagecustomizerapi.Config{
+		SystemConfig: imagecustomizerapi.SystemConfig{
+			AdditionalFiles: map[string]imagecustomizerapi.FileConfigList{
+				"files/missing_a.txt": {{Path: "/a.txt"}},
+			},
+		}})
 	assert.Error(t, err)
 }
 
 func TestValidateConfigdditionalFilesIsDir(t *testing.T) {
 	var err error
 
-	err = validateConfig(testDir, &imagecustomizerapi.SystemConfig{
-		AdditionalFiles: map[string]imagecustomizerapi.FileConfigList{
-			"files": {{Path: "/a.txt"}},
-		},
-	})
+	err = validateConfig(testDir, &imagecustomizerapi.Config{
+		SystemConfig: imagecustomizerapi.SystemConfig{
+			AdditionalFiles: map[string]imagecustomizerapi.FileConfigList{
+				"files": {{Path: "/a.txt"}},
+			},
+		}})
 	assert.Error(t, err)
 }
 
 func TestValidateConfigScript(t *testing.T) {
-	err := validateConfig(testDir, &imagecustomizerapi.SystemConfig{
-		PostInstallScripts: []imagecustomizerapi.Script{
-			{
-				Path: "scripts/postinstallscript.sh",
+	err := validateConfig(testDir, &imagecustomizerapi.Config{
+		SystemConfig: imagecustomizerapi.SystemConfig{
+			PostInstallScripts: []imagecustomizerapi.Script{
+				{
+					Path: "scripts/postinstallscript.sh",
+				},
 			},
-		},
-		FinalizeImageScripts: []imagecustomizerapi.Script{
-			{
-				Path: "scripts/finalizeimagescript.sh",
+			FinalizeImageScripts: []imagecustomizerapi.Script{
+				{
+					Path: "scripts/finalizeimagescript.sh",
+				},
 			},
-		},
-	})
+		}})
 	assert.NoError(t, err)
 }
 
 func TestValidateConfigScriptNonLocalFile(t *testing.T) {
-	err := validateConfig(testDir, &imagecustomizerapi.SystemConfig{
-		PostInstallScripts: []imagecustomizerapi.Script{
-			{
-				Path: "../a.sh",
+	err := validateConfig(testDir, &imagecustomizerapi.Config{
+		SystemConfig: imagecustomizerapi.SystemConfig{
+			PostInstallScripts: []imagecustomizerapi.Script{
+				{
+					Path: "../a.sh",
+				},
 			},
-		},
-	})
+		}})
 	assert.Error(t, err)
 }
 
 func TestValidateConfigScriptNonExecutable(t *testing.T) {
-	err := validateConfig(testDir, &imagecustomizerapi.SystemConfig{
-		FinalizeImageScripts: []imagecustomizerapi.Script{
-			{
-				Path: "files/a.txt",
+	err := validateConfig(testDir, &imagecustomizerapi.Config{
+		SystemConfig: imagecustomizerapi.SystemConfig{
+			FinalizeImageScripts: []imagecustomizerapi.Script{
+				{
+					Path: "files/a.txt",
+				},
 			},
-		},
-	})
+		}})
 	assert.Error(t, err)
 }
 

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/addfiles-config.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/addfiles-config.yaml
@@ -1,2 +1,3 @@
-AdditionalFiles:
-  files/a.txt: /a.txt
+SystemConfig:
+  AdditionalFiles:
+    files/a.txt: /a.txt

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/addusers-config.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/addusers-config.yaml
@@ -1,9 +1,10 @@
-Users:
-- Name: root
-  Password: password
+SystemConfig:
+  Users:
+  - Name: root
+    Password: password
 
-- Name: test
-  Password: $6$aEzRqlIsXn8I$uvdD6RgzdAao5qUxap/Edc/ABW2Qfvqe4ZK7AjoguwS1rX2Q5l72/4L4OW5lqOdY5pIIahBco3hdR32NAuZ/O1
-  PasswordHashed: true
-  SecondaryGroups:
-  - sudo
+  - Name: test
+    Password: $6$aEzRqlIsXn8I$uvdD6RgzdAao5qUxap/Edc/ABW2Qfvqe4ZK7AjoguwS1rX2Q5l72/4L4OW5lqOdY5pIIahBco3hdR32NAuZ/O1
+    PasswordHashed: true
+    SecondaryGroups:
+    - sudo

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/runscripts-config.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/runscripts-config.yaml
@@ -1,5 +1,6 @@
-PostInstallScripts:
-- Path: scripts/postinstallscript.sh
+SystemConfig:
+  PostInstallScripts:
+  - Path: scripts/postinstallscript.sh
 
-FinalizeImageScripts:
-- Path: scripts/finalizeimagescript.sh
+  FinalizeImageScripts:
+  - Path: scripts/finalizeimagescript.sh

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/services-config.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/services-config.yaml
@@ -1,5 +1,6 @@
-Services:
-  Enable:
-    - Name: console-getty
-  Disable:
-    - Name: chronyd
+SystemConfig:
+  Services:
+    Enable:
+      - Name: console-getty
+    Disable:
+      - Name: chronyd

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/updatepackages-config.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/updatepackages-config.yaml
@@ -1,13 +1,14 @@
-UpdateBaseImagePackages: true
+SystemConfig:
+  UpdateBaseImagePackages: true
 
-PackagesRemove:
-- which
+  PackagesRemove:
+  - which
 
-PackagesInstall:
-- setools-console
+  PackagesInstall:
+  - setools-console
 
-PackageListsInstall:
-- lists/dracut-fips.yaml
+  PackageListsInstall:
+  - lists/dracut-fips.yaml
 
-PackagesUpdate:
-- setools-console
+  PackagesUpdate:
+  - setools-console


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->

Currently, the image customizer API uses the `SystemConfig` struct directly for its config. However, there is supposed to be a parent `Config` struct on top. This is so the API better mirrors the new image config.

###### Change Log  <!-- REQUIRED -->

- Image Customizer: Add `Config` struct to API.

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Ran UTs
