### PR TITLE
Add a patch to fix CVE-2023-49083

### DIFF
--- a/SPECS/python-cryptography/CVE-2023-49083.patch
+++ b/SPECS/python-cryptography/CVE-2023-49083.patch
@@ -1,0 +1,118 @@
+From 87c06ca129dbf3d58a1391ca4ea45514262db72b Mon Sep 17 00:00:00 2001
+From: Alex Gaynor <alex.gaynor@gmail.com>
+Date: Wed, 22 Nov 2023 16:49:56 -0500
+Subject: [PATCH 1/2] Fixed crash when loading a PKCS#7 bundle with no
+ certificates
+
+---
+ src/cryptography/hazmat/backends/openssl/backend.py | 5 ++++-
+ tests/hazmat/primitives/test_pkcs7.py               | 6 ++++++
+ 2 files changed, 10 insertions(+), 1 deletion(-)
+
+diff --git a/src/cryptography/hazmat/backends/openssl/backend.py b/src/cryptography/hazmat/backends/openssl/backend.py
+index 45d4a1a..f0317c7 100644
+--- a/src/cryptography/hazmat/backends/openssl/backend.py
++++ b/src/cryptography/hazmat/backends/openssl/backend.py
+@@ -2664,9 +2664,12 @@ class Backend(object):
+                 _Reasons.UNSUPPORTED_SERIALIZATION,
+             )
+ 
++        certs: list[x509.Certificate] = []
++        if p7.d.sign == self._ffi.NULL:
++            return certs
++
+         sk_x509 = p7.d.sign.cert
+         num = self._lib.sk_X509_num(sk_x509)
+-        certs = []
+         for i in range(num):
+             x509 = self._lib.sk_X509_value(sk_x509, i)
+             self.openssl_assert(x509 != self._ffi.NULL)
+diff --git a/tests/hazmat/primitives/test_pkcs7.py b/tests/hazmat/primitives/test_pkcs7.py
+index 8b93cb6..148a1e1 100644
+--- a/tests/hazmat/primitives/test_pkcs7.py
++++ b/tests/hazmat/primitives/test_pkcs7.py
+@@ -80,6 +80,12 @@ class TestPKCS7Loading(object):
+                 mode="rb",
+             )
+ 
++    def test_load_pkcs7_empty_certificates(self):
++        der = b"\x30\x0B\x06\x09\x2A\x86\x48\x86\xF7\x0D\x01\x07\x02"
++
++        certificates = pkcs7.load_der_pkcs7_certificates(der)
++        assert certificates == []
++
+ 
+ # We have no public verification API and won't be adding one until we get
+ # some requirements from users so this function exists to give us basic
+-- 
+2.17.1
+
+
+From ce104165dd90d8f2f8ff9aaa64327daccf27b82b Mon Sep 17 00:00:00 2001
+From: Paul Kehrer <paul.l.kehrer@gmail.com>
+Date: Thu, 30 Nov 2023 20:30:34 -0600
+Subject: [PATCH 2/2] raise an exception instead of returning an empty list and
+ update CHANGELOG.rst
+
+---
+ CHANGELOG.rst                                       | 5 +++++
+ src/cryptography/hazmat/backends/openssl/backend.py | 7 +++++--
+ tests/hazmat/primitives/test_pkcs7.py               | 4 ++--
+ 3 files changed, 12 insertions(+), 4 deletions(-)
+
+diff --git a/CHANGELOG.rst b/CHANGELOG.rst
+index 4dd7146..ccc6133 100644
+--- a/CHANGELOG.rst
++++ b/CHANGELOG.rst
+@@ -6,6 +6,11 @@ Changelog
+ 3.3.2 - 2021-02-07
+ ~~~~~~~~~~~~~~~~~~
+ 
++* **BACKWARDS INCOMPATIBLE:** Loading a PKCS7 with no content field using
++  :func:`~cryptography.hazmat.primitives.serialization.pkcs7.load_pem_pkcs7_certificates`
++  or
++  :func:`~cryptography.hazmat.primitives.serialization.pkcs7.load_der_pkcs7_certificates`
++  will now raise a ``ValueError`` rather than return an empty list.
+ * **SECURITY ISSUE:** Fixed a bug where certain sequences of ``update()`` calls
+   when symmetrically encrypting very large payloads (>2GB) could result in an
+   integer overflow, leading to buffer overflows. *CVE-2020-36242*
+diff --git a/src/cryptography/hazmat/backends/openssl/backend.py b/src/cryptography/hazmat/backends/openssl/backend.py
+index f0317c7..b276f9b 100644
+--- a/src/cryptography/hazmat/backends/openssl/backend.py
++++ b/src/cryptography/hazmat/backends/openssl/backend.py
+@@ -2664,12 +2664,15 @@ class Backend(object):
+                 _Reasons.UNSUPPORTED_SERIALIZATION,
+             )
+ 
+-        certs: list[x509.Certificate] = []
+         if p7.d.sign == self._ffi.NULL:
+-            return certs
++            raise ValueError(
++                "The provided PKCS7 has no certificate data, but a cert "
++                "loading method was called."
++            )
+ 
+         sk_x509 = p7.d.sign.cert
+         num = self._lib.sk_X509_num(sk_x509)
++        certs: list[x509.Certificate] = []
+         for i in range(num):
+             x509 = self._lib.sk_X509_value(sk_x509, i)
+             self.openssl_assert(x509 != self._ffi.NULL)
+diff --git a/tests/hazmat/primitives/test_pkcs7.py b/tests/hazmat/primitives/test_pkcs7.py
+index 148a1e1..34cbb16 100644
+--- a/tests/hazmat/primitives/test_pkcs7.py
++++ b/tests/hazmat/primitives/test_pkcs7.py
+@@ -83,8 +83,8 @@ class TestPKCS7Loading(object):
+     def test_load_pkcs7_empty_certificates(self):
+         der = b"\x30\x0B\x06\x09\x2A\x86\x48\x86\xF7\x0D\x01\x07\x02"
+ 
+-        certificates = pkcs7.load_der_pkcs7_certificates(der)
+-        assert certificates == []
++        with pytest.raises(ValueError):
++            pkcs7.load_der_pkcs7_certificates(der)
+ 
+ 
+ # We have no public verification API and won't be adding one until we get
+-- 
+2.17.1
+

