### PR TITLE
timestamp: overwrite timestamp logs on different builds

### DIFF
--- a/toolkit/tools/internal/timestamp/timestamp_mgr.go
+++ b/toolkit/tools/internal/timestamp/timestamp_mgr.go
@@ -144,7 +144,7 @@ func BeginTiming(toolName, outputFile string) (*TimeStamp, error) {
 
 	initTimeStampManager()
 
-	outputFileDescriptor, err := os.OpenFile(outputFile, os.O_CREATE|os.O_WRONLY, 0664)
+	outputFileDescriptor, err := os.OpenFile(outputFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0664)
 	if err != nil {
 		err = fmt.Errorf("unable to create file %s: %v", outputFile, err)
 		logger.Log.Warn(err.Error())

--- a/toolkit/tools/internal/timestamp/timestamp_test.go
+++ b/toolkit/tools/internal/timestamp/timestamp_test.go
@@ -234,3 +234,44 @@ func TestPauseResumeEvent(t *testing.T) {
 	assert.Greater(records[1].ElapsedTime(), time.Duration(0))
 	assert.Less(*records[0].EndTime, *records[1].StartTime)
 }
+
+func TestRerun(t *testing.T) {
+	assert := assert.New(t)
+
+	testFile := filepath.Join(t.TempDir(), "test_rerun.jsonl")
+
+	// first, create a file and write complete timestamp data to it
+	root, _ := BeginTiming("test", testFile)
+	StartEvent("A", root)
+	StopEvent(nil)
+	StartEvent("B", root)
+	StopEvent(nil)
+	CompleteTiming()
+
+	assert.FileExists(testFile)
+
+	// now, simulate a new run on the same file, there should be no error
+	// and existing data should be erased, i.e the new file should have 1 line
+	_, err := BeginTiming("test", testFile)
+	assert.NoError(err)
+	FlushAndCleanUpResources()
+
+	records := make([]*TimeStamp, 0)
+	fd, err := os.OpenFile(testFile, os.O_RDONLY, 0644)
+	if err != nil {
+		return
+	}
+	scanner := bufio.NewScanner(fd)
+	for scanner.Scan() {
+		var record TimeStampRecord
+		err = json.Unmarshal(scanner.Bytes(), &record)
+		if err != nil {
+			return
+		}
+		records = append(records, record.TimeStamp)
+	}
+
+	root = timestampMgr.root
+	assert.Equal(len(records), 1)
+	assert.Equal(records[0].ID, root.ID)
+}


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
- When we re-run build commands that has timestamp feature on, the timestamp log file for that specific program should be overwritten. This is not an issue most of the time, but it could error out if we try to read the timestamp file content and some unexpected data are present. Adding os.O_TRUNC flag when opening log file for the first time to make sure existing content is erased before we proceed with the program.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add os.O_TRUNC flag when beginning timestamp for a program.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build