### PR TITLE
Update kernel-mshv, kernel-uvm, kernel-uvm-cvm BuildRequires to inclu…

### DIFF
--- a/SPECS/kernel-mshv/kernel-mshv.spec
+++ b/SPECS/kernel-mshv/kernel-mshv.spec
@@ -11,7 +11,7 @@
 Summary:        Mariner kernel that has MSHV Host support
 Name:           kernel-mshv
 Version:        5.15.126.mshv9
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Group:          Development/Tools
 Vendor:         Microsoft Corporation
@@ -24,6 +24,7 @@ ExclusiveArch:  x86_64
 BuildRequires:  audit-devel
 BuildRequires:  bash
 BuildRequires:  bc
+BuildRequires:  cpio
 BuildRequires:  diffutils
 BuildRequires:  dwarves
 BuildRequires:  elfutils-libelf-devel
@@ -247,6 +248,9 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner-mshv.cfg
 %{_includedir}/perf/perf_dlfilter.h
 
 %changelog
+* Mon Nov 20 2023 Rachel Menge <rachelmenge@microsoft.com> - 5.15.126.mshv9-2
+- Add cpio as BuildRequires
+
 * Mon Nov 6 2023 Dallas Delaney <dadelan@microsoft.com> - 5.15.126.mshv9-1
 - Update to v5.15.126.mshv9
 

--- a/SPECS/kernel-uvm-cvm/kernel-uvm-cvm.spec
+++ b/SPECS/kernel-uvm-cvm/kernel-uvm-cvm.spec
@@ -11,7 +11,7 @@
 Summary:        Linux Kernel for SEV SNP enabled Kata UVMs
 Name:           kernel-uvm-cvm
 Version:        6.1.0.mshv14
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -21,6 +21,7 @@ Source1:        config
 BuildRequires:  audit-devel
 BuildRequires:  bash
 BuildRequires:  bc
+BuildRequires:  cpio
 BuildRequires:  diffutils
 BuildRequires:  dwarves
 BuildRequires:  elfutils-libelf-devel
@@ -153,6 +154,9 @@ find %{buildroot}/lib/modules -name '*.ko' -exec chmod u+x {} +
 %{_prefix}/src/linux-headers-%{uname_r}
 
 %changelog
+* Mon Nov 20 2023 Rachel Menge <rachelmenge@microsoft.com> - 6.1.0.mshv14-2
+- Add cpio as BuildRequires
+
 * Mon Nov 6 2023 Dallas Delaney <dadelan@microsoft.com> - 6.1.0.mshv14-1
 - Update to v6.1.0.mshv14
 

--- a/SPECS/kernel-uvm/kernel-uvm.spec
+++ b/SPECS/kernel-uvm/kernel-uvm.spec
@@ -11,7 +11,7 @@
 Summary:        Linux Kernel for Kata UVM
 Name:           kernel-uvm
 Version:        6.1.0.mshv14
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -21,6 +21,7 @@ Source1:        config
 BuildRequires:  audit-devel
 BuildRequires:  bash
 BuildRequires:  bc
+BuildRequires:  cpio
 BuildRequires:  diffutils
 BuildRequires:  dwarves
 BuildRequires:  elfutils-libelf-devel
@@ -153,6 +154,9 @@ find %{buildroot}/lib/modules -name '*.ko' -exec chmod u+x {} +
 %{_prefix}/src/linux-headers-%{uname_r}
 
 %changelog
+* Mon Nov 20 2023 Rachel Menge <rachelmenge@microsoft.com> - 6.1.0.mshv14-2
+- Add cpio as BuildRequires
+
 * Mon Nov 6 2023 Dallas Delaney <dadelan@microsoft.com> - 6.1.0.mshv14-1
 - Update to v6.1.0.mshv14
 


### PR DESCRIPTION
…de cpio

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Update kernel-mshv, kernel-uvm, kernel-uvm-cvm BuildRequires to include cpio

Similar to https://github.com/microsoft/CBL-Mariner/commit/1f4f655bb15892177e9d4e8b950d538bd26ea6a8

When testing kernel builds in the latest Mariner 2.0 container, it was noted that the list of kernel's BuildRequires is missing cpio. The container (unlike our core images used in VMs) does not include "cpio" by default as defined in core-package.spec. This led to kheaders errors:
```
make[1]: *** [kernel/Makefile:160: kernel/kheaders_data.tar.xz] Error 127
make: *** [Makefile:1907: kernel] Error 2
```
Therefore, add as a buildRequires.

Note that cpio is also listed as a minimal requirement for the kernel to build: https://www.kernel.org/doc/html/latest/process/changes.html?highlight=cpio

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Update kernel-mshv, kernel-uvm, kernel-uvm-cvm BuildRequires to include cpio

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://microsoft.visualstudio.com/OS/_queries/edit/47331687/?triage=true

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=456228&view=results
