### PR TITLE
go-tool: pass error instead of logging utility files

### DIFF
--- a/toolkit/tools/imager/imager.go
+++ b/toolkit/tools/imager/imager.go
@@ -269,11 +269,8 @@ func buildSystemConfig(systemConfig configuration.SystemConfig, disks []configur
 		}
 
 		// Extract image package manifest from the 'setuproot' chroot
-		err = setupChroot.MoveOutFile(installutils.PackageManifestRelativePath, imgContentFile)
-		if err != nil {
-			logger.Log.Errorf("Failed to move files %v", err)
-			return
-		}
+		setupChroot.MoveOutFile(installutils.PackageManifestRelativePath, imgContentFile)
+
 		err = cleanupExtraFilesInChroot(setupChroot)
 		if err != nil {
 			logger.Log.Error("Failed to cleanup extra files in setup chroot")

--- a/toolkit/tools/imager/imager.go
+++ b/toolkit/tools/imager/imager.go
@@ -269,8 +269,11 @@ func buildSystemConfig(systemConfig configuration.SystemConfig, disks []configur
 		}
 
 		// Extract image package manifest from the 'setuproot' chroot
-		setupChroot.MoveOutFile(installutils.PackageManifestRelativePath, imgContentFile)
-
+		err = setupChroot.MoveOutFile(installutils.PackageManifestRelativePath, imgContentFile)
+		if err != nil {
+			logger.Log.Errorf("Failed to move files %v", err)
+			return
+		}
 		err = cleanupExtraFilesInChroot(setupChroot)
 		if err != nil {
 			logger.Log.Error("Failed to cleanup extra files in setup chroot")

--- a/toolkit/tools/internal/file/file.go
+++ b/toolkit/tools/internal/file/file.go
@@ -45,12 +45,12 @@ func Move(src, dst string) (err error) {
 
 	src, err = filepath.Abs(src)
 	if err != nil {
-		return fmt.Errorf("Failed to get absolute path for move source (%s):\n%w", src, err)
+		return fmt.Errorf("failed to get absolute path for move source (%s)\n%w", src, err)
 	}
 
 	dst, err = filepath.Abs(dst)
 	if err != nil {
-		return fmt.Errorf("Failed to get absolute path for move destination (%s):\n%w", dst, err)
+		return fmt.Errorf("failed to get absolute path for move destination (%s)\n%w", dst, err)
 		return
 	}
 

--- a/toolkit/tools/internal/file/file.go
+++ b/toolkit/tools/internal/file/file.go
@@ -45,12 +45,12 @@ func Move(src, dst string) (err error) {
 
 	src, err = filepath.Abs(src)
 	if err != nil {
-		return fmt.Errorf("failed to get absolute path for move source (%s)\n%w", src, err)
+		return fmt.Errorf("failed to get absolute path for move source (%s):\n%w", src, err)
 	}
 
 	dst, err = filepath.Abs(dst)
 	if err != nil {
-		return fmt.Errorf("failed to get absolute path for move destination (%s)\n%w", dst, err)
+		return fmt.Errorf("failed to get absolute path for move destination (%s):\n%w", dst, err)
 	}
 
 	if src == dst {

--- a/toolkit/tools/internal/file/file.go
+++ b/toolkit/tools/internal/file/file.go
@@ -51,7 +51,6 @@ func Move(src, dst string) (err error) {
 	dst, err = filepath.Abs(dst)
 	if err != nil {
 		return fmt.Errorf("failed to get absolute path for move destination (%s)\n%w", dst, err)
-		return
 	}
 
 	if src == dst {

--- a/toolkit/tools/internal/file/file.go
+++ b/toolkit/tools/internal/file/file.go
@@ -45,13 +45,12 @@ func Move(src, dst string) (err error) {
 
 	src, err = filepath.Abs(src)
 	if err != nil {
-		logger.Log.Errorf("Failed to get absolute path for move source (%s).", src)
-		return
+		return fmt.Errorf("Failed to get absolute path for move source (%s):\n%w", src, err)
 	}
 
 	dst, err = filepath.Abs(dst)
 	if err != nil {
-		logger.Log.Errorf("Failed to get absolute path for move destination (%s).", dst)
+		return fmt.Errorf("Failed to get absolute path for move destination (%s):\n%w", dst, err)
 		return
 	}
 

--- a/toolkit/tools/internal/rpm/rpm.go
+++ b/toolkit/tools/internal/rpm/rpm.go
@@ -536,7 +536,7 @@ func buildAllSpecsList(baseDir string) (specPaths []string, err error) {
 
 	specPaths, err = filepath.Glob(specFilesGlob)
 	if err != nil {
-		return nil, fmt.Errorf("Failed while trying to enumerate all spec files with (%s). Error: %w", specFilesGlob, err)
+		return nil, fmt.Errorf("failed to enumerate all spec files with (%s)\n%w", specFilesGlob, err)
 	}
 
 	return

--- a/toolkit/tools/internal/rpm/rpm.go
+++ b/toolkit/tools/internal/rpm/rpm.go
@@ -536,7 +536,8 @@ func buildAllSpecsList(baseDir string) (specPaths []string, err error) {
 
 	specPaths, err = filepath.Glob(specFilesGlob)
 	if err != nil {
-		return nil, fmt.Errorf("failed to enumerate all spec files with (%s)\n%w", specFilesGlob, err)
+		specPaths, err = nil, fmt.Errorf("failed to enumerate all spec files with (%s):\n%w", specFilesGlob, err)
+		return
 	}
 
 	return

--- a/toolkit/tools/internal/rpm/rpm.go
+++ b/toolkit/tools/internal/rpm/rpm.go
@@ -536,7 +536,7 @@ func buildAllSpecsList(baseDir string) (specPaths []string, err error) {
 
 	specPaths, err = filepath.Glob(specFilesGlob)
 	if err != nil {
-		return fmt.Errorf("Failed while trying to enumerate all spec files with (%s). Error: %w", specFilesGlob, err)
+		return nil, fmt.Errorf("Failed while trying to enumerate all spec files with (%s). Error: %w", specFilesGlob, err)
 	}
 
 	return

--- a/toolkit/tools/internal/rpm/rpm.go
+++ b/toolkit/tools/internal/rpm/rpm.go
@@ -536,7 +536,7 @@ func buildAllSpecsList(baseDir string) (specPaths []string, err error) {
 
 	specPaths, err = filepath.Glob(specFilesGlob)
 	if err != nil {
-		logger.Log.Errorf("Failed while trying to enumerate all spec files with (%s). Error: %v.", specFilesGlob, err)
+		return fmt.Errorf("Failed while trying to enumerate all spec files with (%s). Error: %w", specFilesGlob, err)
 	}
 
 	return

--- a/toolkit/tools/internal/safechroot/safechroot.go
+++ b/toolkit/tools/internal/safechroot/safechroot.go
@@ -319,8 +319,7 @@ func AddFilesToDestination(destDir string, filesToCopy ...FileToCopy) error {
 		}
 
 		if err != nil {
-			logger.Log.Errorf("Error copying file '%s'", f.Src)
-			return err
+			return fmt.Errorf("Error copying file %s. Error: %w", f.Src, err)
 		}
 	}
 	return nil
@@ -331,8 +330,7 @@ func (c *Chroot) CopyOutFile(srcPath string, destPath string) (err error) {
 	srcPathFull := filepath.Join(c.rootDir, srcPath)
 	err = file.Copy(srcPathFull, destPath)
 	if err != nil {
-		logger.Log.Errorf("Error copying file '%s'", err)
-		return
+		return fmt.Errorf("Error copying file. Error: %w", err)
 	}
 	return
 }
@@ -342,8 +340,7 @@ func (c *Chroot) MoveOutFile(srcPath string, destPath string) (err error) {
 	srcPathFull := filepath.Join(c.rootDir, srcPath)
 	err = file.Move(srcPathFull, destPath)
 	if err != nil {
-		logger.Log.Errorf("Error moving file '%s'", err)
-		return
+		return fmt.Errorf("Error moving file from %s to %s. Error: %w", srcPath, destPath, err)
 	}
 	return
 }

--- a/toolkit/tools/internal/safechroot/safechroot.go
+++ b/toolkit/tools/internal/safechroot/safechroot.go
@@ -319,7 +319,7 @@ func AddFilesToDestination(destDir string, filesToCopy ...FileToCopy) error {
 		}
 
 		if err != nil {
-			return fmt.Errorf("failed to copy (%s)\n%w", f.Src, err)
+			return fmt.Errorf("failed to copy (%s):\n%w", f.Src, err)
 		}
 	}
 	return nil
@@ -330,7 +330,7 @@ func (c *Chroot) CopyOutFile(srcPath string, destPath string) (err error) {
 	srcPathFull := filepath.Join(c.rootDir, srcPath)
 	err = file.Copy(srcPathFull, destPath)
 	if err != nil {
-		return fmt.Errorf("failed to copy (%s)\n%w", srcPathFull, err)
+		return fmt.Errorf("failed to copy (%s):\n%w", srcPathFull, err)
 	}
 	return
 }
@@ -340,7 +340,7 @@ func (c *Chroot) MoveOutFile(srcPath string, destPath string) (err error) {
 	srcPathFull := filepath.Join(c.rootDir, srcPath)
 	err = file.Move(srcPathFull, destPath)
 	if err != nil {
-		return fmt.Errorf("failed to move file from (%s) to (%s)\n%w", srcPath, destPath, err)
+		return fmt.Errorf("failed to move file from (%s) to (%s):\n%w", srcPath, destPath, err)
 	}
 	return
 }

--- a/toolkit/tools/internal/safechroot/safechroot.go
+++ b/toolkit/tools/internal/safechroot/safechroot.go
@@ -319,7 +319,7 @@ func AddFilesToDestination(destDir string, filesToCopy ...FileToCopy) error {
 		}
 
 		if err != nil {
-			return fmt.Errorf("Error copying file %s. Error: %w", f.Src, err)
+			return fmt.Errorf("failed to copy (%s)\n%w", f.Src, err)
 		}
 	}
 	return nil
@@ -330,7 +330,7 @@ func (c *Chroot) CopyOutFile(srcPath string, destPath string) (err error) {
 	srcPathFull := filepath.Join(c.rootDir, srcPath)
 	err = file.Copy(srcPathFull, destPath)
 	if err != nil {
-		return fmt.Errorf("Error copying file. Error: %w", err)
+		return fmt.Errorf("failed to copy (%s)\n%w", srcPathFull, err)
 	}
 	return
 }
@@ -340,7 +340,7 @@ func (c *Chroot) MoveOutFile(srcPath string, destPath string) (err error) {
 	srcPathFull := filepath.Join(c.rootDir, srcPath)
 	err = file.Move(srcPathFull, destPath)
 	if err != nil {
-		return fmt.Errorf("Error moving file from %s to %s. Error: %w", srcPath, destPath, err)
+		return fmt.Errorf("failed to move file from (%s) to (%s)\n%w", srcPath, destPath, err)
 	}
 	return
 }


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Pass error instead of logging in go utility code

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Remove error logging from go utility code
- Construct new error with message and error and return that to caller
- Log error in caller if missing

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Successful full pipeline build id: [506062](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=506062&view=results)