### PR TITLE
Add epoch to libdwarf spec to fix versioning order

### DIFF
--- a/SPECS/libdwarf/libdwarf.spec
+++ b/SPECS/libdwarf/libdwarf.spec
@@ -1,6 +1,7 @@
 Name:          libdwarf
+Epoch:         1
 Version:       0.9.0
-Release:       1%{?dist}
+Release:       2%{?dist}
 Summary:       Library to access the DWARF Debugging file format 
 
 License:       LGPL-2.1-only AND BSD-2-Clause-FreeBSD
@@ -11,6 +12,7 @@ Source0:       https://www.prevanders.net/%{name}-%{version}.tar.xz
 Patch0:        libdwarf_skip_test.patch
 
 BuildRequires: gcc make python3
+Provides:      %{name} = %{version}-%{release}
 
 %description
 Library to access the DWARF debugging file format which supports
@@ -21,6 +23,7 @@ and Fortran.  Please see http://www.dwarfstd.org for DWARF specification.
 Summary:       Library and header files of libdwarf
 License:       LGPL-2.1-only AND BSD-2-Clause-FreeBSD
 Requires:      %{name} = %{version}-%{release}
+Provides:      %{name}-devel = %{version}-%{release}
 
 %description devel
 Development package containing library and header files of libdwarf.
@@ -89,6 +92,9 @@ TZ=:America/Los_Angeles %__make check
 
 
 %changelog
+* Fri Jan 19 2024 Sindhu Karri <lakarri@microsoft.com> - 1:0.9.0-2
+- Add Epoch to fix version ordering as date versioning had changed to normal versioning
+
 * Tue Jan 02 2024 Sindhu Karri <lakarri@microsoft.com> - 0.9.0-1
 - Upgraded to 0.9.0
 - License verified


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
The PR adds an epoch version to the package.
The versioning of the package has changed from date versioning to normal versioning in the last [upgrade](https://github.com/microsoft/CBL-Mariner/pull/6827).
version before upgrade: 20200114
version after upgrade: 0.9.0
Since the version after upgrade is numerically lower, package manager treats it as an older version and the CVEs on the earlier versions are being detected on the current version even though they're not applicable.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add Epoch to fix version ordering as date versioning had changed to normal versioning

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-YYYY-XXXX

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- https://dev.azure.com/mariner-org/mariner/_build/results?buildId=486988&view=results
