### PR TITLE
Add kata-containers-cc patch to retain uvm dependencies

### DIFF
--- a/SPECS/kata-containers-cc/kata-containers-cc.spec
+++ b/SPECS/kata-containers-cc/kata-containers-cc.spec
@@ -8,7 +8,7 @@
 
 Name:         kata-containers-cc
 Version:      0.6.1
-Release:      3%{?dist}
+Release:      4%{?dist}
 Summary:      Kata Confidential Containers
 License:      ASL 2.0
 Vendor:       Microsoft Corporation
@@ -19,6 +19,7 @@ Source2:      %{name}-%{version}-cargo.tar.gz
 Source3:      mariner-coco-build-uvm.sh
 Patch0:       0001-tardev-snapshotter-enable-feature-impl_trait_in_asso.patch
 Patch1:       drop-mut-for-variables-that-are-not-mutated.patch
+Patch2:       keep-uvm-rootfs-dependencies.patch
 
 ExclusiveArch: x86_64
 
@@ -290,8 +291,11 @@ install -D -m 0755 %{_builddir}/%{name}-%{version}/tools/osbuilder/image-builder
 %exclude %{osbuilder}/tools/osbuilder/rootfs-builder/ubuntu
 
 %changelog
-* Mon Oct 16 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 0.6.1-3
-- Bump release to rebuild with go 1.20.10
+*   Fri Nov 3 2023 Dallas Delaney <dadelan@microsoft.com> - 0.6.1-4
+-   Add patch to retain UVM rootfs dependencies
+
+*   Mon Oct 16 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 0.6.1-3
+-   Bump release to rebuild with go 1.20.10
 
 *   Tue Oct 10 2023 Dan Streetman <ddstreet@ieee.org> - 0.6.1-2
 -   Bump release to rebuild with updated version of Go.

--- a/SPECS/kata-containers-cc/keep-uvm-rootfs-dependencies.patch
+++ b/SPECS/kata-containers-cc/keep-uvm-rootfs-dependencies.patch
@@ -1,0 +1,32 @@
+From 6e102a0341a926d8c271bf04472a87d924569910 Mon Sep 17 00:00:00 2001
+From: dallasd1 <dadelan@microsoft.com>
+Date: Fri, 3 Nov 2023 08:35:42 -0700
+Subject: [PATCH] Don't remove UVM packages with dependencies and add back
+ zstd-lib dependency
+
+---
+ tools/osbuilder/rootfs-builder/cbl-mariner/rootfs_lib.sh | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/tools/osbuilder/rootfs-builder/cbl-mariner/rootfs_lib.sh b/tools/osbuilder/rootfs-builder/cbl-mariner/rootfs_lib.sh
+index 0988f08f6..7663c669e 100644
+--- a/tools/osbuilder/rootfs-builder/cbl-mariner/rootfs_lib.sh
++++ b/tools/osbuilder/rootfs-builder/cbl-mariner/rootfs_lib.sh
+@@ -78,13 +78,12 @@ build_rootfs()
+ 		"tar" \
+ 		"tzdata" \
+ 		"xz" \
+-		"zstd-libs" \
+ 	)
+ 
+ 	for MARINER_REMOVED_PACKAGE in ${MARINER_REMOVED_PACKAGES[@]}
+ 	do
+ 		info "removing package ${MARINER_REMOVED_PACKAGE}"
+-		rpm -e "${MARINER_REMOVED_PACKAGE}" --nodeps --root=${ROOTFS_DIR}
++		rpm -e "${MARINER_REMOVED_PACKAGE}" --root=${ROOTFS_DIR}
+ 	done
+ 
+ 	rm -rf ${ROOTFS_DIR}/usr/share/{bash-completion,cracklib,doc,info,locale,man,misc,pixmaps,terminfo,zoneinfo,zsh}
+-- 
+2.17.1
+

--- a/SPECS/kata-containers-cc/keep-uvm-rootfs-dependencies.patch
+++ b/SPECS/kata-containers-cc/keep-uvm-rootfs-dependencies.patch
@@ -1,18 +1,17 @@
-From 6e102a0341a926d8c271bf04472a87d924569910 Mon Sep 17 00:00:00 2001
+From e2ef156d481aacc24f20695c0ec65c81e4f85c17 Mon Sep 17 00:00:00 2001
 From: dallasd1 <dadelan@microsoft.com>
-Date: Fri, 3 Nov 2023 08:35:42 -0700
-Subject: [PATCH] Don't remove UVM packages with dependencies and add back
- zstd-lib dependency
+Date: Thu, 2 Nov 2023 19:58:26 -0700
+Subject: [PATCH] Keep zstd-libs in UVM rootfs
 
 ---
