### PR TITLE
Tobiasb/openssl align config flags with azl 2

### DIFF
--- a/SPECS/openssl/openssl.spec
+++ b/SPECS/openssl/openssl.spec
@@ -232,12 +232,58 @@ export HASHBANGPERL=/usr/bin/perl
 # usable on all platforms.  The Configure script already knows to use -fPIC and
 # NEW_RPM_OPT_FLAGS, so we can skip specifiying them here.
 ./Configure \
-	--prefix=%{_prefix} --openssldir=%{_sysconfdir}/pki/tls --libdir=lib \
-	zlib enable-camellia enable-seed enable-rfc3779 no-sctp \
-	enable-cms enable-md2 enable-rc5 enable-ec_nistp_64_gcc_128 enable-ktls enable-fips\
-	no-mdc2 no-ec2m no-sm2 no-sm4 enable-buildtest-c++\
-	shared $NEW_RPM_OPT_FLAGS '-DDEVRANDOM="\"/dev/urandom\""'\
-	-Wl,--allow-multiple-definition
+    --prefix=%{_prefix} \
+    --openssldir=%{_sysconfdir}/pki/tls \
+    --libdir=lib \
+    shared \
+    no-aria \
+    enable-bf \
+    no-blake2 \
+    enable-camellia \
+    no-capieng \
+    enable-cast \
+    no-chacha \
+    enable-cms \
+    no-comp \
+    enable-ct \
+    enable-deprecated \
+    enable-des \
+    enable-dh \
+    enable-dsa \
+    no-dtls1 \
+    no-ec2m \
+    enable-ec_nistp_64_gcc_128 \
+    enable-ecdh \
+    enable-ecdsa \
+    no-gost \
+    no-idea \
+    no-mdc2 \
+    no-md2 \
+    enable-md4 \
+    no-poly1305 \
+    enable-rc2 \
+    enable-rc4 \
+    enable-rc5 \
+    no-rfc3779 \
+    enable-rmd160 \
+    no-sctp \
+    no-seed \
+    no-siphash \
+    no-sm2 \
+    no-sm3 \
+    no-sm4 \
+    no-ssl \
+    no-ssl3 \
+    no-weak-ssl-ciphers \
+    no-whirlpool \
+    no-zlib \
+    no-zlib-dynamic \
+    enable-ktls \
+    enable-fips\
+    enable-buildtest-c++ \
+    $NEW_RPM_OPT_FLAGS \
+    '-DDEVRANDOM="\"/dev/urandom\""'\
+    -Wl,--allow-multiple-definition
 
 # Do not run this in a production package the FIPS symbols must be patched-in
 #util/mkdef.pl crypto update

--- a/SPECS/openssl/openssl.spec
+++ b/SPECS/openssl/openssl.spec
@@ -467,6 +467,7 @@ install -m644 %{SOURCE9} \
 - License verified
 - Removed redhat-specific REDHAT_FIPS_VERSION and added/updated relevant patches
 - Remove handling of different architectures -- we always build on the target architecture
+- Align config options with Marinver version 2.0
 
 * Thu Oct 26 2023 Sahana Prasad <sahana@redhat.com> - 1:3.1.4-1
 - Rebase to upstream version 3.1.4


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
When first migrating to `openssl 3`, we pretty kept the spec file like the upstream, including `./Configure` flags. This change brings us back in line with what we had for `AZL 2.0`, which was `openssl 1.1.1k`.

Mostly these are either not really changes or things we had already decided on for `AZL 2.0`. There are, however, four flags that had been in the upstream that we're keeping (for now):
- `enable-ktls`: This enables the use of Kernel-TLS (if available). See #6919.
- `enable-fips`: This will _likely_ be removed in a future change; working with an internal team on the right way to do this.
- `enable-buildtest-c++`: Adds some unit tests with C++. Test-only and seems to do no harm so I left it in.
- `-Wl,--allow-multiple-definition`: Necessary due to one or more of the patches we use; will remove in the future if possible.


###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Align `./Configure` flags with the flags from our previous version.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Builds locally
- Pipeline: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=467580&view=results
