### PR TITLE
kubernetes: fix version subcommand for components

### DIFF
--- a/SPECS/kubernetes/kubernetes.spec
+++ b/SPECS/kubernetes/kubernetes.spec
@@ -93,7 +93,7 @@ Pause component for Microsoft Kubernetes %{version}.
 %setup -q -c -n %{name}
 
 %build
-# set version information using version file
+# set version information using KUBE_GIT_VERSION
 # (see k8s code: hack/lib/version.sh for more detail)
 export KUBE_GIT_TREE_STATE=archive
 export KUBE_GIT_VERSION=v%{version}

--- a/SPECS/kubernetes/kubernetes.spec
+++ b/SPECS/kubernetes/kubernetes.spec
@@ -10,7 +10,7 @@
 Summary:        Microsoft Kubernetes
 Name:           kubernetes
 Version:        1.28.3
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -95,7 +95,8 @@ Pause component for Microsoft Kubernetes %{version}.
 %build
 # set version information using version file
 # (see k8s code: hack/lib/version.sh for more detail)
-export KUBE_GIT_VERSION_FILE=%{_builddir}/%{name}/version-file.sh
+export KUBE_GIT_TREE_STATE=archive
+export KUBE_GIT_VERSION=v%{version}
 
 # build host and container image related components
 echo "+++ build kubernetes components"
@@ -262,6 +263,9 @@ fi
 %{_exec_prefix}/local/bin/pause
 
 %changelog
+* Fri Nov 10 2023 Muhammad Falak <mwani@microsoft.com> - 1.28.3-2
+- Fix version subcommand for components
+
 * Mon Oct 23 2023 Nicolas Guibourge <nicolasg@microsoft.com> - 1.28.3-1
 - Upgrade to 1.28.3 to address CVE-2023-44487 and CVE-2023-39325.
 


### PR DESCRIPTION
Signed-off-by: Muhammad Falak R Wani <falakreyaz@gmail.com>

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?

Fixes: #6719

The KUBE_GIT_VERSION_FILE seems to be not present in the release.
Use the alternative KUBE_GIT_VERSION instead.
Reference: https://github.com/kubernetes/kubernetes/blob/v1.28.3/hack/lib/version.sh#L26

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Fix `version` subcommand for components

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #6719

###### Links to CVEs  <!-- optional -->
- NA

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: [PR-6722](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=450075&view=results)
- Local build w/o `RUN_CHECK=y` & verified with an install in a AzureLinux VM

```bash
root [ ~ ]# rpm -qa | grep kubeadm
kubernetes-kubeadm-1.28.3-2.cm2.x86_64
root [ ~ ]# kubeadm version
kubeadm version: &version.Info{Major:"1", Minor:"28", GitVersion:"v1.28.3", GitCommit:"a8a1abc25cad87333840cd7d54be2efaf31a3177", GitTreeState:"archive", BuildDate:"2023-11-10T08:27:30Z", GoVersion:"go1.20.7", Compiler:"gc", Platform:"linux/amd64"}
```
