### PR TITLE
Fix mariadb install post script

### DIFF
--- a/SPECS/mariadb/fix_symlink_location_db_install.patch
+++ b/SPECS/mariadb/fix_symlink_location_db_install.patch
@@ -1,0 +1,13 @@
+diff --git a/scripts/CMakeLists.txt b/scripts/CMakeLists.txt
+index 9eec793c9fb..1b0f6bfb680 100644
+--- a/scripts/CMakeLists.txt
++++ b/scripts/CMakeLists.txt
+@@ -223,7 +223,7 @@ IF(UNIX AND NOT WITHOUT_SERVER)
+     DESTINATION ${INSTALL_SCRIPTDIR}
+     COMPONENT Server)
+
+-  INSTALL_LINK(mariadb-install-db mysql_install_db ${INSTALL_SCRIPTDIR} Server)
++  INSTALL_LINK(mariadb-install-db mysql_install_db ${INSTALL_BINDIR} Server)
+ ENDIF()
+
+ SET(prefix "${CMAKE_INSTALL_PREFIX}")

--- a/SPECS/mariadb/mariadb.spec
+++ b/SPECS/mariadb/mariadb.spec
@@ -465,7 +465,7 @@ fi
 %{_datadir}/mysql/hindi/errmsg.sys
 
 %changelog
-* Thu Jan 17 2024 Andy Zaugg <azaugg@linkedin.com> - 10.6.9-6
+* Thu Jan 18 2024 Andy Zaugg <azaugg@linkedin.com> - 10.6.9-6
 - Fix post scripts for rpm install, missing setup(mysql_install_db) script.
 
 * Wed Sep 20 2023 Jon Slobodzian <joslobo@microsoft.com> - 10.6.9-5

--- a/SPECS/mariadb/mariadb.spec
+++ b/SPECS/mariadb/mariadb.spec
@@ -1,7 +1,7 @@
 Summary:        Database servers made by the original developers of MySQL.
 Name:           mariadb
 Version:        10.6.9
-Release:        5%{?dist}
+Release:        6%{?dist}
 License:        GPLv2 WITH exceptions AND LGPLv2 AND BSD
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -12,6 +12,7 @@ Group:          Applications/Databases
 URL:            https://mariadb.org/
 Source0:        https://github.com/MariaDB/server/archive/mariadb-%{version}.tar.gz
 Patch0:         CVE-2022-47015.patch
+Patch1:         fix_symlink_location_db_install.patch
 BuildRequires:  cmake
 BuildRequires:  curl-devel
 BuildRequires:  e2fsprogs-devel
@@ -68,6 +69,7 @@ errmsg for maridb
 
 %prep
 %autosetup -p1
+
 # Remove PerconaFT from here because of AGPL licence
 rm -rf storage/tokudb/PerconaFT
 # Disable "embedded" directory which only contains "test-connect" test
@@ -154,7 +156,7 @@ fi
 %post server
 /sbin/ldconfig
 chown  mysql:mysql %{_sharedstatedir}/mysql || :
-mysql_install_db --datadir="%{_sharedstatedir}/mysql" --user="mysql" --basedir="%{_prefix}" >/dev/null || :
+mariadb-install-db --datadir="%{_sharedstatedir}/mysql" --user="mysql" --basedir="%{_prefix}" >/dev/null || :
 %systemd_post  mariadb.service
 
 %postun server
@@ -211,6 +213,7 @@ fi
 %{_bindir}/msql2mysql
 %{_bindir}/mysql
 %{_bindir}/mysql_find_rows
+%{_bindir}/mysql_install_db
 %{_bindir}/mysql_plugin
 %{_bindir}/mysql_waitpid
 %{_bindir}/mysqlaccess
@@ -295,7 +298,7 @@ fi
 %{_bindir}/myisamchk
 %{_bindir}/myisamlog
 %{_bindir}/myisampack
-%{_bindir}/mysql_install_db
+%{_bindir}/mariadb-install-db
 %{_bindir}/mysql_secure_installation
 %{_bindir}/mysql_tzinfo_to_sql
 %{_bindir}/mysqld_safe
@@ -462,6 +465,9 @@ fi
 %{_datadir}/mysql/hindi/errmsg.sys
 
 %changelog
+* Thu Jan 17 2024 Andy Zaugg <azaugg@linkedin.com> - 10.6.9-6
+- Fix post scripts for rpm install, missing setup(mysql_install_db) script.
+
 * Wed Sep 20 2023 Jon Slobodzian <joslobo@microsoft.com> - 10.6.9-5
 - Recompile with stack-protection fixed gcc version (CVE-2023-4039)
 


### PR DESCRIPTION

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
The post scripts for mariadb don't run due to missing script. As part of cmake install, mariadb-install-db script is removed. Adding patch to ensure script is correctly added to buildroot
```
Installing/Updating: mariadb-connector-c-config-3.1.10-6.cm2.noarch
Installing/Updating: mariadb-server-10.6.9-5.cm2.x86_64
/var/tmp/rpm-tmp.wjMLcK: line 3: mysql_install_db: command not found
```

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- patch upstream mariadb to ensure scripts that RPM post scripts need to finalise the install, work as expected


