### PR TITLE
take patch from main that relaces deprecated functions with a NULL or the latest version

### DIFF
--- a/SPECS/openssl/0001-Replacing-deprecated-functions-with-NULL-or-highest.patch
+++ b/SPECS/openssl/0001-Replacing-deprecated-functions-with-NULL-or-highest.patch
@@ -1,0 +1,84 @@
+From c8978b7be6dbe388596fb899ab41a29e414ea5dc Mon Sep 17 00:00:00 2001
+From: Daniel Mihai <Daniel.Mihai@microsoft.com>
+Date: Wed, 28 Jul 2021 14:55:12 -0700
+Subject: [PATCH] Replacing deprecated functions with NULL or highest
+ supported.
+
+This is a workaround until OpenSSL issue #7048 is officially resolved.
+Issue link: https://github.com/openssl/openssl/issues/7048.
+
+The main purpose of the change is to prevent breaking applications
+as they dynamically link to 'libssl.so' where APIs for some
+deprecated protocols are no longer present. With this change
+OpenSSL's build time configuration may skip the 'no-<prot>-method'
+switch, while still not supporting the deprecated protocols disabled
+through the 'no-<prot>' switch.
+
+For deprecated DTLS protocol versions behind the scenes we're calling
+into 'DTLS_(client_|server_)?method()' set of methods, which
+automatically negotiate the highest supported protocol.
+
+For SSLv3 methods we're returning a NULL pointer as there are no
+more supported methods for the SSL protocol.
+---
+ ssl/methods.c | 18 +++++++++++++++---
+ 1 file changed, 15 insertions(+), 3 deletions(-)
+
+diff --git a/ssl/methods.c b/ssl/methods.c
+index c846143277..a7ae074bfd 100644
+--- a/ssl/methods.c
++++ b/ssl/methods.c
+@@ -215,17 +215,29 @@ const SSL_METHOD *TLSv1_client_method(void)
+ # ifndef OPENSSL_NO_SSL3_METHOD
+ const SSL_METHOD *SSLv3_method(void)
+ {
++#  ifdef OPENSSL_NO_SSL3
++    return NULL;
++#  else
+     return sslv3_method();
++#  endif
+ }
+ 
+ const SSL_METHOD *SSLv3_server_method(void)
+ {
++#  ifdef OPENSSL_NO_SSL3
++    return NULL;
++#  else
+     return sslv3_server_method();
++#  endif
+ }
+ 
+ const SSL_METHOD *SSLv3_client_method(void)
+ {
++#  ifdef OPENSSL_NO_SSL3
++    return NULL;
++#  else
+     return sslv3_client_method();
++#  endif
+ }
+ # endif
+ 
+@@ -249,17 +261,17 @@ const SSL_METHOD *DTLSv1_2_client_method(void)
+ # ifndef OPENSSL_NO_DTLS1_METHOD
+ const SSL_METHOD *DTLSv1_method(void)
+ {
+-    return dtlsv1_method();
++    return DTLS_method();
+ }
+ 
+ const SSL_METHOD *DTLSv1_server_method(void)
+ {
+-    return dtlsv1_server_method();
++    return DTLS_server_method();
+ }
+ 
+ const SSL_METHOD *DTLSv1_client_method(void)
+ {
+-    return dtlsv1_client_method();
++    return DTLS_client_method();
+ }
+ # endif
+ 
+-- 
+2.25.1
+

--- a/SPECS/openssl/openssl.spec
+++ b/SPECS/openssl/openssl.spec
@@ -56,7 +56,9 @@ Patch49:  0049-Allow-disabling-of-SHA1-signatures.patch
 Patch52:  0052-Allow-SHA1-in-seclevel-1-if-rh-allow-sha1-signatures.patch
 # # https://github.com/openssl/openssl/pull/13817
 Patch79:  0079-RSA-PKCS15-implicit-rejection.patch
-
+# See notes in the patch for details, but this patch will not be needed if
+# the openssl issue https://github.com/openssl/openssl/issues/7048 is ever implemented and released.
+Patch80:  0001-Replacing-deprecated-functions-with-NULL-or-highest.patch
 
 License: Apache-2.0
 URL: http://www.openssl.org/


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Apply a patch we had in `main` (for `openssl1.1.1k`) that returns `NULL` or a default when getting some methods that are turned off by default. There's a discussion of why this is necessary/desirable on the [openssl github](https://github.com/openssl/openssl/issues/7048).

###### Change Log  <!-- REQUIRED -->
- Copy patch file from `main` and update `openssl.spec`.

###### Does this affect the toolchain?  <!-- REQUIRED -->
**YES**

###### Test Methodology
- Builds locally
