### PR TITLE
fix cloud init sources

### DIFF
--- a/SPECS/cloud-init/cloud-init.signatures.json
+++ b/SPECS/cloud-init/cloud-init.signatures.json
@@ -1,5 +1,6 @@
 {
  "Signatures": {
+  "10-azure-kvp.cfg": "79e0370c010be5cd4717960e4b414570c9ec6e6d29aede77ccecc43d2b03bb9a",
   "cloud-init-23.3.3.tar.gz": "60c6e970ea0a97732478524007b3d4d13425b075d5d1c63c6cb89f2ce8ac7489"
  }
 }

--- a/SPECS/cloud-init/cloud-init.spec
+++ b/SPECS/cloud-init/cloud-init.spec
@@ -7,7 +7,7 @@ Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Group:          System Environment/Base
 URL:            https://launchpad.net/cloud-init
-Source0:        https://github.com/canonical/%{name}/archive/refs/tags/%{version}.tar.gz#%{name}-%{version}.tar.gz
+Source0:        https://github.com/canonical/%{name}/archive/refs/tags/%{version}.tar.gz#/%{name}-%{version}.tar.gz
 Source1:        10-azure-kvp.cfg
 Patch0:         overrideDatasourceDetection.patch
 Patch1:         make_fallback_network_config_work.patch


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Fix the following build break:
```
WARN[0058][srpmpacker] Failed to download (https://cblmarinerstorage.blob.core.windows.net/sources/core/23.3.3.tar.gz#cloud-init-23.3.3.tar.gz). Error: invalid response: 404 
ERRO[0058][srpmpacker] unable to hydrate file: 23.3.3.tar.gz#cloud-init-23.3.3.tar.gz 
ERRO[0058][srpmpacker] unable to hydrate file: 10-azure-kvp.cfg     
ERRO[0058][srpmpacker] Failed to pack (/specs/cloud-init/cloud-init.spec). Cancelling outstanding workers. Error: unable to hydrate file: 10-azure-kvp.cfg 
PANI[0078][srpmpacker] unable to hydrate file: 10-azure-kvp.cfg     
panic: (*logrus.Entry) 0xc003800070
```

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change cloud-init spec and signatures.json

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- sudo make input-srpms REBUILD_TOOLS=y
