### PR TITLE
Revert "Increase image size for baremetal and qemu guest to 4GB"

### DIFF
--- a/toolkit/imageconfigs/baremetal.json
+++ b/toolkit/imageconfigs/baremetal.json
@@ -2,7 +2,7 @@
     "Disks": [
         {
             "PartitionTableType": "gpt",
-            "MaxSize": 4096,
+            "MaxSize": 1024,
             "Artifacts": [
                 {
                     "Name": "core",

--- a/toolkit/imageconfigs/qemu-guest.json
+++ b/toolkit/imageconfigs/qemu-guest.json
@@ -2,7 +2,7 @@
     "Disks": [
         {
             "PartitionTableType": "gpt",
-            "MaxSize": 4096,
+            "MaxSize": 1024,
             "Artifacts": [
                 {
                     "Name": "core",


### PR DESCRIPTION
Reverts microsoft/CBL-Mariner#6572

With the addition of customize partitions support through MIC, the image size increase is no longer needed. 
Users of the image can customize it using the MIC APIs.