### PR TITLE
Toolkit: Use test short mode flag.

### DIFF
--- a/toolkit/scripts/tools.mk
+++ b/toolkit/scripts/tools.mk
@@ -105,7 +105,7 @@ else
 # Rebuild the go tools as needed
 $(TOOL_BINS_DIR)/%: $(go_common_files)
 	cd $(TOOLS_DIR)/$* && \
-		go test -covermode=atomic -coverprofile=$(BUILD_DIR)/tools/$*.test_coverage ./... && \
+		go test -test.short -covermode=atomic -coverprofile=$(BUILD_DIR)/tools/$*.test_coverage ./... && \
 		CGO_ENABLED=0 go build \
 			-ldflags="-X github.com/microsoft/CBL-Mariner/toolkit/tools/internal/exe.ToolkitVersion=$(RELEASE_VERSION)" \
 			-o $(TOOL_BINS_DIR)
@@ -114,7 +114,7 @@ endif
 # Runs tests for common components
 $(BUILD_DIR)/tools/internal.test_coverage: $(go_internal_files) $(go_imagegen_files) $(STATUS_FLAGS_DIR)/got_go_deps.flag
 	cd $(TOOLS_DIR)/$* && \
-		go test -covermode=atomic -coverprofile=$@ ./...
+		go test -test.short -covermode=atomic -coverprofile=$@ ./...
 
 # Downloads all the go dependencies without using sudo, so we don't break other go use cases for the user.
 # We can check if $SUDO_USER is set (the user who invoked sudo), and if so, use that user to run go get via sudo -u.

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeutils_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeutils_test.go
@@ -15,6 +15,10 @@ import (
 )
 
 func TestUpdateHostname(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("Test must be run as root because it uses a chroot")
+	}
+
 	// Setup environment.
 	proposedDir := filepath.Join(tmpDir, "TestUpdateHostname")
 	chroot := safechroot.NewChroot(proposedDir, false)
@@ -37,6 +41,10 @@ func TestUpdateHostname(t *testing.T) {
 }
 
 func TestCopyAdditionalFiles(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("Test must be run as root because it uses a chroot")
+	}
+
 	proposedDir := filepath.Join(tmpDir, "TestCopyAdditionalFiles")
 	chroot := safechroot.NewChroot(proposedDir, false)
 	baseConfigPath := testDir

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
@@ -22,8 +22,16 @@ import (
 func TestCustomizeImageEmptyConfig(t *testing.T) {
 	var err error
 
+	if testing.Short() {
+		t.Skip("Short mode enabled")
+	}
+
 	if !buildpipeline.IsRegularBuild() {
 		t.Skip("loopback block device not available")
+	}
+
+	if os.Geteuid() != 0 {
+		t.Skip("Test must be run as root because it uses a chroot")
 	}
 
 	buildDir := filepath.Join(tmpDir, "TestCustomizeImageEmptyConfig")
@@ -49,8 +57,16 @@ func TestCustomizeImageEmptyConfig(t *testing.T) {
 func TestCustomizeImageCopyFiles(t *testing.T) {
 	var err error
 
+	if testing.Short() {
+		t.Skip("Short mode enabled")
+	}
+
 	if !buildpipeline.IsRegularBuild() {
 		t.Skip("loopback block device not available")
+	}
+
+	if os.Geteuid() != 0 {
+		t.Skip("Test must be run as root because it uses a chroot")
 	}
 
 	buildDir := filepath.Join(tmpDir, "TestCustomizeImageCopyFiles")


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->

When running the toolkit UTs as part of the toolkit build, enable to go's test short mode flag. Then use that flag to disable a couple of the longer running and less reliable image customizer tests.

###### Change Log  <!-- REQUIRED -->

- Toolkit: Use test short mode flag.
- Ensure tests that need root privileges are skipped when not running as root.

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Ran toolkit UTs.

