### PR TITLE
3.0 toolchain: remove references to deleted patches

### DIFF
--- a/toolkit/scripts/toolchain/container/Dockerfile
+++ b/toolkit/scripts/toolchain/container/Dockerfile
@@ -94,8 +94,6 @@ USER lfs
 COPY [ "./toolchain_build_temp_tools.sh", \
        "./sanity_check.sh", \
        "./coreutils-fix-get-sys_getdents-aarch64.patch", \
-       "./cpio_extern_nocommon.patch", \
-       "./CVE-2021-38185.patch", \
        "./CVE-2023-4039.patch", \
        "./linker-script-readonly-keyword-support.patch", \
        "./rpm-define-RPM-LD-FLAGS.patch", \

--- a/toolkit/scripts/toolchain/create_toolchain_in_container.sh
+++ b/toolkit/scripts/toolchain/create_toolchain_in_container.sh
@@ -27,9 +27,6 @@ if [ "$INCREMENTAL_TOOLCHAIN" != "y" ] || [ -z "$(docker images -q marinertoolch
     # docker rmi $(docker images -a -q)
     # docker rmi $(docker history marinertoolchain -q)
 
-    # CPIO patch
-    cp -v $MARINER_SPECS_DIR/cpio/cpio_extern_nocommon.patch ./container
-    cp -v $MARINER_SPECS_DIR/cpio/CVE-2021-38185.patch ./container
     # Coreutils aarch64 patch
     cp -v $MARINER_SPECS_DIR/coreutils/coreutils-fix-get-sys_getdents-aarch64.patch ./container
     # Binutils readonly patch


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Remove toolchain references to patch files that were recently deleted, to resolve build break:
https://dev.azure.com/mariner-org/mariner/_build/results?buildId=458736&view=logs&j=db98f19e-da46-5e4d-a4ba-372cf3771a92&t=49710eeb-120d-5327-a9f7-33c000ddb429&l=439
```
+ cp -v /mnt/vss/_work/1/s/SPECS/cpio/cpio_extern_nocommon.patch ./container
cp: cannot stat '/mnt/vss/_work/1/s/SPECS/cpio/cpio_extern_nocommon.patch': No such file or directory
```

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Remove references to deleted patch files

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=458771&view=results
