### PR TITLE
Fix test runner invocation in future

### DIFF
--- a/SPECS/future/future.spec
+++ b/SPECS/future/future.spec
@@ -16,7 +16,7 @@ clean Py3-style codebase, module by module.
 Name: future
 Summary: Easy, clean, reliable Python 2/3 compatibility
 Version: 0.18.3
-Release: 6%{?dist}
+Release: 7%{?dist}
 License: MIT
 URL: http://python-future.org/
 Source0: https://github.com/PythonCharmers/python-future/archive/refs/tags/v%{version}/python-%{name}-%{version}.tar.gz#/%{name}-%{version}.tar.gz
@@ -85,15 +85,9 @@ chmod a+x $RPM_BUILD_ROOT%{python3_sitelib}/future/backports/test/pystone.py
 ## This packages ships PEM certificates in future/backports/test directory.
 ## It's for testing purpose, i guess. Ignore them.
 %check
-
 # Bugs
 # https://github.com/PythonCharmers/python-future/issues/508
-%if 0%{?python3_version_nodots} > 37
-PYTHONPATH=$PWD/build/lib py.test-%{python3_version} -k "not test_urllibnet and not test_single_exception_stacktrace" -q
-%endif
-%if 0%{?python3_version_nodots} <= 37
-PYTHONPATH=$PWD/build/lib py.test-%{python3_version}
-%endif
+PYTHONPATH=$PWD/build/lib py.test%{python3_version} -k "not test_urllibnet and not test_single_exception_stacktrace" -q
 
 %files -n python%{python3_pkgversion}-%{name}
 %license LICENSE.txt
@@ -111,6 +105,9 @@ PYTHONPATH=$PWD/build/lib py.test-%{python3_version}
 %{python3_sitelib}/*.egg-info
 
 %changelog
+* Thu Nov 30 2023 Olivia Crain <oliviacrain@microsoft.com> - 0.18.2-7
+- Fix pytest invocation
+
 * Tue May 30 2023 Vince Perri <viperri@microsoft.com> - 0.18.2-6
 - License verified.
 - Initial CBL-Mariner import from Fedora 39 (license: MIT).


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
The package tests for `future` invoke the `py.test-3.9` name, which doesn't exist on Mariner. I changed the test to invoke `py.test3.9`, which is present on Mariner. I also cleaned out a bit of Fedora cruft from the check section of the spec, but I don't aim to completely clean up the package in this PR.

Will create an action item to investigate the addition of a `py.test-3.9` symlink in the future, to make sure Mariner provides all common aliases.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Invoke `pytest` properly in `future` package test

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: [460932](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=460932&view=results)