--- a/SPECS/python-cryptography/python-cryptography.spec
+++ b/SPECS/python-cryptography/python-cryptography.spec
@@ -65,7 +65,7 @@ pip3 install pretend pytest hypothesis iso8601 cryptography_vectors pytz
 %{python3_sitelib}/*
 
 %changelog
-* Wed Dec 08 2023 Aadhar Agarwal <aadagarwal@microsoft.com> - 3.3.2-6
+* Fri Dec 08 2023 Aadhar Agarwal <aadagarwal@microsoft.com> - 3.3.2-6
 - Patch CVE-2023-49083
 
 * Wed Sep 20 2023 Jon Slobodzian <joslobo@microsoft.com> - 3.3.2-5

--- a/SPECS/python-cryptography/python-cryptography.spec
+++ b/SPECS/python-cryptography/python-cryptography.spec
@@ -1,7 +1,7 @@
 Summary:        Python cryptography library
 Name:           python-cryptography
 Version:        3.3.2
-Release:        5%{?dist}
+Release:        6%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -9,6 +9,7 @@ Group:          Development/Languages/Python
 URL:            https://pypi.python.org/pypi/cryptography
 Source0:        https://pypi.io/packages/source/c/cryptography/cryptography-%{version}.tar.gz
 Patch0:         CVE-2023-23931.patch
+Patch1:         CVE-2023-49083.patch
 %if %{with_check}
 BuildRequires:  python3-pip
 %endif
@@ -64,6 +65,9 @@ pip3 install pretend pytest hypothesis iso8601 cryptography_vectors pytz
 %{python3_sitelib}/*
 
 %changelog
+* Wed Dec 08 2023 Aadhar Agarwal <aadagarwal@microsoft.com> - 3.3.2-6
+- Patch CVE-2023-49083
+
 * Wed Sep 20 2023 Jon Slobodzian <joslobo@microsoft.com> - 3.3.2-5
 - Recompile with stack-protection fixed gcc version (CVE-2023-4039)
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
- This PR adds a patch to fix CVE-2023-49083
- Calling `load_pem_pkcs7_certificates` or `load_der_pkcs7_certificates` could lead to a NULL-pointer dereference and segfault. Exploitation of this vulnerability poses a serious risk of Denial of Service (DoS) for any application attempting to deserialize a PKCS7 blob/certificate.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- This is the upstream [PR](https://github.com/pyca/cryptography/pull/9926) in pyca/cryptography that fixes the issue
- There was a comment (regarding raising an exception) that was addressed later on in this [PR](https://github.com/pyca/cryptography/pull/9947)
- The patch has the changes from both of these PRs


###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2023-49083

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Buddy Build - [Pass](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=465848&view=results)
- In the [GitHub advisory](https://github.com/advisories/GHSA-jfhm-5ghh-2f97), there is a reproducer for this issue. Used this reproducer to test the patch. Results are below.
- Using python3-cryptography-3.3.2-5, we see the seg fault:
![image](https://github.com/microsoft/CBL-Mariner/assets/108542189/b9e06c13-1412-46ec-8b44-f3a292379a5b)

- Using the updated python3-cryptography-3.3.2-6, we see the ValueError exception being thrown:
![image](https://github.com/microsoft/CBL-Mariner/assets/108542189/fd8e3353-b79a-4b7b-afa2-1711795ca807)

