### PR TITLE
Patch gdk-pixbuf2 for CVE-2025-6199

### DIFF
--- a/SPECS/gdk-pixbuf2/CVE-2025-6199.patch
+++ b/SPECS/gdk-pixbuf2/CVE-2025-6199.patch
@@ -1,0 +1,27 @@
+From 471970c9af2fe447a47c4338dfd36e80065e0036 Mon Sep 17 00:00:00 2001
+From: Azure Linux Security Servicing Account
+ <azurelinux-security@microsoft.com>
+Date: Mon, 30 Jun 2025 17:52:46 +0000
+Subject: [PATCH] Fix CVE CVE-2025-6199 in gdk-pixbuf2
+
+[Backported] Upstream Patch Reference: https://gitlab.gnome.org/GNOME/gdk-pixbuf/-/merge_requests/191/diffs?commit_id=c4986342b241cdc075259565f3fa7a7597d32a32
+---
+ gdk-pixbuf/lzw.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/gdk-pixbuf/lzw.c b/gdk-pixbuf/lzw.c
+index 9e052a6..2ea9a63 100644
+--- a/gdk-pixbuf/lzw.c
++++ b/gdk-pixbuf/lzw.c
+@@ -200,7 +200,7 @@ lzw_decoder_feed (LZWDecoder *self,
+                                         else {
+                                                 /* Invalid code received - just stop here */
+                                                 self->last_code = self->eoi_code;
+-                                                return output_length;
++                                                return n_written;
+                                         }
+ 
+                                         /* When table is full increase code size */
+-- 
+2.45.3
+

--- a/SPECS/gdk-pixbuf2/gdk-pixbuf2.spec
+++ b/SPECS/gdk-pixbuf2/gdk-pixbuf2.spec
@@ -2,13 +2,14 @@
 Summary:        An image loading library
 Name:           gdk-pixbuf2
 Version:        2.40.0
-Release:        6%{?dist}
+Release:        7%{?dist}
 License:        LGPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 URL:            https://gitlab.gnome.org/GNOME/gdk-pixbuf
 Source0:        https://download.gnome.org/sources/gdk-pixbuf/2.40/gdk-pixbuf-%{version}.tar.xz
 Patch0:         CVE-2022-48622.patch
+Patch1:         CVE-2025-6199.patch
 BuildRequires:  gettext
 BuildRequires:  gtk-doc
 BuildRequires:  jasper-devel
@@ -58,6 +59,7 @@ the functionality of the installed %{name} package.
 
 %prep
 %autosetup -n gdk-pixbuf-%{version} -p1
+%patch1 -p1
 
 %build
 %meson -Dbuiltin_loaders=png \
@@ -117,6 +119,9 @@ gdk-pixbuf-query-loaders-%{__isa_bits} --update-cache
 %{_datadir}/installed-tests
 
 %changelog
+* Mon Jun 30 2025 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 2.40.0-7
+- Patch for CVE-2025-6199
+
 * Thu Sep 19 2024 Sumedh Sharma <sumsharma@microsoft.com> - 2.40.0-6
 - Add patch for CVE-2022-48622
 


### PR DESCRIPTION
Auto Patch gdk-pixbuf2 for CVE-2025-6199.

Autosec pipeline run -> https://dev.azure.com/mariner-org/mariner-chatbot/_build/results?buildId=853292&view=results