### PR TITLE
[3.0] Passed Azure config to toolkit build env.

### DIFF
--- a/toolkit/Makefile
+++ b/toolkit/Makefile
@@ -201,6 +201,9 @@ all: toolchain go-tools chroot-tools
 # its help will be displayed at the top of the help output.
 include $(SCRIPTS_DIR)/help.mk
 
+# Set-up the Azure configuration for the build
+include $(SCRIPTS_DIR)/azure_config.mk
+
 # Set up for the timestamp feature
 include $(SCRIPTS_DIR)/timestamp.mk
 

--- a/toolkit/scripts/azure_config.mk
+++ b/toolkit/scripts/azure_config.mk
@@ -1,0 +1,9 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# By default pass original user's Azure configuration if running as root.
+# Running as root is required by how the toolkit operates while
+# in most cases the user expects to still use their Azure configuration, thus the default.
+ifneq ($(SUDO_USER),)
+	export AZURE_CONFIG_DIR ?= $(shell sudo -u "$(SUDO_USER)" bash -c 'echo $${AZURE_CONFIG_DIR:-$${HOME}/.azure}')
+endif


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [X] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [X] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

We're adding support for anonymous Azure blob stores in #14494. This change is to help with that work by making the Azure configuration (including login info) exposed during build-time. Since the toolkit requires to be run as root, the user's Azure config is not visible by default, because it's saved under `$HOME/.azure` and since we're running as root, the home directory is different from the running user's home directory.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
No.

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #14494

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local tests.
- Budd builds where the toolkit attempts to upload files to a test Azure Storage Account using the new authentication method:
    - [Before the fix](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=906655&view=logs&j=bac295d9-f2e0-5165-e63e-e76f383e1a27&t=0d701f49-04ec-5f4d-856b-f175ca457ff8&l=3189).
    - [After the fix](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=906640&view=logs&j=bac295d9-f2e0-5165-e63e-e76f383e1a27&t=0d701f49-04ec-5f4d-856b-f175ca457ff8&l=3194).