### PR TITLE
Giving image package fetcher access to all toolchain packages.

### DIFF
--- a/toolkit/scripts/imggen.mk
+++ b/toolkit/scripts/imggen.mk
@@ -112,7 +112,7 @@ ifeq ($(USE_PREVIEW_REPO),y)
 imagepkgfetcher_extra_flags += --use-preview-repo
 endif
 
-$(image_package_cache_summary): $(go-imagepkgfetcher) $(chroot_worker) $(imggen_local_repo) $(depend_REPO_LIST) $(REPO_LIST) $(depend_CONFIG_FILE) $(CONFIG_FILE) $(validate-config) $(RPMS_DIR) $(imggen_rpms)
+$(image_package_cache_summary): $(go-imagepkgfetcher) $(chroot_worker) $(toolchain_rpms) $(imggen_local_repo) $(depend_REPO_LIST) $(REPO_LIST) $(depend_CONFIG_FILE) $(CONFIG_FILE) $(validate-config) $(RPMS_DIR) $(imggen_rpms)
 	$(if $(CONFIG_FILE),,$(error Must set CONFIG_FILE=))
 	$(go-imagepkgfetcher) \
 		--input=$(CONFIG_FILE) \


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

# Issue overview

Image package fetcher was searching for required packages having access to only a subset of the toolchain packages. This was causing issues if a newer version of the toolchain package was available in Mariner's upstream RPMs repository and the imager tried to access it instead of the version from the local toolchain.

# Example
Context: 
- An image requires `python3-pip`.
- `python3-pip` is part of the toolchain but not part of the worker chroot.
- The toolchain manifest declares version `N` of `python3-pip`.
- The upstream repo has version `N+1`.

Imager now tries to install `python3-pip` through `tdnf install python3-pip --installroot /installroot ...` and fails with the following error:
```bash
(...)
1. package python3-pip-3.9.14-8.cm2.noarch requires python3 = 3.9.14-8.cm2, but none of the providers can be installed
...
```

It looks like `tdnf` has an issue with the chroot being on version `3.9.14-7.cm2` of `python3`, while `python3-pip` found upstream requires the `3.9.14-8.cm2` version. It cannot upgrade the chroot's `python3`, because `--installroot` points to a different root and seems to be unable to realize it should instead only install `python3` required by `python3-pip` into the other root.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Made the full set of toolchain packages available to the image package fetcher during package resolution.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local image build.