### PR TITLE
toolkit: fix worker chroot progress [main]

### DIFF
--- a/toolkit/tools/pkggen/worker/create_worker_chroot.sh
+++ b/toolkit/tools/pkggen/worker/create_worker_chroot.sh
@@ -24,7 +24,7 @@ chroot_log="$log_path"/$chroot_name.log
 
 # We have two major steps per entry in the packages file: install the RPM, then add to database
 total_steps=$(wc -l < "$packages")
-total_steps=$((total_steps * 2))
+total_steps=$((total_steps * 1))
 current_step=0
 # Print "<progress>%" and increment current_step
 function increment_progress() {
@@ -91,6 +91,8 @@ if [[ "$HOST_RPM_DB_BACKEND" == "$GUEST_RPM_DB_BACKEND" ]]; then
     echo "The host rpm db '$HOST_RPM_DB_BACKEND' matches the guest. Not rebuilding the database." | tee -a "$chroot_log"
 else
     echo "The host rpm db ('$HOST_RPM_DB_BACKEND') differs from the guest ('$GUEST_RPM_DB_BACKEND'). Rebuilding database for compatibility" | tee -a "$chroot_log"
+    # Reset current_step to show 0-100% progress for rebuild
+    current_step=0
     TEMP_DB_PATH="/temp_db"
     chroot "$chroot_builder_folder" mkdir -p "$TEMP_DB_PATH"
     chroot "$chroot_builder_folder" rpm --initdb --dbpath="$TEMP_DB_PATH"


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?

This is a port from the same fix in 3.0-dev #7188 

Fix logging issue when creating the worker chroot. It currently stops just before 50% instead of showing 100% completion, whenever the rpm database does not need to be rebuilt. 

Before:
```
Adding RPM to worker chroot 0%: filesystem-1.1-18.azl3.x86_64.rpm.
...
Adding RPM to worker chroot 49%: audit-libs-3.1.2-1.azl3.x86_64.rpm.
Current host 'RPM version 4.18.0' with rpm db 'sqlite', guest has 'RPM version 4.18.0' with rpm db 'sqlite'
The host rpm db 'sqlite' matches the guest. Not rebuilding the database.
```

After:
```
Adding RPM to worker chroot 0%: filesystem-1.1-18.azl3.x86_64.rpm.
...
Adding RPM to worker chroot 99%: audit-libs-3.1.2-1.azl3.x86_64.rpm.
Current host 'RPM version 4.18.0' with rpm db 'sqlite', guest has 'RPM version 4.18.0' with rpm db 'sqlite'
The host rpm db 'sqlite' matches the guest. Not rebuilding the database.
```


###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change percentage calculation in worker chroot script

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build. I built a package locally using the steps below and verified the output.
```
sudo make toolchain REBUILD_TOOLS=y
sudo make build-packages REBUILD_TOOLS=y SRPM_PACK_LIST="tree" PACKAGE_REBUILD_LIST="tree"
```