### PR TITLE
Adding support for multiple cache inputs

### DIFF
--- a/.pipelines/templates/PackageBuild.yml
+++ b/.pipelines/templates/PackageBuild.yml
@@ -162,7 +162,7 @@ steps:
       - task: DownloadPipelineArtifact@2
         displayName: "Download input cache RPM from ${{ inputCacheArtifact.name }}"
         inputs:
-          artifact: ${{ inputCacheArtifact.name }}
+          artifact: "${{ inputCacheArtifact.name }}"
           patterns: "**/${{ inputCacheArtifact.rpmsTarball }}"
 
       - script: |

--- a/.pipelines/templates/PackageBuild.yml
+++ b/.pipelines/templates/PackageBuild.yml
@@ -30,6 +30,13 @@ parameters:
     type: boolean
     default: true
 
+  - name: inputCacheArtifacts
+    type: object
+    default: []
+    # Sample:
+    # - name: build-artifacts
+    #   rpmsTarball: cache.tar.gz
+
   - name: isCheckBuild
     type: string
     default: "default"
@@ -86,6 +93,18 @@ parameters:
     type: string
     default: ""
 
+  - name: outputRPMsCacheTarballName
+    type: string
+    default: ""
+
+  - name: outputRPMsTarballName
+    type: string
+    default: "rpms.tar.gz"
+
+  - name: outputSRPMsTarballName
+    type: string
+    default: "srpms.tar.gz"
+
   - name: pipArtifactFeeds
     type: string
     default: ""
@@ -93,18 +112,6 @@ parameters:
   - name: publishLogs
     type: boolean
     default: true
-
-  - name: rpmsCacheArtifactName
-    type: string
-    default: ""
-
-  - name: rpmsCacheTarballName
-    type: string
-    default: "rpms.tar.gz"
-
-  - name: rpmsTarballName
-    type: string
-    default: "rpms.tar.gz"
 
   - name: selfRepoName
     type: string
@@ -117,10 +124,6 @@ parameters:
   - name: srpmPackList
     type: string
     default: ""
-
-  - name: srpmsTarballName
-    type: string
-    default: "srpms.tar.gz"
 
   - name: testSuiteName
     type: string
@@ -155,22 +158,23 @@ steps:
           sudo make -C "${{ parameters.buildRepoRoot }}/toolkit" toolchain TOOLCHAIN_ARCHIVE="$toolchain_archive"
         displayName: "Populate toolchain"
 
-  - ${{ if parameters.rpmsCacheArtifactName }}:
+  - ${{ each inputCacheArtifact in parameters.inputCacheArtifacts }}:
       - task: DownloadPipelineArtifact@2
-        displayName: "Download RPM cache"
+        displayName: "Download input cache RPM from ${{ inputCacheArtifact.name }}"
         inputs:
-          artifact: "${{ parameters.rpmsCacheArtifactName }}"
-          patterns: "**/${{ parameters.rpmsCacheTarballName }}"
+          artifact: ${{ inputCacheArtifact.name }}
+          patterns: "**/${{ inputCacheArtifact.rpmsTarball }}"
 
       - script: |
-          rpms_archive="$(find "$(Pipeline.Workspace)" -name "${{ parameters.rpmsCacheTarballName }}" -print -quit)"
+          rpms_archive="$(find "$(Pipeline.Workspace)" -name "${{ inputCacheArtifact.rpmsTarball }}" -print -quit)"
           if [[ ! -f "$rpms_archive" ]]; then
-            echo "ERROR: RPMs cache archive not found!" >&2
+            echo "ERROR: cache RPMs archive '${{ inputCacheArtifact.rpmsTarball }}' not found!" >&2
             exit 1
           fi
 
           sudo make -C "${{ parameters.buildRepoRoot }}/toolkit" hydrate-cached-rpms CACHED_PACKAGES_ARCHIVE="$rpms_archive"
-        displayName: "Populate RPMs cache"
+          rm "$rpms_archive"
+        displayName: "Populate cache RPMs"
 
   - script: |
       if [[ ${{ parameters.isDeltaBuild }} == "true" ]]; then
@@ -219,7 +223,18 @@ steps:
     displayName: "Build packages"
 
   - ${{ if parameters.outputArtifactsFolder }}:
-      - ${{ if parameters.rpmsTarballName }}:
+      - ${{ if parameters.outputRPMsCacheTarballName }}:
+          - script: |
+              sudo make -C "${{ parameters.buildRepoRoot }}/toolkit" compress-cached-rpms
+            displayName: "Compress cached RPMs"
+
+          - bash: |
+              published_artifacts_dir="${{ parameters.outputArtifactsFolder }}/${{ parameters.outputArtifactsPackagesSubfolder }}"
+              mkdir -p "$published_artifacts_dir"
+              cp "${{ parameters.buildRepoRoot }}"/out/cache.tar.gz "$published_artifacts_dir/${{ parameters.outputRPMsCacheTarballName }}"
+            displayName: "Copy cached RPMs for publishing"
+
+      - ${{ if parameters.outputRPMsTarballName }}:
           - script: |
               sudo make -C "${{ parameters.buildRepoRoot }}/toolkit" compress-rpms
             displayName: "Compress RPMs"
@@ -227,10 +242,10 @@ steps:
           - bash: |
               published_artifacts_dir="${{ parameters.outputArtifactsFolder }}/${{ parameters.outputArtifactsPackagesSubfolder }}"
               mkdir -p "$published_artifacts_dir"
-              cp "${{ parameters.buildRepoRoot }}"/out/rpms.tar.gz "$published_artifacts_dir/${{ parameters.rpmsTarballName }}"
+              cp "${{ parameters.buildRepoRoot }}"/out/rpms.tar.gz "$published_artifacts_dir/${{ parameters.outputRPMsTarballName }}"
             displayName: "Copy RPMs for publishing"
 
-      - ${{ if parameters.srpmsTarballName }}:
+      - ${{ if parameters.outputSRPMsTarballName }}:
           - script: |
               sudo make -C "${{ parameters.buildRepoRoot }}/toolkit" compress-srpms
             displayName: "Compress SRPMs"
@@ -238,7 +253,7 @@ steps:
           - bash: |
               published_artifacts_dir="${{ parameters.outputArtifactsFolder }}/${{ parameters.outputArtifactsPackagesSubfolder }}"
               mkdir -p "$published_artifacts_dir"
-              cp "${{ parameters.buildRepoRoot }}"/out/srpms.tar.gz "$published_artifacts_dir/${{ parameters.srpmsTarballName }}"
+              cp "${{ parameters.buildRepoRoot }}"/out/srpms.tar.gz "$published_artifacts_dir/${{ parameters.outputSRPMsTarballName }}"
             displayName: "Copy SRPMs for publishing"
 
       - ${{ if parameters.publishLogs }}:


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

In more complex scenarios package builds want to hydrate their external RPMs cache from more than one source. This change makes that possible by making the input cache parameters an array.

Similarly, in some scenarios it's required to export the cache of the current package build.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Converted singe input cache into an arbitrary number of input caches.
- Added a parameter for exporting the RPMs cache.
- Updating the toolkit with the `compress-cached-rpms` target.
- Clarified the naming of the input and output parameters.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- PR check.