### PR TITLE
Pass toolchain archive to make  in pipeline template

### DIFF
--- a/.pipelines/templates/PackageBuild.yml
+++ b/.pipelines/templates/PackageBuild.yml
@@ -160,6 +160,17 @@ steps:
         displayName: "Populate RPMs cache"
 
   - script: |
+      # Make sure toolchain_archive is empty
+      if [[ -n "$toolchain_archive" ]]; then
+        echo "ERROR: toolchain_archive is not empty!" >&2
+        exit 1
+      fi
+      toolchain_archive="$(find "$(Pipeline.Workspace)" -name "${{ parameters.customToolchainTarballName }}" -print -quit)"
+      if [[ ! -f "$toolchain_archive" ]]; then
+        echo "ERROR: toolchain archive not found!" >&2
+        exit 1
+      fi
+
       if [[ ${{ parameters.isDeltaBuild }} == "true" ]]; then
         delta_fetch_arg="DELTA_FETCH=y"
       elif [[ ${{ parameters.isDeltaBuild }} == "false" ]]; then
@@ -185,6 +196,7 @@ steps:
       fi
 
       sudo make -C "${{ parameters.buildRepoRoot }}/toolkit" build-packages -j$(nproc) \
+        TOOLCHAIN_ARCHIVE="$toolchain_archive" \
         CONCURRENT_PACKAGE_BUILDS=${{ parameters.concurrentPackageBuilds }} \
         CONFIG_FILE="" \
         REBUILD_TOOLS=y \

--- a/.pipelines/templates/PackageBuild.yml
+++ b/.pipelines/templates/PackageBuild.yml
@@ -164,8 +164,11 @@ steps:
       if [[ -n "$toolchain_archive" ]]; then
         echo "ERROR: toolchain_archive is not empty!" >&2
         exit 1
+      else
+        echo "toolchain_archive is empty"
       fi
       toolchain_archive="$(find "$(Pipeline.Workspace)" -name "${{ parameters.customToolchainTarballName }}" -print -quit)"
+      echo "toolchain_archive: $toolchain_archive"
       if [[ ! -f "$toolchain_archive" ]]; then
         echo "ERROR: toolchain archive not found!" >&2
         exit 1

--- a/.pipelines/templates/PackageBuild.yml
+++ b/.pipelines/templates/PackageBuild.yml
@@ -160,15 +160,7 @@ steps:
         displayName: "Populate RPMs cache"
 
   - script: |
-      # Make sure toolchain_archive is empty
-      if [[ -n "$toolchain_archive" ]]; then
-        echo "ERROR: toolchain_archive is not empty!" >&2
-        exit 1
-      else
-        echo "toolchain_archive is empty"
-      fi
       toolchain_archive="$(find "$(Pipeline.Workspace)" -name "${{ parameters.customToolchainTarballName }}" -print -quit)"
-      echo "toolchain_archive: $toolchain_archive"
       if [[ ! -f "$toolchain_archive" ]]; then
         echo "ERROR: toolchain archive not found!" >&2
         exit 1

--- a/.pipelines/templates/PackageBuild.yml
+++ b/.pipelines/templates/PackageBuild.yml
@@ -185,7 +185,7 @@ steps:
         use_ccache_arg="USE_CCACHE=n"
       fi
 
-      if [[ -n ${{ if parameters.customToolchainArtifactName }} ]]; then
+      if [[ -n ${{ parameters.customToolchainArtifactName }} ]]; then
         toolchain_archive_arg="TOOLCHAIN_ARCHIVE=$(toolchainArchive)"
       fi
 

--- a/.pipelines/templates/PackageBuild.yml
+++ b/.pipelines/templates/PackageBuild.yml
@@ -140,7 +140,7 @@ steps:
           fi
           echo "##vso[task.setvariable variable=toolchainArchive]$toolchain_archive"
 
-          sudo make -C "${{ parameters.buildRepoRoot }}/toolkit" toolchain TOOLCHAIN_ARCHIVE="$(toolchainArchive)"
+          sudo make -C "${{ parameters.buildRepoRoot }}/toolkit" toolchain TOOLCHAIN_ARCHIVE="$toolchain_archive"
         displayName: "Populate toolchain"
 
   - ${{ if parameters.rpmsCacheArtifactName }}:

--- a/.pipelines/templates/PackageBuild.yml
+++ b/.pipelines/templates/PackageBuild.yml
@@ -138,8 +138,10 @@ steps:
             echo "ERROR: toolchain archive not found!" >&2
             exit 1
           fi
+          # Toolchain archive may be "", the tools will treat that as no custom archive.
+          echo "##vso[task.setvariable variable=toolchainArchive]$toolchain_archive"
 
-          sudo make -C "${{ parameters.buildRepoRoot }}/toolkit" toolchain TOOLCHAIN_ARCHIVE="$toolchain_archive"
+          sudo make -C "${{ parameters.buildRepoRoot }}/toolkit" toolchain TOOLCHAIN_ARCHIVE="$(toolchainArchive)"
         displayName: "Populate toolchain"
 
   - ${{ if parameters.rpmsCacheArtifactName }}:
@@ -160,12 +162,6 @@ steps:
         displayName: "Populate RPMs cache"
 
   - script: |
-      toolchain_archive="$(find "$(Pipeline.Workspace)" -name "${{ parameters.customToolchainTarballName }}" -print -quit)"
-      if [[ ! -f "$toolchain_archive" ]]; then
-        echo "ERROR: toolchain archive not found!" >&2
-        exit 1
-      fi
-
       if [[ ${{ parameters.isDeltaBuild }} == "true" ]]; then
         delta_fetch_arg="DELTA_FETCH=y"
       elif [[ ${{ parameters.isDeltaBuild }} == "false" ]]; then
@@ -191,7 +187,7 @@ steps:
       fi
 
       sudo make -C "${{ parameters.buildRepoRoot }}/toolkit" build-packages -j$(nproc) \
-        TOOLCHAIN_ARCHIVE="$toolchain_archive" \
+        TOOLCHAIN_ARCHIVE="$(toolchainArchive)" \
         CONCURRENT_PACKAGE_BUILDS=${{ parameters.concurrentPackageBuilds }} \
         CONFIG_FILE="" \
         REBUILD_TOOLS=y \

--- a/.pipelines/templates/PackageBuild.yml
+++ b/.pipelines/templates/PackageBuild.yml
@@ -185,7 +185,7 @@ steps:
         use_ccache_arg="USE_CCACHE=n"
       fi
 
-      if [[ -n ${{ parameters.customToolchainArtifactName }} ]]; then
+      if [[ -n "${{ parameters.customToolchainArtifactName }}" ]]; then
         toolchain_archive_arg="TOOLCHAIN_ARCHIVE=$(toolchainArchive)"
       fi
 

--- a/.pipelines/templates/PackageBuild.yml
+++ b/.pipelines/templates/PackageBuild.yml
@@ -138,7 +138,6 @@ steps:
             echo "ERROR: toolchain archive not found!" >&2
             exit 1
           fi
-          # Toolchain archive may be "", the tools will treat that as no custom archive.
           echo "##vso[task.setvariable variable=toolchainArchive]$toolchain_archive"
 
           sudo make -C "${{ parameters.buildRepoRoot }}/toolkit" toolchain TOOLCHAIN_ARCHIVE="$(toolchainArchive)"
@@ -186,8 +185,11 @@ steps:
         use_ccache_arg="USE_CCACHE=n"
       fi
 
+      if [[ -n ${{ if parameters.customToolchainArtifactName }} ]]; then
+        toolchain_archive_arg="TOOLCHAIN_ARCHIVE=$(toolchainArchive)"
+      fi
+
       sudo make -C "${{ parameters.buildRepoRoot }}/toolkit" build-packages -j$(nproc) \
-        TOOLCHAIN_ARCHIVE="$(toolchainArchive)" \
         CONCURRENT_PACKAGE_BUILDS=${{ parameters.concurrentPackageBuilds }} \
         CONFIG_FILE="" \
         REBUILD_TOOLS=y \
@@ -197,7 +199,8 @@ steps:
         $delta_fetch_arg \
         $quick_rebuild_packages_arg \
         $run_check_arg \
-        $use_ccache_arg
+        $use_ccache_arg \
+        $toolchain_archive_arg
     displayName: "Build packages"
 
   - ${{ if parameters.outputArtifactsFolder }}:

--- a/.pipelines/templates/PackageBuild.yml
+++ b/.pipelines/templates/PackageBuild.yml
@@ -199,8 +199,8 @@ steps:
         $delta_fetch_arg \
         $quick_rebuild_packages_arg \
         $run_check_arg \
-        $use_ccache_arg \
-        $toolchain_archive_arg
+        $toolchain_archive_arg \
+        $use_ccache_arg
     displayName: "Build packages"
 
   - ${{ if parameters.outputArtifactsFolder }}:


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
The toolkit should generally be called with a static set of inputs, we are using `TOOLCHAIN_ARCHIVE=./path/to/toolchain.tar.gz` when we call `make toolchain`. We should continue to use the same input for future commands. Generally we won't re-create the toolchain .rpms since nothing will cause a rebuild, but we should be defensive. If something DOES change, without setting `TOOLCHAIN_ARCHIVE` the toolkit will assume it should download the .rpms. This may fail if one of the toolchain packages has been bumped and was rebuild in the previous stage.

If we pass `TOOLCHAIN_ARCHIVE` to all commnads that use the toolchain the toolkit will know to extract antying that is missing from the archive instead of trying to download a missing file from PMC.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Pass `TOOLCHAIN_ARCHIVE` to the `"Build packages"` stage of `PackageBuild.yml`.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://dev.azure.com/mariner-org/mariner/_git/CBL-Mariner-Pipelines/pullrequest/16818

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=443426&view=results
