### PR TITLE
Image config: Fix for when no user password is specified.

### DIFF
--- a/toolkit/docs/building/prerequisites-mariner.md
+++ b/toolkit/docs/building/prerequisites-mariner.md
@@ -23,6 +23,7 @@ sudo tdnf -y install \
     make \
     moby-cli \
     moby-engine \
+    openssl \
     parted \
     pigz \
     qemu-img \

--- a/toolkit/docs/building/prerequisites-ubuntu.md
+++ b/toolkit/docs/building/prerequisites-ubuntu.md
@@ -20,6 +20,7 @@ sudo apt -y install \
     make \
     parted \
     pigz \
+    openssl \
     qemu-utils \
     rpm \
     tar \

--- a/toolkit/tools/internal/userutils/main_test.go
+++ b/toolkit/tools/internal/userutils/main_test.go
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package userutils
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/logger"
+)
+
+var (
+	tmpDir string
+)
+
+func TestMain(m *testing.M) {
+	var err error
+
+	logger.InitStderrLog()
+
+	workingDir, err := os.Getwd()
+	if err != nil {
+		logger.Log.Panicf("Failed to get working directory, error: %s", err)
+	}
+
+	tmpDir = filepath.Join(workingDir, "_tmp")
+
+	err = os.MkdirAll(tmpDir, os.ModePerm)
+	if err != nil {
+		logger.Log.Panicf("Failed to create tmp directory, error: %s", err)
+	}
+
+	retVal := m.Run()
+
+	err = os.RemoveAll(tmpDir)
+	if err != nil {
+		logger.Log.Warnf("Failed to cleanup tmp dir (%s). Error: %s", tmpDir, err)
+	}
+
+	os.Exit(retVal)
+}

