### PR TITLE
Image Customizer: Kernel Command Line

### DIFF
--- a/toolkit/tools/imagecustomizerapi/kernelcommandline.go
+++ b/toolkit/tools/imagecustomizerapi/kernelcommandline.go
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package imagecustomizerapi
+
+type KernelCommandLine struct {
+	ExtraCommandLine string `yaml:"ExtraCommandLine"`
+}
+
+func (s *KernelCommandLine) IsValid() error {
+	return nil
+}

--- a/toolkit/tools/imagecustomizerapi/systemconfig.go
+++ b/toolkit/tools/imagecustomizerapi/systemconfig.go
@@ -20,6 +20,7 @@ type SystemConfig struct {
 	PackagesRemove          []string                  `yaml:"PackagesRemove"`
 	PackageListsUpdate      []string                  `yaml:"PackageListsUpdate"`
 	PackagesUpdate          []string                  `yaml:"PackagesUpdate"`
+	KernelCommandLine       KernelCommandLine         `yaml:"KernelCommandLine"`
 	AdditionalFiles         map[string]FileConfigList `yaml:"AdditionalFiles"`
 	PostInstallScripts      []Script                  `yaml:"PostInstallScripts"`
 	FinalizeImageScripts    []Script                  `yaml:"FinalizeImageScripts"`
@@ -34,6 +35,11 @@ func (s *SystemConfig) IsValid() error {
 		if !govalidator.IsDNSName(s.Hostname) || strings.Contains(s.Hostname, "_") {
 			return fmt.Errorf("invalid hostname: %s", s.Hostname)
 		}
+	}
+
+	err = s.KernelCommandLine.IsValid()
+	if err != nil {
+		return fmt.Errorf("invalid KernelCommandLine: %w", err)
 	}
 
 	for sourcePath, fileConfigList := range s.AdditionalFiles {

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeboot.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeboot.go
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package imagecustomizerlib
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/safechroot"
+)
+
+var (
+	linuxCommandLineRegex = regexp.MustCompile(`\tlinux .* (\$kernelopts)`)
+)
+
+func handleKernelCommandLine(extraCommandLine string, imageChroot *safechroot.Chroot) error {
+	var err error
+
+	if extraCommandLine == "" {
+		// Nothing to do.
+		return nil
+	}
+
+	grub2ConfigFilePath := filepath.Join(imageChroot.RootDir(), "/boot/grub2/grub.cfg")
+
+	// Read the existing grub.cfg file.
+	grub2ConfigFileBytes, err := os.ReadFile(grub2ConfigFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to read existing grub2 config file: %w", err)
+	}
+
+	grub2ConfigFile := string(grub2ConfigFileBytes)
+
+	// Find the point where the new command line arguments should be added.
+	match := linuxCommandLineRegex.FindStringSubmatchIndex(grub2ConfigFile)
+	if match == nil {
+		return fmt.Errorf("failed to find Linux kernel command line params in grub2 config file")
+	}
+
+	// Get the location of "$kernelopts".
+	// Note: regexp returns index pairs. So, [2] is the start index of the 1st group.
+	insertIndex := match[2]
+
+	// Insert new command line arguments.
+	newGrub2ConfigFile := grub2ConfigFile[:insertIndex] + extraCommandLine + " " + grub2ConfigFile[insertIndex:]
+
+	// Update grub.cfg file.
+	err = os.WriteFile(grub2ConfigFilePath, []byte(newGrub2ConfigFile), 0)
+	if err != nil {
+		return fmt.Errorf("failed to write new grub2 config file: %w", err)
+	}
+
+	return nil
+}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeutils.go
@@ -69,6 +69,11 @@ func doCustomizations(buildDir string, baseConfigPath string, config *imagecusto
 		return err
 	}
 
+	err = handleKernelCommandLine(config.KernelCommandLine.ExtraCommandLine, imageChroot)
+	if err != nil {
+		return fmt.Errorf("failed to add extra kernel command line: %w", err)
+	}
+
 	err = runScripts(baseConfigPath, config.FinalizeImageScripts, imageChroot)
 	if err != nil {
 		return err


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->

Mariner Image Customizer: Add support for adding kernel command line arguments to the image.

Note that this change does not include support for images that use grub-mkconfig. That will need to be handled in a subsequent change.

###### Change Log  <!-- REQUIRED -->

- Image Customizer: Kernel Command Line

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Added toolkit tools UT.

