### PR TITLE
The isomaker library should return errors on failure and not terminate …

### DIFF
--- a/toolkit/tools/isomaker/isomaker.go
+++ b/toolkit/tools/isomaker/isomaker.go
@@ -37,7 +37,7 @@ func main() {
 
 	logger.InitBestEffort(*logFilePath, *logLevel)
 
-	isoMaker := isomakerlib.NewIsoMaker(
+	isoMaker, err := isomakerlib.NewIsoMaker(
 		*unattendedInstall,
 		*baseDirPath,
 		*buildDirPath,
@@ -48,5 +48,11 @@ func main() {
 		*isoRepoDirPath,
 		*outputDir,
 		*imageTag)
-	isoMaker.Make()
+	if err != nil {
+		logger.PanicOnError(err)
+	}
+	err = isoMaker.Make()
+	if err != nil {
+		logger.PanicOnError(err)
+	}
 }

--- a/toolkit/tools/pkg/isomakerlib/isomaker.go
+++ b/toolkit/tools/pkg/isomakerlib/isomaker.go
@@ -47,20 +47,25 @@ type IsoMaker struct {
 	imageNameBase      string               // Base name of the ISO to generate (no path, and no file extension).
 	imageNameTag       string               // Optional user-supplied tag appended to the generated ISO's name.
 
-	isoMakerCleanUpTasks []func() // List of clean-up tasks to perform at the end of the ISO generation process.
+	isoMakerCleanUpTasks []func() error // List of clean-up tasks to perform at the end of the ISO generation process.
 }
 
 // NewIsoMaker returns a new ISO maker.
-func NewIsoMaker(unattendedInstall bool, baseDirPath, buildDirPath, releaseVersion, resourcesDirPath, configFilePath, initrdPath, isoRepoDirPath, outputDir, imageNameTag string) *IsoMaker {
+func NewIsoMaker(unattendedInstall bool, baseDirPath, buildDirPath, releaseVersion, resourcesDirPath, configFilePath, initrdPath, isoRepoDirPath, outputDir, imageNameTag string) (*IsoMaker, error) {
 	if baseDirPath == "" {
 		baseDirPath = filepath.Dir(configFilePath)
 	}
 
 	imageNameBase := strings.TrimSuffix(filepath.Base(configFilePath), ".json")
 
-	// readConfigFile() and verifyConfig() panic if an error occurs.
-	config := readConfigFile(configFilePath, baseDirPath)
-	verifyConfig(config, unattendedInstall)
+	config, err := readConfigFile(configFilePath, baseDirPath)
+	if err != nil {
+		return nil, err
+	}
+	err = verifyConfig(config, unattendedInstall)
+	if err != nil {
+		return nil, err
+	}
 
 	return &IsoMaker{
 		enableBiosBoot:     true,
@@ -75,17 +80,19 @@ func NewIsoMaker(unattendedInstall bool, baseDirPath, buildDirPath, releaseVersi
 		outputDirPath:      outputDir,
 		imageNameBase:      imageNameBase,
 		imageNameTag:       imageNameTag,
-	}
+	}, nil
 }
 
-func NewIsoMakerWithConfig(unattendedInstall, enableBiosBoot bool, baseDirPath, buildDirPath, releaseVersion, resourcesDirPath string, config configuration.Config, initrdPath, grubCfgPath, isoRepoDirPath, outputDir, imageNameBase, imageNameTag string) *IsoMaker {
+func NewIsoMakerWithConfig(unattendedInstall, enableBiosBoot bool, baseDirPath, buildDirPath, releaseVersion, resourcesDirPath string, config configuration.Config, initrdPath, grubCfgPath, isoRepoDirPath, outputDir, imageNameBase, imageNameTag string) (*IsoMaker, error) {
 
 	if imageNameBase == "" {
 		imageNameBase = defaultImageNameBase
 	}
 
-	// verifyConfig() panics if an error occurs.
-	verifyConfig(config, unattendedInstall)
+	err := verifyConfig(config, unattendedInstall)
+	if err != nil {
+		return nil, err
+	}
 
 	return &IsoMaker{
 		enableBiosBoot:     enableBiosBoot,
@@ -101,25 +108,51 @@ func NewIsoMakerWithConfig(unattendedInstall, enableBiosBoot bool, baseDirPath, 
 		outputDirPath:      outputDir,
 		imageNameBase:      imageNameBase,
 		imageNameTag:       imageNameTag,
-	}
+	}, nil
 }
 
 // Make builds the ISO image to 'buildDirPath' with the packages included in the config JSON.
-func (im *IsoMaker) Make() {
-	defer im.isoMakerCleanUp()
+func (im *IsoMaker) Make() (err error) {
+	defer func() {
+		cleanupErr := im.isoMakerCleanUp()
+		if cleanupErr != nil {
+			if err != nil {
+				err = fmt.Errorf("%w\n%w", err, cleanupErr)
+			} else {
+				err = fmt.Errorf("%w", cleanupErr)
+			}
+		}
+	}()
 
-	im.initializePaths()
+	err = im.initializePaths()
+	if err != nil {
+		return err
+	}
 
-	im.prepareWorkDirectory()
+	err = im.prepareWorkDirectory()
+	if err != nil {
+		return err
+	}
 
-	im.createIsoRpmsRepo()
+	err = im.createIsoRpmsRepo()
+	if err != nil {
+		return err
+	}
 
-	im.prepareIsoBootLoaderFilesAndFolders()
+	err = im.prepareIsoBootLoaderFilesAndFolders()
+	if err != nil {
+		return err
+	}
 
-	im.buildIsoImage()
+	err = im.buildIsoImage()
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
-func (im *IsoMaker) buildIsoImage() {
+func (im *IsoMaker) buildIsoImage() error {
 	isoImageFilePath := im.buildIsoImageFilePath()
 
 	logger.Log.Infof("Generating ISO image under '%s'.", isoImageFilePath)
@@ -145,30 +178,51 @@ func (im *IsoMaker) buildIsoImage() {
 		// Directory to convert to an ISO.
 		im.buildDirPath)
 
-	shell.MustExecuteLive("mkisofs", mkisofsArgs...)
+	err := shell.ExecuteLive(false /*squashErrors*/, "mkisofs", mkisofsArgs...)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // prepareIsoBootLoaderFilesAndFolders copies the files required by the ISO's bootloader
-func (im *IsoMaker) prepareIsoBootLoaderFilesAndFolders() {
-	im.setUpIsoGrub2Bootloader()
+func (im *IsoMaker) prepareIsoBootLoaderFilesAndFolders() error {
+	err := im.setUpIsoGrub2Bootloader()
+	if err != nil {
+		return err
+	}
 
-	im.createVmlinuzImage()
+	err = im.createVmlinuzImage()
+	if err != nil {
+		return err
+	}
 
-	im.copyInitrd()
+	err = im.copyInitrd()
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // copyInitrd copies a pre-built initrd into the isolinux folder.
-func (im *IsoMaker) copyInitrd() {
+func (im *IsoMaker) copyInitrd() error {
 	initrdDestinationPath := filepath.Join(im.buildDirPath, "isolinux/initrd.img")
 
 	logger.Log.Debugf("Copying initrd from '%s'.", im.initrdPath)
 
-	file.Copy(im.initrdPath, initrdDestinationPath)
+	err := file.Copy(im.initrdPath, initrdDestinationPath)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // setUpIsoGrub2BootLoader prepares an efiboot.img containing Grub2,
 // which is booted in case of an UEFI boot of the ISO image.
-func (im *IsoMaker) setUpIsoGrub2Bootloader() {
+func (im *IsoMaker) setUpIsoGrub2Bootloader() (err error) {
 	const (
 		blockSizeInBytes     = 1024 * 1024
 		numberOfBlocksToCopy = 3
@@ -183,18 +237,34 @@ func (im *IsoMaker) setUpIsoGrub2Bootloader() {
 		fmt.Sprintf("count=%d", numberOfBlocksToCopy), // Number of blocks to copy to the output file.
 	}
 	logger.Log.Debugf("Creating an empty '%s' file of %d bytes.", im.efiBootImgPath, blockSizeInBytes*numberOfBlocksToCopy)
-	shell.MustExecuteLive("dd", ddArgs...)
+	err = shell.ExecuteLive(false /*squashErrors*/, "dd", ddArgs...)
+	if err != nil {
+		return err
+	}
 
 	logger.Log.Debugf("Formatting '%s' as an MS-DOS filesystem.", im.efiBootImgPath)
-	shell.MustExecuteLive("mkdosfs", im.efiBootImgPath)
+	err = shell.ExecuteLive(false /*squashErrors*/, "mkdosfs", im.efiBootImgPath)
+	if err != nil {
+		return err
+	}
 
 	efiBootImgTempMountDir := filepath.Join(im.buildDirPath, "efiboot_temp")
 	logger.Log.Tracef("Creating temporary mount directory '%s'.", efiBootImgTempMountDir)
-	logger.PanicOnError(os.Mkdir(efiBootImgTempMountDir, os.ModePerm))
+	err = os.Mkdir(efiBootImgTempMountDir, os.ModePerm)
+	if err != nil {
+		return err
+	}
 
 	defer func() {
 		logger.Log.Debugf("Removing '%s'.", efiBootImgTempMountDir)
-		logger.PanicOnError(os.RemoveAll(efiBootImgTempMountDir), "Failed to remove temporary mount directory '%s'.", efiBootImgTempMountDir)
+		cleanupErr := os.RemoveAll(efiBootImgTempMountDir)
+		if cleanupErr != nil {
+			if err != nil {
+				err = fmt.Errorf("failed to remove temporary mount directory '%s':\n%w\n%w", efiBootImgTempMountDir, err, cleanupErr)
+			} else {
+				err = fmt.Errorf("failed to remove temporary mount directory '%s':\n%w", efiBootImgTempMountDir, cleanupErr)
+			}
+		}
 	}()
 
 	mountArgs := []string{
@@ -204,34 +274,63 @@ func (im *IsoMaker) setUpIsoGrub2Bootloader() {
 		efiBootImgTempMountDir, // Path to mount the image to.
 	}
 	logger.Log.Debugf("Mounting '%s' to '%s' to copy EFI modules required to boot grub2.", im.efiBootImgPath, efiBootImgTempMountDir)
-	shell.MustExecuteLive("mount", mountArgs...)
+	err = shell.ExecuteLive(false /*squashErrors*/, "mount", mountArgs...)
+	if err != nil {
+		return err
+	}
 
 	defer func() {
 		logger.Log.Debugf("Unmounting '%s'.", efiBootImgTempMountDir)
-		logger.PanicOnError(syscall.Unmount(efiBootImgTempMountDir, 0), "Failed to unmount '%s'.", efiBootImgTempMountDir)
+		cleanupErr := syscall.Unmount(efiBootImgTempMountDir, 0)
+		if cleanupErr != nil {
+			if err != nil {
+				err = fmt.Errorf("failed to unmount '%s':\n%w\n%w", efiBootImgTempMountDir, err, cleanupErr)
+			} else {
+				err = fmt.Errorf("failed to unmount '%s':\n%w", efiBootImgTempMountDir, cleanupErr)
+			}
+		}
 	}()
 
 	logger.Log.Debug("Copying EFI modules into efiboot.img.")
 	// Copy Shim (boot<arch>64.efi) and grub2 (grub<arch>64.efi)
 	if runtime.GOARCH == "arm64" {
-		im.copyShimFromInitrd(efiBootImgTempMountDir, "bootaa64.efi", "grubaa64.efi")
+		err = im.copyShimFromInitrd(efiBootImgTempMountDir, "bootaa64.efi", "grubaa64.efi")
+		if err != nil {
+			return err
+		}
 	} else {
-		im.copyShimFromInitrd(efiBootImgTempMountDir, "bootx64.efi", "grubx64.efi")
+		err = im.copyShimFromInitrd(efiBootImgTempMountDir, "bootx64.efi", "grubx64.efi")
+		if err != nil {
+			return err
+		}
 	}
+
+	return nil
 }
 
-func (im *IsoMaker) copyShimFromInitrd(efiBootImgTempMountDir, bootBootloaderFile, grubBootloaderFile string) {
+func (im *IsoMaker) copyShimFromInitrd(efiBootImgTempMountDir, bootBootloaderFile, grubBootloaderFile string) error {
 	bootDirPath := filepath.Join(efiBootImgTempMountDir, "EFI", "BOOT")
 
 	initrdBootBootloaderFilePath := filepath.Join(initrdEFIBootDirectoryPath, bootBootloaderFile)
 	buildDirBootEFIFilePath := filepath.Join(bootDirPath, bootBootloaderFile)
-	im.extractFromInitrdAndCopy(initrdBootBootloaderFilePath, buildDirBootEFIFilePath)
+	err := im.extractFromInitrdAndCopy(initrdBootBootloaderFilePath, buildDirBootEFIFilePath)
+	if err != nil {
+		return err
+	}
 
 	initrdGrubBootloaderFilePath := filepath.Join(initrdEFIBootDirectoryPath, grubBootloaderFile)
 	buildDirGrubEFIFilePath := filepath.Join(bootDirPath, grubBootloaderFile)
-	im.extractFromInitrdAndCopy(initrdGrubBootloaderFilePath, buildDirGrubEFIFilePath)
+	err = im.extractFromInitrdAndCopy(initrdGrubBootloaderFilePath, buildDirGrubEFIFilePath)
+	if err != nil {
+		return err
+	}
 
-	im.applyRufusWorkaround(bootBootloaderFile, grubBootloaderFile)
+	err = im.applyRufusWorkaround(bootBootloaderFile, grubBootloaderFile)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // Rufus ISO-to-USB converter has a limitation where it will only copy the boot<arch>64.efi binary from a given efi*.img
@@ -245,21 +344,29 @@ func (im *IsoMaker) copyShimFromInitrd(efiBootImgTempMountDir, bootBootloaderFil
 // Rufus prioritizes the presence of an EFI folder on the ISO disk over extraction of the efi*.img archive.
 // So to workaround the limitation, create an EFI folder and make a duplicate copy of the bootloader files
 // in EFI/Boot so Rufus doesn't attempt to extract the efi*.img in the first place.
-func (im *IsoMaker) applyRufusWorkaround(bootBootloaderFile, grubBootloaderFile string) {
+func (im *IsoMaker) applyRufusWorkaround(bootBootloaderFile, grubBootloaderFile string) error {
 	const buildDirBootEFIDirectoryPath = "efi/boot"
 
 	initrdBootloaderFilePath := filepath.Join(initrdEFIBootDirectoryPath, bootBootloaderFile)
 	buildDirBootEFIUsbFilePath := filepath.Join(im.buildDirPath, buildDirBootEFIDirectoryPath, bootBootloaderFile)
-	im.extractFromInitrdAndCopy(initrdBootloaderFilePath, buildDirBootEFIUsbFilePath)
+	err := im.extractFromInitrdAndCopy(initrdBootloaderFilePath, buildDirBootEFIUsbFilePath)
+	if err != nil {
+		return err
+	}
 
 	initrdGrubEFIFilePath := filepath.Join(initrdEFIBootDirectoryPath, grubBootloaderFile)
 	buildDirGrubEFIUsbFilePath := filepath.Join(im.buildDirPath, buildDirBootEFIDirectoryPath, grubBootloaderFile)
-	im.extractFromInitrdAndCopy(initrdGrubEFIFilePath, buildDirGrubEFIUsbFilePath)
+	err = im.extractFromInitrdAndCopy(initrdGrubEFIFilePath, buildDirGrubEFIUsbFilePath)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // createVmlinuzImage builds the 'vmlinuz' file containing the Linux kernel
 // ran by the ISO bootloader.
-func (im *IsoMaker) createVmlinuzImage() {
+func (im *IsoMaker) createVmlinuzImage() error {
 	const bootKernelFile = "boot/vmlinuz"
 
 	vmlinuzFilePath := filepath.Join(im.buildDirPath, "isolinux/vmlinuz")
@@ -267,55 +374,87 @@ func (im *IsoMaker) createVmlinuzImage() {
 	// In order to select the correct kernel for isolinux, open the initrd archive
 	// and extract the vmlinuz file in it. An initrd is a gzip of a cpio archive.
 	//
-	im.extractFromInitrdAndCopy(bootKernelFile, vmlinuzFilePath)
+	err := im.extractFromInitrdAndCopy(bootKernelFile, vmlinuzFilePath)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // createIsoRpmsRepo initializes the RPMs repo on the ISO image
 // later accessed by the ISO installer.
-func (im *IsoMaker) createIsoRpmsRepo() {
+func (im *IsoMaker) createIsoRpmsRepo() error {
 	isoRpmsRepoDirPath := filepath.Join(im.buildDirPath, "RPMS")
 
 	logger.Log.Debugf("Creating ISO RPMs repo under '%s'.", isoRpmsRepoDirPath)
 
-	logger.PanicOnError(os.MkdirAll(isoRpmsRepoDirPath, os.ModePerm), "Failed to mkdir '%s'.", isoRpmsRepoDirPath)
+	err := os.MkdirAll(isoRpmsRepoDirPath, os.ModePerm)
+	if err != nil {
+		return fmt.Errorf("failed to mkdir '%s'.", isoRpmsRepoDirPath)
+	}
 
 	fetchedRepoDirContentsPath := filepath.Join(im.fetchedRepoDirPath, "*")
-	recursiveCopyDereferencingLinks(fetchedRepoDirContentsPath, isoRpmsRepoDirPath)
+	err = recursiveCopyDereferencingLinks(fetchedRepoDirContentsPath, isoRpmsRepoDirPath)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // prepareWorkDirectory makes sure we start with a clean directory
 // under "im.buildDirPath". The work directory will contain the contents of the ISO image.
-func (im *IsoMaker) prepareWorkDirectory() {
+func (im *IsoMaker) prepareWorkDirectory() error {
 	logger.Log.Infof("Building ISO under '%s'.", im.buildDirPath)
 
 	exists, err := file.DirExists(im.buildDirPath)
-	logger.PanicOnError(err, "Failed while checking if directory '%s' exists.", im.buildDirPath)
+	if err != nil {
+		return fmt.Errorf("failed while checking if directory '%s' exists:\n%w", im.buildDirPath, err)
+	}
 	if exists {
 		logger.Log.Warningf("Unexpected: temporary ISO build path '%s' exists. Removing.", im.buildDirPath)
 		logger.PanicOnError(os.RemoveAll(im.buildDirPath), "Failed while removing directory '%s'.", im.buildDirPath)
 	}
 
-	logger.PanicOnError(os.Mkdir(im.buildDirPath, os.ModePerm), "Failed while creating directory '%s'.", im.buildDirPath)
+	err = os.Mkdir(im.buildDirPath, os.ModePerm)
+	if err != nil {
+		return fmt.Errorf("failed while creating directory '%s':\n%w", im.buildDirPath, err)
+	}
 
-	im.deferIsoMakerCleanUp(func() {
+	im.deferIsoMakerCleanUp(func() error {
 		logger.Log.Debugf("Removing '%s'.", im.buildDirPath)
-
-		logger.PanicOnError(os.RemoveAll(im.buildDirPath), "Failed to remove '%s'.", im.buildDirPath)
+		err := os.RemoveAll(im.buildDirPath)
+		if err != nil {
+			err = fmt.Errorf("failed to remove '%s':\n%w", im.buildDirPath, err)
+		}
+		return err
 	})
 
-	im.copyStaticIsoRootFiles()
+	err = im.copyStaticIsoRootFiles()
+	if err != nil {
+		return err
+	}
 
-	im.copyArchitectureDependentIsoRootFiles()
+	err = im.copyArchitectureDependentIsoRootFiles()
+	if err != nil {
+		return err
+	}
 
-	im.copyAndRenameConfigFiles()
+	err = im.copyAndRenameConfigFiles()
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // copyStaticIsoRootFiles copies architecture-independent files from the
 // Mariner repo directories.
-func (im *IsoMaker) copyStaticIsoRootFiles() {
+func (im *IsoMaker) copyStaticIsoRootFiles() error {
 
 	if im.resourcesDirPath == "" && im.grubCfgPath == "" {
-		logger.Log.Panicf("missing required parameters. Must specify either the resources directory or provide a grub.cfg.")
+		return fmt.Errorf("missing required parameters. Must specify either the resources directory or provide a grub.cfg.")
 	}
 
 	if im.resourcesDirPath != "" {
@@ -323,7 +462,10 @@ func (im *IsoMaker) copyStaticIsoRootFiles() {
 
 		logger.Log.Debugf("Copying static ISO root files from '%s' to '%s'.", staticIsoRootFilesPath, im.buildDirPath)
 
-		recursiveCopyDereferencingLinks(staticIsoRootFilesPath, im.buildDirPath)
+		err := recursiveCopyDereferencingLinks(staticIsoRootFilesPath, im.buildDirPath)
+		if err != nil {
+			return err
+		}
 	}
 
 	// im.grubCfgPath allows the user to overwrite the default grub.cfg that is
@@ -331,16 +473,23 @@ func (im *IsoMaker) copyStaticIsoRootFiles() {
 	if im.grubCfgPath != "" {
 		targetGrubCfg := filepath.Join(im.buildDirPath, "boot/grub2/grub.cfg")
 		targetGrubCfgDir := filepath.Dir(targetGrubCfg)
-		logger.PanicOnError(os.MkdirAll(targetGrubCfgDir, os.ModePerm), "Failed while creating directory '%s'.", targetGrubCfgDir)
+		err := os.MkdirAll(targetGrubCfgDir, os.ModePerm)
+		if err != nil {
+			return fmt.Errorf("failed while creating directory '%s':\n%w", targetGrubCfgDir, err)
+		}
 
-		logger.Log.Debugf("Copying '%s' to '%s'.", im.grubCfgPath, targetGrubCfg)
-		shell.MustExecuteLive("cp", im.grubCfgPath, targetGrubCfg)
+		err = file.Copy(im.grubCfgPath, targetGrubCfg)
+		if err != nil {
+			return err
+		}
 	}
+
+	return nil
 }
 
 // copyArchitectureDependentIsoRootFiles copies the pre-built BIOS modules required
 // to boot the ISO image.
-func (im *IsoMaker) copyArchitectureDependentIsoRootFiles() {
+func (im *IsoMaker) copyArchitectureDependentIsoRootFiles() error {
 	// If the user does not want the generated ISO to have the BIOS bootloaders
 	// (which are copied from the im.resourcesDirPath folder), the user can
 	// either set im.resourcesDirPath to an empty string or enableBiosBoot to
@@ -352,7 +501,7 @@ func (im *IsoMaker) copyArchitectureDependentIsoRootFiles() {
 	// enableBiosBoot will not affect those on-architecture dependent files
 	// though.
 	if im.resourcesDirPath == "" || !im.enableBiosBoot {
-		return
+		return nil
 	}
 
 	if im.resourcesDirPath == "" && im.enableBiosBoot {
@@ -363,33 +512,57 @@ func (im *IsoMaker) copyArchitectureDependentIsoRootFiles() {
 
 	logger.Log.Debugf("Copying architecture-dependent (%s) ISO root files from '%s'.", runtime.GOARCH, architectureDependentFilesDirectory)
 
-	recursiveCopyDereferencingLinks(architectureDependentFilesDirectory, im.buildDirPath)
+	return recursiveCopyDereferencingLinks(architectureDependentFilesDirectory, im.buildDirPath)
 }
 
 // copyAndRenameConfigFiles takes care of copying the config JSON along with all the files
 // required by the installed system.
-func (im *IsoMaker) copyAndRenameConfigFiles() {
+func (im *IsoMaker) copyAndRenameConfigFiles() error {
 	const configDirName = "config"
 
 	logger.Log.Debugf("Copying the config JSON and required files to the ISO's root.")
 
 	configFilesAbsDirPath := filepath.Join(im.buildDirPath, configDirName)
-	logger.PanicOnError(os.Mkdir(configFilesAbsDirPath, os.ModePerm), "Failed to create ISO's config files directory under '%s'.", configFilesAbsDirPath)
-
-	im.copyAndRenameAdditionalFiles(configFilesAbsDirPath)
-	im.copyAndRenamePackagesJSONs(configFilesAbsDirPath)
-	im.copyAndRenamePreInstallScripts(configFilesAbsDirPath)
-	im.copyAndRenamePostInstallScripts(configFilesAbsDirPath)
-	im.copyAndRenameFinalizeImageScripts(configFilesAbsDirPath)
-	im.copyAndRenameSSHPublicKeys(configFilesAbsDirPath)
-	im.saveConfigJSON(configFilesAbsDirPath)
+	err := os.Mkdir(configFilesAbsDirPath, os.ModePerm)
+	if err != nil {
+		return fmt.Errorf("failed to create ISO's config files directory under '%s':\n%w", configFilesAbsDirPath, err)
+	}
+	err = im.copyAndRenameAdditionalFiles(configFilesAbsDirPath)
+	if err != nil {
+		return err
+	}
+	err = im.copyAndRenamePackagesJSONs(configFilesAbsDirPath)
+	if err != nil {
+		return err
+	}
+	err = im.copyAndRenamePreInstallScripts(configFilesAbsDirPath)
+	if err != nil {
+		return err
+	}
+	err = im.copyAndRenamePostInstallScripts(configFilesAbsDirPath)
+	if err != nil {
+		return err
+	}
+	err = im.copyAndRenameFinalizeImageScripts(configFilesAbsDirPath)
+	if err != nil {
+		return err
+	}
+	err = im.copyAndRenameSSHPublicKeys(configFilesAbsDirPath)
+	if err != nil {
+		return err
+	}
+	err = im.saveConfigJSON(configFilesAbsDirPath)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 // copyAndRenameAdditionalFiles will copy all additional files into an
 // ISO directory to make them available to the installer.
 // Each file gets placed in a separate directory to avoid potential name conflicts and
 // the config gets updated with the new ISO paths.
-func (im *IsoMaker) copyAndRenameAdditionalFiles(configFilesAbsDirPath string) {
+func (im *IsoMaker) copyAndRenameAdditionalFiles(configFilesAbsDirPath string) error {
 	const additionalFilesSubDirName = "additionalfiles"
 
 	for i := range im.config.SystemConfigs {
@@ -397,98 +570,128 @@ func (im *IsoMaker) copyAndRenameAdditionalFiles(configFilesAbsDirPath string) {
 
 		absAdditionalFiles := make(map[string]configuration.FileConfigList)
 		for localAbsFilePath, installedSystemFileConfigs := range systemConfig.AdditionalFiles {
-			isoRelativeFilePath := im.copyFileToConfigRoot(configFilesAbsDirPath, additionalFilesSubDirName, localAbsFilePath)
+			isoRelativeFilePath, err := im.copyFileToConfigRoot(configFilesAbsDirPath, additionalFilesSubDirName, localAbsFilePath)
+			if err != nil {
+				return err
+			}
 			absAdditionalFiles[isoRelativeFilePath] = installedSystemFileConfigs
 		}
 		systemConfig.AdditionalFiles = absAdditionalFiles
 	}
+
+	return nil
 }
 
 // copyAndRenamePackagesJSONs will copy all package list JSONs into an
 // ISO directory to make them available to the installer.
 // Each file gets placed in a separate directory to avoid potential name conflicts and
 // the config gets updated with the new ISO paths.
-func (im *IsoMaker) copyAndRenamePackagesJSONs(configFilesAbsDirPath string) {
+func (im *IsoMaker) copyAndRenamePackagesJSONs(configFilesAbsDirPath string) error {
 	const packagesSubDirName = "packages"
 
 	for _, systemConfig := range im.config.SystemConfigs {
 		for i, localPackagesAbsFilePath := range systemConfig.PackageLists {
-			isoPackagesRelativeFilePath := im.copyFileToConfigRoot(configFilesAbsDirPath, packagesSubDirName, localPackagesAbsFilePath)
+			isoPackagesRelativeFilePath, err := im.copyFileToConfigRoot(configFilesAbsDirPath, packagesSubDirName, localPackagesAbsFilePath)
+			if err != nil {
+				return err
+			}
 
 			systemConfig.PackageLists[i] = isoPackagesRelativeFilePath
 		}
 	}
+
+	return nil
 }
 
 // copyAndRenamePreInstallScripts will copy all pre-install scripts into an
 // ISO directory to make them available to the installer.
 // Each file gets placed in a separate directory to avoid potential name conflicts and
 // the config gets updated with the new ISO paths.
-func (im *IsoMaker) copyAndRenamePreInstallScripts(configFilesAbsDirPath string) {
+func (im *IsoMaker) copyAndRenamePreInstallScripts(configFilesAbsDirPath string) error {
 	const preInstallScriptsSubDirName = "preinstallscripts"
 
 	for _, systemConfig := range im.config.SystemConfigs {
 		for i, localScriptAbsFilePath := range systemConfig.PreInstallScripts {
-			isoScriptRelativeFilePath := im.copyFileToConfigRoot(configFilesAbsDirPath, preInstallScriptsSubDirName, localScriptAbsFilePath.Path)
+			isoScriptRelativeFilePath, err := im.copyFileToConfigRoot(configFilesAbsDirPath, preInstallScriptsSubDirName, localScriptAbsFilePath.Path)
+			if err != nil {
+				return err
+			}
 
 			systemConfig.PreInstallScripts[i].Path = isoScriptRelativeFilePath
 		}
 	}
+
+	return nil
 }
 
 // copyAndRenamePostInstallScripts will copy all post-install scripts into an
 // ISO directory to make them available to the installer.
 // Each file gets placed in a separate directory to avoid potential name conflicts and
 // the config gets updated with the new ISO paths.
-func (im *IsoMaker) copyAndRenamePostInstallScripts(configFilesAbsDirPath string) {
+func (im *IsoMaker) copyAndRenamePostInstallScripts(configFilesAbsDirPath string) error {
 	const postInstallScriptsSubDirName = "postinstallscripts"
 
 	for _, systemConfig := range im.config.SystemConfigs {
 		for i, localScriptAbsFilePath := range systemConfig.PostInstallScripts {
-			isoScriptRelativeFilePath := im.copyFileToConfigRoot(configFilesAbsDirPath, postInstallScriptsSubDirName, localScriptAbsFilePath.Path)
+			isoScriptRelativeFilePath, err := im.copyFileToConfigRoot(configFilesAbsDirPath, postInstallScriptsSubDirName, localScriptAbsFilePath.Path)
+			if err != nil {
+				return err
+			}
 
 			systemConfig.PostInstallScripts[i].Path = isoScriptRelativeFilePath
 		}
 	}
+
+	return nil
 }
 
 // copyAndRenameFinalizeImageScripts will copy all finalize-image scripts into an
 // ISO directory to make them available to the installer.
 // Each file gets placed in a separate directory to avoid potential name conflicts and
 // the config gets updated with the new ISO paths.
-func (im *IsoMaker) copyAndRenameFinalizeImageScripts(configFilesAbsDirPath string) {
+func (im *IsoMaker) copyAndRenameFinalizeImageScripts(configFilesAbsDirPath string) error {
 	const finalizeImageScriptsSubDirName = "finalizeimagescripts"
 
 	for _, systemConfig := range im.config.SystemConfigs {
 		for i, localScriptAbsFilePath := range systemConfig.FinalizeImageScripts {
-			isoScriptRelativeFilePath := im.copyFileToConfigRoot(configFilesAbsDirPath, finalizeImageScriptsSubDirName, localScriptAbsFilePath.Path)
+			isoScriptRelativeFilePath, err := im.copyFileToConfigRoot(configFilesAbsDirPath, finalizeImageScriptsSubDirName, localScriptAbsFilePath.Path)
+			if err != nil {
+				return err
+			}
 
 			systemConfig.FinalizeImageScripts[i].Path = isoScriptRelativeFilePath
 		}
 	}
+
+	return nil
 }
 
 // copyAndRenameSSHPublicKeys will copy all SSH public keys into an
 // ISO directory to make them available to the installer.
 // Each file gets placed in a separate directory to avoid potential name conflicts and
 // the config gets updated with the new ISO paths.
-func (im *IsoMaker) copyAndRenameSSHPublicKeys(configFilesAbsDirPath string) {
+func (im *IsoMaker) copyAndRenameSSHPublicKeys(configFilesAbsDirPath string) error {
 	const sshPublicKeysSubDirName = "sshpublickeys"
 
 	for _, systemConfig := range im.config.SystemConfigs {
 		for _, user := range systemConfig.Users {
 			for i, localSSHPublicKeyAbsPath := range user.SSHPubKeyPaths {
-				isoSSHPublicKeyRelativeFilePath := im.copyFileToConfigRoot(configFilesAbsDirPath, sshPublicKeysSubDirName, localSSHPublicKeyAbsPath)
+				isoSSHPublicKeyRelativeFilePath, err := im.copyFileToConfigRoot(configFilesAbsDirPath, sshPublicKeysSubDirName, localSSHPublicKeyAbsPath)
+				if err != nil {
+					return err
+				}
 
 				user.SSHPubKeyPaths[i] = isoSSHPublicKeyRelativeFilePath
 			}
 		}
 	}
+
+	return nil
 }
 
 // saveConfigJSON will save the modified config JSON into an
 // ISO directory to make it available to the installer.
-func (im *IsoMaker) saveConfigJSON(configFilesAbsDirPath string) {
+func (im *IsoMaker) saveConfigJSON(configFilesAbsDirPath string) error {
 	const (
 		attendedInstallConfigFileName   = "attended_config.json"
 		unattendedInstallConfigFileName = "unattended_config.json"
@@ -499,37 +702,51 @@ func (im *IsoMaker) saveConfigJSON(configFilesAbsDirPath string) {
 		isoConfigFileAbsPath = filepath.Join(configFilesAbsDirPath, unattendedInstallConfigFileName)
 	}
 
-	logger.PanicOnError(jsonutils.WriteJSONFile(isoConfigFileAbsPath, &im.config), "Failed to save config JSON to '%s'.", isoConfigFileAbsPath)
+	err := jsonutils.WriteJSONFile(isoConfigFileAbsPath, &im.config)
+	if err != nil {
+		return fmt.Errorf("failed to save config JSON to '%s':\n%w", isoConfigFileAbsPath, err)
+	}
+	return nil
 }
 
 // copyFileToConfigRoot copies a single file to its own, numbered subdirectory to avoid name conflicts
 // and returns the relative path to the file for the sake of config updates for the installer.
-func (im *IsoMaker) copyFileToConfigRoot(configFilesAbsDirPath, configFilesSubDirName, localAbsFilePath string) string {
+func (im *IsoMaker) copyFileToConfigRoot(configFilesAbsDirPath, configFilesSubDirName, localAbsFilePath string) (string, error) {
 	fileName := filepath.Base(localAbsFilePath)
 	configFileSubDirRelativePath := fmt.Sprintf("%s/%d", configFilesSubDirName, im.configSubDirNumber)
 	configFileSubDirAbsPath := filepath.Join(configFilesAbsDirPath, configFileSubDirRelativePath)
 
-	logger.PanicOnError(os.MkdirAll(configFileSubDirAbsPath, os.ModePerm), "Failed to create ISO's config subdirectory '%s'.", configFileSubDirAbsPath)
+	err := os.MkdirAll(configFileSubDirAbsPath, os.ModePerm)
+	if err != nil {
+		return "", fmt.Errorf("failed to create ISO's config subdirectory '%s':\n%w", configFileSubDirAbsPath, err)
+	}
 
 	isoRelativeFilePath := filepath.Join(configFileSubDirRelativePath, fileName)
 	isoAbsFilePath := filepath.Join(configFilesAbsDirPath, isoRelativeFilePath)
 
 	logger.Log.Tracef("Copying file to ISO's config root '%s' from '%s'.", isoAbsFilePath, localAbsFilePath)
 
-	logger.PanicOnError(file.Copy(localAbsFilePath, isoAbsFilePath), "Failed to copy file to ISO's config root '%s' from '%s'.", isoAbsFilePath, localAbsFilePath)
+	err = file.Copy(localAbsFilePath, isoAbsFilePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to copy file to ISO's config root '%s' from '%s':\n%w", isoAbsFilePath, localAbsFilePath, err)
+	}
 
 	im.configSubDirNumber++
 
-	return isoRelativeFilePath
+	return isoRelativeFilePath, nil
 }
 
 // initializePaths initializes absolute, global directory paths used by multiple other functions.
-func (im *IsoMaker) initializePaths() {
+func (im *IsoMaker) initializePaths() error {
 	var err error
 	im.buildDirPath, err = filepath.Abs(im.buildDirPath)
-	logger.PanicOnError(err, "Failed while retrieving absolute path from source root path: '%s'.", im.buildDirPath)
+	if err != nil {
+		return fmt.Errorf("failed while retrieving absolute path from source root path: '%s':\n%w", im.buildDirPath, err)
+	}
 
 	im.efiBootImgPath = filepath.Join(im.buildDirPath, efiBootImgPathRelativeToIsoRoot)
+
+	return nil
 }
 
 // buildIsoImageFilePath gets the output ISO file path from the config JSON file name
@@ -546,27 +763,39 @@ func (im *IsoMaker) buildIsoImageFilePath() string {
 
 // deferIsoMakerCleanUp accepts clean-up tasks to be ran when the entire
 // build process has finished, NOT at the end of the current scope.
-func (im *IsoMaker) deferIsoMakerCleanUp(cleanUpTask func()) {
+func (im *IsoMaker) deferIsoMakerCleanUp(cleanUpTask func() error) {
 	im.isoMakerCleanUpTasks = append(im.isoMakerCleanUpTasks, cleanUpTask)
 }
 
 // isoMakerCleanUp runs all clean-up tasks scheduled through "deferIsoMakerCleanUp".
 // Tasks are ran in reverse order to how they were scheduled.
-func (im *IsoMaker) isoMakerCleanUp() {
+func (im *IsoMaker) isoMakerCleanUp() (err error) {
 	// We defer again to run the tasks in the correct order AND so that a potential
 	// panic from one of these doesn't prevent other ones from running.
 	for _, cleanUpTask := range im.isoMakerCleanUpTasks {
-		defer cleanUpTask()
+		defer func() {
+			cleanupErr := cleanUpTask()
+			if cleanupErr != nil {
+				if err != nil {
+					err = fmt.Errorf("%w\n%w", err, cleanupErr)
+				} else {
+					err = fmt.Errorf("%w", cleanupErr)
+				}
+			}
+		}()
 	}
+	return err
 }
 
-func readConfigFile(configFilePath, baseDirPath string) configuration.Config {
+func readConfigFile(configFilePath, baseDirPath string) (configuration.Config, error) {
 	config, err := configuration.LoadWithAbsolutePaths(configFilePath, baseDirPath)
-	logger.PanicOnError(err, "Failed while reading config file from '%s' with base directory '%s'.", configFilePath, baseDirPath)
-	return config
+	if err != nil {
+		return configuration.Config{}, fmt.Errorf("failed while reading config file from '%s' with base directory '%s':\n%w", configFilePath, baseDirPath, err)
+	}
+	return config, nil
 }
 
-func verifyConfig(config configuration.Config, unattendedInstall bool) {
+func verifyConfig(config configuration.Config, unattendedInstall bool) error {
 
 	// Set IsIsoInstall to true
 	for id := range config.SystemConfigs {
@@ -574,20 +803,25 @@ func verifyConfig(config configuration.Config, unattendedInstall bool) {
 	}
 
 	if unattendedInstall && (len(config.SystemConfigs) > 1) && !config.DefaultSystemConfig.IsDefault {
-		logger.Log.Panic("For unattended installation with more than one system configuration present you must select a default one with the [IsDefault] field.")
+		return fmt.Errorf("for unattended installation with more than one system configuration present you must select a default one with the [IsDefault] field.")
 	}
+	return nil
 }
 
 // recursiveCopyDereferencingLinks simulates the behavior of "cp -r -L".
-func recursiveCopyDereferencingLinks(source string, target string) {
+func recursiveCopyDereferencingLinks(source string, target string) error {
 	err := os.MkdirAll(target, os.ModePerm)
-	logger.PanicOnError(err)
+	if err != nil {
+		return err
+	}
 
 	sourceToTarget := make(map[string]string)
 
 	if filepath.Base(source) == "*" {
 		filesToCopy, err := filepath.Glob(source)
-		logger.PanicOnError(err)
+		if err != nil {
+			return err
+		}
 		for _, file := range filesToCopy {
 			sourceToTarget[file] = target
 		}
@@ -596,21 +830,30 @@ func recursiveCopyDereferencingLinks(source string, target string) {
 	}
 
 	for sourcePath, targetPath := range sourceToTarget {
-		shell.MustExecuteLive("cp", "-r", "-L", sourcePath, targetPath)
+		err := shell.ExecuteLive(false /*squashErrors*/, "cp", "-r", "-L", sourcePath, targetPath)
+		if err != nil {
+			return err
+		}
 	}
+
+	return nil
 }
 
-func (im *IsoMaker) extractFromInitrdAndCopy(srcFileName, destFilePath string) {
+func (im *IsoMaker) extractFromInitrdAndCopy(srcFileName, destFilePath string) error {
 	// Setup a series of io readers: initrd file -> parallelized gzip -> cpio
 
 	logger.Log.Debugf("Searching for (%s) in initrd (%s) and copying to (%s)", srcFileName, im.initrdPath, destFilePath)
 
 	initrdFile, err := os.Open(im.initrdPath)
-	logger.PanicOnError(err)
+	if err != nil {
+		return err
+	}
 	defer initrdFile.Close()
 
 	gzipReader, err := pgzip.NewReader(initrdFile)
-	logger.PanicOnError(err)
+	if err != nil {
+		return err
+	}
 	cpioReader := cpio.NewReader(gzipReader)
 
 	for {
@@ -618,24 +861,33 @@ func (im *IsoMaker) extractFromInitrdAndCopy(srcFileName, destFilePath string) {
 		var hdr *cpio.Header
 		hdr, err = cpioReader.Next()
 		if err == io.EOF {
-			err = fmt.Errorf("did not find (%s) in initrd (%s)", srcFileName, im.initrdPath)
-			logger.PanicOnError(err)
+			return fmt.Errorf("did not find (%s) in initrd (%s)", srcFileName, im.initrdPath)
 		}
-		logger.PanicOnError(err)
+		if err != nil {
+			return err
+		}
 
 		if strings.HasPrefix(hdr.Name, srcFileName) {
 			logger.Log.Debugf("Found source file (%s) in initrd", srcFileName)
 			// Source file found, copy it to destination
 			err = os.MkdirAll(filepath.Dir(destFilePath), os.ModePerm)
-			logger.PanicOnError(err)
+			if err != nil {
+				return err
+			}
+
 			dstFile, err := os.Create(destFilePath)
-			logger.PanicOnError(err)
+			if err != nil {
+				return err
+			}
 			defer dstFile.Close()
 
 			logger.Log.Debugf("Copying (%s) to (%s)", srcFileName, destFilePath)
 			_, err = io.Copy(dstFile, cpioReader)
-			logger.PanicOnError(err)
+			if err != nil {
+				return err
+			}
 			break
 		}
 	}
+	return nil
 }

--- a/toolkit/tools/pkg/isomakerlib/isomaker.go
+++ b/toolkit/tools/pkg/isomakerlib/isomaker.go
@@ -380,7 +380,7 @@ func (im *IsoMaker) createIsoRpmsRepo() (err error) {
 
 	err = os.MkdirAll(isoRpmsRepoDirPath, os.ModePerm)
 	if err != nil {
-		return fmt.Errorf("failed to mkdir '%s'.", isoRpmsRepoDirPath)
+		return fmt.Errorf("failed to mkdir '%s'", isoRpmsRepoDirPath)
 	}
 
 	fetchedRepoDirContentsPath := filepath.Join(im.fetchedRepoDirPath, "*")
@@ -402,7 +402,7 @@ func (im *IsoMaker) prepareWorkDirectory() (err error) {
 		return fmt.Errorf("failed while checking if directory '%s' exists:\n%w", im.buildDirPath, err)
 	}
 	if exists {
-		logger.Log.Warningf("Unexpected: temporary ISO build path '%s' exists. Removing.", im.buildDirPath)
+		logger.Log.Warningf("Unexpected: temporary ISO build path '%s' exists. Removing", im.buildDirPath)
 		err = os.RemoveAll(im.buildDirPath)
 		if err != nil {
 			return fmt.Errorf("failed while removing directory '%s':\n%w", im.buildDirPath, err)
@@ -414,13 +414,13 @@ func (im *IsoMaker) prepareWorkDirectory() (err error) {
 		return fmt.Errorf("failed while creating directory '%s':\n%w", im.buildDirPath, err)
 	}
 
-	im.deferIsoMakerCleanUp(func() error {
+	im.deferIsoMakerCleanUp(func() (removeErr error) {
 		logger.Log.Debugf("Removing '%s'.", im.buildDirPath)
-		err := os.RemoveAll(im.buildDirPath)
-		if err != nil {
-			err = fmt.Errorf("failed to remove '%s':\n%w", im.buildDirPath, err)
+		removeErr = os.RemoveAll(im.buildDirPath)
+		if removeErr != nil {
+			removeErr = fmt.Errorf("failed to remove '%s':\n%w", im.buildDirPath, err)
 		}
-		return err
+		return removeErr
 	})
 
 	err = im.copyStaticIsoRootFiles()
@@ -446,13 +446,13 @@ func (im *IsoMaker) prepareWorkDirectory() (err error) {
 func (im *IsoMaker) copyStaticIsoRootFiles() (err error) {
 
 	if im.resourcesDirPath == "" && im.grubCfgPath == "" {
-		return fmt.Errorf("missing required parameters. Must specify either the resources directory or provide a grub.cfg.")
+		return fmt.Errorf("missing required parameters. Must specify either the resources directory or provide a grub.cfg")
 	}
 
 	if im.resourcesDirPath != "" {
 		staticIsoRootFilesPath := filepath.Join(im.resourcesDirPath, "assets/isomaker/iso_root_static_files/*")
 
-		logger.Log.Debugf("Copying static ISO root files from '%s' to '%s'.", staticIsoRootFilesPath, im.buildDirPath)
+		logger.Log.Debugf("Copying static ISO root files from '%s' to '%s'", staticIsoRootFilesPath, im.buildDirPath)
 
 		err = recursiveCopyDereferencingLinks(staticIsoRootFilesPath, im.buildDirPath)
 		if err != nil {
@@ -497,7 +497,7 @@ func (im *IsoMaker) copyArchitectureDependentIsoRootFiles() error {
 	}
 
 	if im.resourcesDirPath == "" && im.enableBiosBoot {
-		return fmt.Errorf("missing required parameters. Must specify the resources directory if BIOS bootloaders are to be included.")
+		return fmt.Errorf("missing required parameters. Must specify the resources directory if BIOS bootloaders are to be included")
 	}
 
 	architectureDependentFilesDirectory := filepath.Join(im.resourcesDirPath, isoRootArchDependentDirPath, runtime.GOARCH, "*")
@@ -791,7 +791,7 @@ func verifyConfig(config configuration.Config, unattendedInstall bool) error {
 	}
 
 	if unattendedInstall && (len(config.SystemConfigs) > 1) && !config.DefaultSystemConfig.IsDefault {
-		return fmt.Errorf("for unattended installation with more than one system configuration present you must select a default one with the [IsDefault] field.")
+		return fmt.Errorf("for unattended installation with more than one system configuration present you must select a default one with the [IsDefault] field")
 	}
 	return nil
 }


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
IsoMaker was originally written as a single go package.  However, as MIC is starting to support ISO, it needs to share some of this code, and the code has been refactored into a separate package.
The problem is that this code still panics when errors are returned. A software library should not painic and terminate the process. Instead, it should report errors to the caller, and the caller can decide how to handle it.
This change converts all function calls in the isomaker pkg to return error codes.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Update pkg/isomakerlib so that it does not panic on error, and instead returns an error.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- [6755 Update iso maker golang pkg to return errors](https://dev.azure.com/mariner-org/ECF/_workitems/edit/6755)

###### Links to CVEs  <!-- optional -->
- n/a

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Build an iso based on the baremetal image defintiion.
- Install the iso on a hyper-v VM.
