### PR TITLE
tests: pin cloud-init's pytest to <8.0.0

### DIFF
--- a/SPECS/cloud-init/ci-Pin-pytest-8.0.0.patch
+++ b/SPECS/cloud-init/ci-Pin-pytest-8.0.0.patch
@@ -1,0 +1,41 @@
+From 7c96c9cd9318e816ce4564b58a2c98271363c447 Mon Sep 17 00:00:00 2001
+From: Brett Holman <brett.holman@canonical.com>
+Date: Mon, 29 Jan 2024 12:03:36 -0700
+Subject: [PATCH] ci: Pin pytest<8.0.0. (#4816)
+
+The latest pytest release broke some tests in non-obvious ways. Pin
+the version for now so that CI passes.
+---
+ integration-requirements.txt | 2 +-
+ test-requirements.txt        | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/integration-requirements.txt b/integration-requirements.txt
+index dc17759a..208a0c6a 100644
+--- a/integration-requirements.txt
++++ b/integration-requirements.txt
+@@ -7,7 +7,7 @@ pycloudlib>=5.10.0,<1!6
+ # test/unittests/conftest.py to be loaded by our integration-tests tox env
+ # resulting in an unmet dependency issue:
+ # https://github.com/pytest-dev/pytest/issues/11104
+-pytest!=7.3.2
++pytest!=7.3.2,<8.0.0
+ 
+ packaging
+ passlib
+diff --git a/test-requirements.txt b/test-requirements.txt
+index 46a98b4c..3d2480fd 100644
+--- a/test-requirements.txt
++++ b/test-requirements.txt
+@@ -4,7 +4,7 @@
+ # test/unittests/conftest.py to be loaded by our integration-tests tox env
+ # resulting in an unmet dependency issue:
+ # https://github.com/pytest-dev/pytest/issues/11104
+-pytest!=7.3.2
++pytest!=7.3.2,<8.0.0
+ 
+ pytest-cov
+ pytest-mock
+-- 
+2.33.8
+

--- a/SPECS/cloud-init/cloud-init.spec
+++ b/SPECS/cloud-init/cloud-init.spec
@@ -1,7 +1,7 @@
 Summary:        Cloud instance init scripts
 Name:           cloud-init
 Version:        23.4.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        GPLv3
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -10,6 +10,7 @@ URL:            https://launchpad.net/cloud-init
 Source0:        https://launchpad.net/cloud-init/trunk/%{version}/+download/%{name}-%{version}.tar.gz
 Source1:        10-azure-kvp.cfg
 Patch0:         Retain-exit-code-in-cloud-init-status-for-recoverabl.patch
+Patch1:         ci-Pin-pytest-8.0.0.patch
 %define cl_services cloud-config.service cloud-config.target cloud-final.service cloud-init.service cloud-init.target cloud-init-local.service
 BuildRequires:  automake
 BuildRequires:  dbus
@@ -145,6 +146,9 @@ make check %{?_smp_mflags}
 %config(noreplace) %{_sysconfdir}/cloud/cloud.cfg.d/10-azure-kvp.cfg
 
 %changelog
+* Fri Feb 09 2024 Chris Co <chrco@microsoft.com> - 23.4.1-3
+- Add patch to pin pytest to <8.0.0 so cloud-init tests run correctly
+
 * Fri Jan 19 2024 Chris Co <chrco@microsoft.com> - 23.4.1-2
 - Add patch to retain exit code for recoverable errors
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Latest pytest 8.0.0 release had breaking changes which broke the cloud-init tests. Pin to previous versions of pytest.

See https://github.com/canonical/cloud-init/commit/7c96c9cd9318e816ce4564b58a2c98271363c447

Signed-off-by: Chris Co <chrco@microsoft.com>

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://microsoft.visualstudio.com/OS/_workitems/edit/48917787

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- https://dev.azure.com/mariner-org/mariner/_build/results?buildId=502644&view=results
- `cloud-init` tests are now passing (results from same build as above) - https://dev.azure.com/mariner-org/mariner/_build/results?buildId=502644&view=ms.vss-test-web.build-test-results-tab
