### PR TITLE
[Medium] Patch gh for CVE-2025-48938

### DIFF
--- a/SPECS/gh/CVE-2025-48938.patch
+++ b/SPECS/gh/CVE-2025-48938.patch
@@ -1,0 +1,98 @@
+From f30373d5ac9c1af048f352ce32eaddc7c83a9156 Mon Sep 17 00:00:00 2001
+From: Sreenivasulu Malavathula <v-smalavathu@microsoft.com>
+Date: Mon, 16 Jun 2025 16:28:52 -0500
+Subject: [PATCH] Address CVE-2025-48938
+Upstream Patch Reference: https://github.com/cli/go-gh/commit/a08820a.diff
+
+---
+ .../cli/go-gh/v2/pkg/browser/browser.go       | 59 +++++++++++++++++++
+ 1 file changed, 59 insertions(+)
+
+diff --git a/vendor/github.com/cli/go-gh/v2/pkg/browser/browser.go b/vendor/github.com/cli/go-gh/v2/pkg/browser/browser.go
+index 4d56710..d17951a 100644
+--- a/vendor/github.com/cli/go-gh/v2/pkg/browser/browser.go
++++ b/vendor/github.com/cli/go-gh/v2/pkg/browser/browser.go
+@@ -2,7 +2,9 @@
+ package browser
+ 
+ import (
++	"fmt"
+ 	"io"
++	"net/url"
+ 	"os"
+ 	"os/exec"
+ 
+@@ -45,9 +47,20 @@ func (b *Browser) Browse(url string) error {
+ }
+ 
+ func (b *Browser) browse(url string, env []string) error {
++	// Ensure the URL is supported including the scheme,
++	// overwrite `url` for use within the function.
++	urlParsed, err := isPossibleProtocol(url)
++	if err != nil {
++		return err
++	}
++
++	url = urlParsed.String()
++
++	// Use default `gh` browsing module for opening URL if not customized.
+ 	if b.launcher == "" {
+ 		return cliBrowser.OpenURL(url)
+ 	}
++
+ 	launcherArgs, err := shlex.Split(b.launcher)
+ 	if err != nil {
+ 		return err
+@@ -78,3 +91,49 @@ func resolveLauncher() string {
+ 	}
+ 	return os.Getenv("BROWSER")
+ }
++
++func isSupportedScheme(scheme string) bool {
++	switch scheme {
++	case "http", "https", "vscode", "vscode-insiders":
++		return true
++	default:
++		return false
++	}
++}
++
++func isPossibleProtocol(u string) (*url.URL, error) {
++	// Parse URL for known supported schemes before handling unknown cases.
++	urlParsed, err := url.Parse(u)
++	if err != nil {
++		return nil, fmt.Errorf("opening unparsable URL is unsupported: %s", u)
++	}
++
++	if isSupportedScheme(urlParsed.Scheme) {
++		return urlParsed, nil
++	}
++
++	// Disallow any unrecognized URL schemes if explicitly present.
++	if urlParsed.Scheme != "" {
++		return nil, fmt.Errorf("opening unsupport URL scheme: %s", u)
++	}
++
++	// Disallow URLs that match existing files or directories on the filesystem
++	// as these could be executables or executed by the launcher browser due to
++	// the file extension and/or associated application.
++	//
++	// Symlinks should not be resolved in order to avoid broken links or other
++	// vulnerabilities trying to resolve them.
++	if fileInfo, _ := os.Lstat(u); fileInfo != nil {
++		return nil, fmt.Errorf("opening files or directories is unsupported: %s", u)
++	}
++
++	// Disallow URLs that match executables found in the user path.
++	exec, _ := safeexec.LookPath(u)
++	if exec != "" {
++		return nil, fmt.Errorf("opening executables is unsupported: %s", u)
++	}
++
++	// Otherwise, assume HTTP URL using `https` to ensure secure browsing.
++	urlParsed.Scheme = "https"
++	return urlParsed, nil
++}
+-- 
+2.45.2
+

--- a/SPECS/gh/gh.spec
+++ b/SPECS/gh/gh.spec
@@ -1,7 +1,7 @@
 Summary:        GitHub official command line tool
 Name:           gh
 Version:        2.62.0
-Release:        8%{?dist}
+Release:        9%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -22,6 +22,7 @@ Patch6:         CVE-2025-25204.patch
 Patch7:         CVE-2025-27144.patch
 Patch8:         CVE-2025-22869.patch
 Patch9:         CVE-2025-22872.patch
+Patch10:        CVE-2025-48938.patch
 
 BuildRequires:  golang < 1.23
 BuildRequires:  git
@@ -64,6 +65,9 @@ make test
 %{_datadir}/zsh/site-functions/_gh
 
 %changelog
+* Mon Jun 16 2025 Sreeniavsulu Malavathula <v-smalavathu@microsoft.com> - 2.62.0-9
+- Patch CVE-2025-48938
+
 * Tue Apr 22 2025 Jyoti Kanase <v-jykanase@microsoft.com> - 2.62.0-8
 - Patch CVE-2025-22872
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Patch gh for CVE-2025-48938
Patch Modified: Yes

Astrolabe patch reference: https://github.com/cli/go-gh/commit/a08820a.diff. 
 From Upstream patch, file **browser_test.go** is does not exist in our sources.

 
###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- new file: **SPECS/gh/CVE-2025-48938.patch**
- modified: **SPECS/gh/gh.spec**

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2025-48938

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->

- **Applied Patch successfully as shown below snapshot**
![Screenshot 2025-06-16 191207](https://github.com/user-attachments/assets/b5e60c1c-34f8-4def-86c2-b2928eb60851)

- Pipeline build id: xxxx
