### PR TITLE
[MIC] Enable MIC to run in a container.

### DIFF
--- a/toolkit/tools/imagecustomizer/README.md
+++ b/toolkit/tools/imagecustomizer/README.md
@@ -44,7 +44,7 @@ Disadvantages:
    For documentation on the supported configuration options, see:
    [Mariner Image Customizer configuration](./docs/configuration.md)
 
-3. Install prerequisites to run Mariner Image Customizer: `qemu-img,rpm,dd,lsblk,losetup,sfdisk,udevadm,flock,blkid,openssl,sed,createrepo,squashfs-tools,genisoimage`
+3. Install prerequisites to run Mariner Image Customizer: `qemu-img,rpm,dd,lsblk,losetup,sfdisk,udevadm,flock,blkid,openssl,sed,createrepo,squashfs-tools,genisoimage,dosfstools`
 
 4. Run the Mariner Image Customizer tool.
 

--- a/toolkit/tools/imagecustomizer/container/Dockerfile.mic-container
+++ b/toolkit/tools/imagecustomizer/container/Dockerfile.mic-container
@@ -1,0 +1,3 @@
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
+RUN tdnf update -y && tdnf install -y sudo qemu-img rpm coreutils util-linux systemd openssl sed squashfs-tools dosfstools genisoimage
+COPY . /

--- a/toolkit/tools/imagecustomizer/container/build-mic-container.sh
+++ b/toolkit/tools/imagecustomizer/container/build-mic-container.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+# set -x
+set -e
+
+scriptDir="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+enlistmentRoot=$scriptDir/../../../..
+
+function showUsage() {
+    echo
+    echo "usage:"
+    echo
+    echo "build-mic-container.sh \\"
+    echo "    -r <container-registry> \\"
+    echo "    -n <container-name> \\"
+    echo "    -t <container-tag>"
+    echo
+}
+
+while getopts ":r:n:t:" OPTIONS; do
+  case "${OPTIONS}" in
+    r ) containerRegistery=$OPTARG ;;
+    n ) containerName=$OPTARG ;;
+    t ) containerTag=$OPTARG ;;
+  esac
+done
+
+if [[ -z $containerRegistery ]]; then
+    echo "missing required argument '-r containerRegistry'"
+    showUsage
+    exit 1
+fi
+
+if [[ -z $containerName ]]; then
+    echo "missing required argument '-n containerName'"
+    showUsage
+    exit 1
+fi
+
+if [[ -z $containerTag ]]; then
+    echo "missing required argument '-t containerTag'"
+    showUsage
+    exit 1
+fi
+
+# ---- main ----
+
+containerStagingFolder=$(mktemp -d)
+
+function cleanUp() {
+    local exit_code=$?
+    sudo rm -rf $containerStagingFolder
+    exit $exit_code
+}
+trap 'cleanUp' ERR
+
+micLocalFile=$enlistmentRoot/toolkit/tools/imagecustomizer/imagecustomizer
+micContainerFolder=/usr/bin
+
+containerFullPath=$containerRegistery/$containerName/$containerTag
+dockerFile=$enlistmentRoot/toolkit/tools/imagecustomizer/container/Dockerfile.mic-container
+
+# stage those files that need to be in the container
+mkdir -p ${containerStagingFolder}${micContainerFolder}
+cp $micLocalFile ${containerStagingFolder}${micContainerFolder}
+touch ${containerStagingFolder}/.mariner-toolkit-ignore-dockerenv
+
+# build the container
+pushd $containerStagingFolder
+docker build -f $dockerFile . -t $containerFullPath
+popd
+
+# clean-up
+cleanUp

