### PR TITLE
Added CredScan exception for doc and test sample secrets.

### DIFF
--- a/.config/CredScanSuppressions.json
+++ b/.config/CredScanSuppressions.json
@@ -26,11 +26,11 @@
             "_justification": "Secret for a sample, non-production Mariner image."
         },
         {
-            "file": "\\toolkit\\imagecustomizer\\docs\\configuration.md",
+            "file": "\\toolkit\\tools\\imagecustomizer\\docs\\configuration.md",
             "_justification": "Secrets from documentation samples. No production secrets."
         },
         {
-            "file": "\\toolkit\\pkg\\imagecustomizerlib\\testdata\\addusers-config.yaml",
+            "file": "\\toolkit\\tools\\pkg\\imagecustomizerlib\\testdata\\addusers-config.yaml",
             "_justification": "Dummy secrets used to unit test configuration code."
         }
     ]

--- a/.config/CredScanSuppressions.json
+++ b/.config/CredScanSuppressions.json
@@ -24,6 +24,14 @@
         {
             "file": "\\toolkit\\imageconfigs\\read-only-root-efi.json",
             "_justification": "Secret for a sample, non-production Mariner image."
+        },
+        {
+            "file": "\\toolkit\\imagecustomizer\\docs\\configuration.md",
+            "_justification": "Secrets from documentation samples. No production secrets."
+        },
+        {
+            "file": "\\toolkit\\pkg\\imagecustomizerlib\\testdata\\addusers-config.yaml",
+            "_justification": "Dummy secrets used to unit test configuration code."
         }
     ]
 }


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

[Recent CredScan runs](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=448990&view=results) have revealed two new secrets in our code. Fortunately, one is a sample secret in the documentation and another inside a configuration file used as test data. No actual secrets to worry about, so I'm extending the CredScan exceptions to cover these two files.

The CredScan is blocking fast-track PR checks.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Updated `CredScanSuppressions.json` to ignore `toolkit/imagecustomizer/docs/configuration.md` and `toolkit/pkg/imagecustomizerlib/testdata/addusers-config.yaml`.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #6696

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- N/A - doc changes.