### PR TITLE
Fix podman conmon dependency

### DIFF
--- a/SPECS-EXTENDED/podman/podman.spec
+++ b/SPECS-EXTENDED/podman/podman.spec
@@ -31,7 +31,7 @@ Epoch: 0
 # If you're reading this on dist-git, the version is automatically filled in by Packit.
 Version: 5.6.1
 License: Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0
-Release: 3%{?dist}
+Release: 4%{?dist}
 ExclusiveArch: aarch64 ppc64le s390x x86_64 riscv64
 Summary: Manage Pods, Containers and Container Images
 Vendor:         Microsoft Corporation
@@ -68,7 +68,7 @@ BuildRequires: ostree-devel
 BuildRequires: systemd
 BuildRequires: systemd-devel
 Requires: catatonit
-Requires: conmon >= 2:2.1.7-2
+Requires: conmon >= 2.1.7-2
 Requires: libcontainers-common
 Provides: %{name}-quadlet = %{epoch}:%{version}-%{release}
 
@@ -295,6 +295,9 @@ make localunit
 
 # rhcontainerbot account currently managed by lsm5
 %changelog
+* Thu Oct 30 2025 Amber Brown <ambrown@redhat.com> - 0:5.6.1-4
+- Remove incorrect epoch for conmon dependency
+
 * Thu Oct 23 2025 Kanishk Bansal <kanbansal@microsoft.com> - 0:5.6.1-3
 - Bump to rebuild with updated glibc
 


### PR DESCRIPTION

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [X] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
Fixes the podman dependency on conmon with an epoch of 2, which does not exist.

Blocker for https://github.com/Azure/ARO-RP/pull/4421 (ARO moving to Azure Linux 3)

###### Change Log  <!-- REQUIRED -->
- Podman: updates conmon dependency to remove the epoch

###### Does this affect the toolchain?  <!-- REQUIRED -->
No

###### Associated issues  <!-- optional -->

Blocker for ARO-RP moving to Azure Linux 3: https://github.com/Azure/ARO-RP/pull/4421
Also https://github.com/microsoft/azurelinux/issues/14117

###### Test Methodology
Will likely need a pipeline build