### PR TITLE
Upgrade dnf5 to Version 5.1.11 and libsolv to Version 0.7.28

### DIFF
--- a/SPECS/dnf5/dnf5.signatures.json
+++ b/SPECS/dnf5/dnf5.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "dnf5-5.0.14.tar.gz": "d04ad2c6a9259c5e9d896d95c85cfefc570e4cf9ee28b4c32c1926770e1f8ebe"
+  "dnf5-5.1.11.tar.gz": "89f5b5e440f60c5136b8ecabad28de24ba987d37dfe6eb9b6df6a1a91842d403"
  }
 }

--- a/SPECS/dnf5/dnf5.spec
+++ b/SPECS/dnf5/dnf5.spec
@@ -1,55 +1,101 @@
 %global project_version_major 5
-%global project_version_minor 0
-%global project_version_patch 14
-# ========== versions of dependencies ==========
-%global libmodulemd_version 2.5.0
-%global librepo_version 1.15.0
-%global libsolv_version 0.7.21
-%global sqlite_version 3.35.0
-%global swig_version 4
-%global zchunk_version 0.9.11
+%global project_version_minor 1
+%global project_version_patch 11
+
+Name:           dnf5
+Version:        %{project_version_major}.%{project_version_minor}.%{project_version_patch}
+Release:        1%{?dist}
+Summary:        Command-line package manager
+License:        GPL-2.0-or-later
+URL:            https://github.com/rpm-software-management/dnf5
+Source0:        %{url}/archive/%{version}/dnf5-%{version}.tar.gz
+
+Requires:       libdnf5%{?_isa} = %{version}-%{release}
+Requires:       libdnf5-cli%{?_isa} = %{version}-%{release}
+Recommends:     bash-completion
+
+Provides:       dnf5-command(install)
+Provides:       dnf5-command(upgrade)
+Provides:       dnf5-command(remove)
+Provides:       dnf5-command(distro-sync)
+Provides:       dnf5-command(downgrade)
+Provides:       dnf5-command(reinstall)
+Provides:       dnf5-command(swap)
+Provides:       dnf5-command(mark)
+Provides:       dnf5-command(autoremove)
+Provides:       dnf5-command(check)
+Provides:       dnf5-command(check-upgrade)
+Provides:       dnf5-command(provides)
+
+Provides:       dnf5-command(leaves)
+Provides:       dnf5-command(repoquery)
+Provides:       dnf5-command(search)
+Provides:       dnf5-command(list)
+Provides:       dnf5-command(info)
+
+Provides:       dnf5-command(group)
+Provides:       dnf5-command(environment)
+Provides:       dnf5-command(module)
+Provides:       dnf5-command(history)
+Provides:       dnf5-command(repo)
+Provides:       dnf5-command(advisory)
+
+Provides:       dnf5-command(clean)
+Provides:       dnf5-command(download)
+Provides:       dnf5-command(makecache)
+
+
 # ========== build options ==========
-%bcond_with dnf5daemon_client
-%bcond_with dnf5daemon_server
+
+%bcond_with    dnf5daemon_client
+%bcond_with    dnf5daemon_server
 %bcond_without libdnf_cli
 %bcond_without dnf5
 %bcond_without dnf5_plugins
 %bcond_without plugin_actions
+%bcond_with    plugin_rhsm
 %bcond_without python_plugins_loader
+
 %bcond_without comps
 %bcond_without modulemd
 %bcond_without zchunk
+
 %bcond_with    html
 %bcond_with    man
+
+
 # TODO Go bindings fail to build, disable for now
 %bcond_with    go
 %bcond_with    perl5
 %bcond_without python3
 %bcond_with    ruby
+
 %bcond_with    clang
 %bcond_with    sanitizers
 %bcond_without tests
 %bcond_with    performance_tests
 %bcond_with    dnf5daemon_tests
+
 %if %{with clang}
     %global toolchain clang
 %endif
-Summary:        Command-line package manager
-Name:           dnf5
-Version:        %{project_version_major}.%{project_version_minor}.%{project_version_patch}
-Release:        2%{?dist}
-License:        GPL-2.0-or-later
-Vendor:         Microsoft Corporation
-Distribution:   Mariner
-URL:            https://github.com/rpm-software-management/dnf5
-Source0:        %{url}/archive/%{version}/dnf5-%{version}.tar.gz
+
+# ========== versions of dependencies ==========
+
+%global libmodulemd_version 2.5.0
+%global librepo_version 1.15.0
+%global libsolv_version 0.7.24
+%global sqlite_version 3.35.0
+%global swig_version 4
+%global zchunk_version 0.9.11
+
+
 # ========== build requires ==========
+
 BuildRequires:  bash-completion
 BuildRequires:  cmake
 BuildRequires:  doxygen
 BuildRequires:  gettext
-BuildRequires:  pkg-config
-BuildRequires:  toml11-devel
 BuildRequires:  pkgconfig(check)
 BuildRequires:  pkgconfig(fmt)
 BuildRequires:  pkgconfig(json-c)
@@ -59,33 +105,38 @@ BuildRequires:  pkgconfig(libsolv) >= %{libsolv_version}
 BuildRequires:  pkgconfig(libsolvext) >= %{libsolv_version}
 BuildRequires:  pkgconfig(rpm) >= 4.17.0
 BuildRequires:  pkgconfig(sqlite3) >= %{sqlite_version}
