### PR TITLE
Upgrade xfsprogs to 6.6.0

### DIFF
--- a/SPECS/xfsprogs/xfsprogs.signatures.json
+++ b/SPECS/xfsprogs/xfsprogs.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "xfsprogs-6.5.0.tar.xz": "8db81712b32756b97d89dd9a681ac5e325bbb75e585382cd4863fab7f9d021c6"
+  "xfsprogs-6.6.0.tar.xz": "50ca2f4676df8fab4cb4c3ef3dd512d5551e6844d40a65a31d5b8e03593d22df"
  }
 }

--- a/SPECS/xfsprogs/xfsprogs.spec
+++ b/SPECS/xfsprogs/xfsprogs.spec
@@ -1,6 +1,6 @@
 Summary:        Utilities for managing the XFS filesystem
 Name:           xfsprogs
-Version:        6.5.0
+Version:        6.6.0
 Release:        1%{?dist}
 License:        GPL+ and LGPLv2+
 URL:            https://xfs.wiki.kernel.org/
@@ -33,7 +33,7 @@ Requires: %{name} = %{version}-%{release}
 These are the additional language files of xfsprogs.
 
 %prep
-%setup -q
+%autosetup -p1
 
 %build
 %configure \
@@ -53,9 +53,6 @@ find %{buildroot}/%{_lib64dir} -name '*.a' -delete
 
 %find_lang %{name}
 
-%check
-make -k check |& tee %{_specdir}/%{name}-check-log || %{nocheck}
-
 %post -p /sbin/ldconfig
 
 %postun -p /sbin/ldconfig
@@ -66,7 +63,7 @@ make -k check |& tee %{_specdir}/%{name}-check-log || %{nocheck}
 %doc %{_docdir}/%{name}-%{version}/*
 /sbin/*
 /lib64/*.so.*.*
-%{_libdir}/xfsprogs/xfs_scrub_all.cron
+%{_datadir}/xfsprogs/xfs_scrub_all.cron
 %{_mandir}/man2/*
 %{_mandir}/man8/*
 %{_mandir}/man5/*
@@ -86,6 +83,10 @@ make -k check |& tee %{_specdir}/%{name}-check-log || %{nocheck}
 %defattr(-,root,root)
 
 %changelog
+* Thu Feb 08 2024 Rachel Menge <rachelmenge@microsoft.com> - 6.6.0-1
+- Upgrade to version 6.6.0
+- Remove faulty check section
+
 * Tue Dec 19 2023 Andrew Phelps <anphel@microsoft.com> - 6.5.0-1
 - Upgrade to version 6.5.0
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -29725,8 +29725,8 @@
         "type": "other",
         "other": {
           "name": "xfsprogs",
-          "version": "6.5.0",
-          "downloadUrl": "https://kernel.org/pub/linux/utils/fs/xfs/xfsprogs/xfsprogs-6.5.0.tar.xz"
+          "version": "6.6.0",
+          "downloadUrl": "https://kernel.org/pub/linux/utils/fs/xfs/xfsprogs/xfsprogs-6.6.0.tar.xz"
         }
       }
     },


### PR DESCRIPTION
Upgrade xfsprogs to latest stable release, 6.6.0. This version moves the scrub cron job to the data dir. Additionally, the check section was using a make target which doesn't exist and then would report as passing. Therefore, remove misleading check section.

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Upgrade xfsprogs to latest stable release, 6.6.0. This version moves the scrub cron job to the data dir [[3d37d8bf535fd6a8ab241a86433b449152746e6a](https://git.kernel.org/pub/scm/fs/xfs/xfsprogs-dev.git/commit/?h=v6.6.0&id=3d37d8bf535fd6a8ab241a86433b449152746e6a)]. 

Additionally, the check section was using a make target which doesn't exist and then would report as passing. Therefore, remove misleading check section. Based off the [xfs landing page](https://xfs.wiki.kernel.org/), the [xfstests-dev](https://git.kernel.org/pub/scm/fs/xfs/xfstests-dev.git/) git repo is the supported testsuite but this is not used for testing xfsprogs as a standalone program [README - xfs/xfstests-dev.git - XFSQA testsuite (kernel.org)](https://git.kernel.org/pub/scm/fs/xfs/xfstests-dev.git/tree/README).

Previous check section behavior
<img width="376" alt="image" src="https://github.com/microsoft/CBL-Mariner/assets/10325590/6270f4bd-0904-4034-b95e-48f780704353">
 
###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Upgrade xfsprogs to 6.6.0

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- https://dev.azure.com/mariner-org/mariner/_build/results?buildId=506833&view=results
<img width="248" alt="image" src="https://github.com/microsoft/CBL-Mariner/assets/10325590/a61fc0ee-a876-430d-add2-a8be1a6a84e2">

