### PR TITLE
Toolkit: Disable unreliable tests

### DIFF
--- a/toolkit/scripts/tools.mk
+++ b/toolkit/scripts/tools.mk
@@ -104,7 +104,7 @@ else
 # Rebuild the go tools as needed
 $(TOOL_BINS_DIR)/%: $(go_common_files)
 	cd $(TOOLS_DIR)/$* && \
-		go test -covermode=atomic -coverprofile=$(BUILD_DIR)/tools/$*.test_coverage ./... && \
+		go test -test.short -covermode=atomic -coverprofile=$(BUILD_DIR)/tools/$*.test_coverage ./... && \
 		CGO_ENABLED=0 go build \
 			-ldflags="-X github.com/microsoft/CBL-Mariner/toolkit/tools/internal/exe.ToolkitVersion=$(RELEASE_VERSION)" \
 			-o $(TOOL_BINS_DIR)
@@ -113,7 +113,7 @@ endif
 # Runs tests for common components
 $(BUILD_DIR)/tools/internal.test_coverage: $(go_internal_files) $(go_imagegen_files) $(STATUS_FLAGS_DIR)/got_go_deps.flag
 	cd $(TOOLS_DIR)/$* && \
-		go test -covermode=atomic -coverprofile=$@ ./...
+		go test -test.short -covermode=atomic -coverprofile=$@ ./...
 
 # Downloads all the go dependencies without using sudo, so we don't break other go use cases for the user.
 # We can check if $SUDO_USER is set (the user who invoked sudo), and if so, use that user to run go get via sudo -u.
@@ -147,7 +147,7 @@ go-fmt-all:
 # Formats the test coverage for the tools
 .PHONY: $(BUILD_DIR)/tools/all_tools.coverage
 $(BUILD_DIR)/tools/all_tools.coverage: $(call shell_real_build_only, find $(TOOLS_DIR)/ -type f -name '*.go') $(STATUS_FLAGS_DIR)/got_go_deps.flag
-	cd $(TOOLS_DIR) && go test -coverpkg=./... -covermode=atomic -coverprofile=$@ ./...
+	cd $(TOOLS_DIR) && go test -test.short -coverpkg=./... -covermode=atomic -coverprofile=$@ ./...
 $(test_coverage_report): $(BUILD_DIR)/tools/all_tools.coverage
 	cd $(TOOLS_DIR) && go tool cover -html=$(BUILD_DIR)/tools/all_tools.coverage -o $@
 ##help:target:go-test-coverage=Run and publish test coverage for all go tools.

--- a/toolkit/scripts/tools.mk
+++ b/toolkit/scripts/tools.mk
@@ -188,7 +188,8 @@ worker_chroot_rpm_paths := $(shell sed -nr $(sed_regex_full_path) < $(worker_chr
 worker_chroot_deps := \
 	$(worker_chroot_manifest) \
 	$(worker_chroot_rpm_paths) \
-	$(PKGGEN_DIR)/worker/create_worker_chroot.sh
+	$(PKGGEN_DIR)/worker/create_worker_chroot.sh \
+	$(no_repo_acl)
 
 ifeq ($(REFRESH_WORKER_CHROOT),y)
 $(chroot_worker): $(worker_chroot_deps) $(depend_REBUILD_TOOLCHAIN) $(depend_TOOLCHAIN_ARCHIVE)

--- a/toolkit/scripts/utils.mk
+++ b/toolkit/scripts/utils.mk
@@ -100,7 +100,8 @@ $(foreach var,$(watch_vars),$(eval $(call depend_on_var,$(var))))
 #       to always run the "setfacl" command but not trigger a re-run of the targets
 #       depending on this target.
 $(no_repo_acl): setfacl_always_run_phony
-	@setfacl -bnR $(PROJECT_ROOT) &>/dev/null && \
+	setfacl -bnR $(PROJECT_ROOT) && \
+	setfacl -bnR $(CHROOT_DIR) && \
 	if [ ! -f $@ ]; then \
 		touch $@; \
 	fi

--- a/toolkit/tools/internal/pkggraph/pkggraph_test.go
+++ b/toolkit/tools/internal/pkggraph/pkggraph_test.go
@@ -916,6 +916,13 @@ func TestReadWriteGraph(t *testing.T) {
 
 // Validate the reference graph is valid, and that it matches the output of the test graph.
 func TestReferenceDOTFile(t *testing.T) {
+	if testing.Short() {
+		// Encoding is unreliable on some systems. The final output is still a valid
+		// graph but the base64 encoding of the nodes is different. The final graph once
+		// decoded is the same however (probably gob encoding is different since its stateful?)
+		t.Skip("Short mode enabled")
+	}
+
 	gIn, err := ReadDOTGraphFile("test_graph_reference.dot")
 	assert.NoError(t, err)
 

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeutils_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeutils_test.go
@@ -15,6 +15,10 @@ import (
 )
 
 func TestUpdateHostname(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("Test must be run as root because it uses a chroot")
+	}
+
 	// Setup environment.
 	proposedDir := filepath.Join(tmpDir, "TestUpdateHostname")
 	chroot := safechroot.NewChroot(proposedDir, false)
@@ -37,6 +41,10 @@ func TestUpdateHostname(t *testing.T) {
 }
 
 func TestCopyAdditionalFiles(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("Test must be run as root because it uses a chroot")
+	}
+
 	proposedDir := filepath.Join(tmpDir, "TestCopyAdditionalFiles")
 	chroot := safechroot.NewChroot(proposedDir, false)
 	baseConfigPath := testDir

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
@@ -22,8 +22,16 @@ import (
 func TestCustomizeImageEmptyConfig(t *testing.T) {
 	var err error
 
+	if testing.Short() {
+		t.Skip("Short mode enabled")
+	}
+
 	if !buildpipeline.IsRegularBuild() {
 		t.Skip("loopback block device not available")
+	}
+
+	if os.Geteuid() != 0 {
+		t.Skip("Test must be run as root because it uses a chroot")
 	}
 
 	buildDir := filepath.Join(tmpDir, "TestCustomizeImageEmptyConfig")
@@ -48,8 +56,16 @@ func TestCustomizeImageEmptyConfig(t *testing.T) {
 func TestCustomizeImageCopyFiles(t *testing.T) {
 	var err error
 
+	if testing.Short() {
+		t.Skip("Short mode enabled")
+	}
+
 	if !buildpipeline.IsRegularBuild() {
 		t.Skip("loopback block device not available")
+	}
+
+	if os.Geteuid() != 0 {
+		t.Skip("Test must be run as root because it uses a chroot")
 	}
 
 	buildDir := filepath.Join(tmpDir, "TestCustomizeImageCopyFiles")


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->

Some of the toolkit UTs are unreliable. Use the test short mode flag to disable these tests.

###### Change Log  <!-- REQUIRED -->

- Toolkit: Use test short mode flag to disable some unreliable tests.
- Call setfacl on the chroot dir directly in case it is set by the user.

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Ran toolkit UTs.

