### PR TITLE
use strings.Fields to handle whitespace between items in list

### DIFF
--- a/toolkit/tools/internal/exe/exe.go
+++ b/toolkit/tools/internal/exe/exe.go
@@ -53,16 +53,10 @@ func PlaceHolderize(thing []string) string {
 	return fmt.Sprintf("(%s)", strings.Join(thing, "|"))
 }
 
-// ParseListArgument takes a user provided string list that is space seperated
-// and returns a slice of the split and trimmed elements.
-func ParseListArgument(input string) (results []string) {
-	const delimiter = " "
-
-	trimmedInput := strings.TrimSpace(input)
-	if trimmedInput != "" {
-		results = strings.Split(trimmedInput, delimiter)
-	}
-	return
+// ParseListArgument takes a user provided string list that is white-space seperated
+// and returns a slice of the split elements, removing any empty elements and extra whitespace.
+func ParseListArgument(input string) []string {
+	return strings.Fields(input)
 }
 
 type ProfileFlags struct {

--- a/toolkit/tools/internal/exe/exe_test.go
+++ b/toolkit/tools/internal/exe/exe_test.go
@@ -1,0 +1,48 @@
+package exe
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseListArgument(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "empty input",
+			input:    "",
+			expected: []string{},
+		},
+		{
+			name:     "single value",
+			input:    "value",
+			expected: []string{"value"},
+		},
+		{
+			name:     "multiple values",
+			input:    "value1 value2 value3",
+			expected: []string{"value1", "value2", "value3"},
+		},
+		{
+			name:     "leading/trailing spaces",
+			input:    "  value1  value2  value3  ",
+			expected: []string{"value1", "value2", "value3"},
+		},
+		{
+			name:     "extra spaces",
+			input:    "value1  value2   value3",
+			expected: []string{"value1", "value2", "value3"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := ParseListArgument(tt.input)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}

--- a/toolkit/tools/internal/exe/exe_test.go
+++ b/toolkit/tools/internal/exe/exe_test.go
@@ -37,6 +37,16 @@ func TestParseListArgument(t *testing.T) {
 			input:    "value1  value2   value3",
 			expected: []string{"value1", "value2", "value3"},
 		},
+		{
+			name:     "tabs",
+			input:    "value1\tvalue2\tvalue3",
+			expected: []string{"value1", "value2", "value3"},
+		},
+		{
+			name:     "mixed whitespace",
+			input:    "value1\tvalue2  value3",
+			expected: []string{"value1", "value2", "value3"},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
For build parameters like `SRPM_PACK_LIST` we take a space-separated list, like `SRPM_PACK_LIST="openssl SymCrypt"`. Currently, the code that parses those into an array of packages doesn't handle multiple spaces between the package names. For example, if you add an extra space between the package names, like `"openssl  SymCrypt"`, it will parse it into three packages: "`openssl`", "``", and "`SymCrypt`" -- note the empty package name. This makes our build tools fail down the line, as they try to handle an empty package name.

###### Change Log  <!-- REQUIRED -->
- Updated the list parsing code to handle multiple spaces/whitespace between package names.
- Added tests.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Associated issues  <!-- optional -->
- fixes #7895

###### Test Methodology
- Tested locally
- Full Build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=505261&view=results
