### PR TITLE
Image Customizer: Fix disk corruption

### DIFF
--- a/toolkit/tools/imagegen/diskutils/diskutils.go
+++ b/toolkit/tools/imagegen/diskutils/diskutils.go
@@ -248,44 +248,61 @@ func SetupLoopbackDevice(diskFilePath string) (devicePath string, err error) {
 
 // BlockOnDiskIO waits until all outstanding operations against a disk complete.
 func BlockOnDiskIO(diskDevPath string) (err error) {
-	const (
-		// Indices for values in /proc/diskstats
-		majIdx            = 0
-		minIdx            = 1
-		outstandingOpsIdx = 11
-	)
-	var blockDevices blockDevicesOutput
-
-	logger.Log.Infof("Flushing all IO to disk for %s", diskDevPath)
-	_, _, err = shell.Execute("sync")
+	maj, min, err := GetDiskIds(diskDevPath)
 	if err != nil {
 		return
 	}
 
+	return BlockOnDiskIOByIds(diskDevPath, maj, min)
+}
+
+func GetDiskIds(diskDevPath string) (maj string, min string, err error) {
 	rawDiskOutput, stderr, err := shell.Execute("lsblk", "--nodeps", "--json", "--output", "NAME,MAJ:MIN", diskDevPath)
 	if err != nil {
 		logger.Log.Warn(stderr)
+		err = fmt.Errorf("failed to find IDs for disk (%s):\n%w", diskDevPath, err)
 		return
 	}
 
 	bytes := []byte(rawDiskOutput)
+
+	var blockDevices blockDevicesOutput
 	err = json.Unmarshal(bytes, &blockDevices)
 	if err != nil {
 		return
 	}
 
 	if len(blockDevices.Devices) != 1 {
-		return fmt.Errorf("couldn't find disk IDs for %s (%s), expecting only one result", diskDevPath, rawDiskOutput)
+		err = fmt.Errorf("couldn't find disk IDs for %s (%s), expecting only one result", diskDevPath, rawDiskOutput)
+		return
 	}
 	// MAJ:MIN is returned in the form "1:2"
 	diskIDs := strings.Split(blockDevices.Devices[0].MajMin, ":")
 	if len(diskIDs) != 2 {
-		return fmt.Errorf("couldn't find disk IDs for %s (%s), couldn't parse MAJ:MIN", diskDevPath, rawDiskOutput)
+		err = fmt.Errorf("couldn't find disk IDs for %s (%s), couldn't parse MAJ:MIN", diskDevPath, rawDiskOutput)
+		return
 	}
-	maj := diskIDs[0]
-	min := diskIDs[1]
+	maj = diskIDs[0]
+	min = diskIDs[1]
+	return
+}
 
-	logger.Log.Tracef("Searching /proc/diskstats for %s (%s:%s)", blockDevices.Devices[0].Name, maj, min)
+// BlockOnDiskIOById waits until all outstanding operations against a disk complete.
+func BlockOnDiskIOByIds(debugName string, maj string, min string) (err error) {
+	const (
+		// Indices for values in /proc/diskstats
+		majIdx            = 0
+		minIdx            = 1
+		outstandingOpsIdx = 11
+	)
+
+	logger.Log.Infof("Flushing all IO to disk")
+	_, _, err = shell.Execute("sync")
+	if err != nil {
+		return
+	}
+
+	logger.Log.Tracef("Searching /proc/diskstats for %s (%s:%s)", debugName, maj, min)
 	for {
 		var (
 			foundEntry     = false
@@ -310,13 +327,12 @@ func BlockOnDiskIO(diskDevPath string) (err error) {
 
 		err = shell.ExecuteLiveWithCallback(onStdout, logger.Log.Error, true, "cat", "/proc/diskstats")
 		if err != nil {
-			logger.Log.Error(stderr)
 			return
 		}
 		if !foundEntry {
-			return fmt.Errorf("couldn't find entry for '%s' in /proc/diskstats", diskDevPath)
+			return fmt.Errorf("couldn't find entry for '%s' in /proc/diskstats", debugName)
 		}
-		logger.Log.Debugf("Outstanding operations on '%s': %s", diskDevPath, outstandingOps)
+		logger.Log.Debugf("Outstanding operations on '%s': %s", debugName, outstandingOps)
 
 		if outstandingOps == "0" {
 			break

--- a/toolkit/tools/internal/safechroot/safechroot.go
+++ b/toolkit/tools/internal/safechroot/safechroot.go
@@ -403,6 +403,19 @@ func (c *Chroot) Close(leaveOnDisk bool) (err error) {
 	defer activeChrootsMutex.Unlock()
 
 	if buildpipeline.IsRegularBuild() {
+		index := -1
+		for i, chroot := range activeChroots {
+			if chroot == c {
+				index = i
+				break
+			}
+		}
+
+		if index < 0 {
+			// Already closed.
+			return
+		}
+
 		// mount is only supported in regular pipeline
 		err = c.unmountAndRemove(leaveOnDisk, unmountTypeNormal)
 		if err != nil {
@@ -414,13 +427,8 @@ func (c *Chroot) Close(leaveOnDisk bool) (err error) {
 			// Remove this chroot from the list of active ones since it has now been cleaned up.
 			// Create a new slice that is -1 capacity of the current activeChroots.
 			newActiveChroots := make([]*Chroot, emptyLen, len(activeChroots)-1)
-			for _, chroot := range activeChroots {
-				if chroot == c {
-					continue
-				}
-
-				newActiveChroots = append(newActiveChroots, chroot)
-			}
+			newActiveChroots = append(newActiveChroots, activeChroots[:index]...)
+			newActiveChroots = append(newActiveChroots, activeChroots[index+1:]...)
 			activeChroots = newActiveChroots
 		}
 	} else {
@@ -524,6 +532,17 @@ func (c *Chroot) unmountAndRemove(leaveOnDisk, lazyUnmount bool) (err error) {
 
 	for _, mountPoint := range c.mountPoints {
 		fullPath := filepath.Join(c.rootDir, mountPoint.target)
+
+		var exists bool
+		exists, err = file.PathExists(fullPath)
+		if err != nil {
+			err = fmt.Errorf("failed to check if mount point (%s) exists. Error: %s", fullPath, err)
+			return
+		}
+		if !exists {
+			logger.Log.Debugf("Skipping unmount of (%s) because path doesn't exist", fullPath)
+			continue
+		}
 
 		var isMounted bool
 		isMounted, err = mountinfo.Mounted(fullPath)

--- a/toolkit/tools/internal/safeloopback/safeloopback.go
+++ b/toolkit/tools/internal/safeloopback/safeloopback.go
@@ -1,0 +1,101 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Package that assists with attach and detaching a loopback device cleanly.
+package safeloopback
+
+import (
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/imagegen/diskutils"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/logger"
+)
+
+type Loopback struct {
+	devicePath   string
+	diskFilePath string
+	diskIdMaj    string
+	diskIdMin    string
+	isAttached   bool
+}
+
+func NewLoopback(diskFilePath string) (*Loopback, error) {
+	loopback := &Loopback{
+		diskFilePath: diskFilePath,
+	}
+
+	err := loopback.newLoopbackHelper()
+	if err != nil {
+		loopback.Close()
+		return nil, err
+	}
+
+	return loopback, nil
+}
+
+func (l *Loopback) newLoopbackHelper() error {
+	// Try to create the mount.
+	devicePath, err := diskutils.SetupLoopbackDevice(l.diskFilePath)
+	if err != nil {
+		return err
+	}
+
+	l.devicePath = devicePath
+	l.isAttached = true
+
+	// Get the disk's IDs.
+	maj, min, err := diskutils.GetDiskIds(l.devicePath)
+	if err != nil {
+		return err
+	}
+
+	l.diskIdMaj = maj
+	l.diskIdMin = min
+
+	// Ensure all the partitions have finished populating.
+	err = diskutils.WaitForDevicesToSettle()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (l *Loopback) DevicePath() string {
+	return l.devicePath
+}
+
+func (l *Loopback) DiskFilePath() string {
+	return l.diskFilePath
+}
+
+func (l *Loopback) Close() {
+	err := l.close( /*async*/ true)
+	if err != nil {
+		logger.Log.Warnf("failed to close loopback: %s", err)
+	}
+}
+
+func (l *Loopback) CleanClose() error {
+	return l.close( /*async*/ false)
+}
+
+func (l *Loopback) close(async bool) error {
+	if l.isAttached {
+		err := diskutils.DetachLoopbackDevice(l.devicePath)
+		if err != nil {
+			return err
+		}
+
+		l.isAttached = false
+	}
+
+	if !async {
+		// The `losetup --detach` call happens asynchronously.
+		// So, need to wait for it to complete.
+		err := diskutils.BlockOnDiskIOByIds(l.devicePath, l.diskIdMaj, l.diskIdMin)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->

The Image Customizer tool (and some of its UTs) seem to be experiencing issues with the disk getting corrupted. I believe this is due to the tool not properly waiting for all the bytes to be written before trying to use the image. This is caused by loopback detach (`losetup --detach`) being asynchronous. It looks like there is an existing function (`diskutils.BlockOnDiskIO`) that can help with waiting for the disk to be finalized.

###### Change Log  <!-- REQUIRED -->

- Create a variant of `diskutils.BlockOnDiskIO` that takes disk IDs directly, instead of a device path. 
- Allow `safechroot.Close()` to be called multiple times.
- Create `safeloopback` module, which assists with attaching and detaching loopback devices properly.
- Use `safeloopback` throughout the Image Customizer code.

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Ran toolkit UTs.
- Manually ran Image Customizer tool.
