### PR TITLE
Fix pytest version for python-virtualenv

### DIFF
--- a/SPECS/python-virtualenv/pin-pytest-version.patch
+++ b/SPECS/python-virtualenv/pin-pytest-version.patch
@@ -1,0 +1,28 @@
+From 40d446bf7f2c3ee200599ec8675a2b57ed024909 Mon Sep 17 00:00:00 2001
+From: corvus-callidus <108946721+corvus-callidus@users.noreply.github.com>
+Date: Wed, 7 Feb 2024 17:12:27 +0000
+Subject: [PATCH] Restrict pytest versions for compatibility
+
+Version 20.14.0 of virtualenv uses now-deprecated pytest APIs. Version 8 of
+pytest now treats the deprecated APIs as errors, so we need to restrict the
+version of pytest for compatibility with this older version of virtualenv.
+
+---
+ setup.cfg | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/setup.cfg b/setup.cfg
+index 991979b..0fbfac7 100644
+--- a/setup.cfg
++++ b/setup.cfg
+@@ -96,7 +96,7 @@ testing =
+ 	coverage>=4
+ 	coverage-enable-subprocess>=1
+ 	flaky>=3
+-	pytest>=4
++	pytest>=4,<8
+ 	pytest-env>=0.6.2
+ 	pytest-freezegun>=0.4.1
+ 	pytest-mock>=2
+--
+2.33.8

--- a/SPECS/python-virtualenv/python-virtualenv.spec
+++ b/SPECS/python-virtualenv/python-virtualenv.spec
@@ -1,7 +1,7 @@
 Summary:        Virtual Python Environment builder
 Name:           python-virtualenv
 Version:        20.14.0
-Release:        5%{?dist}
+Release:        6%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -10,6 +10,7 @@ URL:            https://pypi.python.org/pypi/virtualenv
 Source0:        https://files.pythonhosted.org/packages/4a/c3/04f361a90ed4e6b3f3f696d61db5c786eaa741d2a6c125bc905b8a1c0200/virtualenv-%{version}.tar.gz#/%{name}-%{version}.tar.gz
 # Derived from upstream patch https://github.com/pypa/virtualenv/commit/9f9dc6250fc88e92b1ca6206429966788846d696
 Patch0:         fix-plugin-attribute-name.patch
+Patch1:         pin-pytest-version.patch
 BuildArch:      noarch
 
 %description
@@ -22,7 +23,7 @@ BuildRequires:  python3-setuptools_scm
 BuildRequires:  python3-xml
 BuildRequires:  python3-wheel
 
-%if %{with_check}
+%if 0%{?with_check}
 BuildRequires:  python3-pip
 %endif
 
@@ -56,6 +57,9 @@ tox -e py
 %{_bindir}/virtualenv
 
 %changelog
+* Wed Feb 07 2024 corvus-callidus <108946721+corvus-callidus@users.noreply.github.com> - 20.14.0-6
+- Fix pytest version to <8 for compatibility
+
 * Thu Jan 25 2024 corvus-callidus <108946721+corvus-callidus@users.noreply.github.com> - 20.14.0-5
 - Add missing runtime dependency on python-six
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
The python-virtualenv package pip installs pytest for the check section. The latest release of pytest (v8.0.0) contains a breaking change, treating use of certain deprecated parameters as errors. This caused failures in the python-virtualenv tests since it's an older version which predates the API changes to pytest. To fix the tests, this PR pins the pytest version to `<8`, ensuring we use a compatible version of pytest.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Added patch to pin pytest version to `<8`
- Fixed check section macro

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
NO

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->


###### Links to CVEs  <!-- optional -->


###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build
- Pipeline build id: [501105](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=501105&view=results)
