### PR TITLE
3.0-dev: Using separate buffer per analyzed spec in `rpmssnapshot.go`

### DIFF
--- a/toolkit/tools/pkg/rpmssnapshot/rpmssnapshot.go
+++ b/toolkit/tools/pkg/rpmssnapshot/rpmssnapshot.go
@@ -152,8 +152,6 @@ func (s *SnapshotGenerator) generateSnapshotInChroot(distTag string) (err error)
 }
 
 func (s *SnapshotGenerator) readBuiltRPMs(specPaths []string, defines map[string]string) (allBuiltRPMs []string, err error) {
-	var builtRPMs []string
-
 	buildArch, err := rpm.GetRpmArch(runtime.GOARCH)
 	if err != nil {
 		return
@@ -171,14 +169,14 @@ func (s *SnapshotGenerator) readBuiltRPMs(specPaths []string, defines map[string
 		specDirPath := filepath.Dir(specPath)
 
 		go func(pathIter string) {
-			builtRPMs, err = rpm.QuerySPECForBuiltRPMs(pathIter, specDirPath, buildArch, defines)
-			if err != nil {
-				err = fmt.Errorf("failed to query built RPMs from (%s):\n%w", pathIter, err)
+			builtRPMs, queryErr := rpm.QuerySPECForBuiltRPMs(pathIter, specDirPath, buildArch, defines)
+			if queryErr != nil {
+				queryErr = fmt.Errorf("failed to query built RPMs from (%s):\n%w", pathIter, queryErr)
 			}
 
 			resultsChannel <- SnapshotResult{
 				rpms: builtRPMs,
-				err:  err,
+				err:  queryErr,
 			}
 		}(specPath)
 	}


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Cherry pick the fix for #6706 into 3.0 dev to fix random errors like: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=455033&view=logs&j=2ccbf1db-6c73-5af8-5ba2-cf05469dcf51&t=62118ca4-5f53-54b3-7ec9-8ef4ab0e9237
```
ERRO[0014][rpmssnapshot] Failed to convert RPMs list to a packages summary file. Error: RPM package name () doesn't match the regular expression (^(.*)-([^-]+-[^-]+)\.([^.]+)\.([^.]+)$).
ERRO[0014][rpmssnapshot] Failed to generate snapshot from specs folder (/mnt/vss/_work/1/s/SPECS) into (/mnt/vss/_work/1/s/build/rpms_snapshots/SPECS_rpms_snapshot.json). Error: RPM package name () doesn't match the regular expression (^(.*)-([^-]+-[^-]+)\.([^.]+)\.([^.]+)$)
cp /mnt/vss/_work/1/s/build/rpms_snapshots/SPECS_rpms_snapshot.json /mnt/vss/_work/1/s/out/rpms_snapshot.json
cp: cannot stat '/mnt/vss/_work/1/s/build/rpms_snapshots/SPECS_rpms_snapshot.json': No such file or directory
make: *** [/mnt/vss/_work/1/s/toolkit/scripts/toolkit.mk:94: /mnt/vss/_work/1/s/out/rpms_snapshot.json] Error 1
```


###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change
- Change
- Change

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: xxxx
