### PR TITLE
Fix debugedit build break

### DIFF
--- a/SPECS/debugedit/debugedit.spec
+++ b/SPECS/debugedit/debugedit.spec
@@ -10,7 +10,9 @@ Source0:        https://sourceware.org/ftp/%{name}/%{version}/%{name}-%{version}
 Patch0:         BUG-28161.patch
 BuildRequires:  automake
 BuildRequires:  binutils
+%if %{with_check}
 BuildRequires:  help2man
+%endif
 
 %description
 %{summary}

--- a/SPECS/debugedit/debugedit.spec
+++ b/SPECS/debugedit/debugedit.spec
@@ -3,9 +3,9 @@ Name:           debugedit
 Version:        5.0
 Release:        3%{?dist}
 License:        GPLv3+
-URL:            https://sourceware.org/debugedit/
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
+URL:            https://sourceware.org/debugedit/
 Source0:        https://sourceware.org/ftp/%{name}/%{version}/%{name}-%{version}.tar.xz
 Patch0:         BUG-28161.patch
 BuildRequires:  automake


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Debugedit fails in the toolchain build since `help2man` package is not available. Since this package is only required for check tests, wrap it in a test for `with_check`
[Toolchain error](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=433711&view=logs&j=db98f19e-da46-5e4d-a4ba-372cf3771a92&t=85232728-442d-5655-33db-c377813e7733)
```
 /usr/src/mariner/BUILD/debugedit-5.0/missing: line 81: help2man: command not found
WARNING: 'help2man' is missing on your system.
```

Not bumping the release number since this update package hasn't build/release yet

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change debugedit to wrap `help2man` BR in with_check

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: [preparebuild](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=434137&view=results)
- Buddy build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=434140&view=results