### PR TITLE
sphinxcontrib: variable naming enhancement to sphinxcontrib packages

### DIFF
--- a/SPECS/python-sphinxcontrib-applehelp/python-sphinxcontrib-applehelp.spec
+++ b/SPECS/python-sphinxcontrib-applehelp/python-sphinxcontrib-applehelp.spec
@@ -1,4 +1,7 @@
-%global pypi_name sphinxcontrib-applehelp
+%global pypi_name_prefix sphinxcontrib
+%global pypi_name_suffix applehelp
+%global pypi_name %{pypi_name_prefix}-${pypi_name_suffix}
+%global pypi_name_underscore %{pypi_name_prefix}_${pypi_name_suffix}
 
 Summary:        Sphinx extension for Apple help books
 Name:           python-%{pypi_name}
@@ -8,7 +11,7 @@ License:        BSD
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
 URL:            http://sphinx-doc.org/
-Source0:        https://files.pythonhosted.org/packages/26/6b/68f470fc337ed24043fec987b101f25b35010970bd958970c2ae5990859f/sphinxcontrib_applehelp-1.0.8.tar.gz#/%{pypi_name}-%{version}.tar.gz
+Source0:        https://files.pythonhosted.org/packages/26/6b/68f470fc337ed24043fec987b101f25b35010970bd958970c2ae5990859f/%{pypi_name_underscore}-%{version}.tar.gz#/%{pypi_name}-%{version}.tar.gz
 
 BuildArch:      noarch
 
@@ -43,7 +46,7 @@ Summary:        %{summary}
 sphinxcontrib-applehelp is a sphinx extension which outputs Apple help books.
 
 %prep
-%autosetup -n sphinxcontrib_applehelp-%{version}
+%autosetup -n %{pypi_name_underscore}-%{version}
 find -name '*.mo' -delete
 
 %build
@@ -76,8 +79,8 @@ pip3 install sphinx exceptiongroup iniconfig tomli
 %files -n python%{python3_pkgversion}-%{pypi_name} -f sphinxcontrib.applehelp.lang
 %license LICENSE
 %doc README.rst
-%{python3_sitelib}/sphinxcontrib/
-%{python3_sitelib}/sphinxcontrib_applehelp-%{version}.dist-info/
+%{python3_sitelib}/%{pypi_name_prefix}/
+%{python3_sitelib}/%{pypi_name_underscore}-%{version}.dist-info/
 
 %changelog
 * Wed Feb 21 2024 Amrita Kohli <amritakohli@microsoft.com> - 1.0.8-1

--- a/SPECS/python-sphinxcontrib-applehelp/python-sphinxcontrib-applehelp.spec
+++ b/SPECS/python-sphinxcontrib-applehelp/python-sphinxcontrib-applehelp.spec
@@ -1,7 +1,7 @@
 %global pypi_name_prefix sphinxcontrib
 %global pypi_name_suffix applehelp
-%global pypi_name %{pypi_name_prefix}-${pypi_name_suffix}
-%global pypi_name_underscore %{pypi_name_prefix}_${pypi_name_suffix}
+%global pypi_name %{pypi_name_prefix}-%{pypi_name_suffix}
+%global pypi_name_underscore %{pypi_name_prefix}_%{pypi_name_suffix}
 
 Summary:        Sphinx extension for Apple help books
 Name:           python-%{pypi_name}

--- a/SPECS/python-sphinxcontrib-devhelp/python-sphinxcontrib-devhelp.spec
+++ b/SPECS/python-sphinxcontrib-devhelp/python-sphinxcontrib-devhelp.spec
@@ -1,4 +1,7 @@
-%global pypi_name sphinxcontrib-devhelp
+%global pypi_name_prefix sphinxcontrib
+%global pypi_name_suffix applehelp
+%global pypi_name %{pypi_name_prefix}-${pypi_name_suffix}
+%global pypi_name_underscore %{pypi_name_prefix}_${pypi_name_suffix}
 
 Summary:        Sphinx extension for Devhelp documents
 Name:           python-%{pypi_name}
@@ -8,7 +11,7 @@ License:        BSD
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
 URL:            http://sphinx-doc.org/
