### PR TITLE
upgrade open-vm-tools to 12.3.5 for 3.0

### DIFF
--- a/SPECS/open-vm-tools/open-vm-tools.signatures.json
+++ b/SPECS/open-vm-tools/open-vm-tools.signatures.json
@@ -1,6 +1,6 @@
 {
  "Signatures": {
-  "open-vm-tools-11.3.0-18090558.tar.gz": "9bad3ee755340853bf7990e92f3d3880959a73e0749e8aaae62730854368bd2c",
+  "open-vm-tools-12.3.5-22544099.tar.gz": "6003eb5643098a43ff116497891a9875d208841667d15894eeceec28b4f1c3cf",
   "open-vm-tools.conf": "c4dd7cab2c42d9d4996a9a8eff44dc5c35f9e4c60bbb423a5dae62688b01927c",
   "vgauthd.service": "a8d40ce52a23c50f58f159af0bbb24450a55ea2944c8d75656ec9bccb489daa0",
   "vmblock.mount": "4869b965f6f1cdefc60c19b48430486b8fdcc77b14201b0588fc37306d455967",

--- a/SPECS/open-vm-tools/open-vm-tools.spec
+++ b/SPECS/open-vm-tools/open-vm-tools.spec
@@ -19,13 +19,13 @@
 ################################################################################
 
 %global _hardened_build 1
-%global toolsbuild      18090558
+%global toolsbuild      22544099
 %global toolsdaemon     vmtoolsd
 %global vgauthdaemon    vgauthd
 Summary:        Open Virtual Machine Tools for virtual machines hosted on VMware
 Name:           open-vm-tools
-Version:        11.3.0
-Release:        2%{?dist}
+Version:        12.3.5
+Release:        1%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -332,6 +332,9 @@ fi
 %{_bindir}/vmware-vgauth-smoketest
 
 %changelog
+* Wed Jan 31 2024 Bala <balakumaran.kannan@microsoft.com> - 12.3.5-1
+- Upgrade to version 12.3.5
+
 * Wed Mar 16 2022 Matthew Torr <matthewtorr@microsoft.com> - 11.3.0-2
 - Reinstate ConditionVirtualization service option so that the services only run on VMware.
 

--- a/SPECS/open-vm-tools/open-vm-tools.spec
+++ b/SPECS/open-vm-tools/open-vm-tools.spec
@@ -303,6 +303,7 @@ fi
 %{_libdir}/%{name}/plugins/vmsvc/libvmbackup.so
 %{_libdir}/%{name}/plugins/vmsvc/libgdp.so
 %{_libdir}/%{name}/plugins/vmsvc/libguestStore.so
+%{_libdir}/%{name}/plugins/vmsvc/libcomponentMgr.so
 #Usually in desktop package
 %{_bindir}/vmware-vmblock-fuse
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -14954,8 +14954,8 @@
         "type": "other",
         "other": {
           "name": "open-vm-tools",
-          "version": "11.3.0",
-          "downloadUrl": "https://github.com/vmware/open-vm-tools/releases/download/stable-11.3.0/open-vm-tools-11.3.0-18090558.tar.gz"
+          "version": "12.3.5",
+          "downloadUrl": "https://github.com/vmware/open-vm-tools/releases/download/stable-12.3.5/open-vm-tools-12.3.5-22544099.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Upgrade open-vm-tools for 3.0

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
Upgrade open-vm-tools to 12.3.5

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->

###### Links to CVEs  <!-- optional -->

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: local

** Building in buddy-build is continuously failing due to the missing package `xmlsec`. `xmlsec` is upgraded but it's not build and hosted in any repo. Building `xmlsec` and `open-vm-tools` also fails saying `nss` is missing. Building all three together fails with `nss` failing to build and other two are blocked. Ref: [pipeline](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=495798&view=logs&j=7909073b-e471-53c1-2c44-627e2efc0564&t=fbeef549-39ab-510c-faa3-78579a516b53)

Build building them locally with containerized build succeeds. Logs can be found below.
```
Checking for unpackaged file(s): /usr/lib/rpm/check-files /usr/src/mariner/BUILDROOT/open-vm-tools-12.3.5-1.azl3.x86_64
Wrote: /usr/src/mariner/SRPMS/open-vm-tools-12.3.5-1.azl3.src.rpm
Wrote: /usr/src/mariner/RPMS/x86_64/open-vm-tools-test-12.3.5-1.azl3.x86_64.rpm
Wrote: /usr/src/mariner/RPMS/x86_64/open-vm-tools-sdmp-12.3.5-1.azl3.x86_64.rpm
Wrote: /usr/src/mariner/RPMS/x86_64/open-vm-tools-devel-12.3.5-1.azl3.x86_64.rpm
Wrote: /usr/src/mariner/RPMS/x86_64/open-vm-tools-12.3.5-1.azl3.x86_64.rpm
Wrote: /usr/src/mariner/RPMS/x86_64/open-vm-tools-debuginfo-12.3.5-1.azl3.x86_64.rpm
Executing(%clean): /bin/sh -e /var/tmp/rpm-tmp.0NNwmL
+ umask 022
+ cd /usr/src/mariner/BUILD
+ cd open-vm-tools-12.3.5-22544099
+ /bin/rm -rf /usr/src/mariner/BUILDROOT/open-vm-tools-12.3.5-1.azl3.x86_64
+ RPM_EC=0
++ jobs -p
+ exit 0
Executing(rmbuild): /bin/sh -e /var/tmp/rpm-tmp.WnRTRs
+ umask 022
+ cd /usr/src/mariner/BUILD
+ rm -rf open-vm-tools-12.3.5-22544099 open-vm-tools-12.3.5-22544099.gemspec
+ RPM_EC=0
++ jobs -p
+ exit 0
-------- refreshing the local repo ---------
/usr/src/mariner/RPMS /usr/src/mariner
Directory walk started
Directory walk done - 8 packages
Temporary output repo path: ./.repodata/
Preparing sqlite DBs
Pool started (with 5 workers)
Pool finished
/usr/src/mariner
Loaded plugin: tdnfrepogpgcheck
Refreshing metadata for: 'CBL-Mariner Official Base 3.0 x86_64'
Refreshing metadata for: 'Mariner Local Build Repo'
Refreshing metadata for: 'Mariner Host Build Repo'%
Error(1238) : Couldn't read a file:// file
Error: Failed to synchronize cache for repo 'Mariner Host Build Repo'
Error(1238) : Couldn't read a file:// file
root [ /usr/src/mariner ]# ls RPMS/
repodata  x86_64
root [ /usr/src/mariner ]# ls RPMS/x86_64/
open-vm-tools-12.3.5-1.azl3.x86_64.rpm            open-vm-tools-devel-12.3.5-1.azl3.x86_64.rpm  open-vm-tools-test-12.3.5-1.azl3.x86_64.rpm  xmlsec1-debuginfo-1.3.1-1.azl3.x86_64.rpm
open-vm-tools-debuginfo-12.3.5-1.azl3.x86_64.rpm  open-vm-tools-sdmp-12.3.5-1.azl3.x86_64.rpm   xmlsec1-1.3.1-1.azl3.x86_64.rpm              xmlsec1-devel-1.3.1-1.azl3.x86_64.rpm
root [ /usr/src/mariner ]# build_pkg open-vm-tools^C
root [ /usr/src/mariner ]#
```
