### PR TITLE
Tobiasb/openssl remove redhat flag

### DIFF
--- a/SPECS/openssl/0001-Disable-most-DSA-tests-that-use-SHA1-which-is-disall.patch
+++ b/SPECS/openssl/0001-Disable-most-DSA-tests-that-use-SHA1-which-is-disall.patch
@@ -1,0 +1,87 @@
+From c316d45e6326f127b6d1d4cba143fc31507cca1f Mon Sep 17 00:00:00 2001
+From: Tobias Brick <tobiasb@microsoft.com>
+Date: Fri, 1 Dec 2023 01:19:25 +0000
+Subject: [PATCH] Disable most DSA tests that use SHA1, which is disallowed
+ with fips.
+
+---
+ test/recipes/30-test_evp_data/evppkey_dsa.txt | 49 -------------------
+ 1 file changed, 49 deletions(-)
+
+diff --git a/test/recipes/30-test_evp_data/evppkey_dsa.txt b/test/recipes/30-test_evp_data/evppkey_dsa.txt
+index debd62b..5f9cab0 100644
+--- a/test/recipes/30-test_evp_data/evppkey_dsa.txt
++++ b/test/recipes/30-test_evp_data/evppkey_dsa.txt
+@@ -44,36 +44,6 @@ PrivPubKeyPair = DSA-1024:DSA-1024-PUBLIC
+ 
+ Title = DSA tests
+ 
+-Verify = DSA-1024
+-Ctrl = digest:SHA1
+-Input = "0123456789ABCDEF1234"
+-Output = 302d021500942b8c5850e05b59e24495116b1e8559e51b610e0214237aedf272d91f2397f63c9fc8790e1a6cde5d87
+-
+-Verify = DSA-1024-PUBLIC
+-Ctrl = digest:SHA1
+-Input = "0123456789ABCDEF1234"
+-Output = 302d021500942b8c5850e05b59e24495116b1e8559e51b610e0214237aedf272d91f2397f63c9fc8790e1a6cde5d87
+-
+-# Modified signature
+-Verify = DSA-1024-PUBLIC
+-Ctrl = digest:SHA1
+-Input = "0123456789ABCDEF1234"
+-Output = 302d021500942b8c5850e05b59e24495116b1e8559e51b610e0214237aedf272d91f2397f63c9fc8790e1a6cde5d88
+-Result = VERIFY_ERROR
+-
+-# Digest too short
+-Verify = DSA-1024-PUBLIC
+-Ctrl = digest:SHA1
+-Input = "0123456789ABCDEF123"
+-Output = 302d021500942b8c5850e05b59e24495116b1e8559e51b610e0214237aedf272d91f2397f63c9fc8790e1a6cde5d87
+-Result = VERIFY_ERROR
+-
+-# Digest too long
+-Verify = DSA-1024-PUBLIC
+-Ctrl = digest:SHA1
+-Input = "0123456789ABCDEF12345"
+-Output = 302d021500942b8c5850e05b59e24495116b1e8559e51b610e0214237aedf272d91f2397f63c9fc8790e1a6cde5d87
+-Result = VERIFY_ERROR
+ 
+ # Garbage after signature
+ Verify = DSA-1024-PUBLIC
+@@ -81,19 +51,6 @@ Input = "0123456789ABCDEF1234"
+ Output = 302d021500942b8c5850e05b59e24495116b1e8559e51b610e0214237aedf272d91f2397f63c9fc8790e1a6cde5d8700
+ Result = VERIFY_ERROR
+ 
+-# Invalid tag
+-Verify = DSA-1024-PUBLIC
+-Ctrl = digest:SHA1
+-Input = "0123456789ABCDEF1234"
+-Output = 312d021500942b8c5850e05b59e24495116b1e8559e51b610e0214237aedf272d91f2397f63c9fc8790e1a6cde5d87
+-Result = VERIFY_ERROR
+-
+-# BER signature
+-Verify = DSA-1024-PUBLIC
+-Ctrl = digest:SHA1
+-Input = "0123456789ABCDEF1234"
+-Output = 3080021500942b8c5850e05b59e24495116b1e8559e51b610e0214237aedf272d91f2397f63c9fc8790e1a6cde5d870000
+-Result = VERIFY_ERROR
+ 
+ Title = Test keypair mismatches
+ 
+@@ -307,12 +264,6 @@ Key = DSA-1024
+ Input = "Hello "
+ Output = 302c02142e32c8a5b0bd19b2ba33fd9c78aad3729dcb1b9e02142c006f7726a9d6833d414865b95167ea5f4f7713
+ 
+-# Test verify with SHA1 is allowed in fips mode
+-DigestVerify = SHA1
+-Key = DSA-1024
+-Input = "Hello "
+-Output = 302c0214602d21ed37e46051bb3d06cc002adddeb4cdb3bd02144f39f75587b286588862d06366b2f29bddaf8cf6
+-
+ # Test verify with a 2048/160 bit key is allowed in fips mode
+ FIPSversion = >3.1.1
+ DigestVerify = SHA256
+-- 
+2.33.8
+

--- a/SPECS/openssl/0025-for-tests.patch
+++ b/SPECS/openssl/0025-for-tests.patch
@@ -1,3 +1,7 @@
+Modified for AZL to take into account other patches and config settings.
+Specifically, removed the second '#' from the blank comment on line 15 of this file.
+
+
 diff -up openssl-3.0.0/apps/openssl.cnf.xxx openssl-3.0.0/apps/openssl.cnf
 --- openssl-3.0.0/apps/openssl.cnf.xxx	2021-11-23 16:29:50.618691603 +0100
 +++ openssl-3.0.0/apps/openssl.cnf	2021-11-23 16:28:16.872882099 +0100

--- a/SPECS/openssl/openssl.signatures.json
+++ b/SPECS/openssl/openssl.signatures.json
@@ -1,6 +1,6 @@
 {
  "Signatures": {
-  "0025-for-tests.patch": "cd03c0551d1df8ad0881f45020836cb682a6ffda4f423e15d2eb7f8e9b99a47e",
+  "0025-for-tests.patch": "449b4a52855275abbc26999a199ff24f35aa31e961650b45764dc138114383b9",
   "Makefile.certificate": "fba3d7313fd8bdf2a585cd76795503584d6f3e1205dcd16a74c817842fda372b",
   "configuration-prefix.h": "11aba0dcfab381269e7e6ba1fdde1e4e8dfe51e39d8c7a2918f3b28a32cb98fd",
   "configuration-switch.h": "400439d7e8c551e7d5de8bfc648dcc0ddf6f4a7552750af4813449f68941b928",


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
The upstream `openssl` spec has a redhat-specific config/compile flag. This change removes that, comments out a relevant patch and adds a patch to disable tests that fail due to the change.

The tests we disable are the `dsa` tests that use `sha1`, which is currently disabled due to FIPS. I believe that this is technically supposed to work, because it will pick up the fact that it's disabled and only do the relevant tests (based on [this commit](https://github.com/openssl/openssl/commit/e43b44824174fb35309b32db9c1cca5d6fdca74a)), but some of our patches seem to muck with that.

Right now I'm focusing on fixing config flags and will then move on to patches, so disabling the tests makes the most sense for now.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Removed `REDHAT_FIPS_VERSION` config/compile flag
- Disabled `dsa` tests that use `SHA1`.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Builds locally
- Pipeline: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=462947&view=results
