### PR TITLE
Removed kernel `devel` subpackages dependency on the kernel.

### DIFF
--- a/SPECS-EXTENDED/kernel-ipe/kernel-ipe.spec
+++ b/SPECS-EXTENDED/kernel-ipe/kernel-ipe.spec
@@ -33,7 +33,7 @@
 Summary:        Linux Kernel
 Name:           kernel-ipe
 Version:        6.6.104.2
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -109,7 +109,6 @@ The kernel package contains the Linux kernel.
 %package devel
 Summary:        Kernel Dev
 Group:          System Environment/Kernel
-Requires:       %{name} = %{version}-%{release}
 Requires:       gawk
 Requires:       python3
 Obsoletes:      linux-dev
@@ -460,6 +459,9 @@ echo "initrd of kernel %{uname_r} removed" >&2
 %{_sysconfdir}/bash_completion.d/bpftool
 
 %changelog
+* Tue Sep 23 2025 Pawel Winogrodzki <pawelwi@microsoft.com> - 6.6.104.2-3
+- Removed invalid run-time dependency from the 'devel' subpackage.
+
 * Tue Sep 23 2025 Rachel Menge <rachelmenge@microsoft.com> - 6.6.104.2-2
 - Bump release to match kernel
 

--- a/SPECS-EXTENDED/kernel-lpg-innovate/kernel-lpg-innovate.spec
+++ b/SPECS-EXTENDED/kernel-lpg-innovate/kernel-lpg-innovate.spec
@@ -29,7 +29,7 @@
 Summary:        Linux Kernel
 Name:           kernel-lpg-innovate
 Version:        6.6.89.2
-Release:        1003%{?dist}
+Release:        1004%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -105,7 +105,6 @@ The kernel package contains the Linux kernel.
 %package devel
 Summary:        Kernel Dev
 Group:          System Environment/Kernel
-Requires:       %{name} = %{version}-%{release}
 Requires:       gawk
 Requires:       python3
 Obsoletes:      linux-dev
@@ -470,6 +469,9 @@ echo "initrd of kernel %{uname_r} removed" >&2
 %{_sysconfdir}/bash_completion.d/bpftool
 
 %changelog
+* Tue Sep 23 2025 Pawel Winogrodzki <pawelwi@microsoft.com> - 6.6.89.2-1004
+- Removed invalid run-time dependency from the 'devel' subpackage.
+
 * Fri Aug 22 2025 Siddharth Chintamaneni <siddharthc@microsoft.com> - 6.6.89.2-1003
 - Introducing kernel-hwe
 

--- a/SPECS-EXTENDED/kernel-rt/kernel-rt.spec
+++ b/SPECS-EXTENDED/kernel-rt/kernel-rt.spec
@@ -25,7 +25,7 @@
 Summary:        Realtime Linux Kernel
 Name:           kernel-rt
 Version:        6.6.85.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -102,7 +102,6 @@ The kernel package contains the Linux kernel.
 %package devel
 Summary:        Kernel Dev
 Group:          System Environment/Kernel
-Requires:       %{name} = %{version}-%{release}
 Requires:       gawk
 Requires:       python3
 Obsoletes:      linux-dev
@@ -426,6 +425,9 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %{_sysconfdir}/bash_completion.d/bpftool
 
 %changelog
+* Tue Sep 23 2025 Pawel Winogrodzki <pawelwi@microsoft.com> - 6.6.85.1-4
+- Removed invalid run-time dependency from the 'devel' subpackage.
+
 * Fri Aug 22 2025 Siddharth Chintamaneni <siddharthc@microsoft.com> - 6.6.85.1-3
 - Introducing kernel-hwe
 

--- a/SPECS-SIGNED/kernel-64k-signed/kernel-64k-signed.spec
+++ b/SPECS-SIGNED/kernel-64k-signed/kernel-64k-signed.spec
@@ -7,7 +7,7 @@
 Summary:        Signed Linux Kernel for %{buildarch} systems
 Name:           kernel-64k-signed-%{buildarch}
 Version:        6.6.104.2
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -105,6 +105,9 @@ echo "initrd of kernel %{uname_r} removed" >&2
 %exclude /module_info.ld
 
 %changelog
+* Tue Sep 30 2025 Pawel Winogrodzki <pawelwi@microsoft.com> - 6.6.104.2-3
+- Bump release to match kernel
+
 * Tue Sep 23 2025 Rachel Menge <rachelmenge@microsoft.com> - 6.6.104.2-2
 - Bump release to match kernel
 

