### PR TITLE
Add compatibility flag to all createrepo commands

### DIFF
--- a/.pipelines/containerSourceData/Dockerfile-Initial
+++ b/.pipelines/containerSourceData/Dockerfile-Initial
@@ -7,7 +7,7 @@ RUN --mount=type=bind,source=./Stage/,target=/dockerStage/ \\\
     tdnf install -y createrepo; \\\
     cp -r ${RPMS_PATH} ${LOCAL_REPO_PATH}; \\\
     cat /dockerStage/marinerLocalRepo.repo >> /etc/yum.repos.d/local.repo; \\\
-    createrepo --database ${LOCAL_REPO_PATH} --workers 10; tdnf makecache \&\& tdnf makecache; \\\
+    createrepo --compatibility --database ${LOCAL_REPO_PATH} --workers 10; tdnf makecache \&\& tdnf makecache; \\\
     tdnf autoremove -y createrepo; \\\
     for rpm in "${RPMS_TO_INSTALL[@]}"; do \\\
        echo "RPM: $rpm"; \\\

--- a/SPECS/fontpackages/dnf.patch
+++ b/SPECS/fontpackages/dnf.patch
@@ -57,7 +57,7 @@ diff -ur fontpackages-1.44.orig/bin/repo-font-audit fontpackages-1.44/bin/repo-f
 -3. indexing this directory with createrepo:
 -$ createrepo path-to-test-directory
 +3. indexing this directory with $CREATEREPO:
-+$ $CREATEREPO path-to-test-directory
++$ $CREATEREPO --compatibility path-to-test-directory
  4. running repo-font-audit:
  $ repo-font-audit test absolute-path-to-test-directory
  

--- a/SPECS/fontpackages/fontpackages.spec
+++ b/SPECS/fontpackages/fontpackages.spec
@@ -8,7 +8,7 @@
 Summary:        Common directory and macro definitions used by font packages
 Name:           fontpackages
 Version:        1.44
-Release:        28%{?dist}
+Release:        29%{?dist}
 # Mostly means the scriptlets inserted via this package do not change the
 # license of the packages they're inserted in.
 License:        LGPLv3+
@@ -101,6 +101,9 @@ EOF
 %{ftcgtemplatedir}/*txt
 
 %changelog
+* Mon Feb 12 2024 Mykhailo Bykhovtsev <mbykhovtsev@microsoft.com> - 1.44-29
+- Added compatibility flag to createrepo command in the patch.
+
 * Thu Dec 02 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.44-28
 - Removing the "*-tools" subpackage.
 - License verified.

--- a/toolkit/scripts/containerized-build/resources/setup_functions.sh
+++ b/toolkit/scripts/containerized-build/resources/setup_functions.sh
@@ -80,7 +80,7 @@ rpmbuild() {
 refresh_local_repo() {
     echo "-------- refreshing the local repo ---------"
     pushd $RPMS_DIR
-    createrepo .
+    createrepo --compatibility .
     popd
 }
 
@@ -98,7 +98,7 @@ enable_local_repo() {
         url="${urlWithPrefix#$prefixToRemove}" #remove 'file://' prefix
         mkdir -p $url || { echo -e "\033[31m WARNING: Could not mkdir at $url, continuing\033[0m"; continue; }
         pushd $url
-        createrepo .
+        createrepo --compatibility .
         popd
         url_list+=" $url"
     done

--- a/toolkit/tools/internal/packagerepo/repomanager/rpmrepomanager/rpmrepomanager.go
+++ b/toolkit/tools/internal/packagerepo/repomanager/rpmrepomanager/rpmrepomanager.go
@@ -37,7 +37,7 @@ func CreateRepo(repoDir string) (err error) {
 	}
 
 	// Create a new repodata
-	_, stderr, err := shell.Execute("createrepo", repoDir)
+	_, stderr, err := shell.Execute("createrepo", "--compatibility", repoDir)
 	if err != nil {
 		logger.Log.Warn(stderr)
 	}


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
PR #7715 upgrades `createrepo_c` package from version `0.17.5` to `1.0.3` which introduces breaking changes to how `createrepo` command creates metadata files, their format changes entirely which makes `tdnf` unable to read it properly. However if run with `--compatibility` flag, it will preserve the format as much as it can and thus `tdnf` can use the created metadata files for the repo. This PR adds such flags to all of our `createrepo` commands used so that we can upgrade the package. This flag does not change behavior of the command in our current version of the package, so it won't break anything in adding this now.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Added `--compatibility` flag to all `creatrepo` commands

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: local
