### PR TITLE
fix cve-2022-21698 in rook

### DIFF
--- a/SPECS/rook/CVE-2022-21698.patch
+++ b/SPECS/rook/CVE-2022-21698.patch
@@ -1,0 +1,364 @@
+From 253029f7ffbade99588df59a8b89a35d99197fe0 Mon Sep 17 00:00:00 2001
+From: Tobias Brick <tobiasb@microsoft.com>
+Date: Tue, 18 Jan 2022 10:19:28 +0100
+Subject: [PATCH] Port upstream patch
+ https://github.com/prometheus/client_golang/commit/9075cdf61646b5adf54d3ba77a0e4f6c65cb4fd7
+
+Differences:
+- Removed tests
+- Removed some comments that don't merge
+- Line numbers and such
+
+Based on:
+
+From 9075cdf61646b5adf54d3ba77a0e4f6c65cb4fd7 Mon Sep 17 00:00:00 2001
+From: Kemal Akkoyun <kakkoyun@users.noreply.github.com>
+Date: Tue, 18 Jan 2022 10:19:28 +0100
+Subject: [PATCH] promhttp: Check validity of method and code label values
+ (#962)
+
+* Check validity of method and code label values
+
+Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>
+
+* Use more flexibly functional option pattern for configuration
+
+Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>
+
+* Update documentation
+
+Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>
+
+* Simplify
+
+Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>
+
+* Fix inconsistent method naming
+
+Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>
+---
+vendor/github.com/prometheus/client_golang/prometheuspromhttp/instrument_client.go | 28 ++++++--
+vendor/github.com/prometheus/client_golang/prometheuspromhttp/instrument_server.go | 82 ++++++++++++++++++------
+vendor/github.com/prometheus/client_golang/prometheuspromhttp/option.go            | 31 +++++++++
+ 3 files changed, 116 insertions(+), 25 deletions(-)
+ create mode 100644vendor/github.com/prometheus/client_golang/prometheuspromhttp/option.go
+
+diff --git a/vendor/github.com/prometheus/client_golang/prometheus/promhttp/instrument_client.go b/vendor/github.com/prometheus/client_golang/prometheus/promhttp/instrument_client.go
+index 83c49b6..861b4d2 100644
+--- a/vendor/github.com/prometheus/client_golang/prometheus/promhttp/instrument_client.go
++++ b/vendor/github.com/prometheus/client_golang/prometheus/promhttp/instrument_client.go
+@@ -49,7 +49,10 @@ func InstrumentRoundTripperInFlight(gauge prometheus.Gauge, next http.RoundTripp
+ // http.RoundTripper to observe the request result with the provided CounterVec.
+ // The CounterVec must have zero, one, or two non-const non-curried labels. For
+ // those, the only allowed label names are "code" and "method". The function
+-// panics otherwise. Partitioning of the CounterVec happens by HTTP status code
++// panics otherwise. For the "method" label a predefined default label value set
++// is used to filter given values. Values besides predefined values will count
++// as `unknown` method.`WithExtraMethods` can be used to add more
++// methods to the set. Partitioning of the CounterVec happens by HTTP status code
+ // and/or HTTP method if the respective instance label names are present in the
+ // CounterVec. For unpartitioned counting, use a CounterVec with zero labels.
+ //
+@@ -57,13 +60,18 @@ func InstrumentRoundTripperInFlight(gauge prometheus.Gauge, next http.RoundTripp
+ // is not incremented.
+ //
+ // See the example for ExampleInstrumentRoundTripperDuration for example usage.
+-func InstrumentRoundTripperCounter(counter *prometheus.CounterVec, next http.RoundTripper) RoundTripperFunc {
++func InstrumentRoundTripperCounter(counter *prometheus.CounterVec, next http.RoundTripper, opts ...Option) RoundTripperFunc {
++	rtOpts := &option{}
++	for _, o := range opts {
++		o(rtOpts)
++	}
++
+ 	code, method := checkLabels(counter)
+ 
+ 	return RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
+ 		resp, err := next.RoundTrip(r)
+ 		if err == nil {
+-			counter.With(labels(code, method, r.Method, resp.StatusCode)).Inc()
++			counter.With(labels(code, method, r.Method, resp.StatusCode, rtOpts.extraMethods...)).Inc()
+ 		}
+ 		return resp, err
+ 	})
+@@ -73,7 +81,10 @@ func InstrumentRoundTripperCounter(counter *prometheus.CounterVec, next http.Rou
+ // http.RoundTripper to observe the request duration with the provided
+ // ObserverVec.  The ObserverVec must have zero, one, or two non-const
+ // non-curried labels. For those, the only allowed label names are "code" and
+-// "method". The function panics otherwise. The Observe method of the Observer
++// "method". The function panics otherwise. For the "method" label a predefined
++// default label value set is used to filter given values. Values besides
++// predefined values will count as `unknown` method. `WithExtraMethods`
++// can be used to add more methods to the set. The Observe method of the Observer
+ // in the ObserverVec is called with the request duration in
+ // seconds. Partitioning happens by HTTP status code and/or HTTP method if the
+ // respective instance label names are present in the ObserverVec. For
+@@ -85,14 +96,19 @@ func InstrumentRoundTripperCounter(counter *prometheus.CounterVec, next http.Rou
+ //
+ // Note that this method is only guaranteed to never observe negative durations
+ // if used with Go1.9+.
+-func InstrumentRoundTripperDuration(obs prometheus.ObserverVec, next http.RoundTripper) RoundTripperFunc {
++func InstrumentRoundTripperDuration(obs prometheus.ObserverVec, next http.RoundTripper, opts ...Option) RoundTripperFunc {
++	rtOpts := &option{}
++	for _, o := range opts {
++		o(rtOpts)
++	}
++
+ 	code, method := checkLabels(obs)
+ 
+ 	return RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
+ 		start := time.Now()
+ 		resp, err := next.RoundTrip(r)
+ 		if err == nil {
+-			obs.With(labels(code, method, r.Method, resp.StatusCode)).Observe(time.Since(start).Seconds())
++			obs.With(labels(code, method, r.Method, resp.StatusCode, rtOpts.extraMethods...)).Observe(time.Since(start).Seconds())
+ 		}
+ 		return resp, err
+ 	})
+diff --git a/vendor/github.com/prometheus/client_golang/prometheus/promhttp/instrument_server.go b/vendor/github.com/prometheus/client_golang/prometheus/promhttp/instrument_server.go
+index 9db2438..91802f8 100644
+--- a/vendor/github.com/prometheus/client_golang/prometheus/promhttp/instrument_server.go
++++ b/vendor/github.com/prometheus/client_golang/prometheus/promhttp/instrument_server.go
+@@ -58,7 +58,12 @@ func InstrumentHandlerInFlight(g prometheus.Gauge, next http.Handler) http.Handl
+ //
+ // Note that this method is only guaranteed to never observe negative durations
+ // if used with Go1.9+.
+-func InstrumentHandlerDuration(obs prometheus.ObserverVec, next http.Handler) http.HandlerFunc {
++func InstrumentHandlerDuration(obs prometheus.ObserverVec, next http.Handler, opts ...Option) http.HandlerFunc {
++	mwOpts := &option{}
++	for _, o := range opts {
++		o(mwOpts)
++	}
++
+ 	code, method := checkLabels(obs)
+ 
+ 	if code {
+@@ -67,14 +72,14 @@ func InstrumentHandlerDuration(obs prometheus.ObserverVec, next http.Handler) ht
+ 			d := newDelegator(w, nil)
+ 			next.ServeHTTP(d, r)
+ 
+-			obs.With(labels(code, method, r.Method, d.Status())).Observe(time.Since(now).Seconds())
++			obs.With(labels(code, method, r.Method, d.Status(), mwOpts.extraMethods...)).Observe(time.Since(now).Seconds())
+ 		})
+ 	}
+ 
+ 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+ 		now := time.Now()
+ 		next.ServeHTTP(w, r)
+-		obs.With(labels(code, method, r.Method, 0)).Observe(time.Since(now).Seconds())
++		obs.With(labels(code, method, r.Method, 0, mwOpts.extraMethods...)).Observe(time.Since(now).Seconds())
+ 	})
+ }
+ 
+@@ -91,20 +96,25 @@ func InstrumentHandlerDuration(obs prometheus.ObserverVec, next http.Handler) ht
+ // If the wrapped Handler panics, the Counter is not incremented.
+ //
+ // See the example for InstrumentHandlerDuration for example usage.
+-func InstrumentHandlerCounter(counter *prometheus.CounterVec, next http.Handler) http.HandlerFunc {
++func InstrumentHandlerCounter(counter *prometheus.CounterVec, next http.Handler, opts ...Option) http.HandlerFunc {
++	mwOpts := &option{}
++	for _, o := range opts {
++		o(mwOpts)
++	}
++
+ 	code, method := checkLabels(counter)
+ 
+ 	if code {
+ 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+ 			d := newDelegator(w, nil)
+ 			next.ServeHTTP(d, r)
+-			counter.With(labels(code, method, r.Method, d.Status())).Inc()
++			counter.With(labels(code, method, r.Method, d.Status(), mwOpts.extraMethods...)).Inc()
+ 		})
+ 	}
+ 
+ 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+ 		next.ServeHTTP(w, r)
+-		counter.With(labels(code, method, r.Method, 0)).Inc()
++		counter.With(labels(code, method, r.Method, 0, mwOpts.extraMethods...)).Inc()
+ 	})
+ }
+ 
+@@ -126,13 +136,18 @@ func InstrumentHandlerCounter(counter *prometheus.CounterVec, next http.Handler)
+ // if used with Go1.9+.
+ //
+ // See the example for InstrumentHandlerDuration for example usage.
+-func InstrumentHandlerTimeToWriteHeader(obs prometheus.ObserverVec, next http.Handler) http.HandlerFunc {
++func InstrumentHandlerTimeToWriteHeader(obs prometheus.ObserverVec, next http.Handler, opts ...Option) http.HandlerFunc {
++	mwOpts := &option{}
++	for _, o := range opts {
++		o(mwOpts)
++	}
++
+ 	code, method := checkLabels(obs)
+ 
+ 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+ 		now := time.Now()
+ 		d := newDelegator(w, func(status int) {
+-			obs.With(labels(code, method, r.Method, status)).Observe(time.Since(now).Seconds())
++			obs.With(labels(code, method, r.Method, status, mwOpts.extraMethods...)).Observe(time.Since(now).Seconds())
+ 		})
+ 		next.ServeHTTP(d, r)
+ 	})
+@@ -154,7 +169,12 @@ func InstrumentHandlerTimeToWriteHeader(obs prometheus.ObserverVec, next http.Ha
+ // If the wrapped Handler panics, no values are reported.
+ //
+ // See the example for InstrumentHandlerDuration for example usage.
+-func InstrumentHandlerRequestSize(obs prometheus.ObserverVec, next http.Handler) http.HandlerFunc {
++func InstrumentHandlerRequestSize(obs prometheus.ObserverVec, next http.Handler, opts ...Option) http.HandlerFunc {
++	mwOpts := &option{}
++	for _, o := range opts {
++		o(mwOpts)
++	}
++
+ 	code, method := checkLabels(obs)
+ 
+ 	if code {
+@@ -162,14 +182,14 @@ func InstrumentHandlerRequestSize(obs prometheus.ObserverVec, next http.Handler)
+ 			d := newDelegator(w, nil)
+ 			next.ServeHTTP(d, r)
+ 			size := computeApproximateRequestSize(r)
+-			obs.With(labels(code, method, r.Method, d.Status())).Observe(float64(size))
++			obs.With(labels(code, method, r.Method, d.Status(), mwOpts.extraMethods...)).Observe(float64(size))
+ 		})
+ 	}
+ 
+ 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+ 		next.ServeHTTP(w, r)
+ 		size := computeApproximateRequestSize(r)
+-		obs.With(labels(code, method, r.Method, 0)).Observe(float64(size))
++		obs.With(labels(code, method, r.Method, 0, mwOpts.extraMethods...)).Observe(float64(size))
+ 	})
+ }
+ 
+@@ -189,12 +209,18 @@ func InstrumentHandlerRequestSize(obs prometheus.ObserverVec, next http.Handler)
+ // If the wrapped Handler panics, no values are reported.
+ //
+ // See the example for InstrumentHandlerDuration for example usage.
+-func InstrumentHandlerResponseSize(obs prometheus.ObserverVec, next http.Handler) http.Handler {
++func InstrumentHandlerResponseSize(obs prometheus.ObserverVec, next http.Handler, opts ...Option) http.Handler {
++	mwOpts := &option{}
++	for _, o := range opts {
++		o(mwOpts)
++	}
++
+ 	code, method := checkLabels(obs)
++
+ 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+ 		d := newDelegator(w, nil)
+ 		next.ServeHTTP(d, r)
+-		obs.With(labels(code, method, r.Method, d.Status())).Observe(float64(d.Written()))
++		obs.With(labels(code, method, r.Method, d.Status(), mwOpts.extraMethods...)).Observe(float64(d.Written()))
+ 	})
+ }
+ 
+@@ -279,7 +305,7 @@ func isLabelCurried(c prometheus.Collector, label string) bool {
+ // unnecessary allocations on each request.
+ var emptyLabels = prometheus.Labels{}
+ 
+-func labels(code, method bool, reqMethod string, status int) prometheus.Labels {
++func labels(code, method bool, reqMethod string, status int, extraMethods ...string) prometheus.Labels {
+ 	if !(code || method) {
+ 		return emptyLabels
+ 	}
+@@ -289,7 +315,7 @@ func labels(code, method bool, reqMethod string, status int) prometheus.Labels {
+ 		labels["code"] = sanitizeCode(status)
+ 	}
+ 	if method {
+-		labels["method"] = sanitizeMethod(reqMethod)
++		labels["method"] = sanitizeMethod(reqMethod, extraMethods...)
+ 	}
+ 
+ 	return labels
+@@ -319,7 +345,12 @@ func computeApproximateRequestSize(r *http.Request) int {
+ 	return s
+ }
+ 
+-func sanitizeMethod(m string) string {
++// If the wrapped http.Handler has a known method, it will be sanitized and returned.
++// Otherwise, "unknown" will be returned. The known method list can be extended
++// as needed by using extraMethods parameter.
++func sanitizeMethod(m string, extraMethods ...string) string {
++	// See https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods for
++	// the methods chosen as default.
+ 	switch m {
+ 	case "GET", "get":
+ 		return "get"
+@@ -337,15 +368,25 @@ func sanitizeMethod(m string) string {
+ 		return "options"
+ 	case "NOTIFY", "notify":
+ 		return "notify"
++	case "TRACE", "trace":
++		return "trace"
++	case "PATCH", "patch":
++		return "patch"
+ 	default:
+-		return strings.ToLower(m)
++		for _, method := range extraMethods {
++			if strings.EqualFold(m, method) {
++				return strings.ToLower(m)
++			}
++		}
++		return "unknown"
+ 	}
+ }
+ 
+ // If the wrapped http.Handler has not set a status code, i.e. the value is
+-// currently 0, santizeCode will return 200, for consistency with behavior in
++// currently 0, sanitizeCode will return 200, for consistency with behavior in
+ // the stdlib.
+ func sanitizeCode(s int) string {
++	// See for accepted codes https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
+ 	switch s {
+ 	case 100:
+ 		return "100"
+@@ -442,6 +483,9 @@ func sanitizeCode(s int) string {
+ 		return "511"
+ 
+ 	default:
+-		return strconv.Itoa(s)
++		if s >= 100 && s <= 599 {
++			return strconv.Itoa(s)
++		}
++		return "unknown"
+ 	}
+ }
+diff --git a/vendor/github.com/prometheus/client_golang/prometheus/promhttp/option.go b/vendor/github.com/prometheus/client_golang/prometheus/promhttp/option.go
+new file mode 100644
+index 0000000..35e41bd
+--- /dev/null
++++ b/vendor/github.com/prometheus/client_golang/prometheus/promhttp/option.go
+@@ -0,0 +1,31 @@
++// Copyright 2022 The Prometheus Authors
++// Licensed under the Apache License, Version 2.0 (the "License");
++// you may not use this file except in compliance with the License.
++// You may obtain a copy of the License at
++//
++// http://www.apache.org/licenses/LICENSE-2.0
++//
++// Unless required by applicable law or agreed to in writing, software
++// distributed under the License is distributed on an "AS IS" BASIS,
++// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++// See the License for the specific language governing permissions and
++// limitations under the License.
++
++package promhttp
++
++// Option are used to configure a middleware or round tripper..
++type Option func(*option)
++
++type option struct {
++	extraMethods []string
++}
++
++// WithExtraMethods adds additional HTTP methods to the list of allowed methods.
++// See https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods for the default list.
++//
++// See the example for ExampleInstrumentHandlerWithExtraMethods for example usage.
++func WithExtraMethods(methods ...string) Option {
++	return func(o *option) {
++		o.extraMethods = methods
++	}
++}
+-- 
+2.33.8
+

--- a/SPECS/rook/rook.spec
+++ b/SPECS/rook/rook.spec
@@ -19,7 +19,7 @@
 Summary:        Orchestrator for distributed storage systems in cloud-native environments
 Name:           rook
 Version:        1.6.2
-Release:        15%{?dist}
+Release:        16%{?dist}
 License:        Apache-2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -52,6 +52,9 @@ Source99:       update-tarball.sh
 # creating a new SUSE release branch of Rook.
 # Change the default FlexVolume dir path to support Kubic.
 Patch0:         flexvolume-dir.patch
+# Patches the vendered source tarball; must be applied after untarring that tarball.
+# Can be removed if we upgrade to prometheus-node-exporter 1.10.0 or later.
+Patch1:         CVE-2022-21698.patch
 # Ceph version is needed to set correct container tag in manifests
 BuildRequires:  ceph
 # Rook requirements
@@ -122,8 +125,9 @@ This package contains Helm Charts for Rook.
 %define _buildshell /bin/bash
 
 %prep
-%autosetup -p1
+%autosetup -N
 tar -xf %{SOURCE1} --no-same-owner
+%autopatch -p1
 
 %build
 # remove symbols unsupported by k8s (+) from version
@@ -248,6 +252,9 @@ sed -i -e "s|\(.*tag: \)VERSION|\1%{helm_appVersion}|" %{values_yaml}
 # bother adding docs or changelog or anything
 
 %changelog
+* Wed Feb 07 2024 Tobias Brick <tobiasb@microsoft.com> - 1.6.2-16
+- Patch to fix CVE-2022-21698
+
 * Mon Oct 16 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 1.6.2-15
 - Bump release to rebuild with go 1.20.9
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Fixes [CVE-2022-21698](https://nvd.nist.gov/vuln/detail/CVE-2022-21698) for `rook`. The vulnerability is in the `client_golang` go module, which is vendored in this package. Fix is to apply a (modified) patch to the vendored code.

###### Change Log  <!-- REQUIRED -->
- Applied [upstream patch](https://github.com/prometheus/client_golang/commit/9075cdf61646b5adf54d3ba77a0e4f6c65cb4fd7) to work with the older version of `client_golang` used by this package, along with getting rid of tests.

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2022-21698

###### Test Methodology
- Tested locally in a container.
- Buddy Build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=501233&view=results
