### PR TITLE
Set SELinux as default LSM

### DIFF
--- a/SPECS/kernel/config
+++ b/SPECS/kernel/config
@@ -7324,10 +7324,10 @@ CONFIG_IMA_QUEUE_EARLY_BOOT_KEYS=y
 # CONFIG_IMA_SECURE_AND_OR_TRUSTED_BOOT is not set
 # CONFIG_IMA_DISABLE_HTABLE is not set
 # CONFIG_EVM is not set
-# CONFIG_DEFAULT_SECURITY_SELINUX is not set
-CONFIG_DEFAULT_SECURITY_APPARMOR=y
+CONFIG_DEFAULT_SECURITY_SELINUX=y
+# CONFIG_DEFAULT_SECURITY_APPARMOR is not set
 # CONFIG_DEFAULT_SECURITY_DAC is not set
-CONFIG_LSM="landlock,lockdown,yama,loadpin,safesetid,integrity,apparmor,selinux,tomoyo"
+CONFIG_LSM="landlock,lockdown,yama,loadpin,safesetid,integrity,selinux,apparmor,tomoyo"
 
 #
 # Kernel hardening options

--- a/SPECS/kernel/config_aarch64
+++ b/SPECS/kernel/config_aarch64
@@ -10394,10 +10394,10 @@ CONFIG_IMA_QUEUE_EARLY_BOOT_KEYS=y
 # CONFIG_IMA_SECURE_AND_OR_TRUSTED_BOOT is not set
 # CONFIG_IMA_DISABLE_HTABLE is not set
 # CONFIG_EVM is not set
-# CONFIG_DEFAULT_SECURITY_SELINUX is not set
-CONFIG_DEFAULT_SECURITY_APPARMOR=y
+CONFIG_DEFAULT_SECURITY_SELINUX=y
+# CONFIG_DEFAULT_SECURITY_APPARMOR is not set
 # CONFIG_DEFAULT_SECURITY_DAC is not set
-CONFIG_LSM="landlock,lockdown,yama,loadpin,safesetid,integrity,apparmor,selinux,tomoyo"
+CONFIG_LSM="landlock,lockdown,yama,loadpin,safesetid,integrity,selinux,apparmor,tomoyo"
 
 #
 # Kernel hardening options

--- a/SPECS/kernel/kernel.signatures.json
+++ b/SPECS/kernel/kernel.signatures.json
@@ -1,8 +1,8 @@
 {
   "Signatures": {
     "cbl-mariner-ca-20211013.pem": "5ef124b0924cb1047c111a0ecff1ae11e6ad7cac8d1d9b40f98f99334121f0b0",
-    "config": "806c91b1cfe8fdac5e22372e5310637ce9d0fa48cba504dea27021404b8794e1",
-    "config_aarch64": "504cb9a913d9db1209651984dc1ddd18ca67f10a25f61997772a6f034dd3f2c6",
+    "config": "efaa0a5679bee2694fdc2a6240df4891f70114317b43e9558c625a92796c574f",
+    "config_aarch64": "fdbc2d4b4a57c888beb855d47983017c1b56b6c1592a8a3ac30e56ea91b60b4c",
     "cpupower": "d7518767bf2b1110d146a49c7d42e76b803f45eb8bd14d931aa6d0d346fae985",
     "cpupower.service": "b057fe9e5d0e8c36f485818286b80e3eba8ff66ff44797940e99b1fd5361bb98",
     "sha512hmac-openssl.sh": "02ab91329c4be09ee66d759e4d23ac875037c3b56e5a598e32fd1206da06a27f",

--- a/SPECS/kernel/kernel.spec
+++ b/SPECS/kernel/kernel.spec
@@ -435,6 +435,7 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 - Enable CONFIG_BPF_LSM (Thien Trung Vuong <tvuong@microsoft.com>)
 - Enable CUSE module (Juan Camposeco <juanarturoc@microsoft.com>)
 - Add IOMMU configs for aarch64 (David Daney <daviddaney@microsoft.com>)
+- Set selinux as default LSM
 
 * Wed Dec 13 2023 Rachel Menge <rachelmenge@microsoft.com> - 6.6.2.1-1
 - Upgrade to 6.6.2.1

--- a/toolkit/scripts/mariner-required-configs.json
+++ b/toolkit/scripts/mariner-required-configs.json
@@ -1362,6 +1362,19 @@
                 "PR": [
                     "https://github.com/microsoft/CBL-Mariner/pull/6829"
                 ]
+            },
+            "CONFIG_DEFAULT_SECURITY_SELINUX": {
+                "value": [
+                    "y"
+                ],
+                "arch": [
+                    "AMD64",
+                    "ARM64"
+                ],
+                "comment": "Set SELinux as default LSM",
+                "PR": [
+                    "https://github.com/microsoft/CBL-Mariner/pull/"
+                ]
             }
         }
     }


### PR DESCRIPTION
.

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Change the default Linux Security module to be SELinux. Previously, it was Apparmor. Note that both modules are still available

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Set SELinux as default LSM

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://microsoft.visualstudio.com/OS/_workitems/edit/47059310

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- [Prep](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=486483&view=results)
- [AMD Rpms](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=486589&view=results)
- [AMD image](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=486850&view=results)
- [ARM Rpms](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=486636&view=logs&j=75cba72d-09cb-503a-3927-4ab61ac4a179&t=88a626d5-bd2d-5bcb-0f14-68ce5ab12667&l=8950)
- local build and test in vm
```
$ dmesg | grep SELinux
# shows SELinux Initializing
 
$ cat /sys/system/kernel/security/lsm # doesn't show apparmor
 
$ tdnf install selinux-policy
$ sestatus
# sestatus "works"
 
$ ls /sys/module/apparmor
# shows apparmor stuff
```
![image](https://github.com/microsoft/CBL-Mariner/assets/10325590/44b00b0a-fdd4-439c-be9f-94209c87a9da)
![image](https://github.com/microsoft/CBL-Mariner/assets/10325590/b3bd574f-6722-41ee-b34e-1276c6f5aa8d)

Also confirmed using the specific selinux image from the amd pipelines that removing security=selinux did not impact the behavior
![image](https://github.com/microsoft/CBL-Mariner/assets/10325590/87c8a666-89fc-4437-bd61-1f87acd8bf97)


