### PR TITLE
Update dracut to allow supressing user confirmation prompt when the liveos overlay is backed by memory.

### DIFF
--- a/SPECS/dracut/allow-liveos-overlay-no-user-confirmation-prompt.patch
+++ b/SPECS/dracut/allow-liveos-overlay-no-user-confirmation-prompt.patch
@@ -1,0 +1,49 @@
+From 4d47f0bae243577a4cf634ae5e01b324cf78e7eb Mon Sep 17 00:00:00 2001
+From: George Mileka <gmileka@microsoft.com>
+Date: Thu, 25 Jan 2024 15:06:13 -0800
+Subject: [PATCH] Update dracut to allow supressing user confirmation prompt
+ when the liveos overlay is backed by memory.
+
+Dracut allows the creation of a LiveOS using a read-only squashfs and an read-write overlay on top.
+
+If the read-write overlay is backed by a ram-disk, Dracut halts booting and prompts the user to confirm
+whether to continue or not.
+
+This interaction during the boot process is not desired in all cases.
+
+This change introduces a new flag (rd.live.overlay.nouserconfirmprompt) that when defined, it supresses
+the prompt and allows the boot process to continue to completion without user interation.
+
+There is no impact to existing configurations and their associated behavior. Only when the new switch
+is explicitly define by the image build (as a kernel parameter), the new behavior will take effect.
+---
+ modules.d/90dmsquash-live/dmsquash-live-root.sh | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/modules.d/90dmsquash-live/dmsquash-live-root.sh b/modules.d/90dmsquash-live/dmsquash-live-root.sh
+index 09128076..90d3e620 100755
+--- a/modules.d/90dmsquash-live/dmsquash-live-root.sh
++++ b/modules.d/90dmsquash-live/dmsquash-live-root.sh
+@@ -25,6 +25,10 @@ squash_image=$(getarg rd.live.squashimg)
+ getargbool 0 rd.live.ram -d -y live_ram && live_ram="yes"
+ getargbool 0 rd.live.overlay.reset -d -y reset_overlay && reset_overlay="yes"
+ getargbool 0 rd.live.overlay.readonly -d -y readonly_overlay && readonly_overlay="--readonly" || readonly_overlay=""
++# 'nouserconfirmprompt' is used to suppress a blocking prompt that asks for a
++# user confirmation before proceeding during boot time. This is to provide a
++# path for the image builder to boot it without user interaction.
++getargbool 0 rd.live.overlay.nouserconfirmprompt -d -y overlay_no_user_confirm_prompt && overlay_no_user_confirm_prompt="--noprompt" || overlay_no_user_confirm_prompt=""
+ overlay=$(getarg rd.live.overlay -d overlay)
+ getargbool 0 rd.writable.fsimg -d -y writable_fsimg && writable_fsimg="yes"
+ overlay_size=$(getarg rd.live.overlay.size=)
+@@ -185,7 +189,7 @@ do_live_overlay() {
+     fi
+ 
+     if [ -z "$setup" -o -n "$readonly_overlay" ]; then
+-        if [ -n "$setup" ]; then
++        if [ -n "$setup" -o -n "$overlay_no_user_confirm_prompt" ]; then
+             warn "Using temporary overlay."
+         elif [ -n "$devspec" -a -n "$pathspec" ]; then
+             [ -z "$m" ] \
+-- 
+2.34.1
+

--- a/SPECS/dracut/dracut.spec
+++ b/SPECS/dracut/dracut.spec
@@ -4,7 +4,7 @@
 Summary:        dracut to create initramfs
 Name:           dracut
 Version:        055
-Release:        5%{?dist}
+Release:        6%{?dist}
 # The entire source code is GPLv2+
 # except install/* which is LGPLv2+
 License:        GPLv2+ AND LGPLv2+
@@ -19,6 +19,11 @@ Source3:        megaraid.conf
 Patch0:         disable-xattr.patch
 Patch1:         fix-initrd-naming-for-mariner.patch
 Patch2:         fix-functions-Avoid-calling-grep-with-PCRE-P.patch
+# allow-liveos-overlay-no-user-confirmation-prompt.patch has been introduced by
+# the Mariner team to allow skipping the user confirmation prompt during boot
+# when the overlay of the liveos is backed by ram. This allows the machine to
+# boot without being blocked on user input in such a scenario.
+Patch3:         allow-liveos-overlay-no-user-confirmation-prompt.patch
 BuildRequires:  asciidoc
 BuildRequires:  bash
 BuildRequires:  git
@@ -188,6 +193,9 @@ ln -sr %{buildroot}%{_bindir}/dracut %{buildroot}%{_sbindir}/dracut
 %dir %{_sharedstatedir}/dracut/overlay
 
 %changelog
+* Wed Jan 24 2024 George Mileka <gmileka@microsoft.com> - 055-6
+- Add an option to supress user confirmation prompt for ram overlays.
+
 * Thu Apr 27 2023 Daniel McIlvaney <damcilva@microsoft.com> - 055-5
 - Avoid using JIT'd perl in grep since it is blocked by SELinux.
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Update dracut to allow supressing user confirmation prompt when the liveos overlay is backed by memory.

Dracut allows the creation of a LiveOS using a read-only squashfs and an read-write overlay on top.

If the read-write overlay is backed by a ram-disk, Dracut halts booting and prompts the user to confirm
whether to continue or not.

This interaction during the boot process is not desired in all cases.

This change introduces a new flag (rd.live.overlay.nouserconfirmprompt) that when defined, it supresses
the prompt and allows the boot process to continue to completion without user interation.

There is no impact to existing configurations and their associated behavior. Only when the new switch
is explicitly define by the image build (as a kernel parameter), the new behavior will take effect.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- n/a

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- n/a

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-YYYY-XXXX

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Build dracut package.
- Build baremetal core image.
- generate a LiveOS iso where the new flag is included in the kernel parameters in grub.cfg.
- create a VM and boot from thee iso.
- verify the boot is successful and no user input is required.
