### PR TITLE
Image Customizer: Improve safemount.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/customizeutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeutils.go
@@ -15,7 +15,7 @@ import (
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/file"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/logger"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/safechroot"
-	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/safemount.go"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/safemount"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/shell"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/userutils"
 	"golang.org/x/sys/unix"
@@ -186,7 +186,7 @@ func runScripts(baseConfigPath string, scripts []imagecustomizerapi.Script, imag
 		}
 	}
 
-	err = mount.Close()
+	err = mount.CleanClose()
 	if err != nil {
 		return err
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -14,7 +14,7 @@ import (
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/imagegen/diskutils"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/file"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/safechroot"
-	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/safemount.go"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/safemount"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/shell"
 )
 
@@ -193,12 +193,6 @@ func customizeImageHelper(buildDir string, baseConfigPath string, config *imagec
 	}
 	defer diskutils.DetachLoopbackDevice(diskDevPath)
 
-	// Wait for the partitions to show up.
-	err = diskutils.WaitForDevicesToSettle()
-	if err != nil {
-		return err
-	}
-
 	// Look for all the partitions on the image.
 	newMountDirectories, mountPoints, err := findPartitions(buildDir, diskDevPath)
 	if err != nil {
@@ -304,7 +298,7 @@ func findBootLoaderPartitionFromEsp(efiSystemPartition *diskutils.PartitionInfo,
 	}
 
 	// Close the EFI System Partition mount.
-	err = efiSystemPartitionMount.Close()
+	err = efiSystemPartitionMount.CleanClose()
 	if err != nil {
 		return nil, fmt.Errorf("failed to close EFI system partition mount:\n%w", err)
 	}
@@ -404,7 +398,7 @@ func findMountsFromRootfs(rootfsPartition *diskutils.PartitionInfo, diskPartitio
 	}
 
 	// Close the rootfs partition mount.
-	err = rootfsPartitionMount.Close()
+	err = rootfsPartitionMount.CleanClose()
 	if err != nil {
 		return nil, fmt.Errorf("failed to close rootfs partition mount (%s):\n%w", rootfsPartition.Path, err)
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -358,7 +358,7 @@ func findBootLoaderPartitionFromBiosBootPartition(biosBootLoaderPartition *disku
 			return nil, fmt.Errorf("failed to stat grub.cfg file (%s):\n%w", grubCfgPath, err)
 		}
 
-		err = partitionMount.Close()
+		err = partitionMount.CleanClose()
 		if err != nil {
 			return nil, fmt.Errorf("failed to unmount partition (%s):\n%w", diskPartition.Path, err)
 		}

--- a/toolkit/tools/pkg/imagecustomizerlib/rpmsourcesmounts.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/rpmsourcesmounts.go
@@ -15,7 +15,7 @@ import (
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/logger"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/packagerepo/repomanager/rpmrepomanager"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/safechroot"
-	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/safemount.go"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/safemount"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 	"gopkg.in/ini.v1"
@@ -246,7 +246,7 @@ func (m *rpmSourcesMounts) close() error {
 
 	// Unmount rpm source directories.
 	for _, mount := range m.mounts {
-		err = mount.Close()
+		err = mount.CleanClose()
 		if err != nil {
 			errs = append(errs, err)
 			continue


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->

Improve the safemount class so that if an unmount fails (usually because the device is still busy), then the unmount is reattempted using the asynchronous flag (MNT_DETACH). This reduces the likelihood that the user's system will be left in a bad state.

To be specific, the `Close()` function has been split into a synchronous and asynchronous version. The synchronous version is intended to be used in the code's golden path. Whereas the asynchronous version should be used with `defer`.

###### Change Log  <!-- REQUIRED -->

- safemount: Provide synchronous and asynchronous versions of `Close`.
- Fix name of `safemount.go` module to `safemount`.
- Remove redundant `diskutils.WaitForDevicesToSettle()` call.

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Ran toolkit's UTs.

