### PR TITLE
[Medium] patch qt5-qtbase for CVE-2025-30348

### DIFF
--- a/SPECS/qt5-qtbase/CVE-2025-30348.patch
+++ b/SPECS/qt5-qtbase/CVE-2025-30348.patch
@@ -1,0 +1,93 @@
+From ccf4cbf309f7d1da4df07e2239e5b674b9534bce Mon Sep 17 00:00:00 2001
+From: jykanase <v-jykanase@microsoft.com>
+Date: Fri, 13 Jun 2025 14:00:19 +0000
+Subject: [PATCH] CVE-2025-30348.patch
+
+Upstream Patch Reference: https://codereview.qt-project.org/c/qt/qtbase/+/581442/1/src/xml/dom/qdom.cpp#3643
+---
+ src/xml/dom/qdom.cpp | 60 ++++++++++++++------------------------------
+ 1 file changed, 19 insertions(+), 41 deletions(-)
+
+diff --git a/src/xml/dom/qdom.cpp b/src/xml/dom/qdom.cpp
+index dd6916f9..cb33b78c 100644
+--- a/src/xml/dom/qdom.cpp
++++ b/src/xml/dom/qdom.cpp
+@@ -4159,56 +4159,34 @@ static QString encodeText(const QString &str,
+     const QTextCodec *const codec = s.codec();
+     Q_ASSERT(codec);
+ #endif
+-    QString retval(str);
+-    int len = retval.length();
+-    int i = 0;
++    const qsizetype len = str.size();
++    QString retval;
++    retval.reserve(len * 1.2);
++    qsizetype i = 0;
+ 
+     while (i < len) {
+-        const QChar ati(retval.at(i));
++        const QChar ati(str.at(i));
+ 
+         if (ati == QLatin1Char('<')) {
+-            retval.replace(i, 1, QLatin1String("&lt;"));
+-            len += 3;
+-            i += 4;
++            retval.append(QLatin1String("&lt;"));
+         } else if (encodeQuotes && (ati == QLatin1Char('"'))) {
+-            retval.replace(i, 1, QLatin1String("&quot;"));
+-            len += 5;
+-            i += 6;
++            retval.append(QLatin1String("&quot;"));
+         } else if (ati == QLatin1Char('&')) {
+-            retval.replace(i, 1, QLatin1String("&amp;"));
+-            len += 4;
+-            i += 5;
+-        } else if (ati == QLatin1Char('>') && i >= 2 && retval[i - 1] == QLatin1Char(']') && retval[i - 2] == QLatin1Char(']')) {
+-            retval.replace(i, 1, QLatin1String("&gt;"));
+-            len += 3;
+-            i += 4;
++            retval.append(QLatin1String("&amp;"));
++        } else if (ati == QLatin1Char('>') && i >= 2 && str.at(i - 1) == QLatin1Char(']') && str.at(i - 2) == QLatin1Char(']')) {
++            retval.append(QLatin1String("&gt;"));
+         } else if (performAVN &&
+-                   (ati == QChar(0xA) ||
+-                    ati == QChar(0xD) ||
+-                    ati == QChar(0x9))) {
++                   (ati == QLatin1Char(0xA) ||
++                    ati == QLatin1Char(0xD) ||
++                    ati == QLatin1Char(0x9))) {
+             const QString replacement(QLatin1String("&#x") + QString::number(ati.unicode(), 16) + QLatin1Char(';'));
+-            retval.replace(i, 1, replacement);
+-            i += replacement.length();
+-            len += replacement.length() - 1;
+-        } else if (encodeEOLs && ati == QChar(0xD)) {
+-            retval.replace(i, 1, QLatin1String("&#xd;")); // Replace a single 0xD with a ref for 0xD
+-            len += 4;
+-            i += 5;
++            retval.append(replacement);
++        } else if (encodeEOLs && ati == QLatin1Char(0xD)) {
++            retval.append(QLatin1String("&#xd;")); // Replace a single 0xD with a ref for 0xD
+         } else {
+-#if QT_CONFIG(textcodec)
+-            if(codec->canEncode(ati))
+-                ++i;
+-            else
+-#endif
+-            {
+-                // We have to use a character reference to get it through.
+-                const ushort codepoint(ati.unicode());
+-                const QString replacement(QLatin1String("&#x") + QString::number(codepoint, 16) + QLatin1Char(';'));
+-                retval.replace(i, 1, replacement);
+-                i += replacement.length();
+-                len += replacement.length() - 1;
+-            }
+-        }
++	    retval.append(ati);
++        } 
++	++i;
+     }
+ 
+     return retval;
+-- 
+2.45.2
+

--- a/SPECS/qt5-qtbase/qt5-qtbase.spec
+++ b/SPECS/qt5-qtbase/qt5-qtbase.spec
@@ -33,7 +33,7 @@
 Name:         qt5-qtbase
 Summary:      Qt5 - QtBase components
 Version:      5.12.11
-Release:      15%{?dist}
+Release:      16%{?dist}
 # See LICENSE.GPL3-EXCEPT.txt, for exception details
 License:      GFDL AND LGPLv3 AND GPLv2 AND GPLv3 with exceptions AND QT License Agreement 4.0
 Vendor:       Microsoft Corporation
@@ -167,6 +167,7 @@ Patch93: CVE-2022-25255.patch
 
 Patch94: CVE-2024-25580.patch
 Patch95: CVE-2023-34410.patch
+Patch96: CVE-2025-30348.patch
 
 # Do not check any files in %%{_qt5_plugindir}/platformthemes/ for requires.
 # Those themes are there for platform integration. If the required libraries are
@@ -270,20 +271,7 @@ Qt5 libraries used for drawing widgets and OpenGL items.
 %patch68 -p1
 
 %patch80 -p1 -b .use-wayland-on-gnome.patch
-%patch81 -p1
-%patch82 -p1
-%patch83 -p1
-%patch84 -p1
-%patch86 -p1
-%patch87 -p1
-%patch88 -p1
-%patch89 -p1
-%patch90 -p1
-%patch91 -p1
-%patch92 -p1
-%patch93 -p1
-%patch94 -p1
-%patch95 -p1
+%autopatch -p1 -m 81
 
 ## upstream patches
 
@@ -789,6 +777,9 @@ fi
 %{_qt5_libdir}/cmake/Qt5Gui/Qt5Gui_QXdgDesktopPortalThemePlugin.cmake
 
 %changelog
+* Fri Jun 13 2025 Jyoti Kanase <v-jykanase@microsoft.com> - 5.12.11-16
+- Fix CVE-2025-30348
+
 * Fri Feb 14 2025 Archana Shettigar <v-shettigara@microsoft.com> - 5.12.11-15
 - Add patch to resolve CVE-2024-25580 & CVE-2023-34410
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
patch qt5-qtbase for CVE-2025-30348
Modified Patch: Yes
- Upstream patch is backported; code is modified accordingly to match the QLatin1String function. 
- Astrolabe reference:  https://codereview.qt-project.org/c/qt/qtbase/+/581442/1

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- qt5-qtbase.spec
- CVE-2025-30348.patch

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/ CVE-2025-30348

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
-Verifed patch is apllied.
![image](https://github.com/user-attachments/assets/6016268b-b8b1-47c9-8eb9-43651913641d)

