### PR TITLE
Small rebranding of mariner-release file changes

### DIFF
--- a/SPECS/mariner-release/mariner-release.spec
+++ b/SPECS/mariner-release/mariner-release.spec
@@ -1,7 +1,7 @@
 Summary:        Azure Linux release files
 Name:           mariner-release
 Version:        3.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Microsoft Azure Linux
@@ -19,8 +19,8 @@ Azure Linux release files such as yum configs and other %{_sysconfdir}/ release 
 install -d %{buildroot}%{_sysconfdir}
 install -d %{buildroot}/%{_libdir}
 
-echo "Azure Linux %{mariner_release_version}" > %{buildroot}%{_sysconfdir}/mariner-release
-echo "MARINER_BUILD_NUMBER=%{mariner_build_number}" >> %{buildroot}%{_sysconfdir}/mariner-release
+echo "Azure Linux %{mariner_release_version}" > %{buildroot}%{_sysconfdir}/azurelinux-release
+echo "AZURELINUX_BUILD_NUMBER=%{mariner_build_number}" >> %{buildroot}%{_sysconfdir}/azurelinux-release
 
 cat > %{buildroot}%{_sysconfdir}/lsb-release <<- "EOF"
 DISTRIB_ID="azurelinux"
@@ -54,7 +54,7 @@ EOF
 
 %files
 %defattr(-,root,root,-)
-%config(noreplace) %{_sysconfdir}/mariner-release
+%config(noreplace) %{_sysconfdir}/azurelinux-release
 %config(noreplace) %{_sysconfdir}/lsb-release
 %config(noreplace) %{_libdir}/os-release
 %config(noreplace) %{_sysconfdir}/os-release
@@ -62,6 +62,10 @@ EOF
 %config(noreplace) %{_sysconfdir}/issue.net
 
 %changelog
+* Thu Feb 01 2023 Mykhailo Bykhovtsev <mbykhovtsev@microsoft.com> - 3.0-3
+- Renamed mariner-release to azurelinux-release file
+- Renamed MARINER_BUILD_NUMBER property to AZURELINUX_BUILD_NUMBER
+
 * Wed Jan 31 2024 Amrita Kohli <amritakohli@microsoft.com> - 3.0-2
 - Remove kernel info from welcome banner for security compliance.
 

--- a/SPECS/supermin/supermin-azurelinux.patch
+++ b/SPECS/supermin/supermin-azurelinux.patch
@@ -1,7 +1,7 @@
 From f4a3020f202d67ad5682304e7710bfc14f1320eb Mon Sep 17 00:00:00 2001
 From: Thomas Crain <thcrain@microsoft.com>
 Date: Wed, 19 Jan 2022 21:36:29 -0800
-Subject: [PATCH] Add Mariner support to supermin
+Subject: [PATCH] Add Microsoft Azure Linux support to supermin
 
 ---
  src/ph_rpm.ml        | 18 +++++++++++++++++-
@@ -16,11 +16,11 @@ index 549bd9a..760c815 100644
        (stat "/etc/ibm_powerkvm-release").st_kind = S_REG
      with Unix_error _ -> false
  
-+let mariner_detect () =
++let azurelinux_detect () =
 +  Config.rpm <> "no" && Config.rpm2cpio <> "no" && rpm_is_available () &&
 +    Config.dnf <> "no" &&
-+    Os_release.get_id () = "mariner" ||
-+     try (stat "/etc/mariner-release").st_kind = S_REG with Unix_error _ -> false
++    Os_release.get_id () = "azurelinux" ||
++     try (stat "/etc/azurelinux-release").st_kind = S_REG with Unix_error _ -> false
 +
  let settings = ref no_settings
  let rpm_major, rpm_minor, rpm_arch = ref 0, ref 0, ref ""
@@ -29,7 +29,7 @@ index 549bd9a..760c815 100644
  
    rpm_unpack tdir dir
  
-+and mariner_download_all_packages pkgs dir =
++and azurelinux_download_all_packages pkgs dir =
 +  let tdir = !settings.tmpdir // string_random8 () in
 +  download_all_packages_with_dnf pkgs dir tdir
 +
