### PR TITLE
Image Customizer: Add support to load and unload modules

### DIFF
--- a/toolkit/tools/imagecustomizerapi/module.go
+++ b/toolkit/tools/imagecustomizerapi/module.go
@@ -20,7 +20,7 @@ func (m *Module) IsValid() error {
 }
 
 type Modules struct {
-	Load   []Module `yaml:"Load"`
+	Load    []Module `yaml:"Load"`
 	Disable []Module `yaml:"Disable"`
 }
 

--- a/toolkit/tools/imagecustomizerapi/module.go
+++ b/toolkit/tools/imagecustomizerapi/module.go
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package imagecustomizerapi
+
+import (
+	"fmt"
+)
+
+type Modules struct {
+	Load   []Module `yaml:"Load"`
+	Unload []Module `yaml:"Unload"`
+}
+
+type Module struct {
+	Name string `yaml:"Name"`
+}
+
+func (m *Module) IsValid() error {
+	if m.Name == "" {
+		return fmt.Errorf("name of module may not be empty")
+	}
+
+	return nil
+}
+
+func (m *Modules) IsValid() error {
+	for i, module := range m.Load {
+		if err := module.IsValid(); err != nil {
+			return fmt.Errorf("invalid Modules.Load item at index %d: %w", i, err)
+		}
+	}
+
+	for i, module := range m.Unload {
+		if err := module.IsValid(); err != nil {
+			return fmt.Errorf("invalid Modules.Unload item at index %d: %w", i, err)
+		}
+	}
+
+	return nil
+}

--- a/toolkit/tools/imagecustomizerapi/module.go
+++ b/toolkit/tools/imagecustomizerapi/module.go
@@ -7,11 +7,6 @@ import (
 	"fmt"
 )
 
-type Modules struct {
-	Load   []Module `yaml:"Load"`
-	Unload []Module `yaml:"Unload"`
-}
-
 type Module struct {
 	Name string `yaml:"Name"`
 }
@@ -24,16 +19,21 @@ func (m *Module) IsValid() error {
 	return nil
 }
 
