### PR TITLE
Image Customizer: Ensure loopback cleanly detaches.

### DIFF
--- a/toolkit/tools/imager/imager.go
+++ b/toolkit/tools/imager/imager.go
@@ -397,7 +397,7 @@ func setupLoopDeviceDisk(outputDir, diskName string, diskConfig configuration.Di
 	}()
 
 	// Create Raw Disk File
-	rawDisk, err := diskutils.CreateEmptyDisk(outputDir, diskName, diskConfig)
+	rawDisk, err := diskutils.CreateEmptyDisk(outputDir, diskName, diskConfig.MaxSize)
 	if err != nil {
 		logger.Log.Errorf("Failed to create empty disk file in (%s)", outputDir)
 		return

--- a/toolkit/tools/internal/safeloopback/main_test.go
+++ b/toolkit/tools/internal/safeloopback/main_test.go
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package safeloopback
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/logger"
+)
+
+var (
+	tmpDir string
+)
+
+func TestMain(m *testing.M) {
+	var err error
+
+	logger.InitStderrLog()
+
+	workingDir, err := os.Getwd()
+	if err != nil {
+		logger.Log.Panicf("Failed to get working directory, error: %s", err)
+	}
+
+	tmpDir = filepath.Join(workingDir, "_tmp")
+
+	err = os.MkdirAll(tmpDir, os.ModePerm)
+	if err != nil {
+		logger.Log.Panicf("Failed to create tmp directory, error: %s", err)
+	}
+
+	retVal := m.Run()
+
+	err = os.RemoveAll(tmpDir)
+	if err != nil {
+		logger.Log.Warnf("Failed to cleanup tmp dir (%s). Error: %s", tmpDir, err)
+	}
+
+	os.Exit(retVal)
+}

--- a/toolkit/tools/internal/safeloopback/safeloopback.go
+++ b/toolkit/tools/internal/safeloopback/safeloopback.go
@@ -91,7 +91,12 @@ func (l *Loopback) close(async bool) error {
 	if !async {
 		// The `losetup --detach` call happens asynchronously.
 		// So, need to wait for it to complete.
-		err := diskutils.BlockOnDiskIOByIds(l.devicePath, l.diskIdMaj, l.diskIdMin)
+		err := diskutils.WaitForLoopbackToDetach(l.devicePath, l.diskFilePath)
+		if err != nil {
+			return err
+		}
+
+		err = diskutils.BlockOnDiskIOByIds(l.devicePath, l.diskIdMaj, l.diskIdMin)
 		if err != nil {
 			return err
 		}

--- a/toolkit/tools/internal/safeloopback/safeloopback_test.go
+++ b/toolkit/tools/internal/safeloopback/safeloopback_test.go
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package safeloopback
+
+import (
+	"os"
+	"testing"
+
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/imagegen/diskutils"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/buildpipeline"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoopbackCloseWithOpenFileHandle(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Short mode enabled")
+	}
+
+	if !buildpipeline.IsRegularBuild() {
+		t.Skip("loopback block device not available")
+	}
+
+	if os.Geteuid() != 0 {
+		t.Skip("Test must be run as root because it uses loopback devices")
+	}
+
+	// Create raw disk image file.
+	rawDisk, err := diskutils.CreateEmptyDisk(tmpDir, "disk.raw", 4096)
+	assert.NoErrorf(t, err, "create empty disk file")
+
+	// Attach image file.
+	loopback, err := NewLoopback(rawDisk)
+	assert.NoErrorf(t, err, "attach disk file")
+	defer loopback.Close()
+
+	// Open a file handle to the disk.
+	// If we wanted to do this properly, we could create partitions, mount those partitions, and then create a
+	// file on the partition. But just opening the disk file itself is easier.
+	diskFile, err := os.OpenFile(loopback.DevicePath(), os.O_RDWR, 0)
+	assert.NoErrorf(t, err, "open disk file")
+	defer diskFile.Close()
+
+	// Attempt to close the loopback with the file handle open.
+	// This should fail since loopback devices won't detach until they are no longer in use.
+	err = loopback.CleanClose()
+	assert.Error(t, err)
+
+	// Now close the disk file.
+	diskFile.Close()
+
+	// Loopback should now detach.
+	err = loopback.CleanClose()
+	assert.NoError(t, err)
+}

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
@@ -230,7 +230,7 @@ func createFakeEfiImage(buildDir string) (string, []string, []*safechroot.MountP
 	}
 
 	// Create raw disk image file.
-	rawDisk, err := diskutils.CreateEmptyDisk(buildDir, "disk.raw", diskConfig)
+	rawDisk, err := diskutils.CreateEmptyDisk(buildDir, "disk.raw", diskConfig.MaxSize)
 	if err != nil {
 		return "", nil, nil, fmt.Errorf("failed to create empty disk file in (%s):\n%w", buildDir, err)
 	}


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->

After requesting a loopback device to detach (`losetup --detach), the loopback device will remain open until all file handles to the device have closed. This change ensures that the Image Customizer waits for the loopback device to fully close before outputting the final image.

###### Change Log  <!-- REQUIRED -->

- Image Customizer: Ensure loopback cleanly detaches.

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Added toolkit UT.

