### PR TITLE
Fixing missing nobody user/group for nfs squash

### DIFF
--- a/SPECS/nfs-utils/nfs-utils.spec
+++ b/SPECS/nfs-utils/nfs-utils.spec
@@ -1,7 +1,7 @@
 Summary:        NFS client utils
 Name:           nfs-utils
 Version:        2.5.4
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        MIT and GPLv2 and GPLv2+ and BSD
 URL:            https://linux-nfs.org/
 Group:          Applications/Nfs-utils-client
@@ -125,10 +125,10 @@ make check
 
 %pre
 if ! getent group nobody >/dev/null; then
-    groupadd -r nobody
+    groupadd -r -g 65534 nobody
 fi
 if ! getent passwd nobody >/dev/null; then
-    useradd -g named -s /bin/false -M -r nobody
+    useradd -g named -u 65534 -s /bin/false -M -r nobody
 fi
 
 %post
@@ -167,6 +167,9 @@ fi
 %{_libdir}/libnfsidmap.so
 
 %changelog
+* Wed Nov 01 2023 Andy Zaugg <azaugg@linkedin.com> - 2.5.4-4
+- Fix post-install script to create nobody user instead of named user
+
 * Wed Sep 20 2023 Jon Slobodzian <joslobo@microsoft.com> - 2.5.4-3
 - Recompile with stack-protection fixed gcc version (CVE-2023-4039)
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
Installing nfs-utils creates a unnecessary group with a GID that is not generally standard for squash on NFS. 

###### Change Log  <!-- REQUIRED -->
- Create a nobody group as stated in the LSB
- Add the nobody group, so when installing nfs-utils we don't get a new group with a non expected GID
- nfs-utils generally should create the user nobody, not named

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Build package filesystem
```
azaugg@azaugg-ld77 [ ~/CBL-Mariner/toolkit ]$ sudo make build-packages -j$(nproc) REBUILD_TOOLS=y SRPM_PACK_LIST="filesystem" PACKAGE_REBUILD_LIST="filesystem" REFRESH_WORKER_CHROOT=y RUN_CHECK=y
...
...

azaugg@azaugg-ld77 [ ~/CBL-Mariner/out/RPMS/x86_64 ]$ cp filesystem-1.1-18.cm2.x86_64.rpm /tmp/
azaugg@azaugg-ld77 [ /tmp ]$ rpm2cpio filesystem-1.1-18.cm2.x86_64.rpm |cpio -idm
azaugg@azaugg-ld77 [ /tmp/ ]$ cat etc/group |grep nobody
nobody:x:65534:
```
- Build nfs-utils
```
azaugg@azaugg-ld77 [ ~/CBL-Mariner/toolkit ]$ sudo make build-packages -j$(nproc) REBUILD_TOOLS=y SRPM_PACK_LIST="nfs-utils" PACKAGE_REBUILD_LIST="nfs-utils" REFRESH_WORKER_CHROOT=y RUN_CHECK=y
...
...
azaugg@azaugg-ld77 [ ~/CBL-Mariner/toolkit ]$ rpm -q --scripts   -p ../out/RPMS/x86_64/nfs-utils-2.5.4-4.cm2.x86_64.rpm
preinstall scriptlet (using /bin/sh):
if ! getent group nobody >/dev/null; then
    groupadd -r -g 65534 nobody
fi
if ! getent passwd nobody >/dev/null; then
    useradd -g nobody -u 65534 -s /bin/false -M -r nobody
fi
postinstall scriptlet (using /bin/sh):
/sbin/ldconfig


if [ $1 -eq 1 ] && [ -x "/usr/lib/systemd/systemd-update-helper" ]; then
    # Initial installation
    /usr/lib/systemd/systemd-update-helper install-system-units nfs-server.service || :
fi
preuninstall scriptlet (using /bin/sh):


if [ $1 -eq 0 ] && [ -x "/usr/lib/systemd/systemd-update-helper" ]; then
    # Package removal, not upgrade
    /usr/lib/systemd/systemd-update-helper remove-system-units nfs-server.service || :
fi
postuninstall scriptlet (using /bin/sh):
/sbin/ldconfig


if [ $1 -ge 1 ] && [ -x "/usr/lib/systemd/systemd-update-helper" ]; then
    # Package upgrade, not uninstall
    /usr/lib/systemd/systemd-update-helper mark-restart-system-units nfs-server.service || :
fi

```