### PR TITLE
[2.0] libgcrypt: upgrade to 1.10.3

### DIFF
--- a/SPECS/libgcrypt/libgcrypt.signatures.json
+++ b/SPECS/libgcrypt/libgcrypt.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "libgcrypt-1.9.4.tar.bz2": "ea849c83a72454e3ed4267697e8ca03390aee972ab421e7df69dfe42b65caaf7"
+  "libgcrypt-1.10.3.tar.bz2": "8b0870897ac5ac67ded568dcfadf45969cfa8a6beb0fd60af2a9eadc2a3272aa"
  }
 }

--- a/SPECS/libgcrypt/libgcrypt.spec
+++ b/SPECS/libgcrypt/libgcrypt.spec
@@ -1,7 +1,7 @@
 Summary:        GNU Crypto Libraries
 Name:           libgcrypt
-Version:        1.9.4
-Release:        2%{?dist}
+Version:        1.10.3
+Release:        1%{?dist}
 License:        GPLv2+ and LGPLv2+ and BSD and MIT and Public Domain
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -59,6 +59,9 @@ rm -rf %{buildroot}%{_infodir}
 %{_libdir}/pkgconfig/%{name}.pc
 
 %changelog
+* Mon Dec 11 2023 Andrew Phelps <anphel@microsoft.com> - 1.10.3-1
+- Upgrade to 1.10.3
+
 * Wed Sep 20 2023 Jon Slobodzian <joslobo@microsoft.com> - 1.9.4-2
 - Recompile with stack-protection fixed gcc version (CVE-2023-4039)
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -9381,8 +9381,8 @@
         "type": "other",
         "other": {
           "name": "libgcrypt",
-          "version": "1.9.4",
-          "downloadUrl": "https://gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-1.9.4.tar.bz2"
+          "version": "1.10.3",
+          "downloadUrl": "https://gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-1.10.3.tar.bz2"
         }
       }
     },

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -215,7 +215,7 @@ tdnf-plugin-repogpgcheck-3.5.2-2.cm2.aarch64.rpm
 libassuan-2.5.5-2.cm2.aarch64.rpm
 libassuan-devel-2.5.5-2.cm2.aarch64.rpm
 libgpg-error-1.46-1.cm2.aarch64.rpm
-libgcrypt-1.9.4-2.cm2.aarch64.rpm
+libgcrypt-1.10.3.2.cm2.aarch64.rpm
 libksba-1.6.3-1.cm2.aarch64.rpm
 libksba-devel-1.6.3-1.cm2.aarch64.rpm
 libxslt-1.1.34-7.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -215,7 +215,7 @@ tdnf-plugin-repogpgcheck-3.5.2-2.cm2.aarch64.rpm
 libassuan-2.5.5-2.cm2.aarch64.rpm
 libassuan-devel-2.5.5-2.cm2.aarch64.rpm
 libgpg-error-1.46-1.cm2.aarch64.rpm
-libgcrypt-1.10.3.2.cm2.aarch64.rpm
+libgcrypt-1.10.3-1.cm2.aarch64.rpm
 libksba-1.6.3-1.cm2.aarch64.rpm
 libksba-devel-1.6.3-1.cm2.aarch64.rpm
 libxslt-1.1.34-7.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -215,7 +215,7 @@ tdnf-plugin-repogpgcheck-3.5.2-2.cm2.x86_64.rpm
 libassuan-2.5.5-2.cm2.x86_64.rpm
 libassuan-devel-2.5.5-2.cm2.x86_64.rpm
 libgpg-error-1.46-1.cm2.x86_64.rpm
-libgcrypt-1.9.4-2.cm2.x86_64.rpm
+libgcrypt-1.10.3.2.cm2.x86_64.rpm
 libksba-1.6.3-1.cm2.x86_64.rpm
 libksba-devel-1.6.3-1.cm2.x86_64.rpm
 libxslt-1.1.34-7.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -215,7 +215,7 @@ tdnf-plugin-repogpgcheck-3.5.2-2.cm2.x86_64.rpm
 libassuan-2.5.5-2.cm2.x86_64.rpm
 libassuan-devel-2.5.5-2.cm2.x86_64.rpm
 libgpg-error-1.46-1.cm2.x86_64.rpm
