### PR TITLE
Image Customizer: Support abs paths

### DIFF
--- a/toolkit/tools/imagecustomizer/docs/configuration.md
+++ b/toolkit/tools/imagecustomizer/docs/configuration.md
@@ -821,6 +821,9 @@ Scripts to run against the image after the packages have been added and removed.
 
 These scripts are run under a chroot of the customized OS.
 
+Note: Scripts must be in the same directory or a child directory of the directory
+that contains the config file.
+
 Example:
 
 ```yaml
@@ -834,6 +837,9 @@ SystemConfig:
 Scripts to run against the image just before the image is finalized.
 
 These scripts are run under a chroot of the customized OS.
+
+Note: Scripts must be in the same directory or a child directory of the directory
+that contains the config file.
 
 Example:
 

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepackages.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepackages.go
@@ -5,10 +5,10 @@ package imagecustomizerlib
 
 import (
 	"fmt"
-	"path"
 	"strings"
 
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/imagecustomizerapi"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/file"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/logger"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/safechroot"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/shell"
@@ -83,7 +83,7 @@ func collectPackagesList(baseConfigPath string, packageLists []string, packages 
 	// Read in the packages from the package list files.
 	var allPackages []string
 	for _, packageListRelativePath := range packageLists {
-		packageListFilePath := path.Join(baseConfigPath, packageListRelativePath)
+		packageListFilePath := file.GetAbsPathWithBase(baseConfigPath, packageListRelativePath)
 
 		var packageList imagecustomizerapi.PackageList
 		err = imagecustomizerapi.UnmarshalYamlFile(packageListFilePath, &packageList)

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeutils.go
@@ -170,7 +170,7 @@ func updateHostname(hostname string, imageChroot *safechroot.Chroot) error {
 
 func copyAdditionalFiles(baseConfigPath string, additionalFiles imagecustomizerapi.AdditionalFilesMap, imageChroot *safechroot.Chroot) error {
 	for sourceFile, fileConfigs := range additionalFiles {
-		absSourceFile := filepath.Join(baseConfigPath, sourceFile)
+		absSourceFile := file.GetAbsPathWithBase(baseConfigPath, sourceFile)
 		for _, fileConfig := range fileConfigs {
 			logger.Log.Infof("Copying: %s", fileConfig.Path)
 
@@ -245,7 +245,7 @@ func addOrUpdateUser(user imagecustomizerapi.User, baseConfigPath string, imageC
 	password := user.Password
 	if user.PasswordPath != "" {
 		// Read password from file.
-		passwordFullPath := filepath.Join(baseConfigPath, user.PasswordPath)
+		passwordFullPath := file.GetAbsPathWithBase(baseConfigPath, user.PasswordPath)
 
 		passwordFileContents, err := os.ReadFile(passwordFullPath)
 		if err != nil {
@@ -305,10 +305,7 @@ func addOrUpdateUser(user imagecustomizerapi.User, baseConfigPath string, imageC
 
 	// Set user's SSH keys.
 	for i, _ := range user.SSHPubKeyPaths {
-		// If absolute path is not provided, then append baseConfigPath.
-		if !filepath.IsAbs(user.SSHPubKeyPaths[i]) {
-			user.SSHPubKeyPaths[i] = filepath.Join(baseConfigPath, user.SSHPubKeyPaths[i])
-		}
+		user.SSHPubKeyPaths[i] = file.GetAbsPathWithBase(baseConfigPath, user.SSHPubKeyPaths[i])
 	}
 
 	err = installutils.ProvisionUserSSHCerts(imageChroot, user.Name, user.SSHPubKeyPaths, user.SSHPubKeys)

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -232,7 +232,7 @@ func hasPartitionCustomizations(config *imagecustomizerapi.Config) bool {
 func validateAdditionalFiles(baseConfigPath string, additionalFiles imagecustomizerapi.AdditionalFilesMap) error {
 	var aggregateErr error
 	for sourceFile := range additionalFiles {
-		sourceFileFullPath := filepath.Join(baseConfigPath, sourceFile)
+		sourceFileFullPath := file.GetAbsPathWithBase(baseConfigPath, sourceFile)
 		isFile, err := file.IsFile(sourceFileFullPath)
 		if err != nil {
 			aggregateErr = errors.Join(aggregateErr, fmt.Errorf("invalid AdditionalFiles source file (%s):\n%w", sourceFile, err))

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
@@ -593,7 +593,7 @@ func micIsoConfigToIsoMakerConfig(baseConfigPath string, isoConfig *imagecustomi
 	additionalIsoFiles = []safechroot.FileToCopy{}
 
 	for sourcePath, fileConfigs := range isoConfig.AdditionalFiles {
-		absSourcePath := filepath.Join(baseConfigPath, sourcePath)
+		absSourcePath := file.GetAbsPathWithBase(baseConfigPath, sourcePath)
 		for _, fileConfig := range fileConfigs {
 			fileToCopy := safechroot.FileToCopy{
 				Src:         absSourcePath,


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->

Allow absolute paths for the `AdditionalFiles`, `PasswordPath`, `SSHPubKeyPaths`, and package list files.

###### Change Log  <!-- REQUIRED -->

- Image Customizer: Support abs paths

###### Does this affect the toolchain?  <!-- REQUIRED -->

NO

###### Test Methodology

- Ran toolkit UTs.
- Manually run image customizer.

