### PR TITLE
Using separate buffer per analyzed spec in `rpmssnapshot.go`.

### DIFF
--- a/toolkit/tools/pkg/rpmssnapshot/rpmssnapshot.go
+++ b/toolkit/tools/pkg/rpmssnapshot/rpmssnapshot.go
@@ -169,14 +169,14 @@ func (s *SnapshotGenerator) readBuiltRPMs(specPaths []string, defines map[string
 		specDirPath := filepath.Dir(specPath)
 
 		go func(pathIter string) {
-			builtRPMs, err := rpm.QuerySPECForBuiltRPMs(pathIter, specDirPath, buildArch, defines)
-			if err != nil {
-				err = fmt.Errorf("failed to query built RPMs from (%s):\n%w", pathIter, err)
+			builtRPMs, queryErr := rpm.QuerySPECForBuiltRPMs(pathIter, specDirPath, buildArch, defines)
+			if queryErr != nil {
+				queryErr = fmt.Errorf("failed to query built RPMs from (%s):\n%w", pathIter, queryErr)
 			}
 
 			resultsChannel <- SnapshotResult{
 				rpms: builtRPMs,
-				err:  err,
+				err:  queryErr,
 			}
 		}(specPath)
 	}

--- a/toolkit/tools/pkg/rpmssnapshot/rpmssnapshot.go
+++ b/toolkit/tools/pkg/rpmssnapshot/rpmssnapshot.go
@@ -152,8 +152,6 @@ func (s *SnapshotGenerator) generateSnapshotInChroot(distTag string) (err error)
 }
 
 func (s *SnapshotGenerator) readBuiltRPMs(specPaths []string, defines map[string]string) (allBuiltRPMs []string, err error) {
-	var builtRPMs []string
-
 	buildArch, err := rpm.GetRpmArch(runtime.GOARCH)
 	if err != nil {
 		return
@@ -171,7 +169,7 @@ func (s *SnapshotGenerator) readBuiltRPMs(specPaths []string, defines map[string
 		specDirPath := filepath.Dir(specPath)
 
 		go func(pathIter string) {
-			builtRPMs, err = rpm.QuerySPECForBuiltRPMs(pathIter, specDirPath, buildArch, defines)
+			builtRPMs, err := rpm.QuerySPECForBuiltRPMs(pathIter, specDirPath, buildArch, defines)
 			if err != nil {
 				err = fmt.Errorf("failed to query built RPMs from (%s):\n%w", pathIter, err)
 			}


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

Occasionally, we'd get [a segfault coming from inside `rpmssnapshot.go:convertResultsToRepoContents()`](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=449140&view=logs&j=e459516c-3865-59c8-4722-7df34429222e&t=9c0c2a89-c5ad-507a-8d51-259303ab0653&l=1279). My current suspicion is that this might be due to the `builtRPMs` slice shared by multiple threads inside the `readBuiltRPMs`. Since slices are not thread-safe, it's possible for it to get partially overwritten by a different thread while it's `SnapshotResult.rpms` is being populate to be sent into the results channel.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Switched to using a separate output buffer for each worker thread inside `rpmssnapshot.go:convertResultsToRepoContents()`.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local tests.