-Source0:        https://files.pythonhosted.org/packages/c7/a1/80b7e9f677abc673cb9320bf255ad4e08931ccbc2e66bde4b59bad3809ad/sphinxcontrib_devhelp-1.0.6.tar.gz#/%{pypi_name}-%{version}.tar.gz
+Source0:        https://files.pythonhosted.org/packages/c7/a1/80b7e9f677abc673cb9320bf255ad4e08931ccbc2e66bde4b59bad3809ad/%{pypi_name_underscore}-%{version}.tar.gz#/%{pypi_name}-%{version}.tar.gz
 
 BuildArch:      noarch
 
@@ -43,7 +46,7 @@ sphinxcontrib-devhelp is a sphinx extension which outputs Devhelp document.
 %pyproject_buildrequires -x test
 
 %prep
-%autosetup -n sphinxcontrib_devhelp-%{version}
+%autosetup -n %{pypi_name_underscore}-%{version}
 find -name '*.mo' -delete
 
 %build
@@ -76,8 +79,8 @@ pip3 install sphinx exceptiongroup iniconfig tomli
 %files -n python%{python3_pkgversion}-%{pypi_name} -f sphinxcontrib.devhelp.lang
 %license LICENSE
 %doc README.rst
-%{python3_sitelib}/sphinxcontrib/
-%{python3_sitelib}/sphinxcontrib_devhelp-%{version}.dist-info/
+%{python3_sitelib}/%{pypi_name_prefix}/
+%{python3_sitelib}/%{pypi_name_underscore}-%{version}.dist-info/
 
 %changelog
 * Wed Feb 21 2024 Amrita Kohli <amritakohli@microsoft.com> - 1.0.6-1

--- a/SPECS/python-sphinxcontrib-devhelp/python-sphinxcontrib-devhelp.spec
+++ b/SPECS/python-sphinxcontrib-devhelp/python-sphinxcontrib-devhelp.spec
@@ -1,5 +1,5 @@
 %global pypi_name_prefix sphinxcontrib
-%global pypi_name_suffix applehelp
+%global pypi_name_suffix devhelp
 %global pypi_name %{pypi_name_prefix}-${pypi_name_suffix}
 %global pypi_name_underscore %{pypi_name_prefix}_${pypi_name_suffix}
 

--- a/SPECS/python-sphinxcontrib-devhelp/python-sphinxcontrib-devhelp.spec
+++ b/SPECS/python-sphinxcontrib-devhelp/python-sphinxcontrib-devhelp.spec
@@ -1,7 +1,7 @@
 %global pypi_name_prefix sphinxcontrib
 %global pypi_name_suffix devhelp
-%global pypi_name %{pypi_name_prefix}-${pypi_name_suffix}
-%global pypi_name_underscore %{pypi_name_prefix}_${pypi_name_suffix}
+%global pypi_name %{pypi_name_prefix}-%{pypi_name_suffix}
+%global pypi_name_underscore %{pypi_name_prefix}_%{pypi_name_suffix}
 
 Summary:        Sphinx extension for Devhelp documents
 Name:           python-%{pypi_name}

--- a/SPECS/python-sphinxcontrib-htmlhelp/python-sphinxcontrib-htmlhelp.spec
+++ b/SPECS/python-sphinxcontrib-htmlhelp/python-sphinxcontrib-htmlhelp.spec
@@ -1,5 +1,5 @@
 %global pypi_name_prefix sphinxcontrib
-%global pypi_name_suffix applehelp
+%global pypi_name_suffix htmlhelp
 %global pypi_name %{pypi_name_prefix}-${pypi_name_suffix}
 %global pypi_name_underscore %{pypi_name_prefix}_${pypi_name_suffix}
 

--- a/SPECS/python-sphinxcontrib-htmlhelp/python-sphinxcontrib-htmlhelp.spec
+++ b/SPECS/python-sphinxcontrib-htmlhelp/python-sphinxcontrib-htmlhelp.spec
@@ -1,7 +1,7 @@
 %global pypi_name_prefix sphinxcontrib
 %global pypi_name_suffix htmlhelp
-%global pypi_name %{pypi_name_prefix}-${pypi_name_suffix}
-%global pypi_name_underscore %{pypi_name_prefix}_${pypi_name_suffix}
+%global pypi_name %{pypi_name_prefix}-%{pypi_name_suffix}
+%global pypi_name_underscore %{pypi_name_prefix}_%{pypi_name_suffix}
 
 Summary:        Sphinx extension for HTML help files
 Name:           python-%{pypi_name}

