### PR TITLE
Fixed building 'jsonbuilder' with 3+ versions of 'catch'.

### DIFF
--- a/SPECS/jsonbuilder/jsonbuilder.spec
+++ b/SPECS/jsonbuilder/jsonbuilder.spec
@@ -1,14 +1,17 @@
 Summary:        Modern C++ library for an efficient container for building JSON objects
 Name:           jsonbuilder
 Version:        0.2.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
 Group:          System Environment
 URL:            https://github.com/microsoft/jsonbuilder
-#Source0:       https://github.com/microsoft/%{name}/archive/v%{version}.tar.gz
-Source0:        %{name}-%{version}.tar.gz
+Source0:        https://github.com/microsoft/%{name}/archive/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
+# Version 0.2.1 of 'jsonbuilder' is not compatible with the 3+ versions of 'catch'.
+# Patch required until upstream switches a newer version of 'catch'.
+# Related upstream issue: https://github.com/microsoft/jsonbuilder/issues/29.
+Patch:          catch-ver3.patch
 BuildRequires:  catch-devel
 BuildRequires:  cmake
 BuildRequires:  gcc
@@ -28,7 +31,7 @@ Requires:       jsonbuilder = %{version}-%{release}
 This package contains the headers and symlinks for using jsonbuilder from libraries and applications.
 
 %prep
-%setup -q
+%autosetup -p1
 
 %build
 mkdir build && cd build
@@ -57,6 +60,9 @@ make test -C build
 %{_includedir}/jsonbuilder
 
 %changelog
+* Tue Feb 20 2024 Pawel Winogrodzki <pawelwi@microsoft.com> - 0.2.1-3
+- Adding a patch to fix the build with 3+ versions of 'catch'.
+
 * Wed Oct 07 2020 Thomas Crain <thcrain@microsoft.com> - 0.2.1-2
 - Updated #Source0 URL
 - Verified License field and %%license macro


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

Our recent update to a 3+ version of `catch` broke the `jsonbuilder` builds. The [3+ version of `catch` is not backwards compatible](https://github.com/catchorg/Catch2/releases/tag/v3.0.0-preview4) and upstream for `jsonbuilder` still relies on the headers from version 2. I've opened [a GitHub issue for the upstream `jsonbuilder`](https://github.com/microsoft/jsonbuilder/issues/29) but while that is being reviewed, I've added our own patch fixing the build.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Added a patch for `jsonbuilder` to enable building for `catch` version 3+.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://github.com/microsoft/jsonbuilder/issues/29

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build and test.
- Buddy build.