### PR TITLE
[HIGH] Patch javapackages-bootstrap for CVE-2024-25710

### DIFF
--- a/SPECS/javapackages-bootstrap/CVE-2024-25710.patch
+++ b/SPECS/javapackages-bootstrap/CVE-2024-25710.patch
@@ -1,0 +1,219 @@
+From 9ba26258615490114ba1b8c510d32d462aed5cee Mon Sep 17 00:00:00 2001
+From: archana25-ms <v-shettigara@microsoft.com>
+Date: Wed, 9 Jul 2025 16:12:01 +0000
+Subject: [PATCH] Address CVE-2024-25710
+Upstream Patch Reference: https://github.com/apache/commons-compress/commit/8a9a5847c04ae39a1d45b365f8bb82022466067d#diff-fe1b45a8f9cafb5f9e7a2c518bbaa8a3766efe002946262fcbb09df1f87fac5d
+
+---
+ .../archivers/dump/DumpArchiveConstants.java  |  3 +-
+ .../archivers/dump/DumpArchiveUtil.java       | 13 ++++---
+ .../archivers/dump/TapeInputStream.java       |  3 ++
+ .../dump/DumpArchiveInputStreamTest.java      | 16 ++++++++
+ .../archivers/dump/DumpArchiveUtilTest.java   | 22 ++++++++++-
+ .../archivers/dump/TapeInputStreamTest.java   | 38 +++++++++++++++++++
+ .../compress/dump/directory_null_bytes.dump   |  0
+ .../dump/invalid_compression_type.dump        |  0
+ 8 files changed, 87 insertions(+), 8 deletions(-)
+ create mode 100644 downstream/commons-compress/src/test/java/org/apache/commons/compress/archivers/dump/TapeInputStreamTest.java
+ create mode 100644 downstream/commons-compress/src/test/resources/org/apache/commons/compress/dump/directory_null_bytes.dump
+ create mode 100644 downstream/commons-compress/src/test/resources/org/apache/commons/compress/dump/invalid_compression_type.dump
+
+diff --git a/downstream/commons-compress/src/main/java/org/apache/commons/compress/archivers/dump/DumpArchiveConstants.java b/downstream/commons-compress/src/main/java/org/apache/commons/compress/archivers/dump/DumpArchiveConstants.java
+index 920a623..0e5070c 100644
+--- a/downstream/commons-compress/src/main/java/org/apache/commons/compress/archivers/dump/DumpArchiveConstants.java
++++ b/downstream/commons-compress/src/main/java/org/apache/commons/compress/archivers/dump/DumpArchiveConstants.java
+@@ -68,6 +68,7 @@ public static SEGMENT_TYPE find(final int code) {
+      * The type of compression.
+      */
+     public enum COMPRESSION_TYPE {
++        UNKNOWN(-1),
+         ZLIB(0),
+         BZLIB(1),
+         LZO(2);
+@@ -85,7 +86,7 @@ public static COMPRESSION_TYPE find(final int code) {
+                 }
+             }
+ 
+-            return null;
++            return UNKNOWN;
+         }
+     }
+ }
+diff --git a/downstream/commons-compress/src/main/java/org/apache/commons/compress/archivers/dump/DumpArchiveUtil.java b/downstream/commons-compress/src/main/java/org/apache/commons/compress/archivers/dump/DumpArchiveUtil.java
+index 20e1eb3..b1222c5 100644
+--- a/downstream/commons-compress/src/main/java/org/apache/commons/compress/archivers/dump/DumpArchiveUtil.java
++++ b/downstream/commons-compress/src/main/java/org/apache/commons/compress/archivers/dump/DumpArchiveUtil.java
+@@ -41,11 +41,9 @@ private DumpArchiveUtil() {
+      */
+     public static int calculateChecksum(final byte[] buffer) {
+         int calc = 0;
+-
+         for (int i = 0; i < 256; i++) {
+             calc += DumpArchiveUtil.convert32(buffer, 4 * i);
+         }
+-
+         return DumpArchiveConstants.CHECKSUM -
+         (calc - DumpArchiveUtil.convert32(buffer, 28));
+     }
+@@ -56,16 +54,16 @@ public static int calculateChecksum(final byte[] buffer) {
+      * @param buffer
+      */
+     public static final boolean verify(final byte[] buffer) {
++        if (buffer == null) {
++            return false;
++        }
+         // verify magic. for now only accept NFS_MAGIC.
+         final int magic = convert32(buffer, 24);
+-
+         if (magic != DumpArchiveConstants.NFS_MAGIC) {
+             return false;
+         }
+-
+         //verify checksum...
+         final int checksum = convert32(buffer, 28);
+-
+         return checksum == calculateChecksum(buffer);
+     }
+ 
+@@ -116,6 +114,9 @@ public static final int convert16(final byte[] buffer, final int offset) {
+      */
+     static String decode(final ZipEncoding encoding, final byte[] b, final int offset, final int len)
+         throws IOException {
+-        return encoding.decode(Arrays.copyOfRange(b, offset, offset + len));
++            if (offset > offset + len) {
++                throw new IOException("Invalid offset/length combination");
++            }
++            return encoding.decode(Arrays.copyOfRange(b, offset, offset + len));
+     }
+ }
+diff --git a/downstream/commons-compress/src/main/java/org/apache/commons/compress/archivers/dump/TapeInputStream.java b/downstream/commons-compress/src/main/java/org/apache/commons/compress/archivers/dump/TapeInputStream.java
+index 006953f..06ae23d 100644
+--- a/downstream/commons-compress/src/main/java/org/apache/commons/compress/archivers/dump/TapeInputStream.java
++++ b/downstream/commons-compress/src/main/java/org/apache/commons/compress/archivers/dump/TapeInputStream.java
+@@ -75,6 +75,9 @@ public void resetBlockSize(final int recsPerBlock, final boolean isCompressed)
+                 + " records found, must be at least 1");
+         }
+         blockSize = RECORD_SIZE * recsPerBlock;
++        if (blockSize < 1) {
++            throw new IOException("Block size cannot be less than or equal to 0: " + blockSize);
++        }
+ 
+         // save first block in case we need it again
+         final byte[] oldBuffer = blockBuffer;
+diff --git a/downstream/commons-compress/src/test/java/org/apache/commons/compress/archivers/dump/DumpArchiveInputStreamTest.java b/downstream/commons-compress/src/test/java/org/apache/commons/compress/archivers/dump/DumpArchiveInputStreamTest.java
+index b31b635..7f95869 100644
+--- a/downstream/commons-compress/src/test/java/org/apache/commons/compress/archivers/dump/DumpArchiveInputStreamTest.java
++++ b/downstream/commons-compress/src/test/java/org/apache/commons/compress/archivers/dump/DumpArchiveInputStreamTest.java
+@@ -96,4 +96,20 @@ public void multiByteReadConsistentlyReturnsMinusOneAtEof() throws Exception {
+         }
+     }
+ 
++    @Test
++    public void testDirectoryNullBytes() throws Exception {
++        try (InputStream is = newInputStream("org/apache/commons/compress/dump/directory_null_bytes.dump");
++             DumpArchiveInputStream archive = new DumpArchiveInputStream(is)) {
++            assertThrows(InvalidFormatException.class, archive::getNextEntry);
++        }
++    }
++
++    @Test
++    public void testInvalidCompressType() throws Exception {
++        try (InputStream is = newInputStream("org/apache/commons/compress/dump/invalid_compression_type.dump")) {
++            final ArchiveException ex = assertThrows(ArchiveException.class, () -> new DumpArchiveInputStream(is).close());
++            assertInstanceOf(UnsupportedCompressionAlgorithmException.class, ex.getCause());
++        }
++    }
++
+ }
+diff --git a/downstream/commons-compress/src/test/java/org/apache/commons/compress/archivers/dump/DumpArchiveUtilTest.java b/downstream/commons-compress/src/test/java/org/apache/commons/compress/archivers/dump/DumpArchiveUtilTest.java
+index 2aceca3..5dbdde7 100644
+--- a/downstream/commons-compress/src/test/java/org/apache/commons/compress/archivers/dump/DumpArchiveUtilTest.java
++++ b/downstream/commons-compress/src/test/java/org/apache/commons/compress/archivers/dump/DumpArchiveUtilTest.java
+@@ -18,7 +18,11 @@
+  */
+ package org.apache.commons.compress.archivers.dump;
+ 
++import static org.junit.Assert.assertThrows;
+ import static org.junit.Assert.assertEquals;
++import static org.junit.Assert.assertFalse;
++
++import java.io.IOException;
+ 
+ import org.junit.Test;
+ 
+@@ -48,4 +52,20 @@ public void convert16() {
+                              (byte) 0xCD, (byte) 0xAB
+                          }, 0));
+     }
+-}
+\ No newline at end of file
++
++    @Test
++    public void testDecodeInvalidArguments() {
++        assertThrows(IOException.class, () -> DumpArchiveUtil.decode(null, new byte[10], 10, -1));
++    }
++
++    @Test
++    public void testVerifyNullArgument() {
++        assertFalse(DumpArchiveUtil.verify(null));
++    }
++
++    @Test
++    public void testVerifyNoMagic() {
++        assertFalse(DumpArchiveUtil.verify(new byte[32]));
++    }
++
++}
+diff --git a/downstream/commons-compress/src/test/java/org/apache/commons/compress/archivers/dump/TapeInputStreamTest.java b/downstream/commons-compress/src/test/java/org/apache/commons/compress/archivers/dump/TapeInputStreamTest.java
+new file mode 100644
+index 0000000..775bb66
+--- /dev/null
++++ b/downstream/commons-compress/src/test/java/org/apache/commons/compress/archivers/dump/TapeInputStreamTest.java
+@@ -0,0 +1,38 @@
++/*
++ * Licensed to the Apache Software Foundation (ASF) under one
++ * or more contributor license agreements.  See the NOTICE file
++ * distributed with this work for additional information
++ * regarding copyright ownership.  The ASF licenses this file
++ * to you under the Apache License, Version 2.0 (the
++ * "License"); you may not use this file except in compliance
++ * with the License.  You may obtain a copy of the License at
++ *
++ * http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing,
++ * software distributed under the License is distributed on an
++ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
++ * KIND, either express or implied.  See the License for the
++ * specific language governing permissions and limitations
++ * under the License.
++ */
++package org.apache.commons.compress.archivers.dump;
++
++import static org.junit.jupiter.api.Assertions.assertThrows;
++
++import java.io.ByteArrayInputStream;
++import java.io.IOException;
++
++import org.apache.commons.compress.AbstractTest;
++import org.junit.jupiter.params.ParameterizedTest;
++import org.junit.jupiter.params.provider.ValueSource;
++
++public class TapeInputStreamTest extends AbstractTest {
++    @ParameterizedTest
++    @ValueSource(ints = {-1, 0, Integer.MAX_VALUE / 1000, Integer.MAX_VALUE})
++    public void testResetBlockSizeWithInvalidValues(final int recsPerBlock) throws Exception {
++        try (TapeInputStream tapeInputStream = new TapeInputStream(new ByteArrayInputStream(new byte[1]))) {
++            assertThrows(IOException.class, () -> tapeInputStream.resetBlockSize(recsPerBlock, true));
++        }
++    }
++}
+diff --git a/downstream/commons-compress/src/test/resources/org/apache/commons/compress/dump/directory_null_bytes.dump b/downstream/commons-compress/src/test/resources/org/apache/commons/compress/dump/directory_null_bytes.dump
+new file mode 100644
+index 0000000..e69de29
+diff --git a/downstream/commons-compress/src/test/resources/org/apache/commons/compress/dump/invalid_compression_type.dump b/downstream/commons-compress/src/test/resources/org/apache/commons/compress/dump/invalid_compression_type.dump
+new file mode 100644
+index 0000000..e69de29
+-- 
+2.45.3
+

