### PR TITLE
Image Customizer: Handle separate boot partition.

### DIFF
--- a/toolkit/tools/imagegen/diskutils/diskutils.go
+++ b/toolkit/tools/imagegen/diskutils/diskutils.go
@@ -51,6 +51,7 @@ type PartitionInfo struct {
 	Uuid              string `json:"uuid"`       // Example: 4BD9-3A78
 	PartUuid          string `json:"partuuid"`   // Example: 7b1367a6-5845-43f2-99b1-a742d873f590
 	Mountpoint        string `json:"mountpoint"` // Example: /mnt/os/boot
+	PartLabel         string `json:"partlabel"`  // Example: boot
 }
 
 type loopbackListOutput struct {
@@ -760,7 +761,7 @@ func GetDiskPartitions(diskDevPath string) ([]PartitionInfo, error) {
 	}
 
 	// Read the disk's partitions.
-	jsonString, _, err := shell.Execute("lsblk", diskDevPath, "--output", "NAME,PATH,PARTTYPE,FSTYPE,UUID,MOUNTPOINT,PARTUUID", "--json", "--list")
+	jsonString, _, err := shell.Execute("lsblk", diskDevPath, "--output", "NAME,PATH,PARTTYPE,FSTYPE,UUID,MOUNTPOINT,PARTUUID,PARTLABEL", "--json", "--list")
 	if err != nil {
 		return nil, fmt.Errorf("failed to list disk (%s) partitions:\n%w", diskDevPath, err)
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -24,7 +24,8 @@ const (
 )
 
 var (
-	rootfsPartitionRegex = regexp.MustCompile(`(?m)^search -n -u ([a-zA-Z0-9\-]+) -s$`)
+	bootPartitionRegex   = regexp.MustCompile(`(?m)^search -n -u ([a-zA-Z0-9\-]+) -s$`)
+	rootfsPartitionRegex = regexp.MustCompile(`(?m)^set rootdevice=PARTUUID=([a-zA-Z0-9\-]+)$`)
 )
 
 func CustomizeImageWithConfigFile(buildDir string, configFile string, imageFile string,
@@ -249,17 +250,17 @@ func findPartitions(buildDir string, diskDevice string) ([]string, []*safechroot
 		return nil, nil, err
 	}
 
-	var bootLoaderPartition *diskutils.PartitionInfo
+	var rootfsPartition *diskutils.PartitionInfo
 
 	switch systemBootPartition.PartitionTypeUuid {
 	case diskutils.EfiSystemPartitionTypeUuid:
-		bootLoaderPartition, err = findBootLoaderPartitionFromEsp(systemBootPartition, diskPartitions, buildDir)
+		rootfsPartition, err = findRootfsPartitionFromEsp(systemBootPartition, diskPartitions, buildDir)
 		if err != nil {
 			return nil, nil, err
 		}
 
 	case diskutils.BiosBootPartitionTypeUuid:
-		bootLoaderPartition, err = findBootLoaderPartitionFromBiosBootPartition(systemBootPartition, diskPartitions, buildDir)
+		rootfsPartition, err = findRootfsPartitionFromBiosBootPartition(systemBootPartition, diskPartitions, buildDir)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -268,7 +269,7 @@ func findPartitions(buildDir string, diskDevice string) ([]string, []*safechroot
 	// Note: This code assumes that the bootloader is installed on the rootfs partition.
 	// However, technically the bootloader can sit on a dedicated partition separate from both the ESP
 	// and the rootfs partition.
-	mountPoints, err := findMountsFromRootfs(bootLoaderPartition, diskPartitions, buildDir)
+	mountPoints, err := findMountsFromRootfs(rootfsPartition, diskPartitions, buildDir)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -298,7 +299,7 @@ func findSystemBootPartition(diskPartitions []diskutils.PartitionInfo) (*diskuti
 	return bootPartition, nil
 }
 
-func findBootLoaderPartitionFromEsp(efiSystemPartition *diskutils.PartitionInfo, diskPartitions []diskutils.PartitionInfo, buildDir string) (*diskutils.PartitionInfo, error) {
+func findRootfsPartitionFromEsp(efiSystemPartition *diskutils.PartitionInfo, diskPartitions []diskutils.PartitionInfo, buildDir string) (*diskutils.PartitionInfo, error) {
 	tmpDir := filepath.Join(buildDir, tmpParitionDirName)
 
 	// Mount the EFI System Partition.
@@ -322,36 +323,48 @@ func findBootLoaderPartitionFromEsp(efiSystemPartition *diskutils.PartitionInfo,
 	}
 
 	// Look for the bootloader partition declaration line in the grub.cfg file.
-	match := rootfsPartitionRegex.FindStringSubmatch(string(grubConfigFile))
+	match := bootPartitionRegex.FindStringSubmatch(string(grubConfigFile))
 	if match == nil {
-		return nil, fmt.Errorf("failed to find rootfs partition in grub.cfg file")
+		return nil, fmt.Errorf("failed to find boot partition in grub.cfg file")
 	}
 
-	rootfsUuid := match[1]
+	bootPartitionUuid := match[1]
 
 	var bootPartition *diskutils.PartitionInfo
 	for i := range diskPartitions {
 		diskPartition := diskPartitions[i]
 
-		if diskPartition.Uuid == rootfsUuid {
+		if diskPartition.Uuid == bootPartitionUuid {
 			bootPartition = &diskPartition
 			break
 		}
 	}
 
+	if bootPartition == nil {
+		return nil, fmt.Errorf("failed to find boot partition with UUID (%s)", bootPartitionUuid)
+	}
+
+	rootfsPartition, err := tryFindRootfsPartitionFromBootPartition(bootPartition, diskPartitions, buildDir)
+	if err != nil {
+		return nil, err
+	}
+
+	if rootfsPartition == nil {
+		return nil, fmt.Errorf("failed to find rootfs partition using boot partition (%s)", bootPartition.Name)
+	}
+
 	return bootPartition, nil
 }
 
-func findBootLoaderPartitionFromBiosBootPartition(biosBootLoaderPartition *diskutils.PartitionInfo,
+func findRootfsPartitionFromBiosBootPartition(biosBootLoaderPartition *diskutils.PartitionInfo,
 	diskPartitions []diskutils.PartitionInfo, buildDir string,
 ) (*diskutils.PartitionInfo, error) {
-	tmpDir := filepath.Join(buildDir, tmpParitionDirName)
 
 	// The BIOS boot parition is just an executable blob that is uniquely built for each system/disk.
 	// So, there is not much that can be done to reliably extract the boot loader partition from it.
-	// So, instead, find the bootloader partition through brute force.
+	// So, instead, find the boot partition through brute force.
 
-	var grubPartitions []*diskutils.PartitionInfo
+	var rootfsPartitions []*diskutils.PartitionInfo
 	for i := range diskPartitions {
 		diskPartition := diskPartitions[i]
 
@@ -364,38 +377,97 @@ func findBootLoaderPartitionFromBiosBootPartition(biosBootLoaderPartition *disku
 			continue
 		}
 
-		// Temporarily mount the partition.
-		partitionMount, err := safemount.NewMount(diskPartition.Path, tmpDir, diskPartition.FileSystemType, 0, "", true)
+		rootfsPartition, err := tryFindRootfsPartitionFromBootPartition(&diskPartition, diskPartitions, buildDir)
 		if err != nil {
-			return nil, fmt.Errorf("failed to mount partition (%s):\n%w", diskPartition.Path, err)
-		}
-		defer partitionMount.Close()
-
-		// Check if grub exists on the file system.
-		grubCfgPath := filepath.Join(tmpDir, "boot/grub2/grub.cfg")
-		grubCfgExists, err := file.PathExists(grubCfgPath)
-		if err != nil {
-			return nil, fmt.Errorf("failed to stat grub.cfg file (%s):\n%w", grubCfgPath, err)
+			return nil, err
 		}
 
-		err = partitionMount.CleanClose()
+		if rootfsPartition != nil {
+			rootfsPartitions = append(rootfsPartitions, rootfsPartition)
+		}
+	}
+
+	if len(rootfsPartitions) > 1 {
+		return nil, fmt.Errorf("found too many rootfs partition candidates (%d)", len(rootfsPartitions))
+	} else if len(rootfsPartitions) < 1 {
+		return nil, fmt.Errorf("failed to find rootfs partition")
+	}
+
+	rootfsPartition := rootfsPartitions[0]
+	return rootfsPartition, nil
+}
+
+func tryFindRootfsPartitionFromBootPartition(bootPartition *diskutils.PartitionInfo,
+	diskPartitions []diskutils.PartitionInfo, buildDir string,
+) (*diskutils.PartitionInfo, error) {
+	tmpDir := filepath.Join(buildDir, tmpParitionDirName)
+
+	// Temporarily mount the partition.
+	partitionMount, err := safemount.NewMount(bootPartition.Path, tmpDir, bootPartition.FileSystemType, 0, "", true)
+	if err != nil {
+		return nil, fmt.Errorf("failed to mount partition (%s):\n%w", bootPartition.Path, err)
+	}
+	defer partitionMount.Close()
+
+	// Check if grub exists on the file system.
+	var rootfsPartition *diskutils.PartitionInfo
+	for _, grubCfgPath := range []string{"boot/grub2/grub.cfg", "grub2/grub.cfg"} {
+		grubCfgFullPath := filepath.Join(tmpDir, grubCfgPath)
+
+		grubCfgExists, err := file.PathExists(grubCfgFullPath)
 		if err != nil {
-			return nil, fmt.Errorf("failed to unmount partition (%s):\n%w", diskPartition.Path, err)
+			return nil, fmt.Errorf("failed to stat file (%s):\n%w", grubCfgFullPath, err)
 		}
 
 		if grubCfgExists {
-			grubPartitions = append(grubPartitions, &diskPartition)
+			rootfsPartition, err = findRootfsPartitionFromGrubCfgFile(grubCfgFullPath, diskPartitions)
+			if err != nil {
+				return nil, err
+			}
+
+			break
 		}
 	}
 
-	if len(grubPartitions) > 1 {
-		return nil, fmt.Errorf("found too many boot loader partition candidates (%d)", len(grubPartitions))
-	} else if len(grubPartitions) < 1 {
-		return nil, fmt.Errorf("failed to find boot loader partition")
+	err = partitionMount.CleanClose()
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmount partition (%s):\n%w", bootPartition.Path, err)
 	}
 
-	grubPartition := grubPartitions[0]
-	return grubPartition, nil
+	return rootfsPartition, nil
+}
+
+func findRootfsPartitionFromGrubCfgFile(grubCfgFilePath string, diskPartitions []diskutils.PartitionInfo) (*diskutils.PartitionInfo, error) {
+	// Read the grub.cfg file.
+	grubConfigFile, err := os.ReadFile(grubCfgFilePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read grub.cfg file:\n%w", err)
+	}
+
+	// Look for the root partition declaration line in the grub.cfg file.
+	match := rootfsPartitionRegex.FindStringSubmatch(string(grubConfigFile))
+	if match == nil {
+		return nil, fmt.Errorf("failed to find rootfs partition in grub.cfg file")
+	}
+
+	rootfsPartUuid := match[1]
+
+	// Search for the partition in the list of partitions.
+	var rootfsPartition *diskutils.PartitionInfo
+	for i := range diskPartitions {
+		diskPartition := diskPartitions[i]
+
+		if diskPartition.PartUuid == rootfsPartUuid {
+			rootfsPartition = &diskPartition
+			break
+		}
+	}
+
+	if rootfsPartition == nil {
+		return nil, fmt.Errorf("failed to find rootfs partition with PARTUUID (%s)", rootfsPartUuid)
+	}
+
+	return rootfsPartition, nil
 }
 
 func findMountsFromRootfs(rootfsPartition *diskutils.PartitionInfo, diskPartitions []diskutils.PartitionInfo,


### PR DESCRIPTION

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->

Currently, the Image Customizer doesn't handle the case where the boot partition is separate from the rootfs partition. So, it fails to find the rootfs partition.

###### Change Log  <!-- REQUIRED -->

- Image Customizer: Handle separate boot partition.

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Manually ran image customizer tool.

