### PR TITLE
fix: add scriptlet to workaround rpm transaction limitation to update /media symlink to directory

### DIFF
--- a/SPECS/filesystem/filesystem.spec
+++ b/SPECS/filesystem/filesystem.spec
@@ -1,7 +1,7 @@
 Summary:      Default file system
 Name:         filesystem
 Version:      1.1
-Release:      18%{?dist}
+Release:      19%{?dist}
 License:      GPLv3
 Group:        System Environment/Base
 Vendor:       Microsoft Corporation
@@ -560,6 +560,24 @@ posix.mkdir("/proc")
 posix.mkdir("/sys")
 posix.chmod("/proc", 0555)
 posix.chmod("/sys", 0555)
+
+# Prior to filesystem-1.1-16, /media used to be a symlink to /run/media but this was
+# replaced with a directory. The RPM upgrade operation generally worked when the /media
+# symlink is a dangling link, which is commonly the case, however not always the case.
+#
+# And when the /media symlink is indeed properly pointing to a real /run/media, RPM has a
+# known limitation where it is not possible to replace an active symlink with a directory,
+# and thus the RPM transation fails.
+#
+# To workaround this, a %pretrans scriptlet must run to test and remove the symlink
+# before RPM attempts to install the new directory.
+#
+# https://docs.fedoraproject.org/en-US/packaging-guidelines/Directory_Replacement
+path = "/media"
+st = posix.stat(path)
+if st and st.type == "link" then
+  os.remove(path)
+end
 return 0
 
 %files
@@ -714,6 +732,9 @@ return 0
 %config(noreplace) /etc/modprobe.d/tipc.conf
 
 %changelog
+* Fri Dec 08 2023 Chris Co <chrco@microsoft.com> - 1.1-19
+- Add scriptlet to handle /media symlink failed upgrade issue
+
 * Thu Dec 07 2023 Dan Streetman <ddstreet@ieee.org> - 1.1-18
 - Add /etc/host.conf with multi enabled
 

--- a/SPECS/filesystem/filesystem.spec
+++ b/SPECS/filesystem/filesystem.spec
@@ -561,18 +561,18 @@ posix.mkdir("/sys")
 posix.chmod("/proc", 0555)
 posix.chmod("/sys", 0555)
 
-# Prior to filesystem-1.1-16, /media used to be a symlink to /run/media but this was
-# replaced with a directory. The RPM upgrade operation generally worked when the /media
-# symlink is a dangling link, which is commonly the case, however not always the case.
-#
-# And when the /media symlink is indeed properly pointing to a real /run/media, RPM has a
-# known limitation where it is not possible to replace an active symlink with a directory,
-# and thus the RPM transation fails.
-#
-# To workaround this, a %pretrans scriptlet must run to test and remove the symlink
-# before RPM attempts to install the new directory.
-#
-# https://docs.fedoraproject.org/en-US/packaging-guidelines/Directory_Replacement
+-- Prior to filesystem-1.1-16, /media used to be a symlink to /run/media but this was
+-- replaced with a directory. The RPM upgrade operation generally worked when the /media
+-- symlink is a dangling link, which is commonly the case, however not always the case.
+--
+-- And when the /media symlink is indeed properly pointing to a real /run/media, RPM has a
+-- known limitation where it is not possible to replace an active symlink with a directory,
+-- and thus the RPM transation fails.
+--
+-- To workaround this, a %pretrans scriptlet must run to test and remove the symlink
+-- before RPM attempts to install the new directory.
+--
+-- https://docs.fedoraproject.org/en-US/packaging-guidelines/Directory_Replacement
 path = "/media"
 st = posix.stat(path)
 if st and st.type == "link" then

--- a/SPECS/filesystem/filesystem.spec
+++ b/SPECS/filesystem/filesystem.spec
@@ -567,7 +567,7 @@ posix.chmod("/sys", 0555)
 --
 -- And when the /media symlink is indeed properly pointing to a real /run/media, RPM has a
 -- known limitation where it is not possible to replace an active symlink with a directory,
--- and thus the RPM transation fails.
+-- and thus the RPM transaction fails.
 --
 -- To workaround this, a %pretrans scriptlet must run to test and remove the symlink
 -- before RPM attempts to install the new directory.

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -1,4 +1,4 @@
-filesystem-1.1-18.cm2.aarch64.rpm
+filesystem-1.1-19.cm2.aarch64.rpm
 kernel-headers-5.15.139.1-1.cm2.noarch.rpm
 glibc-2.35-6.cm2.aarch64.rpm
 glibc-devel-2.35-6.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -1,4 +1,4 @@
-filesystem-1.1-18.cm2.x86_64.rpm
+filesystem-1.1-19.cm2.x86_64.rpm
 kernel-headers-5.15.139.1-1.cm2.noarch.rpm
 glibc-2.35-6.cm2.x86_64.rpm
 glibc-devel-2.35-6.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -81,8 +81,8 @@ file-5.40-2.cm2.aarch64.rpm
 file-debuginfo-5.40-2.cm2.aarch64.rpm
 file-devel-5.40-2.cm2.aarch64.rpm
 file-libs-5.40-2.cm2.aarch64.rpm
-filesystem-1.1-18.cm2.aarch64.rpm
-filesystem-asc-1.1-18.cm2.aarch64.rpm
+filesystem-1.1-19.cm2.aarch64.rpm
+filesystem-asc-1.1-19.cm2.aarch64.rpm
 findutils-4.8.0-5.cm2.aarch64.rpm
 findutils-debuginfo-4.8.0-5.cm2.aarch64.rpm
 findutils-lang-4.8.0-5.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -81,8 +81,8 @@ file-5.40-2.cm2.x86_64.rpm
 file-debuginfo-5.40-2.cm2.x86_64.rpm
 file-devel-5.40-2.cm2.x86_64.rpm
 file-libs-5.40-2.cm2.x86_64.rpm
-filesystem-1.1-18.cm2.x86_64.rpm
-filesystem-asc-1.1-18.cm2.x86_64.rpm
+filesystem-1.1-19.cm2.x86_64.rpm
+filesystem-asc-1.1-19.cm2.x86_64.rpm
 findutils-4.8.0-5.cm2.x86_64.rpm
 findutils-debuginfo-4.8.0-5.cm2.x86_64.rpm
 findutils-lang-4.8.0-5.cm2.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Prior to filesystem-1.1-16, /media used to be a symlink to /run/media but this was
replaced with a directory. The RPM upgrade operation generally worked when the /media
symlink is a dangling link, which is commonly the case, however not always the case.

And when the /media symlink is indeed properly pointing to a real /run/media, RPM has a
known limitation where it is not possible to replace an active symlink with a directory,
and thus the RPM transation fails.

To workaround this, a %pretrans scriptlet must run to test and remove the symlink
before RPM attempts to install the new directory.

https://docs.fedoraproject.org/en-US/packaging-guidelines/Directory_Replacement

Fixes: https://github.com/microsoft/CBL-Mariner/commit/e2d3d55ce1ee7c235e053abbf7b25937450dfd3f ("fix: make /media a directory")

Signed-off-by: Chris Co <chrco@microsoft.com>

Fun Note: Turns out, if RPM Lua scriptlet has syntax errors (at least in the `%pretrans` scriptlet), RPM will just silently skip the scriptlet and trudge forward without any debug messages.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #6948 

###### Links to CVEs  <!-- optional -->

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=465720&view=results

Tests:
- Successful upgrade with /media symlinked to /run/media
- Successful upgrade with /media dangling symlink to /run/media
- Successful upgrade with /media already as directory