### PR TITLE
Fix CVE-2020-8694, CVE-2020-8695 and CVE-2020-12912

### DIFF
--- a/SPECS/moby-cli/moby-cli.signatures.json
+++ b/SPECS/moby-cli/moby-cli.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "moby-cli-20.10.25.tar.gz": "fc80d99f6c929d3d3f7b5322063e1a5236623341a0b671c70cfa15854cadbc18"
+  "moby-cli-20.10.25.tar.gz": "32541cb51a541c6f38b0d4a7a638c28233a29dba5c9a843bc5dbb3a709d8ddf0"
  }
 }

--- a/SPECS/moby-cli/moby-cli.signatures.json
+++ b/SPECS/moby-cli/moby-cli.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "moby-cli-20.10.25.tar.gz": "32541cb51a541c6f38b0d4a7a638c28233a29dba5c9a843bc5dbb3a709d8ddf0"
+  "moby-cli-20.10.27.tar.gz": "32541cb51a541c6f38b0d4a7a638c28233a29dba5c9a843bc5dbb3a709d8ddf0"
  }
 }

--- a/SPECS/moby-cli/moby-cli.spec
+++ b/SPECS/moby-cli/moby-cli.spec
@@ -3,8 +3,8 @@
 
 Summary: The open-source application container engine client.
 Name: moby-%{upstream_name}
-Version: 20.10.25
-Release: 3%{?dist}
+Version: 20.10.27
+Release: 1%{?dist}
 License: ASL 2.0
 Group: Tools/Container
 URL: https://github.com/docker/cli
@@ -80,6 +80,9 @@ install -p -m 644 contrib/completion/fish/docker.fish %{buildroot}%{_datadir}/fi
 %{_datadir}/fish/vendor_completions.d/docker.fish
 
 %changelog
+* Fri Dec 15 2023 Rohit Rawat <rohitrawat@microsoft.com> - 20.10.27-1
+- Bump version to to match with moby-engine
+
 * Mon Oct 16 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 20.10.25-3
 - Bump release to rebuild with go 1.20.9
 

--- a/SPECS/moby-containerd/moby-containerd.signatures.json
+++ b/SPECS/moby-containerd/moby-containerd.signatures.json
@@ -2,6 +2,6 @@
  "Signatures": {
   "containerd.service": "b7908653ff8298fc8c1c21854a6e338f40c607ec40d177269615a8f3448c5153",
   "containerd.toml": "793d4f11a4e69bdb3b1903da2cdf76b7f32dbc97197b12d295a05ecc284e230e",
-  "moby-containerd-1.6.22.tar.gz": "b109aceacc814d7a637ed94ba5ade829cd2642841d03e06971ef124fa3b86899"
+  "moby-containerd-1.6.26.tar.gz": "56700cee7f2733d40d697ab98e289db8c78a470c40c0b4caede521736608830b"
  }
 }

--- a/SPECS/moby-containerd/moby-containerd.spec
+++ b/SPECS/moby-containerd/moby-containerd.spec
@@ -4,8 +4,8 @@
 
 Summary: Industry-standard container runtime
 Name: moby-%{upstream_name}
-Version: 1.6.22
-Release: 4%{?dist}
+Version: 1.6.26
+Release: 1%{?dist}
 License: ASL 2.0
 Group: Tools/Container
 URL: https://www.containerd.io
@@ -90,6 +90,9 @@ fi
 %dir /opt/containerd/lib
 
 %changelog
+* Fri Dec 15 2023 Rohit Rawat <rohitrawat@microsoft.com> - 1.6.26-1
+- Bump version to 1.6.26 to fix CVE-2020-8694, CVE-2020-8695 and CVE-2020-12912
+
 * Tue Oct 18 2023 Chris PeBenito <chpebeni@microsoft.com> - 1.6.22-4
 - Precreate /opt/containerd/{bin,lib} to ensure correct SELinux labeling.
 

--- a/SPECS/moby-engine/moby-engine.signatures.json
+++ b/SPECS/moby-engine/moby-engine.signatures.json
@@ -2,7 +2,7 @@
  "Signatures": {
   "docker.service": "b150b3ce0947a65c655ed09dfe4e48b7464c60542f9f9902330288bbf87af38e",
   "docker.socket": "51a06786cae46bc63b7314c25d0bd5bb2e676120d80874b99e35bf60d0b0ffa8",
-  "moby-engine-20.10.25.tar.gz": "dbd19da08d716cf17866d77ad5022d8b1288cf6ba498fdf67895b1abf1719916",
-  "moby-libnetwork-20.10.25.tar.gz": "3d76ad1fd3a29b34c86501ceb3e43f2e74dc4cd16a61a9a1eff2df0a7adfc0ec"
+  "moby-engine-20.10.27.tar.gz": "e007811da7705f767ffb0b9a97ef04ec6a18f295c3b43cc595bd07443ddd2ba9",
+  "moby-libnetwork-20.10.27.tar.gz": "523bc0bbeb1651da3c236567843f524bbd162507f4445766da40aade7c37222a"
  }
 }

--- a/SPECS/moby-engine/moby-engine.spec
+++ b/SPECS/moby-engine/moby-engine.spec
@@ -3,8 +3,8 @@
 
 Summary: The open-source application container engine
 Name:    %{upstream_name}-engine
-Version: 20.10.25
-Release: 3%{?dist}
+Version: 20.10.27
+Release: 1%{?dist}
 License: ASL 2.0
 Group:   Tools/Container
 URL: https://mobyproject.org
@@ -126,6 +126,9 @@ fi
 %{_unitdir}/*
 
 %changelog
+* Fri Dec 15 2023 Rohit Rawat <rohitrawat@microsoft.com> - 20.10.27-1
+- Upgrade version to fix CVE-2020-8694, CVE-2020-8695 and CVE-2020-12912
+
 * Mon Oct 16 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 20.10.25-3
 - Bump release to rebuild with go 1.20.9
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -13363,8 +13363,8 @@
         "type": "other",
         "other": {
           "name": "moby-cli",
-          "version": "20.10.25",
-          "downloadUrl": "https://github.com/docker/cli/archive/v20.10.25.tar.gz"
+          "version": "20.10.27",
+          "downloadUrl": "https://github.com/docker/cli/archive/v20.10.27.tar.gz"
         }
       }
     },
@@ -13403,8 +13403,8 @@
         "type": "other",
         "other": {
           "name": "moby-engine",
-          "version": "20.10.25",
-          "downloadUrl": "https://github.com/moby/moby/archive/v20.10.25.tar.gz"
+          "version": "20.10.27",
+          "downloadUrl": "https://github.com/moby/moby/archive/v20.10.27.tar.gz"
         }
       }
     },

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -13383,8 +13383,8 @@
         "type": "other",
         "other": {
           "name": "moby-containerd",
-          "version": "1.6.22",
-          "downloadUrl": "https://github.com/containerd/containerd/archive/v1.6.22.tar.gz"
+          "version": "1.6.26",
+          "downloadUrl": "https://github.com/containerd/containerd/archive/v1.6.26.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Fix CVE-2020-8694, CVE-2020-8695 and CVE-2020-12912 in moby-engine and moby-containerd
As mentioned in Advisory: https://github.com/advisories/GHSA-jq35-85cj-fj4p

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Fix CVE-2020-8694, CVE-2020-8695 and CVE-2020-12912 

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2020-8694
- https://nvd.nist.gov/vuln/detail/CVE-2020-8695
- https://nvd.nist.gov/vuln/detail/CVE-2020-12912

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: [469622](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=469622&view=results)
