### PR TITLE
systemd: do not conflict with polkit dir

### DIFF
--- a/SPECS/systemd/systemd.spec
+++ b/SPECS/systemd/systemd.spec
@@ -2,7 +2,7 @@
 Summary:        Systemd
 Name:           systemd
 Version:        254.5
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        LGPLv2+ AND GPLv2+ AND MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -222,7 +222,7 @@ fi
 %{_libdir}/sysctl.d
 %{_libdir}/tmpfiles.d
 /lib/*.so*
-/lib/cryptsetup/libcryptsetup-token-systemd-tpm2.so
+/lib/cryptsetup/libcryptsetup-token-systemd-*.so
 %{_libdir}/modprobe.d/systemd.conf
 %{_libdir}/sysusers.d/*
 %{_bindir}/*
@@ -232,7 +232,8 @@ fi
 %{_datadir}/factory/*
 %{_datadir}/dbus-1
 %{_docdir}/*
-%{_datadir}/polkit-1
+%{_datadir}/polkit-1/actions/*
+%{_datadir}/polkit-1/rules.d/*
 %{_datadir}/systemd
 %{_datadir}/zsh/*
 %dir %{_localstatedir}/log/journal
@@ -256,6 +257,10 @@ fi
 %files lang -f %{name}.lang
 
 %changelog
+* Wed Jan 31 16:28:30 EST 2024 Dan Streetman <ddstreet@ieee.org> - 254.5-2
+- do not conflict with polkit dir
+- include all libcryptsetup plugin libs
+
 * Wed Nov 15 2023 Dan Streetman <ddstreet@ieee.org> - 254.5-1
 - Update to systemd-stable 254.5
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

This is needed since currently the `systemd` and `polkit` packages cannot be installed together on a system.

Also `polkit` FTBFS because it is not packaging one of the built libs.