### PR TITLE
Image Customizer: Resolves bug with SSH public key paths - support for relative path

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/customizeutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeutils.go
@@ -298,7 +298,10 @@ func addOrUpdateUser(user imagecustomizerapi.User, baseConfigPath string, imageC
 
 	// Set user's SSH keys.
 	for i, _ := range user.SSHPubKeyPaths {
-		user.SSHPubKeyPaths[i] = filepath.Join(baseConfigPath, user.SSHPubKeyPaths[i])
+		// If absolute path is not provided, then append baseConfigPath.
+		if filepath.IsAbs(user.SSHPubKeyPaths[i]) == false {
+			user.SSHPubKeyPaths[i] = filepath.Join(baseConfigPath, user.SSHPubKeyPaths[i])
+		}
 	}
 
 	err = installutils.ProvisionUserSSHCerts(imageChroot, user.Name, user.SSHPubKeyPaths)

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeutils.go
@@ -300,7 +300,7 @@ func addOrUpdateUser(user imagecustomizerapi.User, baseConfigPath string, imageC
 	for i, _ := range user.SSHPubKeyPaths {
 		user.SSHPubKeyPaths[i] = filepath.Join(baseConfigPath, user.SSHPubKeyPaths[i])
 	}
-	
+
 	err = installutils.ProvisionUserSSHCerts(imageChroot, user.Name, user.SSHPubKeyPaths)
 	if err != nil {
 		return err

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeutils.go
@@ -299,7 +299,7 @@ func addOrUpdateUser(user imagecustomizerapi.User, baseConfigPath string, imageC
 	// Set user's SSH keys.
 	for i, _ := range user.SSHPubKeyPaths {
 		// If absolute path is not provided, then append baseConfigPath.
-		if filepath.IsAbs(user.SSHPubKeyPaths[i]) == false {
+		if !filepath.IsAbs(user.SSHPubKeyPaths[i]) {
 			user.SSHPubKeyPaths[i] = filepath.Join(baseConfigPath, user.SSHPubKeyPaths[i])
 		}
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeutils.go
@@ -297,6 +297,10 @@ func addOrUpdateUser(user imagecustomizerapi.User, baseConfigPath string, imageC
 	}
 
 	// Set user's SSH keys.
+	for i, _ := range user.SSHPubKeyPaths {
+		user.SSHPubKeyPaths[i] = filepath.Join(baseConfigPath, user.SSHPubKeyPaths[i])
+	}
+	
 	err = installutils.ProvisionUserSSHCerts(imageChroot, user.Name, user.SSHPubKeyPaths)
 	if err != nil {
 		return err


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Resolves bug https://dev.azure.com/mariner-org/ECF/_workitems/edit/6500 where it was found that the copying of user ssh key paths did not work like additional files. This is because when copying additional files we join the baseConfigPath to the file path, but we did not follow this same practice for ssh key paths. This PR adds support for relative paths to SSH public key paths.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Joined baseConfigPath to ssh key paths.
- If path is already absolute, no change is made.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- Fixes https://dev.azure.com/mariner-org/ECF/_workitems/edit/6500

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Validated by testing in a local setup that repro'd the bug.
- Tested with no ssh key paths provided, as well as with. 
- Tested with absolute path provided as well as relative.
