### PR TITLE
Clarify that passwords are not permitted for production use in meta user data configuration file

### DIFF
--- a/toolkit/resources/assets/meta-user-data/user-data
+++ b/toolkit/resources/assets/meta-user-data/user-data
@@ -5,7 +5,7 @@ users:
    shell: /bin/bash
    sudo: [ "ALL=(ALL:ALL) ALL" ]
    lock_passwd: false
-   # The usage of plain_text_password and passwd is strongly discouraged in the production setting.
+   # The usage of plain_text_password and passwd is not permitted in the production setting.
    # ssh-authorized-keys should be used instead for enhanced security.
    plain_text_passwd: <YOUR PASSWORD HERE. NOT RECOMMENDED>
    groups: sudo, docker


### PR DESCRIPTION
Per internal audit clarified the text for usage of passwords 