### PR TITLE
BUG 59454970: Make kexec-tools do not depend on ethtool only, enable user to choose either ethtool or mlnx-ethtool during installation, default is ethtool.

### DIFF
--- a/SPECS/ethtool/ethtool.spec
+++ b/SPECS/ethtool/ethtool.spec
@@ -1,7 +1,7 @@
 Summary:	    Standard Linux utility for controlling network drivers and hardware
 Name:		    ethtool
 Version:        6.4
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:	    GPLv2
 URL:		    https://www.kernel.org/pub/software/network/ethtool/
 Group:		    Productivity/Networking/Diagnostic
@@ -10,6 +10,9 @@ Distribution:   Azure Linux
 Source0:	    https://www.kernel.org/pub/software/network/%{name}/%{name}-%{version}.tar.xz
 
 BuildRequires: libmnl-devel
+
+# To avoid file conflicts
+Conflicts:      mlnx-ethtool
 
 %description
 ethtool is the standard Linux utility for controlling network drivers and hardware,
@@ -38,6 +41,13 @@ make %{?_smp_mflags} check
 %{_datadir}/bash-completion/completions/ethtool
 
 %changelog
+* Tue Nov 11 2025 Mayank Singh <mayansingh@microsoft.com> - 6.4-3
+- Updated dependency handling for kexec-tools:
+  Changed from hard dependency on a single package.
+  Allows installation to satisfy dependency with either `ethtool` or `mlnx-ethtool`.
+  Ensures flexibility for image builds and user choice at install time.
+  Added mutual exclusivity between providers to prevent file conflicts.
+
 * Thu May 16 2024 Daniel McIlvaney <damcilva@microsoft.com> - 6.4-2
 - Sanitize license files
 

--- a/SPECS/kexec-tools/kexec-tools.spec
+++ b/SPECS/kexec-tools/kexec-tools.spec
@@ -6,7 +6,7 @@
 Summary:        The kexec/kdump userspace component
 Name:           kexec-tools
 Version:        2.0.27
-Release:        7%{?dist}
+Release:        8%{?dist}
 License:        GPLv2
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -59,7 +59,8 @@ Requires(preun): systemd
 Requires(postun): systemd
 Requires(pre): coreutils sed zlib
 Requires: dracut
-Requires: ethtool
+Requires: (ethtool or mlnx-ethtool)
+Recommends: ethtool
 Requires: awk
 Requires: squashfs-tools
 %{?grub2_configuration_requires}
@@ -251,7 +252,6 @@ then
 	mv /etc/sysconfig/kdump.new /etc/sysconfig/kdump
 fi
 
-
 %postun
 %systemd_postun_with_restart kdump.service
 %grub2_postun
@@ -330,6 +330,13 @@ done
 /usr/share/makedumpfile/
 
 %changelog
+* Tue Nov 11 2025 Mayank Singh <mayansingh@microsoft.com> - 2.0.27-8
+- Updated dependency handling for kexec-tools:
+  Changed from hard dependency on a single package.
+  Allows installation to satisfy dependency with either `ethtool` or `mlnx-ethtool`.
+  Ensures flexibility for image builds and user choice at install time.
+  Added mutual exclusivity between providers to prevent file conflicts.
+
 * Tue Jul 09 2024 Chris Co <chrco@microsoft.com> - 2.0.27-7
 - Remove requires on dhcp-client
 

--- a/SPECS/mlnx-ethtool/mlnx-ethtool.spec
+++ b/SPECS/mlnx-ethtool/mlnx-ethtool.spec
@@ -1,6 +1,6 @@
 Name:		 mlnx-ethtool
 Version:	 6.9
-Release:	 3%{?dist}
+Release:	 4%{?dist}
 Group:		 Utilities
 Summary:	 Settings tool for Ethernet and other network devices
 License:	 GPLv2
@@ -11,6 +11,10 @@ Buildroot:	 /var/tmp/%{name}-%{version}-build
 Source0:         https://linux.mellanox.com/public/repo/mlnx_ofed/24.10-0.7.0.0/SRPMS/mlnx-ethtool-6.9.tar.gz#/%{name}-%{version}.tar.gz
 
 BuildRequires:  libmnl-devel
+
+Provides:       ethtool
+# To avoid file conflicts
+Conflicts:      ethtool
 
 %description
 This utility allows querying and changing settings such as speed,
@@ -40,6 +44,13 @@ make install DESTDIR=${RPM_BUILD_ROOT}
 
 
 %changelog
+* Tue Nov 11 2025 Mayank Singh <mayansingh@microsoft.com> - 6.9-4
+- Updated dependency handling for kexec-tools:
+  Changed from hard dependency on a single package.
+  Allows installation to satisfy dependency with either `ethtool` or `mlnx-ethtool`.
+  Ensures flexibility for image builds and user choice at install time.
+  Added mutual exclusivity between providers to prevent file conflicts.
+
 * Mon Sep 15 2025 Elaheh Dehghani <edehghani@microsoft.com> - 6.9-3
 - Enable ARM64 build by removing ExclusiveArch
 * Tue Dec  17 2024 Binu Jose Philip <bphilip@microsoft.com> - 6.9-2


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Make kexec-tools do not depend on ethtool only, enable user to choose either ethtool or mlnx-ethtool during installation, default is ethtool.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Make kexec-tools do not depend on ethtool only, enable user to choose either ethtool or mlnx-ethtool during installation, default is ethtool.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://microsoft.visualstudio.com/OS/_workitems/edit/59454970

###### Links to CVEs  <!-- optional -->
- 

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=990020&view=results
Have verified locally by installing ->
-> kexec-tools with mlnx-ethtool 
<img width="808" height="637" alt="mlnx-ethtool_with_kexec-tools" src="https://github.com/user-attachments/assets/cfe412d0-e876-465c-8c07-7f2a4178ccb0" />

-> kexec-tools with ethtool
<img width="643" height="436" alt="ethtool_with_kexec-tools" src="https://github.com/user-attachments/assets/14df1d4c-4e48-4f1b-a598-8d1b432aec2a" />
