### PR TITLE
go-downloader: abort immediately on 404 errors

### DIFF
--- a/toolkit/scripts/toolchain.mk
+++ b/toolkit/scripts/toolchain.mk
@@ -195,6 +195,7 @@ $(toolchain_rpms_rehydrated): $(TOOLCHAIN_MANIFEST) $(go-downloader)
 		$(go-downloader) --no-verbose --no-clobber $$url/$$rpm_filename \
 			$(if $(TLS_CERT),--certificate=$(TLS_CERT)) \
 			$(if $(TLS_KEY),--private-key=$(TLS_KEY)) \
+			--timeout=5s \
 			--log-file $$log_file && \
 		echo "Downloaded toolchain RPM: $$rpm_filename" >> $$log_file && \
 		echo "$$rpm_filename" >> $(toolchain_downloads_manifest) | tee -a "$$log_file" && \

--- a/toolkit/scripts/toolchain.mk
+++ b/toolkit/scripts/toolchain.mk
@@ -195,7 +195,7 @@ $(toolchain_rpms_rehydrated): $(TOOLCHAIN_MANIFEST) $(go-downloader)
 		$(go-downloader) --no-verbose --no-clobber $$url/$$rpm_filename \
 			$(if $(TLS_CERT),--certificate=$(TLS_CERT)) \
 			$(if $(TLS_KEY),--private-key=$(TLS_KEY)) \
-			--timeout=5s \
+			--timeout=15s \
 			--log-file $$log_file && \
 		echo "Downloaded toolchain RPM: $$rpm_filename" >> $$log_file && \
 		echo "$$rpm_filename" >> $(toolchain_downloads_manifest) | tee -a "$$log_file" && \

