### PR TITLE
Image Customizer: Make either one of split partitions format and output image format required

### DIFF
--- a/toolkit/tools/imagecustomizer/docs/cli.md
+++ b/toolkit/tools/imagecustomizer/docs/cli.md
@@ -29,11 +29,11 @@ The file path to write the final customized image to.
 
 ## --output-image-format=FORMAT
 
-Required.
-
 The image format of the the final customized image.
 
 Options: vhd, vhdx, qcow2, and raw.
+
+At least one of --output-image-format and --output-split-partitions-format is required.
 
 ## --output-split-partitions-format=FORMAT
 

--- a/toolkit/tools/imagecustomizer/main.go
+++ b/toolkit/tools/imagecustomizer/main.go
@@ -21,7 +21,7 @@ var (
 	buildDir                    = app.Flag("build-dir", "Directory to run build out of.").Required().String()
 	imageFile                   = app.Flag("image-file", "Path of the base CBL-Mariner image which the customization will be applied to.").Required().String()
 	outputImageFile             = app.Flag("output-image-file", "Path to write the customized image to.").Required().String()
-	outputImageFormat           = app.Flag("output-image-format", "Format of output image. Supported: vhd, vhdx, qcow2, raw.").Required().Enum("vhd", "vhdx", "qcow2", "raw")
+	outputImageFormat           = app.Flag("output-image-format", "Format of output image. Supported: vhd, vhdx, qcow2, raw.").Enum("vhd", "vhdx", "qcow2", "raw")
 	outputSplitPartitionsFormat = app.Flag("output-split-partitions-format", "Format of partition files. Supported: raw, raw-zstd").Enum("raw", "raw-zstd")
 	configFile                  = app.Flag("config-file", "Path of the image customization config file.").Required().String()
 	rpmSources                  = app.Flag("rpm-source", "Path to a RPM repo config file or a directory containing RPMs.").Strings()
@@ -37,6 +37,9 @@ func main() {
 
 	app.Version(imagecustomizerlib.ToolVersion)
 	kingpin.MustParse(app.Parse(os.Args[1:]))
+	if *outputSplitPartitionsFormat == "" && *outputImageFormat == "" {
+		kingpin.Fatalf("Either --output-image-format or --output-split-partitions-format must be specified.")
+	}
 
 	logger.InitBestEffort(*logFile, *logLevel)
 

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -63,10 +63,11 @@ func CustomizeImage(buildDir string, baseConfigPath string, config *imagecustomi
 	rpmsSources []string, outputImageFile string, outputImageFormat string, outputSplitPartitionsFormat string, useBaseImageRpmRepos bool,
 ) error {
 	var err error
+	var qemuOutputImageFormat string
 
 	// Validate 'outputImageFormat' value if specified.
 	if outputImageFormat != "" {
-		qemuOutputImageFormat, err := toQemuImageFormat(outputImageFormat)
+		qemuOutputImageFormat, err = toQemuImageFormat(outputImageFormat)
 		if err != nil {
 			return err
 		}
@@ -120,15 +121,17 @@ func CustomizeImage(buildDir string, baseConfigPath string, config *imagecustomi
 		}
 	}
 
-	// Create final output image file.
-	logger.Log.Infof("Writing: %s", outputImageFile)
+	// Create final output image file if requested.
+	if outputImageFormat != "" {
+		logger.Log.Infof("Writing: %s", outputImageFile)
 
-	outDir := filepath.Dir(outputImageFile)
-	os.MkdirAll(outDir, os.ModePerm)
+		outDir := filepath.Dir(outputImageFile)
+		os.MkdirAll(outDir, os.ModePerm)
 
-	err = shell.ExecuteLiveWithErr(1, "qemu-img", "convert", "-O", qemuOutputImageFormat, buildImageFile, outputImageFile)
-	if err != nil {
-		return fmt.Errorf("failed to convert image file to format: %s:\n%w", outputImageFormat, err)
+		err = shell.ExecuteLiveWithErr(1, "qemu-img", "convert", "-O", qemuOutputImageFormat, buildImageFile, outputImageFile)
+		if err != nil {
+			return fmt.Errorf("failed to convert image file to format: %s:\n%w", outputImageFormat, err)
+		}
 	}
 
 	// If outputSplitPartitionsFormat is specified, extract the partition files.

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -64,10 +64,12 @@ func CustomizeImage(buildDir string, baseConfigPath string, config *imagecustomi
 ) error {
 	var err error
 
-	// Validate 'outputImageFormat' value.
-	qemuOutputImageFormat, err := toQemuImageFormat(outputImageFormat)
-	if err != nil {
-		return err
+	// Validate 'outputImageFormat' value if specified.
+	if outputImageFormat != "" {
+		qemuOutputImageFormat, err := toQemuImageFormat(outputImageFormat)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Validate config.


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
We want to allow user to extract just the partition files and not the image file itself. We also want the user to be able to extract the image and not partition files.
This change makes either one of the two flags, `--output-split-partitions-format` and `--output-image-format`, required to allow for this.
Previously, output image format was a required argument.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add conditionals to make either one of the flags required.
- Documentation updated.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**


###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Tested all cases locally: Neither flag mentioned. Output image format specified only. Output split partitions format specified only. Both specified.
Error example:
sudo go run ./imagecustomizer   --build-dir ./build   --image-file ~/core-2.0.20231115.vhdx   --output-image-file ./out/image5.raw --config-file ~/config-3.yaml
imagecustomizer: error: Either --output-image-format or --output-split-partitions-format must be specified.
exit status 1