### PR TITLE
Revert upgrade of guile 

### DIFF
--- a/SPECS/guile/guile.signatures.json
+++ b/SPECS/guile/guile.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "guile-3.0.9.tar.gz": "18525079ad29a0d46d15c76581b5d91c8702301bfd821666d2e1d13726162811"
+  "guile-2.0.14.tar.gz": "8aeb2f353881282fe01694cce76bb72f7ffdd296a12c7a1a39255c27b0dfe5f1"
  }
 }

--- a/SPECS/guile/guile.spec
+++ b/SPECS/guile/guile.spec
@@ -1,13 +1,13 @@
 Summary:        GNU Ubiquitous Intelligent Language for Extensions
 Name:           guile
-Version:        3.0.9
-Release:        1%{?dist}
+Version:        2.0.14
+Release:        5%{?dist}
 License:        LGPLv3+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Group:          Development/Languages
 URL:            https://www.gnu.org/software/guile/
-Source0:        https://ftp.gnu.org/gnu/guile/%{name}-%{version}.tar.gz
+Source0:        ftp://ftp.gnu.org/pub/gnu/guile/%{name}-%{version}.tar.gz
 BuildRequires:  gc-devel
 BuildRequires:  libffi-devel
 BuildRequires:  libltdl-devel
@@ -72,15 +72,12 @@ make  %{?_smp_mflags} check
 
 %files devel
 %defattr(-,root,root)
-%{_includedir}/guile/3.0/*.h
-%{_includedir}/guile/3.0/libguile/*.h
+%{_includedir}/guile/2.0/*.h
+%{_includedir}/guile/2.0/libguile/*.h
 %{_libdir}/*.so
 %{_libdir}/pkgconfig/*.pc
 
 %changelog
-* Tue Jan 09 2024 Brian Fjeldstad <bfjelds@microsoft.com> 3.0.9-1
-- Update to 3.0.9.
-
 * Wed Sep 20 2023 Jon Slobodzian <joslobo@microsoft.com> - 2.0.14-5
 - Recompile with stack-protection fixed gcc version (CVE-2023-4039)
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -5040,8 +5040,8 @@
         "type": "other",
         "other": {
           "name": "guile",
-          "version": "3.0.9",
-          "downloadUrl": "https://ftp.gnu.org/gnu/guile/guile-3.0.9.tar.gz"
+          "version": "2.0.14",
+          "downloadUrl": "ftp://ftp.gnu.org/pub/gnu/guile/guile-2.0.14.tar.gz"
         }
       }
     },


### PR DESCRIPTION
This reverts commit 00a8a4484c63632f72bce894e88b71b891104f64. 
The existing and latest release of autogen requires guile version <= 2.2 to build. This upgrade breaks autogen, hence reverting.

I did try to build the latest unreleased version 5.18.98 of autogen to see if the dependency has been removed but it isn't the case. I ran into several issues trying to build v5.18.98 which has additional deps on gnulibs etc. The only supported lib versions of guile are:

`_guile_versions_to_search="m4_default([$1], [2.2 2.0 1.8])`

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
Revert the guile version back to 2.0.x
Unblocks building autogen on which several packages depend.

###### Change Log  <!-- REQUIRED -->
Only removes a commit. No changes.

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->


###### Links to CVEs  <!-- optional -->

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
Buddy build to build both guile and autogen -> https://dev.azure.com/mariner-org/mariner/_build/results?buildId=485423&view=results
