### PR TITLE
hard-code enable-ktls

### DIFF
--- a/SPECS/openssl/openssl.spec
+++ b/SPECS/openssl/openssl.spec
@@ -210,11 +210,6 @@ from other formats to the formats used by the OpenSSL toolkit.
 %autosetup -p1 -n %{name}-%{version}
 
 %build
-ktlsopt=enable-ktls
-%ifarch armv7hl
-ktlsopt=disable-ktls
-%endif
-
 # Add -Wa,--noexecstack here so that libcrypto's assembler modules will be
 # marked as not requiring an executable stack.
 # Also add -DPURIFY to make using valgrind with openssl easier as we do not
@@ -230,7 +225,7 @@ export HASHBANGPERL=/usr/bin/perl
 ./Configure \
 	--prefix=%{_prefix} --openssldir=%{_sysconfdir}/pki/tls --libdir=lib \
 	zlib enable-camellia enable-seed enable-rfc3779 no-sctp \
-	enable-cms enable-md2 enable-rc5 enable-ec_nistp_64_gcc_128 ${ktlsopt} enable-fips\
+	enable-cms enable-md2 enable-rc5 enable-ec_nistp_64_gcc_128 enable-ktls enable-fips\
 	no-mdc2 no-ec2m no-sm2 no-sm4 enable-buildtest-c++\
 	shared $NEW_RPM_OPT_FLAGS '-DDEVRANDOM="\"/dev/urandom\""'\
 	-Wl,--allow-multiple-definition


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
The upstream `openssl.spec` decided whether to enabled `ktls` based on the architecture of the system. 

After confirming that `ktls` is approved security-wise, this change removes the architecture-specific decision and just uses the flag directly.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Remove architecture-specific logic around `enable-ktls` and use the flag directly.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Builds Locally
- Pipeline: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=463860&view=results
