### PR TITLE
Imager: Fix for when user password is empty.

### DIFF
--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -1188,11 +1188,6 @@ func createUserWithPassword(installChroot *safechroot.Chroot, user configuration
 	}
 	logger.Log.Tracef("hashed password: %v", hashedPassword)
 
-	if strings.TrimSpace(hashedPassword) == "" {
-		err = fmt.Errorf("empty password for user (%s) is not allowed", user.Name)
-		return
-	}
-
 	// Create the user with the given hashed password
 	if user.Name == userutils.RootUser {
 		if user.UID != "" {


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->

Previously, if the user didn't specify a password in the config then the imager tool would corrupt the `/etc/shadow` file by putting the value `<NULL>` (which came from `openssl` CLI) in the password field.

PR #6443 fixed this for the Image Customizer tool by using the correct value of `!` in the `/etc/shadow` file to disable password login. However, that change didn't apply the fix properly to the Image tool.

###### Change Log  <!-- REQUIRED -->

- Imager: Fix for when user password is empty.

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Manually built and test live installer ISO.

