### PR TITLE
toolkit image build: Fix make error for config files outside imageconfig directory

### DIFF
--- a/toolkit/scripts/get_config_deps.sh
+++ b/toolkit/scripts/get_config_deps.sh
@@ -2,26 +2,32 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-# $1 - CONFIG_FILE
-# $2 - CONFIG_BASE_DIR
+# $1 - config_file
 
-if [[ $# -ne 2 ]]
+if [[ $# -ne 1 ]]
 then
-    echo "ERROR: Must provide CONFIG_FILE and CONFIG_BASE_DIR to get_config_deps.sh" >&2
+    echo "ERROR: Must provide config file to get_config_deps.sh" >&2
     exit 1
 fi
 
-CONFIG_FILE="$1"
-CONFIG_BASE_DIR="$2"
+config_file="$1"
 
-config_other_files=$(grep -E '.json|.sh' $CONFIG_FILE| sed 's/\"Path\"\://' | tr ", \n" " " | tr "\"" " " | xargs)
+if [[ ! -f "$config_file" ]]
+then
+    echo "ERROR: Config file '$config_file' does not exist" >&2
+    exit 1
+fi
+
+config_base_dir=$(dirname "$config_file")
+
+config_other_files=$(grep -E '.json|.sh' $config_file| sed 's/\"Path\"\://' | tr ", \n" " " | tr "\"" " " | xargs)
 for filename in $config_other_files
 do
-    # fix path if it's relative to CONFIG_FILE
+    # fix path if it's relative to config_file
 	if [ "${filename:0:1}" == "/" ]
 	then
-		echo "$filename"
+		echo $(realpath "$filename")
 	else
-		echo "$CONFIG_BASE_DIR$filename"
+		echo $(realpath "$config_base_dir/$filename")
 	fi
 done

--- a/toolkit/scripts/get_config_deps.sh
+++ b/toolkit/scripts/get_config_deps.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# $1 - CONFIG_FILE
+# $2 - CONFIG_BASE_DIR
+
+if [[ $# -ne 2 ]]
+then
+    echo "ERROR: Must provide CONFIG_FILE and CONFIG_BASE_DIR to get_config_deps.sh" >&2
+    exit 1
+fi
+
+CONFIG_FILE="$1"
+CONFIG_BASE_DIR="$2"
+
+config_other_files=$(grep -E '.json|.sh' $CONFIG_FILE| sed 's/\"Path\"\://' | tr ", \n" " " | tr "\"" " " | xargs)
+for filename in $config_other_files
+do
+    # fix path if it's relative to CONFIG_FILE
+	if [ "${filename:0:1}" == "/" ]
+	then
+		echo "$filename"
+	else
+		echo "$CONFIG_BASE_DIR$filename"
+	fi
+done

--- a/toolkit/scripts/imggen.mk
+++ b/toolkit/scripts/imggen.mk
@@ -5,8 +5,7 @@ $(call create_folder,$(IMAGEGEN_DIR))
 
 # Resources
 config_name              = $(notdir $(CONFIG_FILE:%.json=%))
-CONFIG_BASE_DIR          = $(dir $(CONFIG_FILE:%.json=%))
-config_other_files       = $(if $(CONFIG_FILE),$(shell $(SCRIPTS_DIR)/get_config_deps.sh $(CONFIG_FILE) $(CONFIG_BASE_DIR)),)
+config_other_files       = $(if $(CONFIG_FILE),$(shell $(SCRIPTS_DIR)/get_config_deps.sh $(CONFIG_FILE)),)
 assets_dir               = $(RESOURCES_DIR)/assets/
 assets_files             = $(call shell_real_build_only, find $(assets_dir))
 imggen_local_repo        = $(MANIFESTS_DIR)/image/local.repo

--- a/toolkit/scripts/imggen.mk
+++ b/toolkit/scripts/imggen.mk
@@ -6,7 +6,12 @@ $(call create_folder,$(IMAGEGEN_DIR))
 # Resources
 config_name              = $(notdir $(CONFIG_FILE:%.json=%))
 CONFIG_BASE_DIR          = $(dir $(CONFIG_FILE:%.json=%))
-config_other_files       = $(if $(CONFIG_FILE),$(call shell_real_build_only, find $(CONFIG_BASE_DIR) -type f -name $(config_name)))
+config_other_files      := $(shell grep -E '.json|.sh' $(CONFIG_FILE)| sed 's/\"Path\"\://' | tr ", \n" " " | tr "\"" " " | xargs)
+define fix_filenames
+$(call shell, if [ "$1" = "/" ]; then echo $2; else echo $(CONFIG_BASE_DIR)$2 | tr -d '[:blank:]'; fi)
+endef
+config_other_files_fixed := $(foreach filename,$(config_other_files),$(call fix_filenames,$(shell echo $(filename) | head -c 1), $(filename)))
+
 assets_dir               = $(RESOURCES_DIR)/assets/
 assets_files             = $(call shell_real_build_only, find $(assets_dir))
 imggen_local_repo        = $(MANIFESTS_DIR)/image/local.repo
@@ -85,7 +90,7 @@ fetch-external-image-packages: $(image_external_package_cache_summary)
 # Validate the selected config file if any changes occur in the image config base directory.
 # Changes to files located outside the base directory will not be detected.
 validate-image-config: $(validate-config)
-$(STATUS_FLAGS_DIR)/validate-image-config%.flag: $(go-imageconfigvalidator) $(depend_CONFIG_FILE) $(CONFIG_FILE) $(config_other_files)
+$(STATUS_FLAGS_DIR)/validate-image-config%.flag: $(go-imageconfigvalidator) $(depend_CONFIG_FILE) $(CONFIG_FILE) $(config_other_files_fixed)
 	$(if $(CONFIG_FILE),,$(error Must set CONFIG_FILE=))
 	$(go-imageconfigvalidator) \
 		--input=$(CONFIG_FILE) \

--- a/toolkit/scripts/imggen.mk
+++ b/toolkit/scripts/imggen.mk
@@ -5,8 +5,8 @@ $(call create_folder,$(IMAGEGEN_DIR))
 
 # Resources
 config_name              = $(notdir $(CONFIG_FILE:%.json=%))
-config_dir_name          = $(dir $(CONFIG_FILE:%.json=%))
-config_other_files       = $(if $(CONFIG_FILE),$(call shell_real_build_only, find $(config_dir_name) -type f -name $(config_name)))
+CONFIG_BASE_DIR          = $(dir $(CONFIG_FILE:%.json=%))
+config_other_files       = $(if $(CONFIG_FILE),$(call shell_real_build_only, find $(CONFIG_BASE_DIR) -type f -name $(config_name)))
 assets_dir               = $(RESOURCES_DIR)/assets/
 assets_files             = $(call shell_real_build_only, find $(assets_dir))
 imggen_local_repo        = $(MANIFESTS_DIR)/image/local.repo

--- a/toolkit/scripts/imggen.mk
+++ b/toolkit/scripts/imggen.mk
@@ -5,7 +5,7 @@ $(call create_folder,$(IMAGEGEN_DIR))
 
 # Resources
 config_name              = $(notdir $(CONFIG_FILE:%.json=%))
-config_other_files       = $(if $(CONFIG_FILE),$(shell $(SCRIPTS_DIR)/get_config_deps.sh $(CONFIG_FILE)),)
+config_other_files       = $(if $(CONFIG_FILE),$(call shell_real_build_only, $(SCRIPTS_DIR)/get_config_deps.sh $(CONFIG_FILE)),)
 assets_dir               = $(RESOURCES_DIR)/assets/
 assets_files             = $(call shell_real_build_only, find $(assets_dir))
 imggen_local_repo        = $(MANIFESTS_DIR)/image/local.repo

--- a/toolkit/scripts/imggen.mk
+++ b/toolkit/scripts/imggen.mk
@@ -6,7 +6,7 @@ $(call create_folder,$(IMAGEGEN_DIR))
 # Resources
 config_name              = $(notdir $(CONFIG_FILE:%.json=%))
 CONFIG_BASE_DIR          = $(dir $(CONFIG_FILE:%.json=%))
-config_other_files       = $(if $(CONFIG_FILE),$(shell $(SCRIPTS_DIR)/get_config_deps.sh $(CONFIG_FILE) $(CONFIG_BASE_DIR)))
+config_other_files       = $(if $(CONFIG_FILE),$(shell $(SCRIPTS_DIR)/get_config_deps.sh $(CONFIG_FILE) $(CONFIG_BASE_DIR)),)
 assets_dir               = $(RESOURCES_DIR)/assets/
 assets_files             = $(call shell_real_build_only, find $(assets_dir))
 imggen_local_repo        = $(MANIFESTS_DIR)/image/local.repo

--- a/toolkit/scripts/imggen.mk
+++ b/toolkit/scripts/imggen.mk
@@ -5,7 +5,8 @@ $(call create_folder,$(IMAGEGEN_DIR))
 
 # Resources
 config_name              = $(notdir $(CONFIG_FILE:%.json=%))
-config_other_files       = $(if $(CONFIG_FILE),$(call shell_real_build_only, find $(CONFIG_BASE_DIR)))
+config_dir_name          = $(dir $(CONFIG_FILE:%.json=%))
+config_other_files       = $(if $(CONFIG_FILE),$(call shell_real_build_only, find $(config_dir_name) -type f -name $(config_name)))
 assets_dir               = $(RESOURCES_DIR)/assets/
 assets_files             = $(call shell_real_build_only, find $(assets_dir))
 imggen_local_repo        = $(MANIFESTS_DIR)/image/local.repo


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
If config file lies outside the imageconfig/ directory, makefile is not able to find it, and errors out with '*** multiple target patterns. Stop'. This change modifies makefile to extract all .json and .sh filenames from config_name, fixes their paths relative to the makefile, and watches them to set imageconfigvalidator flag.


###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Extract config directory for CONFIG_FILE into CONFIG_BASE_DIR
- Extract all filenames with .sh or .json type in CONFIG_FILE
- Fix paths to these files wrt the makefile using CONFIG_BASE_DIR
- Pass this list of paths to imageconfigvalidator flag to watch for changes

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://microsoft.visualstudio.com/OS/_workitems/edit/44648678

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Built image successfully with `sudo make image CONFIG_FILE=../core-efi.json` and `sudo make image CONFIG_FILE=imagecondigs/core-efi.json` and `sudo make image CONFIG_FILE=complete/path/to/core-efi.json`
- Changes in any config related files (CONFIG_FILE, or any .json or .sh file referenced in CONFIG_FILE are recognized by imageconfigvalidator flag, and imageconfigvalidator is therefore run when any of these file(s) are changed.