- tools/osbuilder/rootfs-builder/cbl-mariner/rootfs_lib.sh | 3 +--
- 1 file changed, 1 insertion(+), 2 deletions(-)
+ tools/osbuilder/rootfs-builder/cbl-mariner/rootfs_lib.sh | 1 -
+ 1 file changed, 1 deletion(-)
 
 diff --git a/tools/osbuilder/rootfs-builder/cbl-mariner/rootfs_lib.sh b/tools/osbuilder/rootfs-builder/cbl-mariner/rootfs_lib.sh
-index 0988f08f6..7663c669e 100644
+index 0988f08f6..359a1c4d9 100644
 --- a/tools/osbuilder/rootfs-builder/cbl-mariner/rootfs_lib.sh
 +++ b/tools/osbuilder/rootfs-builder/cbl-mariner/rootfs_lib.sh
-@@ -78,13 +78,12 @@ build_rootfs()
+@@ -78,7 +78,6 @@ build_rootfs()
  		"tar" \
  		"tzdata" \
  		"xz" \
@@ -20,13 +19,6 @@ index 0988f08f6..7663c669e 100644
  	)
  
  	for MARINER_REMOVED_PACKAGE in ${MARINER_REMOVED_PACKAGES[@]}
- 	do
- 		info "removing package ${MARINER_REMOVED_PACKAGE}"
--		rpm -e "${MARINER_REMOVED_PACKAGE}" --nodeps --root=${ROOTFS_DIR}
-+		rpm -e "${MARINER_REMOVED_PACKAGE}" --root=${ROOTFS_DIR}
- 	done
- 
- 	rm -rf ${ROOTFS_DIR}/usr/share/{bash-completion,cracklib,doc,info,locale,man,misc,pixmaps,terminfo,zoneinfo,zsh}
 -- 
 2.17.1
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
The kata-cc UVM build process pulls in core-packages-base-image as a meta package and removes some unused packages to reduce the image size and optimize boot time. Package zstd-libs is one of these removed packages but has since become a dependency necessary to boot the UVM. This change adds zstd-libs back to the UVM.

Boot sequence with missing zstd-libs:
```
[    0.593882] Run /sbin/init as init process

/sbin/init: error while loading shared libraries: libzstd.so.1: cannot open shared object file: No such file or directory
[    0.647950] Kernel panic - not syncing: Attempted to kill init! exitcode=0x00007f00
[    0.648635] CPU: 0 PID: 1 Comm: init Not tainted 6.1.0.mshv11 #1
[    0.649059] Call Trace:

[    0.649251]  <TASK>
[    0.649529]  dump_stack_lvl+0x3b/0x59
[    0.649881]  panic+0xfb/0x264
[    0.650240]  do_exit.cold+0x15/0x15

[    0.650639]  do_group_exit+0x28/0x80
[    0.651034]  __x64_sys_exit_group+0xf/0x10
[    0.651436]  do_syscall_64+0x43/0x90
[    0.651842]  entry_SYSCALL_64_after_hwframe+0x63/0xcd

[    0.652283] RIP: 0033:0x7f92ce4c6151

[    0.653296] Code: 1f 84 00 00 00 00 00 66 90 f3 0f 1e fa be e7 00 00 00 ba 3c 00 00 00 eb 0d 89 d0 0f 05 48 3d 00 f0 ff ff 77 1c f4 89 f0 0f 05 <48> 3d 00 f0 ff ff 76 e7 f7 d8 89 05 ff 40 01 00 eb dd 0f 1f 44 00
[    0.654484] RSP: 002b:00007fffb0a5e4d8 EFLAGS: 00000246 ORIG_RAX: 00000000000000e7

[    0.655344] RAX: ffffffffffffffda RBX: 0000000000000002 RCX: 00007f92ce4c6151
[    0.656023] RDX: 000000000000003c RSI: 00000000000000e7 RDI: 000000000000007f
[    0.656712] RBP: 00007fffb0a5f110 R08: 0000000000000001 R09: 0000000000000000
[    0.657410] R10: 00000000ffffffff R11: 0000000000000246 R12: 00007f92ce4d0668
[    0.658092] R13: 00007f92ce32e9ff R14: 00007f92ce32ea10 R15: 0000000000000000
[    0.658577]  </TASK>
[    0.658987] Kernel Offset: disabled

[    0.659359] Rebooting in 1 seconds..
```

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add patch for kata-containers-cc

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Buddy build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=445693&view=results
