### PR TITLE
Image Customizer: Add tool version.

### DIFF
--- a/toolkit/scripts/build_tag.mk
+++ b/toolkit/scripts/build_tag.mk
@@ -8,7 +8,8 @@
 
 DIST_TAG           ?= .cm2
 # Running 'git' as the owner of the repo, so it doesn't complain about the repo not belonging to root.
-BUILD_NUMBER       ?= $(call shell_real_build_only, if [ -n "$$UID" ] && [ "$$UID" -eq 0 ]; then runuser -u $$(stat -c "%U" $(PROJECT_ROOT)) -- git rev-parse --short HEAD; else git rev-parse --short HEAD; fi)
+GIT_COMMIT_ID := $(call shell_real_build_only, if [ -n "$$UID" ] && [ "$$UID" -eq 0 ]; then runuser -u $$(stat -c "%U" $(PROJECT_ROOT)) -- git rev-parse --short HEAD; else git rev-parse --short HEAD; fi)
+BUILD_NUMBER ?= $(GIT_COMMIT_ID)
 # an empty BUILD_NUMBER breaks the build later on
 ifeq ($(BUILD_NUMBER),)
    BUILD_NUMBER = non-git
@@ -16,12 +17,13 @@ endif
 # Staticly define BUILD_NUMBER so it is set only once
 BUILD_NUMBER := $(BUILD_NUMBER)
 RELEASE_MAJOR_ID   ?= 2.0
+DATETIME_AS_VERSION := $(shell date +'%Y%m%d.%H%M')
 # use minor ID defined in file (if exist) otherwise define it
 # note this file must be single line
 ifneq ($(wildcard $(OUT_DIR)/version-minor-id.config),)
    RELEASE_MINOR_ID ?= .$(shell cat $(OUT_DIR)/version-minor-id.config)
 else
-   RELEASE_MINOR_ID ?= .$(shell date +'%Y%m%d.%H%M')
+   RELEASE_MINOR_ID ?= .$(DATETIME_AS_VERSION)
 endif
 RELEASE_VERSION    ?= $(RELEASE_MAJOR_ID)$(RELEASE_MINOR_ID)
 
@@ -31,3 +33,8 @@ RELEASE_VERSION := $(RELEASE_VERSION)
 
 # Image tag - empty by default. Does not apply to the initrd.
 IMAGE_TAG          ?=
+
+# Image Customizer Version
+IMAGE_CUSTOMIZER_VERSION ?= 0.1.0
+IMAGE_CUSTOMIZER_VERSION_PREVIEW ?= -dev.$(DATETIME_AS_VERSION)+$(GIT_COMMIT_ID)
+IMAGE_CUSTOMIZER_FULL_VERSION := $(IMAGE_CUSTOMIZER_VERSION)$(IMAGE_CUSTOMIZER_VERSION_PREVIEW)

--- a/toolkit/scripts/build_tag.mk
+++ b/toolkit/scripts/build_tag.mk
@@ -34,7 +34,15 @@ RELEASE_VERSION := $(RELEASE_VERSION)
 # Image tag - empty by default. Does not apply to the initrd.
 IMAGE_TAG          ?=
 
-# Image Customizer Version
+# Mariner Image Customizer version.
+# This is using semantic versioning.
+#
+# IMAGE_CUSTOMIZER_VERSION should have the format:
+#
+#   <major>.<minor>.<patch>
+#
+# and should hold the value of the next (or current) official release, not the previous official
+# release.
 IMAGE_CUSTOMIZER_VERSION ?= 0.1.0
 IMAGE_CUSTOMIZER_VERSION_PREVIEW ?= -dev.$(DATETIME_AS_VERSION)+$(GIT_COMMIT_ID)
 IMAGE_CUSTOMIZER_FULL_VERSION := $(IMAGE_CUSTOMIZER_VERSION)$(IMAGE_CUSTOMIZER_VERSION_PREVIEW)

--- a/toolkit/scripts/tools.mk
+++ b/toolkit/scripts/tools.mk
@@ -107,8 +107,10 @@ else
 $(TOOL_BINS_DIR)/%: $(go_common_files)
 	cd $(TOOLS_DIR)/$* && \
 		go test -test.short -covermode=atomic -coverprofile=$(BUILD_DIR)/tools/$*.test_coverage ./... && \
+		TOOLKIT_VER="-X github.com/microsoft/CBL-Mariner/toolkit/tools/internal/exe.ToolkitVersion=$(RELEASE_VERSION)" && \
+		IMGCUST_VER="-X github.com/microsoft/CBL-Mariner/toolkit/tools/pkg/imagecustomizerlib.ToolVersion=$(IMAGE_CUSTOMIZER_FULL_VERSION)" && \
 		CGO_ENABLED=0 go build \
-			-ldflags="-X github.com/microsoft/CBL-Mariner/toolkit/tools/internal/exe.ToolkitVersion=$(RELEASE_VERSION)" \
+			-ldflags="$$TOOLKIT_VER $$IMGCUST_VER" \
 			-o $(TOOL_BINS_DIR)
 endif
 

--- a/toolkit/tools/imagecustomizer/main.go
+++ b/toolkit/tools/imagecustomizer/main.go
@@ -34,6 +34,7 @@ var (
 func main() {
 	var err error
 
+	app.Version(imagecustomizerlib.ToolVersion)
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 
 	logger.InitBestEffort(*logFile, *logLevel)

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -24,6 +24,10 @@ const (
 )
 
 var (
+	// Version specifies the version of the Mariner Image Customizer tool.
+	// The value of this string is inserted during compilation via a linker flag.
+	ToolVersion = ""
+
 	bootPartitionRegex   = regexp.MustCompile(`(?m)^search -n -u ([a-zA-Z0-9\-]+) -s$`)
 	rootfsPartitionRegex = regexp.MustCompile(`(?m)^set rootdevice=([A-Z]*)=([a-zA-Z0-9\-]+)$`)
 )


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->

Add a version to the image customizer tool. This version and the version format will be different from the CBL-Mariner OS.

This change updates the `Makefile` files to handle this new version. It also ensures that the `--version` CLI option reports the calculated version.

###### Change Log  <!-- REQUIRED -->

- Image Customizer: Add tool version.

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Manually ran image customizer.
