### PR TITLE
Add support for additional files in mic generated isos.

### DIFF
--- a/toolkit/tools/imagecustomizer/docs/configuration.md
+++ b/toolkit/tools/imagecustomizer/docs/configuration.md
@@ -30,7 +30,7 @@ The Mariner Image Customizer is configured using a YAML (or JSON) file.
 
 7. Enable/disable services. ([Services](#services-type))
 
-8. Configure kernel modules.
+8. Configure kernel modules. ([Modules](#modules-type))
 
 9. Write the `/etc/mariner-customizer-release` file.
 
@@ -45,6 +45,10 @@ The Mariner Image Customizer is configured using a YAML (or JSON) file.
 14. Delete `/etc/resolv.conf` file.
 
 15. Enable dm-verity root protection.
+
+And if the output format is set to `iso`:
+
+12. Copy additional iso media files ([Iso](#iso-type)).
 
 ### /etc/resolv.conf
 
@@ -72,6 +76,87 @@ SystemConfig:
   PackagesInstall:
   - kernel-hci
 ```
+
+## Schema Overview
+
+- [Config type](#config-type)
+  - [Disks](#disks-disk)
+    - [Disk type](#disk-type)
+      - [PartitionTableType](#partitiontabletype-string)
+      - [MaxSize](#maxsize-uint64)
+      - [Partitions](#partitions-partition)
+        - [Partition type](#partition-type)
+          - [ID](#id-string)
+          - [FsType](#fstype-string)
+          - [Name](#partition-name)
+          - [Start](#start-uint64)
+          - [End](#end-uint64)
+          - [Size](#size-uint64)
+          - [Flag](#flags-string)
+  - [Iso](#iso-type)
+    - [AdditionalFiles](#additionalfiles-mapstring-fileconfig)
+      - string: []FileConfig | []string
+        - [FileConfig type](#fileconfig-type)
+          - [Path](#path-string)
+          - [Permissions](#permissions-string)
+  - [SystemConfig](#systemconfig-type)
+    - [BootType](#boottype-string)
+    - [Hostname](#hostname-string)
+    - [KernelCommandLine](#kernelcommandline-type)
+      - [ExtraCommandLine](#extracommandline-string)
+    - [UpdateBaseImagePackages](#updatebaseimagepackages-bool)
+    - [PackageListsInstall](#packagelistsinstall-string)
+      - [PackageList type](#packagelist-type)
+        - [Packages](#packages-string)
+    - [PackagesInstall](#packagesinstall-string)
+    - [PackageListsRemove](#packagelistsremove-string)
+      - [PackageList type](#packagelist-type)
+        - [Packages](#packages-string)
+    - [PackagesRemove](#packagesremove-string)
+    - [PackageListsUpdate](#packagelistsupdate-string)
+    - [PackagesUpdate](#packagesupdate-string)
+    - [AdditionalFiles](#additionalfiles-mapstring-fileconfig)
+      - string: []FileConfig | []string
+        - [FileConfig type](#fileconfig-type)
+          - [Path](#path-string)
+          - [Permissions](#permissions-string)
+    - [PartitionSettings](#partitionsettings-partitionsetting)
+      - [PartitionSetting type](#partitionsetting-type)
+        - [ID](#id-string)
+        - [MountIdentifier](#mountidentifier-string)
+        - [MountOptions](#mountoptions-string)
+        - [MountPoint](#mountpoint-string)
+    - [PostInstallScripts](#postinstallscripts-script)
+      - [Script type](#script-type)
+        - [Path](#path-string)
+        - [Args](#args-string)
+    - [FinalizeImageScripts](#finalizeimagescripts-script)
+      - [Script type](#script-type)
+        - [Path](#path-string)
+        - [Args](#args-string)
+    - [Users](#users-user)
+      - [User type](#user-type)
+        - [Name](#user-name)
+        - [UID](#uid-int)
+        - [PasswordHashed](#passwordhashed-bool)
+        - [Password](#password-string)
+        - [PasswordPath](#passwordpath-string)
+        - [PasswordExpiresDays](#passwordexpiresdays-int)
+        - [SSHPubKeyPaths](#sshpubkeypaths-string)
+        - [PrimaryGroup](#primarygroup-string)
+        - [SecondaryGroups](#secondarygroups-string)
+        - [StartupCommand](#startupcommand-string)
+    - [Services](#services-type)
+      -  [Enable](#enable-string)
+      -  [Disable](#disable-string)
+    - [Modules](#modules-type)
+      - [Load](#load-module)
+        - [Module type](#module-type)
+          - [Name](#module-name)
+      - [Disable](#disable-module)
+        - [Module type](#module-type)
+          - [Name](#module-name)
+    - [Verity type](#verity-type)
 
 ## Top-level
 
@@ -149,9 +234,17 @@ Supported options:
 
 The size of the disk, specified in mebibytes (MiB).
 
-### Partitions [[Partition](#partition-type)]
+### Partitions [[][Partition](#partition-type)]
 
 The partitions to provision on the disk.
+
+## Iso type
+
+Specifies the configuration for the generated ISO media.
+
+### AdditionalFiles
+
+- See [AdditionalFiles](#additionalfiles-mapstring-fileconfig).
 
 ## Verity type
 
@@ -224,7 +317,7 @@ SystemConfig:
 
 Options for configuring the kernel.
 
-### ExtraCommandLine
+### ExtraCommandLine [string]
 
 Additional Linux kernel command line options to add to the image.
 
@@ -296,6 +389,8 @@ SystemConfig:
 ## Module type
 
 Options for configuring a kernel module.
+
+<div id="module-name"></div>
 
 ### Name
 
@@ -381,6 +476,8 @@ Supported options:
 - `ext4`
 - `fat32`
 - `xfs`
+
+<div id="partition-name"></div>
 
 ### Name [string]
 
@@ -514,7 +611,7 @@ SystemConfig:
 
 Options for configuring systemd services.
 
-### Enable
+### Enable [[]string]
 
 A list of services to enable.
 That is, services that will be set to automatically run on OS boot.
@@ -528,7 +625,7 @@ SystemConfig:
     - sshd
 ```
 
-### Disable
+### Disable [[]string]
 
 A list of services to disable.
 That is, services that will be set to not automatically run on OS boot.
@@ -774,6 +871,8 @@ Options for configuration kernel modules.
 ## User type
 
 Options for configuring a user account.
+
+<div id="user-name"></div>
 
 ### Name [string]
 

--- a/toolkit/tools/imagecustomizer/docs/configuration.md
+++ b/toolkit/tools/imagecustomizer/docs/configuration.md
@@ -77,87 +77,6 @@ SystemConfig:
   - kernel-hci
 ```
 
-## Schema Overview
-
-- [Config type](#config-type)
-  - [Disks](#disks-disk)
-    - [Disk type](#disk-type)
-      - [PartitionTableType](#partitiontabletype-string)
-      - [MaxSize](#maxsize-uint64)
-      - [Partitions](#partitions-partition)
-        - [Partition type](#partition-type)
-          - [ID](#id-string)
-          - [FsType](#fstype-string)
-          - [Name](#partition-name)
-          - [Start](#start-uint64)
-          - [End](#end-uint64)
-          - [Size](#size-uint64)
-          - [Flag](#flags-string)
-  - [Iso](#iso-type)
-    - [AdditionalFiles](#additionalfiles-mapstring-fileconfig)
-      - string: []FileConfig | []string
-        - [FileConfig type](#fileconfig-type)
-          - [Path](#path-string)
-          - [Permissions](#permissions-string)
-  - [SystemConfig](#systemconfig-type)
-    - [BootType](#boottype-string)
-    - [Hostname](#hostname-string)
-    - [KernelCommandLine](#kernelcommandline-type)
-      - [ExtraCommandLine](#extracommandline-string)
-    - [UpdateBaseImagePackages](#updatebaseimagepackages-bool)
-    - [PackageListsInstall](#packagelistsinstall-string)
-      - [PackageList type](#packagelist-type)
-        - [Packages](#packages-string)
-    - [PackagesInstall](#packagesinstall-string)
-    - [PackageListsRemove](#packagelistsremove-string)
-      - [PackageList type](#packagelist-type)
-        - [Packages](#packages-string)
-    - [PackagesRemove](#packagesremove-string)
-    - [PackageListsUpdate](#packagelistsupdate-string)
-    - [PackagesUpdate](#packagesupdate-string)
-    - [AdditionalFiles](#additionalfiles-mapstring-fileconfig)
-      - string: []FileConfig | []string
-        - [FileConfig type](#fileconfig-type)
-          - [Path](#path-string)
-          - [Permissions](#permissions-string)
-    - [PartitionSettings](#partitionsettings-partitionsetting)
-      - [PartitionSetting type](#partitionsetting-type)
-        - [ID](#id-string)
-        - [MountIdentifier](#mountidentifier-string)
-        - [MountOptions](#mountoptions-string)
-        - [MountPoint](#mountpoint-string)
-    - [PostInstallScripts](#postinstallscripts-script)
-      - [Script type](#script-type)
-        - [Path](#path-string)
-        - [Args](#args-string)
-    - [FinalizeImageScripts](#finalizeimagescripts-script)
-      - [Script type](#script-type)
-        - [Path](#path-string)
-        - [Args](#args-string)
-    - [Users](#users-user)
-      - [User type](#user-type)
-        - [Name](#user-name)
-        - [UID](#uid-int)
-        - [PasswordHashed](#passwordhashed-bool)
-        - [Password](#password-string)
-        - [PasswordPath](#passwordpath-string)
-        - [PasswordExpiresDays](#passwordexpiresdays-int)
-        - [SSHPubKeyPaths](#sshpubkeypaths-string)
-        - [PrimaryGroup](#primarygroup-string)
-        - [SecondaryGroups](#secondarygroups-string)
-        - [StartupCommand](#startupcommand-string)
-    - [Services](#services-type)
-      -  [Enable](#enable-string)
-      -  [Disable](#disable-string)
-    - [Modules](#modules-type)
-      - [Load](#load-module)
-        - [Module type](#module-type)
-          - [Name](#module-name)
-      - [Disable](#disable-module)
-        - [Module type](#module-type)
-          - [Name](#module-name)
-    - [Verity type](#verity-type)
-
 ## Top-level
 
 The top level type for the YAML file is the [Config](#config-type) type.
@@ -234,7 +153,7 @@ Supported options:
 
 The size of the disk, specified in mebibytes (MiB).
 
-### Partitions [[][Partition](#partition-type)]
+### Partitions [[Partition](#partition-type)[]]
 
 The partitions to provision on the disk.
 
@@ -611,7 +530,7 @@ SystemConfig:
 
 Options for configuring systemd services.
 
-### Enable [[]string]
+### Enable [string[]]
 
 A list of services to enable.
 That is, services that will be set to automatically run on OS boot.
@@ -625,7 +544,7 @@ SystemConfig:
     - sshd
 ```
 
-### Disable [[]string]
+### Disable [string[]]
 
 A list of services to disable.
 That is, services that will be set to not automatically run on OS boot.

--- a/toolkit/tools/imagecustomizer/docs/iso.md
+++ b/toolkit/tools/imagecustomizer/docs/iso.md
@@ -1,5 +1,7 @@
 # Mariner Image Customizer ISO Support
 
+## Overview
+
 Given a full disk image, the Mariner Image Customizer (MIC) can generate a
 LiveOS ISO image when the `--output-image-format` is set to `iso`.
 
@@ -33,3 +35,8 @@ The current implementation for the LiveOS ISO does not support the following:
 - disk layout.
   - There is always one disk generated when an `iso` output format is
     specified.
+
+  ## ISO Specific Customizations
+
+  - The user can specify one or more files to be copied to the iso media.
+    See MIC's iso configuration [Config.ISO](./configuration.md#iso-type).

--- a/toolkit/tools/imagecustomizerapi/additionalfilesmap.go
+++ b/toolkit/tools/imagecustomizerapi/additionalfilesmap.go
@@ -4,20 +4,21 @@
 package imagecustomizerapi
 
 import (
+	"errors"
 	"fmt"
 )
 
 type AdditionalFilesMap map[string]FileConfigList
 
-func (afmap *AdditionalFilesMap) IsValid() error {
+func (afmap AdditionalFilesMap) IsValid() error {
 	var aggregateErr error
-	for sourcePath, fileConfigList := range *afmap {
+	for sourcePath, fileConfigList := range afmap {
 		if len(sourcePath) == 0 {
-			aggregateErr = AggregateErrors(aggregateErr, fmt.Errorf("invalid source path. Source path cannot be empty."))
+			aggregateErr = errors.Join(aggregateErr, fmt.Errorf("invalid source path. Source path cannot be empty."))
 		}
 		err := fileConfigList.IsValid()
 		if err != nil {
-			aggregateErr = AggregateErrors(aggregateErr, fmt.Errorf("invalid file configs for (%s):\n%w", sourcePath, err))
+			aggregateErr = errors.Join(aggregateErr, fmt.Errorf("invalid file configs for (%s):\n%w", sourcePath, err))
 		}
 	}
 	return aggregateErr

--- a/toolkit/tools/imagecustomizerapi/additionalfilesmap.go
+++ b/toolkit/tools/imagecustomizerapi/additionalfilesmap.go
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package imagecustomizerapi
+
+import (
+	"fmt"
+)
+
+type AdditionalFilesMap map[string]FileConfigList
+
+func (afmap *AdditionalFilesMap) IsValid() error {
+	var aggregateErr error
+	for sourcePath, fileConfigList := range *afmap {
+		if len(sourcePath) == 0 {
+			aggregateErr = AggregateErrors(aggregateErr, fmt.Errorf("invalid source path. Source path cannot be empty."))
+		}
+		err := fileConfigList.IsValid()
+		if err != nil {
+			aggregateErr = AggregateErrors(aggregateErr, fmt.Errorf("invalid file configs for (%s):\n%w", sourcePath, err))
+		}
+	}
+	return aggregateErr
+}

--- a/toolkit/tools/imagecustomizerapi/config.go
+++ b/toolkit/tools/imagecustomizerapi/config.go
@@ -11,8 +11,8 @@ import (
 
 type Config struct {
 	Disks        *[]Disk      `yaml:"Disks"`
-	SystemConfig SystemConfig `yaml:"SystemConfig"`
 	Iso          *Iso         `yaml:"Iso"`
+	SystemConfig SystemConfig `yaml:"SystemConfig"`
 }
 
 func (c *Config) IsValid() (err error) {

--- a/toolkit/tools/imagecustomizerapi/config.go
+++ b/toolkit/tools/imagecustomizerapi/config.go
@@ -12,9 +12,10 @@ import (
 type Config struct {
 	Disks        *[]Disk      `yaml:"Disks"`
 	SystemConfig SystemConfig `yaml:"SystemConfig"`
+	Iso          *Iso         `yaml:"Iso"`
 }
 
-func (c *Config) IsValid() error {
+func (c *Config) IsValid() (err error) {
 	if c.Disks != nil {
 		disks := *c.Disks
 		if len(disks) < 1 {
@@ -32,7 +33,14 @@ func (c *Config) IsValid() error {
 		}
 	}
 
-	err := c.SystemConfig.IsValid()
+	if c.Iso != nil {
+		err = c.Iso.IsValid()
+		if err != nil {
+			return err
+		}
+	}
+
+	err = c.SystemConfig.IsValid()
 	if err != nil {
 		return err
 	}

--- a/toolkit/tools/imagecustomizerapi/iso.go
+++ b/toolkit/tools/imagecustomizerapi/iso.go
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package imagecustomizerapi
+
+import (
+	"fmt"
+)
+
+// Iso defines how the generated iso media should be configured.
+type Iso struct {
+	AdditionalFiles map[string]FileConfigList `yaml:"AdditionalFiles"`
+}
+
+func (s *Iso) IsValid() error {
+	var err error
+
+	for sourcePath, fileConfigList := range s.AdditionalFiles {
+		err = fileConfigList.IsValid()
+		if err != nil {
+			return fmt.Errorf("invalid file configs for (%s):\n%w", sourcePath, err)
+		}
+	}
+
+	return nil
+}

--- a/toolkit/tools/imagecustomizerapi/iso.go
+++ b/toolkit/tools/imagecustomizerapi/iso.go
@@ -3,11 +3,19 @@
 
 package imagecustomizerapi
 
+import (
+	"fmt"
+)
+
 // Iso defines how the generated iso media should be configured.
 type Iso struct {
 	AdditionalFiles AdditionalFilesMap `yaml:"AdditionalFiles"`
 }
 
 func (i *Iso) IsValid() error {
-	return i.AdditionalFiles.IsValid()
+	err := i.AdditionalFiles.IsValid()
+	if err != nil {
+		return fmt.Errorf("invalid AdditionalFiles: %w", err)
+	}
+	return nil
 }

--- a/toolkit/tools/imagecustomizerapi/iso.go
+++ b/toolkit/tools/imagecustomizerapi/iso.go
@@ -3,24 +3,11 @@
 
 package imagecustomizerapi
 
-import (
-	"fmt"
-)
-
 // Iso defines how the generated iso media should be configured.
 type Iso struct {
-	AdditionalFiles map[string]FileConfigList `yaml:"AdditionalFiles"`
+	AdditionalFiles AdditionalFilesMap `yaml:"AdditionalFiles"`
 }
 
-func (s *Iso) IsValid() error {
-	var err error
-
-	for sourcePath, fileConfigList := range s.AdditionalFiles {
-		err = fileConfigList.IsValid()
-		if err != nil {
-			return fmt.Errorf("invalid file configs for (%s):\n%w", sourcePath, err)
-		}
-	}
-
-	return nil
+func (i *Iso) IsValid() error {
+	return i.AdditionalFiles.IsValid()
 }

--- a/toolkit/tools/imagecustomizerapi/systemconfig.go
+++ b/toolkit/tools/imagecustomizerapi/systemconfig.go
@@ -12,24 +12,24 @@ import (
 
 // SystemConfig defines how each system present on the image is supposed to be configured.
 type SystemConfig struct {
-	BootType                BootType                  `yaml:"BootType"`
-	Hostname                string                    `yaml:"Hostname"`
-	UpdateBaseImagePackages bool                      `yaml:"UpdateBaseImagePackages"`
-	PackageListsInstall     []string                  `yaml:"PackageListsInstall"`
-	PackagesInstall         []string                  `yaml:"PackagesInstall"`
-	PackageListsRemove      []string                  `yaml:"PackageListsRemove"`
-	PackagesRemove          []string                  `yaml:"PackagesRemove"`
-	PackageListsUpdate      []string                  `yaml:"PackageListsUpdate"`
-	PackagesUpdate          []string                  `yaml:"PackagesUpdate"`
-	KernelCommandLine       KernelCommandLine         `yaml:"KernelCommandLine"`
-	AdditionalFiles         map[string]FileConfigList `yaml:"AdditionalFiles"`
-	PartitionSettings       []PartitionSetting        `yaml:"PartitionSettings"`
-	PostInstallScripts      []Script                  `yaml:"PostInstallScripts"`
-	FinalizeImageScripts    []Script                  `yaml:"FinalizeImageScripts"`
-	Users                   []User                    `yaml:"Users"`
-	Services                Services                  `yaml:"Services"`
-	Modules                 Modules                   `yaml:"Modules"`
-	Verity                  *Verity                   `yaml:"Verity"`
+	BootType                BootType           `yaml:"BootType"`
+	Hostname                string             `yaml:"Hostname"`
+	UpdateBaseImagePackages bool               `yaml:"UpdateBaseImagePackages"`
+	PackageListsInstall     []string           `yaml:"PackageListsInstall"`
+	PackagesInstall         []string           `yaml:"PackagesInstall"`
+	PackageListsRemove      []string           `yaml:"PackageListsRemove"`
+	PackagesRemove          []string           `yaml:"PackagesRemove"`
+	PackageListsUpdate      []string           `yaml:"PackageListsUpdate"`
+	PackagesUpdate          []string           `yaml:"PackagesUpdate"`
+	KernelCommandLine       KernelCommandLine  `yaml:"KernelCommandLine"`
+	AdditionalFiles         AdditionalFilesMap `yaml:"AdditionalFiles"`
+	PartitionSettings       []PartitionSetting `yaml:"PartitionSettings"`
+	PostInstallScripts      []Script           `yaml:"PostInstallScripts"`
+	FinalizeImageScripts    []Script           `yaml:"FinalizeImageScripts"`
+	Users                   []User             `yaml:"Users"`
+	Services                Services           `yaml:"Services"`
+	Modules                 Modules            `yaml:"Modules"`
+	Verity                  *Verity            `yaml:"Verity"`
 }
 
 func (s *SystemConfig) IsValid() error {
@@ -51,11 +51,9 @@ func (s *SystemConfig) IsValid() error {
 		return fmt.Errorf("invalid KernelCommandLine: %w", err)
 	}
 
-	for sourcePath, fileConfigList := range s.AdditionalFiles {
-		err = fileConfigList.IsValid()
-		if err != nil {
-			return fmt.Errorf("invalid file configs for (%s):\n%w", sourcePath, err)
-		}
+	err = s.AdditionalFiles.IsValid()
+	if err != nil {
+		return fmt.Errorf("invalid AdditionalFiles: %w", err)
 	}
 
 	partitionIDSet := make(map[string]bool)

--- a/toolkit/tools/imagecustomizerapi/utils.go
+++ b/toolkit/tools/imagecustomizerapi/utils.go
@@ -5,7 +5,6 @@ package imagecustomizerapi
 
 import (
 	"bytes"
-	"fmt"
 	"os"
 
 	"gopkg.in/yaml.v3"
@@ -51,21 +50,4 @@ func UnmarshalYaml[ValueType HasIsValid](yamlData []byte, value ValueType) error
 	}
 
 	return nil
-}
-
-func AggregateErrors(aggregateErr error, err error) error {
-	if aggregateErr != nil {
-		if err != nil {
-			return fmt.Errorf("%w\n%w", aggregateErr, err)
-		} else {
-			return aggregateErr
-		}
-
-	} else {
-		if err != nil {
-			return err
-		} else {
-			return nil
-		}
-	}
 }

--- a/toolkit/tools/imagecustomizerapi/utils.go
+++ b/toolkit/tools/imagecustomizerapi/utils.go
@@ -5,6 +5,7 @@ package imagecustomizerapi
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 
 	"gopkg.in/yaml.v3"
@@ -50,4 +51,21 @@ func UnmarshalYaml[ValueType HasIsValid](yamlData []byte, value ValueType) error
 	}
 
 	return nil
+}
+
+func AggregateErrors(aggregateErr error, err error) error {
+	if aggregateErr != nil {
+		if err != nil {
+			return fmt.Errorf("%w\n%w", aggregateErr, err)
+		} else {
+			return aggregateErr
+		}
+
+	} else {
+		if err != nil {
+			return err
+		} else {
+			return nil
+		}
+	}
 }

--- a/toolkit/tools/internal/safechroot/dummychroot.go
+++ b/toolkit/tools/internal/safechroot/dummychroot.go
@@ -21,5 +21,5 @@ func (d *DummyChroot) UnsafeRun(toRun func() error) (err error) {
 }
 
 func (d *DummyChroot) AddFiles(filesToCopy ...FileToCopy) (err error) {
-	return addFilesToDestination(d.RootDir(), filesToCopy...)
+	return AddFilesToDestination(d.RootDir(), filesToCopy...)
 }

--- a/toolkit/tools/internal/safechroot/safechroot.go
+++ b/toolkit/tools/internal/safechroot/safechroot.go
@@ -303,42 +303,23 @@ func (c *Chroot) Initialize(tarPath string, extraDirectories []string, extraMoun
 
 // AddFiles copies each file 'Src' to the relative path chrootRootDir/'Dest' in the chroot.
 func (c *Chroot) AddFiles(filesToCopy ...FileToCopy) (err error) {
-	return addFilesToDestination(c.rootDir, filesToCopy...)
+	return AddFilesToDestination(c.rootDir, filesToCopy...)
 }
 
-func addFileToDestination(destDir string, fileToCopy FileToCopy) error {
-	dest := filepath.Join(destDir, fileToCopy.Dest)
-	logger.Log.Debugf("Copying '%s' to '%s'", fileToCopy.Src, dest)
-
-	var err error
-	if fileToCopy.Permissions != nil {
-		err = file.CopyAndChangeMode(fileToCopy.Src, dest, os.ModePerm, *fileToCopy.Permissions)
-	} else {
-		err = file.Copy(fileToCopy.Src, dest)
-	}
-
-	if err != nil {
-		logger.Log.Errorf("Error copying file '%s'", fileToCopy.Src)
-		return err
-	}
-
-	return nil
-}
-
-func AddFilesToDestination(destDir string, filesToCopy []FileToCopy) error {
+func AddFilesToDestination(destDir string, filesToCopy ...FileToCopy) error {
 	for _, f := range filesToCopy {
-		err := addFileToDestination(destDir, f)
-		if err != nil {
-			return err
+		dest := filepath.Join(destDir, f.Dest)
+		logger.Log.Debugf("Copying '%s' to '%s'", f.Src, dest)
+
+		var err error
+		if f.Permissions != nil {
+			err = file.CopyAndChangeMode(f.Src, dest, os.ModePerm, *f.Permissions)
+		} else {
+			err = file.Copy(f.Src, dest)
 		}
-	}
-	return nil
-}
 
-func addFilesToDestination(destDir string, filesToCopy ...FileToCopy) error {
-	for _, f := range filesToCopy {
-		err := addFileToDestination(destDir, f)
 		if err != nil {
+			logger.Log.Errorf("Error copying file '%s'", f.Src)
 			return err
 		}
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeutils.go
@@ -168,13 +168,14 @@ func updateHostname(hostname string, imageChroot *safechroot.Chroot) error {
 	return nil
 }
 
-func copyAdditionalFiles(baseConfigPath string, additionalFiles map[string]imagecustomizerapi.FileConfigList, imageChroot *safechroot.Chroot) error {
+func copyAdditionalFiles(baseConfigPath string, additionalFiles imagecustomizerapi.AdditionalFilesMap, imageChroot *safechroot.Chroot) error {
 	for sourceFile, fileConfigs := range additionalFiles {
+		absSourceFile := filepath.Join(baseConfigPath, sourceFile)
 		for _, fileConfig := range fileConfigs {
 			logger.Log.Infof("Copying: %s", fileConfig.Path)
 
 			fileToCopy := safechroot.FileToCopy{
-				Src:         filepath.Join(baseConfigPath, sourceFile),
+				Src:         absSourceFile,
 				Dest:        fileConfig.Path,
 				Permissions: (*fs.FileMode)(fileConfig.Permissions),
 			}

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -165,7 +165,7 @@ func CustomizeImage(buildDir string, baseConfigPath string, config *imagecustomi
 			return fmt.Errorf("failed to convert image file to format: %s:\n%w", outputImageFormat, err)
 		}
 	case ImageFormatIso:
-		err = createLiveOSIsoImage(buildDir, rawImageFile, outputImageDir, outputImageBase)
+		err = createLiveOSIsoImage(buildDir, baseConfigPath, config.Iso, rawImageFile, outputImageDir, outputImageBase)
 		if err != nil {
 			return err
 		}

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -245,6 +245,9 @@ func validateAdditionalFiles(baseConfigPath string, additionalFiles *imagecustom
 }
 
 func validateIsoConfig(baseConfigPath string, config *imagecustomizerapi.Iso) error {
+	if config == nil {
+		return nil
+	}
 	return validateAdditionalFiles(baseConfigPath, &config.AdditionalFiles)
 }
 

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
@@ -135,7 +135,7 @@ func reconnectToFakeEfiImage(buildDir string, imageFilePath string) (*ImageConne
 func TestValidateConfigValidAdditionalFiles(t *testing.T) {
 	err := validateConfig(testDir, &imagecustomizerapi.Config{
 		SystemConfig: imagecustomizerapi.SystemConfig{
-			AdditionalFiles: map[string]imagecustomizerapi.FileConfigList{
+			AdditionalFiles: imagecustomizerapi.AdditionalFilesMap{
 				"files/a.txt": {{Path: "/a.txt"}},
 			},
 		}}, nil, true)
@@ -145,7 +145,7 @@ func TestValidateConfigValidAdditionalFiles(t *testing.T) {
 func TestValidateConfigMissingAdditionalFiles(t *testing.T) {
 	err := validateConfig(testDir, &imagecustomizerapi.Config{
 		SystemConfig: imagecustomizerapi.SystemConfig{
-			AdditionalFiles: map[string]imagecustomizerapi.FileConfigList{
+			AdditionalFiles: imagecustomizerapi.AdditionalFilesMap{
 				"files/missing_a.txt": {{Path: "/a.txt"}},
 			},
 		}}, nil, true)
@@ -155,7 +155,7 @@ func TestValidateConfigMissingAdditionalFiles(t *testing.T) {
 func TestValidateConfigdditionalFilesIsDir(t *testing.T) {
 	err := validateConfig(testDir, &imagecustomizerapi.Config{
 		SystemConfig: imagecustomizerapi.SystemConfig{
-			AdditionalFiles: map[string]imagecustomizerapi.FileConfigList{
+			AdditionalFiles: imagecustomizerapi.AdditionalFilesMap{
 				"files": {{Path: "/a.txt"}},
 			},
 		}}, nil, true)

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
@@ -577,9 +577,10 @@ func micIsoConfigToIsoMakerConfig(baseConfigPath string, isoConfig *imagecustomi
 	additionalIsoFiles = []safechroot.FileToCopy{}
 
 	for sourcePath, fileConfigs := range isoConfig.AdditionalFiles {
+		absSourcePath := filepath.Join(baseConfigPath, sourcePath)
 		for _, fileConfig := range fileConfigs {
 			fileToCopy := safechroot.FileToCopy{
-				Src:         filepath.Join(baseConfigPath, sourcePath),
+				Src:         absSourcePath,
 				Dest:        fileConfig.Path,
 				Permissions: (*fs.FileMode)(fileConfig.Permissions),
 			}

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
@@ -5,9 +5,11 @@ package imagecustomizerlib
 
 import (
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/imagecustomizerapi"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/imagegen/configuration"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/file"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/logger"
@@ -24,21 +26,24 @@ menuentry "Mariner Baremetal Iso" {
 
 	search --label CDROM --set root
 	linux /isolinux/vmlinuz \
-			overlay-size=70% \
+			overlay-size=70%% \
 			selinux=0 \
 			console=tty0 \
 			apparmor=0 \
 			root=live:LABEL=CDROM \
 			rd.shell \
 			rd.live.image \
-			rd.live.dir=config/additionalfiles/0 \
-			rd.live.squashimg=rootfs.img \
+			rd.live.dir=%s \
+			rd.live.squashimg=%s \
 			rd.live.overlay=1 \
 			rd.live.overlay.nouserconfirmprompt
 
 	initrd /isolinux/initrd.img
 }	
 `
+	liveOSDir   = "liveos"
+	liveOSImage = "rootfs.img"
+
 	dracutConfig = `add_dracutmodules+=" dmsquash-live "
 add_drivers+=" overlay "
 `
@@ -291,9 +296,10 @@ func (b *LiveOSIsoBuilder) prepareLiveOSDir(writeableRootfsDir, isoMakerArtifact
 	b.artifacts.vmlinuzPath = targetVmLinuzPath
 
 	// create grub.cfg
+	targetGrubCfgContent := fmt.Sprintf(grubCfgTemplate, liveOSDir, liveOSImage)
 	targetGrubCfgPath := filepath.Join(b.workingDirs.isoArtifactsDir, "grub.cfg")
 
-	err = os.WriteFile(targetGrubCfgPath, []byte(grubCfgTemplate), 0o644)
+	err = os.WriteFile(targetGrubCfgPath, []byte(targetGrubCfgContent), 0o644)
 	if err != nil {
 		return fmt.Errorf("failed to create grub.cfg:\n%w", err)
 	}
@@ -464,57 +470,14 @@ func (b *LiveOSIsoBuilder) prepareArtifactsFromFullImage(rawImageFile string) er
 	return nil
 }
 
-// createIsoMakerConfig
-//
-//	creates an IsoMaker config objects with the necessary configuration.
-//
-// inputs:
-//   - squashfsImagePath:
-//     path to an existing squashfs image file. The configuration will instruct
-//     IsoMaker to place it under:
-//   - /config/additionalfiles/0/$(basename $squashfsImagePath).
-//
-// outputs:
-//   - returns an IsoMaker configuration.Config object.
-func createIsoMakerConfig(squashfsImagePath string) (configuration.Config, error) {
-
-	config := configuration.Config{
-		SystemConfigs: []configuration.SystemConfig{
-			{
-				AdditionalFiles: map[string]configuration.FileConfigList{
-					// 'AdditionalFiles' is meant to do two things:
-					// 1. copy the files from the build machine to the ISO
-					//    media.
-					// 2. have Mariner installer copy those files from the ISO
-					//    media to the target storage device.
-					// In the MIC LiveOS ISO generation sceanrio, we do not
-					// have/run Mariner installer and do not need to copy them.
-					// So, we are setting the destination to 'dummy-name' as it
-					// never be used.
-					squashfsImagePath: {{Path: "/dummy-name"}},
-				},
-			},
-		},
-	}
-
-	return config, nil
-}
-
 // createIsoImage
 //
 //	creates an LiveOS ISO image.
 //
 // inputs:
-//   - isomakerBuildDir:
-//     folder to be created by the IsoMaker tool to place its temporary files.
-//   - grubCfgPath:
-//     path to the grub.cfg file to be used with the bootloaders.
-//   - initrdImagePath:
-//     path to an existing initrd image file. The initrd image must be
-//     configured to run the LiveOS booting flow in Dracut.
-//   - squashfsImagePath:
-//     path to an existing squashfs image file. The squashfs must host a
-//     rootfs so that initrd can pivot.
+//   - additionalIsoFiles:
+//     map of addition files to copy to the iso media.
+//     sourcePath -> [ targetPath0, targetPath1, ...]
 //   - isoOutputDir:
 //     path to a folder where the output image will be placed. It does not
 //     need to be created before calling this function.
@@ -524,7 +487,7 @@ func createIsoMakerConfig(squashfsImagePath string) (configuration.Config, error
 //
 // ouptuts:
 //   - create a LiveOS ISO.
-func (b *LiveOSIsoBuilder) createIsoImage(isoOutputDir, isoOutputBaseName string) error {
+func (b *LiveOSIsoBuilder) createIsoImage(additionalIsoFiles []safechroot.FileToCopy, isoOutputDir, isoOutputBaseName string) error {
 
 	baseDirPath := ""
 
@@ -549,12 +512,18 @@ func (b *LiveOSIsoBuilder) createIsoImage(isoOutputDir, isoOutputBaseName string
 	releaseVersion := ""
 	imageNameTag := ""
 
-	config, err := createIsoMakerConfig(b.artifacts.squashfsImagePath)
-	if err != nil {
-		return err
-	}
+	// empty target system config since LiveOS does not install the OS
+	// artifacts to the target system.
+	targetSystemConfig := configuration.Config{}
 
-	err = os.MkdirAll(isoOutputDir, os.ModePerm)
+	// Add the squashfs file
+	squashfsImageToCopy := safechroot.FileToCopy{
+		Src:  b.artifacts.squashfsImagePath,
+		Dest: filepath.Join(liveOSDir, liveOSImage),
+	}
+	additionalIsoFiles = append(additionalIsoFiles, squashfsImageToCopy)
+
+	err := os.MkdirAll(isoOutputDir, os.ModePerm)
 	if err != nil {
 		return err
 	}
@@ -567,7 +536,8 @@ func (b *LiveOSIsoBuilder) createIsoImage(isoOutputDir, isoOutputBaseName string
 		b.workingDirs.isomakerBuildDir,
 		releaseVersion,
 		isoResourcesDir,
-		config,
+		additionalIsoFiles,
+		targetSystemConfig,
 		b.artifacts.initrdImagePath,
 		b.artifacts.grubCfgPath,
 		isoRepoDirPath,
@@ -586,6 +556,40 @@ func (b *LiveOSIsoBuilder) createIsoImage(isoOutputDir, isoOutputBaseName string
 	return nil
 }
 
+// micIsoConfigToIsoMakerConfig
+//
+//	converts imagecustomizerapi.Iso to isomaker configuration.
+//
+// inputs:
+//
+//   - 'baseConfigPath'
+//     path to the folder where the mic configuration was loaded from.
+//     This path will be used to construct absolute paths for build machine
+//     file references defined in the config.
+//   - 'isoConfig'
+//     user provided configuration for the iso image.
+//
+// outputs:
+//   - 'additionalIsoFiles'
+//     list of files to copy from the build machine to the iso media.
+func micIsoConfigToIsoMakerConfig(baseConfigPath string, isoConfig *imagecustomizerapi.Iso) (additionalIsoFiles []safechroot.FileToCopy, err error) {
+
+	additionalIsoFiles = []safechroot.FileToCopy{}
+
+	for sourcePath, fileConfigs := range isoConfig.AdditionalFiles {
+		for _, fileConfig := range fileConfigs {
+			fileToCopy := safechroot.FileToCopy{
+				Src:         filepath.Join(baseConfigPath, sourcePath),
+				Dest:        fileConfig.Path,
+				Permissions: (*fs.FileMode)(fileConfig.Permissions),
+			}
+			additionalIsoFiles = append(additionalIsoFiles, fileToCopy)
+		}
+	}
+
+	return additionalIsoFiles, nil
+}
+
 // createLiveOSIsoImage
 //
 //	main function to create a LiveOS ISO image from a raw full disk image file.
@@ -594,6 +598,12 @@ func (b *LiveOSIsoBuilder) createIsoImage(isoOutputDir, isoOutputBaseName string
 //
 //   - 'buildDir':
 //     path build directory (can be shared with other tools).
+//   - 'baseConfigPath'
+//     path to the folder where the mic configuration was loaded from.
+//     This path will be used to construct absolute paths for file references
+//     defined in the config.
+//   - 'isoConfig'
+//     user provided configuration for the iso image.
 //   - 'rawImageFile':
 //     path to an existing raw full disk image (has boot + rootfs partitions).
 //   - 'outputImageDir':
@@ -605,7 +615,12 @@ func (b *LiveOSIsoBuilder) createIsoImage(isoOutputDir, isoOutputBaseName string
 // outputs:
 //
 //	creates a LiveOS ISO image.
-func createLiveOSIsoImage(buildDir, rawImageFile, outputImageDir, outputImageBase string) (err error) {
+func createLiveOSIsoImage(buildDir, baseConfigPath string, isoConfig *imagecustomizerapi.Iso, rawImageFile, outputImageDir, outputImageBase string) (err error) {
+
+	additionalIsoFiles, err := micIsoConfigToIsoMakerConfig(baseConfigPath, isoConfig)
+	if err != nil {
+		return fmt.Errorf("failed to convert iso configuration to isomaker format:\n%w", err)
+	}
 
 	isoBuildDir := filepath.Join(buildDir, "tmp")
 
@@ -640,7 +655,7 @@ func createLiveOSIsoImage(buildDir, rawImageFile, outputImageDir, outputImageBas
 		return err
 	}
 
-	err = isoBuilder.createIsoImage(outputImageDir, outputImageBase)
+	err = isoBuilder.createIsoImage(additionalIsoFiles, outputImageDir, outputImageBase)
 	if err != nil {
 		return err
 	}

--- a/toolkit/tools/pkg/isomakerlib/isomaker.go
+++ b/toolkit/tools/pkg/isomakerlib/isomaker.go
@@ -564,7 +564,7 @@ func (im *IsoMaker) copyAndRenameConfigFiles() (err error) {
 // files can be used by custom initrd/LiveOS images that will look for them
 // on the iso media.
 func (im *IsoMaker) copyIsoAdditionalFiles() (err error) {
-	return safechroot.AddFilesToDestination(im.buildDirPath, im.additionalIsoFiles)
+	return safechroot.AddFilesToDestination(im.buildDirPath, im.additionalIsoFiles...)
 }
 
 // copyAndRenameAdditionalFiles will copy all additional files into an

--- a/toolkit/tools/pkg/isomakerlib/isomaker.go
+++ b/toolkit/tools/pkg/isomakerlib/isomaker.go
@@ -564,23 +564,7 @@ func (im *IsoMaker) copyAndRenameConfigFiles() (err error) {
 // files can be used by custom initrd/LiveOS images that will look for them
 // on the iso media.
 func (im *IsoMaker) copyIsoAdditionalFiles() (err error) {
-	for _, fileToCopy := range im.additionalIsoFiles {
-		// im.buildDirPath maps to the iso media root.
-		absTargetPath := filepath.Join(im.buildDirPath, fileToCopy.Dest)
-		if fileToCopy.Permissions == nil {
-			err = file.Copy(fileToCopy.Src, absTargetPath)
-			if err != nil {
-				return err
-			}
-		} else {
-			err = file.CopyAndChangeMode(fileToCopy.Src, absTargetPath, os.ModePerm, *fileToCopy.Permissions)
-			if err != nil {
-				return err
-			}
-		}
-	}
-
-	return nil
+	return safechroot.AddFilesToDestination(im.buildDirPath, im.additionalIsoFiles)
 }
 
 // copyAndRenameAdditionalFiles will copy all additional files into an


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Today, to add files to the LiveOS ISO image, the files need to be embedded within the LiveOS rootfs. This means MIC has to:
1. customize the rootfs
2. regenerate initrd
3. regenerate the squahfs
4. create the final LiveOS ISO.

In scenarios where the user wants to just replace/add files to the ISO, we can save so much time (30 secs out of 35 secs) if we can skip the steps 1-3 above. This can be done if the files are placed directly on the ISO file system.

This change allows the user to include arbitrary files unto the ISO media. It is introducing a new section for the iso configuration, and is re-using the `AdditionalFile` construct already in use unde the `SystemConfig`.

Note that this change by itself does not allow the faster ISO build time mentioned above. That improvement will manifest when we enable incremental builds or building using a liveos iso as input.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change [[Add support for additional files in mic generated isos.](https://github.com/microsoft/CBL-Mariner/pull/7660/commits/28a541eb21e2a72f37043e7b4a357c7b114839db)

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- [6779 05 - Add support for specifying additional artifacts to be added to the LiveOS ISO file system](https://dev.azure.com/mariner-org/ECF/_workitems/edit/6779)

###### Links to CVEs  <!-- optional -->
- n/a

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: [local]
