### PR TITLE
python-jinja2: add patch for CVE-2024-22195

### DIFF
--- a/SPECS/python-jinja2/CVE-2024-22195.patch
+++ b/SPECS/python-jinja2/CVE-2024-22195.patch
@@ -1,0 +1,92 @@
+From 58cbcf78ba645b9f0ac33257a526a5b874bfd7c1 Mon Sep 17 00:00:00 2001
+From: Tobias Brick <tobiasb@microsoft.com>
+Date: Tue, 23 Jan 2024 22:29:04 +0000
+Subject: [PATCH] Backport upstream change
+ https://github.com/pallets/jinja/commit/716795349a41d4983a9a4771f7d883c96ea17be7
+ into 3.0.3.
+
+Backport was very straightforward -- basically line numbers and a small amount of context.
+
+Based on:
+
+From 7dd3680e6eea0d77fde024763657aa4d884ddb23 Mon Sep 17 00:00:00 2001
+From: Calum Hutton <calum.hutton@snyk.io>
+Date: Thu, 26 Oct 2023 12:08:53 +0100
+Subject: [PATCH] xmlattr filter disallows keys with spaces
+---
+ src/jinja2/filters.py | 26 +++++++++++++++++++++-----
+ tests/test_filters.py |  6 ++++++
+ 2 files changed, 27 insertions(+), 5 deletions(-)
+
+diff --git a/src/jinja2/filters.py b/src/jinja2/filters.py
+index ffb98bf..4f90bfe 100644
+--- a/src/jinja2/filters.py
++++ b/src/jinja2/filters.py
+@@ -271,6 +271,9 @@ def do_lower(s: str) -> str:
+     return soft_str(s).lower()
+ 
+ 
++_space_re = re.compile(r"\s", flags=re.ASCII)
++
++
+ @pass_eval_context
+ def do_xmlattr(
+     eval_ctx: "EvalContext", d: t.Mapping[str, t.Any], autospace: bool = True
+@@ -279,6 +282,9 @@ def do_xmlattr(
+     All values that are neither `none` nor `undefined` are automatically
+     escaped:
+ 
++    If any key contains a space, this fails with a ``ValueError``. Values that
++    are neither ``none`` nor ``undefined`` are automatically escaped.
++
+     .. sourcecode:: html+jinja
+ 
+         <ul{{ {'class': 'my_list', 'missing': none,
+@@ -296,12 +302,22 @@ def do_xmlattr(
+ 
+     As you can see it automatically prepends a space in front of the item
+     if the filter returned something unless the second parameter is false.
++
++    .. versionchanged:: 3.1.3
++        Keys with spaces are not allowed. (patched for 3.0.3)
+     """
+-    rv = " ".join(
+-        f'{escape(key)}="{escape(value)}"'
+-        for key, value in d.items()
+-        if value is not None and not isinstance(value, Undefined)
+-    )
++    items = []
++
++    for key, value in d.items():
++        if value is None or isinstance(value, Undefined):
++            continue
++
++        if _space_re.search(key) is not None:
++            raise ValueError(f"Spaces are not allowed in attributes: '{key}'")
++
++        items.append(f'{escape(key)}="{escape(value)}"')
++
++    rv = " ".join(items)
+ 
+     if autospace and rv:
+         rv = " " + rv
+diff --git a/tests/test_filters.py b/tests/test_filters.py
+index 2195157..45843fd 100644
+--- a/tests/test_filters.py
++++ b/tests/test_filters.py
+@@ -463,6 +463,12 @@ class TestFilter:
+         assert 'bar="23"' in out
+         assert 'blub:blub="&lt;?&gt;"' in out
+ 
++    def test_xmlattr_key_with_spaces(self, env):
++        with pytest.raises(ValueError, match="Spaces are not allowed"):
++            env.from_string(
++                "{{ {'src=1 onerror=alert(1)': 'my_class'}|xmlattr }}"
++            ).render()
++
+     def test_sort1(self, env):
+         tmpl = env.from_string("{{ [2, 3, 1]|sort }}|{{ [2, 3, 1]|sort(true) }}")
+         assert tmpl.render() == "[1, 2, 3]|[3, 2, 1]"
+-- 
+2.33.8
+

--- a/SPECS/python-jinja2/python-jinja2.spec
+++ b/SPECS/python-jinja2/python-jinja2.spec
@@ -1,13 +1,14 @@
 Summary:        A fast and easy to use template engine written in pure Python
 Name:           python-jinja2
 Version:        3.0.3
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        BSD
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Group:          Development/Languages/Python
 URL:            https://jinja.pocoo.org/
 Source0:        https://files.pythonhosted.org/packages/91/a5/429efc6246119e1e3fbf562c00187d04e83e54619249eb732bb423efa6c6/Jinja2-%{version}.tar.gz
+Patch0:         CVE-2024-22195.patch
 BuildArch:      noarch
 
 %description
@@ -19,7 +20,7 @@ BuildRequires:  python3-devel
 BuildRequires:  python3-markupsafe >= 2.0
 BuildRequires:  python3-setuptools
 BuildRequires:  python3-xml
-%if %{with_check}
+%if 0%{?with_check}
 BuildRequires:  python3-pip
 %endif
 Requires:       python3
@@ -33,7 +34,7 @@ inspired non-XML syntax but supports inline expressions and an optional
 sandboxed environment.
 
 %prep
-%autosetup -n Jinja2-%{version}
+%autosetup -p1 -n Jinja2-%{version}
 sed -i 's/\r$//' LICENSE.rst # Fix wrong EOL encoding
 
 %build
@@ -53,6 +54,9 @@ tox -e py%{python3_version_nodots}
 %{python3_sitelib}/Jinja2-%{version}-py%{python3_version}.egg-info
 
 %changelog
+* Wed Jan 24 2024 Tobias Brick <tobiasb@microsoft.com> - 3.0.3-3
+- Backport CVE-2024-22195 from upstream
+
 * Tue Mar 15 2022 Muhammad Falak <mwani@microsoft.com> - 3.0.3-2
 - Use `py%{python3_version_nodots}` instead of harcoding `py39`
 

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -518,7 +518,7 @@ python3-Cython-0.29.33-1.cm2.aarch64.rpm
 python3-debuginfo-3.9.14-8.cm2.aarch64.rpm
 python3-devel-3.9.14-8.cm2.aarch64.rpm
 python3-gpg-1.16.0-2.cm2.aarch64.rpm
-python3-jinja2-3.0.3-2.cm2.noarch.rpm
+python3-jinja2-3.0.3-3.cm2.noarch.rpm
 python3-libcap-ng-0.8.2-2.cm2.aarch64.rpm
 python3-libs-3.9.14-8.cm2.aarch64.rpm
 python3-libxml2-2.10.4-2.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -521,7 +521,7 @@ python3-Cython-0.29.33-1.cm2.x86_64.rpm
 python3-debuginfo-3.9.14-8.cm2.x86_64.rpm
 python3-devel-3.9.14-8.cm2.x86_64.rpm
 python3-gpg-1.16.0-2.cm2.x86_64.rpm
-python3-jinja2-3.0.3-2.cm2.noarch.rpm
+python3-jinja2-3.0.3-3.cm2.noarch.rpm
 python3-libcap-ng-0.8.2-2.cm2.x86_64.rpm
 python3-libs-3.9.14-8.cm2.x86_64.rpm
 python3-libxml2-2.10.4-2.cm2.x86_64.rpm


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Fix [CVE-2024-22195](https://nvd.nist.gov/vuln/detail/CVE-2024-22195) in python-jinja2 by backporting the [upstream patch](https://github.com/pallets/jinja/commit/716795349a41d4983a9a4771f7d883c96ea17be7).

###### Change Log  <!-- REQUIRED -->
- Backported patch to apply to version 3.0.3
- updated a `with_check` to work in a containerized build

###### Does this affect the toolchain?  <!-- REQUIRED -->
**YES**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2024-22195

###### Test Methodology
- Built locally in container
- Buddy Build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=489572&view=results
- Full Build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=490014&view=results