--- a/SPECS/python-sphinxcontrib-htmlhelp/python-sphinxcontrib-htmlhelp.spec
+++ b/SPECS/python-sphinxcontrib-htmlhelp/python-sphinxcontrib-htmlhelp.spec
@@ -1,4 +1,7 @@
-%global pypi_name sphinxcontrib-htmlhelp
+%global pypi_name_prefix sphinxcontrib
+%global pypi_name_suffix applehelp
+%global pypi_name %{pypi_name_prefix}-${pypi_name_suffix}
+%global pypi_name_underscore %{pypi_name_prefix}_${pypi_name_suffix}
 
 Summary:        Sphinx extension for HTML help files
 Name:           python-%{pypi_name}
@@ -8,7 +11,7 @@ License:        BSD
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
 URL:            http://sphinx-doc.org/
-Source0:        https://files.pythonhosted.org/packages/8a/03/2f9d699fbfdf03ecb3b6d0e2a268a8998d009f2a9f699c2dcc936899257d/sphinxcontrib_htmlhelp-2.0.5.tar.gz#/%{pypi_name}-%{version}.tar.gz
+Source0:        https://files.pythonhosted.org/packages/8a/03/2f9d699fbfdf03ecb3b6d0e2a268a8998d009f2a9f699c2dcc936899257d/%{pypi_name_underscore}-%{version}.tar.gz#/%{pypi_name}-%{version}.tar.gz
 
 BuildArch:      noarch
 
@@ -41,7 +44,7 @@ Summary:        %{summary}
 sphinxcontrib-htmlhelp is a sphinx extension which renders HTML help files.
 
 %prep
-%autosetup -n sphinxcontrib_htmlhelp-%{version}
+%autosetup -n %{pypi_name_underscore}-%{version}
 find -name '*.mo' -delete
 
 %generate_buildrequires
@@ -78,8 +81,8 @@ pip3 install sphinx webencodings exceptiongroup iniconfig tomli
 %files -n python%{python3_pkgversion}-%{pypi_name} -f sphinxcontrib.htmlhelp.lang
 %license LICENSE
 %doc README.rst
-%{python3_sitelib}/sphinxcontrib/
-%{python3_sitelib}/sphinxcontrib_htmlhelp*.dist-info
+%{python3_sitelib}/%{pypi_name_prefix}/
+%{python3_sitelib}/%{pypi_name_underscore}*.dist-info
 
 %changelog
 * Fri Feb 16 2024 Amrita Kohli <amritakohli@microsoft.com> - 2.0.5-1

--- a/SPECS/python-sphinxcontrib-jsmath/python-sphinxcontrib-jsmath.spec
+++ b/SPECS/python-sphinxcontrib-jsmath/python-sphinxcontrib-jsmath.spec
@@ -7,7 +7,7 @@
 Summary:        Sphinx extension for math in HTML via JavaScript
 Name:           python-%{pypi_name}
 Version:        1.0.1
-Release:        16%{?dist}
+Release:        17%{?dist}
 License:        BSD
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -53,7 +53,7 @@ via JavaScript.
 %py3_install
 
 %check
-pip3 install more-itertools Sphinx
+pip3 install more-itertools sphinx exceptiongroup iniconfig tomli
 python3 -m pytest
 
 %files -n python%{python3_pkgversion}-%{pypi_name}
@@ -64,6 +64,9 @@ python3 -m pytest
 %{python3_sitelib}/%{pypi_name_underscore}-%{version}-py%{python3_version}.egg-info/
 
 %changelog
+* Fri Feb 23 2024 Amrita Kohli <amritakohli@microsoft.com> - 1.0.1-17
+- Installing packages needed for tests to run. 
+
 * Mon Jun 27 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.0.1-16
 - Fixing ptests.
 

--- a/SPECS/python-sphinxcontrib-jsmath/python-sphinxcontrib-jsmath.spec
+++ b/SPECS/python-sphinxcontrib-jsmath/python-sphinxcontrib-jsmath.spec
@@ -1,7 +1,7 @@
 %global pypi_name_prefix sphinxcontrib
 %global pypi_name_suffix jsmath
