### PR TITLE
Enable SELinux labelling for targzip rootFS image formats

### DIFF
--- a/toolkit/docs/formats/imageconfig.md
+++ b/toolkit/docs/formats/imageconfig.md
@@ -407,6 +407,9 @@ The Security Enhanced Linux (SELinux) feature is enabled by using the `SELinux` 
 This will instruct init (systemd) to set the configured mode on boot.  The `force_enforcing` option will set enforcing in the config and also add `enforcing=1` in the kernel command line,
 which is a higher precedent than the config file. This ensures SELinux boots in enforcing even if the /etc/selinux/config was altered.
 
+#### SELinuxPolicy
+An optional field to overwrite the SELinux policy package name. If not set, the default is `selinux-policy`.
+
 #### CGroup
 The version for CGroup in Mariner images can be enabled by using the `CGroup` key with value containing which version to use on boot. The value that can be chosen is either `version_one` or `version_two`.
 The `version_two` value will set the cgroupv2 to be used in Mariner by setting the config value `systemd.unified_cgroup_hierarchy=1` in the default kernel command line. The value `version_one` or no value set will keep cgroupv1 (current default) to be enabled on boot.

--- a/toolkit/docs/formats/imageconfig.md
+++ b/toolkit/docs/formats/imageconfig.md
@@ -116,9 +116,9 @@ A PartitionSetting may set a `MountIdentifier` to control how a partition is ide
 `partlabel` may not be used with `mbr` disks, and requires the `Name` key in the corresponding `Partition` be populated. An example with the rootfs mounted via `PARTLABEL=my_rootfs`, but the boot mount using the default `PARTUUID=<PARTUUID>`:
 ``` json
 "Partitions": [
-    
+
     ...
-    
+
     {
         "ID": "rootfs",
         "Name": "my_rootfs",
@@ -270,7 +270,7 @@ Fields:
 
 ### Networks
 
-The `Networks` entry is added to enable the users to specify the network configuration parameters to enable users to set IP address, configure the hostname, DNS etc. Currently, the Mariner tooling only supports a subset of the kickstart network command options: `bootproto`, `gateway`, `ip`, `net mask`, `DNS` and `device`. Hostname can be configured using the `Hostname` entry of the image config. 
+The `Networks` entry is added to enable the users to specify the network configuration parameters to enable users to set IP address, configure the hostname, DNS etc. Currently, the Mariner tooling only supports a subset of the kickstart network command options: `bootproto`, `gateway`, `ip`, `net mask`, `DNS` and `device`. Hostname can be configured using the `Hostname` entry of the image config.
 
 A sample Networks entry pointing to one network configuration:
 ``` json
@@ -375,7 +375,7 @@ The GUI installer does not currently support read-only roots.
 - `ValidateOnBoot`: Run a validation of the full disk at boot time, normally blocks are validated only as needed. This can take several minutes if the disk is corrupted.
 - `VerityErrorBehavior`: Indicate additional special system behavior when encountering an unrecoverable verity corruption. One of `"ignore"`, `"restart"`, `"panic"`. Normal behavior is to return an IO error when reading corrupt blocks.
 - `TmpfsOverlays`: Mount these paths as writable overlays backed by a tmpfs in memory.
-- `TmpfsOverlaySize`: Maximum amount of memory the overlays may use. Maybe be one of three forms: `"1234"`, `"1234[k,m,g]"`, `"20%"` (default is `"20%"`) 
+- `TmpfsOverlaySize`: Maximum amount of memory the overlays may use. Maybe be one of three forms: `"1234"`, `"1234[k,m,g]"`, `"20%"` (default is `"20%"`)
 - `TmpfsOverlayDebugEnabled`: Make the tmpfs overlay mounts easily accessible for debugging purposes. They can be found in /mnt/verity_overlay_debug_tmpfs. Include the
     `verity-read-only-root-debug-tools` package to create the required mount points.
 
