### PR TITLE
Toolkit: Move `ConfigureDiskBootloader` function.

### DIFF
--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -934,6 +934,92 @@ func addEntryToCrypttab(installRoot string, devicePath string, encryptedRoot dis
 	return
 }
 
+func ConfigureDiskBootloader(bootType string, encryptionEnable bool, readOnlyVerityRootEnable bool,
+	partitionSettings []configuration.PartitionSetting, kernelCommandLine configuration.KernelCommandLine,
+	installChroot *safechroot.Chroot, diskDevPath string, installMap map[string]string,
+	encryptedRoot diskutils.EncryptedRootDevice, readOnlyRoot diskutils.VerityDevice,
+) (err error) {
+	timestamp.StartEvent("configuring bootloader", nil)
+	defer timestamp.StopEvent(nil)
+
+	const rootMountPoint = "/"
+	const bootMountPoint = "/boot"
+
+	var rootDevice string
+
+	// Add bootloader. Prefer a separate boot partition if one exists.
+	bootDevice, isBootPartitionSeparate := installMap[bootMountPoint]
+	bootPrefix := ""
+	if !isBootPartitionSeparate {
+		bootDevice = installMap[rootMountPoint]
+		// If we do not have a separate boot partition we will need to add a prefix to all paths used in the configs.
+		bootPrefix = "/boot"
+	}
+
+	if installMap[rootMountPoint] == NullDevice {
+		// In case of overlay device being mounted at root, no need to change the bootloader.
+		return
+	}
+
+	// Grub only accepts UUID, not PARTUUID or PARTLABEL
+	bootUUID, err := GetUUID(bootDevice)
+	if err != nil {
+		err = fmt.Errorf("failed to get UUID: %s", err)
+		return
+	}
+
+	err = InstallBootloader(installChroot, encryptionEnable, bootType, bootUUID, bootPrefix, diskDevPath)
+	if err != nil {
+		err = fmt.Errorf("failed to install bootloader: %s", err)
+		return
+	}
+
+	// Add grub config to image
+	rootPartitionSetting := configuration.FindRootPartitionSetting(partitionSettings)
+	if rootPartitionSetting == nil {
+		err = fmt.Errorf("failed to find partition setting for root mountpoint")
+		return
+	}
+	rootMountIdentifier := rootPartitionSetting.MountIdentifier
+	if encryptionEnable {
+		// Encrypted devices don't currently support identifiers
+		rootDevice = installMap[rootMountPoint]
+	} else if readOnlyVerityRootEnable {
+		var partIdentifier string
+		partIdentifier, err = FormatMountIdentifier(rootMountIdentifier, readOnlyRoot.BackingDevice)
+		if err != nil {
+			err = fmt.Errorf("failed to get partIdentifier: %s", err)
+			return
+		}
+		rootDevice = fmt.Sprintf("verityroot:%v", partIdentifier)
+	} else {
+		var partIdentifier string
+		partIdentifier, err = FormatMountIdentifier(rootMountIdentifier, installMap[rootMountPoint])
+		if err != nil {
+			err = fmt.Errorf("failed to get partIdentifier: %s", err)
+			return
+		}
+
+		rootDevice = partIdentifier
+	}
+
+	// Grub will always use filesystem UUID, never PARTUUID or PARTLABEL
+	err = InstallGrubCfg(installChroot.RootDir(), rootDevice, bootUUID, bootPrefix, encryptedRoot,
+		kernelCommandLine, readOnlyRoot, isBootPartitionSeparate)
+	if err != nil {
+		err = fmt.Errorf("failed to install main grub config file: %s", err)
+		return
+	}
+
+	err = InstallGrubEnv(installChroot.RootDir())
+	if err != nil {
+		err = fmt.Errorf("failed to install grubenv file: %s", err)
+		return
+	}
+
+	return
+}
+
 // InstallGrubEnv installs an empty grubenv f
 func InstallGrubEnv(installRoot string) (err error) {
 	const (

--- a/toolkit/tools/imager/imager.go
+++ b/toolkit/tools/imager/imager.go
@@ -605,7 +605,9 @@ func buildImage(mountPointMap, mountPointToFsTypeMap, mountPointToMountArgsMap, 
 
 	// Only configure the bootloader or read only partitions for actual disks, a rootfs does not need these
 	if !isRootFS {
-		err = configureDiskBootloader(systemConfig, installChroot, diskDevPath, installMap, encryptedRoot, readOnlyRoot)
+		err = installutils.ConfigureDiskBootloader(systemConfig.BootType, systemConfig.Encryption.Enable,
+			systemConfig.ReadOnlyVerityRoot.Enable, systemConfig.PartitionSettings, systemConfig.KernelCommandLine,
+			installChroot, diskDevPath, installMap, encryptedRoot, readOnlyRoot)
 		if err != nil {
 			err = fmt.Errorf("failed to configure boot loader: %w", err)
 			return
@@ -647,90 +649,6 @@ func buildImage(mountPointMap, mountPointToFsTypeMap, mountPointToMountArgsMap, 
 	err = installutils.RunFinalizeImageScripts(installChroot, systemConfig)
 	if err != nil {
 		err = fmt.Errorf("failed to run finalize image script: %s", err)
-		return
-	}
-
-	return
-}
-
-func configureDiskBootloader(systemConfig configuration.SystemConfig, installChroot *safechroot.Chroot, diskDevPath string, installMap map[string]string, encryptedRoot diskutils.EncryptedRootDevice, readOnlyRoot diskutils.VerityDevice) (err error) {
-	timestamp.StartEvent("configuring bootloader", nil)
-	timestamp.StopEvent(nil)
-
-	const rootMountPoint = "/"
-	const bootMountPoint = "/boot"
-
-	var rootDevice string
-
-	// Add bootloader. Prefer a separate boot partition if one exists.
-	bootDevice, isBootPartitionSeparate := installMap[bootMountPoint]
-	bootPrefix := ""
-	if !isBootPartitionSeparate {
-		bootDevice = installMap[rootMountPoint]
-		// If we do not have a separate boot partition we will need to add a prefix to all paths used in the configs.
-		bootPrefix = "/boot"
-	}
-
-	if installMap[rootMountPoint] == installutils.NullDevice {
-		// In case of overlay device being mounted at root, no need to change the bootloader.
-		return
-	}
-
-	// Grub only accepts UUID, not PARTUUID or PARTLABEL
-	bootUUID, err := installutils.GetUUID(bootDevice)
-	if err != nil {
-		err = fmt.Errorf("failed to get UUID: %s", err)
-		return
-	}
-
-	bootType := systemConfig.BootType
-	err = installutils.InstallBootloader(installChroot, systemConfig.Encryption.Enable, bootType, bootUUID, bootPrefix,
-		diskDevPath)
-	if err != nil {
-		err = fmt.Errorf("failed to install bootloader: %s", err)
-		return
-	}
-
-	// Add grub config to image
-	rootPartitionSetting := systemConfig.GetRootPartitionSetting()
-	if rootPartitionSetting == nil {
-		err = fmt.Errorf("failed to find partition setting for root mountpoint")
-		return
-	}
-	rootMountIdentifier := rootPartitionSetting.MountIdentifier
-	if systemConfig.Encryption.Enable {
-		// Encrypted devices don't currently support identifiers
-		rootDevice = installMap[rootMountPoint]
-	} else if systemConfig.ReadOnlyVerityRoot.Enable {
-		var partIdentifier string
-		partIdentifier, err = installutils.FormatMountIdentifier(rootMountIdentifier, readOnlyRoot.BackingDevice)
-		if err != nil {
-			err = fmt.Errorf("failed to get partIdentifier: %s", err)
-			return
-		}
-		rootDevice = fmt.Sprintf("verityroot:%v", partIdentifier)
-	} else {
-		var partIdentifier string
-		partIdentifier, err = installutils.FormatMountIdentifier(rootMountIdentifier, installMap[rootMountPoint])
-		if err != nil {
-			err = fmt.Errorf("failed to get partIdentifier: %s", err)
-			return
-		}
-
-		rootDevice = partIdentifier
-	}
-
-	// Grub will always use filesystem UUID, never PARTUUID or PARTLABEL
-	err = installutils.InstallGrubCfg(installChroot.RootDir(), rootDevice, bootUUID, bootPrefix, encryptedRoot,
-		systemConfig.KernelCommandLine, readOnlyRoot, isBootPartitionSeparate)
-	if err != nil {
-		err = fmt.Errorf("failed to install main grub config file: %s", err)
-		return
-	}
-
-	err = installutils.InstallGrubEnv(installChroot.RootDir())
-	if err != nil {
-		err = fmt.Errorf("failed to install grubenv file: %s", err)
 		return
 	}
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->

Move the `ConfigureDiskBootloader` function into the `installutils` package. This is being done so that it is usable by the image customizer tool.

###### Change Log  <!-- REQUIRED -->

- Toolkit: Move `ConfigureDiskBootloader` function.

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Ran toolkit UTs,
- Built core-efi image and booted it.
