### PR TITLE
upgrade mysql to 8.0.34

### DIFF
--- a/SPECS/mysql/mysql.signatures.json
+++ b/SPECS/mysql/mysql.signatures.json
@@ -1,5 +1,5 @@
 {
   "Signatures": {
-    "mysql-boost-8.0.33.tar.gz": "ae31e6368617776b43c82436c3736900067fada1289032f3ac3392f7380bcb58"
+    "mysql-boost-8.0.34.tar.gz": "0b881a19bcef732cd4dbbfc8dfeb84eff61f5dfe0d9788d015d699733e0adf1f"
   }
 }

--- a/SPECS/mysql/mysql.spec
+++ b/SPECS/mysql/mysql.spec
@@ -1,6 +1,6 @@
 Summary:        MySQL.
 Name:           mysql
-Version:        8.0.33
+Version:        8.0.34
 Release:        1%{?dist}
 License:        GPLv2 with exceptions AND LGPLv2 AND BSD
 Vendor:         Microsoft Corporation
@@ -80,6 +80,9 @@ make test
 %{_libdir}/pkgconfig/mysqlclient.pc
 
 %changelog
+* Mon Oct 31 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 8.0.34-1
+- Auto-upgrade to 8.0.34 - address CVE-2023-22053, CVE-2023-22054, CVE-2023-22056, CVE-2023-22058, CVE-2023-22065, CVE-2023-22110, CVE-2023-22111, CVE-2023-22113, CVE-2023-22115
+
 * Mon Apr 24 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 8.0.33-1
 - Auto-upgrade to 8.0.33 - address CVE-2023-21976, CVE-2023-21972, CVE-2023-21982, CVE-2023-21977, CVE-2023-21980
 

--- a/SPECS/mysql/mysql.spec
+++ b/SPECS/mysql/mysql.spec
@@ -72,15 +72,15 @@ make test
 %files devel
 %{_libdir}/*.so
 %{_libdir}/*.a
-%{_libdir}/private/icudt69l/brkitr/*.res
-%{_libdir}/private/icudt69l/brkitr/*.brk
-%{_libdir}/private/icudt69l/brkitr/*.dict
-%{_libdir}/private/icudt69l/unames.icu
+%{_libdir}/private/icudt73l/brkitr/*.res
+%{_libdir}/private/icudt73l/brkitr/*.brk
+%{_libdir}/private/icudt73l/brkitr/*.dict
+%{_libdir}/private/icudt73l/unames.icu
 %{_includedir}/*
 %{_libdir}/pkgconfig/mysqlclient.pc
 
 %changelog
-* Mon Oct 31 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 8.0.34-1
+* Wed Nov 1 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 8.0.34-1
 - Auto-upgrade to 8.0.34 - address CVE-2023-22053, CVE-2023-22054, CVE-2023-22056, CVE-2023-22058, CVE-2023-22065, CVE-2023-22110, CVE-2023-22111, CVE-2023-22113, CVE-2023-22115
 
 * Mon Apr 24 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 8.0.33-1

--- a/SPECS/mysql/mysql.spec
+++ b/SPECS/mysql/mysql.spec
@@ -76,6 +76,9 @@ make test
 %{_libdir}/private/icudt73l/brkitr/*.brk
 %{_libdir}/private/icudt73l/brkitr/*.dict
 %{_libdir}/private/icudt73l/unames.icu
+%{_libdir}/private/icudt73l/cnvalias.icu
+%{_libdir}/private/icudt73l/uemoji.icu
+%{_libdir}/private/icudt73l/ulayout.icu
 %{_includedir}/*
 %{_libdir}/pkgconfig/mysqlclient.pc
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -13743,8 +13743,8 @@
         "type": "other",
         "other": {
           "name": "mysql",
-          "version": "8.0.33",
-          "downloadUrl": "https://dev.mysql.com/get/Downloads/MySQL-8.0/mysql-boost-8.0.33.tar.gz"
+          "version": "8.0.34",
+          "downloadUrl": "https://dev.mysql.com/get/Downloads/MySQL-8.0/mysql-boost-8.0.34.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?

Update mysql to v8.0.34 to resolve unavailable medium cves

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Update mysql to v8.0.34 
- Fix CVE: CVE-2023-22053, CVE-2023-22054, CVE-2023-22056, CVE-2023-22058, CVE-2023-22065, CVE-2023-22110, CVE-2023-22111, CVE-2023-22113, CVE-2023-22115
- New files were added, upgrade ICU lib to v73 to mysql in this commit and [commit link] (https://github.com/mysql/mysql-server/commit/6b0c75e9d2283d09b572514c790ff25a7d701699) Adding these files to the mysql-devel package.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
NO

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2023-22053
- https://nvd.nist.gov/vuln/detail/CVE-2023-22054
- https://nvd.nist.gov/vuln/detail/CVE-2023-22056
- https://nvd.nist.gov/vuln/detail/CVE-2023-22058
- https://nvd.nist.gov/vuln/detail/CVE-2023-22065
- https://nvd.nist.gov/vuln/detail/CVE-2023-22110
- https://nvd.nist.gov/vuln/detail/CVE-2023-22111
- https://nvd.nist.gov/vuln/detail/CVE-2023-22113
- https://nvd.nist.gov/vuln/detail/CVE-2023-22115
###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
buddy build https://dev.azure.com/mariner-org/mariner/_build/results?buildId=444387&view=results
https://dev.azure.com/mariner-org/mariner/_build/results?buildId=444896&view=results