### PR TITLE
Toolkit: Cleanup and improve logs.

### DIFF
--- a/toolkit/tools/imagegen/diskutils/diskutils.go
+++ b/toolkit/tools/imagegen/diskutils/diskutils.go
@@ -241,6 +241,7 @@ func CreateSparseDisk(diskPath string, size uint64, perm os.FileMode) (err error
 
 // SetupLoopbackDevice creates a /dev/loop device for the given disk file
 func SetupLoopbackDevice(diskFilePath string) (devicePath string, err error) {
+	logger.Log.Debugf("Attaching Loopback: %v", diskFilePath)
 	stdout, stderr, err := shell.Execute("losetup", "--show", "-f", "-P", diskFilePath)
 	if err != nil {
 		logger.Log.Warnf("Failed to create loopback device using losetup: %v", stderr)
@@ -301,7 +302,7 @@ func BlockOnDiskIOByIds(debugName string, maj string, min string) (err error) {
 		outstandingOpsIdx = 11
 	)
 
-	logger.Log.Infof("Flushing all IO to disk")
+	logger.Log.Debugf("Flushing all IO to disk")
 	_, _, err = shell.Execute("sync")
 	if err != nil {
 		return
@@ -351,7 +352,7 @@ func BlockOnDiskIOByIds(debugName string, maj string, min string) (err error) {
 
 // DetachLoopbackDevice detaches the specified disk
 func DetachLoopbackDevice(diskDevPath string) (err error) {
-	logger.Log.Infof("Detaching Loopback Device Path: %v", diskDevPath)
+	logger.Log.Debugf("Detaching Loopback Device Path: %v", diskDevPath)
 	_, stderr, err := shell.Execute("losetup", "-d", diskDevPath)
 	if err != nil {
 		logger.Log.Warnf("Failed to detach loopback device using losetup: %v", stderr)

--- a/toolkit/tools/internal/shell/shell.go
+++ b/toolkit/tools/internal/shell/shell.go
@@ -141,6 +141,30 @@ func ExecuteLive(squashErrors bool, program string, args ...string) (err error) 
 	return ExecuteLiveWithCallback(onStdout, onStderr, false, program, args...)
 }
 
+// ExecuteLiveWithErr runs a command in the shell and logs it in real-time.
+// In addition, if there is an error, the last x lines of stderr will be attached to the err object.
+func ExecuteLiveWithErr(stderrLines int, program string, args ...string) (err error) {
+	stderrChan := make(chan string, stderrLines)
+
+	err = ExecuteLiveWithCallbackAndChannels(logger.Log.Debug, logger.Log.Debug, nil, stderrChan, program, args...)
+	close(stderrChan)
+	if err != nil {
+		errLines := ""
+		for errLine := range stderrChan {
+			if errLines != "" {
+				errLines += "\n"
+			}
+			errLines += errLine
+		}
+
+		if errLines != "" {
+			err = fmt.Errorf("%s\n%w", errLines, err)
+		}
+		return
+	}
+	return nil
+}
+
 // ExecuteLiveWithCallback runs a command in the shell and invokes the provided callbacks in real-time on each line of stdout and stderr.
 // If printOutputOnError is true, the full output of the command will be printed after completion if the command returns an error. In the event
 // the buffer becomes full the oldest buffered output is discarded.
@@ -148,6 +172,33 @@ func ExecuteLiveWithCallback(onStdout, onStderr func(...interface{}), printOutpu
 	var outputChan chan string
 	const outputChanBufferSize = 1500
 
+	if printOutputOnError {
+		outputChan = make(chan string, outputChanBufferSize)
+	}
+
+	err = ExecuteLiveWithCallbackAndChannels(onStdout, onStderr, outputChan, outputChan, program, args...)
+	if err != nil {
+		return
+	}
+
+	// Optionally dump the output in the event of an error
+	if outputChan != nil {
+		close(outputChan)
+	}
+	if err != nil && printOutputOnError {
+		logger.Log.Errorf("Call to %s returned error, last %d lines of output:", program, outputChanBufferSize)
+		for line := range outputChan {
+			logger.Log.Warn(line)
+		}
+	}
+
+	return
+}
+
+func ExecuteLiveWithCallbackAndChannels(onStdout, onStderr func(...interface{}),
+	stdoutChannel, stderrChannel chan string,
+	program string, args ...string,
+) (err error) {
 	cmd := exec.Command(program, args...)
 
 	stdoutPipe, err := cmd.StdoutPipe()
@@ -174,25 +225,11 @@ func ExecuteLiveWithCallback(onStdout, onStderr func(...interface{}), printOutpu
 	wg := new(sync.WaitGroup)
 	wg.Add(2)
 
-	if printOutputOnError {
-		outputChan = make(chan string, outputChanBufferSize)
-	}
-	go logger.StreamOutput(stdoutPipe, onStdout, wg, outputChan)
-	go logger.StreamOutput(stderrPipe, onStderr, wg, outputChan)
+	go logger.StreamOutput(stdoutPipe, onStdout, wg, stdoutChannel)
+	go logger.StreamOutput(stderrPipe, onStderr, wg, stderrChannel)
 
 	wg.Wait()
 	err = cmd.Wait()
-
-	// Optionally dump the output in the event of an error
-	if outputChan != nil {
-		close(outputChan)
-	}
-	if err != nil && printOutputOnError {
-		logger.Log.Errorf("Call to %s returned error, last %d lines of output:", cmd.Args, outputChanBufferSize)
-		for line := range outputChan {
-			logger.Log.Warn(line)
-		}
-	}
 
 	return
 }

--- a/toolkit/tools/internal/timestamp/timestamp_mgr.go
+++ b/toolkit/tools/internal/timestamp/timestamp_mgr.go
@@ -138,7 +138,7 @@ func ensureManagerExists() error {
 func BeginTiming(toolName, outputFile string) (*TimeStamp, error) {
 	if outputFile == "" {
 		err := fmt.Errorf("timestamp output file is not specified, the feature will be turned off for %s", toolName)
-		logger.Log.Info(err.Error())
+		logger.Log.Debug(err.Error())
 		return &TimeStamp{}, err
 	}
 
@@ -171,7 +171,7 @@ func BeginTiming(toolName, outputFile string) (*TimeStamp, error) {
 func ResumeTiming(toolName, outputFile string) error {
 	if outputFile == "" {
 		err := fmt.Errorf("timestamp output file is not specified, the feature will be turned off for %s", toolName)
-		logger.Log.Info(err.Error())
+		logger.Log.Debug(err.Error())
 		return err
 	}
 

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepackages.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepackages.go
@@ -17,8 +17,6 @@ import (
 func addRemoveAndUpdatePackages(buildDir string, baseConfigPath string, config *imagecustomizerapi.SystemConfig,
 	imageChroot *safechroot.Chroot, rpmsSources []string, useBaseImageRpmRepos bool,
 ) error {
-	var err error
-
 	allPackagesRemove, err := collectPackagesList(baseConfigPath, config.PackageListsRemove, config.PackagesRemove)
 	if err != nil {
 		return err
@@ -62,11 +60,13 @@ func addRemoveAndUpdatePackages(buildDir string, baseConfigPath string, config *
 		}
 	}
 
+	logger.Log.Infof("Installing packages: %v", allPackagesInstall)
 	err = installOrUpdatePackages("install", allPackagesInstall, imageChroot)
 	if err != nil {
 		return err
 	}
 
+	logger.Log.Infof("Updating packages: %v", allPackagesInstall)
 	err = installOrUpdatePackages("update", allPackagesUpdate, imageChroot)
 	if err != nil {
 		return err
@@ -105,7 +105,7 @@ func collectPackagesList(baseConfigPath string, packageLists []string, packages 
 }
 
 func removePackages(allPackagesToRemove []string, imageChroot *safechroot.Chroot) error {
-	var err error
+	logger.Log.Infof("Removing packages: %v", allPackagesToRemove)
 
 	tnfRemoveArgs := []string{
 		"-v", "remove", "--assumeyes", "--disablerepo", "*",
@@ -118,10 +118,9 @@ func removePackages(allPackagesToRemove []string, imageChroot *safechroot.Chroot
 	for _, packageName := range allPackagesToRemove {
 		tnfRemoveArgs[len(tnfRemoveArgs)-1] = packageName
 
-		err = imageChroot.Run(func() error {
-			err := shell.ExecuteLiveWithCallback(tdnfRemoveStdoutFilter, logger.Log.Warn, false, "tdnf",
+		err := imageChroot.Run(func() error {
+			return shell.ExecuteLiveWithCallback(tdnfRemoveStdoutFilter, logger.Log.Debug, false, "tdnf",
 				tnfRemoveArgs...)
-			return err
 		})
 		if err != nil {
 			return fmt.Errorf("failed to remove package (%s):\n%w", packageName, err)
@@ -148,17 +147,16 @@ func tdnfRemoveStdoutFilter(args ...interface{}) {
 }
 
 func updateAllPackages(imageChroot *safechroot.Chroot) error {
-	var err error
+	logger.Log.Infof("Updating base image packages")
 
 	tnfUpdateArgs := []string{
 		"-v", "update", "--nogpgcheck", "--assumeyes",
 		"--setopt", fmt.Sprintf("reposdir=%s", rpmsMountParentDirInChroot),
 	}
 
-	err = imageChroot.Run(func() error {
-		err := shell.ExecuteLiveWithCallback(tdnfInstallOrUpdateStdoutFilter, logger.Log.Warn, false, "tdnf",
+	err := imageChroot.Run(func() error {
+		return shell.ExecuteLiveWithCallback(tdnfInstallOrUpdateStdoutFilter, logger.Log.Debug, false, "tdnf",
 			tnfUpdateArgs...)
-		return err
 	})
 	if err != nil {
 		return fmt.Errorf("failed to update packages:\n%w", err)
@@ -168,8 +166,6 @@ func updateAllPackages(imageChroot *safechroot.Chroot) error {
 }
 
 func installOrUpdatePackages(action string, allPackagesToAdd []string, imageChroot *safechroot.Chroot) error {
-	var err error
-
 	// Create tdnf command args.
 	// Note: When using `--repofromdir`, tdnf will not use any default repos and will only use the last
 	// `--repofromdir` specified.
@@ -185,10 +181,9 @@ func installOrUpdatePackages(action string, allPackagesToAdd []string, imageChro
 	for _, packageName := range allPackagesToAdd {
 		tnfInstallArgs[len(tnfInstallArgs)-1] = packageName
 
-		err = imageChroot.Run(func() error {
-			err := shell.ExecuteLiveWithCallback(tdnfInstallOrUpdateStdoutFilter, logger.Log.Warn, false, "tdnf",
+		err := imageChroot.Run(func() error {
+			return shell.ExecuteLiveWithCallback(tdnfInstallOrUpdateStdoutFilter, logger.Log.Debug, false, "tdnf",
 				tnfInstallArgs...)
-			return err
 		})
 		if err != nil {
 			return fmt.Errorf("failed to %s package (%s):\n%w", action, packageName, err)


### PR DESCRIPTION

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->

1. Add debug log for attaching loopback device.

2. Demote the log for detaching loopback device from info to debug.

3. Add new `shell.Execute` function that attaches the last x lines of stderr to the Go error object.

4. Demote the log for when timestamp log file is not specified from info to debug.

5. Image customizer

   1. Add info log line for installing/updating/removing packages.
   2. Log tdnf's stderr as debug not warn, since it is a tad noisy.
   3. Add info log for setting hostname, copying additional files, and running user scripts.
   4. Attach last 1 line of stderr to `systemctl` enable/disable errors, running user scripts, and calling `qemu-img convert`.

###### Change Log  <!-- REQUIRED -->

- Toolkit: Cleanup and improve logs.

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Ran toolkit UTs.
- Manually ran image customizer tool.

