### PR TITLE
toolkit: fix user instructions on toolchain build error

### DIFF
--- a/toolkit/scripts/toolchain/toolchain_verify.sh
+++ b/toolkit/scripts/toolchain/toolchain_verify.sh
@@ -13,14 +13,14 @@ echo Verify machine is ready to build toolchain
 mount > output_mount
 if grep toolchain output_mount; then
   echo It looks like a toolchain directory is still mounted
-  echo Unmount the directory, then run make toolchain-cleanup
+  echo Unmount the directory
   exit 1
 else
   echo No mounted toolchain directories found
 fi
 if grep $MARINER_BUILD_DIR output_mount; then
   echo It looks like a stage directory is still mounted
-  echo Unmount the directory, then run make toolchain-cleanup
+  echo Unmount the directory
   exit 1
 else
   echo No mounted stage directories found

--- a/toolkit/scripts/toolchain/toolchain_verify.sh
+++ b/toolkit/scripts/toolchain/toolchain_verify.sh
@@ -13,14 +13,14 @@ echo Verify machine is ready to build toolchain
 mount > output_mount
 if grep toolchain output_mount; then
   echo It looks like a toolchain directory is still mounted
-  echo Unmount the directory
+  echo Unmount the directory, then run 'make clean-toolchain'
   exit 1
 else
   echo No mounted toolchain directories found
 fi
 if grep $MARINER_BUILD_DIR output_mount; then
   echo It looks like a stage directory is still mounted
-  echo Unmount the directory
+  echo Unmount the directory, then run 'make clean-toolchain'
   exit 1
 else
   echo No mounted stage directories found


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
toolkit: fix user instructions in case of error

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- If toolchain_verify.sh script detects an error with mounts, it outputs `It looks like a toolchain directory is still mounted. Unmount the directory, then run make toolchain-cleanup` to the user, but we don't have a `toolchain-cleanup` make target. Changing it to the correct target, `clean-toolchain`

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- None