### PR TITLE
CCache failure should not fail the build + Allow in-place updates of remote artifacts

### DIFF
--- a/toolkit/tools/internal/ccachemanager/ccachemanager.go
+++ b/toolkit/tools/internal/ccachemanager/ccachemanager.go
@@ -669,9 +669,13 @@ func (m *CCacheManager) UploadPkgGroupCCache() (err error) {
 		}
 
 		if remoteStoreConfig.KeepLatestOnly {
-			logger.Log.Infof("  keep latest only is enabled. Removing previous ccache archive if it exists...")
+			logger.Log.Infof("  keep latest only is enabled. Checking if we need to remove previous latest archive...")
+			logger.Log.Infof("  - old: (%s)", previousLatestTarSourcePath)
+			logger.Log.Infof("  - new: (%s)", m.CurrentPkgGroup.TarFile.RemoteTargetPath)
 			if previousLatestTarSourcePath == "" {
 				logger.Log.Infof("  cannot remove old archive with an empty name. No previous ccache archive to remove.")
+			} else if previousLatestTarSourcePath == m.CurrentPkgGroup.TarFile.RemoteTargetPath {
+				logger.Log.Infof("  previous latest archive has been overwritten with the current latest archive. Nothing to remove.")
 			} else {
 				logger.Log.Infof("  removing ccache archive (%s) from remote store...", previousLatestTarSourcePath)
 				err = m.AzureBlobStorage.Delete(context.Background(), remoteStoreConfig.ContainerName, previousLatestTarSourcePath)

--- a/toolkit/tools/pkgworker/pkgworker.go
+++ b/toolkit/tools/pkgworker/pkgworker.go
@@ -90,27 +90,27 @@ func main() {
 	defines[rpm.DistroBuildNumberDefine] = *distroBuildNumber
 	defines[rpm.MarinerModuleLdflagsDefine] = "-Wl,-dT,%{_topdir}/BUILD/module_info.ld"
 
-	ccacheManager, err := ccachemanagerpkg.CreateManager(*ccacheRootDir, *ccachConfig)
-	if err == nil {
+	ccacheManager, ccacheErr := ccachemanagerpkg.CreateManager(*ccacheRootDir, *ccachConfig)
+	if ccacheErr == nil {
 		if *useCcache {
-			buildArch, err := rpm.GetRpmArch(runtime.GOARCH)
-			if err == nil {
-				err = ccacheManager.SetCurrentPkgGroup(*basePackageName, buildArch)
-				if err == nil {
+			buildArch, ccacheErr := rpm.GetRpmArch(runtime.GOARCH)
+			if ccacheErr == nil {
+				ccacheErr = ccacheManager.SetCurrentPkgGroup(*basePackageName, buildArch)
+				if ccacheErr == nil {
 					if ccacheManager.CurrentPkgGroup.Enabled {
 						defines[rpm.MarinerCCacheDefine] = "true"
 					}
 				} else {
-					logger.Log.Warnf("Failed to set package ccache configuration:\n%v", err)
+					logger.Log.Warnf("Failed to set package ccache configuration:\n%v", ccacheErr)
 					ccacheManager = nil
 				}
 			} else {
-				logger.Log.Warnf("Failed to get build architecture:\n%v", err)
+				logger.Log.Warnf("Failed to get build architecture:\n%v", ccacheErr)
 				ccacheManager = nil
 			}
 		}
 	} else {
-		logger.Log.Warnf("Failed to initialize the ccache manager:\n%v", err)
+		logger.Log.Warnf("Failed to initialize the ccache manager:\n%v", ccacheErr)
 		ccacheManager = nil
 	}
 
@@ -188,9 +188,9 @@ func buildSRPMInChroot(chrootDir, rpmDirPath, toolchainDirPath, workerTar, srpmF
 	}()
 
 	if isCCacheEnabled(ccacheManager) {
-		err = ccacheManager.DownloadPkgGroupCCache()
-		if err != nil {
-			logger.Log.Infof("CCache will not be able to use previously generated artifacts:\n%v", err)
+		ccacheErr := ccacheManager.DownloadPkgGroupCCache()
+		if ccacheErr != nil {
+			logger.Log.Infof("CCache will not be able to use previously generated artifacts:\n%v", ccacheErr)
 		}
 	}
 
@@ -248,9 +248,9 @@ func buildSRPMInChroot(chrootDir, rpmDirPath, toolchainDirPath, workerTar, srpmF
 	// Only if the groupSize is 1 we can archive since no other packages will
 	// re-update this cache.
 	if isCCacheEnabled(ccacheManager) && ccacheManager.CurrentPkgGroup.Size == 1 {
-		err = ccacheManager.UploadPkgGroupCCache()
-		if err != nil {
-			logger.Log.Warnf("Unable to upload ccache archive:\n%v", err)
+		ccacheErr := ccacheManager.UploadPkgGroupCCache()
+		if ccacheErr != nil {
+			logger.Log.Warnf("Unable to upload ccache archive:\n%v", ccacheErr)
 		}
 	}
 

--- a/toolkit/tools/scheduler/scheduler.go
+++ b/toolkit/tools/scheduler/scheduler.go
@@ -200,10 +200,10 @@ func main() {
 
 	if *useCcache {
 		logger.Log.Infof("  ccache is enabled. processing multi-package groups under (%s)...", *ccacheDir)
-		ccacheManager, err := ccachemanagerpkg.CreateManager(*ccacheDir, *ccacheConfig)
-		if err == nil {
-			err = ccacheManager.UploadMultiPkgGroupCCaches()
-			if err != nil {
+		ccacheManager, ccacheErr := ccachemanagerpkg.CreateManager(*ccacheDir, *ccacheConfig)
+		if ccacheErr == nil {
+			ccacheErr = ccacheManager.UploadMultiPkgGroupCCaches()
+			if ccacheErr != nil {
 				logger.Log.Warnf("Failed to archive CCache artifacts:\n%v.", err)
 			}
 		} else {


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Two Fixes:

(1)
CCache is a build optimization and any failure of its path should not cause the build to fail.
The problem this change is fix is that the ccache code path was returning errors into the `err` variable - which is automatically returned from the higher-level build function. This caused those function to report failure even all rpms were built successfully. The fix creates a new variable to hold the error object returned from ccachemanager functions. That way, we do not pollute the `err` object used by the core build code path.

(2)
CCache configuration allows the user to specify where to download ccache artifacts before the rpm build, and where to upload the generated ccache artifacts after the build. When CCache is configured to keep only the latest build, it will attempt deleting the 'previous latest build'. The problem is that if both the download location and the upload location are the same, then deleting the 'previous latest build' would mean deleting the 'current latest build' as well. The fix checks whether both locations are the same, and if they are, it does not do the deletion.



###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change
- Change
- Change

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES/NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-YYYY-XXXX

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: xxxx
