### PR TITLE
Fix passwd and group reset on package upgrade

### DIFF
--- a/SPECS/bind/bind.spec
+++ b/SPECS/bind/bind.spec
@@ -10,7 +10,7 @@
 Summary:        Domain Name System software
 Name:           bind
 Version:        9.16.44
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        ISC
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -384,22 +384,26 @@ popd
 rm -f %{buildroot}%{_prefix}%{_sysconfdir}/bind.keys
 
 %pre
-if ! getent group named >/dev/null; then
-    groupadd -r named
-fi
-if ! getent passwd named >/dev/null; then
-    useradd -g named -d %{_sharedstatedir}/bind\
-        -s /bin/false -M -r named
+if [ $1 -eq 1 ]; then
+  if ! getent group named >/dev/null; then
+      groupadd -r named
+  fi
+  if ! getent passwd named >/dev/null; then
+      useradd -g named -d %{_sharedstatedir}/bind\
+          -s /bin/false -M -r named
+  fi
 fi
 
 %post -p /sbin/ldconfig
 %postun
 /sbin/ldconfig
-if getent passwd named >/dev/null; then
-    userdel named
-fi
-if getent group named >/dev/null; then
-    groupdel named
+if [ $1 -eq 0 ]; then
+  if getent passwd named >/dev/null; then
+      userdel named
+  fi
+  if getent group named >/dev/null; then
+      groupdel named
+  fi
 fi
 
 # Fix permissions on existing device files on upgrade
@@ -613,6 +617,9 @@ fi;
 %{_mandir}/man8/named-nzd2nzf.8*
 
 %changelog
+* Thu Dec 14 2023 Neha Agarwal <nehaagarwal@microsoft.com> - 9.16.44-2
+- Fix resetting of passwd and group on package update
+
 * Wed Sep 27 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 9.16.44-1
 - Auto-upgrade to 9.16.44 - Fix CVE-2023-3341
 

--- a/SPECS/rsyslog/rsyslog.spec
+++ b/SPECS/rsyslog/rsyslog.spec
@@ -3,7 +3,7 @@
 Summary:        Rocket-fast system for log processing
 Name:           rsyslog
 Version:        8.2308.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv3+ AND ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -133,11 +133,13 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %make_build check
 
 %pre
-if ! (getent passwd syslog >/dev/null); then
-    groupadd --system syslog
-fi
-if ! (getent passwd syslog >/dev/null); then
-useradd --system --comment 'System Logging'  --gid syslog --shell /bin/false syslog
+if [ $1 -eq 1 ]; then
+    if ! (getent passwd syslog >/dev/null); then
+        groupadd --system syslog
+    fi
+    if ! (getent passwd syslog >/dev/null); then
+        useradd --system --comment 'System Logging'  --gid syslog --shell /bin/false syslog
+    fi
 fi
 
 %post
@@ -150,11 +152,13 @@ fi
 %postun
 /sbin/ldconfig
 %systemd_postun_with_restart rsyslog.service
-if getent passwd syslog >/dev/null; then
-    userdel syslog
-fi
-if getent group syslog >/dev/null; then
-    groupdel syslog
+if [ $1 -eq 0 ]; then
+    if getent passwd syslog >/dev/null; then
+        userdel syslog
+    fi
+    if getent group syslog >/dev/null; then
+        groupdel syslog
+    fi
 fi
 
 %files
@@ -175,6 +179,9 @@ fi
 %doc %{_docdir}/%{name}/html
 
 %changelog
+* Thu Dec 14 2023 Neha Agarwal <nehaagarwal@microsoft.com> - 8.2308.0-2
+- Fix resetting of passwd and group on package update
+
 * Mon Nov 06 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 8.2308.0-1
 - Auto-upgrade to 8.2308.0 - Azure Linux 3.0 - package upgrades
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
User disappeared from passwd and group file on package updates. This fixes the postun scriptlet to delete the user only on package removal, but not on update. Fixed for rsyslog and bind packages.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Remove user only if it's not a package update
- Making changes similar to https://github.com/microsoft/CBL-Mariner/pull/6972 for bind and rsyslog

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build and test that verified correct behavior: adding user on install, removing user on uninstall, no change on upgrade