### PR TITLE
No password: Use `*` instead of `!`.

### DIFF
--- a/toolkit/tools/internal/userutils/userutils.go
+++ b/toolkit/tools/internal/userutils/userutils.go
@@ -93,8 +93,11 @@ func UpdateUserPassword(installRoot, username, hashedPassword string) error {
 	shadowFilePath := filepath.Join(installRoot, ShadowFile)
 
 	if hashedPassword == "" {
-		// In the /etc/shadow file, `!` means there is no password and password login is disabled.
-		hashedPassword = "!"
+		// In the /etc/shadow file, `*` means there is no password and password login is disabled, while still
+		// permitting ssh login using public/private keys.
+		// In theory, `!` should also work. But some versions of ssh interpret that as disabling the user, even for ssh
+		// logins.
+		hashedPassword = "*"
 	}
 
 	// Find the line that starts with "<user>:<password>:..."

--- a/toolkit/tools/internal/userutils/userutils.go
+++ b/toolkit/tools/internal/userutils/userutils.go
@@ -93,10 +93,13 @@ func UpdateUserPassword(installRoot, username, hashedPassword string) error {
 	shadowFilePath := filepath.Join(installRoot, ShadowFile)
 
 	if hashedPassword == "" {
-		// In the /etc/shadow file, `*` means there is no password and password login is disabled, while still
-		// permitting ssh login using public/private keys.
-		// In theory, `!` should also work. But some versions of ssh interpret that as disabling the user, even for ssh
-		// logins.
+		// In the /etc/shadow file, the values `*` and `!` both mean the user's password login is disabled but the user
+		// may login using other means (e.g. ssh, auto-login, etc.). This interpretation is also used by PAM. When sshd
+		// has `UsePAM` set to `yes`, then sshd defers to PAM the decision on whether or not the user is disabled.
+		// However, when `UsePAM` is set to `no`, then sshd must make this interpretation for itself. And the Mariner
+		// build of sshd is configured to interpret the `!` in the shadow file to mean the user is fully disabled, even
+		// for ssh login. But it interprets `*` to mean that only password login is disabled but sshd public/private key
+		// login is fine.
 		hashedPassword = "*"
 	}
 

--- a/toolkit/tools/internal/userutils/userutils_test.go
+++ b/toolkit/tools/internal/userutils/userutils_test.go
@@ -80,20 +80,20 @@ func TestHashPasswordNotEmpty(t *testing.T) {
 }
 
 func TestUpdateUserPasswordEmptyToEmpty(t *testing.T) {
-	testUpdateUserPassword(t, "root:!:19634:7:99999:7:::", "root:!:19634:7:99999:7:::", "root", "")
+	testUpdateUserPassword(t, "root:*:19634:7:99999:7:::", "root:*:19634:7:99999:7:::", "root", "")
 }
 
 func TestUpdateUserPasswordSomethingToEmpty(t *testing.T) {
 	testUpdateUserPassword(t,
 		"root:$6$E0M9VkDvOLvO$nr9FjmIiSSP5C5V3Lhuqv4VzWmscABoiQ0mF.ZTbwKEN4nS60nsiU17qA/RGMbXHtJfci/DeLT1Zu2nhNFbwQ.:19634:7:99999:7:::",
-		"root:!:19634:7:99999:7:::",
+		"root:*:19634:7:99999:7:::",
 		"root",
 		"")
 }
 
 func TestUpdateUserPassword(t *testing.T) {
 	testUpdateUserPassword(t,
-		"root:!:19634:7:99999:7:::",
+		"root:*:19634:7:99999:7:::",
 		"root:$6$E0M9VkDvOLvO$nr9FjmIiSSP5C5V3Lhuqv4VzWmscABoiQ0mF.ZTbwKEN4nS60nsiU17qA/RGMbXHtJfci/DeLT1Zu2nhNFbwQ.:19634:7:99999:7:::",
 		"root",
 		"$6$E0M9VkDvOLvO$nr9FjmIiSSP5C5V3Lhuqv4VzWmscABoiQ0mF.ZTbwKEN4nS60nsiU17qA/RGMbXHtJfci/DeLT1Zu2nhNFbwQ.")


### PR DESCRIPTION

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->

When sshd has `UsePAM yes` in its config, then sshd defers the decision about whether or not the user is disabled to PAM. And PAM does not consider the value of `!` in the shadow file to represent the user being disabled.

However, when sshd has `UsePAM no`, then sshd must make the determination itself about whether the user is disabled or not. And sshd considers `!` in the shadow file to mean the user is disabled.

###### Change Log  <!-- REQUIRED -->

- No password: Use `*` instead of `!`.

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Manual testing

