### PR TITLE
Add the repoquerywrapper tool. (#6390)

### DIFF
--- a/toolkit/Makefile
+++ b/toolkit/Makefile
@@ -92,6 +92,7 @@ CCACHE_DIR       ?= $(PROJECT_ROOT)/ccache
 LOGS_DIR           ?= $(BUILD_DIR)/logs
 PKGBUILD_DIR       ?= $(BUILD_DIR)/pkg_artifacts
 CACHED_RPMS_DIR    ?= $(BUILD_DIR)/rpm_cache
+REPO_QUERY_DIR     ?= $(BUILD_DIR)/repo_query
 BUILD_SRPMS_DIR    ?= $(BUILD_DIR)/INTERMEDIATE_SRPMS
 MACRO_DIR          ?= $(BUILD_DIR)/macros
 BUILD_SPECS_DIR    ?= $(BUILD_DIR)/INTERMEDIATE_SPECS
@@ -208,6 +209,10 @@ include $(SCRIPTS_DIR)/toolkit.mk
 # Fill the cache with rpms from the package server without using package manager or chroot with:
 #   pre-cache
 include $(SCRIPTS_DIR)/precache.mk
+
+# Run repo query under chroot with:
+# repo-query
+include $(SCRIPTS_DIR)/repoquerywrapper.mk
 
 # Create a package build workplan with:
 #   workplan, clean-workplan clean-cache

--- a/toolkit/scripts/repoquerywrapper.mk
+++ b/toolkit/scripts/repoquerywrapper.mk
@@ -1,0 +1,57 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# Contains:
+#	- Tools to query rpms repos in bulk.
+
+.PHONY: repo-query clean-repo-query
+
+repoquerywrapper_state_dir = $(REPO_QUERY_DIR)/repoquerywrapper
+repo_urls_file = $(repoquerywrapper_state_dir)/repo_urls.txt
+repoquerywrapper_chroot_dir = $(repoquerywrapper_state_dir)/chroot
+repoquerywrapper_logs_path = $(LOGS_DIR)/repoquerywrapper/repoquerywrapper.log
+
+$(call create_folder,$(repoquerywrapper_state_dir))
+
+clean: clean-repo-query
+clean-repo-query:
+	@echo Verifying no mountpoints present in $(repoquerywrapper_chroot_dir)
+	$(SCRIPTS_DIR)/safeunmount.sh "$(repoquerywrapper_chroot_dir)" && \
+	rm -rf $(repoquerywrapper_state_dir)
+
+#
+# We always want to run the repoquerywrapper tool.
+# However, we do not want targets that depend on repo-query to be re-run if the
+# output of the repoquerywrapper has not changed. Such dependents can reference
+# the $(STATUS_FLAGS_DIR)/repoquerywrapper.flag instead of the repo-query
+# target.
+#
+.PHONY: repoquerywrapper_always_run_phony
+repo-query: $(STATUS_FLAGS_DIR)/repoquerywrapper.flag
+$(STATUS_FLAGS_DIR)/repoquerywrapper.flag: $(go-repoquerywrapper) $(chroot_worker) repoquerywrapper_always_run_phony 
+	@if [ "$(DISABLE_UPSTREAM_REPOS)" = "y" ]; then \
+		echo "ERROR: Upstream repos are disabled (DISABLE_UPSTREAM_REPOS=y), cannot repo-query RPMs"; \
+		exit 1; \
+	fi
+	if [ -f $(QUERY_OUTPUT_FILE) ]; then \
+		cp $(QUERY_OUTPUT_FILE) $(QUERY_OUTPUT_FILE)-old; \
+	fi
+	$(go-repoquerywrapper) \
+		--query-input-file $(QUERY_INPUT_FILE) \
+		--query-cmd $(QUERY_CMD) \
+		--query-output-file $(QUERY_OUTPUT_FILE) \
+		$(foreach url,$(PACKAGE_URL_LIST), --repo-url "$(url)") \
+		$(foreach repofile,$(REPO_LIST), --repo-file "$(repofile)") \
+		--worker-tar $(chroot_worker) \
+		--worker-dir $(repoquerywrapper_chroot_dir) \
+		--log-file=$(repoquerywrapper_logs_path) \
+		--log-level=$(LOG_LEVEL) \
+		--cpu-prof-file=$(PROFILE_DIR)/repoquerywrapper.cpu.pprof \
+		--mem-prof-file=$(PROFILE_DIR)/repoquerywrapper.mem.pprof \
+		--trace-file=$(PROFILE_DIR)/repoquerywrapper.trace \
+		$(if $(filter y,$(ENABLE_CPU_PROFILE)),--enable-cpu-prof) \
+		$(if $(filter y,$(ENABLE_MEM_PROFILE)),--enable-mem-prof) \
+		$(if $(filter y,$(ENABLE_TRACE)),--enable-trace) \
+		--timestamp-file=$(TIMESTAMP_DIR)/repoquerywrapper.jsonl && \
+	scripts/update-target-if-output-changed.sh $@ $(QUERY_OUTPUT_FILE)-old $(QUERY_OUTPUT_FILE)
+

--- a/toolkit/scripts/tools.mk
+++ b/toolkit/scripts/tools.mk
@@ -44,6 +44,7 @@ go_tool_list = \
 	liveinstaller \
 	pkgworker \
 	precacher \
+	repoquerywrapper \
 	roast \
 	rpmssnapshot \
 	scheduler \

--- a/toolkit/scripts/update-target-if-output-changed.sh
+++ b/toolkit/scripts/update-target-if-output-changed.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# $1 path to flag file that will be created if needed.
+# $2 path to the old output file.
+# $3 path to the new output file.
+flagFile=${1}
+oldOutputFile=${2}
+newOutputFile=${3}
+
+usage() {
+	echo
+	echo "./update-target-if-output-changed.sh <flag-file> <old-output-file> <new-output-file>"
+	echo
+	echo "This is a helper script to create/update make flag files if the contents of an output file has changed."
+	echo
+    exit 1
+}
+
+[[ -z "$flagFile" || -z "$oldOutputFile" || -z "$newOutputFile" ]] && usage
+
+if [[ ! -f $flagFile ]] || [[ ! -f $oldOutputFile ]]; then
+	echo "Creating $flagFile"
+	touch $flagFile
+	exit 0
+fi
+
+cmp --silent $oldOutputFile $newOutputFile
+comparisonResult=$?
+
+if [[ $comparisonResult != 0 ]]; then
+	echo "Creating $flagFile"
+	touch $flagFile
+fi
+rm $oldOutputFile

--- a/toolkit/tools/internal/packagerepo/repoutils/repoquery.go
+++ b/toolkit/tools/internal/packagerepo/repoutils/repoquery.go
@@ -1,0 +1,220 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package repoutils
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/imagegen/installutils"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/file"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/logger"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/randomization"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/safechroot"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/shell"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/sliceutils"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/timestamp"
+)
+
+const (
+	chrootRepoDir = "/etc/yum.repos.d/"
+)
+
+// GetAllRepoData returns a map of package names to URLs for all packages
+// available in the given repos. It uses a chroot to run repoquery.
+func GetAllRepoData(repoURLs, repoFiles []string, workerTar, buildDir, repoUrlsFile string) (namesToURLs map[string]string, err error) {
+	const (
+		leaveChrootOnDisk = false
+	)
+	timestamp.StartEvent("pull available package data from repos", nil)
+	defer timestamp.StopEvent(nil)
+
+	queryChroot, err := createChroot(workerTar, buildDir, leaveChrootOnDisk)
+	if err != nil {
+		err = fmt.Errorf("failed to create chroot:\n%w", err)
+		return nil, err
+	}
+	defer queryChroot.Close(leaveChrootOnDisk)
+
+	namesToURLs = make(map[string]string)
+	allPackageURLs := []string{}
+	for _, repoURL := range repoURLs {
+		// Use the chroot to query each repo for the packages it contains
+		var packageRepoURLs []string
+		err = queryChroot.Run(func() (chrootErr error) {
+			packageRepoURLs, chrootErr = getPackageRepoPathsFromUrl(repoURL)
+			return chrootErr
+		})
+		if err != nil {
+			return nil, err
+		}
+		allPackageURLs = append(allPackageURLs, packageRepoURLs...)
+	}
+
+	// Use the chroot to query each repo for the packages it contains
+	for _, repoFile := range repoFiles {
+		// Replace the existing repo file (if it exists) with the one that we want to query
+		logger.Log.Infof("Will query package data from %s", repoFile)
+		destFile := path.Join(chrootRepoDir, path.Base(repoFile))
+		chrootRepoFile := []safechroot.FileToCopy{
+			{Src: repoFile, Dest: destFile},
+		}
+		err = queryChroot.AddFiles(chrootRepoFile...)
+		if err != nil {
+			err = fmt.Errorf("failed to add files to chroot:\n%w", err)
+			return
+		}
+	}
+
+	var packageRepoUrls []string
+	// Only run repoquery if we have repo files to query. --enablerepo=* will not work if there are no repo files
+	// and will return "Error: Unknown repo: '*'"
+	if len(repoFiles) > 0 {
+		err = queryChroot.Run(func() (chrootErr error) {
+			packageRepoUrls, chrootErr = getPackageRepoUrlsFromRepoFiles()
+			return chrootErr
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+	allPackageURLs = append(allPackageURLs, packageRepoUrls...)
+
+	// We will be searching by the name: "<name>-<version>.<distro>.<arch>", the results from the repoquery will be
+	// in the form of "<PARTIAL_URL>/<name>-<version>.<distro>.<arch>.rpm"
+	allPackageURLs = sliceutils.RemoveDuplicatesFromSlice(allPackageURLs)
+	for _, packageURL := range allPackageURLs {
+		packageName := path.Base(packageURL)
+		packageName = strings.TrimSuffix(packageName, ".rpm")
+
+		namesToURLs[packageName] = packageURL
+	}
+
+	if repoUrlsFile != "" {
+		err = file.WriteLines(allPackageURLs, repoUrlsFile)
+	}
+
+	return
+}
+
+// createChroot creates a network-enabled chroot to run repoquery in. The caller is expected to call Close() on the
+// returned chroot unless an error is returned, in which case the chroot will be closed by this function.
+func createChroot(workerTar, chrootDir string, leaveChrootOnDisk bool) (queryChroot *safechroot.Chroot, err error) {
+	const (
+		dnfUtilsPackageName = "dnf-utils"
+		rootDir             = "/"
+	)
+	timestamp.StartEvent("creating repoquery chroot", nil)
+	defer timestamp.StopEvent(nil)
+	logger.Log.Info("Creating chroot for repoquery")
+
+	queryChroot = safechroot.NewChroot(chrootDir, false)
+	err = queryChroot.Initialize(workerTar, nil, nil)
+	if err != nil {
+		err = fmt.Errorf("failed to initialize chroot:\n%w", err)
+		return
+	}
+
+	defer func() {
+		if err != nil {
+			closeErr := queryChroot.Close(leaveChrootOnDisk)
+			if closeErr != nil {
+				logger.Log.Errorf("Failed to close chroot, err: %s", closeErr)
+			}
+		}
+	}()
+
+	// We will need network to install the repoquery package
+	files := []safechroot.FileToCopy{
+		{Src: "/etc/resolv.conf", Dest: "/etc/resolv.conf"},
+	}
+	err = queryChroot.AddFiles(files...)
+	if err != nil {
+		err = fmt.Errorf("failed to add files to chroot:\n%w", err)
+		return
+	}
+
+	// Install the repoquery package from upstream, then clean up any existing repos
+	logger.Log.Infof("Installing '%s' package to get 'repoquery' command", dnfUtilsPackageName)
+	err = queryChroot.Run(func() error {
+		_, chrootErr := installutils.TdnfInstall(dnfUtilsPackageName, rootDir)
+		if chrootErr != nil {
+			chrootErr = fmt.Errorf("failed to install '%s':\n%w", dnfUtilsPackageName, err)
+			return chrootErr
+		}
+
+		// Remove all existing repos, we will be adding the repo files we want to query later
+		chrootErr = os.RemoveAll("/etc/yum.repos.d")
+		return chrootErr
+	})
+	if err != nil {
+		err = fmt.Errorf("failed to install '%s' in chroot:\n%w", dnfUtilsPackageName, err)
+		return
+	}
+	return
+}
+
+// getPackageRepoPathsFromUrl returns a list of packages available in the given repoUrl by running repoquery
+func getPackageRepoPathsFromUrl(repoUrl string) (packageURLs []string, err error) {
+	const (
+		reqoqueryTool    = "repoquery"
+		randomNameLength = 10
+		printErrorOutput = true
+	)
+	var queryCommonArgList = []string{"-y", "-q", "--disablerepo=*", "-a", "--location"}
+
+	logger.Log.Infof("Getting package data from %s", repoUrl)
+
+	// We want to avoid using the same repo name for each repoUrl, so we generate a random name
+	randomName, err := randomization.RandomString(randomNameLength, randomization.LegalCharactersAlphaNum)
+	if err != nil {
+		err = fmt.Errorf("failed to generate random string:\n%w", err)
+		return
+	}
+	repoPathArg := fmt.Sprintf("--repofrompath=mariner-precache-%s,%s", randomName, repoUrl)
+	finalArgList := append(queryCommonArgList, repoPathArg)
+
+	onStdout := func(args ...interface{}) {
+		line := args[0].(string)
+		packageURLs = append(packageURLs, line)
+	}
+
+	// Run the repoquery command
+	err = shell.ExecuteLiveWithCallback(onStdout, logger.Log.Warn, printErrorOutput, reqoqueryTool, finalArgList...)
+	if err != nil {
+		err = fmt.Errorf("failed to run repoquery command:\n%w", err)
+		return
+	}
+
+	return
+}
+
+// getPackageRepoUrlsFromRepoFiles returns a list of packages available in all RPM repos listed in the system's .repo files.
+func getPackageRepoUrlsFromRepoFiles() (packageURLs []string, err error) {
+	const (
+		reqoqueryTool    = "repoquery"
+		randomNameLength = 10
+		printErrorOutput = true
+	)
+	// We have removed all other repo files from the chroot, so we can blindly enable all repos to get the full list of packages
+	var queryCommonArgList = []string{"-y", "-q", "--enablerepo=*", "-a", "--location"}
+
+	logger.Log.Info("Getting package data from repo files")
+
+	onStdout := func(args ...interface{}) {
+		line := args[0].(string)
+		packageURLs = append(packageURLs, line)
+	}
+
+	// Run the repoquery command
+	err = shell.ExecuteLiveWithCallback(onStdout, logger.Log.Warn, printErrorOutput, reqoqueryTool, queryCommonArgList...)
+	if err != nil {
+		err = fmt.Errorf("failed to run repoquery command:\n%w", err)
+		return
+	}
+
+	return
+}

--- a/toolkit/tools/precacher/precacher.go
+++ b/toolkit/tools/precacher/precacher.go
@@ -12,18 +12,14 @@ import (
 	"sync"
 	"time"
 
-	"github.com/microsoft/CBL-Mariner/toolkit/tools/imagegen/installutils"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/exe"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/file"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/jsonutils"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/logger"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/network"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/packagerepo/repocloner"
-	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/randomization"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/packagerepo/repoutils"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/retry"
-	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/safechroot"
-	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/shell"
-	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/sliceutils"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/timestamp"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/pkg/profile"
 	"github.com/sirupsen/logrus"
@@ -33,7 +29,6 @@ import (
 
 const (
 	defaultNetOpsCount = "20"
-	chrootRepoDir      = "/etc/yum.repos.d/"
 )
 
 type downloadResultType int
@@ -88,8 +83,7 @@ func main() {
 	if err != nil {
 		logger.PanicOnError(err)
 	}
-
-	packagesAvailableFromRepos, err := getAllRepoData(*repoUrls, *repoFiles, *workerTar, *buildDir, *repoUrlsFile)
+	packagesAvailableFromRepos, err := repoutils.GetAllRepoData(*repoUrls, *repoFiles, *workerTar, *buildDir, *repoUrlsFile)
 	if err != nil {
 		logger.PanicOnError(err)
 	}
@@ -123,200 +117,6 @@ func rpmSnapshotFromFile(snapshotFile string) (rpmSnapshot *repocloner.RepoConte
 	rand.Shuffle(len(rpmSnapshot.Repo), func(i, j int) {
 		rpmSnapshot.Repo[i], rpmSnapshot.Repo[j] = rpmSnapshot.Repo[j], rpmSnapshot.Repo[i]
 	})
-
-	return
-}
-
-// getAllRepoData returns a map of package names to URLs for all packages available in the given repos. It uses
-// a chroot to run repoquery.
-func getAllRepoData(repoURLs, repoFiles []string, workerTar, buildDir, repoUrlsFile string) (namesToURLs map[string]string, err error) {
-	const (
-		leaveChrootOnDisk = false
-	)
-	timestamp.StartEvent("pull available package data from repos", nil)
-	defer timestamp.StopEvent(nil)
-
-	queryChroot, err := createChroot(workerTar, buildDir, leaveChrootOnDisk)
-	if err != nil {
-		err = fmt.Errorf("failed to create chroot:\n%w", err)
-		return nil, err
-	}
-	defer queryChroot.Close(leaveChrootOnDisk)
-
-	namesToURLs = make(map[string]string)
-	allPackageURLs := []string{}
-	for _, repoURL := range repoURLs {
-		// Use the chroot to query each repo for the packages it contains
-		var packageRepoURLs []string
-		err = queryChroot.Run(func() (chrootErr error) {
-			packageRepoURLs, chrootErr = getPackageRepoPathsFromUrl(repoURL)
-			return chrootErr
-		})
-		if err != nil {
-			return nil, err
-		}
-		allPackageURLs = append(allPackageURLs, packageRepoURLs...)
-	}
-
-	// Use the chroot to query each repo for the packages it contains
-	for _, repoFile := range repoFiles {
-		// Replace the existing repo file (if it exists) with the one that we want to query
-		logger.Log.Infof("Will query package data from %s", repoFile)
-		destFile := path.Join(chrootRepoDir, path.Base(repoFile))
-		chrootRepoFile := []safechroot.FileToCopy{
-			{Src: repoFile, Dest: destFile},
-		}
-		err = queryChroot.AddFiles(chrootRepoFile...)
-		if err != nil {
-			err = fmt.Errorf("failed to add files to chroot:\n%w", err)
-			return
-		}
-	}
-
-	var packageRepoUrls []string
-	// Only run repoquery if we have repo files to query. --enablerepo=* will not work if there are no repo files
-	// and will return "Error: Unknown repo: '*'"
-	if len(repoFiles) > 0 {
-		err = queryChroot.Run(func() (chrootErr error) {
-			packageRepoUrls, chrootErr = getPackageRepoUrlsFromRepoFiles()
-			return chrootErr
-		})
-		if err != nil {
-			return nil, err
-		}
-	}
-	allPackageURLs = append(allPackageURLs, packageRepoUrls...)
-
-	// We will be searching by the name: "<name>-<version>.<distro>.<arch>", the results from the repoquery will be
-	// in the form of "<PARTIAL_URL>/<name>-<version>.<distro>.<arch>.rpm"
-	allPackageURLs = sliceutils.RemoveDuplicatesFromSlice(allPackageURLs)
-	for _, packageURL := range allPackageURLs {
-		packageName := path.Base(packageURL)
-		packageName = strings.TrimSuffix(packageName, ".rpm")
-
-		namesToURLs[packageName] = packageURL
-	}
-
-	err = file.WriteLines(allPackageURLs, repoUrlsFile)
-
-	return
-}
-
-// createChroot creates a network-enabled chroot to run repoquery in. The caller is expected to call Close() on the
-// returned chroot unless an error is returned, in which case the chroot will be closed by this function.
-func createChroot(workerTar, chrootDir string, leaveChrootOnDisk bool) (queryChroot *safechroot.Chroot, err error) {
-	const (
-		dnfUtilsPackageName = "dnf-utils"
-		rootDir             = "/"
-	)
-	timestamp.StartEvent("creating repoquery chroot", nil)
-	defer timestamp.StopEvent(nil)
-	logger.Log.Info("Creating chroot for repoquery")
-
-	queryChroot = safechroot.NewChroot(chrootDir, false)
-	err = queryChroot.Initialize(workerTar, nil, nil)
-	if err != nil {
-		err = fmt.Errorf("failed to initialize chroot:\n%w", err)
-		return
-	}
-
-	defer func() {
-		if err != nil {
-			closeErr := queryChroot.Close(leaveChrootOnDisk)
-			if closeErr != nil {
-				logger.Log.Errorf("Failed to close chroot, err: %s", closeErr)
-			}
-		}
-	}()
-
-	// We will need network to install the repoquery package
-	files := []safechroot.FileToCopy{
-		{Src: "/etc/resolv.conf", Dest: "/etc/resolv.conf"},
-	}
-	err = queryChroot.AddFiles(files...)
-	if err != nil {
-		err = fmt.Errorf("failed to add files to chroot:\n%w", err)
-		return
-	}
-
-	// Install the repoquery package from upstream, then clean up any existing repos
-	logger.Log.Infof("Installing '%s' package to get 'repoquery' command", dnfUtilsPackageName)
-	err = queryChroot.Run(func() error {
-		_, chrootErr := installutils.TdnfInstall(dnfUtilsPackageName, rootDir)
-		if chrootErr != nil {
-			chrootErr = fmt.Errorf("failed to install '%s':\n%w", dnfUtilsPackageName, err)
-			return chrootErr
-		}
-
-		// Remove all existing repos, we will be adding the repo files we want to query later
-		chrootErr = os.RemoveAll("/etc/yum.repos.d")
-		return chrootErr
-	})
-	if err != nil {
-		err = fmt.Errorf("failed to install '%s' in chroot:\n%w", dnfUtilsPackageName, err)
-		return
-	}
-	return
-}
-
-// getPackageRepoPathsFromUrl returns a list of packages available in the given repoUrl by running repoquery
-func getPackageRepoPathsFromUrl(repoUrl string) (packageURLs []string, err error) {
-	const (
-		reqoqueryTool    = "repoquery"
-		randomNameLength = 10
-		printErrorOutput = true
-	)
-	var queryCommonArgList = []string{"-y", "-q", "--disablerepo=*", "-a", "--location"}
-
-	logger.Log.Infof("Getting package data from %s", repoUrl)
-
-	// We want to avoid using the same repo name for each repoUrl, so we generate a random name
-	randomName, err := randomization.RandomString(randomNameLength, randomization.LegalCharactersAlphaNum)
-	if err != nil {
-		err = fmt.Errorf("failed to generate random string:\n%w", err)
-		return
-	}
-	repoPathArg := fmt.Sprintf("--repofrompath=mariner-precache-%s,%s", randomName, repoUrl)
-	finalArgList := append(queryCommonArgList, repoPathArg)
-
-	onStdout := func(args ...interface{}) {
-		line := args[0].(string)
-		packageURLs = append(packageURLs, line)
-	}
-
-	// Run the repoquery command
-	err = shell.ExecuteLiveWithCallback(onStdout, logger.Log.Warn, printErrorOutput, reqoqueryTool, finalArgList...)
-	if err != nil {
-		err = fmt.Errorf("failed to run repoquery command:\n%w", err)
-		return
-	}
-
-	return
-}
-
-// getPackageRepoUrlsFromRepoFiles returns a list of packages available in all RPM repos listed in the system's .repo files.
-func getPackageRepoUrlsFromRepoFiles() (packageURLs []string, err error) {
-	const (
-		reqoqueryTool    = "repoquery"
-		randomNameLength = 10
-		printErrorOutput = true
-	)
-	// We have removed all other repo files from the chroot, so we can blindly enable all repos to get the full list of packages
-	var queryCommonArgList = []string{"-y", "-q", "--enablerepo=*", "-a", "--location"}
-
-	logger.Log.Info("Getting package data from repo files")
-
-	onStdout := func(args ...interface{}) {
-		line := args[0].(string)
-		packageURLs = append(packageURLs, line)
-	}
-
-	// Run the repoquery command
-	err = shell.ExecuteLiveWithCallback(onStdout, logger.Log.Warn, printErrorOutput, reqoqueryTool, queryCommonArgList...)
-	if err != nil {
-		err = fmt.Errorf("failed to run repoquery command:\n%w", err)
-		return
-	}
 
 	return
 }

--- a/toolkit/tools/repoquerywrapper/repoquerywrapper.go
+++ b/toolkit/tools/repoquerywrapper/repoquerywrapper.go
@@ -1,0 +1,113 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/exe"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/logger"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/packagerepo/repoutils"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/timestamp"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/pkg/profile"
+	"github.com/sirupsen/logrus"
+
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+const (
+	QueryCmdFindPresent = "find-present"
+)
+
+var (
+	app = kingpin.New("repoquerywrapper", "Runs queries against RPMs repo in bulk.")
+
+	logFile       = exe.LogFileFlag(app)
+	logLevel      = exe.LogLevelFlag(app)
+	profFlags     = exe.SetupProfileFlags(app)
+	timestampFile = app.Flag("timestamp-file", "File that stores timestamps for this program.").String()
+
+	repoUrls  = app.Flag("repo-url", "URLs of the repos to download from.").Strings()
+	repoFiles = app.Flag("repo-file", "Files containing URLs of the repos to download from.").ExistingFiles()
+	workerTar = app.Flag("worker-tar", "Full path to worker_chroot.tar.gz").Required().ExistingFile()
+	buildDir  = app.Flag("worker-dir", "Directory to store chroot while running repo query.").Required().String()
+
+	queryCmd        = app.Flag("query-cmd", "The query commands to run. Available command is: 'find-present'.").Required().String()
+	queryInputFile  = app.Flag("query-input-file", "Path to a file with the query input data.").Required().String()
+	queryOutputFile = app.Flag("query-output-file", "Path to a file for the query output data.").Required().String()
+)
+
+func main() {
+	app.Version(exe.ToolkitVersion)
+	kingpin.MustParse(app.Parse(os.Args[1:]))
+	logger.InitBestEffort(*logFile, *logLevel)
+
+	prof, err := profile.StartProfiling(profFlags)
+	if err != nil {
+		logger.Log.Warnf("Could not start profiling: %s", err)
+	}
+	defer prof.StopProfiler()
+
+	timestamp.BeginTiming("repoquerywrapper", *timestampFile)
+	defer timestamp.CompleteTiming()
+
+	packagesAvailableFromRepos, err := repoutils.GetAllRepoData(*repoUrls, *repoFiles, *workerTar, *buildDir, "")
+	if err != nil {
+		logger.PanicOnError(err)
+	}
+
+	// cmd         : 'find-present'
+	// query input : a file where each line is the name of an rpm to search for.
+	// query output: a file where each line is the name of an rpm that is
+	//               present on the repo.
+	if *queryCmd == QueryCmdFindPresent {
+
+		inputRpmNames, err := readFileLines(*queryInputFile)
+		if err != nil {
+			logger.PanicOnError(err)
+		}
+
+		var outputRpmNames []string
+		for _, inputRpmName := range inputRpmNames {
+			inputRpmBaseName := strings.TrimSuffix(inputRpmName, ".rpm")
+			_, exists := packagesAvailableFromRepos[inputRpmBaseName]
+			if exists {
+				outputRpmNames = append(outputRpmNames, inputRpmName)
+			}
+		}
+
+		err = writeFileLines(outputRpmNames, *queryOutputFile)
+		if err != nil {
+			logger.PanicOnError(err)
+		}
+	}
+
+	if logger.Log.IsLevelEnabled(logrus.DebugLevel) {
+		for i, pkg := range packagesAvailableFromRepos {
+			logger.Log.Debugf("Found package: %s, %s", i, pkg)
+		}
+	}
+}
+
+func readFileLines(fileName string) (lines []string, err error) {
+	content, err := ioutil.ReadFile(fileName)
+	if err != nil {
+		logger.Log.Errorf("Error reading file: %v", err)
+		return nil, err
+	}
+
+	return strings.Split(string(content), "\n"), nil
+}
+
+func writeFileLines(lines []string, fileName string) (err error) {
+	content := strings.Join(lines, "\n")
+	err = ioutil.WriteFile(fileName, []byte(content), 0644)
+	if err != nil {
+		logger.Log.Errorf("Error writing file: %v", err)
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
* Add the repoquerywrapper tool.

The repoquerywrapper tools creates a chroot, installs dnf packages, and runs specific repoquery commands within that environment.

This tools allows us to run repoquery on systems that may not have repoquery installed/available.

It also allows us to run queries that are not directly supported by repoquery - for example, in this check-in, it allows us to check which packages in a list are available on the target repros.

Such queries are very specific - and can be added incrementally to the tool as the need arises.

* Fix formatting (make go-tidy-all).

* Fix typo in help message.

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Needed to unblock the 3.0-dev image build

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add tool change to unblock 3.0 pipelines

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- [in progress] https://dev.azure.com/mariner-org/mariner/_build/results?buildId=441251&view=results
