### PR TITLE
httpd: upgrade 2.4.56 -> 2.4.58 to address CVE-2023-45802, CVE-2023-43622 & CVE-2023-31122

### DIFF
--- a/SPECS/httpd/httpd.signatures.json
+++ b/SPECS/httpd/httpd.signatures.json
@@ -1,15 +1,15 @@
 {
-  "Signatures": {
-    "00-proxyhtml.conf": "a2211995b7e55b781f68666664f0bcd84550ed9a16edee07121f63477dfaaffa",
-    "00-ssl.conf": "88f04c415dbd1bf0d074965d37261e056d073b675a047a02e55222818640c6e8",
-    "01-ldap.conf": "cbbbdd396fe056e8ab167abd7b2cb5145b42210bfea38452968ff02a03493fc8",
-    "01-session.conf": "51df0ceeb7dae9922817f4af0554f83fe01d6268025ee08260aeed69be3953d1",
-    "10-listen443.conf": "fc7484790ec6328b9082e04083137551a5ae2e8f4d4696d9846b052915b6a0cb",
-    "httpd-init.service": "2501b44bdb02f583d98cc5296accbf0af36957b93ed5b871358aeb10a0512a7c",
-    "httpd-ssl-gencerts": "ae96a94eeb0be8731c0bb976e5b878e0e5a196442a001c9e809bed3873f4755d",
-    "httpd-ssl-pass-dialog": "b9bd4816dda673ad9294a0fbd2904fac9b96eabddb4d72080ae58b498bcd1db9",
-    "macros.httpd": "6dbf9313a5d085cb705fa5ef393372ec940008f08bf1c9350f8f49d58df75dff",
-    "ssl.conf": "6690cb873d2312d0ecffcda3822562cd1b1b11ac44b1fcb7bd1b720a9e53c333",
-    "httpd-2.4.56.tar.bz2": "d8d45f1398ba84edd05bb33ca7593ac2989b17cb9c7a0cafe5442d41afdb2d7c"
-  }
+ "Signatures": {
+  "00-proxyhtml.conf": "a2211995b7e55b781f68666664f0bcd84550ed9a16edee07121f63477dfaaffa",
+  "00-ssl.conf": "88f04c415dbd1bf0d074965d37261e056d073b675a047a02e55222818640c6e8",
+  "01-ldap.conf": "cbbbdd396fe056e8ab167abd7b2cb5145b42210bfea38452968ff02a03493fc8",
+  "01-session.conf": "51df0ceeb7dae9922817f4af0554f83fe01d6268025ee08260aeed69be3953d1",
+  "10-listen443.conf": "fc7484790ec6328b9082e04083137551a5ae2e8f4d4696d9846b052915b6a0cb",
+  "httpd-2.4.58.tar.bz2": "fa16d72a078210a54c47dd5bef2f8b9b8a01d94909a51453956b3ec6442ea4c5",
+  "httpd-init.service": "2501b44bdb02f583d98cc5296accbf0af36957b93ed5b871358aeb10a0512a7c",
+  "httpd-ssl-gencerts": "ae96a94eeb0be8731c0bb976e5b878e0e5a196442a001c9e809bed3873f4755d",
+  "httpd-ssl-pass-dialog": "b9bd4816dda673ad9294a0fbd2904fac9b96eabddb4d72080ae58b498bcd1db9",
+  "macros.httpd": "6dbf9313a5d085cb705fa5ef393372ec940008f08bf1c9350f8f49d58df75dff",
+  "ssl.conf": "6690cb873d2312d0ecffcda3822562cd1b1b11ac44b1fcb7bd1b720a9e53c333"
+ }
 }

--- a/SPECS/httpd/httpd.spec
+++ b/SPECS/httpd/httpd.spec
@@ -2,8 +2,8 @@
 %define _confdir %{_sysconfdir}
 Summary:        The Apache HTTP Server
 Name:           httpd
-Version:        2.4.56
-Release:        2%{?dist}
+Version:        2.4.58
+Release:        1%{?dist}
 License:        Apache-2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -345,6 +345,9 @@ fi
 %{_libexecdir}/httpd-ssl-pass-dialog
 
 %changelog
+* Fri Oct 20 2023 Muhammad Falak <mwani@microsoft.com> - 2.4.58-1
+- Upgrade version to address CVE-2023-45802, CVE-2023-43622 & CVE-2023-31122
+
 * Wed Aug 16 2023 Andy Zaugg <azaugg@linkedin.com> - 2.4.56-1
 - Patch config.layout and provide and provide a real log path
 - Fix PIDfile reference to /run/httpd/httpd.pid

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -5370,8 +5370,8 @@
         "type": "other",
         "other": {
           "name": "httpd",
-          "version": "2.4.56",
-          "downloadUrl": "https://archive.apache.org/dist/httpd/httpd-2.4.56.tar.bz2"
+          "version": "2.4.58",
+          "downloadUrl": "https://archive.apache.org/dist/httpd/httpd-2.4.58.tar.bz2"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
- httpd: upgrade 2.4.56 -> 2.4.58 to address CVE-2023-45802, CVE-2023-43622 & CVE-2023-31122
- Reference: https://[downloads.apache.org/httpd/CHANGES_2.4.58](https://downloads.apache.org/httpd/CHANGES_2.4.58)

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- upgrade httpd `2.4.56 -> 2.4.58`

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- NA

###### Links to CVEs  <!-- optional -->
- https://seclists.org/oss-sec/2023/q4/149
- https://seclists.org/oss-sec/2023/q4/150
- https://seclists.org/oss-sec/2023/q4/151

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build.
- Pipeline build id: [PR-6559](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=439004&view=results)
