### PR TITLE
Fix backtrace parsing in ocaml-ounit

### DIFF
--- a/SPECS/ocaml-ounit/fix-backtrace-parser.patch
+++ b/SPECS/ocaml-ounit/fix-backtrace-parser.patch
@@ -1,0 +1,22 @@
+From 2a9acf70aeb0f47de5a7c7c07129235a5f2ac0f0 Mon Sep 17 00:00:00 2001
+From: octachron <octa@polychoron.fr>
+Date: Tue, 30 Jun 2020 21:25:17 +0200
+Subject: [PATCH] Update the backtrace parser Scanf format string
+
+---
+ src/lib/ounit2/advanced/oUnitUtils.ml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/lib/ounit2/advanced/oUnitUtils.ml b/src/lib/ounit2/advanced/oUnitUtils.ml
+index 3f31da1..350fa3d 100644
+--- a/src/lib/ounit2/advanced/oUnitUtils.ml
++++ b/src/lib/ounit2/advanced/oUnitUtils.ml
+@@ -114,7 +114,7 @@ let extract_backtrace_position str =
+               None
+             else
+               try
+-                Scanf.sscanf eol "file \"%s@\", line %d, characters %d-%d"
++                Scanf.sscanf eol "%_s@\"%s@\", line %d, characters %d-%d"
+                   (fun fn line _ _ -> Some (fn, line))
+               with Scanf.Scan_failure _ ->
+                 None

--- a/SPECS/ocaml-ounit/ocaml-ounit.spec
+++ b/SPECS/ocaml-ounit/ocaml-ounit.spec
@@ -12,7 +12,7 @@
 Summary:        Unit test framework for OCaml
 Name:           ocaml-%{srcname}
 Version:        2.2.2
-Release:        6%{?dist}
+Release:        7%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -25,6 +25,9 @@ Patch0:         %{name}-stdlib-shims.patch
 # Enable ocaml 4.13 compatibility. Source: Fedora 35
 # https://src.fedoraproject.org/rpms/ocaml-ounit/blob/f35/f/ounit-v2.2.4-remove-Thread-kill.patch
 Patch1:         remove-thread-kill.patch
+# Fix backtrace parsing with ocaml>=4.11. Source: Upstreamed in 2.2.3
+# https://github.com/gildor478/ounit/commit/2a9acf70aeb0f47de5a7c7c07129235a5f2ac0f0
+Patch2:         fix-backtrace-parser.patch
 
 # I believe this is actually caused by a missing Requires in another
 # package (perhaps lwt?).  In any case without this the tests fail to
@@ -190,10 +193,13 @@ find %{buildroot}%{_libdir}/ocaml -name \*.cmxs -exec chmod a+x {} \+
 %endif
 
 %changelog
+* Thu Nov 30 2023 Olivia Crain <oliviacrain@microsoft.com> - 2.2.2-7
+- Add upstream patch to fix backtrace parser test
+
 * Thu Mar 31 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 2.2.2-6
 - Cleaning-up spec. License verified.
 
-* Tue Jan 18 2022 Thomas Crain <thcrain@microsoft.com> - 2.2.2-5
+* Tue Jan 18 2022 Olivia Crain <oliviacrain@microsoft.com> - 2.2.2-5
 - Take Fedora patch (license: MIT) to fix building with OCaml 4.13.0
 - License verified
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
The package test for `ocaml-ounit` is failing due to a bug in parsing backtraces from ocaml>=4.11. This PR adds an upstream patch to fix this.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add upstream patch to fix backtrace parsing with ocaml>=4.11

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: [460973](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=460973&view=results)
