### PR TITLE
llvm: fix build break due to <cstdint> header

### DIFF
--- a/SPECS/llvm/llvm.spec
+++ b/SPECS/llvm/llvm.spec
@@ -1,7 +1,7 @@
 Summary:        A collection of modular and reusable compiler and toolchain technologies.
 Name:           llvm
 Version:        12.0.1
-Release:        7%{?dist}
+Release:        8%{?dist}
 License:        NCSA
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -30,6 +30,9 @@ for developing applications that use llvm.
 %prep
 %setup -q -n %{name}-%{version}.src
 %autopatch -p2
+# fix build break with gcc 13 by including cstdint header
+sed -i 's/#include <string>/#include <cstdint>\n#include <string>/g' ./include/llvm/Support/Base64.h
+sed -i 's/#include <string>/#include <cstdint>\n#include <string>/g' ./include/llvm/Support/Signals.h
 
 %build
 # Disable symbol generation
@@ -89,6 +92,9 @@ ninja check-all
 %{_includedir}/*
 
 %changelog
+* Tue Dec 06 2023 Andrew Phelps <anphel@microsoft.com> - 12.0.1-8
+- Fix build break with gcc 13
+
 * Thu Jun 29 2023 Andrew Phelps <anphel@microsoft.com> - 12.0.1-7
 - Modify parallel compile jobs limit to _smp_ncpus_max if set, or _smp_build_ncpus
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Fix `llvm 12.0.1` build break due to gcc 13 upgrade. Note that we plan to upgrade llvm to version 18, but for now this unblocks other package builds.
```
"/usr/src/mariner/BUILD/llvm-12.0.1.src/include/llvm/Support/Base64.h:29:5: error: 'uint32_t' was not declared in this scope"
```
The break is expected from the gcc 13 upgrade; see notes: https://gcc.gnu.org/gcc-13/porting_to.html#header-dep-changes
```
Header dependency changes
Some C++ Standard Library headers have been changed to no longer include other headers that were being used internally by the library. As such, C++ programs that used standard library components without including the right headers will no longer compile.

The following headers are used less widely in libstdc++ and may need to be included explicitly when compiling with GCC 13:

<string> (for std::string, std::to_string, std::stoi etc.)
<system_error> (for std::error_code, std::error_category, std::system_error).
<cstdint> (for std::int8_t, std::int32_t etc.)
<cstdio> (for std::printf, std::fopen etc.)
<cstdlib> (for std::strtol, std::malloc etc.)
```
###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Fix <cstdint> header inclusion in llvm

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build
