### PR TITLE
Update dtc to 1.7.0

### DIFF
--- a/SPECS/dtc/dtc.signatures.json
+++ b/SPECS/dtc/dtc.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "dtc-1.6.1.tar.gz": "38a6257f2c23cb9dfa1781ac4ad122d8358e1a22d33b2da0eb492c190644a376"
+  "dtc-1.7.0.tar.gz": "44844eb5373f8780ca1b7b4f64c073b349da1746aaad76c531f65a9dd2483232"
  }
 }

--- a/SPECS/dtc/dtc.spec
+++ b/SPECS/dtc/dtc.spec
@@ -45,6 +45,10 @@ This package provides development files for libfdt
 sed -i 's@--prefix=$(PREFIX)@--prefix=$(PREFIX) --root=/@' pylibfdt/Makefile.pylibfdt
 
 %build
+# Export version for setuptools-scm to prevent error: 
+# "LookupError: setuptools-scm was unable to detect version"
+# due to using a tarball instead of a git repo. This will no longer be needed
+# once "pylibfdt: use fallback version in tarballs" (cd3e230) is released.
 export SETUPTOOLS_SCM_PRETEND_VERSION=%{version}
 make %{?_smp_mflags} V=1 CC="gcc %{optflags} $LDFLAGS -Wno-error=missing-prototypes -Wno-error=cast-qual" NO_PYTHON=1
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -2978,8 +2978,8 @@
         "type": "other",
         "other": {
           "name": "dtc",
-          "version": "1.6.1",
-          "downloadUrl": "https://kernel.org/pub/software/utils/dtc/dtc-1.6.1.tar.gz"
+          "version": "1.7.0",
+          "downloadUrl": "https://kernel.org/pub/software/utils/dtc/dtc-1.7.0.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Dtc's latest version is 1.7.0. Therefore, update to this version. To support this version, set the SETUPTOOLS_SCM_PRETEND_VERSION to properly register the version and alter the logic to setting the root directory. Additionally, add check section according to [makefile](https://git.kernel.org/pub/scm/utils/dtc/dtc.git/tree/tests/Makefile.tests?h=v1.7.0#:~:text=check%3A%09tests%20%24%7BTESTS_BIN%7D%20%24(TESTS_PYLIBFDT)%0A%09cd%20%24(TESTS_PREFIX)%3B%20./run_tests.sh).

Note that the `SETUPTOOLS_SCM_PRETEND_VERSION ` is a workaround as desribed here: https://github.com/pypa/setuptools_scm/issues/357 but will not be needed in future versions thanks to dtc commit [cd3e2304f4a9c4f725dcc548082ccc6c89d078a4](https://git.kernel.org/pub/scm/utils/dtc/dtc.git/commit/setup.py?id=cd3e2304f4a9c4f725dcc548082ccc6c89d078a4)

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Update to version 1.7.0
- Add %check section

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- local build 

<img width="206" alt="image" src="https://github.com/microsoft/CBL-Mariner/assets/10325590/452410f5-3d58-4c47-9395-4e395e002089">
<img width="199" alt="image" src="https://github.com/microsoft/CBL-Mariner/assets/10325590/25034a0e-dbb9-45c1-899e-e5c99e231fe7">

- pipeline (in progress): https://dev.azure.com/mariner-org/mariner/_build/results?buildId=501177&view=results
