### PR TITLE
[CHERRYPICK FROM FASTTRACK/2.0] fix cve-2022-21698 in nmi (#7681)

### DIFF
--- a/SPECS/nmi/nmi.signatures.json
+++ b/SPECS/nmi/nmi.signatures.json
@@ -1,6 +1,6 @@
 {
  "Signatures": {
-  "nmi-1.8.7-vendor.tar.gz": "988259ffbfbf44452e951c0728de4f23db297face908a2c6c8429ac4be21fbad",
-  "nmi-1.8.7.tar.gz": "37a249105e1e3c6fca6ab6abc64a1af568bc1cf020a0e49bcba2fb485c11346f"
+  "nmi-1.8.11-vendor-v2.tar.gz": "d8bb79dd73d69ef52a3b0022e27c79b756dd3e31686df409ecd762abe3aebf7b",
+  "nmi-1.8.11.tar.gz": "0eb3810ff088d9c9252466da4e6df8da9d43d9588e7b9d445c30c0497d3197fa"
  }
 }

--- a/SPECS/nmi/nmi.spec
+++ b/SPECS/nmi/nmi.spec
@@ -1,8 +1,8 @@
 %global debug_package %{nil}
 Summary:        Node Managed Identity
 Name:           nmi
-Version:        1.8.7
-Release:        15%{?dist}
+Version:        1.8.11
+Release:        1%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -12,7 +12,7 @@ URL:            https://github.com/Azure/aad-pod-identity
 Source0:        %{name}-%{version}.tar.gz
 # Below is a manually created tarball, no download link.
 # We're using pre-populated Go modules from this tarball, since network is disabled during build time.
-# How to re-build this file:
+# How to re-build this file (note the version number will be -v2, etc):
 #   1. wget https://github.com/Azure/aad-pod-identity/archive/refs/tags/v%%{version}.tar.gz -O aad-pod-identity-%%{version}.tar.gz
 #   2. tar -xf aad-pod-identity-%%{version}.tar.gz
 #   3. cd aad-pod-identity-%%{version}
@@ -23,7 +23,7 @@ Source0:        %{name}-%{version}.tar.gz
 #           --pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime \
 #           -cf %%{name}-%%{version}-vendor.tar.gz vendor
 #
-Source1:        %{name}-%{version}-vendor.tar.gz
+Source1:        %{name}-%{version}-vendor-v2.tar.gz
 Patch0:         modify-go-build-option.patch
 BuildRequires:  golang >= 1.15
 
@@ -34,14 +34,12 @@ NMI is the resource that is used when your pods look to use their identity.
 %autosetup -c -N -n %{name}-%{version}
 pushd aad-pod-identity-%{version}
 %patch0 -p1
+# create vendor folder from the vendor tarball and set vendor mode
+tar -xf %{SOURCE1} --no-same-owner
 popd
 
 %build
 pushd aad-pod-identity-%{version}
-
-# create vendor folder from the vendor tarball and set vendor mode
-tar -xf %{SOURCE1} --no-same-owner
-
 make build-nmi
 popd
 
@@ -63,6 +61,9 @@ popd
 %{_bindir}/%{name}
 
 %changelog
+* Fri Feb 06 2024 Tobias Brick <tobiasb@microsoft.com> - 1.8.11-1
+- Upgrade to version 1.8.11 to CVE-2022-21698 
+
 * Mon Oct 16 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 1.8.7-15
 - Bump release to rebuild with go 1.20.9
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -14353,8 +14353,8 @@
         "type": "other",
         "other": {
           "name": "nmi",
-          "version": "1.8.7",
-          "downloadUrl": "https://github.com/Azure/aad-pod-identity/archive/refs/tags/v1.8.7.tar.gz"
+          "version": "1.8.11",
+          "downloadUrl": "https://github.com/Azure/aad-pod-identity/archive/refs/tags/v1.8.11.tar.gz"
         }
       }
     },


### PR DESCRIPTION
Cherry-pick commit 916f9d28c179456d7658fcae4a5eb1caec4b5022 to main. Original PR: #7681

Buddy Build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=502165&view=results