--- a/toolkit/scripts/toolchain.mk
+++ b/toolkit/scripts/toolchain.mk
@@ -314,7 +314,7 @@ $(toolchain_rpms): $(TOOLCHAIN_MANIFEST) $(depend_REBUILD_TOOLCHAIN) $(go-downlo
 		$(go-downloader) --no-verbose --no-clobber $$url/$$rpm_filename \
 			$(if $(TLS_CERT),--certificate=$(TLS_CERT)) \
 			$(if $(TLS_KEY),--private-key=$(TLS_KEY)) \
-			--log-file $$log_file  2>/dev/null && \
+			--log-file $$log_file 2>/dev/null && \
 		echo "Downloaded toolchain RPM: $$rpm_filename" >> $$log_file && \
 		touch $@ && \
 		break; \

--- a/toolkit/scripts/toolchain.mk
+++ b/toolkit/scripts/toolchain.mk
@@ -195,7 +195,7 @@ $(toolchain_rpms_rehydrated): $(TOOLCHAIN_MANIFEST) $(go-downloader)
 		$(go-downloader) --no-verbose --no-clobber $$url/$$rpm_filename \
 			$(if $(TLS_CERT),--certificate=$(TLS_CERT)) \
 			$(if $(TLS_KEY),--private-key=$(TLS_KEY)) \
-			--log-file $$log_file && \
+			--log-file $$log_file 2>/dev/null && \
 		echo "Downloaded toolchain RPM: $$rpm_filename" >> $$log_file && \
 		echo "$$rpm_filename" >> $(toolchain_downloads_manifest) | tee -a "$$log_file" && \
 		touch $@ && \
@@ -314,7 +314,7 @@ $(toolchain_rpms): $(TOOLCHAIN_MANIFEST) $(depend_REBUILD_TOOLCHAIN) $(go-downlo
 		$(go-downloader) --no-verbose --no-clobber $$url/$$rpm_filename \
 			$(if $(TLS_CERT),--certificate=$(TLS_CERT)) \
 			$(if $(TLS_KEY),--private-key=$(TLS_KEY)) \
-			--log-file $$log_file && \
+			--log-file $$log_file  2>/dev/null && \
 		echo "Downloaded toolchain RPM: $$rpm_filename" >> $$log_file && \
 		touch $@ && \
 		break; \

--- a/toolkit/scripts/toolchain.mk
+++ b/toolkit/scripts/toolchain.mk
@@ -195,7 +195,6 @@ $(toolchain_rpms_rehydrated): $(TOOLCHAIN_MANIFEST) $(go-downloader)
 		$(go-downloader) --no-verbose --no-clobber $$url/$$rpm_filename \
 			$(if $(TLS_CERT),--certificate=$(TLS_CERT)) \
 			$(if $(TLS_KEY),--private-key=$(TLS_KEY)) \
-			--timeout=15s \
 			--log-file $$log_file && \
 		echo "Downloaded toolchain RPM: $$rpm_filename" >> $$log_file && \
 		echo "$$rpm_filename" >> $(toolchain_downloads_manifest) | tee -a "$$log_file" && \

--- a/toolkit/tools/downloader/downloader.go
+++ b/toolkit/tools/downloader/downloader.go
@@ -128,9 +128,11 @@ func downloadFile(srcUrl, dstFile string, caCerts *x509.CertPool, tlsCerts []tls
 		netErr := network.DownloadFile(srcUrl, dstFile, caCerts, tlsCerts)
 		if netErr != nil {
 			// Check if the error contains the string "invalid response: 404", we should print a warning in that case so the
-			// sees it even if we are running with --no-verbose.
+			// sees it even if we are running with --no-verbose. 404's are unlikely to fix themselves on retry, give up.
 			if netErr.Error() == "invalid response: 404" {
 				logger.Log.Warnf("Attempt %d/%d: Failed to download '%s' with error: '%s'", retryNum, downloadRetryAttempts, srcUrl, netErr)
+				logger.Log.Warnf("404 errors are likely unrecoverable, will not retry")
+				close(cancel)
 			} else {
 				logger.Log.Infof("Attempt %d/%d: Failed to download '%s' with error: '%s'", retryNum, downloadRetryAttempts, srcUrl, netErr)
 			}

--- a/toolkit/tools/downloader/downloader.go
+++ b/toolkit/tools/downloader/downloader.go
@@ -31,7 +31,6 @@ var (
 	logLevel  = exe.LogLevelFlag(app)
 	noClobber = app.Flag("no-clobber", "Do not overwrite existing files").Bool()
 	noVerbose = app.Flag("no-verbose", "Do not print verbose output").Bool()
-	timeout   = app.Flag("timeout", "Stops retrying after this duration (up to the max of 6 attempts)").Default("0").Duration()
 
 	caCertFile    = app.Flag("ca-certificate", "Root certificate authority to use when downloading files.").String()
 	tlsClientCert = app.Flag("certificate", "TLS client certificate to use when downloading files.").String()
@@ -101,13 +100,13 @@ func main() {
 		}
 	}
 
-	err = downloadFile(*srcUrl, *dstFile, caCerts, tlsCerts, *timeout)
+	err = downloadFile(*srcUrl, *dstFile, caCerts, tlsCerts)
 	if err != nil {
 		logger.Log.Fatalf("Failed to download (%s) to (%s). Error:\n%s", *srcUrl, *dstFile, err)
 	}
 }
 
-func downloadFile(srcUrl, dstFile string, caCerts *x509.CertPool, tlsCerts []tls.Certificate, timeout time.Duration) (err error) {
+func downloadFile(srcUrl, dstFile string, caCerts *x509.CertPool, tlsCerts []tls.Certificate) (err error) {
 	const (
 		// With 6 attempts, initial delay of 1 second, and a backoff factor of 3.0 the total time spent retrying will be
 		// 1 + 3 + 9 + 27 + 81 = 121 seconds.
@@ -115,16 +114,10 @@ func downloadFile(srcUrl, dstFile string, caCerts *x509.CertPool, tlsCerts []tls
 		failureBackoffBase    = 3.0
 		downloadRetryDuration = time.Second
 	)
-	cancel := make(chan struct{})
-	if timeout > 0 {
-		go func() {
-			time.Sleep(timeout)
-			close(cancel)
-		}()
-	}
+	var noCancel chan struct{} = nil
 
 	retryNum := 1
-	timedOut, err := retry.RunWithExpBackoff(func() error {
+	_, err = retry.RunWithExpBackoff(func() error {
 		netErr := network.DownloadFile(srcUrl, dstFile, caCerts, tlsCerts)
 		if netErr != nil {
 			// Check if the error contains the string "invalid response: 404", we should print a warning in that case so the
@@ -132,19 +125,14 @@ func downloadFile(srcUrl, dstFile string, caCerts *x509.CertPool, tlsCerts []tls
 			if netErr.Error() == "invalid response: 404" {
 				logger.Log.Warnf("Attempt %d/%d: Failed to download '%s' with error: '%s'", retryNum, downloadRetryAttempts, srcUrl, netErr)
 				logger.Log.Warnf("404 errors are likely unrecoverable, will not retry")
-				close(cancel)
+				close(noCancel)
 			} else {
 				logger.Log.Infof("Attempt %d/%d: Failed to download '%s' with error: '%s'", retryNum, downloadRetryAttempts, srcUrl, netErr)
 			}
 		}
 		retryNum++
 		return netErr
-	}, downloadRetryAttempts, downloadRetryDuration, failureBackoffBase, cancel)
-
-	if timedOut {
-		err = fmt.Errorf("timed out downloading (%s) after %s", srcUrl, timeout)
-		return
-	}
+	}, downloadRetryAttempts, downloadRetryDuration, failureBackoffBase, noCancel)
 
 	if err != nil {
 		err = fmt.Errorf("failed to download (%s) to (%s). Error:\n%w", srcUrl, dstFile, err)


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
The delta toolchain downloader is fully serial, so the new retry logic on the downloads has a significant effect on the runtime. We expect many of these downloads to return 404 errors. Even if we limit the retry to 5s we get a maximum of `594 * 5sec = ~45min`. This is too much for a delta build. Generally, a 404 won't resolve with retrying, so just give up immediately for 404 errors.

We also hide output from the tool (`2> /dev/null`) since we will expect some errors (we will 404 debuginfo no matter what since its not in the base repo). The makefile will report an error if all options faile.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- `downloader` considers `404` a "valid" response, so does not continue to retry.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local tests
