### PR TITLE
update to cloud-init 23.3.3 and make cloud-init network fallback configuration work

### DIFF
--- a/SPECS/cloud-init/cloud-init.signatures.json
+++ b/SPECS/cloud-init/cloud-init.signatures.json
@@ -1,6 +1,5 @@
 {
  "Signatures": {
-  "10-azure-kvp.cfg": "79e0370c010be5cd4717960e4b414570c9ec6e6d29aede77ccecc43d2b03bb9a",
-  "cloud-init-23.3.tar.gz": "1a5a54369f78891b79f43061c1ff0fb31e2bd74ff9527d7150ddd6517c3e2b07"
+  "cloud-init-23.3.3.tar.gz": "60c6e970ea0a97732478524007b3d4d13425b075d5d1c63c6cb89f2ce8ac7489"
  }
 }

--- a/SPECS/cloud-init/cloud-init.spec
+++ b/SPECS/cloud-init/cloud-init.spec
@@ -1,15 +1,16 @@
 Summary:        Cloud instance init scripts
 Name:           cloud-init
-Version:        23.3
+Version:        23.3.3
 Release:        1%{?dist}
 License:        GPLv3
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Group:          System Environment/Base
 URL:            https://launchpad.net/cloud-init
-Source0:        https://launchpad.net/cloud-init/trunk/%{version}/+download/%{name}-%{version}.tar.gz
+Source0:        https://github.com/canonical/%{name}/archive/refs/tags/%{version}.tar.gz#%{name}-%{version}.tar.gz
 Source1:        10-azure-kvp.cfg
 Patch0:         overrideDatasourceDetection.patch
+Patch1:         make_fallback_network_config_work.patch
 %define cl_services cloud-config.service cloud-config.target cloud-final.service cloud-init.service cloud-init.target cloud-init-local.service
 BuildRequires:  automake
 BuildRequires:  dbus
@@ -143,6 +144,11 @@ make check %{?_smp_mflags}
 %config(noreplace) %{_sysconfdir}/cloud/cloud.cfg.d/10-azure-kvp.cfg
 
 %changelog
+* Tue Oct 15 2023 Dan Streetman <ddstreet@ieee.org> - 23.3.3-1
+- Upgrade to cloud-init 23.3.3
+- Remove Photon-specific behavior of refusal to setup fallback network
+- Update Source0 to point to actual upstream URL
+
 * Tue Oct 10 2023 Minghe Ren <mingheren@microsoft.com> - 23.3-1
 - Upgrade to cloud-init 23.3 and remove unnecessary testGetInterfacesUnitTest.patch
 

--- a/SPECS/cloud-init/make_fallback_network_config_work.patch
+++ b/SPECS/cloud-init/make_fallback_network_config_work.patch
@@ -1,0 +1,12 @@
+diff -urpN cloud-init-23.3/cloudinit/distros/photon.py b/cloudinit/distros/photon.py
+--- cloud-init-23.3/cloudinit/distros/photon.py	2023-08-28 12:20:24.000000000 -0400
++++ b/cloudinit/distros/photon.py	2023-11-15 08:28:15.823815993 -0500
+@@ -55,7 +55,7 @@ class Distro(distros.Distro):
+ 
+     def generate_fallback_config(self):
+         key = "disable_fallback_netcfg"
+-        disable_fallback_netcfg = self._cfg.get(key, True)
++        disable_fallback_netcfg = self._cfg.get(key, False)
+         LOG.debug("%s value is: %s", key, disable_fallback_netcfg)
+ 
+         if not disable_fallback_netcfg:

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -1807,8 +1807,8 @@
         "type": "other",
         "other": {
           "name": "cloud-init",
-          "version": "23.3",
-          "downloadUrl": "https://launchpad.net/cloud-init/trunk/23.3/+download/cloud-init-23.3.tar.gz"
+          "version": "23.3.3",
+          "downloadUrl": "https://github.com/canonical/cloud-init/archive/refs/tags/23.3.3.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

update to cloud-init 23.3.3, and disable the Photon-specific behavior of refusing to perform fallback network configuration.