### PR TITLE
moby-containerd: fix test compatibility with golang 1.21

### DIFF
--- a/SPECS/moby-containerd-cc/fix_cc_tests_for_golang1.21.patch
+++ b/SPECS/moby-containerd-cc/fix_cc_tests_for_golang1.21.patch
@@ -1,0 +1,47 @@
+Backported from upstream 5d9bf7d1398f645882e5c2becc7815daa1770c26
+
+Signed-off-by: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>
+Signed-off-by: Henry Beberman <henry.beberman@microsoft.com>
+
+diff -Naur a/contrib/apparmor/apparmor.go b/contrib/apparmor/apparmor.go
+--- a/contrib/apparmor/apparmor.go	2024-02-09 13:19:03.000000000 +0000
++++ b/contrib/apparmor/apparmor.go	2024-02-22 00:22:43.993021818 +0000
+@@ -39,6 +39,11 @@
+ 
+ // WithDefaultProfile will generate a default apparmor profile under the provided name
+ // for the container.  It is only generated if a profile under that name does not exist.
++//
++// FIXME: pkg/cri/[sb]server/container_create_linux_test.go depends on go:noinline
++// since Go 1.21.
++//
++//go:noinline
+ func WithDefaultProfile(name string) oci.SpecOpts {
+ 	return func(_ context.Context, _ oci.Client, _ *containers.Container, s *specs.Spec) error {
+ 		if err := LoadDefaultProfile(name); err != nil {
+diff -Naur a/contrib/seccomp/seccomp.go b/contrib/seccomp/seccomp.go
+--- a/contrib/seccomp/seccomp.go	2024-02-09 13:19:03.000000000 +0000
++++ b/contrib/seccomp/seccomp.go	2024-02-22 00:49:25.471844786 +0000
+@@ -30,6 +30,11 @@
+ // WithProfile receives the name of a file stored on disk comprising a json
+ // formatted seccomp profile, as specified by the opencontainers/runtime-spec.
+ // The profile is read from the file, unmarshaled, and set to the spec.
++//
++// FIXME: pkg/cri/[sb]server/container_create_linux_test.go depends on go:noinline
++// since Go 1.21.
++//
++//go:noinline
+ func WithProfile(profile string) oci.SpecOpts {
+ 	return func(_ context.Context, _ oci.Client, _ *containers.Container, s *specs.Spec) error {
+ 		s.Linux.Seccomp = &specs.LinuxSeccomp{}
+@@ -46,6 +51,11 @@
+ 
+ // WithDefaultProfile sets the default seccomp profile to the spec.
+ // Note: must follow the setting of process capabilities
++//
++// FIXME: pkg/cri/[sb]server/container_create_linux_test.go depends on go:noinline
++// since Go 1.21.
++//
++//go:noinline
+ func WithDefaultProfile() oci.SpecOpts {
+ 	return func(_ context.Context, _ oci.Client, _ *containers.Container, s *specs.Spec) error {
+ 		s.Linux.Seccomp = DefaultProfile(s)

--- a/SPECS/moby-containerd-cc/moby-containerd-cc.spec
+++ b/SPECS/moby-containerd-cc/moby-containerd-cc.spec
@@ -6,7 +6,7 @@
 Summary: Industry-standard container runtime for confidential containers
 Name: moby-%{upstream_name}
 Version: 1.7.7
-Release: 1%{?dist}
+Release: 2%{?dist}
 License: ASL 2.0
 Group: Tools/Container
 URL: https://www.containerd.io
@@ -18,6 +18,7 @@ Source1: containerd.service
 Source2: containerd.toml
 Patch0: CVE-2023-47108.patch
 Patch1: CVE-2023-44487.patch
+Patch2: fix_cc_tests_for_golang1.21.patch
 
 %{?systemd_requires}
 
@@ -79,6 +80,9 @@ fi
 %config(noreplace) %{_sysconfdir}/containerd/config.toml
 
 %changelog
+* Wed Feb 21 2024 Henry Beberman <henry.beberman@microsoft.com> - 1.7.7-2
+- Backport upstream patch for no-inlining seccomp and apparmor functions to fix tests.
+
 * Tue Feb 20 2024 Mitch Zhu <mitchzhu@microsoft.com> - 1.7.7-1
 - Upgrade to upstream containerd v1.7.7.
 

--- a/SPECS/moby-containerd/fix_tests_for_golang1.21.patch
+++ b/SPECS/moby-containerd/fix_tests_for_golang1.21.patch
@@ -1,0 +1,47 @@
+Backported from upstream 5d9bf7d1398f645882e5c2becc7815daa1770c26
+
+Signed-off-by: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>
+Signed-off-by: Henry Beberman <henry.beberman@microsoft.com>
+
+diff -Naur a/contrib/apparmor/apparmor.go b/contrib/apparmor/apparmor.go
+--- a/contrib/apparmor/apparmor.go	2023-12-08 23:30:22.000000000 +0000
++++ b/contrib/apparmor/apparmor.go	2024-02-21 23:33:58.302514996 +0000
+@@ -40,6 +40,11 @@
+ 
+ // WithDefaultProfile will generate a default apparmor profile under the provided name
+ // for the container.  It is only generated if a profile under that name does not exist.
++//
++// FIXME: pkg/cri/[sb]server/container_create_linux_test.go depends on go:noinline
++// since Go 1.21.
++//
++//go:noinline
+ func WithDefaultProfile(name string) oci.SpecOpts {
+ 	return func(_ context.Context, _ oci.Client, _ *containers.Container, s *specs.Spec) error {
+ 		if err := LoadDefaultProfile(name); err != nil {
+diff -Naur a/contrib/seccomp/seccomp.go b/contrib/seccomp/seccomp.go
+--- a/contrib/seccomp/seccomp.go	2023-12-08 23:30:22.000000000 +0000
++++ b/contrib/seccomp/seccomp.go	2024-02-21 23:34:20.362648277 +0000
+@@ -30,6 +30,11 @@
+ // WithProfile receives the name of a file stored on disk comprising a json
+ // formatted seccomp profile, as specified by the opencontainers/runtime-spec.
+ // The profile is read from the file, unmarshaled, and set to the spec.
++//
++// FIXME: pkg/cri/[sb]server/container_create_linux_test.go depends on go:noinline
++// since Go 1.21.
++//
++//go:noinline
+ func WithProfile(profile string) oci.SpecOpts {
+ 	return func(_ context.Context, _ oci.Client, _ *containers.Container, s *specs.Spec) error {
+ 		s.Linux.Seccomp = &specs.LinuxSeccomp{}
+@@ -46,6 +51,11 @@
+ 
+ // WithDefaultProfile sets the default seccomp profile to the spec.
+ // Note: must follow the setting of process capabilities
++//
++// FIXME: pkg/cri/[sb]server/container_create_linux_test.go depends on go:noinline
++// since Go 1.21.
++//
++//go:noinline
+ func WithDefaultProfile() oci.SpecOpts {
+ 	return func(_ context.Context, _ oci.Client, _ *containers.Container, s *specs.Spec) error {
+ 		s.Linux.Seccomp = DefaultProfile(s)

--- a/SPECS/moby-containerd/moby-containerd.spec
+++ b/SPECS/moby-containerd/moby-containerd.spec
@@ -5,7 +5,7 @@
 Summary: Industry-standard container runtime
 Name: moby-%{upstream_name}
 Version: 1.6.26
-Release: 3%{?dist}
+Release: 4%{?dist}
 License: ASL 2.0
 Group: Tools/Container
 URL: https://www.containerd.io
@@ -17,6 +17,7 @@ Source1: containerd.service
 Source2: containerd.toml
 Patch0:  Makefile.patch
 Patch1:  add_ptrace_readby_tracedby_to_apparmor.patch
+Patch2:  fix_tests_for_golang1.21.patch
 
 %{?systemd_requires}
 
@@ -90,6 +91,9 @@ fi
 %dir /opt/containerd/lib
 
 %changelog
+* Wed Feb 21 2024 Henry Beberman <henry.beberman@microsoft.com> - 1.6.26-4
+- Backport upstream patch for no-inlining seccomp and apparmor functions to fix tests.
+
 * Fri Feb 02 2024 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 1.6.26-3
 - Bump release to rebuild with go 1.21.6
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
After upgrading to golang 1.21 containerd tests started failing. This is a known issue upstream and they have a fix that inlines the offending functions. This change backports those fixes into our current versions of containerd.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Backport containerd upstream patches to fix tests when built with golang 1.21

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local package build
- Buddy build https://dev.azure.com/mariner-org/mariner/_build/results?buildId=510660&view=results
