### PR TITLE
Toolkit: Add retry to safemount.Close().

### DIFF
--- a/toolkit/tools/internal/safemount/main_test.go
+++ b/toolkit/tools/internal/safemount/main_test.go
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package safemount
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/logger"
+)
+
+var (
+	tmpDir     string
+	workingDir string
+)
+
+func TestMain(m *testing.M) {
+	var err error
+
+	logger.InitStderrLog()
+
+	workingDir, err = os.Getwd()
+	if err != nil {
+		logger.Log.Panicf("Failed to get working directory, error: %s", err)
+	}
+
+	tmpDir = filepath.Join(workingDir, "_tmp")
+
+	err = os.MkdirAll(tmpDir, os.ModePerm)
+	if err != nil {
+		logger.Log.Panicf("Failed to create tmp directory, error: %s", err)
+	}
+
+	retVal := m.Run()
+
+	err = os.RemoveAll(tmpDir)
+	if err != nil {
+		logger.Log.Warnf("Failed to cleanup tmp dir (%s). Error: %s", tmpDir, err)
+	}
+
+	os.Exit(retVal)
+}

--- a/toolkit/tools/internal/safemount/safemount_test.go
+++ b/toolkit/tools/internal/safemount/safemount_test.go
@@ -1,0 +1,124 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package safemount
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/imagegen/configuration"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/imagegen/diskutils"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/buildpipeline"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/file"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/safeloopback"
+	"github.com/moby/sys/mountinfo"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResourceBusy(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Short mode enabled")
+	}
+
+	if !buildpipeline.IsRegularBuild() {
+		t.Skip("loopback block device not available")
+	}
+
+	if os.Geteuid() != 0 {
+		t.Skip("Test must be run as root because it uses loopback devices")
+	}
+
+	buildDir := filepath.Join(tmpDir, "TestResourceBusy")
+	err := os.MkdirAll(buildDir, 0o770)
+	if !assert.NoError(t, err, "failed to test temp directory (%s)", buildDir) {
+		return
+	}
+
+	diskConfig := configuration.Disk{
+		PartitionTableType: configuration.PartitionTableTypeGpt,
+		MaxSize:            4096,
+		Partitions: []configuration.Partition{
+			{
+				ID:     "a",
+				Start:  1,
+				End:    0,
+				FsType: "ext4",
+			},
+		},
+	}
+
+	// Create raw disk image file.
+	rawDisk, err := diskutils.CreateEmptyDisk(buildDir, "disk.raw", diskConfig.MaxSize)
+	assert.NoError(t, err, "failed to create empty disk file (%s)", buildDir)
+
+	// Connect raw disk image file.
+	loopback, err := safeloopback.NewLoopback(rawDisk)
+	if !assert.NoError(t, err, "failed to mount raw disk as a loopback device (%s)", rawDisk) {
+		return
+	}
+	defer loopback.Close()
+
+	// Set up partitions.
+	_, _, _, _, err = diskutils.CreatePartitions(loopback.DevicePath(), diskConfig,
+		configuration.RootEncryption{}, configuration.ReadOnlyVerityRoot{})
+	if !assert.NoError(t, err, "failed to create partitions on disk", loopback.DevicePath()) {
+		return
+	}
+
+	// Mount the partition.
+	partitionDevPath := loopback.DevicePath() + "p1"
+	partitionMountPath := filepath.Join(buildDir, "mount")
+
+	mount, err := NewMount(partitionDevPath, partitionMountPath, "ext4", 0, "", true)
+	if !assert.NoError(t, err, "failed to mount partition", partitionDevPath, partitionMountPath) {
+		return
+	}
+	defer mount.Close()
+
+	// Check that the mount exists.
+	exists, err := file.PathExists(partitionMountPath)
+	if !assert.NoError(t, err, "failed to check if mount directory exists") {
+		return
+	}
+	if !assert.Equal(t, true, exists, "mount directory doesn't exist") {
+		return
+	}
+
+	isMounted, err := mountinfo.Mounted(partitionMountPath)
+	if !assert.NoError(t, err, "failed to check if directory is not a mount point") {
+		return
+	}
+	if !assert.Equal(t, true, isMounted, "directory is not a mount point") {
+		return
+	}
+
+	// Open a file.
+	fileOnPartitionPath := filepath.Join(partitionMountPath, "test")
+
+	fileOnPartition, err := os.OpenFile(fileOnPartitionPath, os.O_RDWR|os.O_CREATE, 0)
+	if !assert.NoErrorf(t, err, "failed to open file", fileOnPartitionPath) {
+		return
+	}
+	defer fileOnPartition.Close()
+
+	// Try to close the mount.
+	err = mount.CleanClose()
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "busy")
+
+	// Close the file.
+	fileOnPartition.Close()
+
+	// Try to close the mount again.
+	err = mount.CleanClose()
+	assert.NoError(t, err, "failed to close the mount")
+
+	// Make sure directory is deleted.
+	exists, err = file.PathExists(partitionMountPath)
+	if !assert.NoError(t, err, "failed to check if mount still directory exists") {
+		return
+	}
+	assert.Equal(t, false, exists, "mount directory still exists")
+}


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->

Adds a retry loop when safemount attempts to unmount the directory. This should hopefully prevent the resource busy errors that very occasionally appear.

###### Change Log  <!-- REQUIRED -->

- Toolkit: Add retry to safemount.Close().

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Add UT.

