### PR TITLE
Fix python-remoto ptest (#8247)

### DIFF
--- a/SPECS/python-remoto/python-remoto.spec
+++ b/SPECS/python-remoto/python-remoto.spec
@@ -2,7 +2,7 @@
 Summary:        A very simplistic remote-command-executor
 Name:           python-%{pkgname}
 Version:        1.2.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -44,7 +44,7 @@ remoto as well to inspect Ceph clusters.
 %py3_install
 
 %check
-pip3 install pytest mock
+pip3 install pytest==7.4.4 mock
 python3 -m pytest -v remoto/tests
 
 %files -n python3-%{pkgname}
@@ -53,6 +53,9 @@ python3 -m pytest -v remoto/tests
 %{python3_sitelib}/*
 
 %changelog
+* Sun Mar 03 2024 Jon Slobodzian <joslobo@microsoft.com> - 1.2.1-2
+* Pin pytest to a version less than 8.0.0 to fix package test failures
+
 * Wed Mar 30 2022 Olivia Crain <oliviacrain@microsoft.com> - 1.2.1-1
 - Upgrade to latest upstream version
 - Pass check section with newer python environment


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
This PR carries a ptest fix from 2.0 into 3.0 for pthon-remoto.  There are no functional changes to the package.


###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Test Methodology
Ran buddy build and verified that the ptests now pass.