-%global pypi_name %{pypi_name_prefix}-${pypi_name_suffix}
-%global pypi_name_underscore %{pypi_name_prefix}_${pypi_name_suffix}
+%global pypi_name %{pypi_name_prefix}-%{pypi_name_suffix}
+%global pypi_name_underscore %{pypi_name_prefix}_%{pypi_name_suffix}
 
 
 Summary:        Sphinx extension for math in HTML via JavaScript

--- a/SPECS/python-sphinxcontrib-jsmath/python-sphinxcontrib-jsmath.spec
+++ b/SPECS/python-sphinxcontrib-jsmath/python-sphinxcontrib-jsmath.spec
@@ -1,4 +1,8 @@
-%global pypi_name sphinxcontrib-jsmath
+%global pypi_name_prefix sphinxcontrib
+%global pypi_name_suffix jsmath
+%global pypi_name %{pypi_name_prefix}-${pypi_name_suffix}
+%global pypi_name_underscore %{pypi_name_prefix}_${pypi_name_suffix}
+
 
 Summary:        Sphinx extension for math in HTML via JavaScript
 Name:           python-%{pypi_name}
@@ -55,9 +59,9 @@ python3 -m pytest
 %files -n python%{python3_pkgversion}-%{pypi_name}
 %license LICENSE
 %doc README.rst
-%{python3_sitelib}/sphinxcontrib/
-%{python3_sitelib}/sphinxcontrib_jsmath-%{version}-py%{python3_version}-*.pth
-%{python3_sitelib}/sphinxcontrib_jsmath-%{version}-py%{python3_version}.egg-info/
+%{python3_sitelib}/%{pypi_name_prefix}/
+%{python3_sitelib}/%{pypi_name_underscore}-%{version}-py%{python3_version}-*.pth
+%{python3_sitelib}/%{pypi_name_underscore}-%{version}-py%{python3_version}.egg-info/
 
 %changelog
 * Mon Jun 27 2022 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.0.1-16

--- a/SPECS/python-sphinxcontrib-jsmath/python-sphinxcontrib-jsmath.spec
+++ b/SPECS/python-sphinxcontrib-jsmath/python-sphinxcontrib-jsmath.spec
@@ -3,7 +3,6 @@
 %global pypi_name %{pypi_name_prefix}-%{pypi_name_suffix}
 %global pypi_name_underscore %{pypi_name_prefix}_%{pypi_name_suffix}
 
-
 Summary:        Sphinx extension for math in HTML via JavaScript
 Name:           python-%{pypi_name}
 Version:        1.0.1

--- a/SPECS/python-sphinxcontrib-qthelp/python-sphinxcontrib-qthelp.spec
+++ b/SPECS/python-sphinxcontrib-qthelp/python-sphinxcontrib-qthelp.spec
@@ -1,7 +1,7 @@
 %global pypi_name_prefix sphinxcontrib
 %global pypi_name_suffix qthelp
-%global pypi_name %{pypi_name_prefix}-${pypi_name_suffix}
-%global pypi_name_underscore %{pypi_name_prefix}_${pypi_name_suffix}
+%global pypi_name %{pypi_name_prefix}-%{pypi_name_suffix}
+%global pypi_name_underscore %{pypi_name_prefix}_%{pypi_name_suffix}
 
 Summary:        Sphinx extension for QtHelp documents
 Name:           python-%{pypi_name}

--- a/SPECS/python-sphinxcontrib-qthelp/python-sphinxcontrib-qthelp.spec
+++ b/SPECS/python-sphinxcontrib-qthelp/python-sphinxcontrib-qthelp.spec
@@ -1,4 +1,7 @@
-%global pypi_name sphinxcontrib-qthelp
+%global pypi_name_prefix sphinxcontrib
+%global pypi_name_suffix qthelp
+%global pypi_name %{pypi_name_prefix}-${pypi_name_suffix}
+%global pypi_name_underscore %{pypi_name_prefix}_${pypi_name_suffix}
 
 Summary:        Sphinx extension for QtHelp documents
 Name:           python-%{pypi_name}
@@ -8,7 +11,7 @@ License:        BSD
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
 URL:            http://sphinx-doc.org/
-Source0:        https://files.pythonhosted.org/packages/ac/29/705cd4e93e98a8473d62b5c32288e6de3f0c9660d3c97d4e80d3dbbad82b/sphinxcontrib_qthelp-1.0.7.tar.gz#/%{pypi_name}-%{version}.tar.gz
+Source0:        https://files.pythonhosted.org/packages/ac/29/705cd4e93e98a8473d62b5c32288e6de3f0c9660d3c97d4e80d3dbbad82b/%{pypi_name_underscore}-%{version}.tar.gz#/%{pypi_name}-%{version}.tar.gz
 
 BuildArch:      noarch
 
