### PR TITLE
[Low] Patch ruby for CVE-2025-58767

### DIFF
--- a/SPECS/ruby/CVE-2025-58767.patch
+++ b/SPECS/ruby/CVE-2025-58767.patch
@@ -1,0 +1,321 @@
+From 5859bdeac792687eaf93d8e8f0b7e3c1e2ed5c23 Mon Sep 17 00:00:00 2001
+From: NAITOH Jun <naitoh@gmail.com>
+Date: Sat, 23 Aug 2025 08:11:58 +0900
+Subject: [PATCH] Added XML declaration check & `Source#skip_spaces` method
+ (#282)
+
+## Why?
+
+### Added XML declaration check
+
+- The version attribute is required in XML declaration.
+- Only version attribute, encoding attribute, and standalone attribute
+are allowed in XML declaration.
+- XML declaration is only allowed once.
+
+See: https://www.w3.org/TR/xml/#NT-XMLDecl
+
+### Added `Source#skip_spaces` method
+
+In the case of `@source.match?(/\s+/um, true)`, if there are no spaces
+at the beginning, I want to stop reading immediately.
+However, it continues to read the buffer until it finds a match, but it
+never finds a match.
+As a result, it continues reading until the end of the file.
+
+In the case of large XML files, drop_parsed_content occur frequently
+until the buffer is cleared, which may affect performance.
+
+Upstream Patch Reference: https://github.com/ruby/rexml/commit/5859bdeac792687eaf93d8e8f0b7e3c1e2ed5c23.patch
+---
+ .../lib/rexml/parsers/baseparser.rb           | 157 ++++++++++++------
+ .bundle/gems/rexml-3.3.6/lib/rexml/source.rb  |   6 +-
+ 2 files changed, 113 insertions(+), 50 deletions(-)
+
+diff --git a/.bundle/gems/rexml-3.3.6/lib/rexml/parsers/baseparser.rb b/.bundle/gems/rexml-3.3.6/lib/rexml/parsers/baseparser.rb
+index e9ab0ee..ac8f2e1 100644
+--- a/.bundle/gems/rexml-3.3.6/lib/rexml/parsers/baseparser.rb
++++ b/.bundle/gems/rexml-3.3.6/lib/rexml/parsers/baseparser.rb
+@@ -144,6 +144,7 @@ module REXML
+         PEREFERENCE_PATTERN = /#{PEREFERENCE}/um
+         TAG_PATTERN = /((?>#{QNAME_STR}))\s*/um
+         CLOSE_PATTERN = /(#{QNAME_STR})\s*>/um
++	EQUAL_PATTERN = /\s*=\s*/um
+         ATTLISTDECL_END = /\s+#{NAME}(?:#{ATTDEF})*\s*>/um
+         NAME_PATTERN = /#{NAME}/um
+         GEDECL_PATTERN = "\\s+#{NAME}\\s+#{ENTITYDEF}\\s*>"
+@@ -164,6 +165,7 @@ module REXML
+         @listeners = []
+         @prefixes = Set.new
+         @entity_expansion_count = 0
++	@version = nil
+       end
+ 
+       def add_listener( listener )
+@@ -277,7 +279,7 @@ module REXML
+               return [ :comment, md[1] ]
+             elsif @source.match("DOCTYPE", true)
+               base_error_message = "Malformed DOCTYPE"
+-              unless @source.match(/\s+/um, true)
++	      unless @source.skip_spaces
+                 if @source.match(">")
+                   message = "#{base_error_message}: name is missing"
+                 else
+@@ -287,6 +289,7 @@ module REXML
+                 raise REXML::ParseException.new(message, @source)
+               end
+               name = parse_name(base_error_message)
++	      @source.skip_spaces
+               if @source.match(/\s*\[/um, true)
+                 id = [nil, nil, nil]
+                 @document_status = :in_doctype
+@@ -302,6 +305,7 @@ module REXML
+                   # For backward compatibility
+                   id[1], id[2] = id[2], nil
+                 end
++		@source.skip_spaces
+                 if @source.match(/\s*\[/um, true)
+                   @document_status = :in_doctype
+                 elsif @source.match(/\s*>/um, true)
+@@ -314,7 +318,7 @@ module REXML
+               end
+               args = [:start_doctype, name, *id]
+               if @document_status == :after_doctype
+-                @source.match(/\s*/um, true)
++		@source.skip_spaces
+                 @stack << [ :end_doctype ]
+               end
+               return args
+@@ -325,8 +329,8 @@ module REXML
+           end
+         end
+         if @document_status == :in_doctype
+-          @source.match(/\s*/um, true) # skip spaces
+-          start_position = @source.position
++          @source.skip_spaces
++	  start_position = @source.position
+           if @source.match("<!", true)
+             if @source.match("ELEMENT", true)
+               md = @source.match(/(.*?)>/um, true)
+@@ -386,7 +390,7 @@ module REXML
+               return [ :attlistdecl, element, pairs, contents ]
+             elsif @source.match("NOTATION", true)
+               base_error_message = "Malformed notation declaration"
+-              unless @source.match(/\s+/um, true)
++	      unless @source.skip_spaces
+                 if @source.match(">")
+                   message = "#{base_error_message}: name is missing"
+                 else
+@@ -399,6 +403,7 @@ module REXML
+               id = parse_id(base_error_message,
+                             accept_external_id: true,
+                             accept_public_id: true)
++	      @source.skip_spaces
+               unless @source.match(/\s*>/um, true)
+                 message = "#{base_error_message}: garbage before end >"
+                 raise REXML::ParseException.new(message, @source)
+@@ -422,7 +427,7 @@ module REXML
+           end
+         end
+         if @document_status == :after_doctype
+-          @source.match(/\s*/um, true)
++	  @source.skip_spaces
+         end
+         begin
+           start_position = @source.position
+@@ -642,6 +647,10 @@ module REXML
+         true
+       end
+ 
++      def normalize_xml_declaration_encoding(xml_declaration_encoding)
++        /\AUTF-16(?:BE|LE)\z/i.match?(xml_declaration_encoding) ? "UTF-16" : nil
++      end
++
+       def parse_name(base_error_message)
+         md = @source.match(Private::NAME_PATTERN, true)
+         unless md
+@@ -723,37 +732,103 @@ module REXML
+ 
+       def process_instruction
+         name = parse_name("Malformed XML: Invalid processing instruction node")
+-        if @source.match(/\s+/um, true)
+-          match_data = @source.match(/(.*?)\?>/um, true)
+-          unless match_data
+-            raise ParseException.new("Malformed XML: Unclosed processing instruction", @source)
+-          end
+-          content = match_data[1]
+-        else
+-          content = nil
+-          unless @source.match("?>", true)
+-            raise ParseException.new("Malformed XML: Unclosed processing instruction", @source)
++        if name == "xml"
++          xml_declaration
++        else # PITarget
++          if @source.skip_spaces # e.g. <?name content?>
++            start_position = @source.position
++            content = @source.read_until("?>")
++            unless content.chomp!("?>")
++              @source.position = start_position
++              raise ParseException.new("Malformed XML: Unclosed processing instruction: <#{name}>", @source)
++            end
++          else # e.g. <?name?>
++            content = nil
++            unless @source.match?("?>", true)
++              raise ParseException.new("Malformed XML: Unclosed processing instruction: <#{name}>", @source)
++            end
+           end
++          [:processing_instruction, name, content]
+         end
+-        if name == "xml"
+-          if @document_status
+-            raise ParseException.new("Malformed XML: XML declaration is not at the start", @source)
++      end
++
++      def xml_declaration
++        unless @version.nil?
++          raise ParseException.new("Malformed XML: XML declaration is duplicated", @source)
++        end
++        if @document_status
++          raise ParseException.new("Malformed XML: XML declaration is not at the start", @source)
++        end
++        unless @source.skip_spaces
++          raise ParseException.new("Malformed XML: XML declaration misses spaces before version", @source)
++        end
++        unless @source.match?("version", true)
++          raise ParseException.new("Malformed XML: XML declaration misses version", @source)
++        end
++        @version = parse_attribute_value_with_equal("xml")
++        unless @source.skip_space
++	  unless @source.match("?>", true)
++            raise ParseException.new("Malformed XML: Unclosed XML declaration", @source)
+           end
+-          version = VERSION.match(content)
+-          version = version[1] unless version.nil?
+-          encoding = ENCODING.match(content)
+-          encoding = encoding[1] unless encoding.nil?
+-          if need_source_encoding_update?(encoding)
+-            @source.encoding = encoding
++          encoding = normalize_xml_declaration_encoding(@source.encoding)
++          return [ :xmldecl, @version, encoding, nil ] # e.g. <?xml version="1.0"?>
++        end
++
++        if @source.match?("encoding", true)
++          encoding = parse_attribute_value_with_equal("xml")
++          unless @source.skip_spaces
++            unless @source.match?("?>", true)
++              raise ParseException.new("Malformed XML: Unclosed XML declaration", @source)
++            end
++            if need_source_encoding_update?(encoding)
++              @source.encoding = encoding
++            end
++            encoding ||= normalize_xml_declaration_encoding(@source.encoding)
++            return [ :xmldecl, @version, encoding, nil ] # e.g. <?xml version="1.1" encoding="UTF-8"?>
+           end
+-          if encoding.nil? and /\AUTF-16(?:BE|LE)\z/i =~ @source.encoding
+-            encoding = "UTF-16"
++        end
++
++        if @source.match?("standalone", true)
++          standalone = parse_attribute_value_with_equal("xml")
++          case standalone
++          when "yes", "no"
++          else
++            raise ParseException.new("Malformed XML: XML declaration standalone is not yes or no : <#{standalone}>", @source)
+           end
+-          standalone = STANDALONE.match(content)
+-          standalone = standalone[1] unless standalone.nil?
+-          return [ :xmldecl, version, encoding, standalone ]
+         end
+-        [:processing_instruction, name, content]
++        @source.skip_spaces
++        unless @source.match?("?>", true)
++          raise ParseException.new("Malformed XML: Unclosed XML declaration", @source)
++        end
++
++        if need_source_encoding_update?(encoding)
++          @source.encoding = encoding
++        end
++        encoding ||= normalize_xml_declaration_encoding(@source.encoding)
++
++        # e.g. <?xml version="1.0" ?>
++        #      <?xml version="1.1" encoding="UTF-8" ?>
++        #      <?xml version="1.1" standalone="yes"?>
++        #      <?xml version="1.1" encoding="UTF-8" standalone="yes" ?>
++        [ :xmldecl, @version, encoding, standalone ]
++      end
++      def parse_attribute_value_with_equal(name)
++        unless @source.match?(Private::EQUAL_PATTERN, true)
++          message = "Missing attribute equal: <#{name}>"
++          raise REXML::ParseException.new(message, @source)
++        end
++        unless quote = scan_quote
++          message = "Missing attribute value start quote: <#{name}>"
++          raise REXML::ParseException.new(message, @source)
++        end
++        start_position = @source.position
++        value = @source.read_until(quote)
++        unless value.chomp!(quote)
++          @source.position = start_position
++          message = "Missing attribute value end quote: <#{name}>: <#{quote}>"
++          raise REXML::ParseException.new(message, @source)
++        end
++        value
+       end
+ 
+       def parse_attributes(prefixes)
+@@ -770,24 +845,8 @@ module REXML
+             name = match[1]
+             prefix = match[2]
+             local_part = match[3]
+-
+-            unless @source.match(/\s*=\s*/um, true)
+-              message = "Missing attribute equal: <#{name}>"
+-              raise REXML::ParseException.new(message, @source)
+-            end
+-            unless match = @source.match(/(['"])/, true)
+-              message = "Missing attribute value start quote: <#{name}>"
+-              raise REXML::ParseException.new(message, @source)
+-            end
+-            quote = match[1]
+-            start_position = @source.position
+-            value = @source.read_until(quote)
+-            unless value.chomp!(quote)
+-              @source.position = start_position
+-              message = "Missing attribute value end quote: <#{name}>: <#{quote}>"
+-              raise REXML::ParseException.new(message, @source)
+-            end
+-            @source.match(/\s*/um, true)
++            value = parse_attribute_value_with_equal(name)
++            @source.skip_spaces
+             if prefix == "xmlns"
+               if local_part == "xml"
+                 if value != "http://www.w3.org/XML/1998/namespace"
+diff --git a/.bundle/gems/rexml-3.3.6/lib/rexml/source.rb b/.bundle/gems/rexml-3.3.6/lib/rexml/source.rb
+index ff887fc..3ef6600 100644
+--- a/.bundle/gems/rexml-3.3.6/lib/rexml/source.rb
++++ b/.bundle/gems/rexml-3.3.6/lib/rexml/source.rb
+@@ -55,9 +55,10 @@ module REXML
+     attr_reader :encoding
+ 
+     module Private
++      SPACES_PATTERN = /\s+/um
+       SCANNER_RESET_SIZE = 100000
+       PRE_DEFINED_TERM_PATTERNS = {}
+-      pre_defined_terms = ["'", '"', "<"]
++      pre_defined_terms = ["'", '"', "<", "]]>", "?>"]
+       pre_defined_terms.each do |term|
+         PRE_DEFINED_TERM_PATTERNS[term] = /#{Regexp.escape(term)}/
+       end
+@@ -124,6 +125,9 @@ module REXML
+         @scanner.check(pattern).nil? ? nil : @scanner
+       end
+     end
++    def skip_spaces
++      @scanner.skip(Private::SPACES_PATTERN) ? true : false
++    end
+ 
+     def position
+       @scanner.pos
+-- 
+2.45.4
+

--- a/SPECS/ruby/ruby.spec
+++ b/SPECS/ruby/ruby.spec
@@ -87,7 +87,7 @@ Name:           ruby
 # provides should be versioned according to the ruby version.
 # More info: https://stdgems.org/
 Version:        %{ruby_version}
-Release:        5%{?dist}
+Release:        6%{?dist}
 License:        (Ruby OR BSD) AND Public Domain AND MIT AND CC0 AND zlib AND UCD
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -112,6 +112,7 @@ Patch5:         CVE-2025-27220.patch
 Patch6:         CVE-2025-27221.patch
 Patch7:         CVE-2025-6442.patch
 Patch8:         CVE-2025-24294.patch
+Patch9:         CVE-2025-58767.patch
 BuildRequires:  openssl-devel
 # Pkgconfig(yaml-0.1) is needed to build the 'psych' gem.
 BuildRequires:  pkgconfig(yaml-0.1)
@@ -416,6 +417,9 @@ sudo -u test make test TESTS="-v"
 %{_rpmconfigdir}/rubygems.con
 
 %changelog
+* Thu Sep 25 2025 Ratiranjan Behera <v-ratbehera@microsoft.com> - 3.3.5-6
+- Patch CVE-2025-58767
+
 * Tue Jul 15 2025 BinduSri Adabala <v-badabala@microsoft.com> - 3.3.5-5
 - Patch CVE-2025-24294
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Patch ruby for CVE-2025-58767
Astrolabe Patch Reference: https://github.com/ruby/rexml/commit/5859bdeac792687eaf93d8e8f0b7e3c1e2ed5c23
Patch Modified: NO
- Some hunk failed, so applied them manually.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->

- new file:   SPECS/ruby/CVE-2025-58767.patch
- modified:   SPECS/ruby/ruby.spec


###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2025-58767

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
<img width="473" height="203" alt="image" src="https://github.com/user-attachments/assets/d58113a7-d0ed-48a0-839f-c771218057ec" />
