### PR TITLE
nopatch for CVE-2019-0190, which only affects systems with Apache HTTP Server <=2.4.37

### DIFF
--- a/SPECS/openssl/openssl.spec
+++ b/SPECS/openssl/openssl.spec
@@ -20,6 +20,8 @@ Source7: renew-dummy-cert
 Source9: configuration-switch.h
 Source10: configuration-prefix.h
 Source14: 0025-for-tests.patch
+# CVE only applies when Apache HTTP Server version 2.4.37 or less: https://nvd.nist.gov/vuln/detail/CVE-2019-0190
+Patch1:   CVE-2019-0190.nopatch
 # # Use more general default values in openssl.cnf
 Patch2:   0002-Use-more-general-default-values-in-openssl.cnf.patch
 # # Do not install html docs


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
[CVE-2019-0190](https://nvd.nist.gov/vuln/detail/CVE-2019-0190) only affects Apache HTTP Server version <= 2.4.37. We have a higher version, so we don't need a patch for it in openssl.

This comes from the[ openssl.spec file in main](https://github.com/microsoft/CBL-Mariner/blob/3798a92d85758462fd12f7fa8abce93802de6234/SPECS/openssl/openssl.spec#L24), and based on the CVE information is still accurate.

###### Change Log  <!-- REQUIRED -->
- Added nopatch for CVE-2019-0190

###### Does this affect the toolchain?  <!-- REQUIRED -->
**YES**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2019-0190

###### Test Methodology
- Built locally
