### PR TITLE
fix error when using tdnf inside of functions from setup_functions.sh

### DIFF
--- a/toolkit/scripts/containerized-build/resources/mariner.Dockerfile
+++ b/toolkit/scripts/containerized-build/resources/mariner.Dockerfile
@@ -10,7 +10,7 @@ LABEL containerized-rpmbuild=$mariner_repo/build
 COPY resources/local_repo /etc/yum.repos.d/local_repo.disabled_repo
 
 # This is used by setup_functions.sh to determine tdnf default arguments
-ENV CONTAINERIZED_RPMBUILD_MARINER_VERSION=${version}
+ENV CONTAINERIZED_RPMBUILD_AZL_VERSION=${version}
 
 RUN echo "source /mariner_setup_dir/setup_functions.sh"          >> /root/.bashrc && \
     echo "if [[ ! -L /repo ]]; then ln -s /mnt/RPMS/ /repo; fi"  >> /root/.bashrc

--- a/toolkit/scripts/containerized-build/resources/mariner.Dockerfile
+++ b/toolkit/scripts/containerized-build/resources/mariner.Dockerfile
@@ -9,8 +9,10 @@ LABEL containerized-rpmbuild=$mariner_repo/build
 
 COPY resources/local_repo /etc/yum.repos.d/local_repo.disabled_repo
 
-RUN echo "alias tdnf='tdnf --releasever=$version'"               >> /root/.bashrc && \
-    echo "source /mariner_setup_dir/setup_functions.sh"          >> /root/.bashrc && \
+# This is used by setup_functions.sh to determine tdnf default arguments
+ENV CONTAINERIZED_RPMBUILD_MARINER_VERSION=${version}
+
+RUN echo "source /mariner_setup_dir/setup_functions.sh"          >> /root/.bashrc && \
     echo "if [[ ! -L /repo ]]; then ln -s /mnt/RPMS/ /repo; fi"  >> /root/.bashrc
 
 #if enable_local_repo is set to true
@@ -22,9 +24,6 @@ RUN echo "cat /mariner_setup_dir/splash.txt"                     >> /root/.bashr
 RUN if [[ "${mode}" == "build" ]]; then echo "cd /usr/src/mariner || { echo \"ERROR: Could not change directory to /usr/src/mariner \"; exit 1; }"  >> /root/.bashrc; fi
 RUN if [[ "${mode}" == "test" ]]; then echo "cd /mnt || { echo \"ERROR: Could not change directory to /mnt \"; exit 1; }"  >> /root/.bashrc; fi
 
-# TODO: Remove when PMC is available for 3.0
-RUN if [[ "${version}" == "3.0" ]]; then echo "enable_mariner3_repo $extra_packages"  >> /root/.bashrc; else tdnf --releasever=$version install -y vim git $extra_packages ; fi
-
-# TODO: Re-enable when PMC is available for 3.0
-# Install vim & git in the build env
-#RUN tdnf --releasever=$version install -y vim git $extra_packages
+# Install packages from bashrc so we can use the previously setup tdnf defaults.
+RUN echo "echo installing packages vim git ${coextra_packages}" >> /root/.bashrc && \
+    echo "tdnf install -qy vim git ${extra_packages}" >> /root/.bashrc

--- a/toolkit/scripts/containerized-build/resources/setup_functions.sh
+++ b/toolkit/scripts/containerized-build/resources/setup_functions.sh
@@ -21,10 +21,10 @@ do
 done
 
 # Extra arguments for tdnf
-TDNF_ARGS=(--releasever=$CONTAINERIZED_RPMBUILD_MARINER_VERSION)
+TDNF_ARGS=(--releasever=$CONTAINERIZED_RPMBUILD_AZL_VERSION)
 
 # TODO Remove once PMC is available for 3.0
-if [[ $CONTAINERIZED_RPMBUILD_MARINER_VERSION == "3.0" ]]; then
+if [[ $CONTAINERIZED_RPMBUILD_AZL_VERSION == "3.0" ]]; then
     TDNF_ARGS+=("--disablerepo=*" "--enablerepo=mariner-3.0-daily-build")
     mv /mariner_setup_dir/mariner-3_repo /etc/yum.repos.d/mariner-3.repo
 fi

--- a/toolkit/scripts/containerized-build/resources/setup_functions.sh
+++ b/toolkit/scripts/containerized-build/resources/setup_functions.sh
@@ -20,6 +20,15 @@ do
   MACROS+=("--load=$macro_file")
 done
 
+# Extra arguments for tdnf
+TDNF_ARGS=(--releasever=$CONTAINERIZED_RPMBUILD_MARINER_VERSION)
+
+# TODO Remove once PMC is available for 3.0
+if [[ $CONTAINERIZED_RPMBUILD_MARINER_VERSION == "3.0" ]]; then
+    TDNF_ARGS+=("--disablerepo=*" "--enablerepo=mariner-3.0-daily-build")
+    mv /mariner_setup_dir/mariner-3_repo /etc/yum.repos.d/mariner-3.repo
+fi
+
 ## Create $SOURCES_DIR
 mkdir -p $SOURCES_DIR
 
@@ -154,15 +163,9 @@ rpmspec() {
     command "$FUNCNAME" "${DEFINES[@]}" "${args[@]}"
 }
 
-# TODO: Remove when PMC is available for 3.0
-# Add mariner 3.0 Daily Build Repo
-enable_mariner3_repo() {
+# use proper tdnf arguments
+tdnf() {
     local args=("$@")
-    alias tdnf='tdnf --releasever=3.0 --disablerepo=* --enablerepo=mariner-3.0-daily-build'
-    mv /mariner_setup_dir/mariner-3_repo /etc/yum.repos.d/mariner-3.repo
-    echo "Installing vim, git and other packages ..."
-    tdnf  --releasever=3.0 --disablerepo=* --enablerepo=mariner-3.0-daily-build install -qy vim git
-    if [[ ! -z "$@" ]]; then
-        tdnf --releasever=3.0 --disablerepo=* --enablerepo=mariner-3.0-daily-build install -qy "${args[@]}"
-    fi
+    command "$FUNCNAME" "${TDNF_ARGS[@]}" "${args[@]}"
+
 }


### PR DESCRIPTION
Fix errors in the `containerized-rpmbuild` environment for 3.0 when using helper functions that call `tdnf`.

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
In the `containerized-rpmbuild` environment, we have an alias for `tdnf` that adds a `--releasever` flag in all cases and for `3.0` builds adds some flags to fix up what repo we will go to. However, as currently implemented the extra flags for `3.0` are added after sourcing `setup_functions.sh`. Because aliases are expanded when functions are read, not when they are executed, this means that any function from `setup_functions.sh` (like `install_dependencies`) will have the wrong flags. This results in seeing a failure, though oddly the packages still get installed.

To fix this, I changed `tdnf` from an alias to a function and simplified the flag settings a little.

###### Change Log  <!-- REQUIRED -->
- Change docker file to pipe a variable through to the container that has the specified version.
- Define a function `tdnf` in `setup_functions.sh` that uses an array of parameters which is conditionally defined based on that variable.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Tested locally with `containerized-rpmbuild`
