### PR TITLE
Add upstream patch, pin test dependency versions to fix python-daemon ptests

### DIFF
--- a/SPECS/python-daemon/fix-test-socket-errors.patch
+++ b/SPECS/python-daemon/fix-test-socket-errors.patch
@@ -1,0 +1,31 @@
+From 74a3f2f56d1343db18613f3bf0ea908a3d16910c Mon Sep 17 00:00:00 2001
+From: Ben Finney <ben+python@benfinney.id.au>
+Date: Thu, 4 Apr 2019 08:05:19 +0000
+Subject: [PATCH] =?UTF-8?q?Create=20the=20socket=20and=20catch=20=E2=80=9C?=
+ =?UTF-8?q?non-socket=E2=80=9D=20errors.?=
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+---
+ daemon/daemon.py | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/daemon/daemon.py b/daemon/daemon.py
+index f7cbaa2..d75b2c0 100644
+--- a/daemon/daemon.py
++++ b/daemon/daemon.py
+@@ -761,9 +761,8 @@ def is_socket(fd):
+         """
+     result = False
+ 
+-    file_socket = socket.fromfd(fd, socket.AF_INET, socket.SOCK_RAW)
+-
+     try:
++        file_socket = socket.fromfd(fd, socket.AF_INET, socket.SOCK_RAW)
+         file_socket.getsockopt(socket.SOL_SOCKET, socket.SO_TYPE)
+     except socket.error as exc:
+         exc_errno = exc.args[0]
+-- 
+2.41.0
+

--- a/SPECS/python-daemon/python-daemon.spec
+++ b/SPECS/python-daemon/python-daemon.spec
@@ -1,13 +1,15 @@
 Summary:        Library to implement a well-behaved Unix daemon process.
 Name:           python-daemon
 Version:        2.2.0
-Release:        6%{?dist}
-License:        ASL 2.0
+Release:        7%{?dist}
+License:        Apache-2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Group:          Development/Languages/Python
 URL:            https://pypi.python.org/pypi/python-daemon/
 Source0:        https://files.pythonhosted.org/packages/source/p/python-daemon/%{name}-%{version}.tar.gz
+# Upstream: https://pagure.io/python-daemon/c/b7089121e305ef29dee9b72bfdb8b1496ffed48c
+Patch0:         fix-test-socket-errors.patch
 BuildArch:      noarch
 
 %description
@@ -35,7 +37,7 @@ daemon program. A DaemonContext instance holds the behaviour and configured proc
 use the instance as a context manager to enter a daemon state.
 
 %prep
-%autosetup
+%autosetup -p1
 sed -i 's/distclass=version.ChangelogAwareDistribution,/ /g' setup.py
 
 %build
@@ -45,7 +47,8 @@ sed -i 's/distclass=version.ChangelogAwareDistribution,/ /g' setup.py
 %py3_install
 
 %check
-pip3 install mock testscenarios testtools
+# Pinned versions are the most recent releases prior to changes that break the test suite
+pip3 install 'mock==4.0.3' testscenarios 'testtools==2.4.0'
 %python3 -m unittest discover
 
 %files -n python3-daemon
@@ -53,10 +56,15 @@ pip3 install mock testscenarios testtools
 %{python3_sitelib}/*
 
 %changelog
-* Fri Dec 03 2021 Thomas Crain <thcrain@microsoft.com> - 2.2.0-6
+* Mon Dec 04 2023 Olivia Crain <oliviacrain@microsoft.com> - 2.2.0-7
+- Add upstream patch to fix socket errors during tests
+- Pin versions of mock, testtools from PyPI used during tests
+- Use SPDX license expression in license tag
+
+* Fri Dec 03 2021 Olivia Crain <oliviacrain@microsoft.com> - 2.2.0-6
 - Replace easy_install usage with pip in %%check sections
 
-* Wed Oct 20 2021 Thomas Crain <thcrain@microsoft.com> - 2.2.0-5
+* Wed Oct 20 2021 Olivia Crain <oliviacrain@microsoft.com> - 2.2.0-5
 - Add license to python3 package
 - Remove python2 package
 - Lint spec


### PR DESCRIPTION
… package tests

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
The package tests for `python-daemon` are failing for a couple of reasons- one being `mock` and `testtools` releasing versions incompatible with the test suite, and the other relating to an uncaught exception when the library calls `socket.fromfd`. So, let's fix the first by pinning the dependencies and fix the second by adding an upstream patch to catch the exception.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- `python-daemon`: Add patch to fix fallible `socket.fromfd` call
- `python-daemon`: Pin `mock` used in ptest to `4.0.3`
- `python-daemon`: Pin `testtools` used in ptest to `2.4.0`

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: [46030](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=463030)
- The amd64 build fails in pipelines due to transient repo errors, but it builds and passes locally.
