### PR TITLE
Re-add systemd-bootstrap obsoletes to systemd

### DIFF
--- a/SPECS/systemd/systemd.spec
+++ b/SPECS/systemd/systemd.spec
@@ -44,7 +44,7 @@ Version:        255
 # determine the build information from local checkout
 Version:        %(tools/meson-vcs-tag.sh . error | sed -r 's/-([0-9])/.^\1/; s/-g/_g/')
 %endif
-Release:        3%{?dist}
+Release:        4%{?dist}
 
 # FIXME - hardcode to 'stable' for now as that's what we have in our blobstore
 %global stable 1
@@ -260,6 +260,7 @@ Provides:       /bin/systemctl
 Provides:       /sbin/shutdown
 Provides:       syslog
 Provides:       systemd-units = %{version}-%{release}
+%{?azure:Obsoletes:      systemd-bootstrap <= %{version}-%{release}}
 Obsoletes:      system-setup-keyboard < 0.9
 Provides:       system-setup-keyboard = 0.9
 # systemd-sysv-convert was removed in f20: https://fedorahosted.org/fpc/ticket/308
@@ -346,6 +347,7 @@ Systemd PAM module registers the session with systemd-logind.
 %package rpm-macros
 Summary:        Macros that define paths and scriptlets related to systemd
 BuildArch:      noarch
+%{?azure:Obsoletes:      systemd-bootstrap-rpm-macros <= %{version}-%{release}}
 
 %description rpm-macros
 Just the definitions of rpm macros.
@@ -362,6 +364,7 @@ Requires(meta): (%{name}-rpm-macros = %{version}-%{release} if rpm-build)
 Provides:       libudev-devel = %{version}
 Provides:       libudev-devel%{_isa} = %{version}
 Obsoletes:      libudev-devel < 183
+%{?azure:Obsoletes:      systemd-bootstrap-devel <= %{version}-%{release}}
 
 %description devel
 Development headers and auxiliary files for developing applications linking
@@ -1170,6 +1173,9 @@ rm -f %{name}.lang
 # %autochangelog. So we need to continue manually maintaining the
 # changelog here.
 %changelog
+* Tue Feb 13 2024 Daniel McIlvaney <damcilva@microsoft.com> - 255-4
+- Add Obsoletes: systemd-bootstrap* to allow systemd to replace the bootstrap version
+
 * Wed Feb 07 2024 Dan Streetman <ddstreet@ieee.org> - 255-3
 - remove conflicts dracut release number
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Especially during image builds it is possible for `systemd-bootstrap` to be installed, and then for a follow on install step to install `systemd` itself. Until we can update the tools to discard the bootstrap packages we need to allow the real `systemd` package to gracefully replace the bootstrap versions. This behavior is seen most often with `systemd-bootstrap-rpm-macros` since many packages will reference them, and they are needed as part of the core toolchain build.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add `%{?azure:Obsoletes:      systemd-bootstrap-... <= %{version}-%{release}}` entries for each subpackage found in `systemd-bootstrap.spec`

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO** (This change only affects the main systemd which comes later)


###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- https://dev.azure.com/mariner-org/mariner/_build/results?buildId=505195&view=results
- Local container based on 3.0-dev's chroot environment:
   - Install `systemd-bootstrap-rpm-macros`
   - Attempt to install upstream `systemd`, fails with: `file /usr/lib/rpm/macros.d/macros.systemd from install of systemd-rpm-macros-255-3.azl3.noarch conflicts with file from package systemd-bootstrap-rpm-macros-250.3-15.azl3.noarch`
   - Instead install updated systemd:
``` 
...
systemd-libs                      x86_64                   255-3.testing9999.azl3            host_build_repo            1.99M                   887.73k
systemd                           x86_64                   255-3.testing9999.azl3            host_build_repo           14.91M                     5.52M

Total installed size:  37.10M
Total download size:  12.74M

Removing:
systemd-bootstrap-rpm-macros      noarch                   250.3-15.azl3                     @System                    6.01k                     0.00b

Total installed size:   6.01k
Total download size:   0.00b

Obsoleting:
systemd-bootstrap-rpm-macros      noarch                   250.3-15.azl3                     @System                    6.01k                     0.00b

Total installed size:   6.01k
Total download size:   0.00b
...
```