### PR TITLE
Merge meta user data fixes to 3.0-dev branch

### DIFF
--- a/toolkit/docs/quick_start/quickstart.md
+++ b/toolkit/docs/quick_start/quickstart.md
@@ -87,11 +87,7 @@ choose DVD Drive and press Add.
 
 1. Right click your VM and select _Connect..._.
 1. Select _Start_.
-1. Wait for CBL-Mariner to boot to the login prompt, then sign in with:
-
-       mariner_user
-       p@ssw0rd
-
+1. Wait for CBL-Mariner to boot to the login prompt, then sign in with the username and password you provisioned in the meta-user-data.iso above.
 
 ### ISO Image
 

--- a/toolkit/resources/assets/meta-user-data/user-data
+++ b/toolkit/resources/assets/meta-user-data/user-data
@@ -5,7 +5,7 @@ users:
    shell: /bin/bash
    sudo: [ "ALL=(ALL:ALL) ALL" ]
    lock_passwd: false
-   # The usage of plain_text_password and passwd is strongly discouraged in the production setting.
+   # The usage of plain_text_password and passwd is not permitted in the production setting.
    # ssh-authorized-keys should be used instead for enhanced security.
    plain_text_passwd: <YOUR PASSWORD HERE. NOT RECOMMENDED>
    groups: sudo, docker


### PR DESCRIPTION
Removed sample username and password information. Instructions now describe how to use provisioned username and password.