### PR TITLE
Update docs.md - fix Available Packages link

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -276,5 +276,5 @@ To upgrade all your installed packages to the latest CBL-Mariner releases run:
 
 ### Available Packages
 
-Packages that are currently available can be found [here](https://packages.microsoft.com/cbl-mariner). You may add and build packages locally by adding them to your derivative
+Packages that are currently available can be found [here](https://packages.microsoft.com/cbl-mariner/). You may add and build packages locally by adding them to your derivative
 repository. 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

current link points to https://packages.microsoft.com/cbl-mariner which returns a 404 response
![image](https://github.com/microsoft/CBL-Mariner/assets/121931056/eeae5607-16e3-4ed2-a350-bd8cf502d471)

after the fix:
![image](https://github.com/microsoft/CBL-Mariner/assets/121931056/8445589e-3738-4325-b588-065c6dc53631)

###### Does this affect the toolchain?

**NO**