### PR TITLE
Add SymCrypt and SymCrypt-openssl to images with openssl

### DIFF
--- a/SPECS/core-packages/core-packages.spec
+++ b/SPECS/core-packages/core-packages.spec
@@ -74,6 +74,7 @@ Requires:       rpm-libs
 Requires:       sed
 Requires:       sqlite-libs
 Requires:       SymCrypt
+Requires:       SymCrypt-openssl
 Requires:       tdnf
 Requires:       tdnf-plugin-repogpgcheck
 Requires:       xz

--- a/SPECS/core-packages/core-packages.spec
+++ b/SPECS/core-packages/core-packages.spec
@@ -73,6 +73,7 @@ Requires:       rpm
 Requires:       rpm-libs
 Requires:       sed
 Requires:       sqlite-libs
+Requires:       SymCrypt
 Requires:       tdnf
 Requires:       tdnf-plugin-repogpgcheck
 Requires:       xz

--- a/SPECS/distroless-packages/distroless-packages.spec
+++ b/SPECS/distroless-packages/distroless-packages.spec
@@ -32,6 +32,7 @@ Requires:       azurelinux-release
 Requires:       openssl
 Requires:       openssl-libs
 Requires:       SymCrypt
+Requires:       SymCrypt-openssl
 Requires:       tzdata
 
 %description base

--- a/SPECS/distroless-packages/distroless-packages.spec
+++ b/SPECS/distroless-packages/distroless-packages.spec
@@ -31,6 +31,7 @@ Requires:       iana-etc
 Requires:       azurelinux-release
 Requires:       openssl
 Requires:       openssl-libs
+Requires:       SymCrypt
 Requires:       tzdata
 
 %description base

--- a/SPECS/openssl/openssl.spec
+++ b/SPECS/openssl/openssl.spec
@@ -92,6 +92,8 @@ Requires: %{name}-libs%{?_isa} = %{version}-%{release}
 Requires: coreutils
 Requires: perl
 
+Recommends: SymCrypt
+
 %description
 The OpenSSL toolkit provides support for secure communications between
 machines. OpenSSL includes a certificate management tool and shared

--- a/SPECS/openssl/openssl.spec
+++ b/SPECS/openssl/openssl.spec
@@ -93,6 +93,7 @@ Requires: coreutils
 Requires: perl
 
 Recommends: SymCrypt
+Recommends: SymCrypt-openssl
 
 %description
 The OpenSSL toolkit provides support for secure communications between


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Add `SymCrypt` and `SymCrypt-openssl` as `Recommends` packages for `openssl` and add them to images with `openssl`.

<!-- Quick explanation of the changes. -->
In AZL 3 `openssl` relies on `SymCrypt` for `FIPS` mode. As such, we want `SymCrypt` and the related `SymCrypt-openssl` packages installed where `openssl` is installed. To accomplish this, we do two things:
1. Add these packages as `Recommends` in the `openssl` spec. This means that if the package manager can find these packages, it will install them when `openssl` is installed, but it won't refuse to install `openssl` if it can't find them.
2. Add these packages to any image that has `openssl`.

One may wonder why we didn't simply add these packages as `Requires` to `openssl`. The issue here is that `SymCrypt` has a `BuildRequires` on `python`, which in turn requires `openssl`, so there's a circular dependency.

###### Change Log  <!-- REQUIRED -->
- Add `SymCrypt` and `SymCrypt-openssl` as `Recommends` in the `openssl` spec file.
- Add `SymCrypt` and `SymCrypt-openssl` to any image that already has `openssl`
- 
###### Does this affect the toolchain?  <!-- REQUIRED -->
**YES**

###### Test Methodology
- Tested locally to make sure the relevant `Recommends` and `Requires` gets into the built rpms.
- Build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=509741&view=results
