### PR TITLE
Add Mysql user with package install

### DIFF
--- a/SPECS/mysql/mysql.spec
+++ b/SPECS/mysql/mysql.spec
@@ -1,7 +1,7 @@
 Summary:        MySQL.
 Name:           mysql
 Version:        8.0.35
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        GPLv2 with exceptions AND LGPLv2 AND BSD
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -51,6 +51,12 @@ make DESTDIR=%{buildroot} install
 %check
 make test
 
+%pre
+if [ $1 -eq 1 ] ; then
+    getent group  mysql  >/dev/null || groupadd -r mysql
+    getent passwd mysql  >/dev/null || useradd  -c "mysql" -s /bin/false -g mysql -M -r mysql
+fi
+
 %files
 %defattr(-,root,root)
 %license LICENSE router/LICENSE.router
@@ -84,6 +90,9 @@ make test
 %{_libdir}/pkgconfig/mysqlclient.pc
 
 %changelog
+* Wed Jan 10 2024 Andy Zaugg <azaugg@linkedin.com> - 8.0.35-3
+- Add mysql user as part of post scripts
+
 * Wed Dec 20 2023 Suresh Thelkar <sthelkar@microsoft.com> - 8.0.35-2
 - Patch CVE-2023-46218 
 

--- a/SPECS/mysql/mysql.spec
+++ b/SPECS/mysql/mysql.spec
@@ -52,9 +52,15 @@ make DESTDIR=%{buildroot} install
 make test
 
 %pre
-if [ $1 -eq 1 ] ; then
-    getent group  mysql  >/dev/null || groupadd -r mysql
-    getent passwd mysql  >/dev/null || useradd  -c "mysql" -s /bin/false -g mysql -M -r mysql
+getent group  mysql  >/dev/null || groupadd -r mysql
+getent passwd mysql  >/dev/null || useradd  -c "mysql" -s /bin/false -g mysql -M -r mysql
+
+%postun
+if getent passwd mysql >/dev/null; then
+   userdel mysql
+fi
+if getent group mysql >/dev/null; then
+    groupdel mysql
 fi
 
 %files


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
The mysql package install does not add a user, add the mysql user as part of package install operations. This mimics the behaviour that the mariadb package also has.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add mysql user as part of mysql package install


###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-YYYY-XXXX

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Built the package via tool chain
```
INFO[0000][scheduler] Reading DOT graph from /home/azaugg/CBL-Mariner/build/pkg_artifacts/preprocessed_graph.dot
INFO[0000][scheduler] Reading DOT graph from /home/azaugg/CBL-Mariner/build/pkg_artifacts/preprocessed_graph.dot
INFO[0000][scheduler] Successfully created solvable subgraph
INFO[0000][scheduler] Building 20 nodes with 8 workers
INFO[0000][scheduler] Building: mysql-8.0.35-3.cm2.src.rpm
INFO[1998][scheduler] Built: mysql-8.0.35-3.cm2.src.rpm -> [/home/azaugg/CBL-Mariner/out/RPMS/x86_64/mysql-8.0.35-3.cm2.x86_64.rpm /home/azaugg/CBL-Mariner/out/RPMS/x86_64/mysql-debuginfo-8.0.35-3.cm2.x86_64.rpm /home/azaugg/CBL-Mariner/out/RPMS/x86_64/mysql-devel-8.0.35-3.cm2.x86_64.rpm]
INFO[1998][scheduler] 0 currently active build(s): [].
INFO[1998][scheduler] All packages built
INFO[1999][scheduler] ---------------------------
INFO[1999][scheduler] --------- Summary ---------
INFO[1999][scheduler] ---------------------------
INFO[1999][scheduler] Number of built SRPMs:             1
INFO[1999][scheduler] Number of tested SRPMs:            0
INFO[1999][scheduler] Number of prebuilt SRPMs:          0
INFO[1999][scheduler] Number of prebuilt delta SRPMs:    0
INFO[1999][scheduler] Number of skipped SRPMs tests:     0
INFO[1999][scheduler] Number of failed SRPMs:            0
INFO[1999][scheduler] Number of failed SRPMs tests:      0
INFO[1999][scheduler] Number of blocked SRPMs:           0
INFO[1999][scheduler] Number of blocked SRPMs tests:     0
INFO[1999][scheduler] Number of unresolved dependencies: 0
INFO[1999][scheduler] Built SRPMs:
INFO[1999][scheduler] --> mysql-8.0.35-3.cm2.src.rpm
INFO[1999][scheduler] Writing DOT graph to /home/azaugg/CBL-Mariner/build/pkg_artifacts/built_graph.dot
INFO[1999][scheduler] Waiting for outstanding processes to be created
Finished updating /home/azaugg/CBL-Mariner/out/RPMS
```

Installed package and confirmed user was added
```
azaugg@azaugg-ld77 [ ~ ]$ grep mysql /etc/passwd
azaugg@azaugg-ld77 [ ~ ]$ sudo rpm -i mysql-8.0.35-3.cm2.x86_64.rpm
azaugg@azaugg-ld77 [ ~ ]$ grep mysql /etc/passwd
mysql:x:996:990:mysql:/home/mysql:/bin/false

```
