### PR TITLE
[Medium] Patch qemu for CVE-2025-11234

### DIFF
--- a/SPECS/qemu/CVE-2025-11234.patch
+++ b/SPECS/qemu/CVE-2025-11234.patch
@@ -1,0 +1,222 @@
+From: Daniel P . Berrangé
+Subject: [PATCH v2 3/3] io: fix use after free in websocket handshake code
+Date: Fri, 3 Oct 2025 16:02:45 +0100
+
+If the QIOChannelWebsock object is freed while it is waiting to
+complete a handshake, a GSource is leaked. This can lead to the
+callback firing later on and triggering a use-after-free in the
+use of the channel. This was observed in the VNC server with the
+following trace from valgrind:
+
+==2523108== Invalid read of size 4
+==2523108==    at 0x4054A24: vnc_disconnect_start (vnc.c:1296)
+==2523108==    by 0x4054A24: vnc_client_error (vnc.c:1392)
+==2523108==    by 0x4068A09: vncws_handshake_done (vnc-ws.c:105)
+==2523108==    by 0x44863B4: qio_task_complete (task.c:197)
+==2523108==    by 0x448343D: qio_channel_websock_handshake_io
+(channel-websock.c:588)
+==2523108==    by 0x6EDB862: UnknownInlinedFun (gmain.c:3398)
+==2523108==    by 0x6EDB862: g_main_context_dispatch_unlocked.lto_priv.0
+(gmain.c:4249)
+==2523108==    by 0x6EDBAE4: g_main_context_dispatch (gmain.c:4237)
+==2523108==    by 0x45EC79F: glib_pollfds_poll (main-loop.c:287)
+==2523108==    by 0x45EC79F: os_host_main_loop_wait (main-loop.c:310)
+==2523108==    by 0x45EC79F: main_loop_wait (main-loop.c:589)
+==2523108==    by 0x423A56D: qemu_main_loop (runstate.c:835)
+==2523108==    by 0x454F300: qemu_default_main (main.c:37)
+==2523108==    by 0x73D6574: (below main) (libc_start_call_main.h:58)
+==2523108==  Address 0x57a6e0dc is 28 bytes inside a block of size 103,608
+free'd
+==2523108==    at 0x5F2FE43: free (vg_replace_malloc.c:989)
+==2523108==    by 0x6EDC444: g_free (gmem.c:208)
+==2523108==    by 0x4053F23: vnc_update_client (vnc.c:1153)
+==2523108==    by 0x4053F23: vnc_refresh (vnc.c:3225)
+==2523108==    by 0x4042881: dpy_refresh (console.c:880)
+==2523108==    by 0x4042881: gui_update (console.c:90)
+==2523108==    by 0x45EFA1B: timerlist_run_timers.part.0 (qemu-timer.c:562)
+==2523108==    by 0x45EFC8F: timerlist_run_timers (qemu-timer.c:495)
+==2523108==    by 0x45EFC8F: qemu_clock_run_timers (qemu-timer.c:576)
+==2523108==    by 0x45EFC8F: qemu_clock_run_all_timers (qemu-timer.c:663)
+==2523108==    by 0x45EC765: main_loop_wait (main-loop.c:600)
+==2523108==    by 0x423A56D: qemu_main_loop (runstate.c:835)
+==2523108==    by 0x454F300: qemu_default_main (main.c:37)
+==2523108==    by 0x73D6574: (below main) (libc_start_call_main.h:58)
+==2523108==  Block was alloc'd at
+==2523108==    at 0x5F343F3: calloc (vg_replace_malloc.c:1675)
+==2523108==    by 0x6EE2F81: g_malloc0 (gmem.c:133)
+==2523108==    by 0x4057DA3: vnc_connect (vnc.c:3245)
+==2523108==    by 0x448591B: qio_net_listener_channel_func (net-listener.c:54)
+==2523108==    by 0x6EDB862: UnknownInlinedFun (gmain.c:3398)
+==2523108==    by 0x6EDB862: g_main_context_dispatch_unlocked.lto_priv.0
+(gmain.c:4249)
+==2523108==    by 0x6EDBAE4: g_main_context_dispatch (gmain.c:4237)
+==2523108==    by 0x45EC79F: glib_pollfds_poll (main-loop.c:287)
+==2523108==    by 0x45EC79F: os_host_main_loop_wait (main-loop.c:310)
+==2523108==    by 0x45EC79F: main_loop_wait (main-loop.c:589)
+==2523108==    by 0x423A56D: qemu_main_loop (runstate.c:835)
+==2523108==    by 0x454F300: qemu_default_main (main.c:37)
+==2523108==    by 0x73D6574: (below main) (libc_start_call_main.h:58)
+==2523108==
+
+The above can be reproduced by launching QEMU with
+
+  $ qemu-system-x86_64 -vnc localhost:0,websocket=5700
+
+and then repeatedly running:
+
+  for i in {1..100}; do
+     (echo -n "GET / HTTP/1.1" && sleep 0.05) | nc -w 1 localhost 5700 &
+  done
+
+CVE-2025-11234
+Reported-by: Grant Millar | Cylo <rid@cylo.io>
+Signed-off-by: Daniel P. Berrangé <berrange@redhat.com>
+
+Upstream Patch Reference:
+1. https://lists.nongnu.org/archive/html/qemu-devel/2025-10/msg00784.html
+2. https://lists.nongnu.org/archive/html/qemu-devel/2025-10/msg00785.html
+3. https://lists.nongnu.org/archive/html/qemu-devel/2025-10/msg00786.html
+---
+ include/io/channel-websock.h |  3 ++-
+ io/channel-tls.c             |  5 +++++
+ io/channel-websock.c         | 33 ++++++++++++++++++++++++++-------
+ io/trace-events              |  1 +
+ 4 files changed, 34 insertions(+), 8 deletions(-)
+
+diff --git a/include/io/channel-websock.h b/include/io/channel-websock.h
+index e180827c5..6700cf894 100644
+--- a/include/io/channel-websock.h
++++ b/include/io/channel-websock.h
+@@ -61,7 +61,8 @@ struct QIOChannelWebsock {
+     size_t payload_remain;
+     size_t pong_remain;
+     QIOChannelWebsockMask mask;
+-    guint io_tag;
++    guint hs_io_tag; /* tracking handshake task */
++    guint io_tag; /* tracking watch task */
+     Error *io_err;
+     gboolean io_eof;
+     uint8_t opcode;
+diff --git a/io/channel-tls.c b/io/channel-tls.c
+index 34476e6b7..f5fca7567 100644
+--- a/io/channel-tls.c
++++ b/io/channel-tls.c
+@@ -252,6 +252,11 @@ static void qio_channel_tls_finalize(Object *obj)
+ {
+     QIOChannelTLS *ioc = QIO_CHANNEL_TLS(obj);
+ 
++    if (ioc->hs_ioc_tag) {
++        trace_qio_channel_tls_handshake_cancel(ioc);
++        g_clear_handle_id(&ioc->hs_ioc_tag, g_source_remove);
++    }
++
+     object_unref(OBJECT(ioc->master));
+     qcrypto_tls_session_free(ioc->session);
+ }
+diff --git a/io/channel-websock.c b/io/channel-websock.c
+index 70889bb54..4773e08e7 100644
+--- a/io/channel-websock.c
++++ b/io/channel-websock.c
+@@ -545,6 +545,7 @@ static gboolean qio_channel_websock_handshake_send(QIOChannel *ioc,
+         trace_qio_channel_websock_handshake_fail(ioc, error_get_pretty(err));
+         qio_task_set_error(task, err);
+         qio_task_complete(task);
++        wioc->hs_io_tag = 0;
+         return FALSE;
+     }
+ 
+@@ -560,6 +561,7 @@ static gboolean qio_channel_websock_handshake_send(QIOChannel *ioc,
+             trace_qio_channel_websock_handshake_complete(ioc);
+             qio_task_complete(task);
+         }
++        wioc->hs_io_tag = 0;
+         return FALSE;
+     }
+     trace_qio_channel_websock_handshake_pending(ioc, G_IO_OUT);
+@@ -586,6 +588,7 @@ static gboolean qio_channel_websock_handshake_io(QIOChannel *ioc,
+         trace_qio_channel_websock_handshake_fail(ioc, error_get_pretty(err));
+         qio_task_set_error(task, err);
+         qio_task_complete(task);
++        wioc->hs_io_tag = 0;
+         return FALSE;
+     }
+     if (ret == 0) {
+@@ -597,7 +600,7 @@ static gboolean qio_channel_websock_handshake_io(QIOChannel *ioc,
+     error_propagate(&wioc->io_err, err);
+ 
+     trace_qio_channel_websock_handshake_reply(ioc);
+-    qio_channel_add_watch(
++    wioc->hs_io_tag = qio_channel_add_watch(
+         wioc->master,
+         G_IO_OUT,
+         qio_channel_websock_handshake_send,
+@@ -906,11 +909,12 @@ void qio_channel_websock_handshake(QIOChannelWebsock *ioc,
+ 
+     trace_qio_channel_websock_handshake_start(ioc);
+     trace_qio_channel_websock_handshake_pending(ioc, G_IO_IN);
+-    qio_channel_add_watch(ioc->master,
+-                          G_IO_IN,
+-                          qio_channel_websock_handshake_io,
+-                          task,
+-                          NULL);
++    ioc->hs_io_tag = qio_channel_add_watch(
++        ioc->master,
++        G_IO_IN,
++        qio_channel_websock_handshake_io,
++        task,
++        NULL);
+ }
+ 
+ 
+@@ -921,13 +925,16 @@ static void qio_channel_websock_finalize(Object *obj)
+     buffer_free(&ioc->encinput);
+     buffer_free(&ioc->encoutput);
+     buffer_free(&ioc->rawinput);
+-    object_unref(OBJECT(ioc->master));
++    if (ioc->hs_io_tag) {
++        g_source_remove(ioc->hs_io_tag);
++    }
+     if (ioc->io_tag) {
+         g_source_remove(ioc->io_tag);
+     }
+     if (ioc->io_err) {
+         error_free(ioc->io_err);
+     }
++    object_unref(OBJECT(ioc->master));
+ }
+ 
+ 
+@@ -1216,6 +1223,18 @@ static int qio_channel_websock_close(QIOChannel *ioc,
+     QIOChannelWebsock *wioc = QIO_CHANNEL_WEBSOCK(ioc);
+ 
+     trace_qio_channel_websock_close(ioc);
++    buffer_free(&wioc->encinput);
++    buffer_free(&wioc->encoutput);
++    buffer_free(&wioc->rawinput);
++    if (wioc->hs_io_tag) {
++        g_clear_handle_id(&wioc->hs_io_tag, g_source_remove);
++    }
++    if (wioc->io_tag) {
++        g_clear_handle_id(&wioc->io_tag, g_source_remove);
++    }
++    if (wioc->io_err) {
++        g_clear_pointer(&wioc->io_err, error_free);
++    }
+     return qio_channel_close(wioc->master, errp);
+ }
+ 
+diff --git a/io/trace-events b/io/trace-events
+index c5e814eb4..916ad2932 100644
+--- a/io/trace-events
++++ b/io/trace-events
+@@ -40,6 +40,7 @@ qio_channel_tls_handshake_start(void *ioc) "TLS handshake start ioc=%p"
+ qio_channel_tls_handshake_pending(void *ioc, int status) "TLS handshake pending ioc=%p status=%d"
+ qio_channel_tls_handshake_fail(void *ioc) "TLS handshake fail ioc=%p"
+ qio_channel_tls_handshake_complete(void *ioc) "TLS handshake complete ioc=%p"
++qio_channel_tls_handshake_cancel(void *ioc) "TLS handshake cancel ioc=%p"
+ qio_channel_tls_credentials_allow(void *ioc) "TLS credentials allow ioc=%p"
+ qio_channel_tls_credentials_deny(void *ioc) "TLS credentials deny ioc=%p"
+ 
+-- 
+2.45.4
+

--- a/SPECS/qemu/qemu.spec
+++ b/SPECS/qemu/qemu.spec
@@ -217,7 +217,7 @@ Obsoletes: %{name}-system-unicore32-core <= %{version}-%{release}
 Summary:        QEMU is a FAST! processor emulator
 Name:           qemu
 Version:        6.2.0
-Release:        24%{?dist}
+Release:        25%{?dist}
 License:        BSD AND CC-BY AND GPLv2+ AND LGPLv2+ AND MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -298,6 +298,7 @@ Patch1026:      CVE-2023-3301.patch
 Patch1027:      CVE-2024-3447.patch
 Patch1028:      CVE-2024-4467.patch
 Patch1029:      CVE-2024-6505.patch
+Patch1030:      CVE-2025-11234.patch
 
 # alsa audio output
 BuildRequires:  alsa-lib-devel
@@ -2332,6 +2333,9 @@ useradd -r -u 107 -g qemu -G kvm -d / -s %{_sbindir}/nologin \
 
 
 %changelog
+* Thu Oct 09 2025 Ratiranjan Behera <v-ratbehera@microsoft.com> - 6.2.0-25
+- Add patch for CVE-2025-11234
+
 * Thu Apr 24 2025 Kshitiz Godara <kgodara@microsoft.com> - 6.2.0-24
 - Add patch for CVE-2024-3447
 - Add patch for CVE-2024-4467


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
[Medium] Patch qemu for CVE-2025-11234
Astrolabe Patch Reference: https://lists.nongnu.org/archive/html/qemu-devel/2025-10/msg00786.html

for qemu-6.2.0 
- The upstream patch has been manually backported.
- Certain code segments were removed from "io/channel-tls.c" because the field "ioc->bye_ioc_tag" does not exist in qemu 6.2.0.
- Additionally, "trace_qio_channel_tls_handshake_cancel" was added to the "io/trace-events" file to maintain completeness.

Upstream Patch Reference:
1. https://lists.nongnu.org/archive/html/qemu-devel/2025-10/msg00784.html
2. https://lists.nongnu.org/archive/html/qemu-devel/2025-10/msg00785.html
3. https://lists.nongnu.org/archive/html/qemu-devel/2025-10/msg00786.html

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Modified file: qemu.spec
- New file: CVE-2025-11234.patch

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2025-11234

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
Build log:
[qemu-6.2.0-25.cm2.src.rpm.log](https://github.com/user-attachments/files/22902736/qemu-6.2.0-25.cm2.src.rpm.log)

- Patch applied cleanly.
<img width="479" height="227" alt="SS 2025-10-14-Qemu-patch" src="https://github.com/user-attachments/assets/ea305856-1831-4d4d-a5fe-70582f336b68" />
