### PR TITLE
[CHERRYPICK] cups: patch CVE-2023-32324 and CVE-2023-34241 (#8778)

### DIFF
--- a/SPECS/cups/CVE-2023-32324.patch
+++ b/SPECS/cups/CVE-2023-32324.patch
@@ -1,0 +1,26 @@
+From d6111307960d248e65bad1b7d481721606067fe9 Mon Sep 17 00:00:00 2001
+From: amritakohli <amritakohli@microsoft.com>
+Date: Fri, 12 Apr 2024 00:25:52 -0700
+Subject: [PATCH] Modified patch based on upstream commit
+
+---
+ cups/string.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/cups/string.c b/cups/string.c
+index 93cdad1..90c6cdb 100644
+--- a/cups/string.c
++++ b/cups/string.c
+@@ -696,6 +696,9 @@ _cups_strlcat(char       *dst,		/* O - Destination string */
+ 
+   size -= dstlen + 1;
+ 
++  if (size == 0)
++    return (0);
++
+  /*
+   * Figure out how much room is needed...
+   */
+-- 
+2.34.1
+

--- a/SPECS/cups/CVE-2023-34241.patch
+++ b/SPECS/cups/CVE-2023-34241.patch
@@ -1,0 +1,61 @@
+From 7e31390fe53336f22affad901e101b3da25062a8 Mon Sep 17 00:00:00 2001
+From: amritakohli <amritakohli@microsoft.com>
+Date: Fri, 12 Apr 2024 00:54:36 -0700
+Subject: [PATCH] Modified patch based on upstream commit for CVE-2023-34241
+
+---
+ scheduler/client.c | 16 +++++++---------
+ 1 file changed, 7 insertions(+), 9 deletions(-)
+
+diff --git a/scheduler/client.c b/scheduler/client.c
+index 9730eea..91060f8 100644
+--- a/scheduler/client.c
++++ b/scheduler/client.c
+@@ -192,13 +192,11 @@ cupsdAcceptClient(cupsd_listener_t *lis)/* I - Listener socket */
+    /*
+     * Can't have an unresolved IP address with double-lookups enabled...
+     */
+-
+-    httpClose(con->http);
+-
+     cupsdLogClient(con, CUPSD_LOG_WARN,
+-                    "Name lookup failed - connection from %s closed!",
++                    "Name lookup failed - closing connection from %s!",
+                     httpGetHostname(con->http, NULL, 0));
+ 
++    httpClose(con->http);
+     free(con);
+     return;
+   }
+@@ -234,11 +232,11 @@ cupsdAcceptClient(cupsd_listener_t *lis)/* I - Listener socket */
+       * with double-lookups enabled...
+       */
+ 
+-      httpClose(con->http);
+-
+       cupsdLogClient(con, CUPSD_LOG_WARN,
+-                      "IP lookup failed - connection from %s closed!",
++                      "IP lookup failed - closing connection from %s!",
+                       httpGetHostname(con->http, NULL, 0));
++
++      httpClose(con->http);
+       free(con);
+       return;
+     }
+@@ -255,11 +253,11 @@ cupsdAcceptClient(cupsd_listener_t *lis)/* I - Listener socket */
+ 
+   if (!hosts_access(&wrap_req))
+   {
+-    httpClose(con->http);
+-
+     cupsdLogClient(con, CUPSD_LOG_WARN,
+                     "Connection from %s refused by /etc/hosts.allow and "
+ 		    "/etc/hosts.deny rules.", httpGetHostname(con->http, NULL, 0));
++
++    httpClose(con->http);
+     free(con);
+     return;
+   }
+-- 
+2.34.1
+

--- a/SPECS/cups/cups.spec
+++ b/SPECS/cups/cups.spec
@@ -12,7 +12,7 @@
 Summary:        CUPS printing system
 Name:           cups
 Version:        2.3.3%{OP_VER}
-Release:        6%{?dist}
+Release:        7%{?dist}
 License:        ASL 2.0 with exceptions
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -61,6 +61,8 @@ Patch12:        cups-failover-backend.patch
 # add device id for dymo printer
 Patch13:        cups-dymo-deviceid.patch
 Patch14:        CVE-2023-4504.patch
+Patch15:        CVE-2023-32324.patch
+Patch16:        CVE-2023-34241.patch
 #### UPSTREAM PATCHES (starts with 1000) ####
 ##### Patches removed because IMHO they aren't no longer needed
 ##### but still I'll leave them in git in case their removal
@@ -258,8 +260,10 @@ to CUPS daemon. This solution will substitute printer drivers and raw queues in 
 # Added IEEE 1284 Device ID for a Dymo device (bug #747866).
 %patch13 -p1 -b .dymo-deviceid
 
-# UPSTREAM PATCHES
+# CVE Patches
 %patch14 -p1 
+%patch15 -p1
+%patch16 -p1
 
 # LSPP support.
 %patch100 -p1 -b .lspp
@@ -651,6 +655,10 @@ rm -f %{cups_serverbin}/backend/smb
 %{_mandir}/man7/ippeveps.7.gz
 
 %changelog
+* Fri Apr 12 2024 Amrita Kohli <amritakohli@microsoft.com> - 2.3.3op2-7
+- Add patch for CVE-2023-32324.
+- Add patch for CVE-2023-34241.
+
 * Wed Apr 10 2024 Amrita Kohli <amritakohli@microsoft.com> - 2.3.3op2-6
 - Add patch for CVE-2023-4504.
 


### PR DESCRIPTION
<!-- Quick explanation of the changes. -->
Pull request to cherry-pick commit e1523e40e6e08b014e60952ffb9d7ea7e5b32b04 to main. Original PR: #8778 