-libgcrypt-1.10.3.2.cm2.x86_64.rpm
+libgcrypt-1.10.3-1.cm2.x86_64.rpm
 libksba-1.6.3-1.cm2.x86_64.rpm
 libksba-devel-1.6.3-1.cm2.x86_64.rpm
 libxslt-1.1.34-7.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -163,9 +163,9 @@ libffi-devel-3.4.2-3.cm2.aarch64.rpm
 libgcc-11.2.0-7.cm2.aarch64.rpm
 libgcc-atomic-11.2.0-7.cm2.aarch64.rpm
 libgcc-devel-11.2.0-7.cm2.aarch64.rpm
-libgcrypt-1.10.3.2.cm2.aarch64.rpm
-libgcrypt-debuginfo-1.10.3.2.cm2.aarch64.rpm
-libgcrypt-devel-1.10.3.2.cm2.aarch64.rpm
+libgcrypt-1.10.3-1.cm2.aarch64.rpm
+libgcrypt-debuginfo-1.10.3-1.cm2.aarch64.rpm
+libgcrypt-devel-1.10.3-1.cm2.aarch64.rpm
 libgomp-11.2.0-7.cm2.aarch64.rpm
 libgomp-devel-11.2.0-7.cm2.aarch64.rpm
 libgpg-error-1.46-1.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -163,9 +163,9 @@ libffi-devel-3.4.2-3.cm2.aarch64.rpm
 libgcc-11.2.0-7.cm2.aarch64.rpm
 libgcc-atomic-11.2.0-7.cm2.aarch64.rpm
 libgcc-devel-11.2.0-7.cm2.aarch64.rpm
-libgcrypt-1.9.4-2.cm2.aarch64.rpm
-libgcrypt-debuginfo-1.9.4-2.cm2.aarch64.rpm
-libgcrypt-devel-1.9.4-2.cm2.aarch64.rpm
+libgcrypt-1.10.3.2.cm2.aarch64.rpm
+libgcrypt-debuginfo-1.10.3.2.cm2.aarch64.rpm
+libgcrypt-devel-1.10.3.2.cm2.aarch64.rpm
 libgomp-11.2.0-7.cm2.aarch64.rpm
 libgomp-devel-11.2.0-7.cm2.aarch64.rpm
 libgpg-error-1.46-1.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -163,9 +163,9 @@ libffi-devel-3.4.2-3.cm2.x86_64.rpm
 libgcc-11.2.0-7.cm2.x86_64.rpm
 libgcc-atomic-11.2.0-7.cm2.x86_64.rpm
 libgcc-devel-11.2.0-7.cm2.x86_64.rpm
-libgcrypt-1.10.3.2.cm2.x86_64.rpm
-libgcrypt-debuginfo-1.10.3.2.cm2.x86_64.rpm
-libgcrypt-devel-1.10.3.2.cm2.x86_64.rpm
+libgcrypt-1.10.3-1.cm2.x86_64.rpm
+libgcrypt-debuginfo-1.10.3-1.cm2.x86_64.rpm
+libgcrypt-devel-1.10.3-1.cm2.x86_64.rpm
 libgomp-11.2.0-7.cm2.x86_64.rpm
 libgomp-devel-11.2.0-7.cm2.x86_64.rpm
 libgpg-error-1.46-1.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -163,9 +163,9 @@ libffi-devel-3.4.2-3.cm2.x86_64.rpm
 libgcc-11.2.0-7.cm2.x86_64.rpm
 libgcc-atomic-11.2.0-7.cm2.x86_64.rpm
 libgcc-devel-11.2.0-7.cm2.x86_64.rpm
-libgcrypt-1.9.4-2.cm2.x86_64.rpm
-libgcrypt-debuginfo-1.9.4-2.cm2.x86_64.rpm
-libgcrypt-devel-1.9.4-2.cm2.x86_64.rpm
+libgcrypt-1.10.3.2.cm2.x86_64.rpm
+libgcrypt-debuginfo-1.10.3.2.cm2.x86_64.rpm
+libgcrypt-devel-1.10.3.2.cm2.x86_64.rpm
 libgomp-11.2.0-7.cm2.x86_64.rpm
 libgomp-devel-11.2.0-7.cm2.x86_64.rpm
 libgpg-error-1.46-1.cm2.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Upgrade `libgcrypt` to version 1.10.3, which is the latest stable version. This resolves bug `48127839`

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change `libgcrypt` to 1.10.3

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- [[FIPS] GPG in FIPS mode spits out useless "out of core handler ignored in FIPS mode" message on every execution](https://microsoft.visualstudio.com/OS/_workitems/edit/48127839)
###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-YYYY-XXXX

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Buddy build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=466990&view=results