@@ -408,7 +408,7 @@ This will instruct init (systemd) to set the configured mode on boot.  The `forc
 which is a higher precedent than the config file. This ensures SELinux boots in enforcing even if the /etc/selinux/config was altered.
 
 #### CGroup
-The version for CGroup in Mariner images can be enabled by using the `CGroup` key with value containing which version to use on boot. The value that can be chosen is either `version_one` or `version_two`. 
+The version for CGroup in Mariner images can be enabled by using the `CGroup` key with value containing which version to use on boot. The value that can be chosen is either `version_one` or `version_two`.
 The `version_two` value will set the cgroupv2 to be used in Mariner by setting the config value `systemd.unified_cgroup_hierarchy=1` in the default kernel command line. The value `version_one` or no value set will keep cgroupv1 (current default) to be enabled on boot.
 For more information about cgroups with Kubernetes, see [About cgroupv2](https://kubernetes.io/docs/concepts/architecture/cgroups/).
 
@@ -426,6 +426,15 @@ A sample KernelCommandLine enabling SELinux and booting in enforcing mode:
 ``` json
 "KernelCommandLine": {
     "SELinux": "enforcing"
+},
+```
+
+A sample KernelCommandLine enabling SELinux and overwriting the default 'selinux-policy' package name:
+
+``` json
+"KernelCommandLine": {
+    "SELinux": "enforcing",
+    "SELinuxPolicy": "my-selinux-policy"
 },
 ```
 

--- a/toolkit/tools/imageconfigvalidator/imageconfigvalidator.go
+++ b/toolkit/tools/imageconfigvalidator/imageconfigvalidator.go
@@ -145,7 +145,7 @@ func validatePackages(config configuration.Config) (err error) {
 			if pkg == dracutFipsPkgName {
 				foundDracutFipsPackage = true
 			}
-			if pkg == selinuxPkgName {
+			if strings.Contains(pkg, selinuxPkgName) {
 				foundSELinuxPackage = true
 			}
 		}

--- a/toolkit/tools/imageconfigvalidator/imageconfigvalidator.go
+++ b/toolkit/tools/imageconfigvalidator/imageconfigvalidator.go
@@ -114,7 +114,6 @@ func validatePackages(config configuration.Config) (err error) {
 	defer timestamp.StopEvent(nil)
 
 	const (
-		selinuxPkgName     = "selinux-policy"
 		validateError      = "failed to validate package lists in config"
 		verityPkgName      = "verity-read-only-root"
 		verityDebugPkgName = "verity-read-only-root-debug-tools"
@@ -132,6 +131,11 @@ func validatePackages(config configuration.Config) (err error) {
 		foundVerityInitramfsDebugPackage := false
 		foundDracutFipsPackage := false
 		kernelCmdLineString := systemConfig.KernelCommandLine.ExtraCommandLine
+		selinuxPkgName := systemConfig.KernelCommandLine.SELinuxPolicy
+		if selinuxPkgName == "" {
+			selinuxPkgName = "selinux-policy"
+		}
+
 		for _, pkg := range packageList {
 			if pkg == "kernel" {
 				return fmt.Errorf("%s: kernel should not be included in a package list, add via config file's [KernelOptions] entry", validateError)
@@ -145,7 +149,7 @@ func validatePackages(config configuration.Config) (err error) {
 			if pkg == dracutFipsPkgName {
 				foundDracutFipsPackage = true
 			}
-			if strings.Contains(pkg, selinuxPkgName) {
+			if pkg == selinuxPkgName {
 				foundSELinuxPackage = true
 			}
 		}

--- a/toolkit/tools/imagegen/configuration/kernelcommandline.go
+++ b/toolkit/tools/imagegen/configuration/kernelcommandline.go
@@ -20,6 +20,7 @@ type KernelCommandLine struct {
 	CGroup           CGroup      `json:"CGroup"`
 	ImaPolicy        []ImaPolicy `json:"ImaPolicy"`
 	SELinux          SELinux     `json:"SELinux"`
+	SELinuxPolicy    string      `json:"SELinuxPolicy"`
 	EnableFIPS       bool        `json:"EnableFIPS"`
 	ExtraCommandLine string      `json:"ExtraCommandLine"`
 }

--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -1590,7 +1590,7 @@ func ProvisionUserSSHCerts(installChroot *safechroot.Chroot, username string, ss
 }
 
 // SELinuxConfigure pre-configures SELinux file labels and configuration files
-func SELinuxConfigure(systemConfig configuration.SystemConfig, installChroot *safechroot.Chroot, mountPointToFsTypeMap map[string]string) (err error) {
+func SELinuxConfigure(systemConfig configuration.SystemConfig, installChroot *safechroot.Chroot, mountPointToFsTypeMap map[string]string, isRootFS bool) (err error) {
 	timestamp.StartEvent("SELinux", nil)
 	defer timestamp.StopEvent(nil)
 	logger.Log.Infof("Preconfiguring SELinux policy in %s mode", systemConfig.KernelCommandLine.SELinux)
@@ -1600,7 +1600,7 @@ func SELinuxConfigure(systemConfig configuration.SystemConfig, installChroot *sa
 		logger.Log.Errorf("Failed to update SELinux config")
 		return
 	}
-	err = selinuxRelabelFiles(systemConfig, installChroot, mountPointToFsTypeMap)
+	err = selinuxRelabelFiles(systemConfig, installChroot, mountPointToFsTypeMap, isRootFS)
 	if err != nil {
 		logger.Log.Errorf("Failed to label SELinux files")
 		return
@@ -1628,7 +1628,7 @@ func selinuxUpdateConfig(systemConfig configuration.SystemConfig, installChroot 
 	return
 }
 
-func selinuxRelabelFiles(systemConfig configuration.SystemConfig, installChroot *safechroot.Chroot, mountPointToFsTypeMap map[string]string) (err error) {
+func selinuxRelabelFiles(systemConfig configuration.SystemConfig, installChroot *safechroot.Chroot, mountPointToFsTypeMap map[string]string, isRootFS bool) (err error) {
 	const (
 		squashErrors        = false
 		configFile          = "etc/selinux/config"
@@ -1636,18 +1636,22 @@ func selinuxRelabelFiles(systemConfig configuration.SystemConfig, installChroot 
 	)
 	var listOfMountsToLabel []string
 
-	// Search through all our mount points for supported filesystem types
-	// Note for the future: SELinux can support any of {btrfs, encfs, ext2-4, f2fs, jffs2, jfs, ubifs, xfs, zfs}, but the build system currently
-	//     only supports the below cases:
-	for mount, fsType := range mountPointToFsTypeMap {
-		switch fsType {
-		case "ext2", "ext3", "ext4", "xfs":
-			listOfMountsToLabel = append(listOfMountsToLabel, mount)
-		case "fat32", "fat16", "vfat":
-			logger.Log.Debugf("SELinux will not label mount at (%s) of type (%s), skipping", mount, fsType)
-		default:
-			err = fmt.Errorf("unknown fsType (%s) for mount (%s), cannot configure SELinux", fsType, mount)
-			return
+	if isRootFS {
+		listOfMountsToLabel = append(listOfMountsToLabel, "/")
+	} else {
+		// Search through all our mount points for supported filesystem types
+		// Note for the future: SELinux can support any of {btrfs, encfs, ext2-4, f2fs, jffs2, jfs, ubifs, xfs, zfs}, but the build system currently
+		//     only supports the below cases:
+		for mount, fsType := range mountPointToFsTypeMap {
+			switch fsType {
+			case "ext2", "ext3", "ext4", "xfs":
+				listOfMountsToLabel = append(listOfMountsToLabel, mount)
+			case "fat32", "fat16", "vfat":
+				logger.Log.Debugf("SELinux will not label mount at (%s) of type (%s), skipping", mount, fsType)
+			default:
+				err = fmt.Errorf("unknown fsType (%s) for mount (%s), cannot configure SELinux", fsType, mount)
+				return
+			}
 		}
 	}
 
@@ -1661,10 +1665,6 @@ func selinuxRelabelFiles(systemConfig configuration.SystemConfig, installChroot 
 	}
 	selinuxType := strings.TrimSpace(stdout)
 	fileContextPath := fmt.Sprintf(fileContextBasePath, selinuxType)
-
-	if len(listOfMountsToLabel) == 0 {
-		listOfMountsToLabel = append(listOfMountsToLabel, "/")
-	}
 
 	logger.Log.Debugf("Running setfiles to apply SELinux labels on mount points: %v", listOfMountsToLabel)
 	err = installChroot.UnsafeRun(func() error {

--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -1662,6 +1662,10 @@ func selinuxRelabelFiles(systemConfig configuration.SystemConfig, installChroot 
 	selinuxType := strings.TrimSpace(stdout)
 	fileContextPath := fmt.Sprintf(fileContextBasePath, selinuxType)
 
+	if len(listOfMountsToLabel) == 0 {
+		listOfMountsToLabel = append(listOfMountsToLabel, "/")
+	}
+
 	logger.Log.Debugf("Running setfiles to apply SELinux labels on mount points: %v", listOfMountsToLabel)
 	err = installChroot.UnsafeRun(func() error {
 		args := []string{"-m", "-v", fileContextPath}

--- a/toolkit/tools/imager/imager.go
+++ b/toolkit/tools/imager/imager.go
@@ -616,7 +616,7 @@ func buildImage(mountPointMap, mountPointToFsTypeMap, mountPointToMountArgsMap, 
 
 	// Preconfigure SELinux labels now since all the changes to the filesystem should be done
 	if systemConfig.KernelCommandLine.SELinux != configuration.SELinuxOff {
-		err = installutils.SELinuxConfigure(systemConfig, installChroot, mountPointToFsTypeMap)
+		err = installutils.SELinuxConfigure(systemConfig, installChroot, mountPointToFsTypeMap, isRootFS)
 		if err != nil {
 			err = fmt.Errorf("failed to configure selinux: %w", err)
 			return
@@ -624,7 +624,7 @@ func buildImage(mountPointMap, mountPointToFsTypeMap, mountPointToMountArgsMap, 
 	}
 
 	// Snapshot the root filesystem as a read-only verity disk and update the initramfs.
-	if systemConfig.ReadOnlyVerityRoot.Enable {
+	if !isRootFS && systemConfig.ReadOnlyVerityRoot.Enable {
 		timestamp.StartEvent("configure DM Verity", nil)
 		var initramfsPathList []string
 		err = readOnlyRoot.SwitchDeviceToReadOnly(mountPointMap["/"], mountPointToMountArgsMap["/"])

--- a/toolkit/tools/imager/imager.go
+++ b/toolkit/tools/imager/imager.go
@@ -612,37 +612,37 @@ func buildImage(mountPointMap, mountPointToFsTypeMap, mountPointToMountArgsMap, 
 			err = fmt.Errorf("failed to configure boot loader: %w", err)
 			return
 		}
+	}
 
-		// Preconfigure SELinux labels now since all the changes to the filesystem should be done
-		if systemConfig.KernelCommandLine.SELinux != configuration.SELinuxOff {
-			err = installutils.SELinuxConfigure(systemConfig, installChroot, mountPointToFsTypeMap)
-			if err != nil {
-				err = fmt.Errorf("failed to configure selinux: %w", err)
-				return
-			}
+	// Preconfigure SELinux labels now since all the changes to the filesystem should be done
+	if systemConfig.KernelCommandLine.SELinux != configuration.SELinuxOff {
+		err = installutils.SELinuxConfigure(systemConfig, installChroot, mountPointToFsTypeMap)
+		if err != nil {
+			err = fmt.Errorf("failed to configure selinux: %w", err)
+			return
 		}
+	}
 
-		// Snapshot the root filesystem as a read-only verity disk and update the initramfs.
-		if systemConfig.ReadOnlyVerityRoot.Enable {
-			timestamp.StartEvent("configure DM Verity", nil)
-			var initramfsPathList []string
-			err = readOnlyRoot.SwitchDeviceToReadOnly(mountPointMap["/"], mountPointToMountArgsMap["/"])
-			if err != nil {
-				err = fmt.Errorf("failed to switch root to read-only: %w", err)
-				return
-			}
-			installutils.ReportAction("Hashing root for read-only with dm-verity, this may take a long time if error correction is enabled")
-			initramfsPathList, err = filepath.Glob(filepath.Join(installRoot, "/boot/initrd.img*"))
-			if err != nil || len(initramfsPathList) != 1 {
-				return fmt.Errorf("could not find single initramfs (%v): %w", initramfsPathList, err)
-			}
-			err = readOnlyRoot.AddRootVerityFilesToInitramfs(verityWorkingDir, initramfsPathList[0])
-			if err != nil {
-				err = fmt.Errorf("failed to include read-only root files in initramfs: %w", err)
-				return
-			}
-			timestamp.StopEvent(nil) // configure DM Verity
+	// Snapshot the root filesystem as a read-only verity disk and update the initramfs.
+	if systemConfig.ReadOnlyVerityRoot.Enable {
+		timestamp.StartEvent("configure DM Verity", nil)
+		var initramfsPathList []string
+		err = readOnlyRoot.SwitchDeviceToReadOnly(mountPointMap["/"], mountPointToMountArgsMap["/"])
+		if err != nil {
+			err = fmt.Errorf("failed to switch root to read-only: %w", err)
+			return
 		}
+		installutils.ReportAction("Hashing root for read-only with dm-verity, this may take a long time if error correction is enabled")
+		initramfsPathList, err = filepath.Glob(filepath.Join(installRoot, "/boot/initrd.img*"))
+		if err != nil || len(initramfsPathList) != 1 {
+			return fmt.Errorf("could not find single initramfs (%v): %w", initramfsPathList, err)
+		}
+		err = readOnlyRoot.AddRootVerityFilesToInitramfs(verityWorkingDir, initramfsPathList[0])
+		if err != nil {
+			err = fmt.Errorf("failed to include read-only root files in initramfs: %w", err)
+			return
+		}
+		timestamp.StopEvent(nil) // configure DM Verity
 	}
 
 	// Run finalize image scripts from within the installroot chroot

--- a/toolkit/tools/roast/formats/targzip.go
+++ b/toolkit/tools/roast/formats/targzip.go
@@ -25,9 +25,9 @@ func (t *TarGzip) Convert(input, output string, isInputFile bool) (err error) {
 	}
 
 	if isInputFile {
-		err = shell.ExecuteLive(squashErrors, "tar", "--xattrs", "-I", tool, "-cf", output, input)
+		err = shell.ExecuteLive(squashErrors, "tar", "--xattrs", "--selinux", "-I", tool, "-cf", output, input)
 	} else {
-		err = shell.ExecuteLive(squashErrors, "tar", "--xattrs", "-I", tool, "-cf", output, "-C", input, ".")
+		err = shell.ExecuteLive(squashErrors, "tar", "--xattrs", "--selinux", "-I", tool, "-cf", output, "-C", input, ".")
 	}
 
 	return

--- a/toolkit/tools/roast/formats/targzip.go
+++ b/toolkit/tools/roast/formats/targzip.go
@@ -25,9 +25,9 @@ func (t *TarGzip) Convert(input, output string, isInputFile bool) (err error) {
 	}
 
 	if isInputFile {
-		err = shell.ExecuteLive(squashErrors, "tar", "-I", tool, "-cf", output, input)
+		err = shell.ExecuteLive(squashErrors, "tar", "--xattrs", "-I", tool, "-cf", output, input)
 	} else {
-		err = shell.ExecuteLive(squashErrors, "tar", "-I", tool, "-cf", output, "-C", input, ".")
+		err = shell.ExecuteLive(squashErrors, "tar", "--xattrs", "-I", tool, "-cf", output, "-C", input, ".")
 	}
 
 	return


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Some projects need to build only a targzip or squashfs image format of rootFS using Mariner toolkit. The existing logic for SELinux labeling was not working for those cases because they are not building an ISO or VHD images that include different image partitions. 
Here are the changes that are introduced in this PR:
-	Factor out the SELinux labeling logic from !isRootFS {} condition block.
-	Allow overwriting the SELinux policy RPM package name through a parameter in image config json file. Currently it’s expecting the `selinux-policy` package, however some projects need their own policies. 
-	“—xattrs” option is added to tar command to capture the extended attributes as well.


###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: xxxx
