### PR TITLE
Mask kdump.service; remove crashkernel when kernel-mshv is installed

### DIFF
--- a/SPECS/kernel-mshv/kernel-mshv.spec
+++ b/SPECS/kernel-mshv/kernel-mshv.spec
@@ -11,7 +11,7 @@
 Summary:        Mariner kernel that has MSHV Host support
 Name:           kernel-mshv
 Version:        5.15.126.mshv9
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        GPLv2
 Group:          Development/Tools
 Vendor:         Microsoft Corporation
@@ -139,7 +139,7 @@ ln -s vmlinux-%{uname_r} %{buildroot}%{_libdir}/debug/lib/modules/%{uname_r}/vml
 
 cat > %{buildroot}/boot/linux-%{uname_r}.cfg << "EOF"
 # GRUB Environment Block
-mariner_cmdline_mshv=rd.auto=1 lockdown=integrity sysctl.kernel.unprivileged_bpf_disabled=1 init=/lib/systemd/systemd ro no-vmw-sta crashkernel=128M audit=0 console=ttyS0,115200n8 earlyprintk
+mariner_cmdline_mshv=rd.auto=1 lockdown=integrity sysctl.kernel.unprivileged_bpf_disabled=1 init=/lib/systemd/systemd ro no-vmw-sta audit=0 console=ttyS0,115200n8 earlyprintk
 mariner_linux_mshv=vmlinuz-%{uname_r}
 mariner_initrd_mshv=initrd.img-%{uname_r}
 EOF
@@ -208,6 +208,9 @@ fi
 ln -sf linux-%{uname_r}.cfg /boot/mariner-mshv.cfg
 %grub2_post
 
+%posttrans
+systemctl mask kdump.service >/dev/null 2>&1 || :
+
 %files
 %defattr(-,root,root)
 %license COPYING
@@ -248,6 +251,9 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner-mshv.cfg
 %{_includedir}/perf/perf_dlfilter.h
 
 %changelog
+* Mon Dec 04 2023 Cameron Baird <cameronbaird@microsoft.com> - 5.15.126.mshv9-3
+- Disable kdump.service, crashkernel allocation
+
 * Mon Nov 20 2023 Rachel Menge <rachelmenge@microsoft.com> - 5.15.126.mshv9-2
 - Add cpio as BuildRequires
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
The smallest SKU we currently support for kata scenarios has 16G of ram. This can go all the way up to 384G of ram in the more expensive skus. Since we don't currently support vmcore compression nor omission of zero/unallocated pages, this can very quickly fill out our rootfs. 

Given this info, I think it is rather risky to keep kdump enabled by default. The larger skus may naively fill up their rootfs after a single crash. We really need to get that compression behavior configuration working, and, per /etc/kdump.conf man page:

```kdump.conf provides post-kexec instructions to the kdump kernel. It is stored in the initrd file managed by the kdump service. If you change this file and do not want to restart before it takes effect, restart the kdump service to rebuild to initrd.```

Basically we need to make kdump-generated initrd work in order to configure compression, see earlier comments in this thread as well as https://github.com/microsoft/CBL-Mariner/pull/6479.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- kernel-mshv masks kdump.service in posttrans script
- remove crashkernel= param from kernel-mshv legacy boot
- remove crashkernel= param from kernel-mshv mkconfig boot

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES/NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-YYYY-XXXX

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- https://dev.azure.com/mariner-org/mariner/_build/results?buildId=463004&view=results
