### PR TITLE
Fixed toolkit missing package rebuilds.

### DIFF
--- a/toolkit/tools/internal/pkggraph/pkggraph_test.go
+++ b/toolkit/tools/internal/pkggraph/pkggraph_test.go
@@ -1070,3 +1070,36 @@ func TestShouldGetSRPMNameFromEmptySRPMPath(t *testing.T) {
 
 	assert.Equal(t, ".", node.SRPMFileName())
 }
+
+func TestShouldGetAllBuildNodesWithFilter(t *testing.T) {
+	gOut, err := buildTestGraphHelper()
+	assert.NoError(t, err)
+	assert.NotNil(t, gOut)
+
+	foundNodes := gOut.NodesMatchingFilter(func(node *PkgNode) bool {
+		return node.Type == TypeLocalBuild
+	})
+	assert.ElementsMatch(t, buildNodes, foundNodes)
+}
+
+func TestShouldGetAllRunNodesWithFilter(t *testing.T) {
+	gOut, err := buildTestGraphHelper()
+	assert.NoError(t, err)
+	assert.NotNil(t, gOut)
+
+	foundNodes := gOut.NodesMatchingFilter(func(node *PkgNode) bool {
+		return node.Type == TypeLocalRun
+	})
+	assert.ElementsMatch(t, runNodes, foundNodes)
+}
+
+func TestShouldGetAllUnresolvedNodesWithFilter(t *testing.T) {
+	gOut, err := buildTestGraphHelper()
+	assert.NoError(t, err)
+	assert.NotNil(t, gOut)
+
+	foundNodes := gOut.NodesMatchingFilter(func(node *PkgNode) bool {
+		return node.State == StateUnresolved
+	})
+	assert.ElementsMatch(t, unresolvedNodes, foundNodes)
+}

--- a/toolkit/tools/internal/pkggraph/pkggraph_test.go
+++ b/toolkit/tools/internal/pkggraph/pkggraph_test.go
@@ -163,6 +163,9 @@ func addNodeToGraphHelper(g *PkgGraph, node *PkgNode) (newNode *PkgNode, err err
 		node.Architecture,
 		node.SourceRepo,
 	)
+
+	// Updating node's ID for the sake of equality testing.
+	node.nodeID = newNode.nodeID
 	return
 }
 
