### PR TITLE
Image Customizer: Refresh initrd when partitions are customized

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/customizepartitions.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepartitions.go
@@ -11,11 +11,11 @@ import (
 
 func customizePartitions(buildDir string, baseConfigPath string, config *imagecustomizerapi.Config,
 	buildImageFile string,
-) (string, error) {
-	if config.Disks == nil && config.SystemConfig.BootType == imagecustomizerapi.BootTypeUnset {
+) (bool, string, error) {
+	if !hasPartitionCustomizations(config) {
 		// No changes to make to the partitions.
 		// So, just use the original disk.
-		return buildImageFile, nil
+		return false, buildImageFile, nil
 	}
 
 	newBuildImageFile := filepath.Join(buildDir, PartitionCustomizedImageName)
@@ -24,8 +24,8 @@ func customizePartitions(buildDir string, baseConfigPath string, config *imagecu
 	// then fallback to creating the new partitions from scratch and doing a file copy.
 	err := customizePartitionsUsingFileCopy(buildDir, baseConfigPath, config, buildImageFile, newBuildImageFile)
 	if err != nil {
-		return "", err
+		return false, "", err
 	}
 
-	return newBuildImageFile, nil
+	return true, newBuildImageFile, nil
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeutils.go
@@ -28,7 +28,7 @@ const (
 )
 
 func doCustomizations(buildDir string, baseConfigPath string, config *imagecustomizerapi.Config,
-	imageChroot *safechroot.Chroot, rpmsSources []string, useBaseImageRpmRepos bool,
+	imageChroot *safechroot.Chroot, rpmsSources []string, useBaseImageRpmRepos bool, partitionsCustomized bool,
 ) error {
 	var err error
 
@@ -42,7 +42,8 @@ func doCustomizations(buildDir string, baseConfigPath string, config *imagecusto
 		return err
 	}
 
-	err = addRemoveAndUpdatePackages(buildDir, baseConfigPath, &config.SystemConfig, imageChroot, rpmsSources, useBaseImageRpmRepos)
+	err = addRemoveAndUpdatePackages(buildDir, baseConfigPath, &config.SystemConfig, imageChroot, rpmsSources,
+		useBaseImageRpmRepos, partitionsCustomized)
 	if err != nil {
 		return err
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
@@ -119,38 +119,32 @@ func TestCustomizeImageCopyFiles(t *testing.T) {
 }
 
 func TestValidateConfigValidAdditionalFiles(t *testing.T) {
-	var err error
-
-	err = validateConfig(testDir, &imagecustomizerapi.Config{
+	err := validateConfig(testDir, &imagecustomizerapi.Config{
 		SystemConfig: imagecustomizerapi.SystemConfig{
 			AdditionalFiles: map[string]imagecustomizerapi.FileConfigList{
 				"files/a.txt": {{Path: "/a.txt"}},
 			},
-		}})
+		}}, nil, true)
 	assert.NoError(t, err)
 }
 
 func TestValidateConfigMissingAdditionalFiles(t *testing.T) {
-	var err error
-
-	err = validateConfig(testDir, &imagecustomizerapi.Config{
+	err := validateConfig(testDir, &imagecustomizerapi.Config{
 		SystemConfig: imagecustomizerapi.SystemConfig{
 			AdditionalFiles: map[string]imagecustomizerapi.FileConfigList{
 				"files/missing_a.txt": {{Path: "/a.txt"}},
 			},
-		}})
+		}}, nil, true)
 	assert.Error(t, err)
 }
 
 func TestValidateConfigdditionalFilesIsDir(t *testing.T) {
-	var err error
-
-	err = validateConfig(testDir, &imagecustomizerapi.Config{
+	err := validateConfig(testDir, &imagecustomizerapi.Config{
 		SystemConfig: imagecustomizerapi.SystemConfig{
 			AdditionalFiles: map[string]imagecustomizerapi.FileConfigList{
 				"files": {{Path: "/a.txt"}},
 			},
-		}})
+		}}, nil, true)
 	assert.Error(t, err)
 }
 
@@ -167,7 +161,7 @@ func TestValidateConfigScript(t *testing.T) {
 					Path: "scripts/finalizeimagescript.sh",
 				},
 			},
-		}})
+		}}, nil, true)
 	assert.NoError(t, err)
 }
 
@@ -179,7 +173,7 @@ func TestValidateConfigScriptNonLocalFile(t *testing.T) {
 					Path: "../a.sh",
 				},
 			},
-		}})
+		}}, nil, true)
 	assert.Error(t, err)
 }
 
@@ -191,7 +185,7 @@ func TestValidateConfigScriptNonExecutable(t *testing.T) {
 					Path: "files/a.txt",
 				},
 			},
-		}})
+		}}, nil, true)
 	assert.Error(t, err)
 }
 


### PR DESCRIPTION

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->

When the image's partitions are customized, then initrd file needs to refreshed so that the hardcoded partition UUIDs within the initrd file can be updated. The initrd file is refreshed by reinstalling the `initramfs` package. It is done this way because only the RPM post- install scripts within the `initramfs` package know how to properly refresh the initrd file.

###### Change Log  <!-- REQUIRED -->

- Image Customizer:
  - Refresh initrd when partitions are customized.
  - Check that we have RPM sources (when needed) during config validation.

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Ran toolkit UTs.
- Manually ran image customizer tool.

