### PR TITLE
systemd: enable zstd support in journald

### DIFF
--- a/SPECS/systemd/mariner-2-do-not-default-zstd-journal-files-for-backwards-compatibility.patch
+++ b/SPECS/systemd/mariner-2-do-not-default-zstd-journal-files-for-backwards-compatibility.patch
@@ -1,0 +1,12 @@
+diff -urpN a/src/libsystemd/sd-journal/journal-file.c b/src/libsystemd/sd-journal/journal-file.c
+--- a/src/libsystemd/sd-journal/journal-file.c	2022-01-18 11:35:43.000000000 +0000
++++ b/src/libsystemd/sd-journal/journal-file.c	2023-10-19 19:15:42.093295820 +0000
+@@ -3254,7 +3254,7 @@ int journal_file_open(
+                 .flags = flags,
+                 .writable = (flags & O_ACCMODE) != O_RDONLY,
+ 
+-#if HAVE_ZSTD
++#if HAVE_ZSTD && 0 /* For Mariner 2, disable journal compression with zstd for backwards compatibility */
+                 .compress_zstd = compress,
+ #elif HAVE_LZ4
+                 .compress_lz4 = compress,

--- a/SPECS/systemd/systemd.spec
+++ b/SPECS/systemd/systemd.spec
@@ -1,7 +1,7 @@
 Summary:        Systemd-250
 Name:           systemd
 Version:        250.3
-Release:        17%{?dist}
+Release:        18%{?dist}
 License:        LGPLv2+ AND GPLv2+ AND MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -27,6 +27,8 @@ Patch5:         backport-helper-util-macros.patch
 Patch6:         CVE-2022-4415.patch
 Patch7:         serve-stale-0001-resolved-added-serve-stale-feature-implementation-of.patch
 Patch8:         serve-stale-0002-resolved-Initialize-until_valid-while-storing-negati.patch
+# Patch9 should be dropped for mariner 3
+Patch9:         mariner-2-do-not-default-zstd-journal-files-for-backwards-compatibility.patch
 BuildRequires:  audit-devel
 BuildRequires:  cryptsetup-devel
 BuildRequires:  docbook-dtd-xml
@@ -49,6 +51,7 @@ BuildRequires:  python3-jinja2
 BuildRequires:  tpm2-tss-devel
 BuildRequires:  util-linux-devel
 BuildRequires:  xz-devel
+BuildRequires:  zstd-devel
 Requires:       %{name}-rpm-macros = %{version}-%{release}
 Requires:       glib
 Requires:       kmod
@@ -134,7 +137,7 @@ meson  --prefix %{_prefix}                                            \
        -Dlibcryptsetup=true                                           \
        -Dgcrypt=true                                                  \
        -Dlz4=true                                                     \
-       -Dzstd=false                                                   \
+       -Dzstd=true                                                    \
        -Ddbuspolicydir=%{_sysconfdir}/dbus-1/system.d                 \
        -Ddbussessionservicedir=%{_datadir}/dbus-1/services            \
        -Ddbussystemservicedir=%{_datadir}/dbus-1/system-services      \
@@ -283,6 +286,9 @@ fi
 %files lang -f %{name}.lang
 
 %changelog
+* Thu Oct 19 2023 Dan Streetman <ddstreet@ieee.org> - 250.3-18
+- Enable zstd support for journalctl, but force journald to not use zstd to keep backwards compatibility
+
 * Fri Jul 07 2023 Dan Streetman <ddstreet@ieee.org> - 250.3-17
 - Add support to systemd-resolved to serve stale dns data
 


### PR DESCRIPTION
Also for mariner 2, force journald to not use zstd compression, to retain backwards compatibility.

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
allows journalctl to read zstd compressed journal files
###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change
- Change
- Change
build systemd with zstd support
disable journald from defaulting to zstd-compressed journal file creation, to retain backwards compatibility for mariner 2

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**/NO

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #6424


###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=438674&view=results
- 
