### PR TITLE
Upgrade nfs-utils to 2.6.4 and libtirpc to 1.3.4 

### DIFF
--- a/SPECS/libtirpc/libtirpc.signatures.json
+++ b/SPECS/libtirpc/libtirpc.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "libtirpc-1.3.3.tar.bz2": "6474e98851d9f6f33871957ddee9714fdcd9d8a5ee9abb5a98d63ea2e60e12f3"
+  "libtirpc-1.3.4.tar.bz2": "1e0b0c7231c5fa122e06c0609a76723664d068b0dba3b8219b63e6340b347860"
  }
 }

--- a/SPECS/libtirpc/libtirpc.spec
+++ b/SPECS/libtirpc/libtirpc.spec
@@ -1,6 +1,6 @@
 Summary:        Libraries for Transport Independent RPC
 Name:           libtirpc
-Version:        1.3.3
+Version:        1.3.4
 Release:        1%{?dist}
 License:        BSD
 Group:          System Environment/Libraries
@@ -35,7 +35,7 @@ Requires:   krb5-devel
 This package includes header files and libraries necessary for developing programs which use the tirpc library.
 
 %prep
-%setup -q
+%autosetup -p1
 
 %build
 ./configure --prefix=%{_prefix} --sysconfdir=%{_sysconfdir}
