### PR TITLE
postgresql: update to v14.10 to fix CVE-2023-5868, CVE-2023-5869 and CVE-2023-5870 (CP #7138)

### DIFF
--- a/SPECS/postgresql/postgresql.signatures.json
+++ b/SPECS/postgresql/postgresql.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "postgresql-14.8.tar.bz2": "39d38f0030737ed03835debeefee3b37d335462ce4995e2497bc38d621ebe45a"
- }
+  "postgresql-14.10.tar.bz2": "c99431c48e9d470b0d0ab946eb2141a3cd19130c2fb4dc4b3284a7774ecc8399"
+  }
 }

--- a/SPECS/postgresql/postgresql.spec
+++ b/SPECS/postgresql/postgresql.spec
@@ -1,6 +1,6 @@
 Summary:        PostgreSQL database engine
 Name:           postgresql
-Version:        14.8
+Version:        14.10
 Release:        1%{?dist}
 License:        PostgreSQL
 Vendor:         Microsoft Corporation
@@ -172,6 +172,9 @@ sudo -u nobody -s /bin/bash -c "PATH=$PATH make -k check"
 %{_libdir}/libpgtypes.a
 
 %changelog
+* Fri Dec 29 2023 Neha Agarwal <nehaagarwal@microsoft.com> - 14.10-1
+- Upgrade to 14.10 to fix CVE-2023-5868, CVE-2023-5869 and CVE-2023-5870
+
 * Tue Jun 20 2023 Bala <balakumaran.kannan@microsoft.com> - 14.8-1
 - Upgrade to 14.8 to fix CVE-2023-2454, CVE-2023-2455 and CVE-2022-41862
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -21424,8 +21424,8 @@
         "type": "other",
         "other": {
           "name": "postgresql",
-          "version": "14.8",
-          "downloadUrl": "https://ftp.postgresql.org/pub/source/v14.8/postgresql-14.8.tar.bz2"
+          "version": "14.10",
+          "downloadUrl": "https://ftp.postgresql.org/pub/source/v14.10/postgresql-14.10.tar.bz2"
         }
       }
     },


### PR DESCRIPTION
…
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
update to v14.10 to fix CVE-2023-5868, CVE-2023-5869 and CVE-2023-5870 (CP #7138)

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- update to v14.10 to fix CVE-2023-5868, CVE-2023-5869 and CVE-2023-5870 

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2023-5868
- https://nvd.nist.gov/vuln/detail/CVE-2023-5869
- https://nvd.nist.gov/vuln/detail/CVE-2023-5870

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- None,  CP #7138