--- a/toolkit/tools/imagecustomizer/container/run-mic-container.sh
+++ b/toolkit/tools/imagecustomizer/container/run-mic-container.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+
+set -e
+
+function showUsage() {
+    echo
+    echo "usage:"
+    echo
+    echo "build-mic-container.sh \\"
+    echo "    -r <container-registry> \\"
+    echo "    -n <container-name> \\"
+    echo "    -t <container-tag> \\"
+    echo "    -i <input-image-path> \\"
+    echo "    -c <input-config-path> \\"
+    echo "    -f <output-format> \\"
+    echo "    -o <output-image-path> \\"
+    echo "   [-l <log-level>"]
+    echo
+}
+
+while getopts ":r:n:t:i:c:f:o:l:" OPTIONS; do
+  case "${OPTIONS}" in
+    r ) containerRegistery=$OPTARG ;;
+    n ) containerName=$OPTARG ;;
+    t ) containerTag=$OPTARG ;;
+    i ) inputImage=$OPTARG ;;
+    c ) inputConfig=$OPTARG ;;
+    f ) outputFormat=$OPTARG ;;
+    o ) outputImage=$OPTARG ;;
+    l ) logLevel=$OPTARG ;;
+  esac
+done
+
+if [[ -z $containerRegistery ]]; then
+    echo "missing required argument '-r containerRegistry'"
+    showUsage
+    exit 1
+fi
+
+if [[ -z $containerName ]]; then
+    echo "missing required argument '-n containerName'"
+    showUsage
+    exit 1
+fi
+
+if [[ -z $containerTag ]]; then
+    echo "missing required argument '-t containerTag'"
+    showUsage
+    exit 1
+fi
+
+if [[ -z $inputImage ]]; then
+    echo "missing required argument '-i inputImage'"
+    showUsage
+    exit 1
+fi
+
+if [[ -z $inputConfig ]]; then
+    echo "missing required argument '-c inputConfig'"
+    showUsage
+    exit 1
+fi
+
+if [[ -z $outputFormat ]]; then
+    echo "missing required argument '-f outputFormat'"
+    showUsage
+    exit 1
+fi
+
+if [[ -z $outputImage ]]; then
+    echo "missing required argument '-o outputImage'"
+    showUsage
+    exit 1
+fi
+
+if [[ -z $logLevel ]]; then
+    logLevel=info
+fi
+
+# ---- main ----
+
+containerFullPath=$containerRegistery/$containerName/$containerTag
+
+inputImageDir=$(dirname $inputImage)
+inputConfigDdir=$(dirname $inputConfig)
+outputImageDir=$(dirname $outputImage)
+
+sudo rm -rf $outputImageDir
+sudo mkdir -p $outputImageDir
+
+# setup input image within the container
+containerInputImageDir=/mic/input
+containerInputImage=$containerInputImageDir/$(basename $inputImage)
+
+# setup input config within the container
+containerInputConfigDir=/mic/config
+containerInputConfig=$containerInputConfigDir/$(basename $inputConfig)
+
+# setup build folder within the container
+containerBuildDir=/mic/build
+
+# setup output image within the container
+containerOutputDir=/mic/output
+containerOutputImage=$containerOutputDir/$(basename $outputImage)
+
+# invoke
+docker run --rm \
+  --privileged=true \
+   -v $inputImageDir:$containerInputImageDir:z \
+   -v $inputConfigDdir:$containerInputConfigDir:z \
+   -v $outputImageDir:$containerOutputDir:z \
+   -v /dev:/dev:z \
+   $containerFullPath \
+   /usr/bin/imagecustomizer \
+      --image-file $containerInputImage \
+      --config-file $containerInputConfig \
+      --build-dir $containerBuildDir \
+      --output-image-format $outputFormat \
+      --output-image-file $containerOutputImage \
+      --log-level $logLevel

--- a/toolkit/tools/imagecustomizer/container/run-mic-container.sh
+++ b/toolkit/tools/imagecustomizer/container/run-mic-container.sh
@@ -111,7 +111,7 @@ docker run --rm \
    -v $outputImageDir:$containerOutputDir:z \
    -v /dev:/dev:z \
    $containerFullPath \
-   /usr/bin/imagecustomizer \
+   imagecustomizer \
       --image-file $containerInputImage \
       --config-file $containerInputConfig \
       --build-dir $containerBuildDir \

--- a/toolkit/tools/internal/buildpipeline/buildpipeline.go
+++ b/toolkit/tools/internal/buildpipeline/buildpipeline.go
@@ -27,8 +27,9 @@ func IsRegularBuild() bool {
 	// some specific build pipeline builds Mariner from a Docker container and
 	// consequently have special requirements with regards to chroot
 	// check if .dockerenv file exist to disambiguate build pipeline
-	exists, _ := file.PathExists("/.dockerenv")
-	return !exists
+	dockerEnvExists, _ := file.PathExists("/.dockerenv")
+	ignoreDockerEnvExists, _ := file.PathExists("/.mariner-toolkit-ignore-dockerenv")
+	return ignoreDockerEnvExists || !dockerEnvExists
 }
 
 // GetChrootDir returns the chroot folder


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
It is desired for some MIC users to run MIC from within a container. This change enables that scenario by:
- updating MIC dependencies to work within a container.
  - buildpipeline.go: has code to assume that if run from a container, it's a CDPX/OneBranch build with a pool of Chroot to re-use. However, for user scenarios that does not apply. To avoid breaking backward compatibility, we are defining a new file within the container (`./mariner-toolkit-ignore-dockerenv`). If this file is present, it will allow the buildpipeline.go to behave as usual. Then, in our MIC container, we include that file.
- adding bash scripts/docker file to show how to build and launch the container.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- [Enable MIC to run in a container](https://github.com/microsoft/CBL-Mariner/commit/58cd5d5298561709d920e3f970ed30981db9fadc)

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- [7680: 07 - Ensure MIC LiveOS ISO generation can be run from a container](https://dev.azure.com/mariner-org/ECF/_workitems/edit/6780)

###### Links to CVEs  <!-- optional -->
- n/a

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Build/test locally.