--- a/SPECS-SIGNED/kernel-hwe-signed/kernel-hwe-signed.spec
+++ b/SPECS-SIGNED/kernel-hwe-signed/kernel-hwe-signed.spec
@@ -4,7 +4,7 @@
 Summary:        Signed Linux Kernel for %{buildarch} systems
 Name:           kernel-hwe-signed-%{buildarch}
 Version:        6.12.40.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -96,6 +96,9 @@ echo "initrd of kernel %{uname_r} removed" >&2
 %exclude /module_info.ld
 
 %changelog
+* Tue Sep 30 2025 Pawel Winogrodzki <pawelwi@microsoft.com> - 6.12.40.1-3
+- Bump release to match kernel
+
 * Fri Sep 12 2025 Rachel Menge <rachelmenge@microsoft.com> - 6.12.40.1-2
 - Bump to match kernel-hwe
 

--- a/SPECS-SIGNED/kernel-mshv-signed/kernel-mshv-signed.spec
+++ b/SPECS-SIGNED/kernel-mshv-signed/kernel-mshv-signed.spec
@@ -7,7 +7,7 @@
 Summary:        Signed MSHV-enabled Linux Kernel for %{buildarch} systems
 Name:           kernel-mshv-signed-%{buildarch}
 Version:        6.6.100.mshv1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -136,6 +136,9 @@ echo "initrd of kernel %{uname_r} removed" >&2
 %exclude /lib/modules/%{uname_r}/build
 
 %changelog
+* Tue Sep 30 2025 Pawel Winogrodzki <pawelwi@microsoft.com> - 6.6.100.mshv1-2
+- Bump release to match kernel
+
 * Tue Sep 09 2025 Saul Paredes <saulparedes@microsoft.com> - 6.6.100.mshv1-1
 - Upgrade to 6.6.100.mshv1
 

--- a/SPECS-SIGNED/kernel-signed/kernel-signed.spec
+++ b/SPECS-SIGNED/kernel-signed/kernel-signed.spec
@@ -10,7 +10,7 @@
 Summary:        Signed Linux Kernel for %{buildarch} systems
 Name:           kernel-signed-%{buildarch}
 Version:        6.6.104.2
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -145,6 +145,9 @@ echo "initrd of kernel %{uname_r} removed" >&2
 %exclude /module_info.ld
 
 %changelog
+* Tue Sep 30 2025 Pawel Winogrodzki <pawelwi@microsoft.com> - 6.6.104.2-3
+- Bump release to match kernel
+
 * Tue Sep 23 2025 Rachel Menge <rachelmenge@microsoft.com> - 6.6.104.2-2
 - Bump release to match kernel
 

--- a/SPECS-SIGNED/kernel-uki-signed/kernel-uki-signed.spec
+++ b/SPECS-SIGNED/kernel-uki-signed/kernel-uki-signed.spec
@@ -6,7 +6,7 @@
 Summary:        Signed Unified Kernel Image for %{buildarch} systems
 Name:           kernel-uki-signed-%{buildarch}
 Version:        6.6.104.2
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -68,6 +68,9 @@ popd
 /boot/efi/EFI/Linux/vmlinuz-uki-%{kernelver}.efi
 
 %changelog
+* Tue Sep 30 2025 Pawel Winogrodzki <pawelwi@microsoft.com> - 6.6.104.2-3
+- Bump release to match kernel
+
 * Tue Sep 23 2025 Rachel Menge <rachelmenge@microsoft.com> - 6.6.104.2-2
 - Bump release to match kernel
 

--- a/SPECS/kernel-64k/kernel-64k.spec
+++ b/SPECS/kernel-64k/kernel-64k.spec
@@ -27,7 +27,7 @@
 Summary:        Linux Kernel
 Name:           kernel-64k
 Version:        6.6.104.2
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -98,7 +98,6 @@ The kernel package contains the Linux kernel.
 %package devel
 Summary:        Kernel Dev
 Group:          System Environment/Kernel
-Requires:       %{name} = %{version}-%{release}
 Requires:       gawk
 Requires:       python3
 Obsoletes:      linux-dev
@@ -380,6 +379,9 @@ echo "initrd of kernel %{uname_r} removed" >&2
 %{_sysconfdir}/bash_completion.d/bpftool
 
 %changelog
+* Tue Sep 23 2025 Pawel Winogrodzki <pawelwi@microsoft.com> - 6.6.104.2-3
+- Removed invalid run-time dependency from the 'devel' subpackage.
+
 * Tue Sep 23 2025 Rachel Menge <rachelmenge@microsoft.com> - 6.6.104.2-2
 - Enable ipmitool for kernel-64k
 