--- a/SPECS/javapackages-bootstrap/javapackages-bootstrap.spec
+++ b/SPECS/javapackages-bootstrap/javapackages-bootstrap.spec
@@ -13,7 +13,7 @@
 
 Name:           javapackages-bootstrap
 Version:        1.5.0
-Release:        7%{?dist}
+Release:        8%{?dist}
 Summary:        A means of bootstrapping Java Packages Tools
 # For detailed info see the file javapackages-bootstrap-PACKAGE-LICENSING
 License:        ASL 2.0 and ASL 1.1 and (ASL 2.0 or EPL-2.0) and (EPL-2.0 or GPLv2 with exceptions) and MIT and (BSD with advertising) and BSD-3-Clause and EPL-1.0 and EPL-2.0 and CDDL-1.0 and xpp and CC0 and Public Domain
@@ -141,6 +141,7 @@ Patch1:         0001-Remove-usage-of-ArchiveStreamFactory.patch
 Patch2:         CVE-2023-37460.patch
 Patch3:         Internal-Java-API.patch
 Patch4:         CVE-2021-36373.patch
+Patch5:         CVE-2024-25710.patch
 
 Provides:       bundled(ant) = 1.10.9
 Provides:       bundled(apache-parent) = 23
@@ -305,6 +306,8 @@ pushd "downstream/ant"
 %patch4 -p1
 popd
 
