### PR TITLE
Revert "Upgrade asciidoc to 10.2.0 (#7272)"

### DIFF
--- a/SPECS/asciidoc/asciidoc.signatures.json
+++ b/SPECS/asciidoc/asciidoc.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "asciidoc-10.2.0.tar.gz": "237b2ba5c35c0ae7ccd4cd44ebf1d87c20b2695dae01798954416d492ef7fa0e" 
+  "asciidoc-9.1.0.tar.gz": "fd499fcf51317b1aaf27336fb5e919c44c1f867f1ae6681ee197365d3065238b" 
  }
 }

--- a/SPECS/asciidoc/asciidoc.spec
+++ b/SPECS/asciidoc/asciidoc.spec
@@ -1,6 +1,6 @@
 Summary:        AsciiDoc is a human readable text document format
 Name:           asciidoc
-Version:        10.2.0
+Version:        9.1.0
 Release:        1%{?dist}
 License:        GPLv2
 URL:            https://asciidoc.org/
@@ -14,7 +14,6 @@ BuildRequires:  python3-xml
 BuildRequires:  libxslt
 BuildRequires:  docbook-style-xsl
 BuildRequires:  docbook-dtd-xml
-BuildRequires:  python3-pip
 Requires:       python3
 Requires:       python3-xml
 Requires:       libxslt
@@ -36,14 +35,7 @@ make %{?_smp_mflags}
 
 %install
 rm -rf %{buildroot}%{_infodir}
-make install docs manpages DESTDIR=%{buildroot}
-mkdir -p %{buildroot}%{_mandir}/man1
-mv %{buildroot}/share/doc/doc/{asciidoc.1,a2x.1,testasciidoc.1} %{buildroot}%{_mandir}/man1/
-mkdir -p %{buildroot}/%{_pkgdocdir}/doc
-mv %{buildroot}/share/doc/doc/ %{buildroot}/%{_pkgdocdir}/doc
-mkdir -p %{buildroot}/%{_pkgdocdir}/doc/images
-mv %{buildroot}/share/doc/images/ %{buildroot}/%{_pkgdocdir}/doc/images
-rm  %{buildroot}/share/doc/{BUGS.adoc,CHANGELOG.adoc,INSTALL.adoc,README.md,dblatex/dblatex-readme.txt,docbook-xsl/asciidoc-docbook-xsl.txt}
+make DESTDIR=%{buildroot} install
 
 %check
 python3 tests/testasciidoc.py update
@@ -55,21 +47,11 @@ python3 tests/testasciidoc.py run
 %files
 %defattr(-,root,root)
 %license COPYRIGHT
-%doc BUGS.adoc CHANGELOG.adoc README.md
 %{_bindir}/*
+%{_sysconfdir}/*
 %{_mandir}/*
-%{python3_sitelib}/asciidoc/
-%{_pkgdocdir}/doc
-%{python3_sitelib}/asciidoc-*.egg-info
-%dir %{python3_sitelib}/asciidoc/resources/filters/latex
-%dir %{python3_sitelib}/asciidoc/resources/filters/music
-
 
 %changelog
-*   Mon Jan 15 2024 Suresh Thelkar <sthelkar@microsoft.com> - 10.2.0-1
--   Upgraded to 10.2.0
--   Added BR for python3-pip
--   Added doc and man pages related changes as well
 *   Wed May 05 2021 Nick Samson <nisamson@microsoft.com> - 9.1.0-1
 -   Updated to 9.1.0, removed python2 support, verified license
 *   Sat May 09 2020 Nick Samson <nisamson@microsoft.com> - 8.6.10-4

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -575,8 +575,8 @@
         "type": "other",
         "other": {
           "name": "asciidoc",
-          "version": "10.2.0",
-          "downloadUrl": "https://github.com/asciidoc-py/asciidoc-py/releases/download/10.2.0/asciidoc-10.2.0.tar.gz"
+          "version": "9.1.0",
+          "downloadUrl": "https://github.com/asciidoc-py/asciidoc-py/releases/download/9.1.0/asciidoc-9.1.0.tar.gz"
         }
       }
     },

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -1,4 +1,4 @@
-asciidoc-10.2.0-1.azl3.noarch.rpm
+asciidoc-9.1.0-1.azl3.noarch.rpm
 audit-3.1.2-1.azl3.aarch64.rpm
 audit-debuginfo-3.1.2-1.azl3.aarch64.rpm
 audit-devel-3.1.2-1.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -1,4 +1,4 @@
-asciidoc-10.2.0-1.azl3.noarch.rpm
+asciidoc-9.1.0-1.azl3.noarch.rpm
 audit-3.1.2-1.azl3.x86_64.rpm
 audit-debuginfo-3.1.2-1.azl3.x86_64.rpm
 audit-devel-3.1.2-1.azl3.x86_64.rpm


### PR DESCRIPTION
This reverts commit acd878463c152479f8abfaf75bb63b3bc382938e.

Revert commit from PR #7272 due to build break: (it breaks `ca-certificates` in the toolchain build for both architectures)

https://dev.azure.com/mariner-org/mariner/_build/results?buildId=486956&view=results

```
time="2024-01-19T10:25:36UTC" /usr/src/mariner/BUILD
time="2024-01-19T10:25:36UTC" + cp /usr/src/mariner/SOURCES/update-ca-trust.8.txt ca-certificates/update-ca-trust.8.txt
time="2024-01-19T10:25:36UTC" + asciidoc.py -v -d manpage -b docbook ca-certificates/update-ca-trust.8.txt
time="2024-01-19T10:25:36UTC" /var/tmp/rpm-tmp.3egnuw: line 65: asciidoc.py: command not found
time="2024-01-19T10:25:36UTC" error: Bad exit status from /var/tmp/rpm-tmp.3egnuw (%build)

...
=================================
list of RPMs that failed to build
=================================
ca-certificates-3.0.0-1.azl3.src.rpm
```