### PR TITLE
Fix CVE-2024-21626 by patching vendored runc in kubernetes, kubevirt, cri-tools

### DIFF
--- a/SPECS/cri-tools/CVE-2024-21626.patch
+++ b/SPECS/cri-tools/CVE-2024-21626.patch
@@ -1,0 +1,93 @@
+diff -urN b/cri-tools-1.28.0/vendor/github.com/opencontainers/runc/libcontainer/utils/utils_unix.go a/cri-tools-1.28.0/vendor/github.com/opencontainers/runc/libcontainer/utils/utils_unix.go
+--- b/cri-tools-1.28.0/vendor/github.com/opencontainers/runc/libcontainer/utils/utils_unix.go	2023-08-11 06:45:27.000000000 -0700
++++ a/cri-tools-1.28.0/vendor/github.com/opencontainers/runc/libcontainer/utils/utils_unix.go	2024-02-13 15:41:56.671537200 -0800
+@@ -7,6 +7,7 @@
+ 	"fmt"
+ 	"os"
+ 	"strconv"
++	_ "unsafe" // for go:linkname
+ 
+ 	"golang.org/x/sys/unix"
+ )
+@@ -23,9 +24,11 @@
+ 	return nil
+ }
+ 
+-// CloseExecFrom applies O_CLOEXEC to all file descriptors currently open for
+-// the process (except for those below the given fd value).
+-func CloseExecFrom(minFd int) error {
++type fdFunc func(fd int)
++
++// fdRangeFrom calls the passed fdFunc for each file descriptor that is open in
++// the current process.
++func fdRangeFrom(minFd int, fn fdFunc) error {
+ 	fdDir, err := os.Open("/proc/self/fd")
+ 	if err != nil {
+ 		return err
+@@ -50,15 +53,60 @@
+ 		if fd < minFd {
+ 			continue
+ 		}
+-		// Intentionally ignore errors from unix.CloseOnExec -- the cases where
+-		// this might fail are basically file descriptors that have already
+-		// been closed (including and especially the one that was created when
+-		// os.ReadDir did the "opendir" syscall).
+-		unix.CloseOnExec(fd)
++		// Ignore the file descriptor we used for readdir, as it will be closed
++		// when we return.
++		if uintptr(fd) == fdDir.Fd() {
++			continue
++		}
++		// Run the closure.
++		fn(fd)
+ 	}
+ 	return nil
+ }
+ 
++// CloseExecFrom sets the O_CLOEXEC flag on all file descriptors greater or
++// equal to minFd in the current process.
++func CloseExecFrom(minFd int) error {
++	return fdRangeFrom(minFd, unix.CloseOnExec)
++}
++
++//go:linkname runtime_IsPollDescriptor internal/poll.IsPollDescriptor
++
++// In order to make sure we do not close the internal epoll descriptors the Go
++// runtime uses, we need to ensure that we skip descriptors that match
++// "internal/poll".IsPollDescriptor. Yes, this is a Go runtime internal thing,
++// unfortunately there's no other way to be sure we're only keeping the file
++// descriptors the Go runtime needs. Hopefully nothing blows up doing this...
++func runtime_IsPollDescriptor(fd uintptr) bool //nolint:revive
++
++// UnsafeCloseFrom closes all file descriptors greater or equal to minFd in the
++// current process, except for those critical to Go's runtime (such as the
++// netpoll management descriptors).
++//
++// NOTE: That this function is incredibly dangerous to use in most Go code, as
++// closing file descriptors from underneath *os.File handles can lead to very
++// bad behaviour (the closed file descriptor can be re-used and then any
++// *os.File operations would apply to the wrong file). This function is only
++// intended to be called from the last stage of runc init.
++func UnsafeCloseFrom(minFd int) error {
++	// We must not close some file descriptors.
++	return fdRangeFrom(minFd, func(fd int) {
++		if runtime_IsPollDescriptor(uintptr(fd)) {
++			// These are the Go runtimes internal netpoll file descriptors.
++			// These file descriptors are operated on deep in the Go scheduler,
++			// and closing those files from underneath Go can result in panics.
++			// There is no issue with keeping them because they are not
++			// executable and are not useful to an attacker anyway. Also we
++			// don't have any choice.
++			return
++		}
++		// There's nothing we can do about errors from close(2), and the
++		// only likely error to be seen is EBADF which indicates the fd was
++		// already closed (in which case, we got what we wanted).
++		_ = unix.Close(fd)
++	})
++}
++
+ // NewSockPair returns a new unix socket pair
+ func NewSockPair(name string) (parent *os.File, child *os.File, err error) {
+ 	fds, err := unix.Socketpair(unix.AF_LOCAL, unix.SOCK_STREAM|unix.SOCK_CLOEXEC, 0)
+Binary files b/v1.28.0.tar.gz and a/v1.28.0.tar.gz differ

--- a/SPECS/cri-tools/CVE-2024-21626.patch
+++ b/SPECS/cri-tools/CVE-2024-21626.patch
@@ -1,6 +1,6 @@
 diff -urN b/cri-tools-1.28.0/vendor/github.com/opencontainers/runc/libcontainer/utils/utils_unix.go a/cri-tools-1.28.0/vendor/github.com/opencontainers/runc/libcontainer/utils/utils_unix.go
---- b/cri-tools-1.28.0/vendor/github.com/opencontainers/runc/libcontainer/utils/utils_unix.go	2023-08-11 06:45:27.000000000 -0700
-+++ a/cri-tools-1.28.0/vendor/github.com/opencontainers/runc/libcontainer/utils/utils_unix.go	2024-02-13 15:41:56.671537200 -0800
+--- cri-tools-1.28.0/vendor/github.com/opencontainers/runc/libcontainer/utils/utils_unix.go	2023-08-11 06:45:27.000000000 -0700
++++ cri-tools-1.28.0/vendor/github.com/opencontainers/runc/libcontainer/utils/utils_unix.go	2024-02-13 15:41:56.671537200 -0800
 @@ -7,6 +7,7 @@
  	"fmt"
  	"os"

--- a/SPECS/cri-tools/cri-tools.spec
+++ b/SPECS/cri-tools/cri-tools.spec
@@ -7,13 +7,14 @@
 Summary:        CRI tools
 Name:           cri-tools
 Version:        1.28.0
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        Apache-2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 Group:          Development/Tools
 URL:            https://github.com/kubernetes-sigs/cri-tools
 Source0:        https://github.com/kubernetes-sigs/cri-tools/archive/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
+Patch0:         CVE-2024-21626.patch
 BuildRequires:  glib-devel
 BuildRequires:  glibc-devel
 BuildRequires:  golang
@@ -44,6 +45,9 @@ install -p -m 755 -t %{buildroot}%{_bindir} "${BUILD_FOLDER}/critest"
 %{_bindir}/critest
 
 %changelog
+* Wed Feb 14 2024 Riken Maharjan <rmaharjan@microsoft.com> - 1.28.0-4
+- Patch runc for CVE-2024-21626
+
 * Mon Oct 16 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 1.28.0-3
 - Bump release to rebuild with go 1.20.9
 

--- a/SPECS/kubernetes/CVE-2024-21626.patch
+++ b/SPECS/kubernetes/CVE-2024-21626.patch
@@ -1,0 +1,369 @@
+diff -urN a/vendor/github.com/opencontainers/runc/libcontainer/cgroups/file.go b/vendor/github.com/opencontainers/runc/libcontainer/cgroups/file.go
+--- a/vendor/github.com/opencontainers/runc/libcontainer/cgroups/file.go	2023-11-15 08:48:52.000000000 -0800
++++ b/vendor/github.com/opencontainers/runc/libcontainer/cgroups/file.go	2024-02-14 12:37:41.501627000 -0800
+@@ -10,6 +10,7 @@
+ 	"strings"
+ 	"sync"
+ 
++	"github.com/opencontainers/runc/libcontainer/utils"
+ 	"github.com/sirupsen/logrus"
+ 	"golang.org/x/sys/unix"
+ )
+@@ -76,16 +77,16 @@
+ 	// TestMode is set to true by unit tests that need "fake" cgroupfs.
+ 	TestMode bool
+ 
+-	cgroupFd     int = -1
+-	prepOnce     sync.Once
+-	prepErr      error
+-	resolveFlags uint64
++	cgroupRootHandle *os.File
++	prepOnce     	sync.Once
++	prepErr      	error
++	resolveFlags 	uint64
+ )
+ 
+ func prepareOpenat2() error {
+ 	prepOnce.Do(func() {
+ 		fd, err := unix.Openat2(-1, cgroupfsDir, &unix.OpenHow{
+-			Flags: unix.O_DIRECTORY | unix.O_PATH,
++			Flags: unix.O_DIRECTORY | unix.O_PATH | unix.O_CLOEXEC,
+ 		})
+ 		if err != nil {
+ 			prepErr = &os.PathError{Op: "openat2", Path: cgroupfsDir, Err: err}
+@@ -96,15 +97,16 @@
+ 			}
+ 			return
+ 		}
++		file := os.NewFile(uintptr(fd), cgroupfsDir)
++
+ 		var st unix.Statfs_t
+-		if err = unix.Fstatfs(fd, &st); err != nil {
++		if err := unix.Fstatfs(int(file.Fd()), &st); err != nil {
+ 			prepErr = &os.PathError{Op: "statfs", Path: cgroupfsDir, Err: err}
+ 			logrus.Warnf("falling back to securejoin: %s", prepErr)
+ 			return
+ 		}
+ 
+-		cgroupFd = fd
+-
++		cgroupRootHandle = file
+ 		resolveFlags = unix.RESOLVE_BENEATH | unix.RESOLVE_NO_MAGICLINKS
+ 		if st.Type == unix.CGROUP2_SUPER_MAGIC {
+ 			// cgroupv2 has a single mountpoint and no "cpu,cpuacct" symlinks
+@@ -131,7 +133,7 @@
+ 		return openFallback(path, flags, mode)
+ 	}
+ 
+-	fd, err := unix.Openat2(cgroupFd, relPath,
++	fd, err := unix.Openat2(int(cgroupRootHandle.Fd()), relPath,
+ 		&unix.OpenHow{
+ 			Resolve: resolveFlags,
+ 			Flags:   uint64(flags) | unix.O_CLOEXEC,
+@@ -139,20 +141,20 @@
+ 		})
+ 	if err != nil {
+ 		err = &os.PathError{Op: "openat2", Path: path, Err: err}
+-		// Check if cgroupFd is still opened to cgroupfsDir
++		// Check if cgroupRootHandle is still opened to cgroupfsDir
+ 		// (happens when this package is incorrectly used
+ 		// across the chroot/pivot_root/mntns boundary, or
+ 		// when /sys/fs/cgroup is remounted).
+ 		//
+ 		// TODO: if such usage will ever be common, amend this
+-		// to reopen cgroupFd and retry openat2.
+-		fdStr := strconv.Itoa(cgroupFd)
++		// to reopen cgroupRootHandle and retry openat2.
++		fdStr := strconv.Itoa(int(cgroupRootHandle.Fd()))
+ 		fdDest, _ := os.Readlink("/proc/self/fd/" + fdStr)
+ 		if fdDest != cgroupfsDir {
+-			// Wrap the error so it is clear that cgroupFd
++			// Wrap the error so it is clear that cgroupRootHandle
+ 			// is opened to an unexpected/wrong directory.
+-			err = fmt.Errorf("cgroupFd %s unexpectedly opened to %s != %s: %w",
+-				fdStr, fdDest, cgroupfsDir, err)
++			err = fmt.Errorf("cgroupRootHandle %s unexpectedly opened to %s != %s: %w",
++			cgroupRootHandle.Fd(), fdDest, cgroupfsDir, err)
+ 		}
+ 		return nil, err
+ 	}
+diff -urN a/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/paths.go b/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/paths.go
+--- a/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/paths.go	2023-11-15 08:48:52.000000000 -0800
++++ b/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/paths.go	2024-02-14 12:39:26.175507500 -0800
+@@ -83,6 +83,7 @@
+ 	if err != nil {
+ 		return ""
+ 	}
++	defer dir.Close()
+ 	names, err := dir.Readdirnames(1)
+ 	if err != nil {
+ 		return ""
+diff -urN a/vendor/github.com/opencontainers/runc/libcontainer/container_linux.go b/vendor/github.com/opencontainers/runc/libcontainer/container_linux.go
+--- a/vendor/github.com/opencontainers/runc/libcontainer/container_linux.go	2023-11-15 08:48:52.000000000 -0800
++++ b/vendor/github.com/opencontainers/runc/libcontainer/container_linux.go	2024-02-14 12:40:26.176722600 -0800
+@@ -350,7 +350,15 @@
+ 			}
+ 		}()
+ 	}
+-
++	// Before starting "runc init", mark all non-stdio open files as O_CLOEXEC
++	// to make sure we don't leak any files into "runc init". Any files to be
++	// passed to "runc init" through ExtraFiles will get dup2'd by the Go
++	// runtime and thus their O_CLOEXEC flag will be cleared. This is some
++	// additional protection against attacks like CVE-2024-21626, by making
++	// sure we never leak files to "runc init" we didn't intend to.
++	if err := utils.CloseExecFrom(3); err != nil {
++		return fmt.Errorf("unable to mark non-stdio fds as cloexec: %w", err)
++	}
+ 	if err := parent.start(); err != nil {
+ 		return fmt.Errorf("unable to start container process: %w", err)
+ 	}
+diff -urN a/vendor/github.com/opencontainers/runc/libcontainer/init_linux.go b/vendor/github.com/opencontainers/runc/libcontainer/init_linux.go
+--- a/vendor/github.com/opencontainers/runc/libcontainer/init_linux.go	2023-11-15 08:48:52.000000000 -0800
++++ b/vendor/github.com/opencontainers/runc/libcontainer/init_linux.go	2024-02-14 12:42:06.529814300 -0800
+@@ -8,6 +8,7 @@
+ 	"io"
+ 	"net"
+ 	"os"
++	"path/filepath"
+ 	"strings"
+ 	"unsafe"
+ 
+@@ -135,6 +136,32 @@
+ 	return nil
+ }
+ 
++// verifyCwd ensures that the current directory is actually inside the mount
++// namespace root of the current process.
++func verifyCwd() error {
++	// getcwd(2) on Linux detects if cwd is outside of the rootfs of the
++	// current mount namespace root, and in that case prefixes "(unreachable)"
++	// to the returned string. glibc's getcwd(3) and Go's Getwd() both detect
++	// when this happens and return ENOENT rather than returning a non-absolute
++	// path. In both cases we can therefore easily detect if we have an invalid
++	// cwd by checking the return value of getcwd(3). See getcwd(3) for more
++	// details, and CVE-2024-21626 for the security issue that motivated this
++	// check.
++	//
++	// We have to use unix.Getwd() here because os.Getwd() has a workaround for
++	// $PWD which involves doing stat(.), which can fail if the current
++	// directory is inaccessible to the container process.
++	if wd, err := unix.Getwd(); errors.Is(err, unix.ENOENT) {
++		return errors.New("current working directory is outside of container mount namespace root -- possible container breakout detected")
++	} else if err != nil {
++		return fmt.Errorf("failed to verify if current working directory is safe: %w", err)
++	} else if !filepath.IsAbs(wd) {
++		// We shouldn't ever hit this, but check just in case.
++		return fmt.Errorf("current working directory is not absolute -- possible container breakout detected: cwd is %q", wd)
++	}
++	return nil
++}
++
+ // finalizeNamespace drops the caps, sets the correct user
+ // and working dir, and closes any leaked file descriptors
+ // before executing the command inside the namespace
+@@ -193,6 +220,10 @@
+ 			return fmt.Errorf("chdir to cwd (%q) set in config.json failed: %w", config.Cwd, err)
+ 		}
+ 	}
++	// Make sure our final working directory is inside the container.
++	if err := verifyCwd(); err != nil {
++		return err
++	}
+ 	if err := system.ClearKeepCaps(); err != nil {
+ 		return fmt.Errorf("unable to clear keep caps: %w", err)
+ 	}
+diff -urN a/vendor/github.com/opencontainers/runc/libcontainer/setns_init_linux.go b/vendor/github.com/opencontainers/runc/libcontainer/setns_init_linux.go
+--- a/vendor/github.com/opencontainers/runc/libcontainer/setns_init_linux.go	2023-11-15 08:48:52.000000000 -0800
++++ b/vendor/github.com/opencontainers/runc/libcontainer/setns_init_linux.go	2024-02-14 12:43:51.669049600 -0800
+@@ -4,6 +4,7 @@
+ 	"errors"
+ 	"fmt"
+ 	"os"
++	"os/exec"
+ 	"strconv"
+ 
+ 	"github.com/opencontainers/selinux/go-selinux"
+@@ -14,6 +15,7 @@
+ 	"github.com/opencontainers/runc/libcontainer/keys"
+ 	"github.com/opencontainers/runc/libcontainer/seccomp"
+ 	"github.com/opencontainers/runc/libcontainer/system"
++	"github.com/opencontainers/runc/libcontainer/utils"
+ )
+ 
+ // linuxSetnsInit performs the container's initialization for running a new process
+@@ -82,6 +84,21 @@
+ 	if err := apparmor.ApplyProfile(l.config.AppArmorProfile); err != nil {
+ 		return err
+ 	}
++
++	// Check for the arg before waiting to make sure it exists and it is
++	// returned as a create time error.
++	name, err := exec.LookPath(l.config.Args[0])
++	if err != nil {
++		return err
++	}
++	// exec.LookPath in Go < 1.20 might return no error for an executable
++	// residing on a file system mounted with noexec flag, so perform this
++	// extra check now while we can still return a proper error.
++	// TODO: remove this once go < 1.20 is not supported.
++	if err := eaccess(name); err != nil {
++		return &os.PathError{Op: "eaccess", Path: name, Err: err}
++	}
++
+ 	// Set seccomp as close to execve as possible, so as few syscalls take
+ 	// place afterward (reducing the amount of syscalls that users need to
+ 	// enable in their seccomp profiles).
+@@ -101,5 +118,23 @@
+ 		return &os.PathError{Op: "close log pipe", Path: "fd " + strconv.Itoa(l.logFd), Err: err}
+ 	}
+ 
+-	return system.Execv(l.config.Args[0], l.config.Args[0:], os.Environ())
++	// Close all file descriptors we are not passing to the container. This is
++	// necessary because the execve target could use internal runc fds as the
++	// execve path, potentially giving access to binary files from the host
++	// (which can then be opened by container processes, leading to container
++	// escapes). Note that because this operation will close any open file
++	// descriptors that are referenced by (*os.File) handles from underneath
++	// the Go runtime, we must not do any file operations after this point
++	// (otherwise the (*os.File) finaliser could close the wrong file). See
++	// CVE-2024-21626 for more information as to why this protection is
++	// necessary.
++	//
++	// This is not needed for runc-dmz, because the extra execve(2) step means
++	// that all O_CLOEXEC file descriptors have already been closed and thus
++	// the second execve(2) from runc-dmz cannot access internal file
++	// descriptors from runc.
++	if err := utils.UnsafeCloseFrom(l.config.PassedFilesCount + 3); err != nil {
++		return err
++	}
++	return system.Exec(name, l.config.Args[0:], os.Environ())
+ }
+diff -urN a/vendor/github.com/opencontainers/runc/libcontainer/standard_init_linux.go b/vendor/github.com/opencontainers/runc/libcontainer/standard_init_linux.go
+--- a/vendor/github.com/opencontainers/runc/libcontainer/standard_init_linux.go	2023-11-15 08:48:52.000000000 -0800
++++ b/vendor/github.com/opencontainers/runc/libcontainer/standard_init_linux.go	2024-02-14 12:44:48.265103900 -0800
+@@ -17,6 +17,7 @@
+ 	"github.com/opencontainers/runc/libcontainer/keys"
+ 	"github.com/opencontainers/runc/libcontainer/seccomp"
+ 	"github.com/opencontainers/runc/libcontainer/system"
++	"github.com/opencontainers/runc/libcontainer/utils"
+ )
+ 
+ type linuxStandardInit struct {
+@@ -257,6 +258,23 @@
+ 	if err := l.config.Config.Hooks[configs.StartContainer].RunHooks(s); err != nil {
+ 		return err
+ 	}
+-
++	// Close all file descriptors we are not passing to the container. This is
++	// necessary because the execve target could use internal runc fds as the
++	// execve path, potentially giving access to binary files from the host
++	// (which can then be opened by container processes, leading to container
++	// escapes). Note that because this operation will close any open file
++	// descriptors that are referenced by (*os.File) handles from underneath
++	// the Go runtime, we must not do any file operations after this point
++	// (otherwise the (*os.File) finaliser could close the wrong file). See
++	// CVE-2024-21626 for more information as to why this protection is
++	// necessary.
++	//
++	// This is not needed for runc-dmz, because the extra execve(2) step means
++	// that all O_CLOEXEC file descriptors have already been closed and thus
++	// the second execve(2) from runc-dmz cannot access internal file
++	// descriptors from runc.
++	if err := utils.UnsafeCloseFrom(l.config.PassedFilesCount + 3); err != nil {
++		return err
++	}
+ 	return system.Exec(name, l.config.Args[0:], os.Environ())
+ }
+diff -urN a/vendor/github.com/opencontainers/runc/libcontainer/utils/utils_unix.go b/vendor/github.com/opencontainers/runc/libcontainer/utils/utils_unix.go
+--- a/vendor/github.com/opencontainers/runc/libcontainer/utils/utils_unix.go	2023-11-15 08:48:52.000000000 -0800
++++ b/vendor/github.com/opencontainers/runc/libcontainer/utils/utils_unix.go	2024-02-14 12:46:18.107644800 -0800
+@@ -7,6 +7,7 @@
+ 	"fmt"
+ 	"os"
+ 	"strconv"
++	_ "unsafe" // for go:linkname
+ 
+ 	"golang.org/x/sys/unix"
+ )
+@@ -23,9 +24,11 @@
+ 	return nil
+ }
+ 
+-// CloseExecFrom applies O_CLOEXEC to all file descriptors currently open for
+-// the process (except for those below the given fd value).
+-func CloseExecFrom(minFd int) error {
++type fdFunc func(fd int)
++
++// fdRangeFrom calls the passed fdFunc for each file descriptor that is open in
++// the current process.
++func fdRangeFrom(minFd int, fn fdFunc) error {
+ 	fdDir, err := os.Open("/proc/self/fd")
+ 	if err != nil {
+ 		return err
+@@ -50,15 +53,60 @@
+ 		if fd < minFd {
+ 			continue
+ 		}
+-		// Intentionally ignore errors from unix.CloseOnExec -- the cases where
+-		// this might fail are basically file descriptors that have already
+-		// been closed (including and especially the one that was created when
+-		// os.ReadDir did the "opendir" syscall).
+-		unix.CloseOnExec(fd)
++		// Ignore the file descriptor we used for readdir, as it will be closed
++		// when we return.
++		if uintptr(fd) == fdDir.Fd() {
++			continue
++		}
++		// Run the closure.
++		fn(fd)
+ 	}
+ 	return nil
+ }
+ 
++// CloseExecFrom sets the O_CLOEXEC flag on all file descriptors greater or
++// equal to minFd in the current process.
++func CloseExecFrom(minFd int) error {
++	return fdRangeFrom(minFd, unix.CloseOnExec)
++}
++
++//go:linkname runtime_IsPollDescriptor internal/poll.IsPollDescriptor
++
++// In order to make sure we do not close the internal epoll descriptors the Go
++// runtime uses, we need to ensure that we skip descriptors that match
++// "internal/poll".IsPollDescriptor. Yes, this is a Go runtime internal thing,
++// unfortunately there's no other way to be sure we're only keeping the file
++// descriptors the Go runtime needs. Hopefully nothing blows up doing this...
++func runtime_IsPollDescriptor(fd uintptr) bool //nolint:revive
++
++// UnsafeCloseFrom closes all file descriptors greater or equal to minFd in the
++// current process, except for those critical to Go's runtime (such as the
++// netpoll management descriptors).
++//
++// NOTE: That this function is incredibly dangerous to use in most Go code, as
++// closing file descriptors from underneath *os.File handles can lead to very
++// bad behaviour (the closed file descriptor can be re-used and then any
++// *os.File operations would apply to the wrong file). This function is only
++// intended to be called from the last stage of runc init.
++func UnsafeCloseFrom(minFd int) error {
++	// We must not close some file descriptors.
++	return fdRangeFrom(minFd, func(fd int) {
++		if runtime_IsPollDescriptor(uintptr(fd)) {
++			// These are the Go runtimes internal netpoll file descriptors.
++			// These file descriptors are operated on deep in the Go scheduler,
++			// and closing those files from underneath Go can result in panics.
++			// There is no issue with keeping them because they are not
++			// executable and are not useful to an attacker anyway. Also we
++			// don't have any choice.
++			return
++		}
++		// There's nothing we can do about errors from close(2), and the
++		// only likely error to be seen is EBADF which indicates the fd was
++		// already closed (in which case, we got what we wanted).
++		_ = unix.Close(fd)
++	})
++}
++
+ // NewSockPair returns a new unix socket pair
+ func NewSockPair(name string) (parent *os.File, child *os.File, err error) {
+ 	fds, err := unix.Socketpair(unix.AF_LOCAL, unix.SOCK_STREAM|unix.SOCK_CLOEXEC, 0)

--- a/SPECS/kubernetes/CVE-2024-21626.patch
+++ b/SPECS/kubernetes/CVE-2024-21626.patch
@@ -1,15 +1,7 @@
 diff -urN a/vendor/github.com/opencontainers/runc/libcontainer/cgroups/file.go b/vendor/github.com/opencontainers/runc/libcontainer/cgroups/file.go
 --- a/vendor/github.com/opencontainers/runc/libcontainer/cgroups/file.go	2023-11-15 08:48:52.000000000 -0800
-+++ b/vendor/github.com/opencontainers/runc/libcontainer/cgroups/file.go	2024-02-14 12:37:41.501627000 -0800
-@@ -10,6 +10,7 @@
- 	"strings"
- 	"sync"
- 
-+	"github.com/opencontainers/runc/libcontainer/utils"
- 	"github.com/sirupsen/logrus"
- 	"golang.org/x/sys/unix"
- )
-@@ -76,16 +77,16 @@
++++ b/vendor/github.com/opencontainers/runc/libcontainer/cgroups/file.go	2024-02-14 14:33:18.150232100 -0800
+@@ -76,16 +76,16 @@
  	// TestMode is set to true by unit tests that need "fake" cgroupfs.
  	TestMode bool
  
@@ -31,7 +23,7 @@ diff -urN a/vendor/github.com/opencontainers/runc/libcontainer/cgroups/file.go b
  		})
  		if err != nil {
  			prepErr = &os.PathError{Op: "openat2", Path: cgroupfsDir, Err: err}
-@@ -96,15 +97,16 @@
+@@ -96,15 +96,16 @@
  			}
  			return
  		}
