### PR TITLE
Cherry-pick image customizer changes from main branch to 3.0-dev

### DIFF
--- a/toolkit/imageconfigs/baremetal.json
+++ b/toolkit/imageconfigs/baremetal.json
@@ -2,7 +2,7 @@
     "Disks": [
         {
             "PartitionTableType": "gpt",
-            "MaxSize": 4096,
+            "MaxSize": 1024,
             "Artifacts": [
                 {
                     "Name": "core",

--- a/toolkit/imageconfigs/qemu-guest.json
+++ b/toolkit/imageconfigs/qemu-guest.json
@@ -2,7 +2,7 @@
     "Disks": [
         {
             "PartitionTableType": "gpt",
-            "MaxSize": 4096,
+            "MaxSize": 1024,
             "Artifacts": [
                 {
                     "Name": "core",

--- a/toolkit/tools/imagecustomizer/docs/cli.md
+++ b/toolkit/tools/imagecustomizer/docs/cli.md
@@ -29,11 +29,11 @@ The file path to write the final customized image to.
 
 ## --output-image-format=FORMAT
 
-Required.
-
 The image format of the the final customized image.
 
 Options: vhd, vhdx, qcow2, and raw.
+
+At least one of --output-image-format and --output-split-partitions-format is required.
 
 ## --output-split-partitions-format=FORMAT
 

--- a/toolkit/tools/imagecustomizer/docs/cli.md
+++ b/toolkit/tools/imagecustomizer/docs/cli.md
@@ -35,6 +35,12 @@ The image format of the the final customized image.
 
 Options: vhd, vhdx, qcow2, and raw.
 
+## --output-split-partitions-format=FORMAT
+
+Format of partition files. If specified, disk partitions will be extracted as separate files.
+
+Options: raw, raw-zstd.
+
 ## --config-file=FILE-PATH
 
 Required.

--- a/toolkit/tools/imagecustomizer/docs/configuration.md
+++ b/toolkit/tools/imagecustomizer/docs/configuration.md
@@ -268,7 +268,7 @@ Packages:
 Required.
 
 The ID of the partition.
-This is used correlate Partition objects with [PartitionSetting](#partitionsetting-type)
+This is used to correlate Partition objects with [PartitionSetting](#partitionsetting-type)
 objects.
 
 ### FsType [string]

--- a/toolkit/tools/imagecustomizer/docs/configuration.md
+++ b/toolkit/tools/imagecustomizer/docs/configuration.md
@@ -179,6 +179,21 @@ SystemConfig:
       Permissions: "664"
 ```
 
+## KernelCommandLine type
+
+Options for configuring the kernel.
+
+### ExtraCommandLine
+
+Additional Linux kernel command line options to add to the image.
+
+If the partitions are customized, then the `grub.cfg` file will be reset to handle the
+new partition layout.
+So, any existing ExtraCommandLine value in the base image will be replaced.
+
+If the partitions are not customized, then the `ExtraCommandLine` value will be appended
+to the existing `grub.cfg` file.
+
 ## Module type
 
 Options for configuring a kernel module.
@@ -460,6 +475,11 @@ Example:
 SystemConfig:
   Hostname: example-image
 ```
+
+### KernelCommandLine [[KernelCommandLine](#kernelcommandline-type)]
+
+Specifies extra kernel command line options, as well as other configuration values
+relating to the kernel.
 
 ### UpdateBaseImagePackages [bool]
 

--- a/toolkit/tools/imagecustomizer/docs/configuration.md
+++ b/toolkit/tools/imagecustomizer/docs/configuration.md
@@ -35,6 +35,8 @@ The Mariner Image Customizer is configured using a YAML (or JSON) file.
 
 10. Delete `/etc/resolv.conf` file.
 
+11. Enable dm-verity root protection.
+
 ### /etc/resolv.conf
 
 The `/etc/resolv.conf` file is overridden so that the package installation and
@@ -141,6 +143,36 @@ The size of the disk, specified in mebibytes (MiB).
 ### Partitions [[Partition](#partition-type)]
 
 The partitions to provision on the disk.
+
+## Verity type
+
+Specifies the configuration for dm-verity root integrity verification.
+
+- DataPartition: A partition configured with dm-verity, which verifies integrity
+  at each system boot.
+
+  - IdType: Specifies the type of id for the partition. The options are
+    `PartLabel` (partition label), `Uuid` (filesystem UUID), and `PartUuid`
+    (partition UUID).
+
+  - Id: The unique identifier value of the partition, corresponding to the
+    specified IdType.
+
+- HashPartition: A partition used exclusively for storing a calculated hash
+  tree.
+
+Example:
+
+```yaml
+SystemConfig:
+  Verity:
+    DataPartition:
+      IdType: PartUuid
+      Id: 00000000-0000-0000-0000-000000000000
+    HashPartition:
+      IdType: PartLabel
+      Id: hash_partition
+```
 
 ## FileConfig type
 

--- a/toolkit/tools/imagecustomizer/main.go
+++ b/toolkit/tools/imagecustomizer/main.go
@@ -21,7 +21,7 @@ var (
 	buildDir                    = app.Flag("build-dir", "Directory to run build out of.").Required().String()
 	imageFile                   = app.Flag("image-file", "Path of the base CBL-Mariner image which the customization will be applied to.").Required().String()
 	outputImageFile             = app.Flag("output-image-file", "Path to write the customized image to.").Required().String()
-	outputImageFormat           = app.Flag("output-image-format", "Format of output image. Supported: vhd, vhdx, qcow2, raw.").Required().Enum("vhd", "vhdx", "qcow2", "raw")
+	outputImageFormat           = app.Flag("output-image-format", "Format of output image. Supported: vhd, vhdx, qcow2, raw.").Enum("vhd", "vhdx", "qcow2", "raw")
 	outputSplitPartitionsFormat = app.Flag("output-split-partitions-format", "Format of partition files. Supported: raw, raw-zstd").Enum("raw", "raw-zstd")
 	configFile                  = app.Flag("config-file", "Path of the image customization config file.").Required().String()
 	rpmSources                  = app.Flag("rpm-source", "Path to a RPM repo config file or a directory containing RPMs.").Strings()
@@ -37,6 +37,9 @@ func main() {
 
 	app.Version(imagecustomizerlib.ToolVersion)
 	kingpin.MustParse(app.Parse(os.Args[1:]))
+	if *outputSplitPartitionsFormat == "" && *outputImageFormat == "" {
+		kingpin.Fatalf("Either --output-image-format or --output-split-partitions-format must be specified.")
+	}
 
 	logger.InitBestEffort(*logFile, *logLevel)
 

--- a/toolkit/tools/imagecustomizer/main.go
+++ b/toolkit/tools/imagecustomizer/main.go
@@ -18,17 +18,18 @@ import (
 var (
 	app = kingpin.New("imagecustomizer", "Customizes a pre-built CBL-Mariner image")
 
-	buildDir                 = app.Flag("build-dir", "Directory to run build out of.").Required().String()
-	imageFile                = app.Flag("image-file", "Path of the base CBL-Mariner image which the customization will be applied to.").Required().String()
-	outputImageFile          = app.Flag("output-image-file", "Path to write the customized image to.").Required().String()
-	outputImageFormat        = app.Flag("output-image-format", "Format of output image. Supported: vhd, vhdx, qcow2, raw.").Required().Enum("vhd", "vhdx", "qcow2", "raw")
-	configFile               = app.Flag("config-file", "Path of the image customization config file.").Required().String()
-	rpmSources               = app.Flag("rpm-source", "Path to a RPM repo config file or a directory containing RPMs.").Strings()
-	disableBaseImageRpmRepos = app.Flag("disable-base-image-rpm-repos", "Disable the base image's RPM repos as an RPM source").Bool()
-	logFile                  = exe.LogFileFlag(app)
-	logLevel                 = exe.LogLevelFlag(app)
-	profFlags                = exe.SetupProfileFlags(app)
-	timestampFile            = app.Flag("timestamp-file", "File that stores timestamps for this program.").String()
+	buildDir                    = app.Flag("build-dir", "Directory to run build out of.").Required().String()
+	imageFile                   = app.Flag("image-file", "Path of the base CBL-Mariner image which the customization will be applied to.").Required().String()
+	outputImageFile             = app.Flag("output-image-file", "Path to write the customized image to.").Required().String()
+	outputImageFormat           = app.Flag("output-image-format", "Format of output image. Supported: vhd, vhdx, qcow2, raw.").Required().Enum("vhd", "vhdx", "qcow2", "raw")
+	outputSplitPartitionsFormat = app.Flag("output-split-partitions-format", "Format of partition files. Supported: raw, raw-zstd").Enum("raw", "raw-zstd")
+	configFile                  = app.Flag("config-file", "Path of the image customization config file.").Required().String()
+	rpmSources                  = app.Flag("rpm-source", "Path to a RPM repo config file or a directory containing RPMs.").Strings()
+	disableBaseImageRpmRepos    = app.Flag("disable-base-image-rpm-repos", "Disable the base image's RPM repos as an RPM source").Bool()
+	logFile                     = exe.LogFileFlag(app)
+	logLevel                    = exe.LogLevelFlag(app)
+	profFlags                   = exe.SetupProfileFlags(app)
+	timestampFile               = app.Flag("timestamp-file", "File that stores timestamps for this program.").String()
 )
 
 func main() {
@@ -58,7 +59,7 @@ func customizeImage() error {
 	var err error
 
 	err = imagecustomizerlib.CustomizeImageWithConfigFile(*buildDir, *configFile, *imageFile,
-		*rpmSources, *outputImageFile, *outputImageFormat, !*disableBaseImageRpmRepos)
+		*rpmSources, *outputImageFile, *outputImageFormat, *outputSplitPartitionsFormat, !*disableBaseImageRpmRepos)
 	if err != nil {
 		return err
 	}

--- a/toolkit/tools/imagecustomizerapi/config.go
+++ b/toolkit/tools/imagecustomizerapi/config.go
@@ -39,9 +39,14 @@ func (c *Config) IsValid() error {
 
 	hasDisks := c.Disks != nil
 	hasBootType := c.SystemConfig.BootType != BootTypeUnset
+	hasPartitionSettings := len(c.SystemConfig.PartitionSettings) > 0
 
 	if hasDisks != hasBootType {
 		return fmt.Errorf("SystemConfig.BootType and Disks must be specified together")
+	}
+
+	if hasPartitionSettings && !hasDisks {
+		return fmt.Errorf("the Disks and SystemConfig.BootType values must also be specified if SystemConfig.PartitionSettings is specified")
 	}
 
 	// Ensure the correct partitions exist to support the specified the boot type.

--- a/toolkit/tools/imagecustomizerapi/idtype.go
+++ b/toolkit/tools/imagecustomizerapi/idtype.go
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package imagecustomizerapi
+
+import (
+	"fmt"
+)
+
+type IdType string
+
+const (
+	IdTypePartLabel IdType = "PartLabel"
+	IdTypeUuid      IdType = "Uuid"
+	IdTypePartUuid  IdType = "PartUuid"
+)
+
+func (i IdType) IsValid() error {
+	switch i {
+	case IdTypePartLabel, IdTypeUuid, IdTypePartUuid:
+		// All good.
+		return nil
+
+	default:
+		return fmt.Errorf("invalid IdType value (%v)", i)
+	}
+}

--- a/toolkit/tools/imagecustomizerapi/idtype_test.go
+++ b/toolkit/tools/imagecustomizerapi/idtype_test.go
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package imagecustomizerapi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIdTypeIsValid(t *testing.T) {
+	err := IdTypePartLabel.IsValid()
+	assert.NoError(t, err)
+}
+
+func TestIdTypeIsValidBadValue(t *testing.T) {
+	err := IdType("bad").IsValid()
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "invalid IdType value")
+}

--- a/toolkit/tools/imagecustomizerapi/kernelcommandline.go
+++ b/toolkit/tools/imagecustomizerapi/kernelcommandline.go
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package imagecustomizerapi
+
+import (
+	"fmt"
+	"strings"
+)
+
+type KernelCommandLine struct {
+	// Extra kernel command line args.
+	ExtraCommandLine string `yaml:"ExtraCommandLine"`
+}
+
+func (s *KernelCommandLine) IsValid() error {
+	err := commandLineIsValid(s.ExtraCommandLine, "ExtraCommandLine")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func commandLineIsValid(commandLine string, fieldName string) error {
+	// Disallow special characters to avoid breaking the grub.cfg file.
+	// In addition, disallow the "`" character, since it is used as the sed escape character by
+	// `installutils.setGrubCfgAdditionalCmdLine()`.
+	if strings.ContainsAny(commandLine, "\n'\"\\$`") {
+		return fmt.Errorf("the %s value contains invalid characters", fieldName)
+	}
+
+	return nil
+}

--- a/toolkit/tools/imagecustomizerapi/systemconfig.go
+++ b/toolkit/tools/imagecustomizerapi/systemconfig.go
@@ -29,6 +29,7 @@ type SystemConfig struct {
 	Users                   []User                    `yaml:"Users"`
 	Services                Services                  `yaml:"Services"`
 	Modules                 Modules                   `yaml:"Modules"`
+	Verity                  *Verity                   `yaml:"Verity"`
 }
 
 func (s *SystemConfig) IsValid() error {
@@ -98,6 +99,13 @@ func (s *SystemConfig) IsValid() error {
 
 	if err := s.Modules.IsValid(); err != nil {
 		return err
+	}
+
+	if s.Verity != nil {
+		err = s.Verity.IsValid()
+		if err != nil {
+			return fmt.Errorf("invalid Verity: %w", err)
+		}
 	}
 
 	return nil

--- a/toolkit/tools/imagecustomizerapi/systemconfig.go
+++ b/toolkit/tools/imagecustomizerapi/systemconfig.go
@@ -21,6 +21,7 @@ type SystemConfig struct {
 	PackagesRemove          []string                  `yaml:"PackagesRemove"`
 	PackageListsUpdate      []string                  `yaml:"PackageListsUpdate"`
 	PackagesUpdate          []string                  `yaml:"PackagesUpdate"`
+	KernelCommandLine       KernelCommandLine         `yaml:"KernelCommandLine"`
 	AdditionalFiles         map[string]FileConfigList `yaml:"AdditionalFiles"`
 	PartitionSettings       []PartitionSetting        `yaml:"PartitionSettings"`
 	PostInstallScripts      []Script                  `yaml:"PostInstallScripts"`
@@ -42,6 +43,11 @@ func (s *SystemConfig) IsValid() error {
 		if !govalidator.IsDNSName(s.Hostname) || strings.Contains(s.Hostname, "_") {
 			return fmt.Errorf("invalid hostname: %s", s.Hostname)
 		}
+	}
+
+	err = s.KernelCommandLine.IsValid()
+	if err != nil {
+		return fmt.Errorf("invalid KernelCommandLine: %w", err)
 	}
 
 	for sourcePath, fileConfigList := range s.AdditionalFiles {

--- a/toolkit/tools/imagecustomizerapi/systemconfig_test.go
+++ b/toolkit/tools/imagecustomizerapi/systemconfig_test.go
@@ -41,3 +41,15 @@ func TestSystemConfigIsValidDuplicatePartitionID(t *testing.T) {
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "duplicate PartitionSettings ID")
 }
+
+func TestSystemConfigIsValidKernelCommandLineInvalidChars(t *testing.T) {
+	value := SystemConfig{
+		KernelCommandLine: KernelCommandLine{
+			ExtraCommandLine: "example=\"example\"",
+		},
+	}
+
+	err := value.IsValid()
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "ExtraCommandLine")
+}

--- a/toolkit/tools/imagecustomizerapi/user.go
+++ b/toolkit/tools/imagecustomizerapi/user.go
@@ -17,6 +17,7 @@ type User struct {
 	PasswordPath        string   `yaml:"PasswordPath"`
 	PasswordExpiresDays *int64   `yaml:"PasswordExpiresDays"`
 	SSHPubKeyPaths      []string `yaml:"SSHPubKeyPaths"`
+	SSHPubKeys          []string `yaml:"SSHPubKeys"`
 	PrimaryGroup        string   `yaml:"PrimaryGroup"`
 	SecondaryGroups     []string `yaml:"SecondaryGroups"`
 	StartupCommand      string   `yaml:"StartupCommand"`

--- a/toolkit/tools/imagecustomizerapi/verity.go
+++ b/toolkit/tools/imagecustomizerapi/verity.go
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package imagecustomizerapi
+
+import (
+	"fmt"
+)
+
+type Verity struct {
+	DataPartition VerityPartition `yaml:"DataPartition"`
+	HashPartition VerityPartition `yaml:"HashPartition"`
+}
+
+func (v *Verity) IsValid() error {
+	if err := v.DataPartition.IdType.IsValid(); err != nil {
+		return fmt.Errorf("invalid DataPartition: %v", err)
+	}
+
+	if err := v.HashPartition.IdType.IsValid(); err != nil {
+		return fmt.Errorf("invalid HashPartition: %v", err)
+	}
+
+	return nil
+}

--- a/toolkit/tools/imagecustomizerapi/verity_partition.go
+++ b/toolkit/tools/imagecustomizerapi/verity_partition.go
@@ -1,0 +1,43 @@
+// verity_partition.go
+
+package imagecustomizerapi
+
+import (
+	"fmt"
+	"regexp"
+)
+
+type VerityPartition struct {
+	IdType IdType `yaml:"IdType"`
+	Id     string `yaml:"Id"`
+}
+
+var uuidRegex = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[4][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$`)
+
+func (v *VerityPartition) IsValid() error {
+	// Check if IdType is valid
+	if err := v.IdType.IsValid(); err != nil {
+		return fmt.Errorf("invalid IdType: %v", err)
+	}
+
+	// Check if Id is not empty
+	if v.Id == "" {
+		return fmt.Errorf("invalid Id: empty string")
+	}
+
+	// Check Id format based on IdType
+	switch v.IdType {
+	case IdTypePartLabel:
+		// Validate using isGPTNameValid function for IdTypePartLabel
+		if err := isGPTNameValid(v.Id); err != nil {
+			return fmt.Errorf("invalid Id for IdTypePartLabel: %v", err)
+		}
+	case IdTypeUuid, IdTypePartUuid:
+		// UUID validation (standard format)
+		if !uuidRegex.MatchString(v.Id) {
+			return fmt.Errorf("invalid Id format for %s: %s", v.IdType, v.Id)
+		}
+	}
+
+	return nil
+}

--- a/toolkit/tools/imagegen/configuration/user.go
+++ b/toolkit/tools/imagegen/configuration/user.go
@@ -21,6 +21,7 @@ type User struct {
 	Password            string   `json:"Password"`
 	PasswordExpiresDays int64    `json:"PasswordExpiresDays"`
 	SSHPubKeyPaths      []string `json:"SSHPubKeyPaths"`
+	SSHPubKeys          []string `json:"SSHPubKeys"`
 	PrimaryGroup        string   `json:"PrimaryGroup"`
 	SecondaryGroups     []string `json:"SecondaryGroups"`
 	StartupCommand      string   `json:"StartupCommand"`

--- a/toolkit/tools/imagegen/diskutils/diskutils.go
+++ b/toolkit/tools/imagegen/diskutils/diskutils.go
@@ -53,6 +53,7 @@ type PartitionInfo struct {
 	PartUuid          string `json:"partuuid"`   // Example: 7b1367a6-5845-43f2-99b1-a742d873f590
 	Mountpoint        string `json:"mountpoint"` // Example: /mnt/os/boot
 	PartLabel         string `json:"partlabel"`  // Example: boot
+	Type              string `json:"type"`       // Example: part
 }
 
 type loopbackListOutput struct {
@@ -769,7 +770,7 @@ func GetDiskPartitions(diskDevPath string) ([]PartitionInfo, error) {
 	}
 
 	// Read the disk's partitions.
-	jsonString, _, err := shell.Execute("lsblk", diskDevPath, "--output", "NAME,PATH,PARTTYPE,FSTYPE,UUID,MOUNTPOINT,PARTUUID,PARTLABEL", "--json", "--list")
+	jsonString, _, err := shell.Execute("lsblk", diskDevPath, "--output", "NAME,PATH,PARTTYPE,FSTYPE,UUID,MOUNTPOINT,PARTUUID,PARTLABEL,TYPE", "--json", "--list")
 	if err != nil {
 		return nil, fmt.Errorf("failed to list disk (%s) partitions:\n%w", diskDevPath, err)
 	}

--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -1262,7 +1262,7 @@ func addUsers(installChroot *safechroot.Chroot, users []configuration.User) (err
 			return
 		}
 
-		err = ProvisionUserSSHCerts(installChroot, user.Name, user.SSHPubKeyPaths)
+		err = ProvisionUserSSHCerts(installChroot, user.Name, user.SSHPubKeyPaths, user.SSHPubKeys)
 		if err != nil {
 			return
 		}
@@ -1497,7 +1497,7 @@ func ConfigureUserStartupCommand(installChroot safechroot.ChrootInterface, usern
 	return
 }
 
-func ProvisionUserSSHCerts(installChroot safechroot.ChrootInterface, username string, sshPubKeyPaths []string) (err error) {
+func ProvisionUserSSHCerts(installChroot safechroot.ChrootInterface, username string, sshPubKeyPaths []string, sshPubKeys []string) (err error) {
 	var (
 		pubKeyData []string
 		exists     bool
@@ -1538,8 +1538,10 @@ func ProvisionUserSSHCerts(installChroot safechroot.ChrootInterface, username st
 	}
 	defer os.Remove(authorizedKeysTempFile)
 
+	allSSHKeys := make([]string, 0, len(sshPubKeyPaths)+len(sshPubKeys))
+
+	// Add SSH keys from sshPubKeyPaths
 	for _, pubKey := range sshPubKeyPaths {
-		logger.Log.Infof("Adding ssh key (%s) to user (%s)", filepath.Base(pubKey), username)
 		relativeDst := filepath.Join(userSSHKeyDir, filepath.Base(pubKey))
 
 		fileToCopy := safechroot.FileToCopy{
@@ -1552,21 +1554,26 @@ func ProvisionUserSSHCerts(installChroot safechroot.ChrootInterface, username st
 			return
 		}
 
-		logger.Log.Infof("Adding ssh key (%s) to user (%s) .ssh/authorized_users", filepath.Base(pubKey), username)
 		pubKeyData, err = file.ReadLines(pubKey)
 		if err != nil {
 			logger.Log.Warnf("Failed to read from SSHPubKey : %v", err)
 			return
 		}
 
-		// Append to the tmp/authorized_users file
-		for _, sshkey := range pubKeyData {
-			sshkey += "\n"
-			err = file.Append(sshkey, authorizedKeysTempFile)
-			if err != nil {
-				logger.Log.Warnf("Failed to append to %s : %v", authorizedKeysTempFile, err)
-				return
-			}
+		allSSHKeys = append(allSSHKeys, pubKeyData...)
+	}
+
+	// Add direct SSH keys
+	allSSHKeys = append(allSSHKeys, sshPubKeys...)
+
+	for _, pubKey := range allSSHKeys {
+		logger.Log.Infof("Adding ssh key (%s) to user (%s) .ssh/authorized_users", filepath.Base(pubKey), username)
+		pubKey += "\n"
+
+		err = file.Append(pubKey, authorizedKeysTempFile)
+		if err != nil {
+			logger.Log.Warnf("Failed to append to %s : %v", authorizedKeysTempFile, err)
+			return
 		}
 	}
 

--- a/toolkit/tools/imagegen/installutils/installutils_test.go
+++ b/toolkit/tools/imagegen/installutils/installutils_test.go
@@ -71,7 +71,7 @@ func TestCopyAdditionalFiles(t *testing.T) {
 	proposedDir := filepath.Join(tmpDir, "TestCopyAdditionalFiles")
 	chroot := safechroot.NewChroot(proposedDir, false)
 
-	err := chroot.Initialize("", []string{}, []*safechroot.MountPoint{})
+	err := chroot.Initialize("", []string{}, []*safechroot.MountPoint{}, true)
 	assert.NoError(t, err)
 
 	defer chroot.Close(false)

--- a/toolkit/tools/imager/imager.go
+++ b/toolkit/tools/imager/imager.go
@@ -417,7 +417,7 @@ func setupLoopDeviceDisk(outputDir, diskName string, diskConfig configuration.Di
 
 func setupRealDisk(diskDevPath string, diskConfig configuration.Disk, rootEncryption configuration.RootEncryption, readOnlyRootConfig configuration.ReadOnlyVerityRoot) (partIDToDevPathMap, partIDToFsTypeMap map[string]string, encryptedRoot diskutils.EncryptedRootDevice, readOnlyRoot diskutils.VerityDevice, err error) {
 	// Set up partitions
-	partIDToDevPathMap, partIDToFsTypeMap, encryptedRoot, readOnlyRoot, err = diskutils.CreatePartitions(diskDevPath, diskConfig, rootEncryption, readOnlyRootConfig, nil)
+	partIDToDevPathMap, partIDToFsTypeMap, encryptedRoot, readOnlyRoot, err = diskutils.CreatePartitions(diskDevPath, diskConfig, rootEncryption, readOnlyRootConfig)
 	if err != nil {
 		logger.Log.Errorf("Failed to create partitions on disk (%s)", diskDevPath)
 		return

--- a/toolkit/tools/imager/imager.go
+++ b/toolkit/tools/imager/imager.go
@@ -244,7 +244,7 @@ func buildSystemConfig(systemConfig configuration.SystemConfig, disks []configur
 		extraMountPoints = append(extraMountPoints, additionalExtraMountPoints...)
 
 		setupChroot := safechroot.NewChroot(setupChrootDir, existingChrootDir)
-		err = setupChroot.Initialize(*tdnfTar, extraDirectories, extraMountPoints)
+		err = setupChroot.Initialize(*tdnfTar, extraDirectories, extraMountPoints, true)
 		if err != nil {
 			logger.Log.Error("Failed to create setup chroot")
 			return
@@ -559,7 +559,7 @@ func buildImage(mountPointMap, mountPointToFsTypeMap, mountPointToMountArgsMap, 
 	installChroot := safechroot.NewChroot(installRoot, existingChrootDir)
 	extraInstallMountPoints := []*safechroot.MountPoint{}
 	extraDirectories := []string{}
-	err = installChroot.Initialize(emptyWorkerTar, extraDirectories, extraInstallMountPoints)
+	err = installChroot.Initialize(emptyWorkerTar, extraDirectories, extraInstallMountPoints, true)
 	if err != nil {
 		err = fmt.Errorf("failed to create install chroot: %s", err)
 		return

--- a/toolkit/tools/imager/imager.go
+++ b/toolkit/tools/imager/imager.go
@@ -416,13 +416,8 @@ func setupLoopDeviceDisk(outputDir, diskName string, diskConfig configuration.Di
 }
 
 func setupRealDisk(diskDevPath string, diskConfig configuration.Disk, rootEncryption configuration.RootEncryption, readOnlyRootConfig configuration.ReadOnlyVerityRoot) (partIDToDevPathMap, partIDToFsTypeMap map[string]string, encryptedRoot diskutils.EncryptedRootDevice, readOnlyRoot diskutils.VerityDevice, err error) {
-	const (
-		defaultBlockSize = diskutils.MiB
-		noMaxSize        = 0
-	)
-
 	// Set up partitions
-	partIDToDevPathMap, partIDToFsTypeMap, encryptedRoot, readOnlyRoot, err = diskutils.CreatePartitions(diskDevPath, diskConfig, rootEncryption, readOnlyRootConfig)
+	partIDToDevPathMap, partIDToFsTypeMap, encryptedRoot, readOnlyRoot, err = diskutils.CreatePartitions(diskDevPath, diskConfig, rootEncryption, readOnlyRootConfig, nil)
 	if err != nil {
 		logger.Log.Errorf("Failed to create partitions on disk (%s)", diskDevPath)
 		return

--- a/toolkit/tools/internal/packagerepo/repocloner/rpmrepocloner/rpmrepocloner.go
+++ b/toolkit/tools/internal/packagerepo/repocloner/rpmrepocloner/rpmrepocloner.go
@@ -165,7 +165,7 @@ func (r *RpmRepoCloner) initialize(destinationDir, tmpDir, workerTar, existingRp
 
 	// Also request that /overlaywork is created before any chroot mounts happen so the overlay can
 	// be created successfully
-	err = r.chroot.Initialize(workerTar, overlayExtraDirs, extraMountPoints)
+	err = r.chroot.Initialize(workerTar, overlayExtraDirs, extraMountPoints, true)
 	if err != nil {
 		r.chroot = nil
 		return

--- a/toolkit/tools/internal/packagerepo/repoutils/repoquery.go
+++ b/toolkit/tools/internal/packagerepo/repoutils/repoquery.go
@@ -112,7 +112,7 @@ func createChroot(workerTar, chrootDir string, leaveChrootOnDisk bool) (queryChr
 	logger.Log.Info("Creating chroot for repoquery")
 
 	queryChroot = safechroot.NewChroot(chrootDir, false)
-	err = queryChroot.Initialize(workerTar, nil, nil)
+	err = queryChroot.Initialize(workerTar, nil, nil, true)
 	if err != nil {
 		err = fmt.Errorf("failed to initialize chroot:\n%w", err)
 		return

--- a/toolkit/tools/internal/safechroot/safechroot.go
+++ b/toolkit/tools/internal/safechroot/safechroot.go
@@ -173,7 +173,9 @@ func NewChroot(rootDir string, isExistingDir bool) *Chroot {
 //
 // This call will block until the chroot initializes successfully.
 // Only one Chroot will initialize at a given time.
-func (c *Chroot) Initialize(tarPath string, extraDirectories []string, extraMountPoints []*MountPoint) (err error) {
+func (c *Chroot) Initialize(tarPath string, extraDirectories []string, extraMountPoints []*MountPoint,
+	includeDefaultMounts bool,
+) (err error) {
 	// On failed initialization, cleanup all chroot files
 	const leaveChrootOnDisk = false
 
@@ -256,7 +258,9 @@ func (c *Chroot) Initialize(tarPath string, extraDirectories []string, extraMoun
 			}
 		}
 
-		allMountPoints = append(allMountPoints, defaultMountPoints()...)
+		if includeDefaultMounts {
+			allMountPoints = append(allMountPoints, defaultMountPoints()...)
+		}
 
 		for _, mountPoint := range extraMountPoints {
 			if !mountPoint.mountBeforeDefaults {

--- a/toolkit/tools/internal/safechroot/safechroot_test.go
+++ b/toolkit/tools/internal/safechroot/safechroot_test.go
@@ -56,7 +56,7 @@ func TestInitializeShouldCreateRoot(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "TestInitializeShouldCreateRoot")
 	chroot := NewChroot(dir, isExistingDir)
 
-	err := chroot.Initialize(emptyPath, extraDirectories, extraMountPoints)
+	err := chroot.Initialize(emptyPath, extraDirectories, extraMountPoints, true)
 	assert.NoError(t, err)
 
 	defer chroot.Close(defaultLeaveOnDisk)
@@ -72,7 +72,7 @@ func TestCloseShouldRemoveRoot(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "TestCloseShouldRemoveRoot")
 	chroot := NewChroot(dir, isExistingDir)
 
-	err := chroot.Initialize(emptyPath, extraDirectories, extraMountPoints)
+	err := chroot.Initialize(emptyPath, extraDirectories, extraMountPoints, true)
 	assert.NoError(t, err)
 
 	// save away chroot location and close
@@ -102,7 +102,7 @@ func TestCloseShouldLeaveRootOnRequest(t *testing.T) {
 		dir := filepath.Join(t.TempDir(), "TestCloseShouldLeaveRootOnRequest")
 		chroot := NewChroot(dir, isExistingDir)
 
-		err := chroot.Initialize(emptyPath, extraDirectories, extraMountPoints)
+		err := chroot.Initialize(emptyPath, extraDirectories, extraMountPoints, true)
 		assert.NoError(t, err)
 
 		err = chroot.Close(leaveOnDisk)
@@ -134,7 +134,7 @@ func TestRunShouldReturnCorrectError(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "TestRunShouldReturnCorrectError")
 	chroot := NewChroot(dir, isExistingDir)
 
-	err := chroot.Initialize(emptyPath, extraDirectories, extraMountPoints)
+	err := chroot.Initialize(emptyPath, extraDirectories, extraMountPoints, true)
 	assert.NoError(t, err)
 	defer chroot.Close(defaultLeaveOnDisk)
 
@@ -153,7 +153,7 @@ func TestRunShouldChangeCWD(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "TestRunShouldChangeCWD")
 	chroot := NewChroot(dir, isExistingDir)
 
-	err := chroot.Initialize(emptyPath, extraDirectories, extraMountPoints)
+	err := chroot.Initialize(emptyPath, extraDirectories, extraMountPoints, true)
 	assert.NoError(t, err)
 	defer chroot.Close(defaultLeaveOnDisk)
 
@@ -178,7 +178,7 @@ func TestShouldRestoreCWD(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "TestShouldRestoreCWD")
 	chroot := NewChroot(dir, isExistingDir)
 
-	err := chroot.Initialize(emptyPath, extraDirectories, extraMountPoints)
+	err := chroot.Initialize(emptyPath, extraDirectories, extraMountPoints, true)
 	assert.NoError(t, err)
 	defer chroot.Close(defaultLeaveOnDisk)
 
@@ -205,7 +205,7 @@ func TestInitializeShouldExtractTar(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "TestInitializeShouldExtractTar")
 	chroot := NewChroot(dir, isExistingDir)
 
-	err := chroot.Initialize(tarPath, extraDirectories, extraMountPoints)
+	err := chroot.Initialize(tarPath, extraDirectories, extraMountPoints, true)
 	assert.NoError(t, err)
 	defer chroot.Close(defaultLeaveOnDisk)
 
@@ -228,7 +228,7 @@ func TestInitializeShouldCreateCustomMountPoints(t *testing.T) {
 		dir := filepath.Join(t.TempDir(), "TestInitializeShouldCreateCustomMountPoints")
 		chroot := NewChroot(dir, isExistingDir)
 
-		err := chroot.Initialize(emptyPath, extraDirectories, extraMountPoints)
+		err := chroot.Initialize(emptyPath, extraDirectories, extraMountPoints, true)
 		assert.NoError(t, err)
 		defer chroot.Close(defaultLeaveOnDisk)
 
@@ -251,7 +251,7 @@ func TestInitializeShouldCleanupOnBadMountPoint(t *testing.T) {
 		dir := filepath.Join(t.TempDir(), "TestInitializeShouldCleanupOnBadMountPoint")
 		chroot := NewChroot(dir, isExistingDir)
 
-		err := chroot.Initialize(emptyPath, extraDirectories, extraMountPoints)
+		err := chroot.Initialize(emptyPath, extraDirectories, extraMountPoints, true)
 		assert.Error(t, err)
 
 		_, err = os.Stat(dir)
@@ -268,7 +268,7 @@ func TestInitializeShouldCreateExtraDirectories(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "TestInitializeShouldCreateExtraDirectories")
 	chroot := NewChroot(dir, isExistingDir)
 
-	err := chroot.Initialize(emptyPath, extraDirectories, extraMountPoints)
+	err := chroot.Initialize(emptyPath, extraDirectories, extraMountPoints, true)
 	assert.NoError(t, err)
 	defer chroot.Close(defaultLeaveOnDisk)
 

--- a/toolkit/tools/internal/safemount/safemount_test.go
+++ b/toolkit/tools/internal/safemount/safemount_test.go
@@ -67,7 +67,7 @@ func TestResourceBusy(t *testing.T) {
 
 	// Set up partitions.
 	_, _, _, _, err = diskutils.CreatePartitions(loopback.DevicePath(), diskConfig,
-		configuration.RootEncryption{}, configuration.ReadOnlyVerityRoot{}, nil)
+		configuration.RootEncryption{}, configuration.ReadOnlyVerityRoot{})
 	if !assert.NoError(t, err, "failed to create partitions on disk", loopback.DevicePath()) {
 		return
 	}

--- a/toolkit/tools/internal/safemount/safemount_test.go
+++ b/toolkit/tools/internal/safemount/safemount_test.go
@@ -67,7 +67,7 @@ func TestResourceBusy(t *testing.T) {
 
 	// Set up partitions.
 	_, _, _, _, err = diskutils.CreatePartitions(loopback.DevicePath(), diskConfig,
-		configuration.RootEncryption{}, configuration.ReadOnlyVerityRoot{})
+		configuration.RootEncryption{}, configuration.ReadOnlyVerityRoot{}, nil)
 	if !assert.NoError(t, err, "failed to create partitions on disk", loopback.DevicePath()) {
 		return
 	}

--- a/toolkit/tools/internal/shell/shell.go
+++ b/toolkit/tools/internal/shell/shell.go
@@ -144,9 +144,17 @@ func ExecuteLive(squashErrors bool, program string, args ...string) (err error) 
 // ExecuteLiveWithErr runs a command in the shell and logs it in real-time.
 // In addition, if there is an error, the last x lines of stderr will be attached to the err object.
 func ExecuteLiveWithErr(stderrLines int, program string, args ...string) (err error) {
+	return ExecuteLiveWithErrAndCallbacks(stderrLines, logger.Log.Debug, logger.Log.Debug, program, args...)
+}
+
+// ExecuteLiveWithErr runs a command in the shell and logs it in real-time.
+// In addition, if there is an error, the last x lines of stderr will be attached to the err object.
+func ExecuteLiveWithErrAndCallbacks(stderrLines int, onStdout, onStderr func(...interface{}), program string,
+	args ...string,
+) (err error) {
 	stderrChan := make(chan string, stderrLines)
 
-	err = ExecuteLiveWithCallbackAndChannels(logger.Log.Debug, logger.Log.Debug, nil, stderrChan, program, args...)
+	err = ExecuteLiveWithCallbackAndChannels(onStdout, onStderr, nil, stderrChan, program, args...)
 	close(stderrChan)
 	if err != nil {
 		errLines := ""

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeboot.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeboot.go
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package imagecustomizerlib
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/logger"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/safechroot"
+)
+
+var (
+	linuxCommandLineRegex = regexp.MustCompile(`\tlinux .* (\$kernelopts)`)
+)
+
+func handleKernelCommandLine(extraCommandLine string, imageChroot *safechroot.Chroot, partitionsCustomized bool) error {
+	var err error
+
+	if partitionsCustomized {
+		// ExtraCommandLine was handled when the new image was created and the grub.cfg file was regenerated from
+		// scatch.
+		return nil
+	}
+
+	if extraCommandLine == "" {
+		// Nothing to do.
+		return nil
+	}
+
+	logger.Log.Infof("Setting KernelCommandLine.ExtraCommandLine")
+
+	grub2ConfigFilePath := filepath.Join(imageChroot.RootDir(), "/boot/grub2/grub.cfg")
+
+	// Read the existing grub.cfg file.
+	grub2ConfigFileBytes, err := os.ReadFile(grub2ConfigFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to read existing grub2 config file: %w", err)
+	}
+
+	grub2ConfigFile := string(grub2ConfigFileBytes)
+
+	// Find the point where the new command line arguments should be added.
+	match := linuxCommandLineRegex.FindStringSubmatchIndex(grub2ConfigFile)
+	if match == nil {
+		return fmt.Errorf("failed to find Linux kernel command line params in grub2 config file")
+	}
+
+	// Get the location of "$kernelopts".
+	// Note: regexp returns index pairs. So, [2] is the start index of the 1st group.
+	insertIndex := match[2]
+
+	// Insert new command line arguments.
+	newGrub2ConfigFile := grub2ConfigFile[:insertIndex] + extraCommandLine + " " + grub2ConfigFile[insertIndex:]
+
+	// Update grub.cfg file.
+	err = os.WriteFile(grub2ConfigFilePath, []byte(newGrub2ConfigFile), 0)
+	if err != nil {
+		return fmt.Errorf("failed to write new grub2 config file: %w", err)
+	}
+
+	return nil
+}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepartitionsfilecopy.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepartitionsfilecopy.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/imagecustomizerapi"
-	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/logger"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/safechroot"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/shell"
 )
@@ -30,7 +29,7 @@ func customizePartitionsUsingFileCopy(buildDir string, baseConfigPath string, co
 	}
 
 	newImageConnection, err := createNewImage(newBuildImageFile, diskConfig, config.SystemConfig.PartitionSettings,
-		config.SystemConfig.BootType, buildDir, "newimageroot", installOSFunc)
+		config.SystemConfig.BootType, config.SystemConfig.KernelCommandLine, buildDir, "newimageroot", installOSFunc)
 	if err != nil {
 		return err
 	}
@@ -82,8 +81,7 @@ func copyFilesIntoNewDiskHelper(existingImageChroot *safechroot.Chroot, newImage
 		copyArgs = append(copyArgs, fullFileName)
 	}
 
-	err = shell.ExecuteLiveWithCallback(func(...interface{}) {}, logger.Log.Warn, false,
-		"cp", copyArgs...)
+	err = shell.ExecuteLiveWithErr(1, "cp", copyArgs...)
 	if err != nil {
 		return fmt.Errorf("failed to copy files:\n%w", err)
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepartitionsfilecopy.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepartitionsfilecopy.go
@@ -5,10 +5,9 @@ package imagecustomizerlib
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/imagecustomizerapi"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/logger"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/safechroot"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/shell"
 )
@@ -16,7 +15,7 @@ import (
 func customizePartitionsUsingFileCopy(buildDir string, baseConfigPath string, config *imagecustomizerapi.Config,
 	buildImageFile string, newBuildImageFile string,
 ) error {
-	existingImageConnection, err := connectToExistingImage(buildImageFile, buildDir, "imageroot")
+	existingImageConnection, err := connectToExistingImage(buildImageFile, buildDir, "imageroot", false)
 	if err != nil {
 		return err
 	}
@@ -28,14 +27,8 @@ func customizePartitionsUsingFileCopy(buildDir string, baseConfigPath string, co
 		return copyFilesIntoNewDisk(existingImageConnection.Chroot(), imageChroot)
 	}
 
-	newImageConnection, err := createNewImage(newBuildImageFile, diskConfig, config.SystemConfig.PartitionSettings,
+	err = createNewImage(newBuildImageFile, diskConfig, config.SystemConfig.PartitionSettings,
 		config.SystemConfig.BootType, config.SystemConfig.KernelCommandLine, buildDir, "newimageroot", installOSFunc)
-	if err != nil {
-		return err
-	}
-	defer newImageConnection.Close()
-
-	err = newImageConnection.CleanClose()
 	if err != nil {
 		return err
 	}
@@ -60,28 +53,10 @@ func copyFilesIntoNewDiskHelper(existingImageChroot *safechroot.Chroot, newImage
 	// Notes:
 	// `-a` ensures unix permissions, extended attributes (including SELinux), and sub-directories (-r) are copied.
 	// `--no-dereference` ensures that symlinks are copied as symlinks.
-	copyArgs := []string{"--verbose", "--no-clobber", "-a", "--no-dereference", "--sparse", "always", "-t", newImageChroot.RootDir()}
+	copyArgs := []string{"--verbose", "--no-clobber", "-a", "--no-dereference", "--sparse", "always",
+		existingImageChroot.RootDir() + "/.", newImageChroot.RootDir()}
 
-	files, err := os.ReadDir(existingImageChroot.RootDir())
-	if err != nil {
-		return fmt.Errorf("failed to read base image root directory:\n%w", err)
-	}
-
-	for _, file := range files {
-		switch file.Name() {
-		case "dev", "proc", "sys", "run", "tmp":
-			// Exclude special directories.
-			//
-			// Note: Under /var, there are symlinks to a couple of these special directories.
-			// However, the `cp` command is called with `--no-dereference`. So, the symlinks will be copied as symlinks.
-			continue
-		}
-
-		fullFileName := filepath.Join(existingImageChroot.RootDir(), file.Name())
-		copyArgs = append(copyArgs, fullFileName)
-	}
-
-	err = shell.ExecuteLiveWithErr(1, "cp", copyArgs...)
+	err := shell.ExecuteLiveWithErrAndCallbacks(1, func(...interface{}) {}, logger.Log.Debug, "cp", copyArgs...)
 	if err != nil {
 		return fmt.Errorf("failed to copy files:\n%w", err)
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeutils.go
@@ -304,7 +304,7 @@ func addOrUpdateUser(user imagecustomizerapi.User, baseConfigPath string, imageC
 		}
 	}
 
-	err = installutils.ProvisionUserSSHCerts(imageChroot, user.Name, user.SSHPubKeyPaths)
+	err = installutils.ProvisionUserSSHCerts(imageChroot, user.Name, user.SSHPubKeyPaths, user.SSHPubKeys)
 	if err != nil {
 		return err
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeutils.go
@@ -99,7 +99,7 @@ func doCustomizations(buildDir string, baseConfigPath string, config *imagecusto
 		return err
 	}
 
-	err = enableVerityPartition(imageChroot)
+	err = enableVerityPartition(config.SystemConfig.Verity, imageChroot)
 	if err != nil {
 		return err
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeutils.go
@@ -297,6 +297,13 @@ func addOrUpdateUser(user imagecustomizerapi.User, baseConfigPath string, imageC
 	}
 
 	// Set user's SSH keys.
+	for i, _ := range user.SSHPubKeyPaths {
+		// If absolute path is not provided, then append baseConfigPath.
+		if !filepath.IsAbs(user.SSHPubKeyPaths[i]) {
+			user.SSHPubKeyPaths[i] = filepath.Join(baseConfigPath, user.SSHPubKeyPaths[i])
+		}
+	}
+
 	err = installutils.ProvisionUserSSHCerts(imageChroot, user.Name, user.SSHPubKeyPaths)
 	if err != nil {
 		return err

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeutils.go
@@ -83,6 +83,12 @@ func doCustomizations(buildDir string, baseConfigPath string, config *imagecusto
 		return err
 	}
 
+	err = handleKernelCommandLine(config.SystemConfig.KernelCommandLine.ExtraCommandLine, imageChroot,
+		partitionsCustomized)
+	if err != nil {
+		return fmt.Errorf("failed to add extra kernel command line: %w", err)
+	}
+
 	err = runScripts(baseConfigPath, config.SystemConfig.FinalizeImageScripts, imageChroot)
 	if err != nil {
 		return err

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeutils.go
@@ -99,6 +99,11 @@ func doCustomizations(buildDir string, baseConfigPath string, config *imagecusto
 		return err
 	}
 
+	err = enableVerityPartition(imageChroot)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeutils_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeutils_test.go
@@ -25,7 +25,7 @@ func TestUpdateHostname(t *testing.T) {
 	// Setup environment.
 	proposedDir := filepath.Join(tmpDir, "TestUpdateHostname")
 	chroot := safechroot.NewChroot(proposedDir, false)
-	err := chroot.Initialize("", []string{}, []*safechroot.MountPoint{})
+	err := chroot.Initialize("", []string{}, []*safechroot.MountPoint{}, false)
 	assert.NoError(t, err)
 	defer chroot.Close(false)
 
@@ -52,7 +52,7 @@ func TestCopyAdditionalFiles(t *testing.T) {
 	chroot := safechroot.NewChroot(proposedDir, false)
 	baseConfigPath := testDir
 
-	err := chroot.Initialize("", []string{}, []*safechroot.MountPoint{})
+	err := chroot.Initialize("", []string{}, []*safechroot.MountPoint{}, false)
 	assert.NoError(t, err)
 	defer chroot.Close(false)
 
@@ -109,7 +109,7 @@ func TestAddCustomizerRelease(t *testing.T) {
 
 	proposedDir := filepath.Join(tmpDir, "TestAddCustomizerRelease")
 	chroot := safechroot.NewChroot(proposedDir, false)
-	err := chroot.Initialize("", []string{}, []*safechroot.MountPoint{})
+	err := chroot.Initialize("", []string{}, []*safechroot.MountPoint{}, false)
 	assert.NoError(t, err)
 	defer chroot.Close(false)
 

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeverity.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeverity.go
@@ -1,0 +1,242 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package imagecustomizerlib
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/imagecustomizerapi"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/imagegen/diskutils"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/file"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/safechroot"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/shell"
+)
+
+func enableVerityPartition(imageChroot *safechroot.Chroot) error {
+	var err error
+
+	// Integrate systemd veritysetup dracut module into initramfs img.
+	systemdVerityDracutModule := "systemd-veritysetup"
+	err = buildDracutModule(systemdVerityDracutModule, imageChroot)
+	if err != nil {
+		return err
+	}
+
+	// Update mariner config file with the new generated initramfs file.
+	err = updateMarinerCfgWithInitramfs(imageChroot)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func buildDracutModule(dracutModuleName string, imageChroot *safechroot.Chroot) error {
+	var err error
+
+	listKernels := func() ([]string, error) {
+		var kernels []string
+		// Use RootDir to get the path on the host OS
+		bootDir := filepath.Join(imageChroot.RootDir(), "boot")
+		files, err := filepath.Glob(filepath.Join(bootDir, "vmlinuz-*"))
+		if err != nil {
+			return nil, err
+		}
+		for _, file := range files {
+			kernels = append(kernels, filepath.Base(file))
+		}
+		return kernels, nil
+	}
+
+	kernelFiles, err := listKernels()
+	if err != nil {
+		return fmt.Errorf("failed to list kernels: %w", err)
+	}
+
+	if len(kernelFiles) != 1 {
+		return fmt.Errorf("expected one kernel file, but found %d", len(kernelFiles))
+	}
+
+	// Extract the version from the kernel filename (e.g., vmlinuz-5.15.131.1-2.cm2 -> 5.15.131.1-2.cm2)
+	kernelVersion := strings.TrimPrefix(kernelFiles[0], "vmlinuz-")
+
+	dracutConfigFile := filepath.Join(imageChroot.RootDir(), "etc", "dracut.conf.d", dracutModuleName+".conf")
+
+	// Check if the dracut module configuration file already exists.
+	if _, err := os.Stat(dracutConfigFile); os.IsNotExist(err) {
+		lines := []string{"add_dracutmodules+=\"" + dracutModuleName + "\""}
+		err = file.WriteLines(lines, dracutConfigFile)
+		if err != nil {
+			return fmt.Errorf("failed to write to dracut module config file (%s): %w", dracutConfigFile, err)
+		}
+	}
+
+	err = imageChroot.Run(func() error {
+		err = shell.ExecuteLiveWithErr(1, "dracut", "-f", "--kver", kernelVersion)
+		return err
+	})
+	if err != nil {
+		return fmt.Errorf("failed to build dracut module - (%s):\n%w", dracutModuleName, err)
+	}
+
+	return nil
+}
+
+func updateMarinerCfgWithInitramfs(imageChroot *safechroot.Chroot) error {
+	var err error
+
+	initramfsPattern := filepath.Join(imageChroot.RootDir(), "boot", "initramfs-*")
+	// Fetch the initramfs file name.
+	var initramfsFiles []string
+	initramfsFiles, err = filepath.Glob(initramfsPattern)
+	if err != nil {
+		return fmt.Errorf("failed to list initramfs file: %w", err)
+	}
+
+	// Ensure an initramfs file is found
+	if len(initramfsFiles) != 1 {
+		return fmt.Errorf("expected one initramfs file, but found %d", len(initramfsFiles))
+	}
+
+	newInitramfs := filepath.Base(initramfsFiles[0])
+
+	cfgPath := filepath.Join(imageChroot.RootDir(), "boot", "mariner.cfg")
+
+	lines, err := file.ReadLines(cfgPath)
+	if err != nil {
+		return fmt.Errorf("failed to read mariner.cfg: %w", err)
+	}
+
+	// Update lines to reference the new initramfs
+	for i, line := range lines {
+		if strings.HasPrefix(line, "mariner_initrd=") {
+			lines[i] = "mariner_initrd=" + newInitramfs
+		}
+	}
+	// Write the updated lines back to mariner.cfg using the internal method
+	err = file.WriteLines(lines, cfgPath)
+	if err != nil {
+		return fmt.Errorf("failed to write to mariner.cfg: %w", err)
+	}
+
+	return nil
+}
+
+func updateGrubConfig(dataPartitionIdType imagecustomizerapi.IdType, dataPartitionId string,
+	hashPartitionIdType imagecustomizerapi.IdType, hashPartitionId string, rootHash string, grubCfgFullPath string,
+) error {
+	var err error
+
+	// Format the dataPartitionId and hashPartitionId using the helper function.
+	formattedDataPartition, err := systemdFormatPartitionId(dataPartitionIdType, dataPartitionId)
+	if err != nil {
+		return err
+	}
+	formattedHashPartition, err := systemdFormatPartitionId(hashPartitionIdType, hashPartitionId)
+	if err != nil {
+		return err
+	}
+
+	newArgs := fmt.Sprintf(
+		"rd.systemd.verity=1 roothash=%s systemd.verity_root_data=%s systemd.verity_root_hash=%s systemd.verity_root_options=panic-on-corruption",
+		rootHash, formattedDataPartition, formattedHashPartition,
+	)
+
+	// Read grub.cfg using the internal method
+	lines, err := file.ReadLines(grubCfgFullPath)
+	if err != nil {
+		return fmt.Errorf("failed to read grub config: %v", err)
+	}
+
+	var updatedLines []string
+	linuxLineRegex := regexp.MustCompile(`^linux .*rd.systemd.verity=(1|0).*`)
+	for _, line := range lines {
+		trimmedLine := strings.TrimSpace(line)
+		if linuxLineRegex.MatchString(trimmedLine) {
+			// Replace existing arguments
+			verityRegexPattern := `rd.systemd.verity=(1|0)` +
+				`( roothash=[^ ]*)?` +
+				`( systemd.verity_root_data=[^ ]*)?` +
+				`( systemd.verity_root_hash=[^ ]*)?` +
+				`( systemd.verity_root_options=[^ ]*)?`
+			verityRegex := regexp.MustCompile(verityRegexPattern)
+			newLinuxLine := verityRegex.ReplaceAllString(trimmedLine, newArgs)
+			updatedLines = append(updatedLines, newLinuxLine)
+		} else if strings.HasPrefix(trimmedLine, "linux ") {
+			// Append new arguments
+			updatedLines = append(updatedLines, line+" "+newArgs)
+		} else if strings.HasPrefix(trimmedLine, "set rootdevice=PARTUUID=") {
+			line = "set rootdevice=/dev/mapper/root"
+			updatedLines = append(updatedLines, line)
+		} else {
+			// Add other lines unchanged
+			updatedLines = append(updatedLines, line)
+		}
+	}
+
+	err = file.WriteLines(updatedLines, grubCfgFullPath)
+	if err != nil {
+		return fmt.Errorf("failed to write updated grub config: %v", err)
+	}
+
+	return nil
+}
+
+// idToPartitionBlockDevicePath returns the block device path for a given idType and id.
+func idToPartitionBlockDevicePath(idType imagecustomizerapi.IdType, id string, nbdDevice string, diskPartitions []diskutils.PartitionInfo) (string, error) {
+	// Iterate over each partition to find the matching id.
+	for _, partition := range diskPartitions {
+		switch idType {
+		case imagecustomizerapi.IdTypePartLabel:
+			if partition.PartLabel == id {
+				return partition.Path, nil
+			}
+		case imagecustomizerapi.IdTypeUuid:
+			if partition.Uuid == id {
+				return partition.Path, nil
+			}
+		case imagecustomizerapi.IdTypePartUuid:
+			if partition.PartUuid == id {
+				return partition.Path, nil
+			}
+		default:
+			return "", fmt.Errorf("invalid idType provided (%s)", string(idType))
+		}
+	}
+
+	// If no partition is found with the given id.
+	return "", fmt.Errorf("no partition found for %s: %s", idType, id)
+}
+
+// systemdFormatPartitionId formats the partition ID based on the ID type following systemd dm-verity style.
+func systemdFormatPartitionId(idType imagecustomizerapi.IdType, id string) (string, error) {
+	switch idType {
+	case imagecustomizerapi.IdTypePartLabel, imagecustomizerapi.IdTypeUuid, imagecustomizerapi.IdTypePartUuid:
+		return fmt.Sprintf("%s=%s", strings.ToUpper(string(idType)), id), nil
+	default:
+		return "", fmt.Errorf("invalid idType provided (%s)", string(idType))
+	}
+}
+
+// findFreeNBDDevice finds the first available NBD device.
+func findFreeNBDDevice() (string, error) {
+	files, err := filepath.Glob("/sys/class/block/nbd*")
+	if err != nil {
+		return "", err
+	}
+
+	for _, file := range files {
+		// Check if the pid file exists. If it does not exist, the device is likely free.
+		pidFile := filepath.Join(file, "pid")
+		if _, err := os.Stat(pidFile); os.IsNotExist(err) {
+			return "/dev/" + filepath.Base(file), nil
+		}
+	}
+
+	return "", fmt.Errorf("no free nbd devices available")
+}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeverity.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeverity.go
@@ -17,8 +17,12 @@ import (
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/shell"
 )
 
-func enableVerityPartition(imageChroot *safechroot.Chroot) error {
+func enableVerityPartition(verity *imagecustomizerapi.Verity, imageChroot *safechroot.Chroot) error {
 	var err error
+
+	if verity == nil {
+		return nil
+	}
 
 	// Integrate systemd veritysetup dracut module into initramfs img.
 	systemdVerityDracutModule := "systemd-veritysetup"

--- a/toolkit/tools/pkg/imagecustomizerlib/extractpartitions.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/extractpartitions.go
@@ -13,13 +13,10 @@ import (
 )
 
 // Extract all partitions of connected image into separate files with specified format.
-func extractPartitions(imageConnection *ImageConnection, outputImageFile string, partitionFormat string) error {
+func extractPartitions(imageLoopDevice string, outputImageFile string, partitionFormat string) error {
 
 	// Extract basename from outputImageFile. E.g. if outputImageFile is "image.qcow2", then basename is "image".
 	basename := strings.TrimSuffix(filepath.Base(outputImageFile), filepath.Ext(outputImageFile))
-
-	// Get path of loop device associated with the image.
-	imageLoopDevice := imageConnection.Loopback().DevicePath()
 
 	// Get output directory path.
 	outDir := filepath.Dir(outputImageFile)

--- a/toolkit/tools/pkg/imagecustomizerlib/extractpartitions.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/extractpartitions.go
@@ -1,0 +1,99 @@
+package imagecustomizerlib
+
+import (
+	"fmt"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/imagegen/diskutils"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/logger"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/shell"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// Extract all partitions of connected image into separate files with specified format.
+func extractPartitions(imageConnection *ImageConnection, outputImageFile string, partitionFormat string) error {
+
+	// Extract basename from outputImageFile. E.g. if outputImageFile is "image.qcow2", then basename is "image".
+	basename := strings.TrimSuffix(filepath.Base(outputImageFile), filepath.Ext(outputImageFile))
+
+	// Get path of loop device associated with the image.
+	imageLoopDevice := imageConnection.Loopback().DevicePath()
+
+	// Get output directory path.
+	outDir := filepath.Dir(outputImageFile)
+
+	// Get partition info.
+	diskPartitions, err := diskutils.GetDiskPartitions(imageLoopDevice)
+	if err != nil {
+		return err
+	}
+
+	for partitionNum := 0; partitionNum < len(diskPartitions); partitionNum++ {
+		if diskPartitions[partitionNum].Type == "part" {
+			rawFilename := basename + "_" + strconv.Itoa(partitionNum) + ".raw"
+			partitionLoopDevice := diskPartitions[partitionNum].Path
+
+			partitionFilepath, err := copyBlockDeviceToFile(outDir, partitionLoopDevice, rawFilename)
+			if err != nil {
+				return err
+			}
+
+			switch partitionFormat {
+			case "raw":
+				// Do nothing for "raw" case.
+			case "raw-zstd":
+				partitionFilepath, err = compressWithZstd(partitionFilepath)
+				if err != nil {
+					return err
+				}
+			default:
+				return fmt.Errorf("unsupported partition format (supported: raw, raw-zstd): %s", partitionFormat)
+			}
+
+			logger.Log.Infof("Partition file created: %s", partitionFilepath)
+		}
+	}
+	return nil
+}
+
+// Creates .raw file for the mentioned partition path.
+func copyBlockDeviceToFile(outDir, devicePath, name string) (filename string, err error) {
+	const (
+		defaultBlockSize = 1024 * 1024 // 1MB
+		squashErrors     = true
+	)
+
+	fullPath := filepath.Join(outDir, name)
+	ddArgs := []string{
+		fmt.Sprintf("if=%s", devicePath),       // Input file.
+		fmt.Sprintf("of=%s", fullPath),         // Output file.
+		fmt.Sprintf("bs=%d", defaultBlockSize), // Size of one copied block.
+	}
+
+	err = shell.ExecuteLive(squashErrors, "dd", ddArgs...)
+	if err != nil {
+		return "", fmt.Errorf("failed to copy block device into file:\n%w", err)
+	}
+
+	return fullPath, nil
+}
+
+// Compress file from raw to raw-zstd format using zstd.
+func compressWithZstd(partitionRawFilepath string) (partitionFilepath string, err error) {
+	// Using -f to overwrite a file with same name if it exists.
+	cmd := exec.Command("zstd", "-f", "-9", "-T0", partitionRawFilepath)
+	_, err = cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to compress %s with zstd:\n%w", partitionRawFilepath, err)
+	}
+
+	// Remove raw file since output partition format is raw-zstd.
+	err = os.Remove(partitionRawFilepath)
+	if err != nil {
+		return "", fmt.Errorf("failed to remove raw file %s:\n%w", partitionRawFilepath, err)
+	}
+
+	return partitionRawFilepath + ".zst", nil
+}

--- a/toolkit/tools/pkg/imagecustomizerlib/imageConnection.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imageConnection.go
@@ -34,14 +34,14 @@ func (c *ImageConnection) ConnectLoopback(diskFilePath string) error {
 }
 
 func (c *ImageConnection) ConnectChroot(rootDir string, isExistingDir bool, extraDirectories []string,
-	extraMountPoints []*safechroot.MountPoint,
+	extraMountPoints []*safechroot.MountPoint, includeDefaultMounts bool,
 ) error {
 	if c.chroot != nil {
 		return fmt.Errorf("chroot already connected")
 	}
 
 	chroot := safechroot.NewChroot(rootDir, isExistingDir)
-	err := chroot.Initialize("", extraDirectories, extraMountPoints)
+	err := chroot.Initialize("", extraDirectories, extraMountPoints, includeDefaultMounts)
 	if err != nil {
 		return err
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -287,7 +287,7 @@ func validatePackageLists(baseConfigPath string, config *imagecustomizerapi.Syst
 func customizeImageHelper(buildDir string, baseConfigPath string, config *imagecustomizerapi.Config,
 	buildImageFile string, rpmsSources []string, useBaseImageRpmRepos bool, partitionsCustomized bool,
 ) error {
-	imageConnection, err := connectToExistingImage(buildImageFile, buildDir, "imageroot")
+	imageConnection, err := connectToExistingImage(buildImageFile, buildDir, "imageroot", true)
 	if err != nil {
 		return err
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -29,7 +29,7 @@ var (
 
 func CustomizeImageWithConfigFile(buildDir string, configFile string, imageFile string,
 	rpmsSources []string, outputImageFile string, outputImageFormat string,
-	useBaseImageRpmRepos bool,
+	outputSplitPartitionsFormat string, useBaseImageRpmRepos bool,
 ) error {
 	var err error
 
@@ -47,7 +47,7 @@ func CustomizeImageWithConfigFile(buildDir string, configFile string, imageFile 
 	}
 
 	err = CustomizeImage(buildDir, absBaseConfigPath, &config, imageFile, rpmsSources, outputImageFile, outputImageFormat,
-		useBaseImageRpmRepos)
+		outputSplitPartitionsFormat, useBaseImageRpmRepos)
 	if err != nil {
 		return err
 	}
@@ -56,7 +56,7 @@ func CustomizeImageWithConfigFile(buildDir string, configFile string, imageFile 
 }
 
 func CustomizeImage(buildDir string, baseConfigPath string, config *imagecustomizerapi.Config, imageFile string,
-	rpmsSources []string, outputImageFile string, outputImageFormat string, useBaseImageRpmRepos bool,
+	rpmsSources []string, outputImageFile string, outputImageFormat string, outputSplitPartitionsFormat string, useBaseImageRpmRepos bool,
 ) error {
 	var err error
 
@@ -115,6 +115,15 @@ func CustomizeImage(buildDir string, baseConfigPath string, config *imagecustomi
 	err = shell.ExecuteLiveWithErr(1, "qemu-img", "convert", "-O", qemuOutputImageFormat, buildImageFile, outputImageFile)
 	if err != nil {
 		return fmt.Errorf("failed to convert image file to format: %s:\n%w", outputImageFormat, err)
+	}
+
+	// If outputSplitPartitionsFormat is specified, extract the partition files.
+	if outputSplitPartitionsFormat != "" {
+		logger.Log.Infof("Extracting partition files")
+		err = extractPartitionsHelper(buildDirAbs, buildImageFile, outputImageFile, outputSplitPartitionsFormat)
+		if err != nil {
+			return err
+		}
 	}
 
 	logger.Log.Infof("Success!")
@@ -275,6 +284,27 @@ func customizeImageHelper(buildDir string, baseConfigPath string, config *imagec
 	// Do the actual customizations.
 	err = doCustomizations(buildDir, baseConfigPath, config, imageConnection.Chroot(), rpmsSources,
 		useBaseImageRpmRepos, partitionsCustomized)
+	if err != nil {
+		return err
+	}
+
+	err = imageConnection.CleanClose()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func extractPartitionsHelper(buildDir string, buildImageFile string, outputImageFile string, outputSplitPartitionsFormat string) error {
+	imageConnection, err := connectToExistingImage(buildImageFile, buildDir, "imageroot")
+	if err != nil {
+		return err
+	}
+	defer imageConnection.Close()
+
+	// Extract the partitions as files.
+	err = extractPartitions(imageConnection, outputImageFile, outputSplitPartitionsFormat)
 	if err != nil {
 		return err
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -63,11 +63,14 @@ func CustomizeImage(buildDir string, baseConfigPath string, config *imagecustomi
 	rpmsSources []string, outputImageFile string, outputImageFormat string, outputSplitPartitionsFormat string, useBaseImageRpmRepos bool,
 ) error {
 	var err error
+	var qemuOutputImageFormat string
 
-	// Validate 'outputImageFormat' value.
-	qemuOutputImageFormat, err := toQemuImageFormat(outputImageFormat)
-	if err != nil {
-		return err
+	// Validate 'outputImageFormat' value if specified.
+	if outputImageFormat != "" {
+		qemuOutputImageFormat, err = toQemuImageFormat(outputImageFormat)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Validate config.
@@ -118,15 +121,17 @@ func CustomizeImage(buildDir string, baseConfigPath string, config *imagecustomi
 		}
 	}
 
-	// Create final output image file.
-	logger.Log.Infof("Writing: %s", outputImageFile)
+	// Create final output image file if requested.
+	if outputImageFormat != "" {
+		logger.Log.Infof("Writing: %s", outputImageFile)
 
-	outDir := filepath.Dir(outputImageFile)
-	os.MkdirAll(outDir, os.ModePerm)
+		outDir := filepath.Dir(outputImageFile)
+		os.MkdirAll(outDir, os.ModePerm)
 
-	err = shell.ExecuteLiveWithErr(1, "qemu-img", "convert", "-O", qemuOutputImageFormat, buildImageFile, outputImageFile)
-	if err != nil {
-		return fmt.Errorf("failed to convert image file to format: %s:\n%w", outputImageFormat, err)
+		err = shell.ExecuteLiveWithErr(1, "qemu-img", "convert", "-O", qemuOutputImageFormat, buildImageFile, outputImageFile)
+		if err != nil {
+			return fmt.Errorf("failed to convert image file to format: %s:\n%w", outputImageFormat, err)
+		}
 	}
 
 	// If outputSplitPartitionsFormat is specified, extract the partition files.

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -138,9 +138,16 @@ func toQemuImageFormat(imageFormat string) (string, error) {
 func validateConfig(baseConfigPath string, config *imagecustomizerapi.Config, rpmsSources []string,
 	useBaseImageRpmRepos bool,
 ) error {
+	// Note: This IsValid() check does duplicate the one in UnmarshalYamlFile().
+	// But it is useful for functions that call CustomizeImage() directly. For example, test code.
+	err := config.IsValid()
+	if err != nil {
+		return err
+	}
+
 	partitionsCustomized := hasPartitionCustomizations(config)
 
-	err := validateSystemConfig(baseConfigPath, &config.SystemConfig, rpmsSources, useBaseImageRpmRepos,
+	err = validateSystemConfig(baseConfigPath, &config.SystemConfig, rpmsSources, useBaseImageRpmRepos,
 		partitionsCustomized)
 	if err != nil {
 		return err

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
@@ -48,7 +48,7 @@ func TestCustomizeImageEmptyConfig(t *testing.T) {
 
 	// Customize image.
 	err = CustomizeImage(buildDir, buildDir, &imagecustomizerapi.Config{}, diskFilePath, nil, outImageFilePath,
-		"vhd", false)
+		"vhd", "", false)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -83,7 +83,7 @@ func TestCustomizeImageCopyFiles(t *testing.T) {
 	}
 
 	// Customize image.
-	err = CustomizeImageWithConfigFile(buildDir, configFile, diskFilePath, nil, outImageFilePath, "raw", false)
+	err = CustomizeImageWithConfigFile(buildDir, configFile, diskFilePath, nil, outImageFilePath, "raw", "", false)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -235,7 +235,7 @@ func TestCustomizeImageKernelCommandLineAdd(t *testing.T) {
 		},
 	}
 
-	err = CustomizeImage(buildDir, buildDir, config, diskFilePath, nil, outImageFilePath, "raw", false)
+	err = CustomizeImage(buildDir, buildDir, config, diskFilePath, nil, outImageFilePath, "raw", "", false)
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
@@ -122,7 +122,7 @@ func reconnectToFakeEfiImage(buildDir string, imageFilePath string) (*ImageConne
 		safechroot.NewMountPoint(bootPartitionDevPath, "/boot/efi", "vfat", 0, ""),
 	}
 
-	err = imageConnection.ConnectChroot(rootDir, false, []string{}, mountPoints)
+	err = imageConnection.ConnectChroot(rootDir, false, []string{}, mountPoints, false)
 	if err != nil {
 		imageConnection.Close()
 		return nil, err
@@ -317,12 +317,11 @@ func createFakeEfiImage(buildDir string) (string, error) {
 		return nil
 	}
 
-	imageConnection, err := createNewImage(rawDisk, diskConfig, partitionSettings, "efi",
+	err = createNewImage(rawDisk, diskConfig, partitionSettings, "efi",
 		imagecustomizerapi.KernelCommandLine{}, buildDir, testImageRootDirName, installOS)
 	if err != nil {
 		return "", err
 	}
-	defer imageConnection.Close()
 
 	return rawDisk, nil
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
@@ -8,14 +8,18 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"testing"
 
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/imagecustomizerapi"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/buildpipeline"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/ptrutils"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/safechroot"
-	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/safeloopback"
 	"github.com/stretchr/testify/assert"
+)
+
+const (
+	testImageRootDirName = "testimageroot"
 )
 
 func TestCustomizeImageEmptyConfig(t *testing.T) {
@@ -88,34 +92,43 @@ func TestCustomizeImageCopyFiles(t *testing.T) {
 	checkFileType(t, outImageFilePath, "raw")
 
 	// Mount the output disk image so that its contents can be checked.
-	loopback, err := safeloopback.NewLoopback(outImageFilePath)
+	imageConnection, err := reconnectToFakeEfiImage(buildDir, outImageFilePath)
 	if !assert.NoError(t, err) {
 		return
 	}
-	defer loopback.Close()
+	defer imageConnection.Close()
 
-	// Create partition mount config.
-	// Note: The assigned loopback device might be different from the one assigned when `createFakeEfiImage` ran.
-	bootPartitionDevPath := fmt.Sprintf("%sp1", loopback.DevicePath())
-	osPartitionDevPath := fmt.Sprintf("%sp2", loopback.DevicePath())
+	// Check the contents of the copied file.
+	file_contents, err := os.ReadFile(filepath.Join(imageConnection.Chroot().RootDir(), "a.txt"))
+	assert.NoError(t, err)
+	assert.Equal(t, "abcdefg\n", string(file_contents))
+}
 
-	newMountDirectories := []string{}
+func reconnectToFakeEfiImage(buildDir string, imageFilePath string) (*ImageConnection, error) {
+	imageConnection := NewImageConnection()
+	err := imageConnection.ConnectLoopback(imageFilePath)
+	if err != nil {
+		imageConnection.Close()
+		return nil, err
+	}
+
+	rootDir := filepath.Join(buildDir, testImageRootDirName)
+
+	bootPartitionDevPath := fmt.Sprintf("%sp1", imageConnection.Loopback().DevicePath())
+	osPartitionDevPath := fmt.Sprintf("%sp2", imageConnection.Loopback().DevicePath())
+
 	mountPoints := []*safechroot.MountPoint{
 		safechroot.NewPreDefaultsMountPoint(osPartitionDevPath, "/", "ext4", 0, ""),
 		safechroot.NewMountPoint(bootPartitionDevPath, "/boot/efi", "vfat", 0, ""),
 	}
 
-	imageChroot := safechroot.NewChroot(filepath.Join(buildDir, "imageroot"), false)
-	err = imageChroot.Initialize("", newMountDirectories, mountPoints)
-	if !assert.NoError(t, err) {
-		return
+	err = imageConnection.ConnectChroot(rootDir, false, []string{}, mountPoints)
+	if err != nil {
+		imageConnection.Close()
+		return nil, err
 	}
-	defer imageChroot.Close(false)
 
-	// Check the contents of the copied file.
-	file_contents, err := os.ReadFile(filepath.Join(imageChroot.RootDir(), "a.txt"))
-	assert.NoError(t, err)
-	assert.Equal(t, "abcdefg\n", string(file_contents))
+	return imageConnection, nil
 }
 
 func TestValidateConfigValidAdditionalFiles(t *testing.T) {
@@ -189,6 +202,69 @@ func TestValidateConfigScriptNonExecutable(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestCustomizeImageKernelCommandLineAdd(t *testing.T) {
+	var err error
+
+	if testing.Short() {
+		t.Skip("Short mode enabled")
+	}
+
+	if !buildpipeline.IsRegularBuild() {
+		t.Skip("loopback block device not available")
+	}
+
+	if os.Geteuid() != 0 {
+		t.Skip("Test must be run as root because it uses a chroot")
+	}
+
+	buildDir := filepath.Join(tmpDir, "TestCustomizeImageKernelCommandLine")
+	outImageFilePath := filepath.Join(buildDir, "image.vhd")
+
+	// Create fake disk.
+	diskFilePath, err := createFakeEfiImage(buildDir)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	// Customize image.
+	config := &imagecustomizerapi.Config{
+		SystemConfig: imagecustomizerapi.SystemConfig{
+			KernelCommandLine: imagecustomizerapi.KernelCommandLine{
+				ExtraCommandLine: "console=tty0 console=ttyS0",
+			},
+		},
+	}
+
+	err = CustomizeImage(buildDir, buildDir, config, diskFilePath, nil, outImageFilePath, "raw", false)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	// Mount the output disk image so that its contents can be checked.
+	imageConnection, err := reconnectToFakeEfiImage(buildDir, outImageFilePath)
+	if !assert.NoError(t, err) {
+		return
+	}
+	defer imageConnection.Close()
+
+	// Read the grub.cfg file.
+	grub2ConfigFilePath := filepath.Join(imageConnection.Chroot().RootDir(), "/boot/grub2/grub.cfg")
+
+	grub2ConfigFile, err := os.ReadFile(grub2ConfigFilePath)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	t.Logf("%s", grub2ConfigFile)
+
+	linuxCommandLineRegex, err := regexp.Compile(`linux .* console=tty0 console=ttyS0 `)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	assert.True(t, linuxCommandLineRegex.Match(grub2ConfigFile))
+}
+
 func createFakeEfiImage(buildDir string) (string, error) {
 	var err error
 
@@ -241,8 +317,8 @@ func createFakeEfiImage(buildDir string) (string, error) {
 		return nil
 	}
 
-	imageConnection, err := createNewImage(rawDisk, diskConfig, partitionSettings, "efi", buildDir, "imageroot",
-		installOS)
+	imageConnection, err := createNewImage(rawDisk, diskConfig, partitionSettings, "efi",
+		imagecustomizerapi.KernelCommandLine{}, buildDir, testImageRootDirName, installOS)
 	if err != nil {
 		return "", err
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/imageutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imageutils.go
@@ -16,18 +16,6 @@ import (
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/safechroot"
 )
 
-var (
-	// When calling mkfs, the default options change depending on the host OS you are running on and typically match
-	// what the distro has decided is best for their OS. For example, for ext2/3/4, the defaults are stored in
-	// /etc/mke2fs.conf.
-	// However, for the image customizer tool, the defaults should be as consistent as possible.
-	DefaultMkfsOptions = map[string][]string{
-		"ext2": {"-b", "4096", "-O", "none,sparse_super,large_file,filetype,resize_inode,dir_index,ext_attr"},
-		"ext3": {"-b", "4096", "-O", "none,sparse_super,large_file,filetype,resize_inode,dir_index,ext_attr,has_journal"},
-		"ext4": {"-b", "4096", "-O", "none,sparse_super,large_file,filetype,resize_inode,dir_index,ext_attr,has_journal,extent,huge_file,flex_bg,metadata_csum,64bit,dir_nlink,extra_isize"},
-	}
-)
-
 type installOSFunc func(imageChroot *safechroot.Chroot) error
 
 func connectToExistingImage(imageFilePath string, buildDir string, chrootDirName string, includeDefaultMounts bool,
@@ -175,7 +163,7 @@ func createImageBoilerplate(imageConnection *ImageConnection, filename string, b
 	// Set up partitions.
 	partIDToDevPathMap, partIDToFsTypeMap, _, _, err := diskutils.CreatePartitions(
 		imageConnection.Loopback().DevicePath(), imagerDiskConfig, configuration.RootEncryption{},
-		configuration.ReadOnlyVerityRoot{}, DefaultMkfsOptions)
+		configuration.ReadOnlyVerityRoot{})
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to create partitions on disk (%s):\n%w", imageConnection.Loopback().DevicePath(), err)
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/imageutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imageutils.go
@@ -16,6 +16,18 @@ import (
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/safechroot"
 )
 
+var (
+	// When calling mkfs, the default options change depending on the host OS you are running on and typically match
+	// what the distro has decided is best for their OS. For example, for ext2/3/4, the defaults are stored in
+	// /etc/mke2fs.conf.
+	// However, for the image customizer tool, the defaults should be as consistent as possible.
+	DefaultMkfsOptions = map[string][]string{
+		"ext2": {"-b", "4096", "-O", "none,sparse_super,large_file,filetype,resize_inode,dir_index,ext_attr"},
+		"ext3": {"-b", "4096", "-O", "none,sparse_super,large_file,filetype,resize_inode,dir_index,ext_attr,has_journal"},
+		"ext4": {"-b", "4096", "-O", "none,sparse_super,large_file,filetype,resize_inode,dir_index,ext_attr,has_journal,extent,huge_file,flex_bg,metadata_csum,64bit,dir_nlink,extra_isize"},
+	}
+)
+
 type installOSFunc func(imageChroot *safechroot.Chroot) error
 
 func connectToExistingImage(imageFilePath string, buildDir string, chrootDirName string) (*ImageConnection, error) {
@@ -156,7 +168,7 @@ func createImageBoilerplate(imageConnection *ImageConnection, filename string, b
 	// Set up partitions.
 	partIDToDevPathMap, partIDToFsTypeMap, _, _, err := diskutils.CreatePartitions(
 		imageConnection.Loopback().DevicePath(), imagerDiskConfig, configuration.RootEncryption{},
-		configuration.ReadOnlyVerityRoot{})
+		configuration.ReadOnlyVerityRoot{}, DefaultMkfsOptions)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to create partitions on disk (%s):\n%w", imageConnection.Loopback().DevicePath(), err)
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/imageutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imageutils.go
@@ -58,13 +58,14 @@ func connectToExistingImageHelper(imageConnection *ImageConnection, imageFilePat
 }
 
 func createNewImage(filename string, diskConfig imagecustomizerapi.Disk,
-	partitionSettings []imagecustomizerapi.PartitionSetting, bootType imagecustomizerapi.BootType, buildDir string,
-	chrootDirName string, installOS installOSFunc,
+	partitionSettings []imagecustomizerapi.PartitionSetting, bootType imagecustomizerapi.BootType,
+	kernelCommandLine imagecustomizerapi.KernelCommandLine, buildDir string, chrootDirName string,
+	installOS installOSFunc,
 ) (*ImageConnection, error) {
 	imageConnection := &ImageConnection{}
 
-	err := createNewImageHelper(imageConnection, filename, diskConfig, partitionSettings, bootType, buildDir,
-		chrootDirName, installOS,
+	err := createNewImageHelper(imageConnection, filename, diskConfig, partitionSettings, bootType, kernelCommandLine,
+		buildDir, chrootDirName, installOS,
 	)
 	if err != nil {
 		imageConnection.Close()
@@ -75,8 +76,9 @@ func createNewImage(filename string, diskConfig imagecustomizerapi.Disk,
 }
 
 func createNewImageHelper(imageConnection *ImageConnection, filename string, diskConfig imagecustomizerapi.Disk,
-	partitionSettings []imagecustomizerapi.PartitionSetting, bootType imagecustomizerapi.BootType, buildDir string,
-	chrootDirName string, installOS installOSFunc,
+	partitionSettings []imagecustomizerapi.PartitionSetting, bootType imagecustomizerapi.BootType,
+	kernelCommandLine imagecustomizerapi.KernelCommandLine, buildDir string, chrootDirName string,
+	installOS installOSFunc,
 ) error {
 	// Convert config to image config types, so that the imager's utils can be used.
 	imagerBootType, err := bootTypeToImager(bootType)
@@ -94,13 +96,18 @@ func createNewImageHelper(imageConnection *ImageConnection, filename string, dis
 		return err
 	}
 
+	imagerKernelCommandLine, err := kernelCommandLineToImager(kernelCommandLine)
+	if err != nil {
+		return err
+	}
+
 	// Sort the partitions so that they are mounted in the correct oder.
 	sort.Slice(imagerPartitionSettings, func(i, j int) bool {
 		return imagerPartitionSettings[i].MountPoint < imagerPartitionSettings[j].MountPoint
 	})
 
 	// Create imager boilerplate.
-	mountPointMap, err := createImageBoilerplate(imageConnection, filename, buildDir, chrootDirName, imagerDiskConfig,
+	mountPointMap, tmpFstabFile, err := createImageBoilerplate(imageConnection, filename, buildDir, chrootDirName, imagerDiskConfig,
 		imagerPartitionSettings)
 	if err != nil {
 		return err
@@ -112,9 +119,17 @@ func createNewImageHelper(imageConnection *ImageConnection, filename string, dis
 		return err
 	}
 
+	// Move the fstab file into the image.
+	imageFstabFilePath := filepath.Join(imageConnection.Chroot().RootDir(), "etc/fstab")
+
+	err = file.Move(tmpFstabFile, imageFstabFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to move fstab into new image:\n%w", err)
+	}
+
 	// Configure the boot loader.
 	err = installutils.ConfigureDiskBootloader(imagerBootType, false, false, imagerPartitionSettings,
-		configuration.KernelCommandLine{}, imageConnection.Chroot(), imageConnection.Loopback().DevicePath(),
+		imagerKernelCommandLine, imageConnection.Chroot(), imageConnection.Loopback().DevicePath(),
 		mountPointMap, diskutils.EncryptedRootDevice{}, diskutils.VerityDevice{}, false /*enableGrubMkconfig*/)
 	if err != nil {
 		return fmt.Errorf("failed to install bootloader:\n%w", err)
@@ -125,17 +140,17 @@ func createNewImageHelper(imageConnection *ImageConnection, filename string, dis
 
 func createImageBoilerplate(imageConnection *ImageConnection, filename string, buildDir string, chrootDirName string,
 	imagerDiskConfig configuration.Disk, imagerPartitionSettings []configuration.PartitionSetting,
-) (map[string]string, error) {
+) (map[string]string, string, error) {
 	// Create raw disk image file.
 	err := diskutils.CreateSparseDisk(filename, imagerDiskConfig.MaxSize, 0o644)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create empty disk file (%s):\n%w", filename, err)
+		return nil, "", fmt.Errorf("failed to create empty disk file (%s):\n%w", filename, err)
 	}
 
 	// Connect raw disk image file.
 	err = imageConnection.ConnectLoopback(filename)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
 	// Set up partitions.
@@ -143,13 +158,13 @@ func createImageBoilerplate(imageConnection *ImageConnection, filename string, b
 		imageConnection.Loopback().DevicePath(), imagerDiskConfig, configuration.RootEncryption{},
 		configuration.ReadOnlyVerityRoot{})
 	if err != nil {
-		return nil, fmt.Errorf("failed to create partitions on disk (%s):\n%w", imageConnection.Loopback().DevicePath(), err)
+		return nil, "", fmt.Errorf("failed to create partitions on disk (%s):\n%w", imageConnection.Loopback().DevicePath(), err)
 	}
 
 	// Read the disk partitions.
 	diskPartitions, err := diskutils.GetDiskPartitions(imageConnection.Loopback().DevicePath())
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
 	// Create the fstab file.
@@ -166,13 +181,13 @@ func createImageBoilerplate(imageConnection *ImageConnection, filename string, b
 		mountPointToMountArgsMap, partIDToDevPathMap, partIDToFsTypeMap, false, /*hidepidEnabled*/
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to write temp fstab file:\n%w", err)
+		return nil, "", fmt.Errorf("failed to write temp fstab file:\n%w", err)
 	}
 
 	// Read back the fstab file.
 	mountPoints, err := findMountsFromFstabFile(tmpFstabFile, diskPartitions)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
 	// Create chroot environment.
@@ -180,16 +195,8 @@ func createImageBoilerplate(imageConnection *ImageConnection, filename string, b
 
 	err = imageConnection.ConnectChroot(imageChrootDir, false, nil, mountPoints)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
-	// Move the fstab file into the image.
-	imageFstabFilePath := filepath.Join(imageConnection.Chroot().RootDir(), "etc/fstab")
-
-	err = file.Move(tmpFstabFile, imageFstabFilePath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to move fstab into new image:\n%w", err)
-	}
-
-	return mountPointMap, nil
+	return mountPointMap, tmpFstabFile, nil
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/commandline-config.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/commandline-config.yaml
@@ -1,0 +1,3 @@
+SystemConfig:
+  KernelCommandLine:
+    ExtraCommandLine: console=tty0 console=ttyS0

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/partitions-config.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/partitions-config.yaml
@@ -39,3 +39,6 @@ SystemConfig:
 
   - ID: var
     MountPoint: /var
+
+  KernelCommandLine:
+    ExtraCommandLine: console=tty0 console=ttyS0

--- a/toolkit/tools/pkg/imagecustomizerlib/typeConversion.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/typeConversion.go
@@ -161,3 +161,11 @@ func mountIdentifierTypeToImager(mountIdentifierType imagecustomizerapi.MountIde
 		return "", fmt.Errorf("unknwon MountIdentifierType value (%s)", mountIdentifierType)
 	}
 }
+
+func kernelCommandLineToImager(kernelCommandLine imagecustomizerapi.KernelCommandLine,
+) (configuration.KernelCommandLine, error) {
+	imagerKernelCommandLine := configuration.KernelCommandLine{
+		ExtraCommandLine: kernelCommandLine.ExtraCommandLine,
+	}
+	return imagerKernelCommandLine, nil
+}

--- a/toolkit/tools/pkg/simpletoolchroot/simpletoolchroot.go
+++ b/toolkit/tools/pkg/simpletoolchroot/simpletoolchroot.go
@@ -58,7 +58,7 @@ func (s *SimpleToolChroot) InitializeChroot(buildDir, chrootName, workerTarPath,
 	extraMountPoints := []*safechroot.MountPoint{
 		safechroot.NewMountPoint(specsDirPath, chrootSpecDirPath, "", safechroot.BindMountPointFlags, ""),
 	}
-	err = s.chroot.Initialize(workerTarPath, extraDirectories, extraMountPoints)
+	err = s.chroot.Initialize(workerTarPath, extraDirectories, extraMountPoints, true)
 	if err != nil {
 		logger.Log.Errorf("Failed to initialize chroot (%s) inside (%s). Error: %v.", workerTarPath, chrootDirPath, err)
 	}

--- a/toolkit/tools/pkgworker/pkgworker.go
+++ b/toolkit/tools/pkgworker/pkgworker.go
@@ -213,7 +213,7 @@ func buildSRPMInChroot(chrootDir, rpmDirPath, toolchainDirPath, workerTar, srpmF
 		extraDirs = append(extraDirs, chrootCcacheDir)
 	}
 
-	err = chroot.Initialize(workerTar, extraDirs, mountPoints)
+	err = chroot.Initialize(workerTar, extraDirs, mountPoints, true)
 	if err != nil {
 		return
 	}

--- a/toolkit/tools/specreader/specreader.go
+++ b/toolkit/tools/specreader/specreader.go
@@ -211,7 +211,7 @@ func createChroot(workerTar, buildDir, specsDir, srpmsDir string) (chroot *safec
 	chrootDir := filepath.Join(buildDir, chrootName)
 	chroot = safechroot.NewChroot(chrootDir, existingDir)
 
-	err = chroot.Initialize(workerTar, extraDirectories, extraMountPoints)
+	err = chroot.Initialize(workerTar, extraDirectories, extraMountPoints, true)
 	if err != nil {
 		return
 	}

--- a/toolkit/tools/srpmpacker/srpmpacker.go
+++ b/toolkit/tools/srpmpacker/srpmpacker.go
@@ -320,7 +320,7 @@ func createChroot(workerTar, buildDir, outDir, specsDir string) (chroot *safechr
 	chrootDir := filepath.Join(buildDir, chrootName)
 	chroot = safechroot.NewChroot(chrootDir, existingDir)
 
-	err = chroot.Initialize(workerTar, extraDirectories, extraMountPoints)
+	err = chroot.Initialize(workerTar, extraDirectories, extraMountPoints, true)
 	if err != nil {
 		return
 	}

--- a/toolkit/tools/validatechroot/validatechroot.go
+++ b/toolkit/tools/validatechroot/validatechroot.go
@@ -76,7 +76,7 @@ func validateWorker(rpmsDir, chrootDir, workerTarPath, manifestPath string) (err
 	rpmMount := safechroot.NewMountPoint(rpmsDir, chrootToolchainRpmsDir, "", safechroot.BindMountPointFlags, "")
 	extraDirectories := []string{chrootToolchainRpmsDir}
 	rpmMounts := []*safechroot.MountPoint{rpmMount}
-	err = chroot.Initialize(workerTarPath, extraDirectories, rpmMounts)
+	err = chroot.Initialize(workerTarPath, extraDirectories, rpmMounts, true)
 	if err != nil {
 		chroot = nil
 		return


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->

Cherry-pick the changes relating to the image customizer tool into the 3.0-dev branch.

###### Change Log  <!-- REQUIRED -->

- Cherry-pick image customizer changes from main branch to 3.0-dev

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Ran UTs