+%patch5 -p1
+
 # remove guava.xml from javapackage-bootstrap 1.5.0
 # import guava.xml 32.1.3 from Fedora 40
 # edit version from guava.properties
@@ -393,6 +396,9 @@ sed -i 's|/usr/lib/jvm/java-11-openjdk|%{java_home}|' %{buildroot}%{launchersPat
 %doc AUTHORS
 
 %changelog
+* Thu Jul 10 2025 Archana Shettigar <v-shettigara@microsoft.com> - 1.5.0-8
+- Patch CVE-2024-25710
+
 * Thu May 15 2025 Andrew Phelps <anphel@microsoft.com> - 1.5.0-7
 - Attempt incremental build twice to avoid random Dependency cycle errors
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Patch javapackages-bootstrap for CVE-2024-25710

- Patch taken from https://github.com/apache/commons-compress/commit/8a9a5847c04ae39a1d45b365f8bb82022466067d as mentioned in Astrolabe
- Manually patch is backported, modified.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- SPECS/javapackages-bootstrap/CVE-2024-25710.patch
- SPECS/javapackages-bootstrap/javapackages-bootstrap.spec


###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2024-25710

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=863163&view=results
- [x] Patch applies cleanly
![image](https://github.com/user-attachments/assets/6055b3aa-6474-4f0b-a8e8-8edb0862cc0b)
- [x] Builds successfully - 
[javapackages-bootstrap-1.5.0-8.cm2.src.rpm.log](https://github.com/user-attachments/files/21161976/javapackages-bootstrap-1.5.0-8.cm2.src.rpm.log)
