### PR TITLE
Specialcased 5XX errors during package downloads.

### DIFF
--- a/toolkit/tools/downloader/downloader.go
+++ b/toolkit/tools/downloader/downloader.go
@@ -12,7 +12,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"time"
 
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/exe"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/file"
@@ -107,32 +106,24 @@ func main() {
 }
 
 func downloadFile(srcUrl, dstFile string, caCerts *x509.CertPool, tlsCerts []tls.Certificate) (err error) {
-	const (
-		// With 6 attempts, initial delay of 1 second, and a backoff factor of 3.0 the total time spent retrying will be
-		// 1 + 3 + 9 + 27 + 81 = 121 seconds.
-		downloadRetryAttempts = 6
-		failureBackoffBase    = 3.0
-		downloadRetryDuration = time.Second
-	)
 	cancel := make(chan struct{})
-
 	retryNum := 1
-	_, err = retry.RunWithExpBackoff(func() error {
+	_, err = retry.RunWithDefaultDownloadBackoff(func() error {
 		netErr := network.DownloadFile(srcUrl, dstFile, caCerts, tlsCerts)
 		if netErr != nil {
 			// Check if the error contains the string "invalid response: 404", we should print a warning in that case so the
 			// sees it even if we are running with --no-verbose. 404's are unlikely to fix themselves on retry, give up.
 			if netErr.Error() == "invalid response: 404" {
-				logger.Log.Warnf("Attempt %d/%d: Failed to download '%s' with error: '%s'", retryNum, downloadRetryAttempts, srcUrl, netErr)
+				logger.Log.Warnf("Attempt %d/%d: Failed to download '%s' with error: '%s'", retryNum, retry.DefaultDownloadRetryAttempts, srcUrl, netErr)
 				logger.Log.Warnf("404 errors are likely unrecoverable, will not retry")
 				close(cancel)
 			} else {
-				logger.Log.Infof("Attempt %d/%d: Failed to download '%s' with error: '%s'", retryNum, downloadRetryAttempts, srcUrl, netErr)
+				logger.Log.Infof("Attempt %d/%d: Failed to download '%s' with error: '%s'", retryNum, retry.DefaultDownloadRetryAttempts, srcUrl, netErr)
 			}
 		}
 		retryNum++
 		return netErr
-	}, downloadRetryAttempts, downloadRetryDuration, failureBackoffBase, cancel)
+	}, cancel)
 
 	if err != nil {
 		err = fmt.Errorf("failed to download (%s) to (%s). Error:\n%w", srcUrl, dstFile, err)

--- a/toolkit/tools/internal/packagerepo/repocloner/rpmrepocloner/rpmrepocloner.go
+++ b/toolkit/tools/internal/packagerepo/repocloner/rpmrepocloner/rpmrepocloner.go
@@ -53,8 +53,8 @@ const (
 )
 
 var (
-	serverErrorsRegex = regexp.MustCompile(`(?m)Error: (5\d{2}) when downloading`)
-	errorCodeIndex    = 1
+	serverErrorsRegex    = regexp.MustCompile(`(?m)Error: (5\d{2}) when downloading`)
+	serverErrorCodeIndex = 1
 )
 
 // RpmRepoCloner represents an RPM repository cloner.
@@ -626,6 +626,7 @@ func (r *RpmRepoCloner) clonePackage(baseArgs []string) (preBuilt bool, err erro
 				if retriable {
 					logger.Log.Debugf("Package cloning attempt %d/%d failed with a retriable error.", retryNum, retry.DefaultDownloadRetryAttempts)
 				} else {
+					logger.Log.Debugf("Package cloning attempt %d/%d failed with an unrecoverable error. Cancelling.", retryNum, retry.DefaultDownloadRetryAttempts)
 					close(cancel)
 				}
 			}
@@ -832,8 +833,8 @@ func tdnfDownload(args ...string) (err error, retriable bool) {
 	//
 	if err != nil {
 		serverErrorMatch := serverErrorsRegex.FindStringSubmatch(stderr)
-		if len(serverErrorMatch) > errorCodeIndex {
-			logger.Log.Debugf("Encountered possibly intermittent HTTP %s error.", serverErrorMatch[errorCodeIndex])
+		if len(serverErrorMatch) > serverErrorCodeIndex {
+			logger.Log.Debugf("Encountered possibly intermittent HTTP %s error.", serverErrorMatch[serverErrorCodeIndex])
 			retriable = true
 		}
 	}

--- a/toolkit/tools/internal/packagerepo/repocloner/rpmrepocloner/rpmrepocloner.go
+++ b/toolkit/tools/internal/packagerepo/repocloner/rpmrepocloner/rpmrepocloner.go
@@ -645,9 +645,9 @@ func (r *RpmRepoCloner) clonePackage(baseArgs []string) (preBuilt bool, err erro
 
 func tdnfDownload(args ...string) (err error, retriable bool) {
 	const (
-		unresolvedOutputPrefix  = "No package"
 		toyboxConflictsPrefix   = "toybox conflicts"
 		unresolvedOutputPostfix = "available"
+		unresolvedOutputPrefix  = "No package"
 	)
 
 	var (

--- a/toolkit/tools/internal/packagerepo/repocloner/rpmrepocloner/rpmrepocloner.go
+++ b/toolkit/tools/internal/packagerepo/repocloner/rpmrepocloner/rpmrepocloner.go
@@ -10,12 +10,14 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/buildpipeline"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/logger"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/packagerepo/repocloner"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/packagerepo/repomanager/rpmrepomanager"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/pkgjson"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/retry"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/safechroot"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/shell"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/tdnf"
@@ -598,9 +600,14 @@ func (r *RpmRepoCloner) Close() error {
 // It will gradually enable more repos to consider until the package is found.
 func (r *RpmRepoCloner) clonePackage(baseArgs []string) (preBuilt bool, err error) {
 	const (
-		unresolvedOutputPrefix  = "No package"
-		toyboxConflictsPrefix   = "toybox conflicts"
-		unresolvedOutputPostfix = "available"
+		// With 6 attempts, initial delay of 1 second, and a backoff factor of 3.0 the total time spent retrying will be
+		// 1 + 3 + 9 + 27 + 81 = 121 seconds.
+		//
+		// *NOTE* These values are copied from downloader/downloader.go; they need not be the same but seemed like a
+		// good enough starting point.
+		downloadRetryAttempts = 6
+		failureBackoffBase    = 3.0
+		downloadRetryDuration = time.Second
 	)
 
 	releaseverCliArg, err := tdnf.GetReleaseverCliArg()
@@ -615,44 +622,89 @@ func (r *RpmRepoCloner) clonePackage(baseArgs []string) (preBuilt bool, err erro
 
 		finalArgs := append(baseArgs, reposArgs...)
 
-		var (
-			stdout string
-			stderr string
-		)
-		stdout, stderr, err = shell.Execute("tdnf", finalArgs...)
-
-		logger.Log.Debugf("stdout: %s", stdout)
-		logger.Log.Debugf("stderr: %s", stderr)
-
-		if err != nil {
-			logger.Log.Debugf("tdnf error (will continue if the only errors are toybox conflicts):\n '%s'", stderr)
-		}
-
-		// ============== TDNF SPECIFIC IMPLEMENTATION ==============
-		// Check if TDNF could not resolve a given package. If TDNF does not find a requested package,
-		// it will not error. Instead it will print a message to stdout. Check for this message.
-		//
-		// *NOTE*: TDNF will attempt best effort. If N packages are requested, and 1 cannot be found,
-		// it will still download N-1 packages while also printing the message.
-		splitStdout := strings.Split(stdout, "\n")
-		for _, line := range splitStdout {
-			trimmedLine := strings.TrimSpace(line)
-			// Toybox conflicts are a known issue, reset the err value if encountered
-			if strings.HasPrefix(trimmedLine, toyboxConflictsPrefix) {
-				logger.Log.Warn("Ignoring known toybox conflict")
-				err = nil
-				continue
+		// We run in a retry loop on errors deemed retriable.
+		cancel := make(chan struct{})
+		retryNum := 1
+		_, err = retry.RunWithExpBackoff(func() error {
+			downloadErr, retriable := tdnfDownload(finalArgs...)
+			if downloadErr != nil {
+				if retriable {
+					logger.Log.Warnf("Attempt %d/%d: Failed to clone packages", retryNum, downloadRetryAttempts)
+				} else {
+					close(cancel)
+				}
 			}
-			// If a package was not available, update err
-			if strings.HasPrefix(trimmedLine, unresolvedOutputPrefix) && strings.HasSuffix(trimmedLine, unresolvedOutputPostfix) {
-				err = fmt.Errorf(trimmedLine)
-				break
-			}
-		}
+
+			retryNum++
+			return downloadErr
+		}, downloadRetryAttempts, downloadRetryDuration, failureBackoffBase, cancel)
 
 		if err == nil {
 			preBuilt = r.reposArgsHaveOnlyLocalSources(reposArgs)
 			break
+		}
+	}
+
+	return
+}
+
+func tdnfDownload(args ...string) (err error, retriable bool) {
+	const (
+		unresolvedOutputPrefix  = "No package"
+		toyboxConflictsPrefix   = "toybox conflicts"
+		unresolvedOutputPostfix = "available"
+	)
+
+	var (
+		stdout string
+		stderr string
+	)
+	stdout, stderr, err = shell.Execute("tdnf", args...)
+
+	logger.Log.Debugf("stdout: %s", stdout)
+	logger.Log.Debugf("stderr: %s", stderr)
+
+	if err != nil {
+		logger.Log.Debugf("tdnf error (will continue if the only errors are toybox conflicts):\n '%s'", stderr)
+	}
+
+	// ============== TDNF SPECIFIC IMPLEMENTATION ==============
+	//
+	// Check if TDNF could not resolve a given package. If TDNF does not find a requested package,
+	// it will not error. Instead it will print a message to stdout. Check for this message.
+	//
+	// *NOTE*: TDNF will attempt best effort. If N packages are requested, and 1 cannot be found,
+	// it will still download N-1 packages while also printing the message.
+	splitStdout := strings.Split(stdout, "\n")
+	for _, line := range splitStdout {
+		trimmedLine := strings.TrimSpace(line)
+		// Toybox conflicts are a known issue, reset the err value if encountered
+		if strings.HasPrefix(trimmedLine, toyboxConflictsPrefix) {
+			logger.Log.Warn("Ignoring known toybox conflict")
+			err = nil
+			continue
+		}
+		// If a package was not available, update err
+		if strings.HasPrefix(trimmedLine, unresolvedOutputPrefix) && strings.HasSuffix(trimmedLine, unresolvedOutputPostfix) {
+			err = fmt.Errorf(trimmedLine)
+			break
+		}
+	}
+
+	//
+	// *NOTE*: There are cases in which some of our upstream package repositories are hosted
+	// on services that are prone to intermittent errors (e.g., HTTP 502 errors). We
+	// specifically look for such known cases and apply some retry logic in hopes of getting
+	// a better result; note that we don't indiscriminately retry because there are legitimate
+	// cases in which the upstream repo doesn't contain the package and a 404 error is to be
+	// expected. This involves scraping through stderr, but it's better than not doing so.
+	//
+	if err != nil {
+		for _, line := range strings.Split(stderr, "\n") {
+			if strings.Contains(line, "Error: 502 when downloading") {
+				logger.Log.Warn("Encountered possibly intermittent HTTP 502 error.")
+				retriable = true
+			}
 		}
 	}
 

--- a/toolkit/tools/internal/packagerepo/repocloner/rpmrepocloner/rpmrepocloner.go
+++ b/toolkit/tools/internal/packagerepo/repocloner/rpmrepocloner/rpmrepocloner.go
@@ -624,7 +624,7 @@ func (r *RpmRepoCloner) clonePackage(baseArgs []string) (preBuilt bool, err erro
 			downloadErr, retriable := tdnfDownload(finalArgs...)
 			if downloadErr != nil {
 				if retriable {
-					logger.Log.Debugf("Package cloning attempt %d/%d failed.", retryNum, retry.DefaultDownloadRetryAttempts)
+					logger.Log.Debugf("Package cloning attempt %d/%d failed with a retriable error.", retryNum, retry.DefaultDownloadRetryAttempts)
 				} else {
 					close(cancel)
 				}

--- a/toolkit/tools/srpmpacker/srpmpacker.go
+++ b/toolkit/tools/srpmpacker/srpmpacker.go
@@ -15,7 +15,6 @@ import (
 	"runtime"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/buildpipeline"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/directory"
@@ -917,13 +916,6 @@ func tryToHydrateFromLocalSource(fileHydrationState map[string]bool, newSourceDi
 // hydrateFromRemoteSource will update fileHydrationState.
 // Will alter `currentSignatures`.
 func hydrateFromRemoteSource(fileHydrationState map[string]bool, newSourceDir string, srcConfig sourceRetrievalConfiguration, skipSignatureHandling bool, currentSignatures map[string]string, cancel <-chan struct{}, netOpsSemaphore chan struct{}) (err error) {
-	const (
-		// With 5 attempts, initial delay of 1 second, and a backoff factor of 2.0 the total time spent retrying will be
-		// ~30 seconds.
-		downloadRetryAttempts = 5
-		failureBackoffBase    = 2.0
-		downloadRetryDuration = time.Second
-	)
 	errPackerCancelReceived := fmt.Errorf("packer cancel signal received")
 
 	for fileName, alreadyHydrated := range fileHydrationState {
@@ -947,14 +939,14 @@ func hydrateFromRemoteSource(fileHydrationState map[string]bool, newSourceDir st
 			}
 		}
 
-		cancelled, internalErr := retry.RunWithExpBackoff(func() error {
+		cancelled, internalErr := retry.RunWithDefaultDownloadBackoff(func() error {
 			downloadErr := network.DownloadFile(url, destinationFile, srcConfig.caCerts, srcConfig.tlsCerts)
 			if downloadErr != nil {
 				logger.Log.Debugf("Failed an attempt to download (%s). Error: %s.", url, downloadErr)
 			}
 
 			return downloadErr
-		}, downloadRetryAttempts, downloadRetryDuration, failureBackoffBase, cancel)
+		}, cancel)
 
 		if netOpsSemaphore != nil {
 			// Clear the channel to allow another operation to start


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

Migrating #7373 to this PR as a hand-off from @reubeno.

We continue to intermittently see HTTP 502 errors (Bad Gateway) when TDNF downloads packages from packages.microsoft.com, usually in build pipelines. This PR introduces granular retry logic for that specific failure case. (We can't retry on any HTTP error, as 404 is an expected error that shows up in normal execution.)

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Update the `rpmrepcloner` to inspect stderr on TDNF download failure. If an error string indicating a 5XX error is found, then we retry with exponential backoff.
- Unified the retry logic for network downloads.
- Removed outdated logic from `rpmrepocloner` looking for errors related with the `toybox` package.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #7373

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- [Fast-track PR check build simulating building the extended packages (tends to fail due to PMC issues)](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=490221&view=results). I was able to observe a few `Package cloning attempt 1/5 failed with a retriable error.` messages in the logs followed by a successful download.