-Requires:       libdnf5%{?_isa} = %{version}-%{release}
-Requires:       libdnf5-cli%{?_isa} = %{version}-%{release}
-Recommends:     bash-completion
+BuildRequires:  toml11-static
+
 %if %{with clang}
 BuildRequires:  clang
 %else
-BuildRequires:  gcc-c++
+BuildRequires:  gcc-c++ >= 10.1
 %endif
+
 %if %{with tests}
 BuildRequires:  createrepo_c
-BuildRequires:  rpm-build
 BuildRequires:  pkgconfig(cppunit)
+BuildRequires:  rpm-build
 %endif
+
 %if %{with comps}
 BuildRequires:  pkgconfig(libcomps)
 %endif
+
 %if %{with modulemd}
 BuildRequires:  pkgconfig(modulemd-2.0) >= %{libmodulemd_version}
 %endif
+
 %if %{with zchunk}
 BuildRequires:  pkgconfig(zck) >= %{zchunk_version}
 %endif
+
 %if %{with html} || %{with man}
 BuildRequires:  python3dist(breathe)
 BuildRequires:  python3dist(sphinx) >= 4.1.2
 BuildRequires:  python3dist(sphinx-rtd-theme)
 %endif
+
 %if %{with sanitizers}
 # compiler-rt is required by sanitizers in clang
 BuildRequires:  compiler-rt
@@ -93,14 +144,20 @@ BuildRequires:  libasan
 BuildRequires:  liblsan
 BuildRequires:  libubsan
 %endif
+
 %if %{with libdnf_cli}
 # required for libdnf5-cli
 BuildRequires:  pkgconfig(smartcols)
 %endif
+
+%if %{with dnf5_plugins}
+BuildRequires:  libcurl-devel >= 7.62.0
+%endif
+
 %if %{with dnf5daemon_server}
-BuildRequires:  systemd-rpm-macros
 # required for dnf5daemon-server
 BuildRequires:  pkgconfig(sdbus-c++) >= 0.8.1
+BuildRequires:  systemd-rpm-macros
 %if %{with dnf5daemon_tests}
 BuildRequires:  dbus-daemon
 BuildRequires:  polkit
@@ -108,21 +165,30 @@ BuildRequires:  python3-devel
 BuildRequires:  python3dist(dbus-python)
 %endif
 %endif
+
+%if %{with plugin_rhsm}
+BuildRequires:  pkgconfig(librhsm) >= 0.0.3
+BuildRequires:  pkgconfig(glib-2.0) >= 2.44.0
+%endif
+
 # ========== language bindings section ==========
+
 %if %{with perl5} || %{with ruby} || %{with python3}
 BuildRequires:  swig >= %{swig_version}
 %endif
+
 %if %{with perl5}
 # required for perl-libdnf5 and perl-libdnf5-cli
 BuildRequires:  perl-devel
 BuildRequires:  perl-generators
 %if %{with tests}
-BuildRequires:  perl(Test::Exception)
-BuildRequires:  perl(Test::More)
 BuildRequires:  perl(strict)
+BuildRequires:  perl(Test::More)
+BuildRequires:  perl(Test::Exception)
 BuildRequires:  perl(warnings)
 %endif
 %endif
+
 %if %{with ruby}
 # required for ruby-libdnf5 and ruby-libdnf5-cli
 BuildRequires:  pkgconfig(ruby)
@@ -130,6 +196,7 @@ BuildRequires:  pkgconfig(ruby)
 BuildRequires:  rubygem-test-unit
 %endif
 %endif
+
 %if %{with python3}
 # required for python3-libdnf5 and python3-libdnf5-cli
 BuildRequires:  python3-devel
@@ -140,7 +207,7 @@ DNF5 is a command-line package manager that automates the process of installing,
 upgrading, configuring, and removing computer programs in a consistent manner.
 It supports RPM packages, modulemd modules, and comps groups & environments.
 
-%files
+%files -f dnf5.lang
 %{_bindir}/dnf5
 
 %dir %{_sysconfdir}/dnf/dnf5-aliases.d
@@ -155,15 +222,15 @@ It supports RPM packages, modulemd modules, and comps groups & environments.
 %dir %{_datadir}/bash-completion/
 %dir %{_datadir}/bash-completion/completions/
 %{_datadir}/bash-completion/completions/dnf5