@@ -68,6 +68,9 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %{_libdir}/*.a
 
 %changelog
+* Tue Jan 02 2024 Rachel Menge <rachelmenge@microsoft.com> - 1.3.4-1
+- Update to version 1.3.4
+
 * Wed Aug 10 2022 Muhammad Falak <mwani@microsoft.com> - 1.3.3-1
 - Bump verison to address CVE-2021-46828
 

--- a/SPECS/nfs-utils/nfs-utils.signatures.json
+++ b/SPECS/nfs-utils/nfs-utils.signatures.json
@@ -4,7 +4,7 @@
   "nfs-client.target": "53b0d04b836ced37f67a690f17080fe4481df57e90ca95c17fa711c3b7725f42",
   "nfs-mountd.service": "7dc86d8993d314f598ae56f93bace853bbf0bf95100a0924a817a0f42e90416a",
   "nfs-server.service": "09f0c70aa286c84c6ef01dca525e2115cd3a436a88f1e0894341916413864837",
-  "nfs-utils-2.5.4.tar.xz": "51997d94e4c8bcef5456dd36a9ccc38e231207c4e9b6a9a2c108841e6aebe3dd",
+  "nfs-utils-2.6.4.tar.xz": "01b3b0fb9c7d0bbabf5114c736542030748c788ec2fd9734744201e9b0a1119d",
   "nfs-utils.defaults": "4aa8d1acae8d7116c14a59d7fa5aa455e01db805da33047430daa5448ed8b507",
   "rpc-statd-notify.service": "ec6e7c1c1457479b84a8d292e08cf17bdde005d4d0fd619f8bfe9dbe8c194405",
   "rpc-statd.service": "07ed5a627c8a523b1a7b216c1dd5d9b14f72718269cbd5f7fef4696b0a46b337"

--- a/SPECS/nfs-utils/nfs-utils.spec
+++ b/SPECS/nfs-utils/nfs-utils.spec
@@ -1,7 +1,7 @@
 Summary:        NFS client utils
 Name:           nfs-utils
-Version:        2.5.4
-Release:        3%{?dist}
+Version:        2.6.4
+Release:        1%{?dist}
 License:        MIT and GPLv2 and GPLv2+ and BSD
 URL:            https://linux-nfs.org/
 Group:          Applications/Nfs-utils-client
@@ -16,24 +16,24 @@ Source7:        nfs-mountd.service
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 
-BuildRequires:  libtool
+BuildRequires:  e2fsprogs-devel
+BuildRequires:  device-mapper-devel
+BuildRequires:  keyutils-devel
 BuildRequires:  krb5-devel
 BuildRequires:  libcap-devel
-BuildRequires:  libtirpc-devel
-BuildRequires:  python3-devel
 BuildRequires:  libevent-devel
-BuildRequires:  device-mapper-devel
-BuildRequires:  systemd-devel
-BuildRequires:  keyutils-devel
+BuildRequires:  libgssglue-devel
+BuildRequires:  libtirpc-devel >= 1.3.4
+BuildRequires:  libtool
+BuildRequires:  python3-devel
 BuildRequires:  sqlite
 BuildRequires:  sqlite-devel
-BuildRequires:  libgssglue-devel
-BuildRequires:  e2fsprogs-devel
+BuildRequires:  systemd-devel
 Requires:       libnfsidmap
 Requires:       libtirpc
+Requires:       python3-libs
 Requires:       rpcbind
 Requires:       shadow-utils
-Requires:       python3-libs
 Requires(pre):  /usr/sbin/useradd /usr/sbin/groupadd
 Requires(postun):/usr/sbin/userdel /usr/sbin/groupdel
 
@@ -90,6 +90,7 @@ sed -i 's/RPCGEN_PATH" =/rpcgen_path" =/' configure
 sed -i 's/-Werror=strict-prototypes/-Wno-error=strict-prototypes/' support/nsm/Makefile
 sed -i 's/CFLAGS = -g/CFLAGS = -Wno-error=strict-prototypes/' support/nsm/Makefile
 make %{?_smp_mflags}
+
 %install
 make DESTDIR=%{buildroot} install
 install -v -m644 utils/mount/nfsmount.conf /etc/nfsmount.conf
@@ -154,6 +155,8 @@ fi
 %config(noreplace) /etc/exports
 /lib/systemd/system/*
 %{_libdir}/systemd/system-preset/50-nfs-server.preset
+%{_libexecdir}/nfsrahead
+%{_udevrulesdir}/99-nfs.rules
 
 %files -n libnfsidmap
 %{_libdir}/libnfsidmap.so.*
@@ -167,6 +170,9 @@ fi
 %{_libdir}/libnfsidmap.so
 
 %changelog
+* Tue Jan 02 2024 Rachel Menge <rachelmenge@microsoft.com> - 2.6.4-1
+- Update to version 2.6.4
+
 * Wed Sep 20 2023 Jon Slobodzian <joslobo@microsoft.com> - 2.5.4-3
 - Recompile with stack-protection fixed gcc version (CVE-2023-4039)
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -11151,8 +11151,8 @@
         "type": "other",
         "other": {
           "name": "libtirpc",
-          "version": "1.3.3",
-          "downloadUrl": "https://downloads.sourceforge.net/libtirpc/libtirpc-1.3.3.tar.bz2"
+          "version": "1.3.4",
+          "downloadUrl": "https://downloads.sourceforge.net/libtirpc/libtirpc-1.3.4.tar.bz2"
         }
       }
     },
@@ -14003,8 +14003,8 @@
         "type": "other",
         "other": {
           "name": "nfs-utils",
-          "version": "2.5.4",
-          "downloadUrl": "https://www.kernel.org/pub/linux/utils/nfs-utils/2.5.4/nfs-utils-2.5.4.tar.xz"
+          "version": "2.6.4",
+          "downloadUrl": "https://www.kernel.org/pub/linux/utils/nfs-utils/2.6.4/nfs-utils-2.6.4.tar.xz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Upgrade nfs-utils to 2.6.4 and libtirpc to 1.3.4 

'nfs-utils' requires a newer version of 'libtirpc' due to an API change to struct rpc_gsss_sec. A good explanation can be seen on this email chain ([link](https://www.spinics.net/lists/linux-nfs/msg100712.html) )  :

```
> I would imagine distros would build matching
> libtirpc and nfs-utils that would either both not have the fix or have
> the fix.
I don't think distros work that way unless they are forced to.
There doesn't seem to be a reason why the nfs-utils change has
to break things -- we can do this without the ABI disruption.
The change to struct rpc_gss_sec can't remain. IMO both
f5b6e6fdb1e6 ("gss-api: expose gss major/minor error in authgss_refresh()")
and
4b272471937d ("gssd: handle KRB5_AP_ERR_BAD_INTEGRITY for machine credentials")
need to be reverted first.
```
Neither has been reverted as of 01/02/2023


Additionally, 'nfs-utils' 2.6.4 introduces new files "nfsrahead" due to commit [f86c4c9065786bd9f08c923ff6a55621b9803f9c] and "99-nfs.rules" due to commit [6011418c3e4e37dd433a6d7560f220d442943f84].

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Upgrade nfs-utils to 2.6.4
- Upgrade libtirpc to 1.3.4 

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=476784&view=results
- local builds
