### PR TITLE
Image Customizer: change raw-zstd to raw-zst

### DIFF
--- a/toolkit/tools/imagecustomizer/docs/cli.md
+++ b/toolkit/tools/imagecustomizer/docs/cli.md
@@ -42,7 +42,7 @@ iso image. For more details on this format, see: [Mariner Image Customizer ISO S
 
 Format of partition files. If specified, disk partitions will be extracted as separate files.
 
-Options: raw, raw-zstd.
+Options: raw, raw-zst.
 
 ## --shrink-filesystems
 

--- a/toolkit/tools/imagecustomizer/main.go
+++ b/toolkit/tools/imagecustomizer/main.go
@@ -22,7 +22,7 @@ var (
 	imageFile                   = app.Flag("image-file", "Path of the base CBL-Mariner image which the customization will be applied to.").Required().String()
 	outputImageFile             = app.Flag("output-image-file", "Path to write the customized image to.").Required().String()
 	outputImageFormat           = app.Flag("output-image-format", "Format of output image. Supported: vhd, vhdx, qcow2, raw, iso.").Enum("vhd", "vhdx", "qcow2", "raw", "iso")
-	outputSplitPartitionsFormat = app.Flag("output-split-partitions-format", "Format of partition files. Supported: raw, raw-zstd").Enum("raw", "raw-zstd")
+	outputSplitPartitionsFormat = app.Flag("output-split-partitions-format", "Format of partition files. Supported: raw, raw-zst").Enum("raw", "raw-zst")
 	configFile                  = app.Flag("config-file", "Path of the image customization config file.").Required().String()
 	rpmSources                  = app.Flag("rpm-source", "Path to a RPM repo config file or a directory containing RPMs.").Strings()
 	disableBaseImageRpmRepos    = app.Flag("disable-base-image-rpm-repos", "Disable the base image's RPM repos as an RPM source").Bool()

--- a/toolkit/tools/pkg/imagecustomizerlib/extractpartitions.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/extractpartitions.go
@@ -32,13 +32,13 @@ func extractPartitions(imageLoopDevice string, outDir string, basename string, p
 			switch partitionFormat {
 			case "raw":
 				// Do nothing for "raw" case.
-			case "raw-zstd":
+			case "raw-zst":
 				partitionFilepath, err = compressWithZstd(partitionFilepath)
 				if err != nil {
 					return err
 				}
 			default:
-				return fmt.Errorf("unsupported partition format (supported: raw, raw-zstd): %s", partitionFormat)
+				return fmt.Errorf("unsupported partition format (supported: raw, raw-zst): %s", partitionFormat)
 			}
 
 			logger.Log.Infof("Partition file created: %s", partitionFilepath)
@@ -70,7 +70,7 @@ func copyBlockDeviceToFile(outDir, devicePath, name string) (filename string, er
 	return fullPath, nil
 }
 
-// Compress file from raw to raw-zstd format using zstd.
+// Compress file from .raw to .raw.zst format using zstd.
 func compressWithZstd(partitionRawFilepath string) (partitionFilepath string, err error) {
 	// Using -f to overwrite a file with same name if it exists.
 	err = shell.ExecuteLive(true, "zstd", "-f", "-9", "-T0", partitionRawFilepath)
@@ -78,7 +78,7 @@ func compressWithZstd(partitionRawFilepath string) (partitionFilepath string, er
 		return "", fmt.Errorf("failed to compress %s with zstd:\n%w", partitionRawFilepath, err)
 	}
 
-	// Remove raw file since output partition format is raw-zstd.
+	// Remove raw file since output partition format is raw-zst.
 	err = os.Remove(partitionRawFilepath)
 	if err != nil {
 		return "", fmt.Errorf("failed to remove raw file %s:\n%w", partitionRawFilepath, err)


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Changes option for image customizer extract partitions format from raw-zstd to raw-zst to be more inline with the extension of the output produced.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change all instances of raw-zstd to raw-zst where needed.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local run