-%dir %{_libdir}/sysimage/dnf
-%verify(not md5 size mtime) %ghost %{_libdir}/sysimage/dnf/*
+%dir %{_prefix}/lib/sysimage/dnf
+%verify(not md5 size mtime) %ghost %{_prefix}/lib/sysimage/dnf/*
 %license COPYING.md
 %license gpl-2.0.txt
-
 %if %{with man}
 %{_mandir}/man8/dnf5.8.*
 %{_mandir}/man8/dnf5-advisory.8.*
 %{_mandir}/man8/dnf5-autoremove.8.*
+%{_mandir}/man8/dnf5-check.8.*
 %{_mandir}/man8/dnf5-clean.8.*
 %{_mandir}/man8/dnf5-distro-sync.8.*
 %{_mandir}/man8/dnf5-downgrade.8.*
@@ -178,6 +245,7 @@ It supports RPM packages, modulemd modules, and comps groups & environments.
 %{_mandir}/man8/dnf5-mark.8.*
 # TODO(jkolarik): module is not ready yet
 # %%{_mandir}/man8/dnf5-module.8.*
+%{_mandir}/man8/dnf5-provides.8.*
 %{_mandir}/man8/dnf5-reinstall.8.*
 %{_mandir}/man8/dnf5-remove.8.*
 %{_mandir}/man8/dnf5-repo.8.*
@@ -185,33 +253,46 @@ It supports RPM packages, modulemd modules, and comps groups & environments.
 %{_mandir}/man8/dnf5-search.8.*
 %{_mandir}/man8/dnf5-swap.8.*
 %{_mandir}/man8/dnf5-upgrade.8.*
+%{_mandir}/man7/dnf5-aliases.7.*
+%{_mandir}/man7/dnf5-caching.7.*
 %{_mandir}/man7/dnf5-comps.7.*
 # TODO(jkolarik): filtering is not ready yet
 # %%{_mandir}/man7/dnf5-filtering.7.*
+%{_mandir}/man7/dnf5-forcearch.7.*
 %{_mandir}/man7/dnf5-installroot.7.*
 # TODO(jkolarik): modularity is not ready yet
 # %%{_mandir}/man7/dnf5-modularity.7.*
 %{_mandir}/man7/dnf5-specs.7.*
+%{_mandir}/man5/dnf5.conf.5.*
+%{_mandir}/man5/dnf5.conf-todo.5.*
+%{_mandir}/man5/dnf5.conf-deprecated.5.*
 %endif
 
 # ========== libdnf5 ==========
 %package -n libdnf5
 Summary:        Package management library
 License:        LGPL-2.1-or-later
-Requires:       librepo%{?_isa} >= %{librepo_version}
 #Requires:       libmodulemd{?_isa} >= {libmodulemd_version}
 Requires:       libsolv%{?_isa} >= %{libsolv_version}
+Requires:       librepo%{?_isa} >= %{librepo_version}
 Requires:       sqlite-libs%{?_isa} >= %{sqlite_version}
 
 %description -n libdnf5
 Package management library.
 
-%files -n libdnf5
+%files -n libdnf5 -f libdnf5.lang
 %exclude %{_sysconfdir}/dnf/dnf.conf
+%dir %{_datadir}/dnf5/libdnf.conf.d
+%dir %{_sysconfdir}/dnf/libdnf5.conf.d
+%dir %{_datadir}/dnf5/repos.override.d
+%dir %{_sysconfdir}/dnf/repos.override.d
+%dir %{_sysconfdir}/dnf/libdnf5-plugins
+%dir %{_datadir}/dnf5/repos.d
+%dir %{_datadir}/dnf5/vars.d
 %dir %{_libdir}/libdnf5
 %{_libdir}/libdnf5.so.1*
 %license lgpl-2.1.txt
-%{_var}/cache/libdnf/
+%{_var}/cache/libdnf5/
 
 # ========== libdnf5-cli ==========
 
@@ -224,8 +305,8 @@ Requires:       libdnf5%{?_isa} = %{version}-%{release}
 %description -n libdnf5-cli
 Library for working with a terminal in a command-line package manager.
 
-%files -n libdnf5-cli
-%{_libdir}/libdnf-cli.so.1*
+%files -n libdnf5-cli -f libdnf5-cli.lang
+%{_libdir}/libdnf5-cli.so.1*
 %license COPYING.md
 %license lgpl-2.1.txt
 %endif
@@ -236,16 +317,17 @@ Library for working with a terminal in a command-line package manager.
 Summary:        Development files for dnf5
 License:        LGPL-2.1-or-later
 Requires:       dnf5%{?_isa} = %{version}-%{release}
-Requires:       libdnf5-cli-devel%{?_isa} = %{version}-%{release}
 Requires:       libdnf5-devel%{?_isa} = %{version}-%{release}
+Requires:       libdnf5-cli-devel%{?_isa} = %{version}-%{release}
 
 %description -n dnf5-devel
-Develpment files for dnf5.
+Development files for dnf5.
 
 %files -n dnf5-devel
 %{_includedir}/dnf5/
 %license COPYING.md
 %license lgpl-2.1.txt
+
 
 # ========== libdnf5-devel ==========
 
@@ -259,12 +341,13 @@ Requires:       libsolv-devel%{?_isa} >= %{libsolv_version}
 Development files for libdnf.
 
 %files -n libdnf5-devel
-%{_includedir}/libdnf/
+%{_includedir}/libdnf5/
 %dir %{_libdir}/libdnf5
 %{_libdir}/libdnf5.so
 %{_libdir}/pkgconfig/libdnf5.pc
 %license COPYING.md
 %license lgpl-2.1.txt
+
 
 # ========== libdnf5-cli-devel ==========
 
@@ -277,11 +360,12 @@ Requires:       libdnf5-cli%{?_isa} = %{version}-%{release}
 Development files for libdnf5-cli.
 
 %files -n libdnf5-cli-devel
-%{_includedir}/libdnf-cli/
-%{_libdir}/libdnf-cli.so
-%{_libdir}/pkgconfig/libdnf-cli.pc
+%{_includedir}/libdnf5-cli/
+%{_libdir}/libdnf5-cli.so
+%{_libdir}/pkgconfig/libdnf5-cli.pc
 %license COPYING.md
 %license lgpl-2.1.txt
+
 
 # ========== perl-libdnf5 ==========
 
@@ -290,6 +374,7 @@ Development files for libdnf5-cli.
 Summary:        Perl 5 bindings for the libdnf library
 License:        LGPL-2.1-or-later
 Requires:       libdnf5%{?_isa} = %{version}-%{release}
+
 
 %description -n perl-libdnf5
 Perl 5 bindings for the libdnf library.
@@ -309,6 +394,7 @@ Perl 5 bindings for the libdnf library.
 Summary:        Perl 5 bindings for the libdnf5-cli library
 License:        LGPL-2.1-or-later
 Requires:       libdnf5-cli%{?_isa} = %{version}-%{release}
+
 
 %description -n perl-libdnf5-cli
 Perl 5 bindings for the libdnf5-cli library.
@@ -367,9 +453,9 @@ Python 3 bindings for the libdnf5-cli library.
 %package -n ruby-libdnf5
 Summary:        Ruby bindings for the libdnf library
 License:        LGPL-2.1-or-later
+Provides:       ruby(libdnf) = %{version}-%{release}
 Requires:       libdnf5%{?_isa} = %{version}-%{release}
 Requires:       ruby(release)
-Provides:       ruby(libdnf) = %{version}-%{release}
 
 %description -n ruby-libdnf5
 Ruby bindings for the libdnf library.
@@ -387,9 +473,9 @@ Ruby bindings for the libdnf library.
 %package -n ruby-libdnf5-cli
 Summary:        Ruby bindings for the libdnf5-cli library
 License:        LGPL-2.1-or-later
+Provides:       ruby(libdnf_cli) = %{version}-%{release}
 Requires:       libdnf5-cli%{?_isa} = %{version}-%{release}
 Requires:       ruby(release)
-Provides:       ruby(libdnf_cli) = %{version}-%{release}
 
 %description -n ruby-libdnf5-cli
 Ruby bindings for the libdnf5-cli library.
@@ -405,15 +491,40 @@ Ruby bindings for the libdnf5-cli library.
 
 %if %{with plugin_actions}
 %package -n libdnf5-plugin-actions
-Summary:        Libdnf plugin that allows to run actions (external executables) on hooks
+Summary:        Libdnf5 plugin that allows to run actions (external executables) on hooks
 License:        LGPL-2.1-or-later
 Requires:       libdnf5%{?_isa} = %{version}-%{release}
 
 %description -n libdnf5-plugin-actions
-Libdnf plugin that allows to run actions (external executables) on hooks.
+Libdnf5 plugin that allows to run actions (external executables) on hooks.
 
-%files -n libdnf5-plugin-actions
+%files -n libdnf5-plugin-actions -f libdnf5-plugin-actions.lang
 %{_libdir}/libdnf5/plugins/actions.*
+%config %{_sysconfdir}/dnf/libdnf5-plugins/actions.conf
+%dir %{_sysconfdir}/dnf/libdnf5-plugins/actions.d
+%if %{with man}
+%{_mandir}/man8/libdnf5-actions.8.*
+%endif
+%endif
+
+
+# ========== libdnf5-plugin-plugin_rhsm ==========
+
+%if %{with plugin_rhsm}
+%package -n libdnf5-plugin-rhsm
+Summary:        Libdnf5 rhsm (Red Hat Subscription Manager) plugin
+License:        LGPL-2.1-or-later
+Requires:       libdnf5%{?_isa} = %{version}-%{release}
+
+%description -n libdnf5-plugin-rhsm
+Libdnf5 plugin with basic support for Red Hat subscriptions.
+Synchronizes the the enrollment with the vendor system. This can change
+the contents of the repositories configuration files according
+to the subscription levels.
+
+%files -n libdnf5-plugin-rhsm -f libdnf5-plugin-rhsm.lang
+%{_libdir}/libdnf5/plugins/rhsm.*
+%config %{_sysconfdir}/dnf/libdnf5-plugins/rhsm.conf
 %endif
 
 
@@ -421,13 +532,13 @@ Libdnf plugin that allows to run actions (external executables) on hooks.
 
 %if %{with python_plugins_loader}
 %package -n python3-libdnf5-python-plugins-loader
-Summary:        Libdnf plugin that allows loading Python plugins
+Summary:        Libdnf5 plugin that allows loading Python plugins
 License:        LGPL-2.1-or-later
 Requires:       libdnf5%{?_isa} = %{version}-%{release}
 Requires:       python3-libdnf5%{?_isa} = %{version}-%{release}
 
 %description -n python3-libdnf5-python-plugins-loader
-Libdnf plugin that allows loading Python plugins.
+Libdnf5 plugin that allows loading Python plugins.
 
 %files -n python3-libdnf5-python-plugins-loader
 %{_libdir}/libdnf5/plugins/python_plugins_loader.*
@@ -442,14 +553,14 @@ Libdnf plugin that allows loading Python plugins.
 %package -n dnf5daemon-client
 Summary:        Command-line interface for dnf5daemon-server
 License:        GPL-2.0-or-later
-Requires:       dnf5daemon-server
 Requires:       libdnf5%{?_isa} = %{version}-%{release}
 Requires:       libdnf5-cli%{?_isa} = %{version}-%{release}
+Requires:       dnf5daemon-server
 
 %description -n dnf5daemon-client
 Command-line interface for dnf5daemon-server.
 
-%files -n dnf5daemon-client
+%files -n dnf5daemon-client -f dnf5daemon-client.lang
 %{_bindir}/dnf5daemon-client
 %license COPYING.md
 %license gpl-2.0.txt
@@ -465,9 +576,9 @@ Command-line interface for dnf5daemon-server.
 %package -n dnf5daemon-server
 Summary:        Package management service with a DBus interface
 License:        GPL-2.0-or-later
-Requires:       dbus
 Requires:       libdnf5%{?_isa} = %{version}-%{release}
 Requires:       libdnf5-cli%{?_isa} = %{version}-%{release}
+Requires:       dbus
 Requires:       polkit
 
 %description -n dnf5daemon-server
@@ -482,7 +593,7 @@ Package management service with a DBus interface.
 %postun -n dnf5daemon-server
 %systemd_postun_with_restart dnf5daemon-server.service
 
-%files -n dnf5daemon-server
+%files -n dnf5daemon-server -f dnf5daemon-server.lang
 %{_sbindir}/dnf5daemon-server
 %{_unitdir}/dnf5daemon-server.service
 %config(noreplace) %{_sysconfdir}/dbus-1/system.d/org.rpm.dnf.v0.conf
@@ -505,15 +616,25 @@ Package management service with a DBus interface.
 Summary:        Plugins for dnf5
 License:        LGPL-2.1-or-later
 Requires:       dnf5%{?_isa} = %{version}-%{release}
+Requires:       libcurl%{?_isa} >= 7.62.0
+Requires:       libdnf5-cli%{?_isa} = %{version}-%{release}
+Provides:       dnf5-command(builddep)
+Provides:       dnf5-command(changelog)
+Provides:       dnf5-command(config-manager)
+Provides:       dnf5-command(copr)
+Provides:       dnf5-command(needs-restarting)
+Provides:       dnf5-command(repoclosure)
 
 %description -n dnf5-plugins
-Core DNF5 plugins that enhance dnf5 with builddep, changelog, copr, and repoclosure commands.
+Core DNF5 plugins that enhance dnf5 with builddep, changelog,
+config-manager, copr, and repoclosure commands.
 
-%files -n dnf5-plugins
+%files -n dnf5-plugins -f dnf5-plugin-builddep.lang -f dnf5-plugin-changelog.lang -f dnf5-plugin-config-manager.lang -f dnf5-plugin-copr.lang -f dnf5-plugin-needs-restarting.lang -f dnf5-plugin-repoclosure.lang
 %{_libdir}/dnf5/plugins/*.so
 %if %{with man}
 %{_mandir}/man8/dnf5-builddep.8.*
 %{_mandir}/man8/dnf5-copr.8.*
+%{_mandir}/man8/dnf5-needs-restarting.8.*
 %{_mandir}/man8/dnf5-repoclosure.8.*
 %endif
 %endif
@@ -535,6 +656,7 @@ Core DNF5 plugins that enhance dnf5 with builddep, changelog, copr, and repoclos
     -DWITH_LIBDNF5_CLI=%{?with_libdnf_cli:ON}%{!?with_libdnf_cli:OFF} \
     -DWITH_DNF5=%{?with_dnf5:ON}%{!?with_dnf5:OFF} \
     -DWITH_PLUGIN_ACTIONS=%{?with_plugin_actions:ON}%{!?with_plugin_actions:OFF} \
+    -DWITH_PLUGIN_RHSM=%{?with_plugin_rhsm:ON}%{!?with_plugin_rhsm:OFF} \
     -DWITH_PYTHON_PLUGINS_LOADER=%{?with_python_plugins_loader:ON}%{!?with_python_plugins_loader:OFF} \
     \
     -DWITH_COMPS=%{?with_comps:ON}%{!?with_comps:OFF} \
@@ -574,22 +696,39 @@ Core DNF5 plugins that enhance dnf5 with builddep, changelog, copr, and repoclos
 
 
 # own dirs and files that dnf5 creates on runtime
-mkdir -p %{buildroot}%{_libdir}/sysimage/dnf
+mkdir -p %{buildroot}%{_prefix}/lib/sysimage/dnf
 for files in \
     groups.toml modules.toml nevras.toml packages.toml \
     system.toml transaction_history.sqlite \
     transaction_history.sqlite-shm \
     transaction_history.sqlite-wal userinstalled.toml
 do
-    touch %{buildroot}%{_libdir}/sysimage/dnf/$files
+    touch %{buildroot}%{_prefix}/lib/sysimage/dnf/$files
 done
 
-#find_lang {name}
+
+%find_lang dnf5
+%find_lang dnf5-plugin-builddep
+%find_lang dnf5-plugin-changelog
+%find_lang dnf5-plugin-config-manager
+%find_lang dnf5-plugin-copr
+%find_lang dnf5-plugin-needs-restarting
+%find_lang dnf5-plugin-repoclosure
+%find_lang dnf5daemon-client
+%find_lang dnf5daemon-server
+%find_lang libdnf5
+%find_lang libdnf5-cli
+%find_lang libdnf5-plugin-actions
+%find_lang libdnf5-plugin-rhsm
 
 %ldconfig_scriptlets
 
 
 %changelog
+* Wed Jan 31 2024 Sam Meluch <sammeluch@microsoft.com> - 5.1.11-1
+- Update to version 5.1.11
+- Merge spec from upstream dnf5 repo
+
 * Wed Sep 20 2023 Jon Slobodzian <joslobo@microsoft.com> - 5.0.14-2
 - Recompile with stack-protection fixed gcc version (CVE-2023-4039)
 

--- a/SPECS/dnf5/dnf5.spec
+++ b/SPECS/dnf5/dnf5.spec
@@ -84,7 +84,7 @@ Provides:       dnf5-command(makecache)
 
 %global libmodulemd_version 2.5.0
 %global librepo_version 1.15.0
-%global libsolv_version 0.7.24
+%global libsolv_version 0.7.25
 %global sqlite_version 3.35.0
 %global swig_version 4
 %global zchunk_version 0.9.11

--- a/SPECS/dnf5/dnf5.spec
+++ b/SPECS/dnf5/dnf5.spec
@@ -105,7 +105,7 @@ BuildRequires:  pkgconfig(libsolv) >= %{libsolv_version}
 BuildRequires:  pkgconfig(libsolvext) >= %{libsolv_version}
 BuildRequires:  pkgconfig(rpm) >= 4.17.0
 BuildRequires:  pkgconfig(sqlite3) >= %{sqlite_version}
-BuildRequires:  toml11-static
+BuildRequires:  toml11-devel
 
 %if %{with clang}
 BuildRequires:  clang
@@ -151,7 +151,7 @@ BuildRequires:  pkgconfig(smartcols)
 %endif
 
 %if %{with dnf5_plugins}
-BuildRequires:  libcurl-devel >= 7.62.0
+BuildRequires:  curl-devel >= 7.62.0
 %endif
 
 %if %{with dnf5daemon_server}
@@ -616,7 +616,7 @@ Package management service with a DBus interface.
 Summary:        Plugins for dnf5
 License:        LGPL-2.1-or-later
 Requires:       dnf5%{?_isa} = %{version}-%{release}
-Requires:       libcurl%{?_isa} >= 7.62.0
+Requires:       curl-libs%{?_isa} >= 7.62.0
 Requires:       libdnf5-cli%{?_isa} = %{version}-%{release}
 Provides:       dnf5-command(builddep)
 Provides:       dnf5-command(changelog)
@@ -728,6 +728,7 @@ done
 * Wed Jan 31 2024 Sam Meluch <sammeluch@microsoft.com> - 5.1.11-1
 - Update to version 5.1.11
 - Merge spec from upstream dnf5 repo
+- Update dependency lists for Azure Linux provided packages
 
 * Wed Sep 20 2023 Jon Slobodzian <joslobo@microsoft.com> - 5.0.14-2
 - Recompile with stack-protection fixed gcc version (CVE-2023-4039)

--- a/SPECS/dnf5/dnf5.spec
+++ b/SPECS/dnf5/dnf5.spec
@@ -106,6 +106,8 @@ BuildRequires:  pkgconfig(libsolvext) >= %{libsolv_version}
 BuildRequires:  pkgconfig(rpm) >= 4.17.0
 BuildRequires:  pkgconfig(sqlite3) >= %{sqlite_version}
 BuildRequires:  toml11-devel
+BuildRequires:  sdbus-cpp-devel >= 0.8.1
+BuildRequires:  sdbus-cpp >= 0.8.1
 
 %if %{with clang}
 BuildRequires:  clang
@@ -156,7 +158,6 @@ BuildRequires:  curl-devel >= 7.62.0
 
 %if %{with dnf5daemon_server}
 # required for dnf5daemon-server
-BuildRequires:  pkgconfig(sdbus-c++) >= 0.8.1
 BuildRequires:  systemd-rpm-macros
 %if %{with dnf5daemon_tests}
 BuildRequires:  dbus-daemon
@@ -207,7 +208,7 @@ DNF5 is a command-line package manager that automates the process of installing,
 upgrading, configuring, and removing computer programs in a consistent manner.
 It supports RPM packages, modulemd modules, and comps groups & environments.
 
-%files -f dnf5.lang
+%files
 %{_bindir}/dnf5
 
 %dir %{_sysconfdir}/dnf/dnf5-aliases.d
@@ -280,7 +281,7 @@ Requires:       sqlite-libs%{?_isa} >= %{sqlite_version}
 %description -n libdnf5
 Package management library.
 
-%files -n libdnf5 -f libdnf5.lang
+%files -n libdnf5
 %exclude %{_sysconfdir}/dnf/dnf.conf
 %dir %{_datadir}/dnf5/libdnf.conf.d
 %dir %{_sysconfdir}/dnf/libdnf5.conf.d
@@ -305,7 +306,7 @@ Requires:       libdnf5%{?_isa} = %{version}-%{release}
 %description -n libdnf5-cli
 Library for working with a terminal in a command-line package manager.
 
-%files -n libdnf5-cli -f libdnf5-cli.lang
+%files -n libdnf5-cli
 %{_libdir}/libdnf5-cli.so.1*
 %license COPYING.md
 %license lgpl-2.1.txt
@@ -498,7 +499,7 @@ Requires:       libdnf5%{?_isa} = %{version}-%{release}
 %description -n libdnf5-plugin-actions
 Libdnf5 plugin that allows to run actions (external executables) on hooks.
 
-%files -n libdnf5-plugin-actions -f libdnf5-plugin-actions.lang
+%files -n libdnf5-plugin-actions
 %{_libdir}/libdnf5/plugins/actions.*
 %config %{_sysconfdir}/dnf/libdnf5-plugins/actions.conf
 %dir %{_sysconfdir}/dnf/libdnf5-plugins/actions.d
@@ -522,7 +523,7 @@ Synchronizes the the enrollment with the vendor system. This can change
 the contents of the repositories configuration files according
 to the subscription levels.
 
-%files -n libdnf5-plugin-rhsm -f libdnf5-plugin-rhsm.lang
+%files -n libdnf5-plugin-rhsm
 %{_libdir}/libdnf5/plugins/rhsm.*
 %config %{_sysconfdir}/dnf/libdnf5-plugins/rhsm.conf
 %endif
@@ -560,7 +561,7 @@ Requires:       dnf5daemon-server
 %description -n dnf5daemon-client
 Command-line interface for dnf5daemon-server.
 
-%files -n dnf5daemon-client -f dnf5daemon-client.lang
+%files -n dnf5daemon-client
 %{_bindir}/dnf5daemon-client
 %license COPYING.md
 %license gpl-2.0.txt
@@ -593,7 +594,7 @@ Package management service with a DBus interface.
 %postun -n dnf5daemon-server
 %systemd_postun_with_restart dnf5daemon-server.service
 
-%files -n dnf5daemon-server -f dnf5daemon-server.lang
+%files -n dnf5daemon-server
 %{_sbindir}/dnf5daemon-server
 %{_unitdir}/dnf5daemon-server.service
 %config(noreplace) %{_sysconfdir}/dbus-1/system.d/org.rpm.dnf.v0.conf
@@ -629,7 +630,7 @@ Provides:       dnf5-command(repoclosure)
 Core DNF5 plugins that enhance dnf5 with builddep, changelog,
 config-manager, copr, and repoclosure commands.
 
-%files -n dnf5-plugins -f dnf5-plugin-builddep.lang -f dnf5-plugin-changelog.lang -f dnf5-plugin-config-manager.lang -f dnf5-plugin-copr.lang -f dnf5-plugin-needs-restarting.lang -f dnf5-plugin-repoclosure.lang
+%files -n dnf5-plugins
 %{_libdir}/dnf5/plugins/*.so
 %if %{with man}
 %{_mandir}/man8/dnf5-builddep.8.*
@@ -678,7 +679,8 @@ config-manager, copr, and repoclosure commands.
     \
     -DPROJECT_VERSION_MAJOR=%{project_version_major} \
     -DPROJECT_VERSION_MINOR=%{project_version_minor} \
-    -DPROJECT_VERSION_PATCH=%{project_version_patch}
+    -DPROJECT_VERSION_PATCH=%{project_version_patch} \
+	-DWITH_TRANSLATIONS=OFF
 %cmake_build
 %if %{with man}
     %cmake_build --target doc-man
@@ -705,21 +707,6 @@ for files in \
 do
     touch %{buildroot}%{_prefix}/lib/sysimage/dnf/$files
 done
-
-
-%find_lang dnf5
-%find_lang dnf5-plugin-builddep
-%find_lang dnf5-plugin-changelog
-%find_lang dnf5-plugin-config-manager
-%find_lang dnf5-plugin-copr
-%find_lang dnf5-plugin-needs-restarting
-%find_lang dnf5-plugin-repoclosure
-%find_lang dnf5daemon-client
-%find_lang dnf5daemon-server
-%find_lang libdnf5
-%find_lang libdnf5-cli
-%find_lang libdnf5-plugin-actions
-%find_lang libdnf5-plugin-rhsm
 
 %ldconfig_scriptlets
 

--- a/SPECS/libsolv/libsolv.signatures.json
+++ b/SPECS/libsolv/libsolv.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "libsolv-0.7.24.tar.gz": "62743265222a729c7fe94c40f7b90ccc1ac5568f5ee6df46884e7ce3c16c78c7"
+  "libsolv-0.7.24.tar.gz": "bd2406f498fea6086ae0eacbf8b188c98b380e59af2267170e6a7b7d715cb207"
  }
 }

--- a/SPECS/libsolv/libsolv.signatures.json
+++ b/SPECS/libsolv/libsolv.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "libsolv-0.7.24.tar.gz": "bd2406f498fea6086ae0eacbf8b188c98b380e59af2267170e6a7b7d715cb207"
+  "libsolv-0.7.28.tar.gz": "bd2406f498fea6086ae0eacbf8b188c98b380e59af2267170e6a7b7d715cb207"
  }
 }

--- a/SPECS/libsolv/libsolv.spec
+++ b/SPECS/libsolv/libsolv.spec
@@ -1,6 +1,6 @@
 Summary:        A free package dependency solver
 Name:           libsolv
-Version:        0.7.24
+Version:        0.7.28
 Release:        1%{?dist}
 License:        BSD
 URL:            https://github.com/openSUSE/libsolv
@@ -77,6 +77,9 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %{_mandir}/man1/*
 
 %changelog
+* Wed Jan 31 2024 Sam Meluch <sammeluch@microsoft.com> - 0.7.28-1
+- Upgrade libsolv to version 0.7.28
+
 * Tue Jun 20 2023 Sam Meluch <sammeluch@microsoft.com> - 0.7.24-1
 - add ENABLE_COMPS option to support dnf5
 - Upgrade to version 0.7.24

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -10911,8 +10911,8 @@
         "type": "other",
         "other": {
           "name": "libsolv",
-          "version": "0.7.24",
-          "downloadUrl": "https://github.com/openSUSE/libsolv/archive/0.7.24/libsolv-0.7.24.tar.gz"
+          "version": "0.7.28",
+          "downloadUrl": "https://github.com/openSUSE/libsolv/archive/0.7.28/libsolv-0.7.28.tar.gz"
         }
       }
     },

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -2708,8 +2708,8 @@
         "type": "other",
         "other": {
           "name": "dnf5",
-          "version": "5.0.14",
-          "downloadUrl": "https://github.com/rpm-software-management/dnf5/archive/5.0.14/dnf5-5.0.14.tar.gz"
+          "version": "5.1.11",
+          "downloadUrl": "https://github.com/rpm-software-management/dnf5/archive/5.1.11/dnf5-5.1.11.tar.gz"
         }
       }
     },

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -184,8 +184,8 @@ rpm-libs-4.18.0-4.azl3.aarch64.rpm
 cpio-2.14-1.azl3.aarch64.rpm
 cpio-lang-2.14-1.azl3.aarch64.rpm
 e2fsprogs-libs-1.47.0-1.azl3.aarch64.rpm
-libsolv-0.7.24-1.azl3.aarch64.rpm
-libsolv-devel-0.7.24-1.azl3.aarch64.rpm
+libsolv-0.7.28-1.azl3.aarch64.rpm
+libsolv-devel-0.7.28-1.azl3.aarch64.rpm
 libssh2-1.11.0-1.azl3.aarch64.rpm
 libssh2-devel-1.11.0-1.azl3.aarch64.rpm
 krb5-1.21.2-1.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -184,8 +184,8 @@ rpm-libs-4.18.0-4.azl3.x86_64.rpm
 cpio-2.14-1.azl3.x86_64.rpm
 cpio-lang-2.14-1.azl3.x86_64.rpm
 e2fsprogs-libs-1.47.0-1.azl3.x86_64.rpm
-libsolv-0.7.24-1.azl3.x86_64.rpm
-libsolv-devel-0.7.24-1.azl3.x86_64.rpm
+libsolv-0.7.28-1.azl3.x86_64.rpm
+libsolv-devel-0.7.28-1.azl3.x86_64.rpm
 libssh2-1.11.0-1.azl3.x86_64.rpm
 libssh2-devel-1.11.0-1.azl3.x86_64.rpm
 krb5-1.21.2-1.azl3.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -199,10 +199,10 @@ libselinux-utils-3.5-1.azl3.aarch64.rpm
 libsepol-3.5-1.azl3.aarch64.rpm
 libsepol-debuginfo-3.5-1.azl3.aarch64.rpm
 libsepol-devel-3.5-1.azl3.aarch64.rpm
-libsolv-0.7.24-1.azl3.aarch64.rpm
-libsolv-debuginfo-0.7.24-1.azl3.aarch64.rpm
-libsolv-devel-0.7.24-1.azl3.aarch64.rpm
-libsolv-tools-0.7.24-1.azl3.aarch64.rpm
+libsolv-0.7.28-1.azl3.aarch64.rpm
+libsolv-debuginfo-0.7.28-1.azl3.aarch64.rpm
+libsolv-devel-0.7.28-1.azl3.aarch64.rpm
+libsolv-tools-0.7.28-1.azl3.aarch64.rpm
 libssh2-1.11.0-1.azl3.aarch64.rpm
 libssh2-debuginfo-1.11.0-1.azl3.aarch64.rpm
 libssh2-devel-1.11.0-1.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -205,10 +205,10 @@ libselinux-utils-3.5-1.azl3.x86_64.rpm
 libsepol-3.5-1.azl3.x86_64.rpm
 libsepol-debuginfo-3.5-1.azl3.x86_64.rpm
 libsepol-devel-3.5-1.azl3.x86_64.rpm
-libsolv-0.7.24-1.azl3.x86_64.rpm
-libsolv-debuginfo-0.7.24-1.azl3.x86_64.rpm
-libsolv-devel-0.7.24-1.azl3.x86_64.rpm
-libsolv-tools-0.7.24-1.azl3.x86_64.rpm
+libsolv-0.7.28-1.azl3.x86_64.rpm
+libsolv-debuginfo-0.7.28-1.azl3.x86_64.rpm
+libsolv-devel-0.7.28-1.azl3.x86_64.rpm
+libsolv-tools-0.7.28-1.azl3.x86_64.rpm
 libssh2-1.11.0-1.azl3.x86_64.rpm
 libssh2-debuginfo-1.11.0-1.azl3.x86_64.rpm
 libssh2-devel-1.11.0-1.azl3.x86_64.rpm


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ x] The toolchain/worker package manifests are up-to-date
- [ x] Any updated packages successfully build (or no packages were changed)
- [ x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ x] All package sources are available
- [ x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [ x] All source files have up-to-date hashes in the `*.signatures.json` files
- [ x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ x] Documentation has been updated to match any changes to the build system
- [ x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
dnf5 was not building on 3.0-dev and is also in need of an upgrade for Azure Linux 3.0.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Upgrade dnf5 to version 5.1.11
- Upgrade libsolv to version 0.7.28 to support dnf5

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local toolchain build on 3.0-dev
- local build and test for dnf5 (since libsolv is a toolchain package in need of an upgrade, buddy builds always fail for dnf5)