@@ -43,7 +46,7 @@ Summary:        %{summary}
 sphinxcontrib-qthelp is a sphinx extension which outputs QtHelp document.
 
 %prep
-%autosetup -p1 -n sphinxcontrib_qthelp-%{version}
+%autosetup -p1 -n %{pypi_name_underscore}-%{version}
 find -name '*.mo' -delete
 
 %build
@@ -76,8 +79,8 @@ pip3 install sphinx exceptiongroup iniconfig tomli
 %files -n python%{python3_pkgversion}-%{pypi_name} -f sphinxcontrib.qthelp.lang
 %license LICENSE
 %doc README.rst
-%{python3_sitelib}/sphinxcontrib/
-%{python3_sitelib}/sphinxcontrib_qthelp-%{version}.dist-info/
+%{python3_sitelib}/%{pypi_name_prefix}/
+%{python3_sitelib}/%{pypi_name_underscore}-%{version}.dist-info/
 
 %changelog
 * Wed Feb 21 2024 Amrita Kohli <amritakohli@microsoft.com> - 1.0.7-1

--- a/SPECS/python-sphinxcontrib-serializinghtml/python-sphinxcontrib-serializinghtml.spec
+++ b/SPECS/python-sphinxcontrib-serializinghtml/python-sphinxcontrib-serializinghtml.spec
@@ -1,4 +1,7 @@
-%global pypi_name sphinxcontrib-serializinghtml
+%global pypi_name_prefix sphinxcontrib
+%global pypi_name_suffix serializinghtml
+%global pypi_name %{pypi_name_prefix}-${pypi_name_suffix}
+%global pypi_name_underscore %{pypi_name_prefix}_${pypi_name_suffix}
 
 Summary:        Sphinx extension for serialized HTML
 Name:           python-%{pypi_name}
@@ -8,7 +11,7 @@ License:        BSD
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
 URL:            https://www.sphinx-doc.org/en/master/
-Source0:        https://files.pythonhosted.org/packages/54/13/8dd7a7ed9c58e16e20c7f4ce8e4cb6943eb580955236d0c0d00079a73c49/sphinxcontrib_serializinghtml-%{version}.tar.gz#/%{pypi_name}-%{version}.tar.gz
+Source0:        https://files.pythonhosted.org/packages/54/13/8dd7a7ed9c58e16e20c7f4ce8e4cb6943eb580955236d0c0d00079a73c49/%{pypi_name_underscore}-%{version}.tar.gz#/%{pypi_name}-%{version}.tar.gz
 
 BuildArch:      noarch
 
@@ -39,7 +42,7 @@ HTML files (json and pickle).
 %pyproject_buildrequires -x test
 
 %prep
-%autosetup -n sphinxcontrib_serializinghtml-%{version}
+%autosetup -n %{pypi_name_underscore}-%{version}
 find -name '*.mo' -delete
 
 %build
@@ -72,8 +75,8 @@ pip3 install sphinx exceptiongroup iniconfig tomli
 %files -n python3-%{pypi_name} -f sphinxcontrib.serializinghtml.lang
 %license LICENSE
 %doc README.rst
-%{python3_sitelib}/sphinxcontrib/	
-%{python3_sitelib}/sphinxcontrib_serializinghtml-%{version}.dist-info/
+%{python3_sitelib}/%{pypi_name_prefix}/	
+%{python3_sitelib}/%{pypi_name_underscore}-%{version}.dist-info/
 
 %changelog
 * Wed Feb 21 2024 Amrita Kohli <amritakohli@microsoft.com> - 1.1.10-1

--- a/SPECS/python-sphinxcontrib-serializinghtml/python-sphinxcontrib-serializinghtml.spec
+++ b/SPECS/python-sphinxcontrib-serializinghtml/python-sphinxcontrib-serializinghtml.spec
@@ -1,7 +1,7 @@
 %global pypi_name_prefix sphinxcontrib
 %global pypi_name_suffix serializinghtml
