### PR TITLE
Patch `frr` for CVE-2024-55553 [High]

### DIFF
--- a/SPECS/frr/CVE-2024-55553.patch
+++ b/SPECS/frr/CVE-2024-55553.patch
@@ -1,0 +1,258 @@
+From ee33d7a891c9e7abb5020e849f51a9ea8a91b850 Mon Sep 17 00:00:00 2001
+From: Kanishk Bansal <kanbansal@microsoft.com>
+Date: Thu, 19 Jun 2025 06:40:11 +0000
+Subject: [PATCH] Backport CVE-2024-55553
+
+Upstream Reference : https://github.com/FRRouting/frr/commit/b0800bfdf04b4fcf48504737ebfe4ba7f05268d3
+
+Signed-off-by: Kanishk Bansal <kanbansal@microsoft.com>
+---
+ bgpd/bgp_rpki.c | 139 ++++++++++++++++++++++--------------------------
+ bgpd/bgpd.c     |   4 --
+ bgpd/bgpd.h     |   1 -
+ 3 files changed, 65 insertions(+), 79 deletions(-)
+
+diff --git a/bgpd/bgp_rpki.c b/bgpd/bgp_rpki.c
+index f0b2ffd..8ccb948 100644
+--- a/bgpd/bgp_rpki.c
++++ b/bgpd/bgp_rpki.c
+@@ -48,6 +48,7 @@ DEFINE_MTYPE_STATIC(BGPD, BGP_RPKI_CACHE_GROUP, "BGP RPKI Cache server group");
+ DEFINE_MTYPE_STATIC(BGPD, BGP_RPKI_RTRLIB, "BGP RPKI RTRLib");
+ DEFINE_MTYPE_STATIC(BGPD, BGP_RPKI_REVALIDATE, "BGP RPKI Revalidation");
+ 
++
+ #define POLLING_PERIOD_DEFAULT 3600
+ #define EXPIRE_INTERVAL_DEFAULT 7200
+ #define RETRY_INTERVAL_DEFAULT 600
+@@ -108,7 +109,6 @@ static void print_record(const struct pfx_record *record, struct vty *vty,
+ 			 json_object *json, enum asnotation_mode asnotation);
+ static bool is_synchronized(void);
+ static bool is_running(void);
+-static bool is_stopping(void);
+ static void route_match_free(void *rule);
+ static enum route_map_cmd_result_t route_match(void *rule,
+ 					       const struct prefix *prefix,
+@@ -116,7 +116,6 @@ static enum route_map_cmd_result_t route_match(void *rule,
+ 					       void *object);
+ static void *route_match_compile(const char *arg);
+ static void revalidate_bgp_node(struct bgp_dest *dest, afi_t afi, safi_t safi);
+-static void revalidate_all_routes(void);
+ 
+ static struct rtr_mgr_config *rtr_config;
+ static struct list *cache_list;
+@@ -354,11 +353,6 @@ inline bool is_running(void)
+ 	return rtr_is_running;
+ }
+ 
+-inline bool is_stopping(void)
+-{
+-	return rtr_is_stopping;
+-}
+-
+ static void pfx_record_to_prefix(struct pfx_record *record,
+ 				 struct prefix *prefix)
+ {
+@@ -402,40 +396,19 @@ static void rpki_revalidate_prefix(struct event *thread)
+ 	XFREE(MTYPE_BGP_RPKI_REVALIDATE, rrp);
+ }
+ 
+-static void bgpd_sync_callback(struct event *thread)
++static void revalidate_single_prefix(struct vrf *vrf, struct prefix prefix, afi_t afi)
+ {
+ 	struct bgp *bgp;
+ 	struct listnode *node;
+-	struct prefix prefix;
+-	struct pfx_record rec;
+-
+-	event_add_read(bm->master, bgpd_sync_callback, NULL,
+-		       rpki_sync_socket_bgpd, NULL);
+-
+-	if (atomic_load_explicit(&rtr_update_overflow, memory_order_seq_cst)) {
+-		while (read(rpki_sync_socket_bgpd, &rec,
+-			    sizeof(struct pfx_record)) != -1)
+-			;
+-
+-		atomic_store_explicit(&rtr_update_overflow, 0,
+-				      memory_order_seq_cst);
+-		revalidate_all_routes();
+-		return;
+-	}
+-
+-	int retval =
+-		read(rpki_sync_socket_bgpd, &rec, sizeof(struct pfx_record));
+-	if (retval != sizeof(struct pfx_record)) {
+-		RPKI_DEBUG("Could not read from rpki_sync_socket_bgpd");
+-		return;
+-	}
+-	pfx_record_to_prefix(&rec, &prefix);
+-
+-	afi_t afi = (rec.prefix.ver == LRTR_IPV4) ? AFI_IP : AFI_IP6;
+ 
+ 	for (ALL_LIST_ELEMENTS_RO(bm->bgp, node, bgp)) {
+ 		safi_t safi;
+ 
++			if (!vrf && bgp->vrf_id != VRF_DEFAULT)
++				continue;
++			if (vrf && bgp->vrf_id != vrf->vrf_id)
++				continue;
++
+ 		for (safi = SAFI_UNICAST; safi < SAFI_MAX; safi++) {
+ 			struct bgp_table *table = bgp->rib[afi][safi];
+ 			struct rpki_revalidate_prefix *rrp;
+@@ -448,12 +421,67 @@ static void bgpd_sync_callback(struct event *thread)
+ 			rrp->prefix = prefix;
+ 			rrp->afi = afi;
+ 			rrp->safi = safi;
+-			event_add_event(bm->master, rpki_revalidate_prefix, rrp,
+-					0, &bgp->t_revalidate[afi][safi]);
++			event_add_event(bm->master, rpki_revalidate_prefix, rrp, 0, &bgp->t_revalidate[afi][safi]);
+ 		}
+ 	}
+ }
+ 
++
++static void bgpd_sync_callback(struct event *thread)
++{
++	struct prefix prefix;
++	struct pfx_record rec;
++	struct rpki_vrf *rpki_vrf = EVENT_ARG(thread);
++	struct vrf *vrf = NULL;
++	afi_t afi;
++	int retval;
++
++	event_add_read(bm->master, bgpd_sync_callback, rpki_vrf, rpki_vrf->rpki_sync_socket_bgpd,
++		       NULL);
++
++	if (rpki_vrf->vrfname) {
++		vrf = vrf_lookup_by_name(rpki_vrf->vrfname);
++		if (!vrf) {
++			zlog_err("%s(): vrf for rpki %s not found", __func__, rpki_vrf->vrfname);
++			return;
++		}
++	}
++
++	if (atomic_load_explicit(&rpki_vrf->rtr_update_overflow, memory_order_seq_cst)) {
++		ssize_t size = 0;
++
++		retval = read(rpki_vrf->rpki_sync_socket_bgpd, &rec, sizeof(struct pfx_record));
++		while (retval != -1) {
++			if (retval != sizeof(struct pfx_record))
++				break;
++
++			size += retval;
++			pfx_record_to_prefix(&rec, &prefix);
++			afi = (rec.prefix.ver == LRTR_IPV4) ? AFI_IP : AFI_IP6;
++			revalidate_single_prefix(vrf, prefix, afi);
++
++			retval = read(rpki_vrf->rpki_sync_socket_bgpd, &rec,
++				      sizeof(struct pfx_record));
++		}
++
++		RPKI_DEBUG("Socket overflow detected (%zu), revalidating affected prefixes", size);
++
++		atomic_store_explicit(&rpki_vrf->rtr_update_overflow, 0, memory_order_seq_cst);
++		return;
++	}
++
++	retval = read(rpki_vrf->rpki_sync_socket_bgpd, &rec, sizeof(struct pfx_record));
++	if (retval != sizeof(struct pfx_record)) {
++		RPKI_DEBUG("Could not read from rpki_sync_socket_bgpd");
++		return;
++	}
++	pfx_record_to_prefix(&rec, &prefix);
++
++	afi = (rec.prefix.ver == LRTR_IPV4) ? AFI_IP : AFI_IP6;
++
++	revalidate_single_prefix(vrf, prefix, afi);
++}
++
+ static void revalidate_bgp_node(struct bgp_dest *bgp_dest, afi_t afi,
+ 				safi_t safi)
+ {
+@@ -501,48 +529,11 @@ static void bgp_rpki_revalidate_peer(struct event *thread)
+ 	XFREE(MTYPE_BGP_RPKI_REVALIDATE, rvp);
+ }
+ 
+-static void revalidate_all_routes(void)
+-{
+-	struct bgp *bgp;
+-	struct listnode *node;
+-
+-	for (ALL_LIST_ELEMENTS_RO(bm->bgp, node, bgp)) {
+-		struct peer *peer;
+-		struct listnode *peer_listnode;
+-
+-		for (ALL_LIST_ELEMENTS_RO(bgp->peer, peer_listnode, peer)) {
+-			afi_t afi;
+-			safi_t safi;
+-
+-			FOREACH_AFI_SAFI (afi, safi) {
+-				struct rpki_revalidate_peer *rvp;
+-
+-				if (!bgp->rib[afi][safi])
+-					continue;
+-
+-				if (!peer_established(peer->connection))
+-					continue;
+-
+-				rvp = XCALLOC(MTYPE_BGP_RPKI_REVALIDATE,
+-					      sizeof(*rvp));
+-				rvp->peer = peer;
+-				rvp->afi = afi;
+-				rvp->safi = safi;
+-
+-				event_add_event(
+-					bm->master, bgp_rpki_revalidate_peer,
+-					rvp, 0,
+-					&peer->t_revalidate_all[afi][safi]);
+-			}
+-		}
+-	}
+-}
+-
+ static void rpki_update_cb_sync_rtr(struct pfx_table *p __attribute__((unused)),
+ 				    const struct pfx_record rec,
+ 				    const bool added __attribute__((unused)))
+ {
+-	if (is_stopping() ||
++	if (rtr_is_stopping ||
+ 	    atomic_load_explicit(&rtr_update_overflow, memory_order_seq_cst))
+ 		return;
+ 
+diff --git a/bgpd/bgpd.c b/bgpd/bgpd.c
+index edb20ac..cfa1930 100644
+--- a/bgpd/bgpd.c
++++ b/bgpd/bgpd.c
+@@ -1248,8 +1248,6 @@ static void peer_free(struct peer *peer)
+ 	bgp_reads_off(peer->connection);
+ 	bgp_writes_off(peer->connection);
+ 	event_cancel_event_ready(bm->master, peer->connection);
+-	FOREACH_AFI_SAFI (afi, safi)
+-		EVENT_OFF(peer->t_revalidate_all[afi][safi]);
+ 	assert(!peer->connection->t_write);
+ 	assert(!peer->connection->t_read);
+ 	event_cancel_event_ready(bm->master, peer->connection);
+@@ -2637,8 +2635,6 @@ int peer_delete(struct peer *peer)
+ 	bgp_reads_off(peer->connection);
+ 	bgp_writes_off(peer->connection);
+ 	event_cancel_event_ready(bm->master, peer->connection);
+-	FOREACH_AFI_SAFI (afi, safi)
+-		EVENT_OFF(peer->t_revalidate_all[afi][safi]);
+ 	assert(!CHECK_FLAG(peer->connection->thread_flags,
+ 			   PEER_THREAD_WRITES_ON));
+ 	assert(!CHECK_FLAG(peer->connection->thread_flags,
+diff --git a/bgpd/bgpd.h b/bgpd/bgpd.h
+index dda108b..70c728c 100644
+--- a/bgpd/bgpd.h
++++ b/bgpd/bgpd.h
+@@ -1568,7 +1568,6 @@ struct peer {
+ 
+ 	/* Threads. */
+ 	struct event *t_llgr_stale[AFI_MAX][SAFI_MAX];
+-	struct event *t_revalidate_all[AFI_MAX][SAFI_MAX];
+ 	struct event *t_refresh_stalepath;
+ 
+ 	/* Thread flags. */
+-- 
+2.45.3
+

--- a/SPECS/frr/frr.spec
+++ b/SPECS/frr/frr.spec
@@ -3,7 +3,7 @@
 Summary:        Routing daemon
 Name:           frr
 Version:        9.1.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        GPL-2.0-or-later
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -17,6 +17,7 @@ Patch2:         0002-disable-eigrp-crypto.patch
 Patch3:         0003-fips-mode.patch
 Patch4:         0004-remove-grpc-test.patch
 Patch5:         CVE-2024-44070.patch
+Patch6:         CVE-2024-55553.patch
 
 BuildRequires:  autoconf
 BuildRequires:  automake
@@ -199,6 +200,9 @@ rm tests/lib/*grpc*
 %{_sysusersdir}/%{name}.conf
 
 %changelog
+* Tue Jun 17 2025 Kanishk Bansal <kanbansal@microsoft.com> - 9.1.1-3
+- Backport Patch CVE-2024-55553
+
 * Wed Aug 21 2024 Brian Fjeldstad <bfjelds@microsoft.com> - 9.1.1-2
 - Fix CVE-2024-44070
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
- Address CVE-2024-55553 by backport

######  Patch Summary
Backports the upstream CVE-2024-55553 fix to FRRouting’s BGP RPKI code.

a. bgpd/bgp_rpki.c
- Removes the function and all uses of revalidate_all_routes().
- Removes use of t_revalidate_all arrays for bulk revalidation.
- Changes bulk revalidation to only operate on single prefixes using the new revalidate_single_prefix() function.
- Moves from using global/static variables to per-VRF context (e.g., struct rpki_vrf *rpki_vrf argument passing).
- Drops the is_stopping() function in favor of checking a flag directly.

b. bgpd/bgpd.c
- Removes cancellation of t_revalidate_all events in peer_free() and peer_delete().

c. bgpd/bgpd.h
- Removes the definition of struct event *t_revalidate_all[AFI_MAX][SAFI_MAX]; from struct peer.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- CVE-2024-55553

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**No**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2024-55553,

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: [Buddy Build](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=841434&view=results)
