### PR TITLE
Sudo ldap netgroup_query bug fix patch

### DIFF
--- a/SPECS/sudo/disable-newgroup-query-when-netgroup-base-is-not-set.patch
+++ b/SPECS/sudo/disable-newgroup-query-when-netgroup-base-is-not-set.patch
@@ -1,0 +1,27 @@
+From 5fbf7a3625cc199e8f350af88c1120e45fa17bf4 Mon Sep 17 00:00:00 2001
+From: "Todd C. Miller" <Todd.Miller@sudo.ws>
+Date: Tue, 19 Dec 2023 20:16:35 -0700
+Subject: [PATCH] Disable netgroup_query when netgroup_base is not set.
+
+The logic was inverted when support for netgroup_query was added.
+This supercedes PR #341.
+---
+ plugins/sudoers/ldap_conf.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/plugins/sudoers/ldap_conf.c b/plugins/sudoers/ldap_conf.c
+index 8c772ade41..10e2373352 100644
+--- a/plugins/sudoers/ldap_conf.c
++++ b/plugins/sudoers/ldap_conf.c
+@@ -599,8 +599,10 @@ sudo_ldap_read_config(const struct sudoers_context *ctx)
+ 	    debug_return_bool(false);
+ 	}
+     }
+-    if (!STAILQ_EMPTY(&ldap_conf.netgroup_base))
++    if (STAILQ_EMPTY(&ldap_conf.netgroup_base)) {
++	/* netgroup_query is only valid in conjunction with netgroup_base */
+ 	ldap_conf.netgroup_query = false;
++    }
+ 
+     DPRINTF1("LDAP Config Summary");
+     DPRINTF1("===================");

--- a/SPECS/sudo/sudo.spec
+++ b/SPECS/sudo/sudo.spec
@@ -1,13 +1,14 @@
 Summary:        Sudo
 Name:           sudo
 Version:        1.9.14p3
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        ISC
 URL:            https://www.sudo.ws/
 Group:          System Environment/Security
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Source0:        https://www.sudo.ws/sudo/dist/%{name}-%{version}.tar.gz
+Patch0:         disable-newgroup-query-when-netgroup-base-is-not-set.patch
 BuildRequires:  audit-devel
 BuildRequires:  man-db
 BuildRequires:  openssl-devel
@@ -99,6 +100,9 @@ fi
 %exclude  /etc/sudoers.dist
 
 %changelog
+* Tue Dec 19 2023 Andy Zaugg <azaugg@linkedin.com> - 1.9.14p3-2
+- Add patch to bug fix support for NETGROUP_QUERY
+
 * Fri Aug 25 2023 Andy Zaugg <azaugg@linkedin.com> - 1.9.14p3-1
 - Bump version to 1.9.14p3
 


### PR DESCRIPTION
sudo backed by ldap is no longer working after moving to the new version of sudo. Patched the fix upstream to get ldap sudo to work with NETGROUP_QUERY

cherry-pick of a48d432a1102fb27c18961d7e594d82c2f345b74