### PR TITLE
Cosmetic change with chrony removed references to NetworkManager

### DIFF
--- a/SPECS/chrony/chrony.spec
+++ b/SPECS/chrony/chrony.spec
@@ -4,7 +4,7 @@
 
 Name:           chrony
 Version:        4.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        An NTP client/server
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -44,9 +44,6 @@ Requires(pre):  shadow-utils
 
 # The 'chrony.helper' script requires the 'dig' command from 'bind-utils'.
 Requires:       bind-utils
-
-# Old NetworkManager expects the dispatcher scripts in a different place
-Conflicts:      NetworkManager < 1.20
 
 # suggest drivers for hardware reference clocks
 Suggests:       ntp-refclock
@@ -124,7 +121,6 @@ mkdir -p $RPM_BUILD_ROOT%{_sysconfdir}/{sysconfig,logrotate.d}
 mkdir -p $RPM_BUILD_ROOT%{_localstatedir}/{lib,log}/chrony
 mkdir -p $RPM_BUILD_ROOT%{_sysconfdir}/dhcp/dhclient.d
 mkdir -p $RPM_BUILD_ROOT%{_libexecdir}
-mkdir -p $RPM_BUILD_ROOT%{_prefix}/lib/NetworkManager/dispatcher.d
 mkdir -p $RPM_BUILD_ROOT{%{_unitdir},%{_prefix}/lib/systemd/ntp-units.d}
 
 install -m 644 -p chrony.conf $RPM_BUILD_ROOT%{_sysconfdir}/chrony.conf
@@ -138,10 +134,6 @@ install -m 644 -p examples/chrony.logrotate \
 
 install -m 644 -p examples/chronyd.service \
         $RPM_BUILD_ROOT%{_unitdir}/chronyd.service
-install -m 755 -p examples/chrony.nm-dispatcher.dhcp \
-        $RPM_BUILD_ROOT%{_prefix}/lib/NetworkManager/dispatcher.d/20-chrony-dhcp
-install -m 755 -p examples/chrony.nm-dispatcher.onoffline \
-        $RPM_BUILD_ROOT%{_prefix}/lib/NetworkManager/dispatcher.d/20-chrony-onoffline
 install -m 644 -p examples/chrony-wait.service \
         $RPM_BUILD_ROOT%{_unitdir}/chrony-wait.service
 install -m 644 -p %{SOURCE5} $RPM_BUILD_ROOT%{_unitdir}/chrony-dnssrv@.service
@@ -195,7 +187,6 @@ systemctl start chronyd.service
 %{_bindir}/chronyc
 %{_sbindir}/chronyd
 %{_libexecdir}/chrony-helper
-%{_prefix}/lib/NetworkManager
 %{_prefix}/lib/systemd/ntp-units.d/*.list
 %{_unitdir}/chrony*.service
 %{_unitdir}/chrony*.timer
@@ -206,6 +197,9 @@ systemctl start chronyd.service
 %dir %attr(-,chrony,chrony) %{_localstatedir}/log/chrony
 
 %changelog
+* Mon Oct 30 2023 Andy Zaugg <azaugg@linkedin.com> - 4.1-3
+- Removed references to NetworkManager
+
 * Thu May 18 2023 Tobias Brick <tobiasb@microsoft.com> - 4.1-2
 - Explicitly run chronyd as the user chrony
 


### PR DESCRIPTION

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
A small cosmetic change, Azure Linux does not use Network Manager, removing references to it.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Remove NetworkManager include files


###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**


###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Built package
```
INFO[0112][scheduler] Tested: chrony-4.1-3.cm2.src.rpm
INFO[0112][scheduler] 0 currently active build(s): [].
INFO[0112][scheduler] 0 currently active test(s): [].
INFO[0112][scheduler] All packages built
INFO[0113][scheduler] ---------------------------
INFO[0113][scheduler] --------- Summary ---------
INFO[0113][scheduler] ---------------------------
INFO[0113][scheduler] Number of built SRPMs:             1
INFO[0113][scheduler] Number of tested SRPMs:            1
INFO[0113][scheduler] Number of prebuilt SRPMs:          0
INFO[0113][scheduler] Number of prebuilt delta SRPMs:    0
INFO[0113][scheduler] Number of skipped SRPMs tests:     0
INFO[0113][scheduler] Number of failed SRPMs:            0
INFO[0113][scheduler] Number of failed SRPMs tests:      0
INFO[0113][scheduler] Number of blocked SRPMs:           0
INFO[0113][scheduler] Number of blocked SRPMs tests:     0
INFO[0113][scheduler] Number of unresolved dependencies: 0
INFO[0113][scheduler] Built SRPMs:
INFO[0113][scheduler] --> chrony-4.1-3.cm2.src.rpm
INFO[0113][scheduler] Tested SRPMs:
INFO[0113][scheduler] --> chrony-4.1-3.cm2.src.rpm
INFO[0113][scheduler] Writing DOT graph to /home/azaugg/CBL-Mariner/build/pkg_artifacts/built_graph.dot
INFO[0113][scheduler] Waiting for outstanding processes to be created
Finished updating /home/azaugg/CBL-Mariner/out/RPMS
```
- Checked package content
```
azaugg@azaugg-ld77 [ ~/CBL-Mariner/out/RPMS/x86_64 ]$ rpm -ql chrony-4.1-3.cm2.x86_64.rpm
/etc/chrony.conf
/etc/chrony.keys
/etc/dhcp/dhclient.d/chrony.sh
/etc/logrotate.d/chrony
/etc/sysconfig/chronyd
/usr/bin/chronyc
/usr/lib/systemd/ntp-units.d/50-chronyd.list
/usr/lib/systemd/system/chrony-dnssrv@.service
/usr/lib/systemd/system/chrony-dnssrv@.timer
/usr/lib/systemd/system/chrony-wait.service
/usr/lib/systemd/system/chronyd.service
/usr/libexec/chrony-helper
/usr/sbin/chronyd
/usr/share/doc/chrony
/usr/share/doc/chrony/FAQ
/usr/share/doc/chrony/NEWS
/usr/share/doc/chrony/README
/usr/share/licenses/chrony
/usr/share/licenses/chrony/COPYING
/usr/share/man/man1/chronyc.1.gz
/usr/share/man/man5/chrony.conf.5.gz
/usr/share/man/man8/chronyd.8.gz
/var/lib/chrony
/var/lib/chrony/drift
/var/lib/chrony/rtc
/var/log/chrony
```
