### PR TITLE
Patch golang related module in moby-buildx  for CVE-2021-44716

### DIFF
--- a/SPECS/moby-buildx/CVE-2021-44716.patch
+++ b/SPECS/moby-buildx/CVE-2021-44716.patch
@@ -1,0 +1,51 @@
+Parent:     db4efeb8 (http2: deflake TestTransportGroupsPendingDials)
+Author:     Damien Neil <dneil@google.com>
+AuthorDate: 2021-12-06 14:31:43 -0800
+Commit:     Filippo Valsorda <filippo@golang.org>
+CommitDate: 2021-12-09 12:49:13 +0000
+
+http2: cap the size of the server's canonical header cache
+
+The HTTP/2 server keeps a per-connection cache mapping header keys
+to their canonicalized form (e.g., "foo-bar" => "Foo-Bar"). Cap the
+maximum size of this cache to prevent a peer sending many unique
+header keys from causing unbounded memory growth.
+
+Cap chosen arbitrarily at 32 entries. Since this cache does not
+include common headers (e.g., "content-type"), 32 seems like more
+than enough for almost all normal uses.
+
+Fixes #50058
+Fixes CVE-2021-44716
+
+Change-Id: Ia83696dc23253c12af8f26d502557c2cc9841105
+Reviewed-on: https://team-review.git.corp.google.com/c/golang/go-private/+/1290827
+Reviewed-by: Roland Shoemaker <bracewell@google.com>
+Reviewed-on: https://go-review.googlesource.com/c/net/+/369794
+Trust: Filippo Valsorda <filippo@golang.org>
+Run-TryBot: Filippo Valsorda <filippo@golang.org>
+Trust: Damien Neil <dneil@google.com>
+Reviewed-by: Russ Cox <rsc@golang.org>
+Reviewed-by: Filippo Valsorda <filippo@golang.org>
+TryBot-Result: Gopher Robot <gobot@golang.org>
+
+diff -ru cli-20.10.27-orig/vendor/golang.org/x/net/http2/server.go cli-20.10.27/vendor/golang.org/x/net/http2/server.go
+--- cli-20.10.27-orig/vendor/golang.org/x/net/http2/server.go	2024-02-05 08:53:30.802532951 -0800
++++ cli-20.10.27/vendor/golang.org/x/net/http2/server.go	2024-02-05 09:19:08.473430121 -0800
+@@ -720,7 +720,15 @@
+ 		sc.canonHeader = make(map[string]string)
+ 	}
+ 	cv = http.CanonicalHeaderKey(v)
+-	sc.canonHeader[v] = cv
++	// maxCachedCanonicalHeaders is an arbitrarily-chosen limit on the number of
++	// entries in the canonHeader cache. This should be larger than the number
++	// of unique, uncommon header keys likely to be sent by the peer, while not
++	// so high as to permit unreaasonable memory usage if the peer sends an unbounded
++	// number of unique header keys.
++	const maxCachedCanonicalHeaders = 32
++	if len(sc.canonHeader) < maxCachedCanonicalHeaders {
++		sc.canonHeader[v] = cv
++	}	
+ 	return cv
+ }
+ 

--- a/SPECS/moby-buildx/moby-buildx.spec
+++ b/SPECS/moby-buildx/moby-buildx.spec
@@ -5,7 +5,7 @@ Summary:        A Docker CLI plugin for extended build capabilities with BuildKi
 Name:           moby-%{upstream_name}
 # update "commit_hash" above when upgrading version
 Version:        0.7.1
-Release:        17%{?dist}
+Release:        18%{?dist}
 License:        ASL 2.0
 Group:          Tools/Container
 Vendor:         Microsoft Corporation
@@ -15,6 +15,7 @@ Source0:        https://github.com/docker/buildx/archive/refs/tags/v%{version}.t
 # Fixed in upstream v0.8.0. Can remove when we upgrade to that version.
 Patch0:         CVE-2022-21698.patch
 Patch1:         CVE-2023-44487.patch
+Patch2:         CVE-2021-44716.patch
 
 BuildRequires: bash
 BuildRequires: golang >= 1.17
@@ -45,6 +46,9 @@ cp -aT buildx "%{buildroot}/%{_libexecdir}/docker/cli-plugins/docker-buildx"
 %{_libexecdir}/docker/cli-plugins/docker-buildx
 
 %changelog
+* Mon Feb 12 2024 Nan Liu<liunan@microsoft.com> - 0.7.1-18
+- Address CVE-2021-44716 by patching vendored golang.org/x/net
+
 * Wed Feb 07 2024 Daniel McIlvaney <damcilva@microsoft.com> - 0.7.1-17
 - Address CVE-2023-44487 by patching vendored golang.org/x/net
 

--- a/SPECS/moby-buildx/moby-buildx.spec
+++ b/SPECS/moby-buildx/moby-buildx.spec
@@ -46,7 +46,7 @@ cp -aT buildx "%{buildroot}/%{_libexecdir}/docker/cli-plugins/docker-buildx"
 %{_libexecdir}/docker/cli-plugins/docker-buildx
 
 %changelog
-* Mon Feb 12 2024 Nan Liu<liunan@microsoft.com> - 0.7.1-18
+* Mon Feb 12 2024 Nan Liu <liunan@microsoft.com> - 0.7.1-18
 - Address CVE-2021-44716 by patching vendored golang.org/x/net
 
 * Wed Feb 07 2024 Daniel McIlvaney <damcilva@microsoft.com> - 0.7.1-17


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Added a patch to the vendored module of moby-buildx to address CVE-2021-44716

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Address CVE-2021-44716 by patching vendored golang.org/x/net

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2021-44716

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=504394&view=results