--- a/toolkit/tools/internal/userutils/userutils.go
+++ b/toolkit/tools/internal/userutils/userutils.go
@@ -5,9 +5,12 @@ package userutils
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/file"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/randomization"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/safechroot"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/shell"
@@ -17,10 +20,16 @@ const (
 	RootUser          = "root"
 	RootHomeDir       = "/root"
 	UserHomeDirPrefix = "/home"
+
+	ShadowFile = "/etc/shadow"
 )
 
 func HashPassword(password string) (string, error) {
 	const postfixLength = 12
+
+	if password == "" {
+		return "", nil
+	}
 
 	salt, err := randomization.RandomString(postfixLength, randomization.LegalCharactersAlphaNum)
 	if err != nil {
@@ -29,7 +38,7 @@ func HashPassword(password string) (string, error) {
 
 	// Generate hashed password based on salt value provided.
 	// -6 option indicates to use the SHA256/SHA512 algorithm
-	stdout, _, err := shell.Execute("openssl", "passwd", "-6", "-salt", salt, password)
+	stdout, _, err := shell.ExecuteWithStdin(password, "openssl", "passwd", "-6", "-salt", salt, "-stdin")
 	if err != nil {
 		return "", fmt.Errorf("failed to generate hashed password:\n%w", err)
 	}
@@ -62,7 +71,10 @@ func UserExists(username string, installChroot *safechroot.Chroot) (bool, error)
 }
 
 func AddUser(username string, hashedPassword string, uid string, installChroot *safechroot.Chroot) error {
-	var args = []string{username, "-m", "-p", hashedPassword}
+	var args = []string{username, "-m"}
+	if hashedPassword != "" {
+		args = append(args, "-p", hashedPassword)
+	}
 	if uid != "" {
 		args = append(args, "-u", uid)
 	}
@@ -72,6 +84,46 @@ func AddUser(username string, hashedPassword string, uid string, installChroot *
 	})
 	if err != nil {
 		return fmt.Errorf("failed to add user (%s):\n%w", username, err)
+	}
+
+	return nil
+}
+
+func UpdateUserPassword(installRoot, username, hashedPassword string) error {
+	shadowFilePath := filepath.Join(installRoot, ShadowFile)
+
+	if hashedPassword == "" {
+		// In the /etc/shadow file, `!` means there is no password and password login is disabled.
+		hashedPassword = "!"
+	}
+
+	// Find the line that starts with "<user>:<password>:..."
+	findUserEntry, err := regexp.Compile(fmt.Sprintf("(?m)^%s:[^:]:", regexp.QuoteMeta(username)))
+	if err != nil {
+		return fmt.Errorf("failed to compile user (%s) password update regex:\n%w", username, err)
+	}
+
+	// Read in existing /etc/shadow file.
+	shadowFileBytes, err := os.ReadFile(shadowFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to read shadow file (%s) to update user's (%s) password:\n%w", shadowFilePath, username, err)
+	}
+
+	shadowFile := string(shadowFileBytes)
+
+	// Update the /etc/shadow file.
+	newEntry := fmt.Sprintf("%v:%v:", username, hashedPassword)
+	newShadowFile := findUserEntry.ReplaceAllLiteralString(shadowFile, newEntry)
+
+	// Check if an update was made.
+	if shadowFile == newShadowFile {
+		return fmt.Errorf("failed to find user (%s) in shadow file (%s)", username, shadowFilePath)
+	}
+
+	// Write new /etc/shadow file.
+	err = file.Write(newShadowFile, shadowFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to write new shadow file (%s) to update user's (%s) password:\n%w", shadowFilePath, username, err)
 	}
 
 	return nil

--- a/toolkit/tools/internal/userutils/userutils_test.go
+++ b/toolkit/tools/internal/userutils/userutils_test.go
@@ -4,6 +4,9 @@
 package userutils
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -62,4 +65,79 @@ func TestPasswordExpiresDaysIsValidTooLarge(t *testing.T) {
 	err := PasswordExpiresDaysIsValid(100000)
 	assert.ErrorContains(t, err, "invalid")
 	assert.ErrorContains(t, err, "PasswordExpiresDays")
+}
+
+func TestHashPasswordEmpty(t *testing.T) {
+	hashedPassword, err := HashPassword("")
+	assert.NoError(t, err, "hash password")
+	assert.Equal(t, "", hashedPassword)
+}
+
+func TestHashPasswordNotEmpty(t *testing.T) {
+	hashedPassword, err := HashPassword("password")
+	assert.NoError(t, err, "hash password")
+	assert.True(t, strings.HasPrefix(hashedPassword, "$6$"), "password prefix")
+}
+
+func TestUpdateUserPasswordEmptyToEmpty(t *testing.T) {
+	testUpdateUserPassword(t, "root:!:19634:7:99999:7:::", "root:!:19634:7:99999:7:::", "root", "")
+}
+
+func TestUpdateUserPasswordSomethingToEmpty(t *testing.T) {
+	testUpdateUserPassword(t,
+		"root:$6$E0M9VkDvOLvO$nr9FjmIiSSP5C5V3Lhuqv4VzWmscABoiQ0mF.ZTbwKEN4nS60nsiU17qA/RGMbXHtJfci/DeLT1Zu2nhNFbwQ.:19634:7:99999:7:::",
+		"root:!:19634:7:99999:7:::",
+		"root",
+		"")
+}
+
+func TestUpdateUserPassword(t *testing.T) {
+	testUpdateUserPassword(t,
+		"root:!:19634:7:99999:7:::",
+		"root:$6$E0M9VkDvOLvO$nr9FjmIiSSP5C5V3Lhuqv4VzWmscABoiQ0mF.ZTbwKEN4nS60nsiU17qA/RGMbXHtJfci/DeLT1Zu2nhNFbwQ.:19634:7:99999:7:::",
+		"root",
+		"$6$E0M9VkDvOLvO$nr9FjmIiSSP5C5V3Lhuqv4VzWmscABoiQ0mF.ZTbwKEN4nS60nsiU17qA/RGMbXHtJfci/DeLT1Zu2nhNFbwQ.")
+}
+
+func testUpdateUserPassword(t *testing.T, originalShadowFile string, expectedShadowFile string, user string, hashedPassword string) {
+	rootFilePath := tmpDir
+
+	writeTestShadowFile(t, rootFilePath, originalShadowFile)
+
+	err := UpdateUserPassword(rootFilePath, user, hashedPassword)
+	if !assert.NoError(t, err, "update password") {
+		return
+	}
+
+	actualShadowFileBytes, err := os.ReadFile(filepath.Join(rootFilePath, ShadowFile))
+	if !assert.NoError(t, err, "read updated shadow file") {
+		return
+	}
+
+	assert.Equal(t, expectedShadowFile, string(actualShadowFileBytes))
+}
+
+func TestUpdateUserPasswordMissingUser(t *testing.T) {
+	rootFilePath := tmpDir
+
+	writeTestShadowFile(t, rootFilePath, "root:!:19634:7:99999:7:::")
+
+	err := UpdateUserPassword(rootFilePath, "test", "")
+	if !assert.ErrorContains(t, err, "failed to find user", "update password") {
+		return
+	}
+}
+
+func writeTestShadowFile(t *testing.T, rootFilePath string, content string) {
+	shadowFilePath := filepath.Join(rootFilePath, ShadowFile)
+
+	err := os.MkdirAll(filepath.Join(rootFilePath, "/etc"), os.ModePerm)
+	if !assert.NoError(t, err, "make /etc dir") {
+		return
+	}
+
+	err = os.WriteFile(shadowFilePath, []byte(content), os.ModePerm)
+	if !assert.NoError(t, err, "write sample shadow file") {
+		return
+	}
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeutils.go
@@ -226,7 +226,7 @@ func addOrUpdateUser(user imagecustomizerapi.User, baseConfigPath string, imageC
 	// Hash the password.
 	hashedPassword := password
 	if !user.PasswordHashed {
-		hashedPassword, err = userutils.HashPassword(user.Password)
+		hashedPassword, err = userutils.HashPassword(password)
 		if err != nil {
 			return err
 		}
@@ -240,7 +240,7 @@ func addOrUpdateUser(user imagecustomizerapi.User, baseConfigPath string, imageC
 
 	if userExists {
 		// Update the user's password.
-		err = installutils.UpdateUserPassword(imageChroot.RootDir(), user.Name, hashedPassword)
+		err = userutils.UpdateUserPassword(imageChroot.RootDir(), user.Name, hashedPassword)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->

Currently, the situation where a user is specified in the new-image config or the image-customizer config without a password is not handled. This change ensures that the user password login is disabled in such situations (by either not passing a password value to `useradd` or by setting the password value to `!` in the /etc/shadow file).

In addition, this change fixes a bug that could allow the plain-text password to be printed when the trace logs are enabled.

###### Change Log  <!-- REQUIRED -->

- Image config: Handle case where user is specified without a password.
- Don't print plain-text password to trace logs.

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Manually ran image customizer tool.

