### PR TITLE
qt5-qtbase: Patch CVE-2021-38593

### DIFF
--- a/SPECS/qt5-qtbase/CVE-2021-38593.patch
+++ b/SPECS/qt5-qtbase/CVE-2021-38593.patch
@@ -1,0 +1,32 @@
+From 1ca02cf2879a5e1511a2f2109f0925cf4c892862 Mon Sep 17 00:00:00 2001
+From: Eirik Aavitsland <eirik.aavitsland@qt.io>
+Date: Fri, 23 Jul 2021 15:53:56 +0200
+Subject: [PATCH] Improve fix for avoiding huge number of tiny dashes
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Some pathological cases were not caught by the previous fix.
+
+Fixes: QTBUG-95239
+Change-Id: I0337ee3923ff93ccb36c4d7b810a9c0667354cc5
+Reviewed-by: Robert LÃ¶hning <robert.loehning@qt.io>
+(cherry picked from commit 6b400e3147dcfd8cc3a393ace1bd118c93762e0c)
+Reviewed-by: Qt Cherry-pick Bot <cherrypick_bot@qt-project.org>
+---
+ src/gui/painting/qpaintengineex.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/gui/painting/qpaintengineex.cpp b/src/gui/painting/qpaintengineex.cpp
+index d8223c1b..3afdbe3d 100644
+--- a/src/gui/painting/qpaintengineex.cpp
++++ b/src/gui/painting/qpaintengineex.cpp
+@@ -426,7 +426,7 @@ void QPaintEngineEx::stroke(const QVectorPath &path, const QPen &inPen)
+         patternLength *= pw;
+         if (qFuzzyIsNull(patternLength)) {
+             pen.setStyle(Qt::NoPen);
+-        } else if (extent / patternLength > 10000) {
++        } else if (qFuzzyIsNull(extent) || extent / patternLength > 10000) {
+             // approximate stream of tiny dashes with semi-transparent solid line
+             pen.setStyle(Qt::SolidLine);
+             QColor color(pen.color());

--- a/SPECS/qt5-qtbase/avoid-processing-intensive-painting-of-tiny-dashes.patch
+++ b/SPECS/qt5-qtbase/avoid-processing-intensive-painting-of-tiny-dashes.patch
@@ -1,0 +1,133 @@
+Backport patch
+
+From 6869d2463a2e0d71bd04dbc82f5d6ef4933dc510 Mon Sep 17 00:00:00 2001
+From: Eirik Aavitsland <eirik.aavitsland@qt.io>
+Date: Tue, 13 Apr 2021 14:23:45 +0200
+Subject: [PATCH] Avoid processing-intensive painting of high number of tiny
+ dashes
+
+When stroking a dashed path, an unnecessary amount of processing would
+be spent if there is a huge number of dashes visible, e.g. because of
+scaling. Since the dashes are too small to be indivdually visible
+anyway, just replace with a semi-transparent solid line for such
+cases.
+
+Change-Id: I9e9f7861257ad5bce46a0cf113d1a9d7824911e6
+Reviewed-by: Allan Sandfeld Jensen <allan.jensen@qt.io>
+(cherry picked from commit f4d791b330d02777fcaf02938732892eb3167e9b)
+Reviewed-by: Qt Cherry-pick Bot <cherrypick_bot@qt-project.org>
+---
+ src/gui/painting/qpaintengineex.cpp           | 44 +++++++++++++++----
+ .../other/lancelot/scripts/tinydashes.qps     | 34 ++++++++++++++
+ 2 files changed, 69 insertions(+), 9 deletions(-)
+ create mode 100644 tests/auto/other/lancelot/scripts/tinydashes.qps
+
+diff --git a/src/gui/painting/qpaintengineex.cpp b/src/gui/painting/qpaintengineex.cpp
+index f4cbf15f..d8223c1b 100644
+--- a/src/gui/painting/qpaintengineex.cpp
++++ b/src/gui/painting/qpaintengineex.cpp
+@@ -385,7 +385,7 @@ QPainterState *QPaintEngineEx::createState(QPainterState *orig) const
+ 
+ Q_GUI_EXPORT extern bool qt_scaleForTransform(const QTransform &transform, qreal *scale); // qtransform.cpp
+ 
+-void QPaintEngineEx::stroke(const QVectorPath &path, const QPen &pen)
++void QPaintEngineEx::stroke(const QVectorPath &path, const QPen &inPen)
+ {
+ #ifdef QT_DEBUG_DRAW
+     qDebug() << "QPaintEngineEx::stroke()" << pen;
+@@ -403,6 +403,38 @@ void QPaintEngineEx::stroke(const QVectorPath &path, const QPen &pen)
+         d->stroker.setCubicToHook(qpaintengineex_cubicTo);
+     }
+ 
++    QRectF clipRect;
++    QPen pen = inPen;
++    if (pen.style() > Qt::SolidLine) {
++        QRectF cpRect = path.controlPointRect();
++        const QTransform &xf = state()->matrix;
++        if (qt_pen_is_cosmetic(pen, state()->renderHints)) {
++            clipRect = d->exDeviceRect;
++            cpRect.translate(xf.dx(), xf.dy());
++        } else {
++            clipRect = xf.inverted().mapRect(QRectF(d->exDeviceRect));
++        }
++        // Check to avoid generating unwieldy amount of dashes that will not be visible anyway
++        qreal pw = pen.widthF() ? pen.widthF() : 1;
++        QRectF extentRect = cpRect.adjusted(-pw, -pw, pw, pw) & clipRect;
++        qreal extent = qMax(extentRect.width(), extentRect.height());
++        qreal patternLength = 0;
++        const QVector<qreal> pattern = pen.dashPattern();
++        const int patternSize = qMin(pattern.size(), 32);
++        for (int i = 0; i < patternSize; i++)
++            patternLength += qMax(pattern.at(i), qreal(0));
++        patternLength *= pw;
++        if (qFuzzyIsNull(patternLength)) {
++            pen.setStyle(Qt::NoPen);
++        } else if (extent / patternLength > 10000) {
++            // approximate stream of tiny dashes with semi-transparent solid line
++            pen.setStyle(Qt::SolidLine);
++            QColor color(pen.color());
++            color.setAlpha(color.alpha() / 2);
++            pen.setColor(color);
++        }
++    }
++
+     if (!qpen_fast_equals(pen, d->strokerPen)) {
+         d->strokerPen = pen;
+         d->stroker.setJoinStyle(pen.joinStyle());
+@@ -430,14 +462,8 @@ void QPaintEngineEx::stroke(const QVectorPath &path, const QPen &pen)
+         return;
+     }
+ 
+-    if (pen.style() > Qt::SolidLine) {
+-        if (qt_pen_is_cosmetic(pen, state()->renderHints)){
+-            d->activeStroker->setClipRect(d->exDeviceRect);
+-        } else {
+-            QRectF clipRect = state()->matrix.inverted().mapRect(QRectF(d->exDeviceRect));
+-            d->activeStroker->setClipRect(clipRect);
+-        }
+-    }
++    if (!clipRect.isNull())
++        d->activeStroker->setClipRect(clipRect);
+ 
+     const QPainterPath::ElementType *types = path.elements();
+     const qreal *points = path.points();
+diff --git a/tests/auto/other/lancelot/scripts/tinydashes.qps b/tests/auto/other/lancelot/scripts/tinydashes.qps
+new file mode 100644
+index 00000000..d41ced7f
+--- /dev/null
++++ b/tests/auto/other/lancelot/scripts/tinydashes.qps
+@@ -0,0 +1,34 @@
++# Version: 1
++# CheckVsReference: 5%
++
++path_addEllipse mypath 20.0 20.0 200.0 200.0
++
++save
++setPen blue 20 SolidLine FlatCap
++pen_setCosmetic true
++pen_setDashPattern [ 0.0004 0.0004 ]
++setBrush yellow
++
++drawPath mypath
++translate 300 0
++setRenderHint Antialiasing true
++drawPath mypath
++restore
++
++path_addEllipse bigpath 200000.0 200000.0 2000000.0 2000000.0
++
++setPen blue 20 DotLine FlatCap
++setBrush yellow
++
++save
++translate 0 300
++scale 0.0001 0.00011
++drawPath bigpath
++restore
++
++save
++translate 300 300
++setRenderHint Antialiasing true
++scale 0.0001 0.00011
++drawPath bigpath
++restore

--- a/SPECS/qt5-qtbase/qt5-qtbase.spec
+++ b/SPECS/qt5-qtbase/qt5-qtbase.spec
@@ -33,7 +33,7 @@
 Name:         qt5-qtbase
 Summary:      Qt5 - QtBase components
 Version:      5.12.11
-Release:      10%{?dist}
+Release:      11%{?dist}
 # See LICENSE.GPL3-EXCEPT.txt, for exception details
 License:      GFDL AND LGPLv3 AND GPLv2 AND GPLv3 with exceptions AND QT License Agreement 4.0
 Vendor:       Microsoft Corporation
@@ -148,6 +148,11 @@ Patch87: CVE-2023-38197.patch
 # Fix CVE-2023-51714
 Patch88: CVE-2023-51714.patch
 
+# Backport: https://github.com/qt/qtbase/commit/6869d2463a2e0d71bd04dbc82f5d6ef4933dc510
+Patch89: avoid-processing-intensive-painting-of-tiny-dashes.patch
+
+Patch90: CVE-2021-38593.patch
+
 # Do not check any files in %%{_qt5_plugindir}/platformthemes/ for requires.
 # Those themes are there for platform integration. If the required libraries are
 # not there, the platform to integrate with isn't either. Then Qt will just
@@ -257,6 +262,8 @@ Qt5 libraries used for drawing widgets and OpenGL items.
 %patch86 -p1
 %patch87 -p1
 %patch88 -p1
+%patch89 -p1
+%patch90 -p1
 
 ## upstream patches
 
@@ -762,6 +769,10 @@ fi
 %{_qt5_libdir}/cmake/Qt5Gui/Qt5Gui_QXdgDesktopPortalThemePlugin.cmake
 
 %changelog
+* Thu Feb 15 2024 Sumedh Sharma <sumsharma@microsoft.com> - 5.12.11-11
+- Backport patch 'avoid processing-intensive painting of high number of tiny dashes'
+- Add patch to resolve CVE-2021-38593
+
 * Fri Jan 05 2024 Henry Beberman <henry.beberman@microsoft.com> - 5.12.11-10
 - Add patch to resolve CVE-2023-51714
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
This PR adds patch for CVE-2021-38593 as below:
- Backport patch for https://github.com/qt/qtbase/commit/6869d2463a2e0d71bd04dbc82f5d6ef4933dc510
- Add patch for CVE on top of above changeset

###### Change Log  <!-- REQUIRED -->
- Add patch files

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Associated issues  <!-- optional -->
https://github.com/qt/qtbase/commit/6869d2463a2e0d71bd04dbc82f5d6ef4933dc510

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2021-38593

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: xxxx
