### PR TITLE
[MEDIUM] Patch libxml2 for CVE-2025-6021

### DIFF
--- a/SPECS/libxml2/CVE-2025-6021.patch
+++ b/SPECS/libxml2/CVE-2025-6021.patch
@@ -1,0 +1,50 @@
+From ff1a4c29bf7268826e3f24357eb191282b9dcc77 Mon Sep 17 00:00:00 2001
+From: Sreenivasulu Malavathula <v-smalavathu@microsoft.com>
+Date: Mon, 30 Jun 2025 11:36:24 -0500
+Subject: [PATCH] Address CVE-2025-6021
+Upstream Patch Reference: https://gitlab.gnome.org/GNOME/libxml2/-/commit/ad346c9a249c4b380bf73c460ad3e81135c5d781
+
+---
+ tree.c | 12 +++++++++---
+ 1 file changed, 9 insertions(+), 3 deletions(-)
+
+diff --git a/tree.c b/tree.c
+index 03572ff..c0b0d70 100644
+--- a/tree.c
++++ b/tree.c
+@@ -47,6 +47,10 @@
+ #include "buf.h"
+ #include "save.h"
+ 
++#ifndef SIZE_MAX
++#define SIZE_MAX ((size_t) -1)
++#endif
++
+ int __xmlRegisterCallbacks = 0;
+ 
+ /************************************************************************
+@@ -219,16 +223,18 @@ xmlGetParameterEntityFromDtd(const xmlDtd *dtd, const xmlChar *name) {
+ xmlChar *
+ xmlBuildQName(const xmlChar *ncname, const xmlChar *prefix,
+ 	      xmlChar *memory, int len) {
+-    int lenn, lenp;
++    size_t lenn, lenp;
+     xmlChar *ret;
+ 
+-    if (ncname == NULL) return(NULL);
++    if ((ncname == NULL) || (len < 0)) return(NULL);
+     if (prefix == NULL) return((xmlChar *) ncname);
+ 
+     lenn = strlen((char *) ncname);
+     lenp = strlen((char *) prefix);
++    if (lenn >= SIZE_MAX - lenp - 1)
++        return(NULL);
+ 
+-    if ((memory == NULL) || (len < lenn + lenp + 2)) {
++    if ((memory == NULL) || ((size_t) len < lenn + lenp + 2)) {
+ 	ret = (xmlChar *) xmlMallocAtomic(lenn + lenp + 2);
+ 	if (ret == NULL) {
+ 	    xmlTreeErrMemory("building QName");
+-- 
+2.45.2
+

--- a/SPECS/libxml2/libxml2.spec
+++ b/SPECS/libxml2/libxml2.spec
@@ -1,7 +1,7 @@
 Summary:        Libxml2
 Name:           libxml2
 Version:        2.10.4
-Release:        7%{?dist}
+Release:        8%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -17,6 +17,7 @@ Patch5:         CVE-2025-24928.patch
 Patch6:         CVE-2025-27113.patch
 Patch7:         CVE-2025-32414.patch
 Patch8:         CVE-2025-32415.patch
+Patch9:         CVE-2025-6021.patch
 BuildRequires:  python3-devel
 BuildRequires:  python3-xml
 Provides:       %{name}-tools = %{version}-%{release}
@@ -87,6 +88,9 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %{_libdir}/cmake/libxml2/libxml2-config.cmake
 
 %changelog
+* Mon Jun 30 2025 Sreeniavsulu Malavathula <v-smalavathu@microsoft.com> - 2.10.4-8
+- Patch CVE-2025-6021
+
 * Mon May 05 2025 Sreeniavsulu Malavathula <v-smalavathu@microsoft.com> - 2.10.4-7
 - Patch CVE-2025-32414 and CVE-2025-32415
 

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -194,8 +194,8 @@ curl-8.8.0-6.cm2.aarch64.rpm
 curl-devel-8.8.0-6.cm2.aarch64.rpm
 curl-libs-8.8.0-6.cm2.aarch64.rpm
 createrepo_c-0.17.5-1.cm2.aarch64.rpm
-libxml2-2.10.4-7.cm2.aarch64.rpm
-libxml2-devel-2.10.4-7.cm2.aarch64.rpm
+libxml2-2.10.4-8.cm2.aarch64.rpm
+libxml2-devel-2.10.4-8.cm2.aarch64.rpm
 docbook-dtd-xml-4.5-11.cm2.noarch.rpm
 docbook-style-xsl-1.79.1-14.cm2.noarch.rpm
 libsepol-3.2-2.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -194,8 +194,8 @@ curl-8.8.0-6.cm2.x86_64.rpm
 curl-devel-8.8.0-6.cm2.x86_64.rpm
 curl-libs-8.8.0-6.cm2.x86_64.rpm
 createrepo_c-0.17.5-1.cm2.x86_64.rpm
-libxml2-2.10.4-7.cm2.x86_64.rpm
-libxml2-devel-2.10.4-7.cm2.x86_64.rpm
+libxml2-2.10.4-8.cm2.x86_64.rpm
+libxml2-devel-2.10.4-8.cm2.x86_64.rpm
 docbook-dtd-xml-4.5-11.cm2.noarch.rpm
 docbook-style-xsl-1.79.1-14.cm2.noarch.rpm
 libsepol-3.2-2.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -209,9 +209,9 @@ libtasn1-debuginfo-4.19.0-2.cm2.aarch64.rpm
 libtasn1-devel-4.19.0-2.cm2.aarch64.rpm
 libtool-2.4.6-8.cm2.aarch64.rpm
 libtool-debuginfo-2.4.6-8.cm2.aarch64.rpm
-libxml2-2.10.4-7.cm2.aarch64.rpm
-libxml2-debuginfo-2.10.4-7.cm2.aarch64.rpm
-libxml2-devel-2.10.4-7.cm2.aarch64.rpm
+libxml2-2.10.4-8.cm2.aarch64.rpm
+libxml2-debuginfo-2.10.4-8.cm2.aarch64.rpm
+libxml2-devel-2.10.4-8.cm2.aarch64.rpm
 libxslt-1.1.34-8.cm2.aarch64.rpm
 libxslt-debuginfo-1.1.34-8.cm2.aarch64.rpm
 libxslt-devel-1.1.34-8.cm2.aarch64.rpm
@@ -521,7 +521,7 @@ python3-gpg-1.16.0-2.cm2.aarch64.rpm
 python3-jinja2-3.0.3-7.cm2.noarch.rpm
 python3-libcap-ng-0.8.2-2.cm2.aarch64.rpm
 python3-libs-3.9.19-14.cm2.aarch64.rpm
-python3-libxml2-2.10.4-7.cm2.aarch64.rpm
+python3-libxml2-2.10.4-8.cm2.aarch64.rpm
 python3-lxml-4.9.1-1.cm2.aarch64.rpm
 python3-magic-5.40-3.cm2.noarch.rpm
 python3-markupsafe-2.1.0-1.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -215,9 +215,9 @@ libtasn1-debuginfo-4.19.0-2.cm2.x86_64.rpm
 libtasn1-devel-4.19.0-2.cm2.x86_64.rpm
 libtool-2.4.6-8.cm2.x86_64.rpm
 libtool-debuginfo-2.4.6-8.cm2.x86_64.rpm
-libxml2-2.10.4-7.cm2.x86_64.rpm
-libxml2-debuginfo-2.10.4-7.cm2.x86_64.rpm
-libxml2-devel-2.10.4-7.cm2.x86_64.rpm
+libxml2-2.10.4-8.cm2.x86_64.rpm
+libxml2-debuginfo-2.10.4-8.cm2.x86_64.rpm
+libxml2-devel-2.10.4-8.cm2.x86_64.rpm
 libxslt-1.1.34-8.cm2.x86_64.rpm
 libxslt-debuginfo-1.1.34-8.cm2.x86_64.rpm
 libxslt-devel-1.1.34-8.cm2.x86_64.rpm
@@ -527,7 +527,7 @@ python3-gpg-1.16.0-2.cm2.x86_64.rpm
 python3-jinja2-3.0.3-7.cm2.noarch.rpm
 python3-libcap-ng-0.8.2-2.cm2.x86_64.rpm
 python3-libs-3.9.19-14.cm2.x86_64.rpm
-python3-libxml2-2.10.4-7.cm2.x86_64.rpm
+python3-libxml2-2.10.4-8.cm2.x86_64.rpm
 python3-lxml-4.9.1-1.cm2.x86_64.rpm
 python3-magic-5.40-3.cm2.noarch.rpm
 python3-markupsafe-2.1.0-1.cm2.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Patch libxml2 for CVE-2025-6021

Duplicate of https://github.com/microsoft/azurelinux/pull/14081

- Patch Modified: Yes

- Astrolabe patch reference: https://gitlab.gnome.org/GNOME/libxml2/-/commit/ad346c9a249c4b380bf73c460ad3e81135c5d781
- From Upstream patch, instead of including <stdinc.h> header file, added 'macro of SIZE_MAX' to our patch file if this macro NOT defined, that required to compile libxml2.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- new file: SPECS/libxml2/CVE-2025-6021.patch
- modified: SPECS/libxml2/libxml2.spec
- modified: toolkit/resources/manifests/package/pkggen_core_aarch64.txt
- modified: toolkit/resources/manifests/package/pkggen_core_x86_64.txt
- modified: toolkit/resources/manifests/package/toolchain_aarch64.txt
- modified: toolkit/resources/manifests/package/toolchain_x86_64.txt

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**


###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2025-6021

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: xxxx
- [x] Patch applies cleanly
<img width="920" height="536" alt="image" src="https://github.com/user-attachments/assets/180cf836-acd2-40b6-9c61-22077b4e289d" />

- [x] Builds successfully
- [x] Tests run successfully
<img width="313" height="364" alt="image" src="https://github.com/user-attachments/assets/ea85b618-3745-43ae-82e2-f744d86d076f" />

- Build log : [libxml2-2.10.4-8.cm2.build.rpm.log](https://github.com/user-attachments/files/21249710/libxml2-2.10.4-8.cm2.src.rpm.log)
- Test log : [libxml2-2.10.4-8.cm2.rpm.test.log](https://github.com/user-attachments/files/21249721/libxml2-2.10.4-8.cm2.src.rpm.test.log)