--- a/SPECS/kernel-headers/kernel-headers.spec
+++ b/SPECS/kernel-headers/kernel-headers.spec
@@ -14,7 +14,7 @@
 Summary:        Linux API header files
 Name:           kernel-headers
 Version:        6.6.104.2
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -75,6 +75,9 @@ done
 %endif
 
 %changelog
+* Tue Sep 23 2025 Pawel Winogrodzki <pawelwi@microsoft.com> - 6.6.104.2-3
+- Bump release to match kernel
+
 * Tue Sep 23 2025 Rachel Menge <rachelmenge@microsoft.com> - 6.6.104.2-2
 - Bump release to match kernel
 

--- a/SPECS/kernel-hwe-headers/kernel-hwe-headers.spec
+++ b/SPECS/kernel-hwe-headers/kernel-hwe-headers.spec
@@ -4,7 +4,7 @@
 Summary:        Linux API header files
 Name:           kernel-hwe-headers
 Version:        6.12.40.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -34,6 +34,9 @@ cp -rv usr/include/* /%{buildroot}%{_includedir}
 %{_includedir}/*
 
 %changelog
+* Tue Sep 23 2025 Pawel Winogrodzki <pawelwi@microsoft.com> - 6.12.40.1-3
+- Bump release to match kernel
+
 * Fri Sep 12 2025 Rachel Menge <rachelmenge@microsoft.com> - 6.12.40.1-2
 - Bump to match kernel-hwe
 

--- a/SPECS/kernel-hwe/kernel-hwe.spec
+++ b/SPECS/kernel-hwe/kernel-hwe.spec
@@ -20,7 +20,7 @@
 Summary:        Linux Kernel
 Name:           kernel-hwe
 Version:        6.12.40.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -84,7 +84,6 @@ The kernel package contains the Linux kernel.
 %package devel
 Summary:        Kernel Dev
 Group:          System Environment/Kernel
-Requires:       %{name} = %{version}-%{release}
 Requires:       gawk
 Requires:       python3
 Obsoletes:      linux-dev
@@ -352,6 +351,9 @@ echo "initrd of kernel %{uname_r} removed" >&2
 %{_sysconfdir}/bash_completion.d/bpftool
 
 %changelog
+* Tue Sep 23 2025 Pawel Winogrodzki <pawelwi@microsoft.com> - 6.12.40.1-3
+- Removed invalid run-time dependency from the 'devel' subpackage.
+
 * Fri Sep 12 2025 Rachel Menge <rachelmenge@microsoft.com> - 6.12.40.1-2
 - Enable ipmitool for kernel-hwe
 

--- a/SPECS/kernel-mshv/kernel-mshv.spec
+++ b/SPECS/kernel-mshv/kernel-mshv.spec
@@ -11,7 +11,7 @@
 Summary:        Mariner kernel that has MSHV Host support
 Name:           kernel-mshv
 Version:        6.6.100.mshv1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Group:          Development/Tools
 Vendor:         Microsoft Corporation
@@ -54,7 +54,6 @@ The Mariner kernel that has MSHV Host support
 %package devel
 Summary:        MSHV kernel Dev
 Group:          System Environment/Kernel
-Requires:       %{name} = %{version}-%{release}
 Requires:       gawk
 Requires:       python3
 
@@ -245,6 +244,9 @@ echo "initrd of kernel %{uname_r} removed" >&2
 %{_includedir}/perf/perf_dlfilter.h
 
 %changelog
+* Tue Sep 23 2025 Pawel Winogrodzki <pawelwi@microsoft.com> - 6.6.100.mshv1-2
+- Removed invalid run-time dependency from the 'devel' subpackage.
+
 * Tue Sep 09 2025 Saul Paredes <saulparedes@microsoft.com> - 6.6.100.mshv1-1
 - Upgrade to 6.6.100.mshv1
 

--- a/SPECS/kernel-uvm/kernel-uvm.spec
+++ b/SPECS/kernel-uvm/kernel-uvm.spec
@@ -11,7 +11,7 @@
 Summary:        Linux Kernel for Kata UVM
 Name:           kernel-uvm
 Version:        6.6.96.mshv1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -78,7 +78,6 @@ The kernel package contains the Linux kernel.
 %package devel
 Summary:        Lightweight kernel Devel package
 Group:          System Environment/Kernel
-Requires:       %{name} = %{version}-%{release}
 
 %description devel
 This package contains the kernel UVM devel files
@@ -154,6 +153,9 @@ find %{buildroot}/lib/modules -name '*.ko' -exec chmod u+x {} +
 %{_prefix}/src/linux-headers-%{uname_r}
 
 %changelog
+* Tue Sep 23 2025 Pawel Winogrodzki <pawelwi@microsoft.com> - 6.6.96.mshv1-2
+- Removed invalid run-time dependency from the 'devel' subpackage.
+
 * Tue Sep 09 2025 Saul Paredes <saulparedes@microsoft.com> - 6.6.96.mshv1-1
 - Upgrade to 6.6.96.mshv1
 

--- a/SPECS/kernel/kernel.spec
+++ b/SPECS/kernel/kernel.spec
@@ -32,7 +32,7 @@
 Summary:        Linux Kernel
 Name:           kernel
 Version:        6.6.104.2
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -105,7 +105,6 @@ The kernel package contains the Linux kernel.
 %package devel
 Summary:        Kernel Dev
 Group:          System Environment/Kernel
-Requires:       %{name} = %{version}-%{release}
 Requires:       gawk
 Requires:       python3
 Obsoletes:      linux-dev
@@ -440,6 +439,9 @@ echo "initrd of kernel %{uname_r} removed" >&2
 %{_sysconfdir}/bash_completion.d/bpftool
 
 %changelog
+* Tue Sep 23 2025 Pawel Winogrodzki <pawelwi@microsoft.com> - 6.6.104.2-3
+- Removed invalid run-time dependency from the 'devel' subpackage.
+
 * Tue Sep 23 2025 Rachel Menge <rachelmenge@microsoft.com> - 6.6.104.2-2
 - Bump release to match kernel-64k
 

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -1,5 +1,5 @@
 filesystem-1.1-21.azl3.aarch64.rpm
-kernel-headers-6.6.104.2-2.azl3.noarch.rpm
+kernel-headers-6.6.104.2-3.azl3.noarch.rpm
 glibc-2.38-13.azl3.aarch64.rpm
 glibc-devel-2.38-13.azl3.aarch64.rpm
 glibc-i18n-2.38-13.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -1,5 +1,5 @@
 filesystem-1.1-21.azl3.x86_64.rpm
-kernel-headers-6.6.104.2-2.azl3.noarch.rpm
+kernel-headers-6.6.104.2-3.azl3.noarch.rpm
 glibc-2.38-13.azl3.x86_64.rpm
 glibc-devel-2.38-13.azl3.x86_64.rpm
 glibc-i18n-2.38-13.azl3.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -158,7 +158,7 @@ intltool-0.51.0-7.azl3.noarch.rpm
 itstool-2.0.7-1.azl3.noarch.rpm
 kbd-2.2.0-2.azl3.aarch64.rpm
 kbd-debuginfo-2.2.0-2.azl3.aarch64.rpm
-kernel-headers-6.6.104.2-2.azl3.noarch.rpm
+kernel-headers-6.6.104.2-3.azl3.noarch.rpm
 kmod-30-1.azl3.aarch64.rpm
 kmod-debuginfo-30-1.azl3.aarch64.rpm
 kmod-devel-30-1.azl3.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -165,8 +165,8 @@ intltool-0.51.0-7.azl3.noarch.rpm
 itstool-2.0.7-1.azl3.noarch.rpm
 kbd-2.2.0-2.azl3.x86_64.rpm
 kbd-debuginfo-2.2.0-2.azl3.x86_64.rpm
-kernel-cross-headers-6.6.104.2-2.azl3.noarch.rpm
-kernel-headers-6.6.104.2-2.azl3.noarch.rpm
+kernel-cross-headers-6.6.104.2-3.azl3.noarch.rpm
+kernel-headers-6.6.104.2-3.azl3.noarch.rpm
 kmod-30-1.azl3.x86_64.rpm
 kmod-debuginfo-30-1.azl3.x86_64.rpm
 kmod-devel-30-1.azl3.x86_64.rpm


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [X] The toolchain has been rebuilt successfully (or no changes were made to it)
- [X] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [X] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [X] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [X] All package sources are available
- [X] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [X] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [X] All source files have up-to-date hashes in the `*.signatures.json` files
- [X] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

Kernel `devel` subpackage differs from other `devel` subpackages in that it is meant for building components calling internal kernel APIs (like kernel modules). They do not require the actual default kernel to be present in order to be functional and in fact it is common to install multiple kernel `devel` subpackages (for different kernel flavours of versions) at the same time for instance to build the same OOT kernel module for all the supported kernels. Current `devel` -> default package dependency prevents these kind of scenarios, because we don't want to install multiple kernels on the user's image in such cases.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
Yes.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- PR checks.