### PR TITLE
patch CVE-2022-21698 in keda

### DIFF
--- a/SPECS/keda/CVE-2022-21698.patch
+++ b/SPECS/keda/CVE-2022-21698.patch
@@ -1,0 +1,40 @@
+From db46a9783a98b9efa3cf3444264e44464e35e7af Mon Sep 17 00:00:00 2001
+From: Tobias Brick <tobiasb@microsoft.com>
+Date: Tue, 30 Jan 2024 20:29:03 +0000
+Subject: [PATCH] update client_golang from 1.11.0 to 1.11.1 to fix
+ CVE-2022-21698
+
+---
+ go.mod | 2 +-
+ go.sum | 2 ++
+ 2 files changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/go.mod b/go.mod
+index aac6e22..cfbde07 100644
+--- a/go.mod
++++ b/go.mod
+@@ -34,7 +34,7 @@ require (
+ 	github.com/onsi/ginkgo v1.16.4
+ 	github.com/onsi/gomega v1.14.0
+ 	github.com/pkg/errors v0.9.1
+-	github.com/prometheus/client_golang v1.11.0
++	github.com/prometheus/client_golang v1.11.1
+ 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475
+ 	github.com/robfig/cron/v3 v3.0.1
+ 	github.com/streadway/amqp v1.0.0
+diff --git a/go.sum b/go.sum
+index 234016c..957b3ec 100644
+--- a/go.sum
++++ b/go.sum
+@@ -836,6 +836,8 @@ github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP
+ github.com/prometheus/client_golang v1.9.0/go.mod h1:FqZLKOZnGdFAhOK4nqGHa7D66IdsO+O441Eve7ptJDU=
+ github.com/prometheus/client_golang v1.11.0 h1:HNkLOAEQMIDv/K+04rukrLx6ch7msSRwf3/SASFAGtQ=
+ github.com/prometheus/client_golang v1.11.0/go.mod h1:Z6t4BnS23TR94PD6BsDNk8yVqroYurpAkEiz0P2BEV0=
++github.com/prometheus/client_golang v1.11.1 h1:+4eQaD7vAZ6DsfsxB15hbE0odUjGI5ARs9yskGu1v4s=
++github.com/prometheus/client_golang v1.11.1/go.mod h1:Z6t4BnS23TR94PD6BsDNk8yVqroYurpAkEiz0P2BEV0=
+ github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
+ github.com/prometheus/client_model v0.0.0-20190115171406-56726106282f/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
+ github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+-- 
+2.33.8
+

--- a/SPECS/keda/keda.signatures.json
+++ b/SPECS/keda/keda.signatures.json
@@ -1,6 +1,6 @@
 {
  "Signatures": {
-  "keda-2.4.0-vendor.tar.gz": "bf5f2e19aac2c178a868aa1b1245b11d5ed4a51b0713d1f41154987f062f986e",
+  "keda-2.4.0-vendor-v2.tar.gz": "3a67ec9a94dd9a714aef2899c83b18c8a2ac64ca30efc27b5ffd3fba9ae3fbb4",
   "keda-2.4.0.tar.gz": "e3a44a7be2d80369fb490898fb3f5605170a2848c8f30c6c24eb68fb57cfd3e0"
  }
 }

--- a/SPECS/keda/keda.spec
+++ b/SPECS/keda/keda.spec
@@ -1,7 +1,7 @@
 Summary:        Kubernetes-based Event Driven Autoscaling
 Name:           keda
 Version:        2.4.0
-Release:        15%{?dist}
+Release:        16%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -10,18 +10,25 @@ URL:            https://github.com/kedacore/keda
 Source0:        %{name}-%{version}.tar.gz
 # Below is a manually created tarball, no download link.
 # We're using pre-populated Go modules from this tarball, since network is disabled during build time.
-# How to re-build this file:
+# A couple of notes:
+#   A: The -v2 suffix just increases as we make more vendored tarballs.
+#   B: Make sure to apply the appropriate patches before creating the tarball.
+#
+# How to re-build this file.
 #   1. wget https://github.com/kedacore/%%{name}/archive/refs/tags/v%%{version}.tar.gz -O %%{name}-%%{version}.tar.gz
 #   2. tar -xf %%{name}-%%{version}.tar.gz
 #   3. cd %%{name}-%%{version}
-#   4. go mod vendor
-#   5. tar  --sort=name \
-#           --mtime="2021-04-26 00:00Z" \
+#   4. Apply appropriate patches
+#   5. go mod vendor
+#   6. tar  --sort=name \
 #           --owner=0 --group=0 --numeric-owner \
 #           --pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime \
-#           -cf %%{name}-%%{version}-vendor.tar.gz vendor
+#           -cf %%{name}-%%{version}-vendor-v2.tar.gz vendor
 #
-Source1:        %{name}-%{version}-vendor.tar.gz
+Source1:        %{name}-%{version}-vendor-v2.tar.gz
+# Patches the version of client_golang used in the vendored source. Should be applied before creating the vendored tarball.
+# Can be removed if we upgrade keda to 2.6.0 or later.
+Patch0:         CVE-2022-21698.patch
 BuildRequires:  golang >= 1.15
 
 %description
@@ -29,11 +36,11 @@ KEDA is a Kubernetes-based Event Driven Autoscaling component.
 It provides event driven scale for any container running in Kubernetes 
 
 %prep
-%setup -q
-
-%build
+%autosetup -p1
 # create vendor folder from the vendor tarball and set vendor mode
 tar -xf %{SOURCE1} --no-same-owner
+
+%build
 export LDFLAGS="-X=github.com/kedacore/keda/v2/version.GitCommit= -X=github.com/kedacore/keda/v2/version.Version=main"
 
 go build -ldflags "$LDFLAGS" -mod=vendor -v -o bin/keda main.go
@@ -55,6 +62,11 @@ cp ./bin/keda-adapter %{buildroot}%{_bindir}
 %{_bindir}/%{name}-adapter
 
 %changelog
+* Tue Jan 01 2024 Tobias Brick <tobiasb@microsoft.com> - 2.4.0-16
+- Patch CVE-2022-21698
+- Update vendored tarball
+- Move tarball expansion to %prep
+
 * Mon Oct 16 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 2.4.0-15
 - Bump release to rebuild with go 1.20.9
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Fixes [CVE-2022-21698](https://nvd.nist.gov/vuln/detail/CVE-2022-21698) for `keda`. The vulnerability is in the `client_golang` go module v1.11.1, and `keda` has a direct dependency on v1.11.0. Fixed by applying a patch to the `keda` code to update that module, then built the vendored tarball.

###### Change Log  <!-- REQUIRED -->
- Patched `keda` code to use `client_golang` 1.11.1.
- Created/uploaded vendored tarball with that patch.
- Applied patch in spec file
- Moved vendored-tarball-related stuff into the `%prep` section

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2022-21698

###### Test Methodology
- Builds locally in container
- Buddy Build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=494344&view=results