@@ -51,7 +43,7 @@ diff -urN a/vendor/github.com/opencontainers/runc/libcontainer/cgroups/file.go b
  		resolveFlags = unix.RESOLVE_BENEATH | unix.RESOLVE_NO_MAGICLINKS
  		if st.Type == unix.CGROUP2_SUPER_MAGIC {
  			// cgroupv2 has a single mountpoint and no "cpu,cpuacct" symlinks
-@@ -131,7 +133,7 @@
+@@ -131,7 +132,7 @@
  		return openFallback(path, flags, mode)
  	}
  
@@ -60,7 +52,7 @@ diff -urN a/vendor/github.com/opencontainers/runc/libcontainer/cgroups/file.go b
  		&unix.OpenHow{
  			Resolve: resolveFlags,
  			Flags:   uint64(flags) | unix.O_CLOEXEC,
-@@ -139,20 +141,20 @@
+@@ -139,20 +140,20 @@
  		})
  	if err != nil {
  		err = &os.PathError{Op: "openat2", Path: path, Err: err}

--- a/SPECS/kubernetes/kubernetes.spec
+++ b/SPECS/kubernetes/kubernetes.spec
@@ -92,6 +92,7 @@ Pause component for Microsoft Kubernetes %{version}.
 
 %prep
 %setup -q -c -n %{name}
+%patch 0 -p1
 
 %build
 # set version information using KUBE_GIT_VERSION
@@ -264,6 +265,9 @@ fi
 %{_exec_prefix}/local/bin/pause
 
 %changelog
+* Wed Feb 14 2024 Riken Maharjan <rmaharjan@microsoft.com> - 1.28.4-2
+- Address CVE-2024-21626 by patching vendored github/opencontainer/runc
+
 * Tue Dec 5 2023 Aadhar Agarwal <aadagarwal@microsoft.com> - 1.28.4-1
 - Upgrade to 1.28.4 to fix CVE-2023-5528
 

--- a/SPECS/kubernetes/kubernetes.spec
+++ b/SPECS/kubernetes/kubernetes.spec
@@ -10,7 +10,7 @@
 Summary:        Microsoft Kubernetes
 Name:           kubernetes
 Version:        1.28.4
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner

--- a/SPECS/kubernetes/kubernetes.spec
+++ b/SPECS/kubernetes/kubernetes.spec
@@ -18,6 +18,7 @@ Group:          Microsoft Kubernetes
 URL:            https://kubernetes.io/
 Source0:        https://dl.k8s.io/v%{version}/kubernetes-src.tar.gz#/%{name}-v%{version}.tar.gz
 Source1:        kubelet.service
+Patch0:         CVE-2024-21626.patch
 BuildRequires:  flex-devel
 BuildRequires:  glibc-static >= 2.35-6%{?dist}
 BuildRequires:  golang

--- a/SPECS/kubevirt/CVE-2024-21626.patch
+++ b/SPECS/kubevirt/CVE-2024-21626.patch
@@ -1,0 +1,514 @@
+diff -urN a/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/file.go b/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/file.go
+--- kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/file.go	2023-02-28 23:50:06.000000000 -0800
++++ kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/file.go	2024-02-13 16:29:02.871394900 -0800
+@@ -10,6 +10,7 @@
+ 	"strings"
+ 	"sync"
+ 
++	"github.com/opencontainers/runc/libcontainer/utils"
+ 	"github.com/sirupsen/logrus"
+ 	"golang.org/x/sys/unix"
+ )
+@@ -76,16 +77,16 @@
+ 	// TestMode is set to true by unit tests that need "fake" cgroupfs.
+ 	TestMode bool
+ 
+-	cgroupFd     int = -1
+-	prepOnce     sync.Once
+-	prepErr      error
+-	resolveFlags uint64
++	cgroupRootHandle *os.File
++	prepOnce     	sync.Once
++	prepErr      	error
++	resolveFlags 	uint64
+ )
+ 
+ func prepareOpenat2() error {
+ 	prepOnce.Do(func() {
+ 		fd, err := unix.Openat2(-1, cgroupfsDir, &unix.OpenHow{
+-			Flags: unix.O_DIRECTORY | unix.O_PATH,
++			Flags: unix.O_DIRECTORY | unix.O_PATH | unix.O_CLOEXEC,
+ 		})
+ 		if err != nil {
+ 			prepErr = &os.PathError{Op: "openat2", Path: cgroupfsDir, Err: err}
+@@ -96,15 +97,16 @@
+ 			}
+ 			return
+ 		}
++		file := os.NewFile(uintptr(fd), cgroupfsDir)
++
+ 		var st unix.Statfs_t
+-		if err = unix.Fstatfs(fd, &st); err != nil {
++		if err := unix.Fstatfs(int(file.Fd()), &st); err != nil {
+ 			prepErr = &os.PathError{Op: "statfs", Path: cgroupfsDir, Err: err}
+ 			logrus.Warnf("falling back to securejoin: %s", prepErr)
+ 			return
+ 		}
+ 
+-		cgroupFd = fd
+-
++		cgroupRootHandle = file
+ 		resolveFlags = unix.RESOLVE_BENEATH | unix.RESOLVE_NO_MAGICLINKS
+ 		if st.Type == unix.CGROUP2_SUPER_MAGIC {
+ 			// cgroupv2 has a single mountpoint and no "cpu,cpuacct" symlinks
+@@ -122,7 +124,7 @@
+ 		flags |= os.O_TRUNC | os.O_CREATE
+ 		mode = 0o600
+ 	}
+-	path := path.Join(dir, file)
++	path := path.Join(dir, utils.CleanPath(file))
+ 	if prepareOpenat2() != nil {
+ 		return openFallback(path, flags, mode)
+ 	}
+@@ -131,7 +133,7 @@
+ 		return openFallback(path, flags, mode)
+ 	}
+ 
+-	fd, err := unix.Openat2(cgroupFd, relPath,
++	fd, err := unix.Openat2(int(cgroupRootHandle.Fd()), relPath,
+ 		&unix.OpenHow{
+ 			Resolve: resolveFlags,
+ 			Flags:   uint64(flags) | unix.O_CLOEXEC,
+@@ -139,20 +141,20 @@
+ 		})
+ 	if err != nil {
+ 		err = &os.PathError{Op: "openat2", Path: path, Err: err}
+-		// Check if cgroupFd is still opened to cgroupfsDir
++		// Check if cgroupRootHandle is still opened to cgroupfsDir
+ 		// (happens when this package is incorrectly used
+ 		// across the chroot/pivot_root/mntns boundary, or
+ 		// when /sys/fs/cgroup is remounted).
+ 		//
+ 		// TODO: if such usage will ever be common, amend this
+-		// to reopen cgroupFd and retry openat2.
+-		fdStr := strconv.Itoa(cgroupFd)
++		// to reopen cgroupRootHandle and retry openat2.
++		fdStr := strconv.Itoa(int(cgroupRootHandle.Fd()))
+ 		fdDest, _ := os.Readlink("/proc/self/fd/" + fdStr)
+ 		if fdDest != cgroupfsDir {
+-			// Wrap the error so it is clear that cgroupFd
++			// Wrap the error so it is clear that cgroupRootHandle
+ 			// is opened to an unexpected/wrong directory.
+-			err = fmt.Errorf("cgroupFd %s unexpectedly opened to %s != %s: %w",
+-				fdStr, fdDest, cgroupfsDir, err)
++			err = fmt.Errorf("cgroupRootHandle %s unexpectedly opened to %s != %s: %w",
++			cgroupRootHandle.Fd(), fdDest, cgroupfsDir, err)
+ 		}
+ 		return nil, err
+ 	}
+diff -urN a/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/hugetlb.go b/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/hugetlb.go
+--- a/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/hugetlb.go	2023-02-28 23:50:06.000000000 -0800
++++ b/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/hugetlb.go	2024-02-14 09:32:40.625722400 -0800
+@@ -1,6 +1,8 @@
+ package fs
+ 
+ import (
++	"errors"
++	"os"
+ 	"strconv"
+ 
+ 	"github.com/opencontainers/runc/libcontainer/cgroups"
+@@ -19,8 +21,23 @@
+ }
+ 
+ func (s *HugetlbGroup) Set(path string, r *configs.Resources) error {
++	const suffix = ".limit_in_bytes"
++	skipRsvd := false
++
+ 	for _, hugetlb := range r.HugetlbLimit {
+-		if err := cgroups.WriteFile(path, "hugetlb."+hugetlb.Pagesize+".limit_in_bytes", strconv.FormatUint(hugetlb.Limit, 10)); err != nil {
++		prefix := "hugetlb." + hugetlb.Pagesize
++		val := strconv.FormatUint(hugetlb.Limit, 10)
++		if err := cgroups.WriteFile(path, prefix+suffix, val); err != nil {
++			return err
++		}
++		if skipRsvd {
++			continue
++		}
++		if err := cgroups.WriteFile(path, prefix+".rsvd"+suffix, val); err != nil {
++			if errors.Is(err, os.ErrNotExist) {
++				skipRsvd = true
++				continue
++			}
+ 			return err
+ 		}
+ 	}
+@@ -32,24 +49,29 @@
+ 	if !cgroups.PathExists(path) {
+ 		return nil
+ 	}
++	rsvd := ".rsvd"
+ 	hugetlbStats := cgroups.HugetlbStats{}
+ 	for _, pageSize := range cgroups.HugePageSizes() {
+-		usage := "hugetlb." + pageSize + ".usage_in_bytes"
+-		value, err := fscommon.GetCgroupParamUint(path, usage)
++		again:
++		prefix := "hugetlb." + pageSize + rsvd
++
++		value, err := fscommon.GetCgroupParamUint(path, prefix+".usage_in_bytes")
+ 		if err != nil {
++			if rsvd != "" && errors.Is(err, os.ErrNotExist) {
++				rsvd = ""
++				goto again
++			}
+ 			return err
+ 		}
+ 		hugetlbStats.Usage = value
+ 
+-		maxUsage := "hugetlb." + pageSize + ".max_usage_in_bytes"
+-		value, err = fscommon.GetCgroupParamUint(path, maxUsage)
++		value, err = fscommon.GetCgroupParamUint(path, prefix+".max_usage_in_bytes")
+ 		if err != nil {
+ 			return err
+ 		}
+ 		hugetlbStats.MaxUsage = value
+ 
+-		failcnt := "hugetlb." + pageSize + ".failcnt"
+-		value, err = fscommon.GetCgroupParamUint(path, failcnt)
++		value, err = fscommon.GetCgroupParamUint(path, prefix+".failcnt")
+ 		if err != nil {
+ 			return err
+ 		}
+diff -urN a/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/memory.go b/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/memory.go
+--- a/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/memory.go	2023-02-28 23:50:06.000000000 -0800
++++ b/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/memory.go	2024-02-14 09:39:52.925477700 -0800
+@@ -170,6 +170,10 @@
+ 		return err
+ 	}
+ 	stats.MemoryStats.SwapUsage = swapUsage
++	stats.MemoryStats.SwapOnlyUsage = cgroups.MemoryData{
++		Usage:   swapUsage.Usage - memoryUsage.Usage,
++		Failcnt: swapUsage.Failcnt - memoryUsage.Failcnt,
++	}
+ 	kernelUsage, err := getMemoryData(path, "kmem")
+ 	if err != nil {
+ 		return err
+@@ -234,6 +238,12 @@
+ 	memoryData.Failcnt = value
+ 	value, err = fscommon.GetCgroupParamUint(path, limit)
+ 	if err != nil {
++		if name == "kmem" && os.IsNotExist(err) {
++			// Ignore ENOENT as kmem.limit_in_bytes has
++			// been removed in newer kernels.
++			return memoryData, nil
++		}
++		
+ 		return cgroups.MemoryData{}, err
+ 	}
+ 	memoryData.Limit = value
+diff -urN a/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/paths.go b/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/paths.go
+--- a/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/paths.go	2023-02-28 23:50:06.000000000 -0800
++++ b/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/paths.go	2024-02-14 09:40:28.763367700 -0800
+@@ -83,6 +83,7 @@
+ 	if err != nil {
+ 		return ""
+ 	}
++	defer dir.Close()
+ 	names, err := dir.Readdirnames(1)
+ 	if err != nil {
+ 		return ""
+diff -urN a/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs2/hugetlb.go b/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs2/hugetlb.go
+--- a/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs2/hugetlb.go	2023-02-28 23:50:06.000000000 -0800
++++ b/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs2/hugetlb.go	2024-02-14 09:43:39.855057300 -0800
+@@ -1,6 +1,8 @@
+ package fs2
+ 
+ import (
++	"errors"
++	"os"
+ 	"strconv"
+ 
+ 	"github.com/opencontainers/runc/libcontainer/cgroups"
+@@ -16,8 +18,22 @@
+ 	if !isHugeTlbSet(r) {
+ 		return nil
+ 	}
++	const suffix = ".max"
++	skipRsvd := false
+ 	for _, hugetlb := range r.HugetlbLimit {
+-		if err := cgroups.WriteFile(dirPath, "hugetlb."+hugetlb.Pagesize+".max", strconv.FormatUint(hugetlb.Limit, 10)); err != nil {
++		prefix := "hugetlb." + hugetlb.Pagesize
++		val := strconv.FormatUint(hugetlb.Limit, 10)
++		if err := cgroups.WriteFile(dirPath, prefix+suffix, val); err != nil {
++			return err
++		}
++		if skipRsvd {
++			continue
++		}
++		if err := cgroups.WriteFile(dirPath, prefix+".rsvd"+suffix, val); err != nil {
++			if errors.Is(err, os.ErrNotExist) {
++				skipRsvd = true
++				continue
++			}
+ 			return err
+ 		}
+ 	}
+@@ -27,15 +43,21 @@
+ 
+ func statHugeTlb(dirPath string, stats *cgroups.Stats) error {
+ 	hugetlbStats := cgroups.HugetlbStats{}
++	rsvd := ".rsvd"
+ 	for _, pagesize := range cgroups.HugePageSizes() {
+-		value, err := fscommon.GetCgroupParamUint(dirPath, "hugetlb."+pagesize+".current")
++	again:
++		prefix := "hugetlb." + pagesize + rsvd
++		value, err := fscommon.GetCgroupParamUint(dirPath, prefix+".current")
+ 		if err != nil {
++			if rsvd != "" && errors.Is(err, os.ErrNotExist) {
++				rsvd = ""
++				goto again
++			}
+ 			return err
+ 		}
+ 		hugetlbStats.Usage = value
+ 
+-		fileName := "hugetlb." + pagesize + ".events"
+-		value, err = fscommon.GetValueByKey(dirPath, fileName, "max")
++		value, err = fscommon.GetValueByKey(dirPath, prefix+".events", "max")
+ 		if err != nil {
+ 			return err
+ 		}
+diff -urN a/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs2/memory.go b/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs2/memory.go
+--- a/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs2/memory.go	2023-02-28 23:50:06.000000000 -0800
++++ b/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs2/memory.go	2024-02-14 10:03:10.747123800 -0800
+@@ -100,17 +100,19 @@
+ 	memoryUsage, err := getMemoryDataV2(dirPath, "")
+ 	if err != nil {
+ 		if errors.Is(err, unix.ENOENT) && dirPath == UnifiedMountpoint {
+-			// The root cgroup does not have memory.{current,max}
++			// The root cgroup does not have memory.{current,max,peak}
+ 			// so emulate those using data from /proc/meminfo.
+ 			return statsFromMeminfo(stats)
+ 		}
+ 		return err
+ 	}
+ 	stats.MemoryStats.Usage = memoryUsage
+-	swapUsage, err := getMemoryDataV2(dirPath, "swap")
++	swapOnlyUsage, err := getMemoryDataV2(dirPath, "swap")
+ 	if err != nil {
+ 		return err
+ 	}
++	stats.MemoryStats.SwapOnlyUsage = swapOnlyUsage
++	swapUsage := swapOnlyUsage
+ 	// As cgroup v1 reports SwapUsage values as mem+swap combined,
+ 	// while in cgroup v2 swap values do not include memory,
+ 	// report combined mem+swap for v1 compatibility.
+@@ -118,6 +120,9 @@
+ 	if swapUsage.Limit != math.MaxUint64 {
+ 		swapUsage.Limit += memoryUsage.Limit
+ 	}
++	// The `MaxUsage` of mem+swap cannot simply combine mem with
++	// swap. So set it to 0 for v1 compatibility.
++	swapUsage.MaxUsage = 0
+ 	stats.MemoryStats.SwapUsage = swapUsage
+ 
+ 	return nil
+@@ -132,6 +137,7 @@
+ 	}
+ 	usage := moduleName + ".current"
+ 	limit := moduleName + ".max"
++	maxUsage := moduleName + ".peak"
+ 
+ 	value, err := fscommon.GetCgroupParamUint(path, usage)
+ 	if err != nil {
+@@ -151,6 +157,14 @@
+ 	}
+ 	memoryData.Limit = value
+ 
++	// `memory.peak` since kernel 5.19
++	// `memory.swap.peak` since kernel 6.5
++	value, err = fscommon.GetCgroupParamUint(path, maxUsage)
++	if err != nil && !os.IsNotExist(err) {
++		return cgroups.MemoryData{}, err
++	}
++	memoryData.MaxUsage = value
++
+ 	return memoryData, nil
+ }
+ 
+diff -urN a/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/stats.go b/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/stats.go
+--- a/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/stats.go	2023-02-28 23:50:06.000000000 -0800
++++ b/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/stats.go	2024-02-14 10:05:06.344130500 -0800
+@@ -78,6 +78,8 @@
+ 	Usage MemoryData `json:"usage,omitempty"`
+ 	// usage of memory + swap
+ 	SwapUsage MemoryData `json:"swap_usage,omitempty"`
++	// usage of swap only
++	SwapOnlyUsage MemoryData `json:"swap_only_usage,omitempty"`
+ 	// usage of kernel memory
+ 	KernelUsage MemoryData `json:"kernel_usage,omitempty"`
+ 	// usage of kernel TCP memory
+diff -urN a/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/configs/config.go b/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/configs/config.go
+--- a/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/configs/config.go	2023-02-28 23:50:06.000000000 -0800
++++ b/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/configs/config.go	2024-02-14 10:05:35.342058000 -0800
+@@ -21,9 +21,9 @@
+ 
+ // IDMap represents UID/GID Mappings for User Namespaces.
+ type IDMap struct {
+-	ContainerID int `json:"container_id"`
+-	HostID      int `json:"host_id"`
+-	Size        int `json:"size"`
++	ContainerID int64 `json:"container_id"`
++	HostID      int64 `json:"host_id"`
++	Size        int64 `json:"size"`
+ }
+ 
+ // Seccomp represents syscall restrictions
+diff -urN a/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/configs/config_linux.go b/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/configs/config_linux.go
+--- a/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/configs/config_linux.go	2023-02-28 23:50:06.000000000 -0800
++++ b/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/configs/config_linux.go	2024-02-14 10:08:08.024297400 -0800
+@@ -1,6 +1,10 @@
+ package configs
+ 
+-import "errors"
++import (
++	"errors"
++	"fmt"
++	"math"
++)
+ 
+ var (
+ 	errNoUIDMap   = errors.New("User namespaces enabled, but no uid mappings found.")
+@@ -16,11 +20,18 @@
+ 		if c.UidMappings == nil {
+ 			return -1, errNoUIDMap
+ 		}
+-		id, found := c.hostIDFromMapping(containerId, c.UidMappings)
++		id, found := c.hostIDFromMapping(int64(containerId), c.UidMappings)
+ 		if !found {
+ 			return -1, errNoUserMap
+ 		}
+-		return id, nil
++		// If we are a 32-bit binary running on a 64-bit system, it's possible
++		// the mapped user is too large to store in an int, which means we
++		// cannot do the mapping. We can't just return an int64, because
++		// os.Setuid() takes an int.
++		if id > math.MaxInt {
++			return -1, fmt.Errorf("mapping for uid %d (host id %d) is larger than native integer size (%d)", containerId, id, math.MaxInt)
++		}
++		return int(id), nil
+ 	}
+ 	// Return unchanged id.
+ 	return containerId, nil
+@@ -39,11 +50,18 @@
+ 		if c.GidMappings == nil {
+ 			return -1, errNoGIDMap
+ 		}
+-		id, found := c.hostIDFromMapping(containerId, c.GidMappings)
++		id, found := c.hostIDFromMapping(int64(containerId), c.GidMappings)
+ 		if !found {
+ 			return -1, errNoGroupMap
+ 		}
+-		return id, nil
++		// If we are a 32-bit binary running on a 64-bit system, it's possible
++		// the mapped user is too large to store in an int, which means we
++		// cannot do the mapping. We can't just return an int64, because
++		// os.Setgid() takes an int.
++		if id > math.MaxInt {
++			return -1, fmt.Errorf("mapping for gid %d (host id %d) is larger than native integer size (%d)", containerId, id, math.MaxInt)
++		}
++		return int(id), nil
+ 	}
+ 	// Return unchanged id.
+ 	return containerId, nil
+@@ -57,7 +75,7 @@
+ 
+ // Utility function that gets a host ID for a container ID from user namespace map
+ // if that ID is present in the map.
+-func (c Config) hostIDFromMapping(containerID int, uMap []IDMap) (int, bool) {
++func (c Config) hostIDFromMapping(containerID int64, uMap []IDMap) (int64, bool) {
+ 	for _, m := range uMap {
+ 		if (containerID >= m.ContainerID) && (containerID <= (m.ContainerID + m.Size - 1)) {
+ 			hostID := m.HostID + (containerID - m.ContainerID)
+diff -urN a/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/utils/utils_unix.go b/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/utils/utils_unix.go
+--- a/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/utils/utils_unix.go	2023-02-28 23:50:06.000000000 -0800
++++ b/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/utils/utils_unix.go	2024-02-14 10:13:21.233843200 -0800
+@@ -7,6 +7,7 @@
+ 	"fmt"
+ 	"os"
+ 	"strconv"
++	_ "unsafe" // for go:linkname
+ 
+ 	"golang.org/x/sys/unix"
+ )
+@@ -23,9 +24,11 @@
+ 	return nil
+ }
+ 
+-// CloseExecFrom applies O_CLOEXEC to all file descriptors currently open for
+-// the process (except for those below the given fd value).
+-func CloseExecFrom(minFd int) error {
++type fdFunc func(fd int)
++
++// fdRangeFrom calls the passed fdFunc for each file descriptor that is open in
++// the current process.
++func fdRangeFrom(minFd int, fn fdFunc) error {
+ 	fdDir, err := os.Open("/proc/self/fd")
+ 	if err != nil {
+ 		return err
+@@ -50,15 +53,60 @@
+ 		if fd < minFd {
+ 			continue
+ 		}
+-		// Intentionally ignore errors from unix.CloseOnExec -- the cases where
+-		// this might fail are basically file descriptors that have already
+-		// been closed (including and especially the one that was created when
+-		// os.ReadDir did the "opendir" syscall).
+-		unix.CloseOnExec(fd)
++		// Ignore the file descriptor we used for readdir, as it will be closed
++		// when we return.
++		if uintptr(fd) == fdDir.Fd() {
++			continue
++		}
++		// Run the closure.
++		fn(fd)
+ 	}
+ 	return nil
+ }
+ 
++// CloseExecFrom sets the O_CLOEXEC flag on all file descriptors greater or
++// equal to minFd in the current process.
++func CloseExecFrom(minFd int) error {
++	return fdRangeFrom(minFd, unix.CloseOnExec)
++}
++
++//go:linkname runtime_IsPollDescriptor internal/poll.IsPollDescriptor
++
++// In order to make sure we do not close the internal epoll descriptors the Go
++// runtime uses, we need to ensure that we skip descriptors that match
++// "internal/poll".IsPollDescriptor. Yes, this is a Go runtime internal thing,
++// unfortunately there's no other way to be sure we're only keeping the file
++// descriptors the Go runtime needs. Hopefully nothing blows up doing this...
++func runtime_IsPollDescriptor(fd uintptr) bool //nolint:revive
++
++// UnsafeCloseFrom closes all file descriptors greater or equal to minFd in the
++// current process, except for those critical to Go's runtime (such as the
++// netpoll management descriptors).
++//
++// NOTE: That this function is incredibly dangerous to use in most Go code, as
++// closing file descriptors from underneath *os.File handles can lead to very
++// bad behaviour (the closed file descriptor can be re-used and then any
++// *os.File operations would apply to the wrong file). This function is only
++// intended to be called from the last stage of runc init.
++func UnsafeCloseFrom(minFd int) error {
++	// We must not close some file descriptors.
++	return fdRangeFrom(minFd, func(fd int) {
++		if runtime_IsPollDescriptor(uintptr(fd)) {
++			// These are the Go runtimes internal netpoll file descriptors.
++			// These file descriptors are operated on deep in the Go scheduler,
++			// and closing those files from underneath Go can result in panics.
++			// There is no issue with keeping them because they are not
++			// executable and are not useful to an attacker anyway. Also we
++			// don't have any choice.
++			return
++		}
++		// There's nothing we can do about errors from close(2), and the
++		// only likely error to be seen is EBADF which indicates the fd was
++		// already closed (in which case, we got what we wanted).
++		_ = unix.Close(fd)
++	})
++}
++
+ // NewSockPair returns a new unix socket pair
+ func NewSockPair(name string) (parent *os.File, child *os.File, err error) {
+ 	fds, err := unix.Socketpair(unix.AF_LOCAL, unix.SOCK_STREAM|unix.SOCK_CLOEXEC, 0)

--- a/SPECS/kubevirt/CVE-2024-21626.patch
+++ b/SPECS/kubevirt/CVE-2024-21626.patch
@@ -1,4 +1,4 @@
-diff -urN a/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/file.go b/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/file.go
+diff -urN kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/file.go kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/file.go
 --- kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/file.go	2023-02-28 23:50:06.000000000 -0800
 +++ kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/file.go	2024-02-13 16:29:02.871394900 -0800
 @@ -10,6 +10,7 @@
@@ -96,9 +96,9 @@ diff -urN a/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/c
  		}
  		return nil, err
  	}
-diff -urN a/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/hugetlb.go b/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/hugetlb.go
---- a/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/hugetlb.go	2023-02-28 23:50:06.000000000 -0800
-+++ b/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/hugetlb.go	2024-02-14 09:32:40.625722400 -0800
+diff -urN kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/hugetlb.go kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/hugetlb.go
+--- kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/hugetlb.go	2023-02-28 23:50:06.000000000 -0800
++++ kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/hugetlb.go	2024-02-14 09:32:40.625722400 -0800
 @@ -1,6 +1,8 @@
  package fs
  
@@ -169,9 +169,9 @@ diff -urN a/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/c
  		if err != nil {
  			return err
  		}
-diff -urN a/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/memory.go b/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/memory.go
---- a/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/memory.go	2023-02-28 23:50:06.000000000 -0800
-+++ b/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/memory.go	2024-02-14 09:39:52.925477700 -0800
+diff -urN kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/memory.go kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/memory.go
+--- kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/memory.go	2023-02-28 23:50:06.000000000 -0800
++++ kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/memory.go	2024-02-14 09:39:52.925477700 -0800
 @@ -170,6 +170,10 @@
  		return err
  	}
@@ -196,9 +196,9 @@ diff -urN a/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/c
  		return cgroups.MemoryData{}, err
  	}
  	memoryData.Limit = value
-diff -urN a/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/paths.go b/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/paths.go
---- a/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/paths.go	2023-02-28 23:50:06.000000000 -0800
-+++ b/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/paths.go	2024-02-14 09:40:28.763367700 -0800
+diff -urN kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/paths.go kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/paths.go
+--- kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/paths.go	2023-02-28 23:50:06.000000000 -0800
++++ kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/paths.go	2024-02-14 09:40:28.763367700 -0800
 @@ -83,6 +83,7 @@
  	if err != nil {
  		return ""
@@ -207,9 +207,9 @@ diff -urN a/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/c
  	names, err := dir.Readdirnames(1)
  	if err != nil {
  		return ""
-diff -urN a/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs2/hugetlb.go b/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs2/hugetlb.go
---- a/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs2/hugetlb.go	2023-02-28 23:50:06.000000000 -0800
-+++ b/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs2/hugetlb.go	2024-02-14 09:43:39.855057300 -0800
+diff -urN kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs2/hugetlb.go kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs2/hugetlb.go
+--- kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs2/hugetlb.go	2023-02-28 23:50:06.000000000 -0800
++++ kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs2/hugetlb.go	2024-02-14 09:43:39.855057300 -0800
 @@ -1,6 +1,8 @@
  package fs2
  
@@ -268,9 +268,9 @@ diff -urN a/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/c
  		if err != nil {
  			return err
  		}
-diff -urN a/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs2/memory.go b/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs2/memory.go
---- a/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs2/memory.go	2023-02-28 23:50:06.000000000 -0800
-+++ b/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs2/memory.go	2024-02-14 10:03:10.747123800 -0800
+diff -urN kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs2/memory.go kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs2/memory.go
+--- kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs2/memory.go	2023-02-28 23:50:06.000000000 -0800
++++ kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs2/memory.go	2024-02-14 10:03:10.747123800 -0800
 @@ -100,17 +100,19 @@
  	memoryUsage, err := getMemoryDataV2(dirPath, "")
  	if err != nil {
@@ -326,9 +326,9 @@ diff -urN a/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/c
  	return memoryData, nil
  }
  
-diff -urN a/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/stats.go b/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/stats.go
---- a/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/stats.go	2023-02-28 23:50:06.000000000 -0800
-+++ b/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/stats.go	2024-02-14 10:05:06.344130500 -0800
+diff -urN kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/stats.go kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/stats.go
+--- kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/stats.go	2023-02-28 23:50:06.000000000 -0800
++++ kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/cgroups/stats.go	2024-02-14 10:05:06.344130500 -0800
 @@ -78,6 +78,8 @@
  	Usage MemoryData `json:"usage,omitempty"`
  	// usage of memory + swap
@@ -338,9 +338,9 @@ diff -urN a/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/c
  	// usage of kernel memory
  	KernelUsage MemoryData `json:"kernel_usage,omitempty"`
  	// usage of kernel TCP memory
-diff -urN a/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/configs/config.go b/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/configs/config.go
---- a/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/configs/config.go	2023-02-28 23:50:06.000000000 -0800
-+++ b/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/configs/config.go	2024-02-14 10:05:35.342058000 -0800
+diff -urN kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/configs/config.go kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/configs/config.go
+--- kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/configs/config.go	2023-02-28 23:50:06.000000000 -0800
++++ kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/configs/config.go	2024-02-14 10:05:35.342058000 -0800
 @@ -21,9 +21,9 @@
  
  // IDMap represents UID/GID Mappings for User Namespaces.
@@ -354,9 +354,9 @@ diff -urN a/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/c
  }
  
  // Seccomp represents syscall restrictions
-diff -urN a/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/configs/config_linux.go b/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/configs/config_linux.go
---- a/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/configs/config_linux.go	2023-02-28 23:50:06.000000000 -0800
-+++ b/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/configs/config_linux.go	2024-02-14 10:08:08.024297400 -0800
+diff -urN kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/configs/config_linux.go kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/configs/config_linux.go
+--- kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/configs/config_linux.go	2023-02-28 23:50:06.000000000 -0800
++++ kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/configs/config_linux.go	2024-02-14 10:08:08.024297400 -0800
 @@ -1,6 +1,10 @@
  package configs
  
@@ -420,9 +420,9 @@ diff -urN a/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/c
  	for _, m := range uMap {
  		if (containerID >= m.ContainerID) && (containerID <= (m.ContainerID + m.Size - 1)) {
  			hostID := m.HostID + (containerID - m.ContainerID)
-diff -urN a/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/utils/utils_unix.go b/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/utils/utils_unix.go
---- a/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/utils/utils_unix.go	2023-02-28 23:50:06.000000000 -0800
-+++ b/kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/utils/utils_unix.go	2024-02-14 10:13:21.233843200 -0800
+diff -urN kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/utils/utils_unix.go kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/utils/utils_unix.go
+--- kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/utils/utils_unix.go	2023-02-28 23:50:06.000000000 -0800
++++ kubevirt-0.59.0/vendor/github.com/opencontainers/runc/libcontainer/utils/utils_unix.go	2024-02-14 10:13:21.233843200 -0800
 @@ -7,6 +7,7 @@
  	"fmt"
  	"os"

--- a/SPECS/kubevirt/kubevirt.spec
+++ b/SPECS/kubevirt/kubevirt.spec
@@ -19,7 +19,7 @@
 Summary:        Container native virtualization
 Name:           kubevirt
 Version:        0.59.0
-Release:        12%{?dist}
+Release:        13%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -213,6 +213,9 @@ install -p -m 0644 cmd/virt-handler/nsswitch.conf %{buildroot}%{_datadir}/kube-v
 %{_bindir}/virt-tests
 
 %changelog
+* Wed Feb 14 2024 Riken Maharjan <rmaharjan@microsoft.com> - 0.59.0-13
+- Address CVE-2024-21626 by patching vendored github/opencontainer/runc
+
 * Thu Feb 01 2024 Daniel McIlvaney <damcilva@microsoft.com> - 0.59.0-12
 - Address CVE-2023-44487 by patching vendored golang.org/x/net
 

--- a/SPECS/kubevirt/kubevirt.spec
+++ b/SPECS/kubevirt/kubevirt.spec
@@ -33,6 +33,7 @@ Patch0:         Cleanup-housekeeping-cgroup-on-vm-del.patch
 Patch1:         Allocate-2-cpu-for-the-emulator-thread.patch
 Patch2:         Hotplug_detach_grace_period.patch
 Patch3:         CVE-2023-44487.patch
+Patch4:         CVE-2024-21626.patch
 %global debug_package %{nil}
 BuildRequires:  glibc-devel
 BuildRequires:  glibc-static >= 2.35-6%{?dist}


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Fix CVE-2024-21626 by patching venodred runc in kubernetes, kubevirt, and cri-tools

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change:  Add patch to mitigate CVE-2024-21626.
- Change: Patch imported for cri-tools from [3245240](https://github.com/kubernetes-sigs/cri-tools/commit/32452408ae7697d7dcd3da90ef4eebb922b2bf63)
- Change: Patch imported for kubevirt from [22dfc39](https://github.com/kubevirt/kubevirt/commit/22dfc39b5f6a1b16e05875412000a7b7b98d22e6)
- Change: Patch imported for kubernetes from [2dd8156](https://github.com/kubernetes/kubernetes/commit/2dd81563a9629f9f88fa3d52f5be3c4a24e6ace8)


###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES/NO**
NO

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2024-21626

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id kubernetes: [506007](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=506007&view=results)
- Pipeline build id kubevirt: [505970](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=505970&view=results)
- Pipeline build id cri-tools: [505952](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=505952&view=results)
