### PR TITLE
Shift user/group creation earlier in image build for rootfs image types

### DIFF
--- a/toolkit/imageconfigs/packagelists/core-packages-image.json
+++ b/toolkit/imageconfigs/packagelists/core-packages-image.json
@@ -6,7 +6,8 @@
         "cronie-anacron",
         "logrotate",
         "core-packages-base-image",
-        "initramfs"
+        "initramfs",
+        "shadow-utils"
     ],
     "_comment": "Install 'initramfs' last to avoid unnecessary regeneration when other packages, such as 'kernel', are installed."
 }

--- a/toolkit/tools/imageconfigvalidator/imageconfigvalidator.go
+++ b/toolkit/tools/imageconfigvalidator/imageconfigvalidator.go
@@ -176,7 +176,7 @@ func validatePackages(config configuration.Config) (err error) {
 				return fmt.Errorf("%s: [SELinux] selected, but '%s' package is not included in the package lists", validateError, selinuxPkgName)
 			}
 		}
-		if len(systemConfig.Users) > 0 {
+		if len(systemConfig.Users) > 0 || len(systemConfig.Groups) > 0 {
 			if !foundUserAddPackage {
 				return fmt.Errorf("%s: add users require '%s' package that is not included in the package lists", validateError, userAddPkgName)
 			}

--- a/toolkit/tools/imageconfigvalidator/imageconfigvalidator.go
+++ b/toolkit/tools/imageconfigvalidator/imageconfigvalidator.go
@@ -119,6 +119,7 @@ func validatePackages(config configuration.Config) (err error) {
 		verityDebugPkgName = "verity-read-only-root-debug-tools"
 		dracutFipsPkgName  = "dracut-fips"
 		fipsKernelCmdLine  = "fips=1"
+		userAddPkgName     = "shadow-utils"
 	)
 
 	for _, systemConfig := range config.SystemConfigs {
@@ -130,6 +131,7 @@ func validatePackages(config configuration.Config) (err error) {
 		foundVerityInitramfsPackage := false
 		foundVerityInitramfsDebugPackage := false
 		foundDracutFipsPackage := false
+		foundUserAddPackage := false
 		kernelCmdLineString := systemConfig.KernelCommandLine.ExtraCommandLine
 		selinuxPkgName := systemConfig.KernelCommandLine.SELinuxPolicy
 		if selinuxPkgName == "" {
@@ -152,6 +154,9 @@ func validatePackages(config configuration.Config) (err error) {
 			if pkg == selinuxPkgName {
 				foundSELinuxPackage = true
 			}
+			if pkg == userAddPkgName {
+				foundUserAddPackage = true
+			}
 		}
 		if systemConfig.ReadOnlyVerityRoot.Enable {
 			if !foundVerityInitramfsPackage {
@@ -169,6 +174,11 @@ func validatePackages(config configuration.Config) (err error) {
 		if systemConfig.KernelCommandLine.SELinux != configuration.SELinuxOff {
 			if !foundSELinuxPackage {
 				return fmt.Errorf("%s: [SELinux] selected, but '%s' package is not included in the package lists", validateError, selinuxPkgName)
+			}
+		}
+		if len(systemConfig.Users) > 0 {
+			if !foundUserAddPackage {
+				return fmt.Errorf("%s: add users require '%s' package that is not included in the package lists", validateError, userAddPkgName)
 			}
 		}
 	}

--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -387,7 +387,7 @@ func PopulateInstallRoot(installChroot *safechroot.Chroot, packagesToInstall []s
 	defer timestamp.StopEvent(nil)
 
 	const (
-		filesystemPkg = "filesystem"
+		filesystemPkg  = "filesystem"
 		shadowUtilsPkg = "shadow-utils"
 	)
 
@@ -441,7 +441,7 @@ func PopulateInstallRoot(installChroot *safechroot.Chroot, packagesToInstall []s
 		return
 	}
 
-	if isRootFS && (len(config.Users) > 0 || len(config.Groups) > 0)  {
+	if isRootFS && (len(config.Users) > 0 || len(config.Groups) > 0) {
 		// Install shadow-utils package
 		packagesInstalled, err = TdnfInstallWithProgress(shadowUtilsPkg, installRoot, packagesInstalled, totalPackages, true)
 		if err != nil {

--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -387,8 +387,7 @@ func PopulateInstallRoot(installChroot *safechroot.Chroot, packagesToInstall []s
 	defer timestamp.StopEvent(nil)
 
 	const (
-		filesystemPkg  = "filesystem"
-		shadowUtilsPkg = "shadow-utils"
+		filesystemPkg = "filesystem"
 	)
 
 	defer stopGPGAgent(installChroot)
@@ -441,26 +440,6 @@ func PopulateInstallRoot(installChroot *safechroot.Chroot, packagesToInstall []s
 		return
 	}
 
-	if isRootFS && (len(config.Users) > 0 || len(config.Groups) > 0) {
-		// Install shadow-utils package
-		packagesInstalled, err = TdnfInstallWithProgress(shadowUtilsPkg, installRoot, packagesInstalled, totalPackages, true)
-		if err != nil {
-			return
-		}
-
-		// Add groups
-		err = addGroups(installChroot, config.Groups)
-		if err != nil {
-			return
-		}
-
-		// Add users
-		err = addUsers(installChroot, config.Users)
-		if err != nil {
-			return
-		}
-	}
-
 	hostname := config.Hostname
 	if !isRootFS && mountPointToFsTypeMap[rootMountPoint] != overlay {
 		// Add /etc/hostname
@@ -468,6 +447,18 @@ func PopulateInstallRoot(installChroot *safechroot.Chroot, packagesToInstall []s
 		if err != nil {
 			return
 		}
+	}
+
+	// Add groups
+	err = addGroups(installChroot, config.Groups)
+	if err != nil {
+		return
+	}
+
+	// Add users
+	err = addUsers(installChroot, config.Users)
+	if err != nil {
+		return
 	}
 
 	// Install packages one-by-one to avoid exhausting memory
@@ -491,18 +482,6 @@ func PopulateInstallRoot(installChroot *safechroot.Chroot, packagesToInstall []s
 	if !isRootFS {
 		// Configure system files
 		err = configureSystemFiles(installChroot, hostname, config, installMap, mountPointToFsTypeMap, mountPointToMountArgsMap, partIDToDevPathMap, partIDToFsTypeMap, encryptedRoot, hidepidEnabled)
-		if err != nil {
-			return
-		}
-
-		// Add groups
-		err = addGroups(installChroot, config.Groups)
-		if err != nil {
-			return
-		}
-
-		// Add users
-		err = addUsers(installChroot, config.Users)
 		if err != nil {
 			return
 		}

--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -387,7 +387,8 @@ func PopulateInstallRoot(installChroot *safechroot.Chroot, packagesToInstall []s
 	defer timestamp.StopEvent(nil)
 
 	const (
-		filesystemPkg = "filesystem"
+		filesystemPkg  = "filesystem"
+		shadowUtilsPkg = "shadow-utils"
 	)
 
 	defer stopGPGAgent(installChroot)
@@ -438,6 +439,14 @@ func PopulateInstallRoot(installChroot *safechroot.Chroot, packagesToInstall []s
 	packagesInstalled, err = TdnfInstallWithProgress(filesystemPkg, installRoot, packagesInstalled, totalPackages, true)
 	if err != nil {
 		return
+	}
+	if len(config.Users) > 0 || len(config.Groups) > 0 {
+		shadowUtilsInstalled := 0
+		shadowUtilsInstalled, err = TdnfInstallWithProgress(shadowUtilsPkg, installRoot, packagesInstalled, totalPackages, true)
+		if err != nil {
+			return
+		}
+		packagesInstalled += shadowUtilsInstalled
 	}
 
 	hostname := config.Hostname


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Mariner toolkit didn't have a capability to set a predefined list of users and groups when building a rootFS image type.
Given some packages also define some users or groups, there is a chance that the user/group is already defined if we do the use/group add after installing the packages in chroot.
This PR is related to https://github.com/microsoft/CBL-Mariner/pull/6876 change.
 
###### Change Log  <!-- REQUIRED -->
- Change toolkit to shift user/group creation earlier in image build for rootfs image types

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
Manually tested with a derivative image and verified it works as expected.
- Pipeline build id: 482218