@@ -338,16 +341,23 @@ func TestDOTID(t *testing.T) {
 	for _, n := range allNodes {
 		assert.NotPanics(t, func() { n.DOTID() })
 	}
-	assert.Equal(t, "A-1-RUN<Meta> (ID=0,TYPE=Run,STATE=Meta)", pkgARun.DOTID())
-	assert.Equal(t, "D--REMOTE<Unresolved> (ID=0,TYPE=Remote,STATE=Unresolved)", pkgD1Unresolved.DOTID())
+
+	expectedARunDOTID := fmt.Sprintf("A-1-RUN<Meta> (ID=%d,TYPE=Run,STATE=Meta)", pkgARun.ID())
+	assert.Equal(t, expectedARunDOTID, pkgARun.DOTID())
+
+	expectedD1UnresolvedDOTID := fmt.Sprintf("D--REMOTE<Unresolved> (ID=%d,TYPE=Remote,STATE=Unresolved)", pkgD1Unresolved.ID())
+	assert.Equal(t, expectedD1UnresolvedDOTID, pkgD1Unresolved.DOTID())
 
 	g := NewPkgGraph()
 	goal, err := g.AddGoalNode("test", nil, nil, false)
 	assert.NoError(t, err)
-	assert.Equal(t, "test (ID=0,TYPE=Goal,STATE=Meta)", goal.DOTID())
+
+	expectedGoalDOTID := fmt.Sprintf("test (ID=%d,TYPE=Goal,STATE=Meta)", goal.ID())
+	assert.Equal(t, expectedGoalDOTID, goal.DOTID())
 
 	meta := g.AddMetaNode([]*PkgNode{}, []*PkgNode{})
-	assert.Equal(t, "Meta(1) (ID=1,TYPE=PureMeta,STATE=Meta)", meta.DOTID())
+	expectedMetaDOTID := fmt.Sprintf("Meta(1) (ID=%d,TYPE=PureMeta,STATE=Meta)", meta.ID())
+	assert.Equal(t, expectedMetaDOTID, meta.DOTID())
 
 	junk := PkgNode{State: -1, Type: -1}
 	assert.Panics(t, func() { junk.DOTID() })
@@ -355,10 +365,15 @@ func TestDOTID(t *testing.T) {
 
 // TestNodeString tests the built-in String() function for PkgNodes
 func TestNodeString(t *testing.T) {
-	assert.Equal(t, "A(1,):<ID:0 Type:Run State:Meta Rpm:A.rpm> from 'A.src.rpm' in 'test_repo'", pkgARun.String())
-	assert.Equal(t, "D(<1,):<ID:0 Type:Remote State:Unresolved Rpm:url://D.rpm> from 'url://D.src.rpm' in 'test_repo'", pkgD1Unresolved.String())
+	expectedARunString := fmt.Sprintf("A(1,):<ID:%d Type:Run State:Meta Rpm:A.rpm> from 'A.src.rpm' in 'test_repo'", pkgARun.ID())
+	assert.Equal(t, expectedARunString, pkgARun.String())
+
+	expectedD1UnresolvedString := fmt.Sprintf("D(<1,):<ID:%d Type:Remote State:Unresolved Rpm:url://D.rpm> from 'url://D.src.rpm' in 'test_repo'", pkgD1Unresolved.ID())
+	assert.Equal(t, expectedD1UnresolvedString, pkgD1Unresolved.String())
+
 	goalNode := PkgNode{GoalName: "goal", Type: TypeGoal, State: StateMeta}
 	assert.Equal(t, "goal():<ID:0 Type:Goal State:Meta Rpm:> from '' in ''", goalNode.String())
+
 	emptyNode := PkgNode{}
 	assert.Panics(t, func() { _ = emptyNode.String() })
 }

--- a/toolkit/tools/internal/pkggraph/pkggraph_test.go
+++ b/toolkit/tools/internal/pkggraph/pkggraph_test.go
@@ -225,6 +225,25 @@ func buildTestGraphHelper() (g *PkgGraph, err error) {
 	return
 }
 
+// Checks if two lists of nodes are equivalent (ignoring order and graph edges)
+func checkEqualComponents(t *testing.T, expected, actual []*PkgNode) {
+	t.Helper()
+	for _, mustHave := range expected {
+		foundPackage := false
+		for _, n := range actual {
+			foundPackage = foundPackage || mustHave.Equal(n)
+		}
+		assert.True(t, foundPackage, "expected to find %s in actual", mustHave.String())
+	}
+	for _, doHave := range actual {
+		foundPackage := false
+		for _, n := range expected {
+			foundPackage = foundPackage || doHave.Equal(n)
+		}
+		assert.True(t, foundPackage, "found %s in actual, but it was unexpected", doHave.String())
+	}
+}
+
 func checkTestGraph(t *testing.T, g *PkgGraph) {
 	// Make sure we got the same graph back!
 	assert.Equal(t, len(allNodes), len(g.AllNodes()))
@@ -1093,7 +1112,7 @@ func TestShouldGetAllBuildNodesWithFilter(t *testing.T) {
 	foundNodes := gOut.NodesMatchingFilter(func(node *PkgNode) bool {
 		return node.Type == TypeLocalBuild
 	})
-	assert.ElementsMatch(t, buildNodes, foundNodes)
+	checkEqualComponents(t, buildNodes, foundNodes)
 }
 
 func TestShouldGetAllNodesWithFilter(t *testing.T) {
@@ -1104,7 +1123,7 @@ func TestShouldGetAllNodesWithFilter(t *testing.T) {
 	foundNodes := gOut.NodesMatchingFilter(func(node *PkgNode) bool {
 		return true
 	})
-	assert.ElementsMatch(t, allNodes, foundNodes)
+	checkEqualComponents(t, allNodes, foundNodes)
 }
 
 func TestShouldGetAllRunNodesWithFilter(t *testing.T) {
@@ -1115,7 +1134,7 @@ func TestShouldGetAllRunNodesWithFilter(t *testing.T) {
 	foundNodes := gOut.NodesMatchingFilter(func(node *PkgNode) bool {
 		return node.Type == TypeLocalRun
 	})
-	assert.ElementsMatch(t, runNodes, foundNodes)
+	checkEqualComponents(t, runNodes, foundNodes)
 }
 
 func TestShouldGetAllUnresolvedNodesWithFilter(t *testing.T) {
@@ -1126,5 +1145,5 @@ func TestShouldGetAllUnresolvedNodesWithFilter(t *testing.T) {
 	foundNodes := gOut.NodesMatchingFilter(func(node *PkgNode) bool {
 		return node.State == StateUnresolved
 	})
-	assert.ElementsMatch(t, unresolvedNodes, foundNodes)
+	checkEqualComponents(t, unresolvedNodes, foundNodes)
 }

--- a/toolkit/tools/internal/pkggraph/pkggraph_test.go
+++ b/toolkit/tools/internal/pkggraph/pkggraph_test.go
@@ -1096,6 +1096,17 @@ func TestShouldGetAllBuildNodesWithFilter(t *testing.T) {
 	assert.ElementsMatch(t, buildNodes, foundNodes)
 }
 
+func TestShouldGetAllNodesWithFilter(t *testing.T) {
+	gOut, err := buildTestGraphHelper()
+	assert.NoError(t, err)
+	assert.NotNil(t, gOut)
+
+	foundNodes := gOut.NodesMatchingFilter(func(node *PkgNode) bool {
+		return true
+	})
+	assert.ElementsMatch(t, allNodes, foundNodes)
+}
+
 func TestShouldGetAllRunNodesWithFilter(t *testing.T) {
 	gOut, err := buildTestGraphHelper()
 	assert.NoError(t, err)

--- a/toolkit/tools/internal/pkggraph/pkggraph_test.go
+++ b/toolkit/tools/internal/pkggraph/pkggraph_test.go
@@ -437,7 +437,6 @@ func TestAddMissingVersion(t *testing.T) {
 	n, err := addNodeToGraphHelper(g, pkgD2Unresolved)
 	assert.NoError(t, err)
 	assert.NotNil(t, n)
-
 }
 
 // Add a run node with an invalid version (for a run node)


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

For the following package dependencies:
```
A_build <-- A_test
^
|
A_run

B_build <-- B_test
^
|
B_run
```

and the following run command:
```
sudo make build-packages RUN_CHECK=y TEST_RERUN_LIST="A B" PACKAGE_REBUILD_LIST="B"
```

the toolkit would skip building and testing package `A`. The issue was the subgraphing logic to only build the required nodes was not updated to correctly handle the test nodes added a month ago. The tool would only look for run nodes and since `A` was not mentioned inside `PACKAGE_REBUILD_LIST`, then the run node `A` would be skipped and thus assumed it was already pre-built. The same logic would ignore test nodes, thus `A` ended up being skipped for tests as well, despite being mentioned inside `TEST_RERUN_LIST`.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Updated logic determining packages, which require a build when build with non-default `PACKAGE_*_LIST` or `TEST_*_LIST` arguments.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local test builds for cases, which used to fail.