### PR TITLE
Image Customizer: Refresh initrd when partitions are customized.

### DIFF
--- a/toolkit/tools/internal/shell/shell.go
+++ b/toolkit/tools/internal/shell/shell.go
@@ -143,10 +143,16 @@ func ExecuteLive(squashErrors bool, program string, args ...string) (err error) 
 
 // ExecuteLiveWithErr runs a command in the shell and logs it in real-time.
 // In addition, if there is an error, the last x lines of stderr will be attached to the err object.
-func ExecuteLiveWithErr(stderrLines int, program string, args ...string) (err error) {
+func ExecuteLiveWithErr(stderrLines int, program string, args ...string) error {
+	return ExecuteLiveWithErrAndCallbacks(logger.Log.Debug, logger.Log.Debug, stderrLines, program, args...)
+}
+
+func ExecuteLiveWithErrAndCallbacks(onStdout, onStderr func(...interface{}), stderrLines int, program string,
+	args ...string,
+) (err error) {
 	stderrChan := make(chan string, stderrLines)
 
-	err = ExecuteLiveWithCallbackAndChannels(logger.Log.Debug, logger.Log.Debug, nil, stderrChan, program, args...)
+	err = ExecuteLiveWithCallbackAndChannels(onStdout, onStderr, nil, stderrChan, program, args...)
 	close(stderrChan)
 	if err != nil {
 		errLines := ""

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepartitions.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepartitions.go
@@ -11,11 +11,11 @@ import (
 
 func customizePartitions(buildDir string, baseConfigPath string, config *imagecustomizerapi.Config,
 	buildImageFile string,
-) (string, error) {
+) (bool, string, error) {
 	if config.Disks == nil && config.SystemConfig.BootType == imagecustomizerapi.BootTypeUnset {
 		// No changes to make to the partitions.
 		// So, just use the original disk.
-		return buildImageFile, nil
+		return false, buildImageFile, nil
 	}
 
 	newBuildImageFile := filepath.Join(buildDir, PartitionCustomizedImageName)
@@ -24,8 +24,8 @@ func customizePartitions(buildDir string, baseConfigPath string, config *imagecu
 	// then fallback to creating the new partitions from scratch and doing a file copy.
 	err := customizePartitionsUsingFileCopy(buildDir, baseConfigPath, config, buildImageFile, newBuildImageFile)
 	if err != nil {
-		return "", err
+		return false, "", err
 	}
 
-	return newBuildImageFile, nil
+	return true, newBuildImageFile, nil
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -94,13 +94,14 @@ func CustomizeImage(buildDir string, baseConfigPath string, config *imagecustomi
 	}
 
 	// Customize the partitions.
-	buildImageFile, err = customizePartitions(buildDirAbs, baseConfigPath, config, buildImageFile)
+	partitionsCustomized, buildImageFile, err := customizePartitions(buildDirAbs, baseConfigPath, config, buildImageFile)
 	if err != nil {
 		return err
 	}
 
 	// Customize the raw image file.
-	err = customizeImageHelper(buildDirAbs, baseConfigPath, config, buildImageFile, rpmsSources, useBaseImageRpmRepos)
+	err = customizeImageHelper(buildDirAbs, baseConfigPath, config, buildImageFile, rpmsSources, useBaseImageRpmRepos,
+		partitionsCustomized)
 	if err != nil {
 		return err
 	}
@@ -201,7 +202,7 @@ func validateScript(baseConfigPath string, script *imagecustomizerapi.Script) er
 }
 
 func customizeImageHelper(buildDir string, baseConfigPath string, config *imagecustomizerapi.Config,
-	buildImageFile string, rpmsSources []string, useBaseImageRpmRepos bool,
+	buildImageFile string, rpmsSources []string, useBaseImageRpmRepos bool, partitionsCustomized bool,
 ) error {
 	imageConnection, err := connectToExistingImage(buildImageFile, buildDir, "imageroot")
 	if err != nil {
@@ -210,7 +211,8 @@ func customizeImageHelper(buildDir string, baseConfigPath string, config *imagec
 	defer imageConnection.Close()
 
 	// Do the actual customizations.
-	err = doCustomizations(buildDir, baseConfigPath, config, imageConnection.Chroot(), rpmsSources, useBaseImageRpmRepos)
+	err = doCustomizations(buildDir, baseConfigPath, config, imageConnection.Chroot(), rpmsSources,
+		useBaseImageRpmRepos, partitionsCustomized)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->

The initrd file typically contains hard coded values for the relevant partitions' IDs. So, if the partitions are customized, these UUIDs will be changed and therefore the initrd file needs to be regenerated. 

###### Change Log  <!-- REQUIRED -->

- Image Customizer: Refresh initrd when partitions are customized.

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Run UTs.
- Manually ran image customizer tool.

