### PR TITLE
Upgrade gtk-vnc version to 1.5.0

### DIFF
--- a/SPECS-EXTENDED/gtk-vnc/0001-make-gtk-vnc-debug-work-with-new-glib.patch
+++ b/SPECS-EXTENDED/gtk-vnc/0001-make-gtk-vnc-debug-work-with-new-glib.patch
@@ -1,0 +1,67 @@
+From ad62a80a4a3b4861e680e17f8877ffdbe024fbda Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Daniel=20P=2E=20Berrang=C3=A9?= <berrange@redhat.com>
+Date: Wed, 19 Feb 2025 15:18:10 +0000
+Subject: [PATCH 1/2] make --gtk-vnc-debug work with new glib
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Glib 2.80 changed its logging impl so that G_MESSAGES_DEBUG is
+only ever read once, which makes it impossible for --gtk-vnc-debug
+to change in many cases.
+
+The only viable way to change logging at runtime is to register
+a custom handler and print to the console ourselves. This is what
+we probably should have done from the start.
+
+Signed-off-by: Daniel P. Berrangé <berrange@redhat.com>
+---
+ src/vncutil.c | 25 ++++++++++++++++++-------
+ 1 file changed, 18 insertions(+), 7 deletions(-)
+
+diff --git a/src/vncutil.c b/src/vncutil.c
+index b9ad611..ec14ff7 100644
+--- a/src/vncutil.c
++++ b/src/vncutil.c
+@@ -27,6 +27,15 @@
+ 
+ 
+ static gboolean debugFlag = FALSE;
++static guint debugHandler = 0;
++
++static void vnc_log_handler(
++    const gchar *log_domain G_GNUC_UNUSED,
++    GLogLevelFlags log_level G_GNUC_UNUSED,
++    const gchar *message,
++    gpointer user_data G_GNUC_UNUSED) {
++    g_printerr("%s\n", message);
++}
+ 
+ /**
+  * vnc_util_set_debug:
+@@ -38,13 +47,15 @@ static gboolean debugFlag = FALSE;
+ void vnc_util_set_debug(gboolean enabled)
+ {
+     if (enabled) {
+-        const gchar *doms = g_getenv("G_MESSAGES_DEBUG");
+-        if (!doms) {
+-            g_setenv("G_MESSAGES_DEBUG", G_LOG_DOMAIN, 1);
+-        } else if (!strstr(doms, G_LOG_DOMAIN)) {
+-            gchar *newdoms = g_strdup_printf("%s %s", doms, G_LOG_DOMAIN);
+-            g_setenv("G_MESSAGES_DEBUG", newdoms, 1);
+-            g_free(newdoms);
++        if (debugHandler == 0) {
++            debugHandler =
++                g_log_set_handler(G_LOG_DOMAIN,  G_LOG_LEVEL_DEBUG,
++                                  vnc_log_handler, NULL);
++        }
++    } else {
++        if (debugHandler != 0) {
++            g_log_remove_handler(G_LOG_DOMAIN, debugHandler);
++            debugHandler = 0;
+         }
+     }
+     debugFlag = enabled;
+-- 
+2.47.1
+

--- a/SPECS-EXTENDED/gtk-vnc/0002-Expand-log-message-to-include-log-domain-and-timesta.patch
+++ b/SPECS-EXTENDED/gtk-vnc/0002-Expand-log-message-to-include-log-domain-and-timesta.patch
@@ -1,0 +1,61 @@
+From 333032105927ab9ae53563f889a3edd9beba0704 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Daniel=20P=2E=20Berrang=C3=A9?= <berrange@redhat.com>
+Date: Wed, 19 Feb 2025 16:22:14 +0000
+Subject: [PATCH 2/2] Expand log message to include log domain and timestamp
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This helps correlate and distinguish logs from other components
+
+Signed-off-by: Daniel P. Berrangé <berrange@redhat.com>
+---
+ src/vncutil.c | 15 +++++++++++++--
+ 1 file changed, 13 insertions(+), 2 deletions(-)
+
+diff --git a/src/vncutil.c b/src/vncutil.c
+index ec14ff7..18fe41e 100644
+--- a/src/vncutil.c
++++ b/src/vncutil.c
+@@ -28,13 +28,21 @@
+ 
+ static gboolean debugFlag = FALSE;
+ static guint debugHandler = 0;
++static GTimeZone *debugTZ = NULL;
+ 
+ static void vnc_log_handler(
+-    const gchar *log_domain G_GNUC_UNUSED,
++    const gchar *log_domain,
+     GLogLevelFlags log_level G_GNUC_UNUSED,
+     const gchar *message,
+     gpointer user_data G_GNUC_UNUSED) {
+-    g_printerr("%s\n", message);
++    GDateTime *now = g_date_time_new_now(debugTZ);
++    gchar *nowstr = g_date_time_format(now, "%H:%M:%S");
++    g_printerr("%s: %s.%d: %s\n",
++               log_domain, nowstr,
++               g_date_time_get_microsecond(now)/1000,
++               message);
++    g_free(nowstr);
++    g_date_time_unref(now);
+ }
+ 
+ /**
+@@ -51,11 +59,14 @@ void vnc_util_set_debug(gboolean enabled)
+             debugHandler =
+                 g_log_set_handler(G_LOG_DOMAIN,  G_LOG_LEVEL_DEBUG,
+                                   vnc_log_handler, NULL);
++            debugTZ = g_time_zone_new_utc();
+         }
+     } else {
+         if (debugHandler != 0) {
+             g_log_remove_handler(G_LOG_DOMAIN, debugHandler);
+             debugHandler = 0;
++            g_time_zone_unref(debugTZ);
++            debugTZ = NULL;
+         }
+     }
+     debugFlag = enabled;
+-- 
+2.47.1
+

--- a/SPECS-EXTENDED/gtk-vnc/gtk-vnc.signatures.json
+++ b/SPECS-EXTENDED/gtk-vnc/gtk-vnc.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "gtk-vnc-1.3.0.tar.xz": "5faaa5823b8cbe8c0b0ba1e456c4e70c4b1ae6685c9fe81a4282d98cf00a211d"
+  "gtk-vnc-1.5.0.tar.xz": "c0beb4747528ad931da43acc567c6a0190f7fc624465571ed9ccece02c34dd23"
  }
 }

--- a/SPECS-EXTENDED/gtk-vnc/gtk-vnc.spec
+++ b/SPECS-EXTENDED/gtk-vnc/gtk-vnc.spec
@@ -1,24 +1,35 @@
 %global tls_priority "@LIBVIRT,SYSTEM"
-%global verdir 1.3
+%global verdir 1.5
 
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
 Summary: A GTK widget for VNC clients
 Name: gtk-vnc
-Version: 1.3.0
+Version: 1.5.0
 Release: 3%{?dist}
-License: LGPLv2+
+License: LGPL-2.1-or-later
 Source: https://download.gnome.org/sources/%{name}/%{verdir}/%{name}-%{version}.tar.xz
+Patch: 0001-make-gtk-vnc-debug-work-with-new-glib.patch
+Patch: 0002-Expand-log-message-to-include-log-domain-and-timesta.patch
 URL: https://gitlab.gnome.org/GNOME/gtk-vnc
 Requires: gvnc = %{version}-%{release}
+BuildRequires: gcc
 BuildRequires: python3-devel
-BuildRequires: gnutls-devel libgcrypt-devel cyrus-sasl-devel zlib-devel
+BuildRequires: gnutls-devel
+BuildRequires: gmp-devel
+BuildRequires: cyrus-sasl-devel
+BuildRequires: zlib-devel
 BuildRequires: gobject-introspection-devel
 BuildRequires: gtk3-devel
 BuildRequires: vala
 BuildRequires: pulseaudio-libs-devel
-BuildRequires: /usr/bin/pod2man
+BuildRequires: perl-podlators
 BuildRequires: meson
+BuildRequires: gi-docgen
+BuildRequires: python-markdown
+BuildRequires: python-markupsafe
+BuildRequires: python-typogrify
+BuildRequires: python-jinja2
 
 %description
 gtk-vnc is a VNC viewer widget for GTK. It is built using coroutines
@@ -97,7 +108,7 @@ allowing it to be completely asynchronous while remaining single threaded.
 Libraries, includes, etc. to compile with the gtk-vnc library
 
 %prep
-%autosetup -n gtk-vnc-%{version}
+%autosetup -n gtk-vnc-%{version} -p1
 
 %build
 %meson
@@ -115,6 +126,8 @@ chmod -x examples/*.pl examples/*.js examples/*.py
 %files -n gvnc -f %{name}.lang
 %{_libdir}/libgvnc-1.0.so.*
 %{_libdir}/girepository-1.0/GVnc-1.0.typelib
+%dir %{_datadir}/vala/
+%dir %{_datadir}/vala/vapi/
 %{_datadir}/vala/vapi/gvnc-1.0.deps
 %{_datadir}/vala/vapi/gvnc-1.0.vapi
 
@@ -124,6 +137,8 @@ chmod -x examples/*.pl examples/*.js examples/*.py
 %{_includedir}/gvnc-1.0/*.h
 %{_libdir}/pkgconfig/gvnc-1.0.pc
 %{_datadir}/gir-1.0/GVnc-1.0.gir
+%{_datadir}/doc/gvnc/
+%{_datadir}/doc/gvnc.toml
 
 %files -n gvncpulse -f %{name}.lang
 %{_libdir}/libgvncpulse-1.0.so.*
@@ -164,11 +179,52 @@ chmod -x examples/*.pl examples/*.js examples/*.py
 %{_includedir}/%{name}-2.0/*.h
 %{_libdir}/pkgconfig/%{name}-2.0.pc
 %{_datadir}/gir-1.0/GtkVnc-2.0.gir
+%{_datadir}/doc/gtk-vnc/
+%{_datadir}/doc/gtk-vnc.toml
 
 %changelog
-* Mon Mar 06 2023 Muhammad Falak R Wani <mwani@microsoft.com> - 1.3.0-3
-- Initial CBL-Mariner import from Fedora 36 (license: MIT).
-- License Verified
+* Mon Oct 06 2025 Aditya Singh <v-aditysing@microsoft.com> - 1.5.0-3
+- Initial Azure Linux import from Fedora 41 (license: MIT).
+- License Verified.
+
+* Wed Feb 19 2025 Daniel P. Berrangé <berrange@redhat.com> - 1.5.0-2
+- Fix --gtk-vnc-debug flag with new glib2
+
+* Fri Feb 07 2025 Daniel P. Berrangé <berrange@redhat.com> - 1.5.0-1
+- Update to 1.5.0 release
+
+* Fri Jan 17 2025 Fedora Release Engineering <releng@fedoraproject.org> - 1.4.0-4
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_42_Mass_Rebuild
+
+* Mon Jan 13 2025 Daniel P. Berrangé <berrange@redhat.com> - 1.4.0-3
+- Own vala dirs (rhbz#2305567)
+
+* Mon Jan  6 2025 Daniel P. Berrangé <berrange@redhat.com> - 1.4.0-1
+- Update to 1.4.0 release
+
+* Thu Jul 18 2024 Fedora Release Engineering <releng@fedoraproject.org> - 1.3.1-6
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_41_Mass_Rebuild
+
+* Wed Jan 24 2024 Fedora Release Engineering <releng@fedoraproject.org> - 1.3.1-5
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_40_Mass_Rebuild
+
+* Sat Jan 20 2024 Fedora Release Engineering <releng@fedoraproject.org> - 1.3.1-4
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_40_Mass_Rebuild
+
+* Thu Jul 20 2023 Fedora Release Engineering <releng@fedoraproject.org> - 1.3.1-3
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_39_Mass_Rebuild
+
+* Thu Jan 19 2023 Fedora Release Engineering <releng@fedoraproject.org> - 1.3.1-2
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_38_Mass_Rebuild
+
+* Mon Jan 16 2023 Yaakov Selkowitz <yselkowi@redhat.com> - 1.3.1-1
+- Update to 1.3.1 release
+
+* Mon Aug  8 2022 Daniel P. Berrangé <berrange@redhat.com> - 1.3.0-5
+- Pull in mingw sub-packages
+
+* Thu Jul 21 2022 Fedora Release Engineering <releng@fedoraproject.org> - 1.3.0-3
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_37_Mass_Rebuild
 
 * Thu Jan 20 2022 Fedora Release Engineering <releng@fedoraproject.org> - 1.3.0-2
 - Rebuilt for https://fedoraproject.org/wiki/Fedora_36_Mass_Rebuild

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -5100,8 +5100,8 @@
         "type": "other",
         "other": {
           "name": "gtk-vnc",
-          "version": "1.3.0",
-          "downloadUrl": "https://download.gnome.org/sources/gtk-vnc/1.3/gtk-vnc-1.3.0.tar.xz"
+          "version": "1.5.0",
+          "downloadUrl": "https://download.gnome.org/sources/gtk-vnc/1.5/gtk-vnc-1.5.0.tar.xz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Upgrade gtk-vnc version to 1.5.0

###### Build/Dependency Information <!-- REQUIRED -->
Please build the following packages with gtk-vnc:
"pulseaudio libasyncns orc speexdsp webrtc-audio-processing rtkit sbc fftw gstreamer1 gstreamer1-plugins-base cdparanoia graphene iso-codes libogg libtheora libvisual libvorbis python-smartypants python-typogrify gi-docgen"

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Modified: gtk-vnc.signatures.json
- Modified: cgmanifest.json
- Modified: gtk-vnc.spec
- New: 0001-make-gtk-vnc-debug-work-with-new-glib.patch
- New: 0002-Expand-log-message-to-include-log-domain-and-timesta.patch

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- N/A

###### Links to CVEs  <!-- optional -->
- N/A

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build
[gtk-vnc-1.5.0-3.azl3.src.rpm.log](https://github.com/user-attachments/files/22878026/gtk-vnc-1.5.0-3.azl3.src.rpm.log)

- Installation Screenshot:
<img width="1728" height="682" alt="image" src="https://github.com/user-attachments/assets/a4a22ad7-9c2e-44ce-b993-0b6aacc58872" />

- Uninstallation Screenshot:
<img width="1730" height="345" alt="image" src="https://github.com/user-attachments/assets/83565af6-a162-4270-8ba2-0512249e527c" />