### PR TITLE
Patch edk2 to fix CVE-2023-0465 and CVE-2023-2650

### DIFF
--- a/SPECS/edk2/CVE-2023-0465.patch
+++ b/SPECS/edk2/CVE-2023-0465.patch
@@ -1,0 +1,51 @@
+From: Matt Caswell <matt@openssl.org>
+Date: Tue, 7 Mar 2023 16:52:55 +0000 (+0000)
+Subject: Ensure that EXFLAG_INVALID_POLICY is checked even in leaf certs
+X-Git-Tag: OpenSSL_1_1_1u~18
+X-Git-Url: https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff_plain;h=b013765abfa80036dc779dd0e50602c57bb3bf95
+
+Ensure that EXFLAG_INVALID_POLICY is checked even in leaf certs
+
+Even though we check the leaf cert to confirm it is valid, we
+later ignored the invalid flag and did not notice that the leaf
+cert was bad.
+
+Fixes: CVE-2023-0465
+
+Reviewed-by: Hugo Landau <hlandau@openssl.org>
+Reviewed-by: Tomas Mraz <tomas@openssl.org>
+(Merged from https://github.com/openssl/openssl/pull/20588)
+---
+
+diff --git a/crypto/x509/x509_vfy.c b/crypto/x509/x509_vfy.c
+index 925fbb5412..1dfe4f9f31 100644
+--- a/crypto/x509/x509_vfy.c
++++ b/crypto/x509/x509_vfy.c
+@@ -1649,18 +1649,25 @@ static int check_policy(X509_STORE_CTX *ctx)
+     }
+     /* Invalid or inconsistent extensions */
+     if (ret == X509_PCY_TREE_INVALID) {
+-        int i;
++        int i, cbcalled = 0;
+ 
+         /* Locate certificates with bad extensions and notify callback. */
+-        for (i = 1; i < sk_X509_num(ctx->chain); i++) {
++        for (i = 0; i < sk_X509_num(ctx->chain); i++) {
+             X509 *x = sk_X509_value(ctx->chain, i);
+ 
+             if (!(x->ex_flags & EXFLAG_INVALID_POLICY))
+                 continue;
++            cbcalled = 1;
+             if (!verify_cb_cert(ctx, x, i,
+                                 X509_V_ERR_INVALID_POLICY_EXTENSION))
+                 return 0;
+         }
++        if (!cbcalled) {
++            /* Should not be able to get here */
++            X509err(X509_F_CHECK_POLICY, ERR_R_INTERNAL_ERROR);
++            return 0;
++        }
++        /* The callback ignored the error so we return success */
+         return 1;
+     }
+     if (ret == X509_PCY_TREE_FAILURE) {

--- a/SPECS/edk2/CVE-2023-2650.patch
+++ b/SPECS/edk2/CVE-2023-2650.patch
@@ -1,0 +1,61 @@
+From: Richard Levitte <levitte@openssl.org>
+Date: Fri, 12 May 2023 08:00:13 +0000 (+0200)
+Subject: Restrict the size of OBJECT IDENTIFIERs that OBJ_obj2txt will translate
+X-Git-Tag: OpenSSL_1_1_1u~2
+X-Git-Url: https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff_plain;h=9e209944b35cf82368071f160a744b6178f9b098
+
+Restrict the size of OBJECT IDENTIFIERs that OBJ_obj2txt will translate
+
+OBJ_obj2txt() would translate any size OBJECT IDENTIFIER to canonical
+numeric text form.  For gigantic sub-identifiers, this would take a very
+long time, the time complexity being O(n^2) where n is the size of that
+sub-identifier.
+
+To mitigate this, a restriction on the size that OBJ_obj2txt() will
+translate to canonical numeric text form is added, based on RFC 2578
+(STD 58), which says this:
+
+> 3.5. OBJECT IDENTIFIER values
+>
+> An OBJECT IDENTIFIER value is an ordered list of non-negative numbers.
+> For the SMIv2, each number in the list is referred to as a sub-identifier,
+> there are at most 128 sub-identifiers in a value, and each sub-identifier
+> has a maximum value of 2^32-1 (4294967295 decimal).
+
+Fixes otc/security#96
+Fixes CVE-2023-2650
+
+Reviewed-by: Matt Caswell <matt@openssl.org>
+Reviewed-by: Tomas Mraz <tomas@openssl.org>
+---
+
+diff --git a/crypto/objects/obj_dat.c b/crypto/objects/obj_dat.c
+index 7e8de727f3..d699915b20 100644
+--- a/crypto/objects/obj_dat.c
++++ b/crypto/objects/obj_dat.c
+@@ -428,6 +428,25 @@ int OBJ_obj2txt(char *buf, int buf_len, const ASN1_OBJECT *a, int no_name)
+     first = 1;
+     bl = NULL;
+ 
++    /*
++     * RFC 2578 (STD 58) says this about OBJECT IDENTIFIERs:
++     *
++     * > 3.5. OBJECT IDENTIFIER values
++     * >
++     * > An OBJECT IDENTIFIER value is an ordered list of non-negative
++     * > numbers. For the SMIv2, each number in the list is referred to as a
++     * > sub-identifier, there are at most 128 sub-identifiers in a value,
++     * > and each sub-identifier has a maximum value of 2^32-1 (4294967295
++     * > decimal).
++     *
++     * So a legitimate OID according to this RFC is at most (32 * 128 / 7),
++     * i.e. 586 bytes long.
++     *
++     * Ref: https://datatracker.ietf.org/doc/html/rfc2578#section-3.5
++     */
++    if (len > 586)
++        goto err;
++
+     while (len > 0) {
+         l = 0;
+         use_bn = 0;

--- a/SPECS/edk2/edk2.spec
+++ b/SPECS/edk2/edk2.spec
@@ -45,7 +45,7 @@ ExclusiveArch: x86_64
 
 Name:       edk2
 Version:    %{GITDATE}git%{GITCOMMIT}
-Release:    35%{?dist}
+Release:    37%{?dist}
 Summary:    UEFI firmware for 64-bit virtual machines
 License:    BSD-2-Clause-Patent and OpenSSL and MIT
 URL:        http://www.tianocore.org
@@ -111,6 +111,8 @@ Patch0017: 0017-OvmfPkg-Relax-assertion-that-interrupts-do-not-occur.patch
 
 Patch1000: CVE-2023-0464.patch
 Patch1001: CVE-2023-3817.patch
+Patch1002: CVE-2023-0465.patch
+Patch1003: CVE-2023-2650.patch
 
 # python3-devel and libuuid-devel are required for building tools.
 # python3-devel is also needed for varstore template generation and
@@ -295,7 +297,12 @@ cp -a -- %{SOURCE1} .
 tar -C CryptoPkg/Library/OpensslLib -a -f %{SOURCE2} -x
 # Need to patch CVE-2023-0464 in the bundled openssl
 (cd CryptoPkg/Library/OpensslLib/openssl && patch -p1 ) < %{PATCH1000}
+# Need to patch CVE-2023-3817 in the bundled openssl
 (cd CryptoPkg/Library/OpensslLib/openssl && patch -p1 ) < %{PATCH1001}
+# Need to patch CVE-2023-0465 in the bundled openssl
+(cd CryptoPkg/Library/OpensslLib/openssl && patch -p1 ) < %{PATCH1002}
+# Need to patch CVE-2023-2650 in the bundled openssl
+(cd CryptoPkg/Library/OpensslLib/openssl && patch -p1 ) < %{PATCH1003}
 
 # extract softfloat into place
 tar -xf %{SOURCE3} --strip-components=1 --directory ArmPkg/Library/ArmSoftFloatLib/berkeley-softfloat-3/
@@ -689,6 +696,9 @@ $tests_ok
 
 
 %changelog
+* Tue Oct 17 2023 Francisco Huelsz Prince <frhuelsz@microsoft.com> - 20230301gitf80f052277c8-37
+- Patch CVE-2023-0465 and CVE-2023-2650 in bundled OpenSSL.
+
 * Tue Oct 13 2023 Sindhu Karri <lakarri@microsoft.com> - 20230301gitf80f052277c8-36
 - Patch CVE-2023-3817 in bundled OpenSSL
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Fix CVE-2023-04-65 and CVE-2023-2650 in edk2.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- CVE-2023-0465: Apply this patch [b013765](https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=b013765abfa80036dc779dd0e50602c57bb3bf95) ([github](https://github.com/openssl/openssl/pull/20588/commits/616b48c880f06cd7d5d2a027c308cb38c574c663))
- CVE-2023-2650: Apply this patch [9e20994](https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=9e209944b35cf82368071f160a744b6178f9b098) ([github](https://github.com/openssl/openssl/commit/9e209944b35cf82368071f160a744b6178f9b098)) The code section of the original patch applies cleanly, but the CHANGES/NEWS sections don't because the original patch is for a newer minor release. (This is 1.1.1k, while the patch is originally for 1.1.1t) I just left the code changes section of the patch.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2023-0465
- https://nvd.nist.gov/vuln/detail/CVE-2023-2650

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- ~~Pipeline build id: 437193~~ (before rebase)
- Pipeline build id: 437592

Depends: 
- #6423