-%global pypi_name %{pypi_name_prefix}-${pypi_name_suffix}
-%global pypi_name_underscore %{pypi_name_prefix}_${pypi_name_suffix}
+%global pypi_name %{pypi_name_prefix}-%{pypi_name_suffix}
+%global pypi_name_underscore %{pypi_name_prefix}_%{pypi_name_suffix}
 
 Summary:        Sphinx extension for serialized HTML
 Name:           python-%{pypi_name}

--- a/SPECS/python-sphinxcontrib-websupport/python-sphinxcontrib-websupport.spec
+++ b/SPECS/python-sphinxcontrib-websupport/python-sphinxcontrib-websupport.spec
@@ -1,19 +1,23 @@
-%define pkgname sphinxcontrib-websupport
+%global pypi_name_prefix sphinxcontrib
+%global pypi_name_suffix websupport
+%global pypi_name %{pypi_name_prefix}-${pypi_name_suffix}
+%global pypi_name_underscore %{pypi_name_prefix}_${pypi_name_suffix}
+
 Summary:        Python API to integrate Sphinx into a web application
-Name:           python-%{pkgname}
+Name:           python-%{pypi_name}
 Version:        1.2.4
 Release:        3%{?dist}
 License:        BSD
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
-URL:            https://github.com/sphinx-doc/sphinxcontrib-websupport
-Source0:        https://github.com/sphinx-doc/%{pkgname}/archive/%{version}.tar.gz#/%{pkgname}-%{version}.tar.gz
+URL:            https://github.com/sphinx-doc/%{pypi_name}
+Source0:        https://github.com/sphinx-doc/%{pypi_name}/archive/%{version}.tar.gz#/%{pypi_name}-%{version}.tar.gz
 BuildArch:      noarch
 
 %description
 Python API to integrate Sphinx into a web application
 
-%package -n python3-%{pkgname}
+%package -n python3-%{pypi_name}
 Summary:        %{summary}
 BuildRequires:  python3-devel
 BuildRequires:  python3-setuptools
@@ -25,11 +29,11 @@ BuildRequires:  python3-pip
 Requires:       python3
 Requires:       python3-sphinxcontrib-serializinghtml
 
-%description -n python3-%{pkgname}
+%description -n python3-%{pypi_name}
 The python-sphinxcontrib-websupport package provides a Python API to easily integrate Sphinx documentation into your Web application.
 
 %prep
-%autosetup -n %{pkgname}-%{version} -p 1
+%autosetup -n %{pypi_name}-%{version} -p 1
 rm -rf *.egg-info
 
 %build
@@ -42,10 +46,10 @@ rm -rf *.egg-info
 pip3 install tox
 tox
 
-%files -n python3-%{pkgname}
+%files -n python3-%{pypi_name}
 %license LICENSE
 %doc README.rst
-%{python3_sitelib}/sphinxcontrib/*
+%{python3_sitelib}/%{pypi_name_prefix}/*
 %{python3_sitelib}/*.egg-info
 %{python3_sitelib}/*.pth
 

--- a/SPECS/python-sphinxcontrib-websupport/python-sphinxcontrib-websupport.spec
+++ b/SPECS/python-sphinxcontrib-websupport/python-sphinxcontrib-websupport.spec
@@ -1,7 +1,7 @@
 %global pypi_name_prefix sphinxcontrib
 %global pypi_name_suffix websupport
-%global pypi_name %{pypi_name_prefix}-${pypi_name_suffix}
-%global pypi_name_underscore %{pypi_name_prefix}_${pypi_name_suffix}
+%global pypi_name %{pypi_name_prefix}-%{pypi_name_suffix}
+%global pypi_name_underscore %{pypi_name_prefix}_%{pypi_name_suffix}
 
 Summary:        Python API to integrate Sphinx into a web application
 Name:           python-%{pypi_name}


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
In the sphinxcontrib package specs, some places the hyphenated form such as sphinxcontrib-applehelp and other places the underscore form e.g. sphinxcontrib_applehelp is used. Enhancing the variable naming to add pypi_name_underscore to improve generalization / usage of variables.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Updated 7 sphinxcontrib packages to have the new variable naming format.
- Note: did not update changelog or bump release since this is ahead of the Mariner 3.0 release and does not affect the inner workings of the spec in any meaningful way.
- Installing packages in jsmath check section for tests to run successfully.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Locally built / tested successfully
Note: websupport tests fail, but a package upgrade for that is underway so it can be handled then.