@@ -42,12 +42,12 @@ index 549bd9a..760c815 100644
    } in
 -  register_package_handler "openmandriva" "rpm" openmandriva
 +  register_package_handler "openmandriva" "rpm" openmandriva;
-+  let mariner = {
++  let azurelinux = {
 +    fedora with
-+    ph_detect = mariner_detect;
-+    ph_download_package = PHDownloadAllPackages mariner_download_all_packages;
++    ph_detect = azurelinux_detect;
++    ph_download_package = PHDownloadAllPackages azurelinux_download_all_packages;
 +  } in
-+  register_package_handler "mariner" "rpm" mariner
++  register_package_handler "azurelinux" "rpm" azurelinux
 diff --git a/tests/test-harder.sh b/tests/test-harder.sh
 index aceef21..223cae9 100755
 --- a/tests/test-harder.sh
@@ -56,7 +56,7 @@ index aceef21..223cae9 100755
          opensuse*|sled|sles) distro=suse ;;
          ubuntu) distro=debian ;;
          openmandriva) distro=openmandriva ;;
-+		mariner) distro=mariner ;;
++		azurelinux) distro=azurelinux ;;
      esac
  elif [ -f /etc/arch-release ]; then
      distro=arch
@@ -64,8 +64,8 @@ index aceef21..223cae9 100755
      distro=suse
  elif [ -f /etc/ibm_powerkvm-release ]; then
      distro=ibm-powerkvm
-+elif [ -f /etc/mariner-release ]; then
-+	distro=mariner
++elif [ -f /etc/azurelinux-release ]; then
++	distro=azurelinux
  else
      exit 77
  fi
@@ -73,7 +73,7 @@ index aceef21..223cae9 100755
  	# installed.  (See commit fb40baade8e3441b73ce6fd10a32fbbfe49cc4da)
  	pkgs="augeas hivex rpm"
  	;;
-+	mariner)
++	azurelinux)
 +	pkgs="augeas hivex tar"
      redhat)
          # Choose tar because it has an epoch > 0 and is commonly
@@ -82,7 +82,7 @@ index aceef21..223cae9 100755
  	    exit 1
  	fi
  	;;
-+	mariner)
++	azurelinux)
 +	if [ ! -x $d2/usr/bin/augtool ]; then
 +	    echo "$0: $distro: augtool binary not installed in chroot"
 +	    ls -lR $d2

--- a/SPECS/supermin/supermin.spec
+++ b/SPECS/supermin/supermin.spec
@@ -21,17 +21,17 @@
 Summary:        Tool for creating supermin appliances
 Name:           supermin
 Version:        5.2.1
-Release:        10%{?dist}
+Release:        11%{?dist}
 License:        GPLv2+
 Vendor:         Microsoft Corporation
-Distribution:   Mariner
+Distribution:   Microsoft Azure Linux
 URL:            https://github.com/libguestfs/supermin
 Source0:        https://download.libguestfs.org/supermin/%{source_directory}/%{name}-%{version}.tar.gz
 # For automatic RPM dependency generation.
 # See: http://www.rpm.org/wiki/PackagerDocs/DependencyGenerator
 Source3:        supermin.attr
 Source4:        supermin-find-requires
-Patch0:         %{name}-mariner.patch
+Patch0:         %{name}-azurelinux.patch
 
 BuildRequires:  %{_bindir}/pod2html
 BuildRequires:  %{_bindir}/pod2man
@@ -129,6 +129,9 @@ make check || {
 %{_rpmconfigdir}/supermin-find-requires
 
 %changelog
+* Thu Feb 01 2024 Mykhailo Bykhovtsev <mbykhovtsev@microsoft.com> - 5.2.1-11
+- Fix patch file with new changed azure linux OS files.
+
 * Tue Nov 07 2023 Andrew Phelps <anphel@microsoft.com> - 5.2.1-10
 - Bump release to rebuild against glibc 2.38-1
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
A mini version of PR #7545. This mainly changes the file provided by `mariner-release` package to be `azurelinux-release` and changes the `MARINER_BUILD_NUMBER` property of the file to be called `AZURELINUX_BUILD_NUMBER`

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- changes the file provided by `mariner-release` package to be `azurelinux-release`
- changes the `MARINER_BUILD_NUMBER` property of the file to be called `AZURELINUX_BUILD_NUMBER`

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=496506&view=results