### PR TITLE
Patched CVE-2023-38545, CVE-2023-38546 for `cmake` and `curl`.

### DIFF
--- a/SPECS/cmake/CVE-2023-38545.patch
+++ b/SPECS/cmake/CVE-2023-38545.patch
@@ -1,0 +1,38 @@
+From ae69a66a23a26299625e404165b947693df2c466 Mon Sep 17 00:00:00 2001
+From: mbykhovtsev-ms <mbykhovtsev@microsoft.com>
+Date: Tue, 10 Oct 2023 14:13:35 -0700
+Subject: [PATCH] fix CVE-2023-38545
+
+---
+ Utilities/cmcurl/lib/socks.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/Utilities/cmcurl/lib/socks.c b/Utilities/cmcurl/lib/socks.c
+index 5cde4a46..fd524a05 100644
+--- a/Utilities/cmcurl/lib/socks.c
++++ b/Utilities/cmcurl/lib/socks.c
+@@ -533,9 +533,9 @@ CURLproxycode Curl_SOCKS5(const char *proxy_user,
+ 
+     /* RFC1928 chapter 5 specifies max 255 chars for domain name in packet */
+     if(!socks5_resolve_local && hostname_len > 255) {
+-      infof(data, "SOCKS5: server resolving disabled for hostnames of "
+-            "length > 255 [actual len=%zu]\n", hostname_len);
+-      socks5_resolve_local = TRUE;
++      failf(data, "SOCKS5: the destination hostname is too long to be "
++            "resolved remotely by the proxy.");
++      return CURLPX_LONG_HOSTNAME;
+     }
+ 
+     if(auth & ~(CURLAUTH_BASIC | CURLAUTH_GSSAPI))
+@@ -855,7 +855,7 @@ CURLproxycode Curl_SOCKS5(const char *proxy_user,
+ 
+     if(!socks5_resolve_local) {
+       socksreq[len++] = 3; /* ATYP: domain name = 3 */
+-      socksreq[len++] = (char) hostname_len; /* one byte address length */
++      socksreq[len++] = (unsigned char) hostname_len; /* one byte length */
+       memcpy(&socksreq[len], hostname, hostname_len); /* address w/o NULL */
+       len += hostname_len;
+       infof(data, "SOCKS5 connect to %s:%d (remotely resolved)\n",
+-- 
+2.25.1
+

--- a/SPECS/cmake/CVE-2023-38546.patch
+++ b/SPECS/cmake/CVE-2023-38546.patch
@@ -1,0 +1,125 @@
+From 4568e746d25e15039b9b4f70a3f8cfcda2aaa241 Mon Sep 17 00:00:00 2001
+From: mbykhovtsev-ms <mbykhovtsev@microsoft.com>
+Date: Tue, 10 Oct 2023 14:18:30 -0700
+Subject: [PATCH] fix CVE-2023-38546
+
+---
+ Utilities/cmcurl/lib/cookie.c | 13 +------------
+ Utilities/cmcurl/lib/cookie.h | 10 ++++------
+ Utilities/cmcurl/lib/easy.c   |  6 ++----
+ 3 files changed, 7 insertions(+), 22 deletions(-)
+
+diff --git a/Utilities/cmcurl/lib/cookie.c b/Utilities/cmcurl/lib/cookie.c
+index 941623f9..77883351 100644
+--- a/Utilities/cmcurl/lib/cookie.c
++++ b/Utilities/cmcurl/lib/cookie.c
+@@ -116,7 +116,6 @@ static void freecookie(struct Cookie *co)
+   free(co->name);
+   free(co->value);
+   free(co->maxage);
+-  free(co->version);
+   free(co);
+ }
+ 
+@@ -670,11 +669,7 @@ Curl_cookie_add(struct Curl_easy *data,
+           }
+         }
+         else if(strcasecompare("version", name)) {
+-          strstore(&co->version, whatptr);
+-          if(!co->version) {
+-            badcookie = TRUE;
+-            break;
+-          }
++          /* just ignore */
+         }
+         else if(strcasecompare("max-age", name)) {
+           /*
+@@ -1095,7 +1090,6 @@ Curl_cookie_add(struct Curl_easy *data,
+         free(clist->path);
+         free(clist->spath);
+         free(clist->expirestr);
+-        free(clist->version);
+         free(clist->maxage);
+ 
+         *clist = *co;  /* then store all the new data */
+@@ -1166,9 +1160,6 @@ struct CookieInfo *Curl_cookie_init(struct Curl_easy *data,
+     c = calloc(1, sizeof(struct CookieInfo));
+     if(!c)
+       return NULL; /* failed to get memory */
+-    c->filename = strdup(file?file:"none"); /* copy the name just in case */
+-    if(!c->filename)
+-      goto fail; /* failed to get memory */
+   }
+   else {
+     /* we got an already existing one, use that */
+@@ -1313,7 +1304,6 @@ static struct Cookie *dup_cookie(struct Cookie *src)
+     CLONE(name);
+     CLONE(value);
+     CLONE(maxage);
+-    CLONE(version);
+     d->expires = src->expires;
+     d->tailmatch = src->tailmatch;
+     d->secure = src->secure;
+@@ -1523,7 +1513,6 @@ void Curl_cookie_cleanup(struct CookieInfo *c)
+ {
+   if(c) {
+     unsigned int i;
+-    free(c->filename);
+     for(i = 0; i < COOKIE_HASH_SIZE; i++)
+       Curl_cookie_freelist(c->cookies[i]);
+     free(c); /* free the base struct as well */
+diff --git a/Utilities/cmcurl/lib/cookie.h b/Utilities/cmcurl/lib/cookie.h
+index 460bbb10..33a0e23d 100644
+--- a/Utilities/cmcurl/lib/cookie.h
++++ b/Utilities/cmcurl/lib/cookie.h
+@@ -35,8 +35,6 @@ struct Cookie {
+   curl_off_t expires;  /* expires = <this> */
+   char *expirestr;   /* the plain text version */
+ 
+-  /* RFC 2109 keywords. Version=1 means 2109-compliant cookie sending */
+-  char *version;     /* Version = <value> */
+   char *maxage;      /* Max-Age = <value> */
+ 
+   bool tailmatch;    /* whether we do tail-matching of the domain name */
+@@ -54,17 +52,17 @@ struct Cookie {
+ #define COOKIE_PREFIX__SECURE (1<<0)
+ #define COOKIE_PREFIX__HOST (1<<1)
+ 
+-#define COOKIE_HASH_SIZE 256
++#define COOKIE_HASH_SIZE 63
+ 
+ struct CookieInfo {
+   /* linked list of cookies we know of */
+   struct Cookie *cookies[COOKIE_HASH_SIZE];
+ 
+-  char *filename;  /* file we read from/write to */
+-  long numcookies; /* number of cookies in the "jar" */
++  curl_off_t next_expiration; /* the next time at which expiration happens */
++  int numcookies;  /* number of cookies in the "jar" */
++  int lastct;      /* last creation-time used in the jar */
+   bool running;    /* state info, for cookie adding information */
+   bool newsession; /* new session, discard session cookies on load */
+-  int lastct;      /* last creation-time used in the jar */
+ };
+ 
+ /* This is the maximum line length we accept for a cookie line. RFC 2109
+diff --git a/Utilities/cmcurl/lib/easy.c b/Utilities/cmcurl/lib/easy.c
+index 530b7c73..1303b61a 100644
+--- a/Utilities/cmcurl/lib/easy.c
++++ b/Utilities/cmcurl/lib/easy.c
+@@ -848,10 +848,8 @@ struct Curl_easy *curl_easy_duphandle(struct Curl_easy *data)
+   if(data->cookies) {
+     /* If cookies are enabled in the parent handle, we enable them
+        in the clone as well! */
+-    outcurl->cookies = Curl_cookie_init(data,
+-                                        data->cookies->filename,
+-                                        outcurl->cookies,
+-                                        data->set.cookiesession);
++    outcurl->cookies = Curl_cookie_init(data, NULL, outcurl->cookies,
++                                         data->set.cookiesession);
+     if(!outcurl->cookies)
+       goto fail;
+   }
+-- 
+2.25.1
+

--- a/SPECS/cmake/cmake.spec
+++ b/SPECS/cmake/cmake.spec
@@ -2,7 +2,7 @@
 Summary:        Cmake
 Name:           cmake
 Version:        3.21.4
-Release:        8%{?dist}
+Release:        9%{?dist}
 License:        BSD AND LGPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -17,6 +17,8 @@ Patch2:         CVE-2023-23914-0001-share-add-sharing-of-HSTS-cache-among-handle
 Patch3:         CVE-2023-23914-0002-hsts-handle-adding-the-same-host-name-again.patch
 Patch4:         CVE-2023-28322-lib-unify-the-upload-method-handling.patch
 Patch5:         CVE-2023-35945.patch
+Patch6:         CVE-2023-38545.patch
+Patch7:         CVE-2023-38546.patch
 BuildRequires:  bzip2
 BuildRequires:  bzip2-devel
 BuildRequires:  curl
@@ -82,6 +84,9 @@ bin/ctest --force-new-ctest-process --rerun-failed --output-on-failure
 %{_prefix}/doc/%{name}-*/*
 
 %changelog
+* Tue Oct 10 2023 Mykhailo Bykhovtsev <mbykhovtsev@microsoft.com> - 3.21.4-9
+- Patch vendored curl for CVE-2023-38545, CVE-2023-38546
+
 * Wed Sep 06 2023 Brian Fjeldstad <bfjelds@microsoft.com> - 3.21.4-8
 - Patch vendored nghttp2 for CVE-2023-35945
 

--- a/SPECS/curl/CVE-2023-38545.patch
+++ b/SPECS/curl/CVE-2023-38545.patch
@@ -1,0 +1,111 @@
+From 061532e794feabd3fe9b2f2e1b802dd471d0da65 Mon Sep 17 00:00:00 2001
+From: mbykhovtsev-ms <mbykhovtsev@microsoft.com>
+Date: Tue, 10 Oct 2023 12:09:51 -0700
+Subject: [PATCH] fix CVE-2023-38545
+
+---
+ lib/socks.c        |  8 +++---
+ tests/data/test728 | 64 ++++++++++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 68 insertions(+), 4 deletions(-)
+ create mode 100644 tests/data/test728
+
+diff --git a/lib/socks.c b/lib/socks.c
+index c492d66..a7b5ab0 100644
+--- a/lib/socks.c
++++ b/lib/socks.c
+@@ -587,9 +587,9 @@ static CURLproxycode do_SOCKS5(struct Curl_cfilter *cf,
+ 
+     /* RFC1928 chapter 5 specifies max 255 chars for domain name in packet */
+     if(!socks5_resolve_local && hostname_len > 255) {
+-      infof(data, "SOCKS5: server resolving disabled for hostnames of "
+-            "length > 255 [actual len=%zu]", hostname_len);
+-      socks5_resolve_local = TRUE;
++      failf(data, "SOCKS5: the destination hostname is too long to be "
++            "resolved remotely by the proxy.");
++      return CURLPX_LONG_HOSTNAME;
+     }
+ 
+     if(auth & ~(CURLAUTH_BASIC | CURLAUTH_GSSAPI))
+@@ -903,7 +903,7 @@ CONNECT_RESOLVE_REMOTE:
+       }
+       else {
+         socksreq[len++] = 3;
+-        socksreq[len++] = (char) hostname_len; /* one byte address length */
++        socksreq[len++] = (unsigned char) hostname_len; /* one byte length */
+         memcpy(&socksreq[len], sx->hostname, hostname_len); /* w/o NULL */
+         len += hostname_len;
+       }
+diff --git a/tests/data/test728 b/tests/data/test728
+new file mode 100644
+index 0000000..e8fe5fe
+--- /dev/null
++++ b/tests/data/test728
+@@ -0,0 +1,64 @@
++<testcase>
++<info>
++<keywords>
++HTTP
++HTTP GET
++SOCKS5
++SOCKS5h
++followlocation
++</keywords>
++</info>
++
++#
++# Server-side
++<reply>
++# The hostname in this redirect is 256 characters and too long (> 255) for
++# SOCKS5 remote resolve. curl must return error CURLE_PROXY in this case.
++<data>
++HTTP/1.1 301 Moved Permanently
++Location: http://AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/
++Content-Length: 0
++Connection: close
++
++</data>
++</reply>
++
++#
++# Client-side
++<client>
++<features>
++proxy
++</features>
++<server>
++http
++socks5
++</server>
++ <name>
++SOCKS5h with HTTP redirect to hostname too long
++ </name>
++ <command>
++--no-progress-meter --location --proxy socks5h://%HOSTIP:%SOCKSPORT http://%HOSTIP:%HTTPPORT/%TESTNUMBER
++</command>
++</client>
++
++#
++# Verify data after the test has been "shot"
++<verify>
++<protocol crlf="yes">
++GET /%TESTNUMBER HTTP/1.1
++Host: %HOSTIP:%HTTPPORT
++User-Agent: curl/%VERSION
++Accept: */*
++
++</protocol>
++<errorcode>
++97
++</errorcode>
++# the error message is verified because error code CURLE_PROXY (97) may be
++# returned for any number of reasons and we need to make sure it is
++# specifically for the reason below so that we know the check is working.
++<stderr mode="text">
++curl: (97) SOCKS5: the destination hostname is too long to be resolved remotely by the proxy.
++</stderr>
++</verify>
++</testcase>
+\ No newline at end of file
+-- 
+2.25.1
+

--- a/SPECS/curl/CVE-2023-38546.patch
+++ b/SPECS/curl/CVE-2023-38546.patch
@@ -1,0 +1,125 @@
+From a3aebb3421fd48dcb4f48743109dc0c4c82f8916 Mon Sep 17 00:00:00 2001
+From: mbykhovtsev-ms <mbykhovtsev@microsoft.com>
+Date: Tue, 10 Oct 2023 11:00:00 -0700
+Subject: [PATCH] fix CVE-2023-38546
+
+---
+ lib/cookie.c | 13 +------------
+ lib/cookie.h | 12 ++++--------
+ lib/easy.c   |  4 +---
+ 3 files changed, 6 insertions(+), 23 deletions(-)
+
+diff --git a/lib/cookie.c b/lib/cookie.c
+index 4345a84..e39c89a 100644
+--- a/lib/cookie.c
++++ b/lib/cookie.c
+@@ -119,7 +119,6 @@ static void freecookie(struct Cookie *co)
+   free(co->name);
+   free(co->value);
+   free(co->maxage);
+-  free(co->version);
+   free(co);
+ }
+ 
+@@ -718,11 +717,7 @@ Curl_cookie_add(struct Curl_easy *data,
+           }
+         }
+         else if((nlen == 7) && strncasecompare("version", namep, 7)) {
+-          strstore(&co->version, valuep, vlen);
+-          if(!co->version) {
+-            badcookie = TRUE;
+-            break;
+-          }
++          /* just ignore */
+         }
+         else if((nlen == 7) && strncasecompare("max-age", namep, 7)) {
+           /*
+@@ -1160,7 +1155,6 @@ Curl_cookie_add(struct Curl_easy *data,
+     free(clist->path);
+     free(clist->spath);
+     free(clist->expirestr);
+-    free(clist->version);
+     free(clist->maxage);
+ 
+     *clist = *co;  /* then store all the new data */
+@@ -1224,9 +1218,6 @@ struct CookieInfo *Curl_cookie_init(struct Curl_easy *data,
+     c = calloc(1, sizeof(struct CookieInfo));
+     if(!c)
+       return NULL; /* failed to get memory */
+-    c->filename = strdup(file?file:"none"); /* copy the name just in case */
+-    if(!c->filename)
+-      goto fail; /* failed to get memory */
+     /*
+      * Initialize the next_expiration time to signal that we don't have enough
+      * information yet.
+@@ -1378,7 +1369,6 @@ static struct Cookie *dup_cookie(struct Cookie *src)
+     CLONE(name);
+     CLONE(value);
+     CLONE(maxage);
+-    CLONE(version);
+     d->expires = src->expires;
+     d->tailmatch = src->tailmatch;
+     d->secure = src->secure;
+@@ -1595,7 +1585,6 @@ void Curl_cookie_cleanup(struct CookieInfo *c)
+ {
+   if(c) {
+     unsigned int i;
+-    free(c->filename);
+     for(i = 0; i < COOKIE_HASH_SIZE; i++)
+       Curl_cookie_freelist(c->cookies[i]);
+     free(c); /* free the base struct as well */
+diff --git a/lib/cookie.h b/lib/cookie.h
+index b3c0063..c1a63bf 100644
+--- a/lib/cookie.h
++++ b/lib/cookie.h
+@@ -37,10 +37,7 @@ struct Cookie {
+   curl_off_t expires;  /* expires = <this> */
+   char *expirestr;   /* the plain text version */
+ 
+-  /* RFC 2109 keywords. Version=1 means 2109-compliant cookie sending */
+-  char *version;     /* Version = <value> */
+   char *maxage;      /* Max-Age = <value> */
+-
+   bool tailmatch;    /* whether we do tail-matching of the domain name */
+   bool secure;       /* whether the 'secure' keyword was used */
+   bool livecookie;   /* updated from a server, not a stored file */
+@@ -56,17 +53,16 @@ struct Cookie {
+ #define COOKIE_PREFIX__SECURE (1<<0)
+ #define COOKIE_PREFIX__HOST (1<<1)
+ 
+-#define COOKIE_HASH_SIZE 256
++#define COOKIE_HASH_SIZE 63
+ 
+ struct CookieInfo {
+   /* linked list of cookies we know of */
+   struct Cookie *cookies[COOKIE_HASH_SIZE];
+-  char *filename;  /* file we read from/write to */
+-  long numcookies; /* number of cookies in the "jar" */
++  curl_off_t next_expiration; /* the next time at which expiration happens */
++  int numcookies;  /* number of cookies in the "jar" */
++  int lastct;      /* last creation-time used in the jar */
+   bool running;    /* state info, for cookie adding information */
+   bool newsession; /* new session, discard session cookies on load */
+-  int lastct;      /* last creation-time used in the jar */
+-  curl_off_t next_expiration; /* the next time at which expiration happens */
+ };
+ 
+ /* The maximum sizes we accept for cookies. RFC 6265 section 6.1 says
+diff --git a/lib/easy.c b/lib/easy.c
+index d034629..2c62196 100644
+--- a/lib/easy.c
++++ b/lib/easy.c
+@@ -909,9 +909,7 @@ struct Curl_easy *curl_easy_duphandle(struct Curl_easy *data)
+   if(data->cookies) {
+     /* If cookies are enabled in the parent handle, we enable them
+        in the clone as well! */
+-    outcurl->cookies = Curl_cookie_init(data,
+-                                        data->cookies->filename,
+-                                        outcurl->cookies,
++    outcurl->cookies = Curl_cookie_init(data, NULL, outcurl->cookies,
+                                         data->set.cookiesession);
+     if(!outcurl->cookies)
+       goto fail;
+-- 
+2.25.1
+

--- a/SPECS/curl/curl.spec
+++ b/SPECS/curl/curl.spec
@@ -1,6 +1,6 @@
 Summary:        An URL retrieval utility and library
 Name:           curl
-Version:        8.2.1
+Version:        8.3.0
 Release:        2%{?dist}
 License:        curl
 Vendor:         Microsoft Corporation
@@ -87,8 +87,11 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %{_libdir}/libcurl.so.*
 
 %changelog
-* Tue Oct 10 2023 Mykhailo Bykhovtsev <mbykhovtsev@microsoft.com> - 8.2.1-2
+* Tue Oct 10 2023 Mykhailo Bykhovtsev <mbykhovtsev@microsoft.com> - 8.3.0-2
 - added patches to fix CVE-2023-38545, CVE-2023-38546
+
+* Thu Sep 21 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 8.3.0-1
+- Auto-upgrade to 8.3.0 - CVE-2023-38039
 
 * Tue Aug 08 2023 Muhammad Falak <mwani@microsoft.com> - 8.2.1-1
 - Bump curl to 8.2.1 to address CVE-2023-32001

--- a/SPECS/curl/curl.spec
+++ b/SPECS/curl/curl.spec
@@ -1,13 +1,15 @@
 Summary:        An URL retrieval utility and library
 Name:           curl
-Version:        8.3.0
-Release:        1%{?dist}
+Version:        8.2.1
+Release:        2%{?dist}
 License:        curl
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Group:          System Environment/NetworkingLibraries
 URL:            https://curl.haxx.se
 Source0:        https://curl.haxx.se/download/%{name}-%{version}.tar.gz
+Patch1:         CVE-2023-38545.patch
+Patch2:         CVE-2023-38546.patch
 BuildRequires:  krb5-devel
 BuildRequires:  libssh2-devel
 BuildRequires:  nghttp2-devel
@@ -85,8 +87,8 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %{_libdir}/libcurl.so.*
 
 %changelog
-* Thu Sep 21 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 8.3.0-1
-- Auto-upgrade to 8.3.0 - CVE-2023-38039
+* Tue Oct 10 2023 Mykhailo Bykhovtsev <mbykhovtsev@microsoft.com> - 8.2.1-2
+- added patches to fix CVE-2023-38545, CVE-2023-38546
 
 * Tue Aug 08 2023 Muhammad Falak <mwani@microsoft.com> - 8.2.1-1
 - Bump curl to 8.2.1 to address CVE-2023-32001

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -190,9 +190,9 @@ libssh2-1.9.0-3.cm2.aarch64.rpm
 libssh2-devel-1.9.0-3.cm2.aarch64.rpm
 krb5-1.19.4-2.cm2.aarch64.rpm
 nghttp2-1.46.0-3.cm2.aarch64.rpm
-curl-8.3.0-1.cm2.aarch64.rpm
-curl-devel-8.3.0-1.cm2.aarch64.rpm
-curl-libs-8.3.0-1.cm2.aarch64.rpm
+curl-8.3.0-2.cm2.aarch64.rpm
+curl-devel-8.3.0-2.cm2.aarch64.rpm
+curl-libs-8.3.0-2.cm2.aarch64.rpm
 createrepo_c-0.17.5-1.cm2.aarch64.rpm
 libxml2-2.10.4-1.cm2.aarch64.rpm
 libxml2-devel-2.10.4-1.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -190,9 +190,9 @@ libssh2-1.9.0-3.cm2.x86_64.rpm
 libssh2-devel-1.9.0-3.cm2.x86_64.rpm
 krb5-1.19.4-2.cm2.x86_64.rpm
 nghttp2-1.46.0-3.cm2.x86_64.rpm
-curl-8.3.0-1.cm2.x86_64.rpm
-curl-devel-8.3.0-1.cm2.x86_64.rpm
-curl-libs-8.3.0-1.cm2.x86_64.rpm
+curl-8.3.0-2.cm2.x86_64.rpm
+curl-devel-8.3.0-2.cm2.x86_64.rpm
+curl-libs-8.3.0-2.cm2.x86_64.rpm
 createrepo_c-0.17.5-1.cm2.x86_64.rpm
 libxml2-2.10.4-1.cm2.x86_64.rpm
 libxml2-devel-2.10.4-1.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -30,8 +30,8 @@ check-debuginfo-0.15.2-1.cm2.aarch64.rpm
 chkconfig-1.20-4.cm2.aarch64.rpm
 chkconfig-debuginfo-1.20-4.cm2.aarch64.rpm
 chkconfig-lang-1.20-4.cm2.aarch64.rpm
-cmake-3.21.4-8.cm2.aarch64.rpm
-cmake-debuginfo-3.21.4-8.cm2.aarch64.rpm
+cmake-3.21.4-9.cm2.aarch64.rpm
+cmake-debuginfo-3.21.4-9.cm2.aarch64.rpm
 coreutils-8.32-7.cm2.aarch64.rpm
 coreutils-debuginfo-8.32-7.cm2.aarch64.rpm
 coreutils-lang-8.32-7.cm2.aarch64.rpm
@@ -46,10 +46,10 @@ cracklib-lang-2.9.7-5.cm2.aarch64.rpm
 createrepo_c-0.17.5-1.cm2.aarch64.rpm
 createrepo_c-debuginfo-0.17.5-1.cm2.aarch64.rpm
 createrepo_c-devel-0.17.5-1.cm2.aarch64.rpm
-curl-8.3.0-1.cm2.aarch64.rpm
-curl-debuginfo-8.3.0-1.cm2.aarch64.rpm
-curl-devel-8.3.0-1.cm2.aarch64.rpm
-curl-libs-8.3.0-1.cm2.aarch64.rpm
+curl-8.3.0-2.cm2.aarch64.rpm
+curl-debuginfo-8.3.0-2.cm2.aarch64.rpm
+curl-devel-8.3.0-2.cm2.aarch64.rpm
+curl-libs-8.3.0-2.cm2.aarch64.rpm
 Cython-debuginfo-0.29.33-1.cm2.aarch64.rpm
 debugedit-5.0-2.cm2.aarch64.rpm
 debugedit-debuginfo-5.0-2.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -30,8 +30,8 @@ check-debuginfo-0.15.2-1.cm2.x86_64.rpm
 chkconfig-1.20-4.cm2.x86_64.rpm
 chkconfig-debuginfo-1.20-4.cm2.x86_64.rpm
 chkconfig-lang-1.20-4.cm2.x86_64.rpm
-cmake-3.21.4-8.cm2.x86_64.rpm
-cmake-debuginfo-3.21.4-8.cm2.x86_64.rpm
+cmake-3.21.4-9.cm2.x86_64.rpm
+cmake-debuginfo-3.21.4-9.cm2.x86_64.rpm
 coreutils-8.32-7.cm2.x86_64.rpm
 coreutils-debuginfo-8.32-7.cm2.x86_64.rpm
 coreutils-lang-8.32-7.cm2.x86_64.rpm
@@ -46,10 +46,10 @@ cracklib-lang-2.9.7-5.cm2.x86_64.rpm
 createrepo_c-0.17.5-1.cm2.x86_64.rpm
 createrepo_c-debuginfo-0.17.5-1.cm2.x86_64.rpm
 createrepo_c-devel-0.17.5-1.cm2.x86_64.rpm
-curl-8.3.0-1.cm2.x86_64.rpm
-curl-debuginfo-8.3.0-1.cm2.x86_64.rpm
-curl-devel-8.3.0-1.cm2.x86_64.rpm
-curl-libs-8.3.0-1.cm2.x86_64.rpm
+curl-8.3.0-2.cm2.x86_64.rpm
+curl-debuginfo-8.3.0-2.cm2.x86_64.rpm
+curl-devel-8.3.0-2.cm2.x86_64.rpm
+curl-libs-8.3.0-2.cm2.x86_64.rpm
 Cython-debuginfo-0.29.33-1.cm2.x86_64.rpm
 debugedit-5.0-2.cm2.x86_64.rpm
 debugedit-debuginfo-5.0-2.cm2.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Patches high and low curl CVEs as well as vendored `curl` in `cmake`

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- patched CVE-2023-38545 for curl
- patched CVE-2023-38546 for curl
- patched CVE-2023-38545 for vendored `curl` in `cmake`
- patched CVE-2023-38546 for vendored `curl` in `cmake`

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://curl.se/docs/CVE-2023-38545.html
- https://curl.se/docs/CVE-2023-38546.html

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- PR fasttrack check
