### PR TITLE
Add missing ID_LIKE field in /etc/os-release

### DIFF
--- a/SPECS/azurelinux-release/azurelinux-release.spec
+++ b/SPECS/azurelinux-release/azurelinux-release.spec
@@ -53,6 +53,7 @@ cat <<-"EOF" > %{buildroot}%{_libdir}/os-release
 NAME="Microsoft %{distribution}"
 VERSION="%{distro_release_version_no_time}"
 ID=azurelinux
+ID_LIKE=fedora
 VERSION_ID="%{version}"
 PRETTY_NAME="Microsoft %{distribution} %{version}"
 ANSI_COLOR="1;34"


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ x] The toolchain/worker package manifests are up-to-date
- [ x] Any updated packages successfully build (or no packages were changed)
- [ x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ x] All package sources are available
- [ x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [ x] All source files have up-to-date hashes in the `*.signatures.json` files
- [ x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ x] Documentation has been updated to match any changes to the build system
- [ x] Ready to merge

---

###### Summary 
The file /etc/os-release is missing "ID_LIKE" field, see https://www.man7.org/linux/man-pages/man5/os-release.5.html#OPTIONS
###### Change Log  <!-- REQUIRED -->
Only /etc/os-release is modified

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO
