### PR TITLE
Fix call to IsSRPMTestActive in new multi build fix

### DIFF
--- a/toolkit/tools/scheduler/schedulerutils/preparerequest.go
+++ b/toolkit/tools/scheduler/schedulerutils/preparerequest.go
@@ -197,7 +197,7 @@ func testNodesToRequests(pkgGraph *pkggraph.PkgGraph, buildState *GraphBuildStat
 		srpmFileName := defaultTestNode.SRPMFileName()
 
 		// Check if we already queued up this build node for building.
-		if buildState.IsSRPMBuildActive(srpmFileName) || buildState.IsNodeProcessed(defaultTestNode) {
+		if buildState.IsSRPMTestActive(srpmFileName) || buildState.IsNodeProcessed(defaultTestNode) {
 			err = fmt.Errorf("unexpected duplicate test for (%s)", srpmFileName)
 			// Temporarily ignore the error, this state is unexpected but not fatal. Error return will be
 			// restored later once the underlying cause of this error is fixed.


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
https://github.com/microsoft/CBL-Mariner/pull/7928/files#diff-642be5aa16a8fe207d6d360bb91652eeab7c7164cd2d6670f1d8ace078869282R200 Calls the wrong function, the actual build is likely running so we need to call the test node variant.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Fix `testNodesToRequests()` to use `IsSRPMTestActive()` instead of `IsSRPMBuildActive()`.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local Build
