### PR TITLE
Image Customizer: Support for partition extraction - raw, raw-zstd

### DIFF
--- a/toolkit/tools/imagecustomizer/docs/cli.md
+++ b/toolkit/tools/imagecustomizer/docs/cli.md
@@ -35,6 +35,12 @@ The image format of the the final customized image.
 
 Options: vhd, vhdx, qcow2, and raw.
 
+## --output-split-partitions-format=FORMAT
+
+Format of partition files. If specified, disk partitions will be extracted as separate files.
+
+Options: raw, raw-zstd.
+
 ## --config-file=FILE-PATH
 
 Required.

--- a/toolkit/tools/imagecustomizer/docs/configuration.md
+++ b/toolkit/tools/imagecustomizer/docs/configuration.md
@@ -268,7 +268,7 @@ Packages:
 Required.
 
 The ID of the partition.
-This is used correlate Partition objects with [PartitionSetting](#partitionsetting-type)
+This is used to correlate Partition objects with [PartitionSetting](#partitionsetting-type)
 objects.
 
 ### FsType [string]

--- a/toolkit/tools/imagecustomizer/main.go
+++ b/toolkit/tools/imagecustomizer/main.go
@@ -18,17 +18,18 @@ import (
 var (
 	app = kingpin.New("imagecustomizer", "Customizes a pre-built CBL-Mariner image")
 
-	buildDir                 = app.Flag("build-dir", "Directory to run build out of.").Required().String()
-	imageFile                = app.Flag("image-file", "Path of the base CBL-Mariner image which the customization will be applied to.").Required().String()
-	outputImageFile          = app.Flag("output-image-file", "Path to write the customized image to.").Required().String()
-	outputImageFormat        = app.Flag("output-image-format", "Format of output image. Supported: vhd, vhdx, qcow2, raw.").Required().Enum("vhd", "vhdx", "qcow2", "raw")
-	configFile               = app.Flag("config-file", "Path of the image customization config file.").Required().String()
-	rpmSources               = app.Flag("rpm-source", "Path to a RPM repo config file or a directory containing RPMs.").Strings()
-	disableBaseImageRpmRepos = app.Flag("disable-base-image-rpm-repos", "Disable the base image's RPM repos as an RPM source").Bool()
-	logFile                  = exe.LogFileFlag(app)
-	logLevel                 = exe.LogLevelFlag(app)
-	profFlags                = exe.SetupProfileFlags(app)
-	timestampFile            = app.Flag("timestamp-file", "File that stores timestamps for this program.").String()
+	buildDir                    = app.Flag("build-dir", "Directory to run build out of.").Required().String()
+	imageFile                   = app.Flag("image-file", "Path of the base CBL-Mariner image which the customization will be applied to.").Required().String()
+	outputImageFile             = app.Flag("output-image-file", "Path to write the customized image to.").Required().String()
+	outputImageFormat           = app.Flag("output-image-format", "Format of output image. Supported: vhd, vhdx, qcow2, raw.").Required().Enum("vhd", "vhdx", "qcow2", "raw")
+	outputSplitPartitionsFormat = app.Flag("output-split-partitions-format", "Format of partition files. Supported: raw, raw-zstd").Enum("raw", "raw-zstd")
+	configFile                  = app.Flag("config-file", "Path of the image customization config file.").Required().String()
+	rpmSources                  = app.Flag("rpm-source", "Path to a RPM repo config file or a directory containing RPMs.").Strings()
+	disableBaseImageRpmRepos    = app.Flag("disable-base-image-rpm-repos", "Disable the base image's RPM repos as an RPM source").Bool()
+	logFile                     = exe.LogFileFlag(app)
+	logLevel                    = exe.LogLevelFlag(app)
+	profFlags                   = exe.SetupProfileFlags(app)
+	timestampFile               = app.Flag("timestamp-file", "File that stores timestamps for this program.").String()
 )
 
 func main() {
@@ -58,7 +59,7 @@ func customizeImage() error {
 	var err error
 
 	err = imagecustomizerlib.CustomizeImageWithConfigFile(*buildDir, *configFile, *imageFile,
-		*rpmSources, *outputImageFile, *outputImageFormat, !*disableBaseImageRpmRepos)
+		*rpmSources, *outputImageFile, *outputImageFormat, *outputSplitPartitionsFormat, !*disableBaseImageRpmRepos)
 	if err != nil {
 		return err
 	}

--- a/toolkit/tools/imagegen/diskutils/diskutils.go
+++ b/toolkit/tools/imagegen/diskutils/diskutils.go
@@ -53,6 +53,7 @@ type PartitionInfo struct {
 	PartUuid          string `json:"partuuid"`   // Example: 7b1367a6-5845-43f2-99b1-a742d873f590
 	Mountpoint        string `json:"mountpoint"` // Example: /mnt/os/boot
 	PartLabel         string `json:"partlabel"`  // Example: boot
+	Type              string `json:"type"`       // Example: part
 }
 
 type loopbackListOutput struct {
@@ -769,7 +770,7 @@ func GetDiskPartitions(diskDevPath string) ([]PartitionInfo, error) {
 	}
 
 	// Read the disk's partitions.
-	jsonString, _, err := shell.Execute("lsblk", diskDevPath, "--output", "NAME,PATH,PARTTYPE,FSTYPE,UUID,MOUNTPOINT,PARTUUID,PARTLABEL", "--json", "--list")
+	jsonString, _, err := shell.Execute("lsblk", diskDevPath, "--output", "NAME,PATH,PARTTYPE,FSTYPE,UUID,MOUNTPOINT,PARTUUID,PARTLABEL,TYPE", "--json", "--list")
 	if err != nil {
 		return nil, fmt.Errorf("failed to list disk (%s) partitions:\n%w", diskDevPath, err)
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/extractpartitions.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/extractpartitions.go
@@ -40,11 +40,16 @@ func extractPartitions(imageConnection *ImageConnection, outputImageFile string,
 				return err
 			}
 
-			if partitionFormat == "raw-zstd" {
+			switch partitionFormat {
+			case "raw":
+				// Do nothing for "raw" case.
+			case "raw-zstd":
 				partitionFilepath, err = compressWithZstd(partitionFilepath)
 				if err != nil {
 					return err
 				}
+			default:
+				return fmt.Errorf("unsupported partition format (supported: raw, raw-zstd): %s", partitionFormat)
 			}
 
 			logger.Log.Infof("Partition file created: %s", partitionFilepath)

--- a/toolkit/tools/pkg/imagecustomizerlib/extractpartitions.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/extractpartitions.go
@@ -3,9 +3,9 @@ package imagecustomizerlib
 import (
 	"fmt"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/imagegen/diskutils"
-	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/file"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/logger"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/shell"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
@@ -80,7 +80,10 @@ func compressWithZstd(partitionRawFilepath string) (err error, partitionFilepath
 	}
 
 	// Remove raw file since output partition format is raw-zstd.
-	file.RemoveFileIfExists(partitionRawFilepath)
+	err = os.Remove(partitionRawFilepath)
+	if err != nil {
+		return err, ""
+	}
 
 	return nil, partitionRawFilepath + ".zst"
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/extractpartitions.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/extractpartitions.go
@@ -30,24 +30,25 @@ func extractPartitions(imageConnection *ImageConnection, outputImageFile string,
 		return err
 	}
 
-	// Start extracting from 1 because the diskPartitions[0] refers to the image itself.
-	for partitionNum := 1; partitionNum < len(diskPartitions); partitionNum++ {
-		rawFilename := basename + "_" + strconv.Itoa(partitionNum) + ".raw"
-		partitionLoopDevice := diskPartitions[partitionNum].Path
+	for partitionNum := 0; partitionNum < len(diskPartitions); partitionNum++ {
+		if diskPartitions[partitionNum].Type == "part" {
+			rawFilename := basename + "_" + strconv.Itoa(partitionNum) + ".raw"
+			partitionLoopDevice := diskPartitions[partitionNum].Path
 
-		err, partitionFilepath := createRawFile(outDir, partitionLoopDevice, rawFilename)
-		if err != nil {
-			return err
-		}
-
-		if partitionFormat == "raw-zstd" {
-			err, partitionFilepath = compressWithZstd(partitionFilepath)
+			err, partitionFilepath := createRawFile(outDir, partitionLoopDevice, rawFilename)
 			if err != nil {
 				return err
 			}
-		}
 
-		logger.Log.Infof("Partition file created: %s", partitionFilepath)
+			if partitionFormat == "raw-zstd" {
+				err, partitionFilepath = compressWithZstd(partitionFilepath)
+				if err != nil {
+					return err
+				}
+			}
+
+			logger.Log.Infof("Partition file created: %s", partitionFilepath)
+		}
 	}
 	return nil
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/extractpartitions.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/extractpartitions.go
@@ -1,0 +1,87 @@
+package imagecustomizerlib
+
+import (
+	"fmt"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/imagegen/diskutils"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/file"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/logger"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/shell"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// Extract all partitions of connected image into separate files with specified format.
+func extractPartitions(imageConnection *ImageConnection, outputImageFile string, partitionFormat string) error {
+
+	// Extract basename from outputImageFile. E.g. if outputImageFile is "image.qcow2", then basename is "image".
+	basename := strings.TrimSuffix(filepath.Base(outputImageFile), filepath.Ext(outputImageFile))
+
+	// Get path of loop device associated with the image.
+	imageLoopDevice := imageConnection.Loopback().DevicePath()
+
+	// Get output directory path.
+	outDir := filepath.Dir(outputImageFile)
+
+	var err error
+
+	// Get partition info.
+	diskPartitions, err := diskutils.GetDiskPartitions(imageLoopDevice)
+	if err != nil {
+		return err
+	}
+
+	// Start extracting from 1 because the diskPartitions[0] refers to the image itself.
+	for partitionNum := 1; partitionNum < len(diskPartitions); partitionNum++ {
+		rawFilename := basename + "_" + strconv.Itoa(partitionNum) + ".raw"
+		partitionLoopDevice := diskPartitions[partitionNum].Path
+
+		err, partitionFilepath := createRawFile(outDir, partitionLoopDevice, rawFilename)
+		if err != nil {
+			return err
+		}
+
+		if partitionFormat == "raw-zstd" {
+			err, partitionFilepath = compressWithZstd(partitionFilepath)
+			if err != nil {
+				return err
+			}
+		}
+
+		logger.Log.Infof("Partition file created: %s", partitionFilepath)
+	}
+	return nil
+}
+
+// Creates .raw file for the mentioned partition path.
+func createRawFile(outDir, devicePath, name string) (err error, filename string) {
+	const (
+		defaultBlockSize = 1024 * 1024 // 1MB
+		squashErrors     = true
+	)
+
+	fullPath := filepath.Join(outDir, name)
+	ddArgs := []string{
+		fmt.Sprintf("if=%s", devicePath),       // Input file.
+		fmt.Sprintf("of=%s", fullPath),         // Output file.
+		fmt.Sprintf("bs=%d", defaultBlockSize), // Size of one copied block.
+	}
+
+	return shell.ExecuteLive(squashErrors, "dd", ddArgs...), fullPath
+}
+
+// Compress file from raw to raw-zstd format using zstd.
+func compressWithZstd(partitionRawFilepath string) (err error, partitionFilepath string) {
+	// Using -f to overwrite a file with same name if it exists.
+	cmd := exec.Command("zstd", "-f", "-9", "-T0", partitionRawFilepath)
+	_, err = cmd.Output()
+	if err != nil {
+		return err, ""
+	}
+
+	// Remove raw file since output partition format is raw-zstd.
+	file.RemoveFileIfExists(partitionRawFilepath)
+
+	return nil, partitionRawFilepath + ".zst"
+}

--- a/toolkit/tools/pkg/imagecustomizerlib/extractpartitions.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/extractpartitions.go
@@ -24,8 +24,6 @@ func extractPartitions(imageConnection *ImageConnection, outputImageFile string,
 	// Get output directory path.
 	outDir := filepath.Dir(outputImageFile)
 
-	var err error
-
 	// Get partition info.
 	diskPartitions, err := diskutils.GetDiskPartitions(imageLoopDevice)
 	if err != nil {

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -304,7 +304,10 @@ func extractPartitionsHelper(buildDir string, buildImageFile string, outputImage
 	defer imageConnection.Close()
 
 	// Extract the partitions as files.
-	extractPartitions(imageConnection, outputImageFile, outputSplitPartitionsFormat)
+	err = extractPartitions(imageConnection, outputImageFile, outputSplitPartitionsFormat)
+	if err != nil {
+		return err
+	}
 
 	err = imageConnection.CleanClose()
 	if err != nil {

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
@@ -235,7 +235,7 @@ func TestCustomizeImageKernelCommandLineAdd(t *testing.T) {
 		},
 	}
 
-	err = CustomizeImage(buildDir, buildDir, config, diskFilePath, nil, outImageFilePath, "raw", false)
+	err = CustomizeImage(buildDir, buildDir, config, diskFilePath, nil, outImageFilePath, "raw", "", false)
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
@@ -48,7 +48,7 @@ func TestCustomizeImageEmptyConfig(t *testing.T) {
 
 	// Customize image.
 	err = CustomizeImage(buildDir, buildDir, &imagecustomizerapi.Config{}, diskFilePath, nil, outImageFilePath,
-		"vhd", false)
+		"vhd", "raw", false)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -83,7 +83,7 @@ func TestCustomizeImageCopyFiles(t *testing.T) {
 	}
 
 	// Customize image.
-	err = CustomizeImageWithConfigFile(buildDir, configFile, diskFilePath, nil, outImageFilePath, "raw", false)
+	err = CustomizeImageWithConfigFile(buildDir, configFile, diskFilePath, nil, outImageFilePath, "raw", "raw", false)
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
@@ -48,7 +48,7 @@ func TestCustomizeImageEmptyConfig(t *testing.T) {
 
 	// Customize image.
 	err = CustomizeImage(buildDir, buildDir, &imagecustomizerapi.Config{}, diskFilePath, nil, outImageFilePath,
-		"vhd", "raw", false)
+		"vhd", "", false)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -83,7 +83,7 @@ func TestCustomizeImageCopyFiles(t *testing.T) {
 	}
 
 	// Customize image.
-	err = CustomizeImageWithConfigFile(buildDir, configFile, diskFilePath, nil, outImageFilePath, "raw", "raw", false)
+	err = CustomizeImageWithConfigFile(buildDir, configFile, diskFilePath, nil, outImageFilePath, "raw", "", false)
 	if !assert.NoError(t, err) {
 		return
 	}


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Introducing an optional `--output-split-partitions-format` flag.
When specified, separate files for all partitions of the image will be created. Currently only supports raw and raw-zstd formats.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Added flag in main.go for output-split-partitions-format
- Added conditional in imagecustomizer.go to handle case when output-split-partitions-format is provided.
- Added extractpartitions.go to imagecustomizerlib which handles partition extraction. 
- Reuses several functions from other internal libraries. 
- createRawFile is inspired from createRawArtifact in installutils.
- Formatted all files with `go fmt`.
- Updated test file function calls to match new function definition parameters.
- Added type to diskutils PartitionInfo struct.
- Updated markdown file.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Tested locally using go run ./image-customizer using customized image made with config that creates 4 partitions.
- Ensured the file format using `file` was in line with the fstype of the partitions.
- Test cases as follows :
-> Optional flag not specified.
-> Optional flag specified with incorrect value.
-> Optional flag specified with "raw" value.
-> Optional flag specified with "raw-zstd" value.
-> Run script when .raw.zst or .raw files already exist in output directory.
- Plan to add unit tests in the future.

