### PR TITLE
OS modifier: fix a bug if condition to not skip processing sshkeys when sshkeypaths is empty

### DIFF
--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -1495,22 +1495,6 @@ func ProvisionUserSSHCerts(installChroot safechroot.ChrootInterface, username st
 
 	homeDir := userutils.UserHomeDirectory(username)
 	userSSHKeyDir := filepath.Join(homeDir, ".ssh")
-
-	exists, err = file.PathExists(userSSHKeyDir)
-	if err != nil {
-		logger.Log.Warnf("Error accessing %s directory: %v", userSSHKeyDir, err)
-		return
-	}
-	if !exists {
-		logger.Log.Debugf("Directory %s does not exist. Creating directory...", userSSHKeyDir)
-
-		err = os.Mkdir(userSSHKeyDir, os.FileMode(sshDirectoryPermission))
-		if err != nil {
-			logger.Log.Warnf("Failed to create %s directory: %v", userSSHKeyDir, err)
-			return
-		}
-	}
-
 	authorizedKeysFile := filepath.Join(userSSHKeyDir, "authorized_keys")
 
 	exists, err = file.PathExists(authorizedKeysTempFile)

--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -1495,6 +1495,29 @@ func ProvisionUserSSHCerts(installChroot safechroot.ChrootInterface, username st
 
 	homeDir := userutils.UserHomeDirectory(username)
 	userSSHKeyDir := filepath.Join(homeDir, ".ssh")
+
+	exists, err = file.PathExists(userSSHKeyDir)
+	if err != nil {
+		logger.Log.Warnf("Error accessing %s directory: %v", userSSHKeyDir, err)
+		return
+	}
+	if !exists {
+		logger.Log.Debugf("Directory %s does not exist. Creating directory...", userSSHKeyDir)
+
+		var permissionVal uint64
+		permissionVal, err = strconv.ParseUint(sshDirectoryPermission, 8, 32)
+		if err != nil {
+			logger.Log.Warnf("Failed to parse permissions: %v", err)
+			return
+		}
+
+		err = os.Mkdir(userSSHKeyDir, os.FileMode(permissionVal))
+		if err != nil {
+			logger.Log.Warnf("Failed to create %s directory: %v", userSSHKeyDir, err)
+			return
+		}
+	}
+
 	authorizedKeysFile := filepath.Join(userSSHKeyDir, "authorized_keys")
 
 	exists, err = file.PathExists(authorizedKeysTempFile)

--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -1489,7 +1489,7 @@ func ProvisionUserSSHCerts(installChroot safechroot.ChrootInterface, username st
 
 	// Skip user SSH directory generation when not provided with public keys
 	// Let SSH handle the creation of this folder on its first use
-	if len(sshPubKeyPaths) == 0 {
+	if len(sshPubKeyPaths) == 0 && len(sshPubKeys) == 0 {
 		return
 	}
 

--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -1485,7 +1485,7 @@ func ProvisionUserSSHCerts(installChroot safechroot.ChrootInterface, username st
 	const squashErrors = false
 	const authorizedKeysTempFilePerms = 0644
 	const authorizedKeysTempFile = "/tmp/authorized_keys"
-	const sshDirectoryPermission = 0700
+	const sshDirectoryPermission = "0700"
 
 	// Skip user SSH directory generation when not provided with public keys
 	// Let SSH handle the creation of this folder on its first use
@@ -1585,8 +1585,7 @@ func ProvisionUserSSHCerts(installChroot safechroot.ChrootInterface, username st
 			return
 		}
 
-		sshDirectoryPermissionStr := fmt.Sprintf("%o", sshDirectoryPermission)
-		err = shell.ExecuteLive(squashErrors, "chmod", "-R", sshDirectoryPermissionStr, userSSHKeyDir)
+		err = shell.ExecuteLive(squashErrors, "chmod", "-R", sshDirectoryPermission, userSSHKeyDir)
 		return
 	})
 

--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -1485,7 +1485,7 @@ func ProvisionUserSSHCerts(installChroot safechroot.ChrootInterface, username st
 	const squashErrors = false
 	const authorizedKeysTempFilePerms = 0644
 	const authorizedKeysTempFile = "/tmp/authorized_keys"
-	const sshDirectoryPermission = "0700"
+	const sshDirectoryPermission = 0700
 
 	// Skip user SSH directory generation when not provided with public keys
 	// Let SSH handle the creation of this folder on its first use
@@ -1504,14 +1504,7 @@ func ProvisionUserSSHCerts(installChroot safechroot.ChrootInterface, username st
 	if !exists {
 		logger.Log.Debugf("Directory %s does not exist. Creating directory...", userSSHKeyDir)
 
-		var permissionVal uint64
-		permissionVal, err = strconv.ParseUint(sshDirectoryPermission, 8, 32)
-		if err != nil {
-			logger.Log.Warnf("Failed to parse permissions: %v", err)
-			return
-		}
-
-		err = os.Mkdir(userSSHKeyDir, os.FileMode(permissionVal))
+		err = os.Mkdir(userSSHKeyDir, os.FileMode(sshDirectoryPermission))
 		if err != nil {
 			logger.Log.Warnf("Failed to create %s directory: %v", userSSHKeyDir, err)
 			return
@@ -1608,7 +1601,8 @@ func ProvisionUserSSHCerts(installChroot safechroot.ChrootInterface, username st
 			return
 		}
 
-		err = shell.ExecuteLive(squashErrors, "chmod", "-R", sshDirectoryPermission, userSSHKeyDir)
+		sshDirectoryPermissionStr := fmt.Sprintf("%o", sshDirectoryPermission)
+		err = shell.ExecuteLive(squashErrors, "chmod", "-R", sshDirectoryPermissionStr, userSSHKeyDir)
 		return
 	})
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
fix a bug if condition to not skip processing sshkeys when sshkeypaths is empty

###### Change Log  <!-- REQUIRED -->
fix a bug if condition to not skip processing sshkeys when sshkeypaths is empty

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Test Methodology
test emu invocation in trident in local dev, and in the log, key was copied into .ssh/authorized_keys, and i can ssh into the vm with the private key on my local machine
![image](https://github.com/microsoft/CBL-Mariner/assets/102555676/144e4714-a342-4759-b93b-266afba9004d)
![image](https://github.com/microsoft/CBL-Mariner/assets/102555676/d691e923-47ce-48e4-b24b-8c1027f152ee)
![image](https://github.com/microsoft/CBL-Mariner/assets/102555676/05fb694c-5f3c-4638-b408-61b840c19aaa)




