### PR TITLE
Add single transaction for image package cloner

### DIFF
--- a/toolkit/tools/graphpkgfetcher/graphpkgfetcher.go
+++ b/toolkit/tools/graphpkgfetcher/graphpkgfetcher.go
@@ -418,7 +418,7 @@ func downloadSingleDeltaRPM(realDependencyGraph *pkggraph.PkgGraph, buildNode *p
 	// already have it in the cache.
 	if !foundCacheRPM {
 		// Avoid any processing since we know the exact RPM we want to download
-		_, err = cloner.CloneRawPackageNames(downloadDependencies, false /*no transaction*/, fullyQualifiedRpmName)
+		_, err = cloner.CloneByName(downloadDependencies, fullyQualifiedRpmName)
 		if err != nil {
 			logger.Log.Warnf("Can't find delta RPM to download for %s: %s (local copy may be newer than published version)", fullyQualifiedRpmName, err)
 			return nil
@@ -480,7 +480,7 @@ func resolveSingleNode(cloner *rpmrepocloner.RpmRepoCloner, node *pkggraph.PkgNo
 				Name: resolvedPackage,
 			}
 
-			preBuilt, err = cloner.Clone(cloneDeps, desiredPackage)
+			preBuilt, err = cloner.CloneByPackageVer(cloneDeps, desiredPackage)
 			if err != nil {
 				err = fmt.Errorf("failed to clone '%s' from RPM repo:\n%w", resolvedPackage, err)
 				return

--- a/toolkit/tools/graphpkgfetcher/graphpkgfetcher.go
+++ b/toolkit/tools/graphpkgfetcher/graphpkgfetcher.go
@@ -418,7 +418,7 @@ func downloadSingleDeltaRPM(realDependencyGraph *pkggraph.PkgGraph, buildNode *p
 	// already have it in the cache.
 	if !foundCacheRPM {
 		// Avoid any processing since we know the exact RPM we want to download
-		_, err = cloner.CloneRawPackageNames(downloadDependencies, fullyQualifiedRpmName)
+		_, err = cloner.CloneRawPackageNames(downloadDependencies, false /*no transaction*/, fullyQualifiedRpmName)
 		if err != nil {
 			logger.Log.Warnf("Can't find delta RPM to download for %s: %s (local copy may be newer than published version)", fullyQualifiedRpmName, err)
 			return nil

--- a/toolkit/tools/imagepkgfetcher/imagepkgfetcher.go
+++ b/toolkit/tools/imagepkgfetcher/imagepkgfetcher.go
@@ -156,7 +156,12 @@ func cloneSystemConfigs(cloner repocloner.RepoCloner, configFile, baseDirPath st
 
 	logger.Log.Infof("Cloning: %v", packageVersionsInConfig)
 	// The image tools don't care if a package was created locally or not, just that it exists. Disregard if it is prebuilt or not.
-	_, err = cloner.Clone(cloneDeps, packageVersionsInConfig...)
+	_, err = cloner.CloneTransaction(cloneDeps, packageVersionsInConfig...)
+	if err != nil {
+		// Fallback to legacy flow with multiple transactions in case we get a OOM error from a large transaction.
+		logger.Log.Warnf("Failed to clone packages in a single transaction, will retry with individual transactions... (%s)", err)
+		_, err = cloner.Clone(cloneDeps, packageVersionsInConfig...)
+	}
 	return
 }
 

--- a/toolkit/tools/imagepkgfetcher/imagepkgfetcher.go
+++ b/toolkit/tools/imagepkgfetcher/imagepkgfetcher.go
@@ -156,11 +156,11 @@ func cloneSystemConfigs(cloner repocloner.RepoCloner, configFile, baseDirPath st
 
 	logger.Log.Infof("Cloning: %v", packageVersionsInConfig)
 	// The image tools don't care if a package was created locally or not, just that it exists. Disregard if it is prebuilt or not.
-	_, err = cloner.CloneTransaction(cloneDeps, packageVersionsInConfig...)
+	_, err = cloner.CloneByPackageVerSingleTransaction(cloneDeps, packageVersionsInConfig...)
 	if err != nil {
 		// Fallback to legacy flow with multiple transactions in case we get a OOM error from a large transaction.
 		logger.Log.Warnf("Failed to clone packages in a single transaction, will retry with individual transactions... (%s)", err)
-		_, err = cloner.Clone(cloneDeps, packageVersionsInConfig...)
+		_, err = cloner.CloneByPackageVer(cloneDeps, packageVersionsInConfig...)
 	}
 	return
 }

--- a/toolkit/tools/internal/packagerepo/repocloner/repocloner.go
+++ b/toolkit/tools/internal/packagerepo/repocloner/repocloner.go
@@ -27,6 +27,7 @@ type RepoPackage struct {
 // and their dependencies.
 type RepoCloner interface {
 	Clone(cloneDeps bool, packagesToClone ...*pkgjson.PackageVer) (allPackagesPrebuilt bool, err error)
+	CloneTransaction(cloneDeps bool, packagesToClone ...*pkgjson.PackageVer) (allPackagesPrebuilt bool, err error)
 	CloneDirectory() string
 	ClonedRepoContents() (repoContents *RepoContents, err error)
 	Close() error

--- a/toolkit/tools/internal/packagerepo/repocloner/repocloner.go
+++ b/toolkit/tools/internal/packagerepo/repocloner/repocloner.go
@@ -26,8 +26,8 @@ type RepoPackage struct {
 // It is capable of generate a local repository consisting of a set of request packages
 // and their dependencies.
 type RepoCloner interface {
-	Clone(cloneDeps bool, packagesToClone ...*pkgjson.PackageVer) (allPackagesPrebuilt bool, err error)
-	CloneTransaction(cloneDeps bool, packagesToClone ...*pkgjson.PackageVer) (allPackagesPrebuilt bool, err error)
+	CloneByPackageVer(cloneDeps bool, packagesToClone ...*pkgjson.PackageVer) (allPackagesPrebuilt bool, err error)
+	CloneByPackageVerSingleTransaction(cloneDeps bool, packagesToClone ...*pkgjson.PackageVer) (allPackagesPrebuilt bool, err error)
 	CloneDirectory() string
 	ClonedRepoContents() (repoContents *RepoContents, err error)
 	Close() error

--- a/toolkit/tools/internal/packagerepo/repocloner/rpmrepocloner/rpmrepocloner.go
+++ b/toolkit/tools/internal/packagerepo/repocloner/rpmrepocloner/rpmrepocloner.go
@@ -45,6 +45,9 @@ const (
 	repoIDCacheRegular   = "fetcher-cloned-repo"
 	repoIDPreview        = "mariner-preview"
 	repoIDToolchain      = "toolchain-repo"
+
+	useSingleTransaction    = true
+	useMultipleTransactions = !useSingleTransaction
 )
 
 // RpmRepoCloner represents an RPM repository cloner.
@@ -330,34 +333,51 @@ func (r *RpmRepoCloner) initializeMountedChrootRepo(repoDir string) (err error) 
 // If cloneDeps is set, package dependencies will also be cloned.
 // It will automatically resolve packages that describe a provide or file from a package.
 // If all packages were pre-built, the cloner will set allPackagesPrebuilt = true.
-func (r *RpmRepoCloner) Clone(cloneDeps bool, packagesToClone ...*pkgjson.PackageVer) (allPackagesPrebuilt bool, err error) {
+func (r *RpmRepoCloner) CloneByPackageVer(cloneDeps bool, packagesToClone ...*pkgjson.PackageVer) (allPackagesPrebuilt bool, err error) {
 	packageNames := []string{}
 	for _, packageToClone := range packagesToClone {
 		logger.Log.Debugf("Cloning (%s).", packageToClone)
 		packageNames = append(packageNames, convertPackageVersionToTdnfArg(packageToClone))
 	}
-	return r.CloneRawPackageNames(cloneDeps, false, packageNames...)
+	return r.CloneByName(cloneDeps, packageNames...)
 }
 
 // CloneTransaction clones the provided list of packages in a single transaction.
 // If cloneDeps is set, package dependencies will also be cloned.
 // It will automatically resolve packages that describe a provide or file from a package.
 // If all packages were pre-built, the cloner will set allPackagesPrebuilt = true.
-func (r *RpmRepoCloner) CloneTransaction(cloneDeps bool, packagesToClone ...*pkgjson.PackageVer) (allPackagesPrebuilt bool, err error) {
+func (r *RpmRepoCloner) CloneByPackageVerSingleTransaction(cloneDeps bool, packagesToClone ...*pkgjson.PackageVer) (allPackagesPrebuilt bool, err error) {
 	packageNames := []string{}
 	for _, packageToClone := range packagesToClone {
 		logger.Log.Debugf("Cloning (%s).", packageToClone)
 		packageNames = append(packageNames, convertPackageVersionToTdnfArg(packageToClone))
 	}
-	return r.CloneRawPackageNames(cloneDeps, true, packageNames...)
+	return r.CloneByNameSingleTransaction(cloneDeps, packageNames...)
 }
 
-// CloneRawPackageNames clones the provided package name exactly as specified.
+// CloneByName clones the provided package name exactly as specified, with one transaction per package.
+// Any conditional strings will be passed to tdnf verbatim (i.e. "pkg = ver1.2.3-4.cm2")
 // If cloneDeps is set, package dependencies will also be cloned.
-// If singleTransaction is true, all packages will be cloned in a single transaction.
 // This version of clone will not resolve provides or files from other packages beyond what tdnf is able to do itself.
 // If all packages were pre-built, the cloner will set allPackagesPrebuilt = true.
-func (r *RpmRepoCloner) CloneRawPackageNames(cloneDeps, singleTransaction bool, rawPackageNames ...string) (allPackagesPrebuilt bool, err error) {
+func (r *RpmRepoCloner) CloneByName(cloneDeps bool, rawPackageNames ...string) (allPackagesPrebuilt bool, err error) {
+	return r.cloneRawPackageNames(cloneDeps, useMultipleTransactions, rawPackageNames...)
+}
+
+// CloneRawPackageNames clones the provided package name exactly as specified, using a single transaction.
+// Any conditional strings will be passed to tdnf verbatim (i.e. "pkg = ver1.2.3-4.cm2")
+// If cloneDeps is set, package dependencies will also be cloned.
+// This version of clone will not resolve provides or files from other packages beyond what tdnf is able to do itself.
+// If all packages were pre-built, the cloner will set allPackagesPrebuilt = true.
+func (r *RpmRepoCloner) CloneByNameSingleTransaction(cloneDeps bool, rawPackageNames ...string) (allPackagesPrebuilt bool, err error) {
+	return r.cloneRawPackageNames(cloneDeps, useSingleTransaction, rawPackageNames...)
+}
+
+// cloneRawPackageNames clones the requested packages by name exactly as requested (including any version or condition).
+// If cloneDeps is set, package dependencies will also be cloned.
+// If singleTransaction is set, all packages will be cloned in a single transaction.
+// If all packages come from the toolchain or local builds, the cloner will set allPackagesPrebuilt = true.
+func (r *RpmRepoCloner) cloneRawPackageNames(cloneDeps, singleTransaction bool, rawPackageNames ...string) (allPackagesPrebuilt bool, err error) {
 	timestamp.StartEvent("cloning packages", nil)
 	defer timestamp.StopEvent(nil)
 

--- a/toolkit/tools/internal/packagerepo/repoutils/repoutils.go
+++ b/toolkit/tools/internal/packagerepo/repoutils/repoutils.go
@@ -38,7 +38,7 @@ func RestoreClonedRepoContents(cloner repocloner.RepoCloner, srcFile string) (er
 	uniquePackages := removePackageDuplicates(repo.Repo)
 	packagesToDownload := filterOutDownloadedPackage(uniquePackages, cloner.CloneDirectory())
 
-	_, err = cloner.Clone(cloneDeps, packagesToDownload...)
+	_, err = cloner.CloneByPackageVer(cloneDeps, packagesToDownload...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x ] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
There can be situations where we end up with conflicting package versions. Consider a config file with two packages listed (either directly or in a package list). `pkgA` which depends on a specific version of `dep`, and `pkgB` which also depends on a specific version of `dep`. Lets say that `dep-v1-1` is available in the toolchain, but we published `dep-v1-2` via a fasttrack publish. `pkgA` is also available in the toolchain.

In the current implementation we clone each package one at a time, prioritizing chroot, then toolchain, then local packages, then PMC. If we clone `pkgA`, we will try the toolchain before PMC, and successfully clone `pkgA` and `dep-v1-1`. If we then clone `pkgB` we will resort to PMC since it's not in the toolchain and get the newer `dep-v1-2`.

Fast forward to install time and we install each package in order. `pkgA` installs, and since it has a specific version requirement it will install `dev-v1-1`. We then install `pkgB`, but it will try to install `dev-v1-2` which conflicts. 

In hindsight we should have either picked an older version of `pkgB`, or downloaded a newer version of `pkgA`, so they could both use the same `dev` dependency.

Attempt to clone all packages for an image in a single transaction with a new function `CloneTransaction()`, falling back to the old flow if it fails for any reason (OOM for example).

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add CloneTransaction() to the cloner interface which attempts to clone all packages as a single transaction.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**


###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: local test only