###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Rebuilt package and confirmed
Rebuild mariadb package with CMake patch
```
INFO[0000][scheduler] Reading DOT graph from /home/azaugg/CBL-Mariner/build/pkg_artifacts/preprocessed_graph.dot
INFO[0000][scheduler] Reading DOT graph from /home/azaugg/CBL-Mariner/build/pkg_artifacts/preprocessed_graph.dot
INFO[0000][scheduler] Successfully created solvable subgraph
INFO[0000][scheduler] Building 43 nodes with 8 workers
INFO[0000][scheduler] Building: mariadb-10.6.9-6.cm2.src.rpm
INFO[0846][scheduler] Built: mariadb-10.6.9-6.cm2.src.rpm -> [/home/azaugg/CBL-Mariner/out/RPMS/x86_64/mariadb-10.6.9-6.cm2.x86_64.rpm /home/azaugg/CBL-Mariner/out/RPMS/x86_64/mariadb-debuginfo-10.6.9-6.cm2.x86_64.rpm /home/azaugg/CBL-Mariner/out/RPMS/x86_64/mariadb-devel-10.6.9-6.cm2.x86_64.rpm /home/azaugg/CBL-Mariner/out/RPMS/x86_64/mariadb-errmsg-10.6.9-6.cm2.x86_64.rpm /home/azaugg/CBL-Mariner/out/RPMS/x86_64/mariadb-server-10.6.9-6.cm2.x86_64.rpm /home/azaugg/CBL-Mariner/out/RPMS/x86_64/mariadb-server-galera-10.6.9-6.cm2.x86_64.rpm]
INFO[0846][scheduler] 0 currently active build(s): [].
INFO[0846][scheduler] All packages built
INFO[0847][scheduler] ---------------------------
INFO[0847][scheduler] --------- Summary ---------
INFO[0847][scheduler] ---------------------------
INFO[0847][scheduler] Number of built SRPMs:             1
INFO[0847][scheduler] Number of tested SRPMs:            0
INFO[0847][scheduler] Number of prebuilt SRPMs:          0
INFO[0847][scheduler] Number of prebuilt delta SRPMs:    0
INFO[0847][scheduler] Number of skipped SRPMs tests:     0
INFO[0847][scheduler] Number of failed SRPMs:            0
INFO[0847][scheduler] Number of failed SRPMs tests:      0
INFO[0847][scheduler] Number of blocked SRPMs:           0
INFO[0847][scheduler] Number of blocked SRPMs tests:     0
INFO[0847][scheduler] Number of unresolved dependencies: 0
INFO[0847][scheduler] Built SRPMs:
INFO[0847][scheduler] --> mariadb-10.6.9-6.cm2.src.rpm
INFO[0847][scheduler] Writing DOT graph to /home/azaugg/CBL-Mariner/build/pkg_artifacts/built_graph.dot
INFO[0847][scheduler] Waiting for outstanding processes to be created
Finished updating /home/azaugg/CBL-Mariner/out/RPMS
azaugg@azaugg-ld1 [ ~/CBL-Mariner/toolkit ] [ mysql-user-add ] $ cd /tmp/
azaugg@azaugg-ld1 [ /tmp ]  $ mkdir bu
azaugg@azaugg-ld1 [ /tmp ]  $ sudo cp /home/azaugg/CBL-Mariner/out/RPMS/x86_64/mariadb-10.6.9-6.cm2.x86_64.rpm bu/
[sudo] password for azaugg:
azaugg@azaugg-ld1 [ /tmp ]  $ cd bu/
azaugg@azaugg-ld1 [ /tmp/bu ]  $ ls
mariadb-10.6.9-6.cm2.x86_64.rpm
azaugg@azaugg-ld1 [ /tmp/bu ]  $ sudo chown azaugg: mariadb-10.6.9-6.cm2.x86_64.rpm
azaugg@azaugg-ld1 [ /tmp/bu ]  $ rpm2cpio mariadb-10.6.9-6.cm2.x86_64.rpm  | cpio -idm
395558 blocks
azaugg@azaugg-ld1 [ /tmp/bu ]  $ cd usr/bin/
azaugg@azaugg-ld1 [ /tmp/bu/usr/bin ]  $ ls -l mysql_install_db
lrwxrwxrwx 1 azaugg eng 18 Jan 18 06:13 mysql_install_db -> mariadb-install-db
azaugg@azaugg-ld1 [ /tmp/bu/usr/bin ]  $ ls -l mariadb-install-db
-rwxr-xr-x 1 azaugg eng 22013 Jan 18 05:59 mariadb-install-db
```

After exploding the package, you can see that the mariadb-install-db and the associated symlink is in place.
