### PR TITLE
Print logs on build/test failure

### DIFF
--- a/toolkit/tools/scheduler/schedulerutils/buildworker.go
+++ b/toolkit/tools/scheduler/schedulerutils/buildworker.go
@@ -299,7 +299,7 @@ func testSRPMFile(agent buildagents.BuildAgent, checkAttempts int, basePackageNa
 
 		_, logFile, buildErr = agent.BuildPackage(basePackageName, srpmFile, logBaseName, outArch, runCheck, dependencies)
 		if buildErr != nil {
-			logger.Log.Warnf("Test build for '%s' failed on a non-test build issue. Error: %s", srpmFile, buildErr)
+			logger.Log.Warnf("Test build for '%s' failed on a non-test build issue. Error: %s, for details see: %s", srpmFile, buildErr, logFile)
 			return
 		}
 
@@ -309,7 +309,7 @@ func testSRPMFile(agent buildagents.BuildAgent, checkAttempts int, basePackageNa
 	}, checkAttempts, retryDuration)
 
 	if err != nil && checkFailed {
-		logger.Log.Warnf("Tests failed for '%s'. Error: %s", srpmFile, err)
+		logger.Log.Warnf("Tests failed for '%s'. Error: %s, for details see: %s", srpmFile, err, logFile)
 		err = nil
 	}
 	return


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Currently, our build output only shows if test of SRPM(s) failed. It doesn't point to the logs which contain details on failure.
This change prints the path to logs so we can debug the failure
Before the log message was:
`Test build for /path/to/srpm failed on a non-test build issue. Error: exit status 2`
`Tests failed for /path/to/srpm. Error: package test failed. Test status line ... EXIT STATUS 127`
and now the log message will look like:
`Test build for /path/to/srpm failed on a non-test build issue. Error: exit status 2, for details see /path/to/logs`
`Tests failed for /path/to/srpm. Error: package test failed. Test status line ... EXIT STATUS 127, for details see /path/to/logs`
Co-Authored by @AZaugg

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Print path to logs when SRPM build/test fails, so we can find the build issue from the logs
- Without this change, the output shows that the build failed, but we don't see the path to the test failure, and therefore, can't triage it

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- [#46098944](https://microsoft.visualstudio.com/OS/_workitems/edit/46098944)

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Locally built and confirmed the changes in output

Before:
Output shows that tests failed but does not point to logs, so we don't know how to fix the failure

![image](https://github.com/microsoft/CBL-Mariner/assets/58672330/aabc4376-71a0-4148-8186-546c2b2bdfc8)

![image](https://github.com/microsoft/CBL-Mariner/assets/58672330/e1548728-2452-4d22-a8eb-f15ad261e1cb)


After:
Output shows the path to logs on failure:

![image](https://github.com/microsoft/CBL-Mariner/assets/58672330/6c847902-ee21-47f4-878b-4a7ec937cbd0)

![image](https://github.com/microsoft/CBL-Mariner/assets/58672330/8211a43f-1a53-407e-bdce-95de1c9320ad)

Co-Authored by @AZaugg