### PR TITLE
sleuthkit: build without libewf

### DIFF
--- a/SPECS/sleuthkit/sleuthkit.spec
+++ b/SPECS/sleuthkit/sleuthkit.spec
@@ -1,7 +1,7 @@
 Summary:        The Sleuth Kit (TSK)
 Name:           sleuthkit
 Version:        4.9.0
-Release:        4%{?dist}
+Release:        5%{?dist}
 License:        BSD AND CPL AND GPLv2+ AND IBM AND MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -9,7 +9,6 @@ URL:            https://www.sleuthkit.org
 Source0:        https://github.com/sleuthkit/sleuthkit/releases/download/sleuthkit-%{version}/sleuthkit-%{version}.tar.gz
 
 BuildRequires:  gcc-c++
-BuildRequires:  libewf-devel
 BuildRequires:  perl-generators
 BuildRequires:  sqlite-devel
 
@@ -140,6 +139,9 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %{_libdir}/*.so
 
 %changelog
+* Thu Jan 18 2024 Andrew Phelps <anphel@microsoft.com> - 4.9.0-5
+- Build without libewf-devel
+
 * Fri Apr 01 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 4.9.0-4
 - Cleaning-up spec. License verified.
 
@@ -299,7 +301,7 @@ find %{buildroot} -type f -name "*.la" -delete -print
 * Tue Jun 17 2008 kwizart < kwizart at gmail.com > - 2.52-1
 - Update to 2.52
 - Remove merged patches
-- Remove clean unused-direct-shlib-dependencies 
+- Remove clean unused-direct-shlib-dependencies
 - Fix rpath at source.
 - Sort license within the spec
 - Move configure.ac to pkg-config detection
@@ -315,5 +317,5 @@ find %{buildroot} -type f -name "*.la" -delete -print
 - Update to 2.10
 
 * Mon Oct 29 2007 kwizart < kwizart at gmail.com > - 2.09-1
-- Initial package for Fedora 
+- Initial package for Fedora
   (inspired from Oden Eriksson mdk spec).


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Fix package build for `sleuthkit` by removing BR for `libewf-devel`.
We are planning to drop the `libewf` package, since it currently fails to build and does not appear to be maintained. `sleuthkit` is able to detect that `libewf` is not present and builds accordingly.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change `sleuthkit` to build without `libewf-devel`

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: xxxx