+type Modules struct {
+	Load   []Module `yaml:"Load"`
+	Disable []Module `yaml:"Disable"`
+}
+
 func (m *Modules) IsValid() error {
 	for i, module := range m.Load {
 		if err := module.IsValid(); err != nil {
-			return fmt.Errorf("invalid Modules.Load item at index %d: %w", i, err)
+			return fmt.Errorf("invalid module '%s' in Modules.Load at index %d: %w", module.Name, i, err)
 		}
 	}
 
-	for i, module := range m.Unload {
+	for i, module := range m.Disable {
 		if err := module.IsValid(); err != nil {
-			return fmt.Errorf("invalid Modules.Unload item at index %d: %w", i, err)
+			return fmt.Errorf("invalid module '%s' in Modules.Disable at index %d: %w", module.Name, i, err)
 		}
 	}
 

--- a/toolkit/tools/imagecustomizerapi/service.go
+++ b/toolkit/tools/imagecustomizerapi/service.go
@@ -7,11 +7,6 @@ import (
 	"fmt"
 )
 
-type Services struct {
-	Enable  []Service `yaml:"Enable"`
-	Disable []Service `yaml:"Disable"`
-}
-
 type Service struct {
 	Name string `yaml:"Name"`
 }
@@ -24,16 +19,21 @@ func (s *Service) IsValid() error {
 	return nil
 }
 
+type Services struct {
+	Enable  []Service `yaml:"Enable"`
+	Disable []Service `yaml:"Disable"`
+}
+
 func (s *Services) IsValid() error {
 	for i, service := range s.Enable {
 		if err := service.IsValid(); err != nil {
-			return fmt.Errorf("invalid Service.Enable item at index %d: %w", i, err)
+			return fmt.Errorf("invalid service '%s' in Service.Enable at index %d: %w", service.Name, i, err)
 		}
 	}
 
 	for i, service := range s.Disable {
 		if err := service.IsValid(); err != nil {
-			return fmt.Errorf("invalid Service.Disable item at index %d: %w", i, err)
+			return fmt.Errorf("invalid service '%s' in Service.Disable at index %d: %w", service.Name, i, err)
 		}
 	}
 

--- a/toolkit/tools/imagecustomizerapi/systemconfig.go
+++ b/toolkit/tools/imagecustomizerapi/systemconfig.go
@@ -25,6 +25,7 @@ type SystemConfig struct {
 	FinalizeImageScripts    []Script                  `yaml:"FinalizeImageScripts"`
 	Users                   []User                    `yaml:"Users"`
 	Services                Services                  `yaml:"Services"`
+	Modules                 Modules                   `yaml:"Modules"`
 }
 
 func (s *SystemConfig) IsValid() error {
@@ -65,6 +66,10 @@ func (s *SystemConfig) IsValid() error {
 	}
 
 	if err := s.Services.IsValid(); err != nil {
+		return err
+	}
+
+	if err := s.Modules.IsValid(); err != nil {
 		return err
 	}
 

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeutils.go
@@ -335,7 +335,7 @@ func loadOrDisableModules(modules imagecustomizerapi.Modules, imageChroot *safec
 	var err error
 
 	for _, module := range modules.Load {
-		logger.Log.Infof("Loading module (%s)", module.Name)
+		logger.Log.Infof("Loading kernel module (%s)", module.Name)
 		moduleFileName := module.Name + ".conf"
 		moduleFilePath := filepath.Join(imageChroot.RootDir(), "/etc/modules-load.d/", moduleFileName)
 		err = file.Write(module.Name, moduleFilePath)
@@ -345,7 +345,7 @@ func loadOrDisableModules(modules imagecustomizerapi.Modules, imageChroot *safec
 	}
 
 	for _, module := range modules.Disable {
-		logger.Log.Infof("Disabling module (%s)", module.Name)
+		logger.Log.Infof("Disabling kernel module (%s)", module.Name)
 		moduleFileName := module.Name + ".conf"
 		moduleFilePath := filepath.Join(imageChroot.RootDir(), "/etc/modprobe.d/", moduleFileName)
 		data := fmt.Sprintf("blacklist %s\n", module.Name)

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeutils.go
@@ -64,7 +64,7 @@ func doCustomizations(buildDir string, baseConfigPath string, config *imagecusto
 		return err
 	}
 
-	err = loadOrUnloadModules(config.SystemConfig.Modules, imageChroot)
+	err = loadOrDisableModules(config.SystemConfig.Modules, imageChroot)
 	if err != nil {
 		return err
 	}
@@ -331,7 +331,7 @@ func enableOrDisableServices(services imagecustomizerapi.Services, imageChroot *
 	return nil
 }
 
-func loadOrUnloadModules(modules imagecustomizerapi.Modules, imageChroot *safechroot.Chroot) error {
+func loadOrDisableModules(modules imagecustomizerapi.Modules, imageChroot *safechroot.Chroot) error {
 	var err error
 
 	for _, module := range modules.Load {
@@ -344,14 +344,14 @@ func loadOrUnloadModules(modules imagecustomizerapi.Modules, imageChroot *safech
 		}
 	}
 
-	for _, module := range modules.Unload {
-		logger.Log.Infof("Unloading module (%s)", module.Name)
+	for _, module := range modules.Disable {
+		logger.Log.Infof("Disabling module (%s)", module.Name)
 		moduleFileName := module.Name + ".conf"
 		moduleFilePath := filepath.Join(imageChroot.RootDir(), "/etc/modprobe.d/", moduleFileName)
 		data := fmt.Sprintf("blacklist %s\n", module.Name)
 		err = file.Write(data, moduleFilePath)
 		if err != nil {
-			return fmt.Errorf("failed to write module unload configuration: %w", err)
+			return fmt.Errorf("failed to write module disable configuration: %w", err)
 		}
 	}
 

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeutils.go
@@ -64,7 +64,7 @@ func doCustomizations(buildDir string, baseConfigPath string, config *imagecusto
 		return err
 	}
 
-	err = loadOrUnloadModules(config.SystemConfig.Modules, baseConfigPath, imageChroot)
+	err = loadOrUnloadModules(config.SystemConfig.Modules, imageChroot)
 	if err != nil {
 		return err
 	}
@@ -331,7 +331,7 @@ func enableOrDisableServices(services imagecustomizerapi.Services, imageChroot *
 	return nil
 }
 
-func loadOrUnloadModules(modules imagecustomizerapi.Modules, baseConfigPath string, imageChroot *safechroot.Chroot) error {
+func loadOrUnloadModules(modules imagecustomizerapi.Modules, imageChroot *safechroot.Chroot) error {
 	var err error
 
 	for _, module := range modules.Load {

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/modules-config.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/modules-config.yaml
@@ -4,5 +4,5 @@ SystemConfig:
       - Name: br_netfilter
       - Name: ib_uverbs
       - Name: mlx5_ib
-    Unload:
+    Disable:
       - Name: mousedev

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/modules-config.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/modules-config.yaml
@@ -1,0 +1,8 @@
+SystemConfig:
+  Modules:
+    Load:
+      - Name: br_netfilter
+      - Name: ib_uverbs
+      - Name: mlx5_ib
+    Unload:
+      - Name: mousedev


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary
add support to load or unload modules to image customizer tool

###### Change Log
Image customizer: add support to load or unload modules

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Test Methodology
did `go run  . --build-dir ./build --config-file ../pkg/imagecustomizerlib/testdata/modules-config.yaml --image-file core-2.0.20231004.vhdx --o
utput-image-file ./out/image1.vhd --output-image-format vhd --log-file=trace` and test with output image , the modules specified in the testdata file are loaded and unloaded.
![image](https://github.com/microsoft/CBL-Mariner/assets/102555676/35a20aa4-0c36-4081-ac57-f65866f94f33)

note: This feature only supports loading existing modules or those with the required environment, and unloading modules without dependencies. For example, it can't load 'ptp_kvm' due to a 'No such device' error, nor unload 'nfit' because of its dependencies.

