### PR TITLE
clamav: Fix resetting of user and group on package update

### DIFF
--- a/SPECS/clamav/clamav.spec
+++ b/SPECS/clamav/clamav.spec
@@ -1,7 +1,7 @@
 Summary:        Open source antivirus engine
 Name:           clamav
 Version:        0.105.2
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        ASL 2.0 AND BSD AND bzip2-1.0.4 AND GPLv2 AND LGPLv2+ AND MIT AND Public Domain AND UnRar
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -98,20 +98,24 @@ mv %{buildroot}%{_sysconfdir}/clamav/freshclam.conf{.sample,}
 chmod 600 %{buildroot}%{_sysconfdir}/clamav/freshclam.conf
 
 %pre
-if ! getent group clamav >/dev/null; then
-    groupadd -r clamav
-fi
-if ! getent passwd clamav >/dev/null; then
-    useradd -g clamav -d %{_sharedstatedir}/clamav\
-        -s /bin/false -M -r clamav
+if [ $1 -eq 1 ]; then
+    if ! getent group clamav >/dev/null; then
+        groupadd -r clamav
+    fi
+    if ! getent passwd clamav >/dev/null; then
+        useradd -g clamav -d %{_sharedstatedir}/clamav\
+            -s /bin/false -M -r clamav
+    fi
 fi
 
 %postun
-if getent passwd clamav >/dev/null; then
-    userdel clamav
-fi
-if getent group clamav >/dev/null; then
-    groupdel clamav
+if [ $1 -eq 0 ]; then
+    if getent passwd clamav >/dev/null; then
+        userdel clamav
+    fi
+    if getent group clamav >/dev/null; then
+        groupdel clamav
+    fi
 fi
 
 %files
@@ -132,6 +136,9 @@ fi
 %dir %attr(-,clamav,clamav) %{_sharedstatedir}/clamav
 
 %changelog
+* Fri Dec 08 2023 Neha Agarwal <nehaagarwal@microsoft.com> - 0.105.2-4
+- Fix resetting of user and group settings on package update
+
 * Thu Sep 07 2023 Daniel McIlvaney <damcilva@microsoft.com> - 0.105.2-3
 - Bump package to rebuild with rust 1.72.0
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Clamav user disappeared from passwd and group file on package updates. This fixes the pre and postun scriptlet to add/delete the user depending on whether it's a package installation, update or removal.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- User would disappear from passwd and group files on package updates.
- Fixed pre and postun scriptlets to run based on input argument so that clamav user does not disappear on package update.  We now add user iff it's a package installation, and remove user iff it's a package removal. For package update, we neither add nor remove the user. Since we know that clamav doesn't have multiple packages by the same name which are 'parallel installable', this should work.
- https://docs.fedoraproject.org/en-US/packaging-guidelines/Scriptlets/#_syntax describes what argument is passed to the scriptlet
- Earlier, the scripts would run on package upgrade also. In that case, the user added by the updated version was deleted during the removal of the old version. The new version is installed before the old version is removed (as observed and supported in this https://docs.fedoraproject.org/en-US/packaging-guidelines/Scriptlets/#ordering)

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #6422 


###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build. Tested these behaviours on the new releases (>=4) built with fixed pre and postun sections. To observe this behaviour, we have to get rid of the RPMS <= clamav-0.105.2-3, and do a fresh installation of clamav-0.105.2-4. But, builds in the future should show correct behaviour, as described below.
- Tested that the user appears on package installation
- Tested that the user does not disappear on package update
![image](https://github.com/microsoft/CBL-Mariner/assets/58672330/13385ae5-1ed9-413c-8cad-9f6a239f6306)

- Tested that the user disappears on package removal
