### PR TITLE
Use most recent available rpm in bootstrap

### DIFF
--- a/toolkit/scripts/toolchain/container/toolchain_build_in_chroot.sh
+++ b/toolkit/scripts/toolchain/container/toolchain_build_in_chroot.sh
@@ -933,11 +933,10 @@ popd
 rm -rf "$DEBUGEDIT_WITH_VERSION"
 touch /logs/status_debugedit_complete
 
-RPM_WITH_VERSION=rpm-4.17.0
-RPM_FOLDER="$RPM_WITH_VERSION"-release
+RPM_WITH_VERSION=rpm-4.18.1
+RPM_FOLDER="$RPM_WITH_VERSION"
 echo $RPM_WITH_VERSION
-tar xf "$RPM_WITH_VERSION"-release.tar.gz
-mv rpm-"$RPM_WITH_VERSION"-release "$RPM_FOLDER"
+tar xf "$RPM_WITH_VERSION".tar.bz2
 pushd "$RPM_FOLDER"
 
 # Still not in the upstream


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
More recent versions of `rpm` are including new features (e.g. `%bcond flag 0/1`). Currently the bootstrap environment builds using rpm 4.17.0, while we need at least 4.18.0 to supply `%bcond`. The version of `rpm` we use in the bootstrap environment should also ideally match the version we use for the rest of the package builds (we don't build `rpm` during the toolchain until quite late, and don't instlal it, so we are using the bootstrap versino to build the toolchain packages).

The bootstrap wget lists are already primed to use `4.18.1`, so start with that. Ideally the spec file will be bumped to match.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Enable `rpm-4.18.1` for bootstrap

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**


###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local testing
- Pipeline: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=491884&view=results
