### PR TITLE
removed unneeded requires and reformat them

### DIFF
--- a/SPECS/openssl/openssl.spec
+++ b/SPECS/openssl/openssl.spec
@@ -144,20 +144,29 @@ Patch115: 0001-Disable-most-DSA-tests-that-use-SHA1-which-is-disall.patch
 License: Apache-2.0
 URL: http://www.openssl.org/
 
-# AZL: NOTE: Removed dependencies we don't have in AZL and that create circular dependencies.
-#            Will go through these as I go through patches and config options.
-BuildRequires: gcc g++
-BuildRequires: coreutils, perl-interpreter, sed, zlib-devel, /usr/bin/cmp
-BuildRequires: /usr/bin/rename
-BuildRequires: /usr/bin/pod2man
-BuildRequires: perl(Test::Harness), perl(Test::More), perl(Math::BigInt)
-BuildRequires: perl(Module::Load::Conditional), perl(File::Temp)
-BuildRequires: perl(Time::HiRes), perl(IPC::Cmd), perl(Pod::Html), perl(Digest::SHA)
-BuildRequires: perl(FindBin), perl(lib), perl(File::Compare), perl(File::Copy), perl(bigint)
+BuildRequires: %{_bindir}/cmp
+BuildRequires: %{_bindir}/pod2man
+BuildRequires: %{_bindir}/rename
+BuildRequires: coreutils
+BuildRequires: g++
+BuildRequires: gcc
+BuildRequires: make
+BuildRequires: perl-core
+BuildRequires: perl(Digest::SHA)
+BuildRequires: perl(FindBin)
+BuildRequires: perl(IPC::Cmd)
+BuildRequires: perl(lib)
+BuildRequires: perl(Pod::Html)
+BuildRequires: perl(Text::Template)
+BuildRequires: sed
 
-Requires: perl
-Requires: coreutils
+%if 0%{?with_check}
+BuildRequires: perl(Test::More)
+%endif
+
 Requires: %{name}-libs%{?_isa} = %{version}-%{release}
+Requires: coreutils
+Requires: perl
 
 %description
 The OpenSSL toolkit provides support for secure communications between


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Initial merge of `openssl.spec` included some `BuildRequires` and `Requires` statements that were not needed and had them formatted counter to our standard. This removes spurious `*Requires` statements and organizes sorts them with one per line.

Note that it's not easy to actually tell what's required -- some things will simply be there. For example, even without the `BuildRequires: gcc`, the compiler was already in the `chroot` we use to build. I made a best attempt from reading docs and experimenting.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Removed spurious `*Requires` statements.
- Separated them out into individual lines and sorted them

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Built locally
- Pipeline: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=464732&view=results
