### PR TITLE
Blocksize 4096

### DIFF
--- a/toolkit/docs/formats/imageconfig.md
+++ b/toolkit/docs/formats/imageconfig.md
@@ -6,7 +6,13 @@ Image configuration consists of two sections - Disks and SystemConfigs - that de
 ## Disks
 Disks entry specifies the disk configuration like its size (for virtual disks), partitions and partition table.
 
-## TargetDisk
+The `PartitionTableType` field may be one of `gpt` or `mbr`.
+
+The `MaxSize` field specifies the size (in MiB) of the disk image.
+
+The optional `BlockSize` field sets the disk image block size (512 or 4096) and defaults to 512 if unspecified.
+
+### TargetDisk
 Required when building unattended ISO installer. This field defines the physical disk to which Mariner should be installed. The `Type` field must be set to `path` and the `Value` field must be set to the desired target disk path.
 
 ### Artifacts

--- a/toolkit/tools/imagegen/configuration/disk.go
+++ b/toolkit/tools/imagegen/configuration/disk.go
@@ -19,6 +19,7 @@ import (
 type Disk struct {
 	PartitionTableType PartitionTableType `json:"PartitionTableType"`
 	MaxSize            uint64             `json:"MaxSize"`
+	BlockSize          uint32             `json:"BlockSize"`
 	TargetDisk         TargetDisk         `json:"TargetDisk"`
 	Artifacts          []Artifact         `json:"Artifacts"`
 	Partitions         []Partition        `json:"Partitions"`
@@ -81,6 +82,9 @@ func checkMaxSizeCorrectness(disk *Disk) (err error) {
 
 // IsValid returns an error if the PartitionTableType is not valid
 func (d *Disk) IsValid() (err error) {
+	if d.BlockSize != 0 && d.BlockSize != 512 && d.BlockSize != 4096 {
+		return fmt.Errorf("invalid [BlockSize]: %d. Must be 0, 512, or 4096", d.BlockSize)
+	}
 	if err = d.PartitionTableType.IsValid(); err != nil {
 		return fmt.Errorf("invalid [PartitionTableType]: %w", err)
 	}

--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -156,7 +156,7 @@ func createOverlayPartition(partitionSetting configuration.PartitionSetting, mou
 	//Mount the base image
 	//Create a temp upper dir
 	//Add to the mount args
-	devicePath, err := diskutils.SetupLoopbackDevice(partitionSetting.OverlayBaseImage)
+	devicePath, err := diskutils.SetupLoopbackDevice(partitionSetting.OverlayBaseImage, nil)
 
 	if err != nil {
 		logger.Log.Errorf("Could not setup loop back device for mount (%s)", partitionSetting.OverlayBaseImage)

--- a/toolkit/tools/imager/imager.go
+++ b/toolkit/tools/imager/imager.go
@@ -400,7 +400,7 @@ func setupLoopDeviceDisk(outputDir, diskName string, diskConfig configuration.Di
 		return
 	}
 
-	diskDevPath, err = diskutils.SetupLoopbackDevice(rawDisk)
+	diskDevPath, err = diskutils.SetupLoopbackDevice(rawDisk, &diskConfig)
 	if err != nil {
 		logger.Log.Errorf("Failed to mount raw disk (%s) as a loopback device", rawDisk)
 		return

--- a/toolkit/tools/internal/safeloopback/safeloopback.go
+++ b/toolkit/tools/internal/safeloopback/safeloopback.go
@@ -33,7 +33,7 @@ func NewLoopback(diskFilePath string) (*Loopback, error) {
 
 func (l *Loopback) newLoopbackHelper() error {
 	// Try to create the mount.
-	devicePath, err := diskutils.SetupLoopbackDevice(l.diskFilePath)
+	devicePath, err := diskutils.SetupLoopbackDevice(l.diskFilePath, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Enable building of disk images with 4096 byte block size.

Some of the systems we want to run Mariner on are either more efficient when using 4096 byte block size storage devices, or in some cases, 4096 is the only supported block size.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add optional "BlockSize" field to Disk parameters and propagate it to losetup invocations.
- Add some documentation on the fields in the Disk section of the config file.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
YES

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local builds on 2.0 branch.
