### PR TITLE
Image Customizer: Fix special directories and partition customization.

### DIFF
--- a/toolkit/tools/imagegen/installutils/installutils_test.go
+++ b/toolkit/tools/imagegen/installutils/installutils_test.go
@@ -71,7 +71,7 @@ func TestCopyAdditionalFiles(t *testing.T) {
 	proposedDir := filepath.Join(tmpDir, "TestCopyAdditionalFiles")
 	chroot := safechroot.NewChroot(proposedDir, false)
 
-	err := chroot.Initialize("", []string{}, []*safechroot.MountPoint{})
+	err := chroot.Initialize("", []string{}, []*safechroot.MountPoint{}, true)
 	assert.NoError(t, err)
 
 	defer chroot.Close(false)

--- a/toolkit/tools/imager/imager.go
+++ b/toolkit/tools/imager/imager.go
@@ -244,7 +244,7 @@ func buildSystemConfig(systemConfig configuration.SystemConfig, disks []configur
 		extraMountPoints = append(extraMountPoints, additionalExtraMountPoints...)
 
 		setupChroot := safechroot.NewChroot(setupChrootDir, existingChrootDir)
-		err = setupChroot.Initialize(*tdnfTar, extraDirectories, extraMountPoints)
+		err = setupChroot.Initialize(*tdnfTar, extraDirectories, extraMountPoints, true)
 		if err != nil {
 			logger.Log.Error("Failed to create setup chroot")
 			return
@@ -562,7 +562,7 @@ func buildImage(mountPointMap, mountPointToFsTypeMap, mountPointToMountArgsMap, 
 	installChroot := safechroot.NewChroot(installRoot, existingChrootDir)
 	extraInstallMountPoints := []*safechroot.MountPoint{}
 	extraDirectories := []string{}
-	err = installChroot.Initialize(emptyWorkerTar, extraDirectories, extraInstallMountPoints)
+	err = installChroot.Initialize(emptyWorkerTar, extraDirectories, extraInstallMountPoints, true)
 	if err != nil {
 		err = fmt.Errorf("failed to create install chroot: %s", err)
 		return

--- a/toolkit/tools/internal/packagerepo/repocloner/rpmrepocloner/rpmrepocloner.go
+++ b/toolkit/tools/internal/packagerepo/repocloner/rpmrepocloner/rpmrepocloner.go
@@ -165,7 +165,7 @@ func (r *RpmRepoCloner) initialize(destinationDir, tmpDir, workerTar, existingRp
 
 	// Also request that /overlaywork is created before any chroot mounts happen so the overlay can
 	// be created successfully
-	err = r.chroot.Initialize(workerTar, overlayExtraDirs, extraMountPoints)
+	err = r.chroot.Initialize(workerTar, overlayExtraDirs, extraMountPoints, true)
 	if err != nil {
 		r.chroot = nil
 		return

--- a/toolkit/tools/internal/packagerepo/repoutils/repoquery.go
+++ b/toolkit/tools/internal/packagerepo/repoutils/repoquery.go
@@ -112,7 +112,7 @@ func createChroot(workerTar, chrootDir string, leaveChrootOnDisk bool) (queryChr
 	logger.Log.Info("Creating chroot for repoquery")
 
 	queryChroot = safechroot.NewChroot(chrootDir, false)
-	err = queryChroot.Initialize(workerTar, nil, nil)
+	err = queryChroot.Initialize(workerTar, nil, nil, true)
 	if err != nil {
 		err = fmt.Errorf("failed to initialize chroot:\n%w", err)
 		return

--- a/toolkit/tools/internal/safechroot/safechroot.go
+++ b/toolkit/tools/internal/safechroot/safechroot.go
@@ -173,7 +173,9 @@ func NewChroot(rootDir string, isExistingDir bool) *Chroot {
 //
 // This call will block until the chroot initializes successfully.
 // Only one Chroot will initialize at a given time.
-func (c *Chroot) Initialize(tarPath string, extraDirectories []string, extraMountPoints []*MountPoint) (err error) {
+func (c *Chroot) Initialize(tarPath string, extraDirectories []string, extraMountPoints []*MountPoint,
+	includeDefaultMounts bool,
+) (err error) {
 	// On failed initialization, cleanup all chroot files
 	const leaveChrootOnDisk = false
 
@@ -256,7 +258,9 @@ func (c *Chroot) Initialize(tarPath string, extraDirectories []string, extraMoun
 			}
 		}
 
-		allMountPoints = append(allMountPoints, defaultMountPoints()...)
+		if includeDefaultMounts {
+			allMountPoints = append(allMountPoints, defaultMountPoints()...)
+		}
 
 		for _, mountPoint := range extraMountPoints {
 			if !mountPoint.mountBeforeDefaults {

--- a/toolkit/tools/internal/safechroot/safechroot_test.go
+++ b/toolkit/tools/internal/safechroot/safechroot_test.go
@@ -56,7 +56,7 @@ func TestInitializeShouldCreateRoot(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "TestInitializeShouldCreateRoot")
 	chroot := NewChroot(dir, isExistingDir)
 
-	err := chroot.Initialize(emptyPath, extraDirectories, extraMountPoints)
+	err := chroot.Initialize(emptyPath, extraDirectories, extraMountPoints, true)
 	assert.NoError(t, err)
 
 	defer chroot.Close(defaultLeaveOnDisk)
@@ -72,7 +72,7 @@ func TestCloseShouldRemoveRoot(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "TestCloseShouldRemoveRoot")
 	chroot := NewChroot(dir, isExistingDir)
 
-	err := chroot.Initialize(emptyPath, extraDirectories, extraMountPoints)
+	err := chroot.Initialize(emptyPath, extraDirectories, extraMountPoints, true)
 	assert.NoError(t, err)
 
 	// save away chroot location and close
@@ -102,7 +102,7 @@ func TestCloseShouldLeaveRootOnRequest(t *testing.T) {
 		dir := filepath.Join(t.TempDir(), "TestCloseShouldLeaveRootOnRequest")
 		chroot := NewChroot(dir, isExistingDir)
 
-		err := chroot.Initialize(emptyPath, extraDirectories, extraMountPoints)
+		err := chroot.Initialize(emptyPath, extraDirectories, extraMountPoints, true)
 		assert.NoError(t, err)
 
 		err = chroot.Close(leaveOnDisk)
@@ -134,7 +134,7 @@ func TestRunShouldReturnCorrectError(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "TestRunShouldReturnCorrectError")
 	chroot := NewChroot(dir, isExistingDir)
 
-	err := chroot.Initialize(emptyPath, extraDirectories, extraMountPoints)
+	err := chroot.Initialize(emptyPath, extraDirectories, extraMountPoints, true)
 	assert.NoError(t, err)
 	defer chroot.Close(defaultLeaveOnDisk)
 
@@ -153,7 +153,7 @@ func TestRunShouldChangeCWD(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "TestRunShouldChangeCWD")
 	chroot := NewChroot(dir, isExistingDir)
 
-	err := chroot.Initialize(emptyPath, extraDirectories, extraMountPoints)
+	err := chroot.Initialize(emptyPath, extraDirectories, extraMountPoints, true)
 	assert.NoError(t, err)
 	defer chroot.Close(defaultLeaveOnDisk)
 
@@ -178,7 +178,7 @@ func TestShouldRestoreCWD(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "TestShouldRestoreCWD")
 	chroot := NewChroot(dir, isExistingDir)
 
-	err := chroot.Initialize(emptyPath, extraDirectories, extraMountPoints)
+	err := chroot.Initialize(emptyPath, extraDirectories, extraMountPoints, true)
 	assert.NoError(t, err)
 	defer chroot.Close(defaultLeaveOnDisk)
 
@@ -205,7 +205,7 @@ func TestInitializeShouldExtractTar(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "TestInitializeShouldExtractTar")
 	chroot := NewChroot(dir, isExistingDir)
 
-	err := chroot.Initialize(tarPath, extraDirectories, extraMountPoints)
+	err := chroot.Initialize(tarPath, extraDirectories, extraMountPoints, true)
 	assert.NoError(t, err)
 	defer chroot.Close(defaultLeaveOnDisk)
 
@@ -228,7 +228,7 @@ func TestInitializeShouldCreateCustomMountPoints(t *testing.T) {
 		dir := filepath.Join(t.TempDir(), "TestInitializeShouldCreateCustomMountPoints")
 		chroot := NewChroot(dir, isExistingDir)
 
-		err := chroot.Initialize(emptyPath, extraDirectories, extraMountPoints)
+		err := chroot.Initialize(emptyPath, extraDirectories, extraMountPoints, true)
 		assert.NoError(t, err)
 		defer chroot.Close(defaultLeaveOnDisk)
 
@@ -251,7 +251,7 @@ func TestInitializeShouldCleanupOnBadMountPoint(t *testing.T) {
 		dir := filepath.Join(t.TempDir(), "TestInitializeShouldCleanupOnBadMountPoint")
 		chroot := NewChroot(dir, isExistingDir)
 
-		err := chroot.Initialize(emptyPath, extraDirectories, extraMountPoints)
+		err := chroot.Initialize(emptyPath, extraDirectories, extraMountPoints, true)
 		assert.Error(t, err)
 
 		_, err = os.Stat(dir)
@@ -268,7 +268,7 @@ func TestInitializeShouldCreateExtraDirectories(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "TestInitializeShouldCreateExtraDirectories")
 	chroot := NewChroot(dir, isExistingDir)
 
-	err := chroot.Initialize(emptyPath, extraDirectories, extraMountPoints)
+	err := chroot.Initialize(emptyPath, extraDirectories, extraMountPoints, true)
 	assert.NoError(t, err)
 	defer chroot.Close(defaultLeaveOnDisk)
 

--- a/toolkit/tools/internal/shell/shell.go
+++ b/toolkit/tools/internal/shell/shell.go
@@ -144,9 +144,17 @@ func ExecuteLive(squashErrors bool, program string, args ...string) (err error) 
 // ExecuteLiveWithErr runs a command in the shell and logs it in real-time.
 // In addition, if there is an error, the last x lines of stderr will be attached to the err object.
 func ExecuteLiveWithErr(stderrLines int, program string, args ...string) (err error) {
+	return ExecuteLiveWithErrAndCallbacks(stderrLines, logger.Log.Debug, logger.Log.Debug, program, args...)
+}
+
+// ExecuteLiveWithErr runs a command in the shell and logs it in real-time.
+// In addition, if there is an error, the last x lines of stderr will be attached to the err object.
+func ExecuteLiveWithErrAndCallbacks(stderrLines int, onStdout, onStderr func(...interface{}), program string,
+	args ...string,
+) (err error) {
 	stderrChan := make(chan string, stderrLines)
 
-	err = ExecuteLiveWithCallbackAndChannels(logger.Log.Debug, logger.Log.Debug, nil, stderrChan, program, args...)
+	err = ExecuteLiveWithCallbackAndChannels(onStdout, onStderr, nil, stderrChan, program, args...)
 	close(stderrChan)
 	if err != nil {
 		errLines := ""

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepartitionsfilecopy.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepartitionsfilecopy.go
@@ -5,10 +5,9 @@ package imagecustomizerlib
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/imagecustomizerapi"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/logger"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/safechroot"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/shell"
 )
@@ -16,7 +15,7 @@ import (
 func customizePartitionsUsingFileCopy(buildDir string, baseConfigPath string, config *imagecustomizerapi.Config,
 	buildImageFile string, newBuildImageFile string,
 ) error {
-	existingImageConnection, err := connectToExistingImage(buildImageFile, buildDir, "imageroot")
+	existingImageConnection, err := connectToExistingImage(buildImageFile, buildDir, "imageroot", false)
 	if err != nil {
 		return err
 	}
@@ -28,14 +27,8 @@ func customizePartitionsUsingFileCopy(buildDir string, baseConfigPath string, co
 		return copyFilesIntoNewDisk(existingImageConnection.Chroot(), imageChroot)
 	}
 
-	newImageConnection, err := createNewImage(newBuildImageFile, diskConfig, config.SystemConfig.PartitionSettings,
+	err = createNewImage(newBuildImageFile, diskConfig, config.SystemConfig.PartitionSettings,
 		config.SystemConfig.BootType, config.SystemConfig.KernelCommandLine, buildDir, "newimageroot", installOSFunc)
-	if err != nil {
-		return err
-	}
-	defer newImageConnection.Close()
-
-	err = newImageConnection.CleanClose()
 	if err != nil {
 		return err
 	}
@@ -60,28 +53,10 @@ func copyFilesIntoNewDiskHelper(existingImageChroot *safechroot.Chroot, newImage
 	// Notes:
 	// `-a` ensures unix permissions, extended attributes (including SELinux), and sub-directories (-r) are copied.
 	// `--no-dereference` ensures that symlinks are copied as symlinks.
-	copyArgs := []string{"--verbose", "--no-clobber", "-a", "--no-dereference", "--sparse", "always", "-t", newImageChroot.RootDir()}
+	copyArgs := []string{"--verbose", "--no-clobber", "-a", "--no-dereference", "--sparse", "always",
+		existingImageChroot.RootDir() + "/.", newImageChroot.RootDir()}
 
-	files, err := os.ReadDir(existingImageChroot.RootDir())
-	if err != nil {
-		return fmt.Errorf("failed to read base image root directory:\n%w", err)
-	}
-
-	for _, file := range files {
-		switch file.Name() {
-		case "dev", "proc", "sys", "run", "tmp":
-			// Exclude special directories.
-			//
-			// Note: Under /var, there are symlinks to a couple of these special directories.
-			// However, the `cp` command is called with `--no-dereference`. So, the symlinks will be copied as symlinks.
-			continue
-		}
-
-		fullFileName := filepath.Join(existingImageChroot.RootDir(), file.Name())
-		copyArgs = append(copyArgs, fullFileName)
-	}
-
-	err = shell.ExecuteLiveWithErr(1, "cp", copyArgs...)
+	err := shell.ExecuteLiveWithErrAndCallbacks(1, func(...interface{}) {}, logger.Log.Debug, "cp", copyArgs...)
 	if err != nil {
 		return fmt.Errorf("failed to copy files:\n%w", err)
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeutils_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeutils_test.go
@@ -25,7 +25,7 @@ func TestUpdateHostname(t *testing.T) {
 	// Setup environment.
 	proposedDir := filepath.Join(tmpDir, "TestUpdateHostname")
 	chroot := safechroot.NewChroot(proposedDir, false)
-	err := chroot.Initialize("", []string{}, []*safechroot.MountPoint{})
+	err := chroot.Initialize("", []string{}, []*safechroot.MountPoint{}, false)
 	assert.NoError(t, err)
 	defer chroot.Close(false)
 
@@ -52,7 +52,7 @@ func TestCopyAdditionalFiles(t *testing.T) {
 	chroot := safechroot.NewChroot(proposedDir, false)
 	baseConfigPath := testDir
 
-	err := chroot.Initialize("", []string{}, []*safechroot.MountPoint{})
+	err := chroot.Initialize("", []string{}, []*safechroot.MountPoint{}, false)
 	assert.NoError(t, err)
 	defer chroot.Close(false)
 
@@ -109,7 +109,7 @@ func TestAddCustomizerRelease(t *testing.T) {
 
 	proposedDir := filepath.Join(tmpDir, "TestAddCustomizerRelease")
 	chroot := safechroot.NewChroot(proposedDir, false)
-	err := chroot.Initialize("", []string{}, []*safechroot.MountPoint{})
+	err := chroot.Initialize("", []string{}, []*safechroot.MountPoint{}, false)
 	assert.NoError(t, err)
 	defer chroot.Close(false)
 

--- a/toolkit/tools/pkg/imagecustomizerlib/imageConnection.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imageConnection.go
@@ -34,14 +34,14 @@ func (c *ImageConnection) ConnectLoopback(diskFilePath string) error {
 }
 
 func (c *ImageConnection) ConnectChroot(rootDir string, isExistingDir bool, extraDirectories []string,
-	extraMountPoints []*safechroot.MountPoint,
+	extraMountPoints []*safechroot.MountPoint, includeDefaultMounts bool,
 ) error {
 	if c.chroot != nil {
 		return fmt.Errorf("chroot already connected")
 	}
 
 	chroot := safechroot.NewChroot(rootDir, isExistingDir)
-	err := chroot.Initialize("", extraDirectories, extraMountPoints)
+	err := chroot.Initialize("", extraDirectories, extraMountPoints, includeDefaultMounts)
 	if err != nil {
 		return err
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -287,7 +287,7 @@ func validatePackageLists(baseConfigPath string, config *imagecustomizerapi.Syst
 func customizeImageHelper(buildDir string, baseConfigPath string, config *imagecustomizerapi.Config,
 	buildImageFile string, rpmsSources []string, useBaseImageRpmRepos bool, partitionsCustomized bool,
 ) error {
-	imageConnection, err := connectToExistingImage(buildImageFile, buildDir, "imageroot")
+	imageConnection, err := connectToExistingImage(buildImageFile, buildDir, "imageroot", true)
 	if err != nil {
 		return err
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
@@ -122,7 +122,7 @@ func reconnectToFakeEfiImage(buildDir string, imageFilePath string) (*ImageConne
 		safechroot.NewMountPoint(bootPartitionDevPath, "/boot/efi", "vfat", 0, ""),
 	}
 
-	err = imageConnection.ConnectChroot(rootDir, false, []string{}, mountPoints)
+	err = imageConnection.ConnectChroot(rootDir, false, []string{}, mountPoints, false)
 	if err != nil {
 		imageConnection.Close()
 		return nil, err
@@ -317,12 +317,11 @@ func createFakeEfiImage(buildDir string) (string, error) {
 		return nil
 	}
 
-	imageConnection, err := createNewImage(rawDisk, diskConfig, partitionSettings, "efi",
+	err = createNewImage(rawDisk, diskConfig, partitionSettings, "efi",
 		imagecustomizerapi.KernelCommandLine{}, buildDir, testImageRootDirName, installOS)
 	if err != nil {
 		return "", err
 	}
-	defer imageConnection.Close()
 
 	return rawDisk, nil
 }

--- a/toolkit/tools/pkg/simpletoolchroot/simpletoolchroot.go
+++ b/toolkit/tools/pkg/simpletoolchroot/simpletoolchroot.go
@@ -58,7 +58,7 @@ func (s *SimpleToolChroot) InitializeChroot(buildDir, chrootName, workerTarPath,
 	extraMountPoints := []*safechroot.MountPoint{
 		safechroot.NewMountPoint(specsDirPath, chrootSpecDirPath, "", safechroot.BindMountPointFlags, ""),
 	}
-	err = s.chroot.Initialize(workerTarPath, extraDirectories, extraMountPoints)
+	err = s.chroot.Initialize(workerTarPath, extraDirectories, extraMountPoints, true)
 	if err != nil {
 		logger.Log.Errorf("Failed to initialize chroot (%s) inside (%s). Error: %v.", workerTarPath, chrootDirPath, err)
 	}

--- a/toolkit/tools/pkgworker/pkgworker.go
+++ b/toolkit/tools/pkgworker/pkgworker.go
@@ -213,7 +213,7 @@ func buildSRPMInChroot(chrootDir, rpmDirPath, toolchainDirPath, workerTar, srpmF
 		extraDirs = append(extraDirs, chrootCcacheDir)
 	}
 
-	err = chroot.Initialize(workerTar, extraDirs, mountPoints)
+	err = chroot.Initialize(workerTar, extraDirs, mountPoints, true)
 	if err != nil {
 		return
 	}

--- a/toolkit/tools/specreader/specreader.go
+++ b/toolkit/tools/specreader/specreader.go
@@ -211,7 +211,7 @@ func createChroot(workerTar, buildDir, specsDir, srpmsDir string) (chroot *safec
 	chrootDir := filepath.Join(buildDir, chrootName)
 	chroot = safechroot.NewChroot(chrootDir, existingDir)
 
-	err = chroot.Initialize(workerTar, extraDirectories, extraMountPoints)
+	err = chroot.Initialize(workerTar, extraDirectories, extraMountPoints, true)
 	if err != nil {
 		return
 	}

--- a/toolkit/tools/srpmpacker/srpmpacker.go
+++ b/toolkit/tools/srpmpacker/srpmpacker.go
@@ -320,7 +320,7 @@ func createChroot(workerTar, buildDir, outDir, specsDir string) (chroot *safechr
 	chrootDir := filepath.Join(buildDir, chrootName)
 	chroot = safechroot.NewChroot(chrootDir, existingDir)
 
-	err = chroot.Initialize(workerTar, extraDirectories, extraMountPoints)
+	err = chroot.Initialize(workerTar, extraDirectories, extraMountPoints, true)
 	if err != nil {
 		return
 	}

--- a/toolkit/tools/validatechroot/validatechroot.go
+++ b/toolkit/tools/validatechroot/validatechroot.go
@@ -76,7 +76,7 @@ func validateWorker(rpmsDir, chrootDir, workerTarPath, manifestPath string) (err
 	rpmMount := safechroot.NewMountPoint(rpmsDir, chrootToolchainRpmsDir, "", safechroot.BindMountPointFlags, "")
 	extraDirectories := []string{chrootToolchainRpmsDir}
 	rpmMounts := []*safechroot.MountPoint{rpmMount}
-	err = chroot.Initialize(workerTarPath, extraDirectories, rpmMounts)
+	err = chroot.Initialize(workerTarPath, extraDirectories, rpmMounts, true)
 	if err != nil {
 		chroot = nil
 		return


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->

Currently, the `safechroot.Chroot` class will auto-mount a bunch of the special directories (e.g. /dev, /proc, etc.). This is done (presumably) to permit more Linux utils to be runnable under the chroot.

However, when the image customizer tool is doing file-copy based partition customization, it has to make sure it avoids copying the contents of the special directories to avoiding messing up the host system. Currently, this is done by just explictly excluding the special directories from the copy operation. However, this can result in problems. For example, a directory not being created (e.g. /tmp) or a mount directory not receiving the correct extended attributes (e.g. SELinux).

This change adds an initialization option to `safechroot.Chroot` to set whether or not the special-directories are mounted. This allows the partition customization to do just a straight file-copy.

###### Change Log  <!-- REQUIRED -->

- Image Customizer: Fix special directories and partition customization.

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Manually ran image customizer.
- Ran existing UTs.

