### PR TITLE
[Low] Patch atop for CVE-2025-31160

### DIFF
--- a/SPECS/atop/CVE-2025-31160.patch
+++ b/SPECS/atop/CVE-2025-31160.patch
@@ -1,0 +1,627 @@
+From ec8f3038497fcf493c6ff9c9f98f7a7c6216a1cb Mon Sep 17 00:00:00 2001
+From: Gerlof Langeveld <gerlof.langeveld@atoptool.nl>
+Date: Sat, 29 Mar 2025 18:56:44 +0100
+Subject: [PATCH] Fix security vulnerability CVE-2025-31160 (#334)
+
+Atop will not connect to the TCP port of 'atopgpud' daemon any more
+by default.  The flag -k can be used explicitly when 'atopgpud' is
+active. Also the code to parse the received strings is improved to
+avoid future issues with heap corruption.
+
+The flag -K has been implemented to connect to netatop/netatop-bpf.
+
+Upstream Patch reference: https://github.com/Atoptool/atop/commit/ec8f3038497fcf493c6ff9c9f98f7a7c6216a1cb.patch
+---
+ atop.c      |  60 +++++++-------
+ atop.h      |   1 +
+ gpucom.c    | 228 +++++++++++++++++++++++++++++++++++++---------------
+ photoproc.c |   3 +-
+ 4 files changed, 198 insertions(+), 94 deletions(-)
+
+diff --git a/atop.c b/atop.c
+index cd311ed..9ac5a7f 100644
+--- a/atop.c
++++ b/atop.c
+@@ -321,6 +321,8 @@ char      	usecolors  = 1;  /* boolean: colors for high occupation  */
+ char		threadview = 0;	 /* boolean: show individual threads     */
+ char      	calcpss    = 0;  /* boolean: read/calculate process PSS  */
+ char      	getwchan   = 0;  /* boolean: obtain wchan string         */
++char		connectgpud    = 0; /* boolean: connect to atopgpud      */
++char		connectnetatop = 0; /* boolean: connect to netatop(bpf)  */
+ 
+ unsigned short	hertz;
+ unsigned int	pagesize;
+@@ -594,6 +596,14 @@ main(int argc, char *argv[])
+ 				getwchan = 1;
+ 				break;
+ 
++                           case 'k':		/* try to open TCP connection to atopgpud */
++				connectgpud = 1;
++				break;
++
++                           case 'K':		/* try to open connection to netatop/netatop-bpf */
++				connectnetatop = 1;
++				break;
++
+ 			   default:		/* gather other flags */
+ 				flaglist[i++] = c;
+ 			}
+@@ -710,7 +720,8 @@ main(int argc, char *argv[])
+ 	/*
+  	** open socket to the IP layer to issue getsockopt() calls later on
+ 	*/
+-	netatop_ipopen();
++	if (connectnetatop)
++		netatop_ipopen();
+ 
+ 	/*
+ 	** since privileged activities are finished now, there is no
+@@ -813,11 +824,15 @@ engine(void)
+ 
+ 	/*
+  	** open socket to the atopgpud daemon for GPU statistics
++	** if explicitly required
+ 	*/
+-        nrgpus = gpud_init();
++	if (connectgpud)
++	{
++		nrgpus = gpud_init();
+ 
+-	if (nrgpus)
+-		supportflags |= GPUSTAT;
++		if (nrgpus)
++			supportflags |= GPUSTAT;
++	}
+ 
+ 	/*
+ 	** MAIN-LOOP:
+@@ -864,7 +879,10 @@ engine(void)
+ 		** send request for statistics to atopgpud 
+ 		*/
+ 		if (nrgpus)
+-			gpupending = gpud_statrequest();
++		{
++			if ((gpupending = gpud_statrequest()) == 0)
++				nrgpus = 0;
++		}
+ 
+ 		/*
+ 		** take a snapshot of the current system-level statistics 
+@@ -889,28 +907,8 @@ engine(void)
+ 			// connection lost or timeout on receive?
+ 			if (nrgpuproc == -1)
+ 			{
+-				int ng;
+-
+-				// try to reconnect
+-        			ng = gpud_init();
+-
+-				if (ng != nrgpus)	// no success
+-					nrgpus = 0;
+-
+-				if (nrgpus)
+-				{
+-					// request for stats again
+-					if (gpud_statrequest())
+-					{
+-						// receive stats response
+-						nrgpuproc = gpud_statresponse(nrgpus,
+-						     cursstat->gpu.gpu, &gp);
+-
+-						// persistent failure?
+-						if (nrgpuproc == -1)
+-							nrgpus = 0;
+-					}
+-				}
++				nrgpus = 0;
++				supportflags &= ~GPUSTAT;
+ 			}
+ 
+ 			cursstat->gpu.nrgpus = nrgpus;
+@@ -999,7 +997,7 @@ engine(void)
+ 		/*
+  		** merge GPU per-process stats with other per-process stats
+ 		*/
+-		if (nrgpus && nrgpuproc)
++		if (nrgpus && nrgpuproc > 0)
+ 			gpumergeproc(curtpres, ntaskpres,
+ 		                     curpexit, nprocexit,
+ 		 	             gp,       nrgpuproc);
+@@ -1030,8 +1028,8 @@ engine(void)
+ 		if (nprocexitnet > 0)
+ 			netatop_exiterase();
+ 
+-		if (gp)
+-			 free(gp);
++		free(gp);
++		gp = NULL;      // avoid double free
+ 
+ 		if (lastcmd == 'r')	/* reset requested ? */
+ 		{
+@@ -1073,6 +1071,8 @@ prusage(char *myname)
+ 	printf("\t  -P  generate parseable output for specified label(s)\n");
+ 	printf("\t  -L  alternate line length (default 80) in case of "
+ 			"non-screen output\n");
++	printf("\t  -k  try to connect to external atopgpud daemon (default: do not connect)\n");
++	printf("\t  -K  try to connect to netatop/netatop-bpf interface (default: do not connect)\n");
+ 
+ 	if (vis.show_usage)
+ 		(*vis.show_usage)();
+diff --git a/atop.h b/atop.h
+index a206226..8e34e03 100644
+--- a/atop.h
++++ b/atop.h
+@@ -83,6 +83,7 @@ extern char		calcpss;
+ extern char		getwchan;
+ extern char		rawname[];
+ extern char		rawreadflag;
++extern char             connectnetatop;
+ extern time_t		begintime, endtime, cursortime;	// epoch or time in day
+ extern char		flaglist[];
+ extern struct visualize vis;
+diff --git a/gpucom.c b/gpucom.c
+index 4834851..c153a5e 100644
+--- a/gpucom.c
++++ b/gpucom.c
+@@ -43,12 +43,12 @@
+ 
+ #define	GPUDPORT	59123
+ 
+-static void	gputype_parse(char *);
++static int	gputype_parse(char *);
+ 
+-static void	gpustat_parse(int, char *, int,
++static int 	gpustat_parse(int, char *, int,
+ 		                      struct pergpu *, struct gpupidstat *);
+-static void	gpuparse(int, char *, struct pergpu *);
+-static void	pidparse(int, char *, struct gpupidstat *);
++static int 	gpuparse(int, char *, struct pergpu *);
++static int 	pidparse(int, char *, struct gpupidstat *);
+ static int	rcvuntil(int, char *, int);
+ 
+ static int	actsock = -1;
+@@ -150,20 +150,24 @@ gpud_init(void)
+ 	if ( rcvuntil(actsock, buf, length) == -1)
+ 	{
+ 		perror("receive type request from atopgpud");
++		free(buf);
+ 		goto close_and_return;
+ 	}
+ 
+ 	buf[length] = '\0';
+ 
+-	gputype_parse(buf);
+-
+-        numgpus = numgpus <= MAXGPU ? numgpus : MAXGPU;
++	if (! gputype_parse(buf))
++	{
++		free(buf);
++		goto close_and_return;
++	}
+ 
+ 	return numgpus;
+ 
+     close_and_return:
+ 	close(actsock);
+ 	actsock = -1;
++	numgpus = 0;
+ 	return 0;
+ }
+ 
+@@ -176,7 +180,7 @@ gpud_init(void)
+ **
+ ** Return value:
+ ** 	0 in case of failure
+-** 	1 in case of success
++** 	1 in case of success (request pending)
+ */
+ int
+ gpud_statrequest(void)
+@@ -190,6 +194,7 @@ gpud_statrequest(void)
+ 	{
+ 		close(actsock);
+ 		actsock = -1;
++		numgpus = 0;
+ 		return 0;
+ 	}
+ 
+@@ -216,7 +221,7 @@ gpud_statresponse(int maxgpu, struct pergpu *ggs, struct gpupidstat **gps)
+ 	uint32_t	prelude;
+ 	char		*buf = NULL, *p;
+ 	int		version, length;
+-	int		pids = 0;
++	int		maxprocs = 0, nrprocs;
+ 
+ 	if (actsock == -1)
+ 		return -1;
+@@ -269,22 +274,22 @@ gpud_statresponse(int maxgpu, struct pergpu *ggs, struct gpupidstat **gps)
+ 	*(buf+length) = '\0';
+ 
+ 	/*
+-	** determine number of per-process stats
+-	** and malloc space to parse these stats
++	** determine number of per-process stats in string
++	** and malloc space to store these stats
+ 	*/
+ 	for (p=buf; *p; p++)
+ 	{
+ 		if (*p == PIDDELIM)
+-			pids++;
++			maxprocs++;
+ 	}
+ 
+ 	if (gps)
+ 	{
+-		if (pids)
++		if (maxprocs)
+ 		{
+-			*gps = malloc(pids * sizeof(struct gpupidstat));
+-			ptrverify(gps, "Malloc failed for gpu pidstats\n");
+-			memset(*gps, 0, pids * sizeof(struct gpupidstat));
++			*gps = malloc(maxprocs * sizeof(struct gpupidstat));
++			ptrverify(*gps, "Malloc failed for gpu pidstats\n");
++			memset(*gps, 0, maxprocs * sizeof(struct gpupidstat));
+ 		}
+ 		else
+ 		{
+@@ -295,18 +300,27 @@ gpud_statresponse(int maxgpu, struct pergpu *ggs, struct gpupidstat **gps)
+ 	/*
+ 	** parse stats string for per-gpu stats
+ 	*/
+-	gpustat_parse(version, buf, maxgpu, ggs, gps ? *gps : NULL);
++	if ( (nrprocs =  gpustat_parse(version, buf, maxgpu, ggs, gps ? *gps : NULL)) == -1)
++	{
++		if (gps)
++		{
++			free(*gps);
++			*gps = NULL;    // avoid double free later on
++		}
++
++		goto close_and_return; // inconsistent data received from atopgpud
++	}
+ 
+ 	free(buf);
+ 
+-	return pids;
++	return nrprocs;
+ 
+     close_and_return:
+-	if (buf)
+-		free(buf);
++	free(buf);
+ 
+ 	close(actsock);
+ 	actsock = -1;
++	numgpus = 0;
+ 	return -1;
+ }
+ 
+@@ -314,6 +328,9 @@ gpud_statresponse(int maxgpu, struct pergpu *ggs, struct gpupidstat **gps)
+ /*
+ ** Receive given number of bytes from given socket
+ ** into given buffer address
++**
++** Return value:  number of bytes received
++**                -1 - failed (including end-of-connection)
+ */
+ static int
+ rcvuntil(int sock, char *buf, int size)
+@@ -339,23 +356,27 @@ rcvuntil(int sock, char *buf, int size)
+ **
+ ** Store the type, busid and tasksupport of every GPU in
+ ** static pointer tables
++**
++** Return value:  1 - success
++**                0 - failed
+ */
+-static void
++static int
+ gputype_parse(char *buf)
+ {
+-	char	*p, *start, **bp, **tp, *cp;
++	char	*p, *start, **bp, **tp, *cp, fails=0;
+ 
+ 	/*
+ 	** determine number of GPUs
+ 	*/
+ 	if ( sscanf(buf, "%d@", &numgpus) != 1)
+-	{
+-		close(actsock);
+-		actsock = -1;
+-		return;
+-	}
++		return 0;
++
++        numgpus = numgpus <= MAXGPU ? numgpus : MAXGPU;
+ 
+-	for (p=buf; *p; p++)	// search for first delimiter
++	/*
++	** search for first GPU delimiter (@)
++	*/
++	for (p=buf; *p; p++)
+ 	{
+ 		if (*p == GPUDELIM)
+ 		{
+@@ -364,6 +385,9 @@ gputype_parse(char *buf)
+ 		}
+ 	}
+ 
++	if (*p == 0)	// no delimiter or no data behind delimeter?
++		return 0;
++
+ 	/*
+ 	** parse GPU info and build arrays of pointers to the
+ 	** busid strings, type strings and tasksupport strings.
+@@ -380,27 +404,47 @@ gputype_parse(char *buf)
+ 		ptrverify(gputypes, "Malloc failed for gpu types\n");
+ 		ptrverify(gputasks, "Malloc failed for gpu tasksup\n");
+ 
+-		for (field=0, start=p; ; p++)
++		for (field=0, start=p; fails == 0; p++)
+ 		{
+ 			if (*p == ' ' || *p == '\0' || *p == GPUDELIM)
+ 			{
+ 				switch(field)
+ 				{
+ 				   case 0:
++					if (bp - gpubusid >= numgpus)
++					{
++						fails++;
++						break; 	// inconsistent with number of GPUs
++					}
++
+ 					if (p-start <= MAXGPUBUS)
+ 						*bp++ = start;
+ 					else
+ 						*bp++ = p - MAXGPUBUS;
+ 					break;
+ 				   case 1:
++					if (tp - gputypes >= numgpus)
++					{
++						fails++;
++						break; 	// inconsistent with number of GPUs
++					}
++
+ 					if (p-start <= MAXGPUTYPE)
+ 						*tp++ = start;
+ 					else
+ 						*tp++ = p - MAXGPUTYPE;
+ 					break;
+ 				   case 2:
++					if (cp - gputasks >= numgpus)
++					{
++						fails++;
++						break; 	// inconsistent with number of GPUs
++					}
++
+ 					*cp++ = *start;
+ 					break;
++				   default:
++					fails++;
+ 				}
+ 
+ 				field++;
+@@ -418,7 +462,25 @@ gputype_parse(char *buf)
+ 
+ 		*bp = NULL;
+ 		*tp = NULL;
++
++		/*
++		** verify if number of GPUs and supplied per-GPU information
++		** appears to be inconsistent
++		*/
++		if (fails || bp - gpubusid != numgpus || tp - gputypes != numgpus || cp - gputasks != numgpus)
++		{
++			free(gpubusid);
++			free(gputypes);
++			free(gputasks);
++			return 0;
++		}
+ 	}
++	else
++	{
++		return 0;
++	}
++
++	return 1;
+ }
+ 
+ 
+@@ -429,106 +491,146 @@ gputype_parse(char *buf)
+ ** with a '@' delimiter.
+ ** Every series with counters on process level is introduced
+ ** with a '#' delimiter (last part of the GPU level data).
++**
++** Return value:  valid number of processes
++**                -1 - failed
+ */
+-static void
++static int
+ gpustat_parse(int version, char *buf, int maxgpu, 
+ 		struct pergpu *gg, struct gpupidstat *gp)
+ {
+-	char	*p, *start, delimlast;
+-	int	gpunum = 0;
++	char		*p, *pp, *start;
++	int		gpunum, nrprocs = 0;
+ 
+ 	/*
+ 	** parse stats string
+ 	*/
+-	for (p=start=buf, delimlast=DUMMY; gpunum <= maxgpu; p++)
++	for (p=buf; *p && *p != GPUDELIM; p++)	// find first GPU deimiter
++		; 
++
++	if (*p == 0)	// string without GPU delimiter
++		return -1;
++
++	for (p++, start=p, gpunum=0; gpunum < maxgpu; p++)
+ 	{
+-		char delimnow;
++		char delimnext;
+ 
+-		if (*p != '\0' && *p != GPUDELIM && *p != PIDDELIM)
++		// search next GPU delimiter
++		//
++		if (*p && *p != GPUDELIM)
+ 			continue;
+ 
+ 		/*
+-		** next delimiter or end-of-string found
++		** next GPU delimiter or end-of-string found
+ 		*/
+-		delimnow = *p;
+-		*p       = 0;
++		delimnext = *p;
++		*p        = 0;
+ 
+- 		switch (delimlast)
+-		{
+-		   case DUMMY:
+-			break;
+-
+-		   case GPUDELIM:
+-			gpuparse(version, start, gg);
+-
+-			strcpy(gg->type,  gputypes[gpunum]);
+-			strcpy(gg->busid, gpubusid[gpunum]);
++		/*
++		** parse GPU itself
++		*/
++		if (! gpuparse(version, start, gg))
++			return -1;
+ 
+-			gpunum++;
+-			gg++;
+-			break;
++               strncpy(gg->type,  gputypes[gpunum], MAXGPUTYPE);
++		strncpy(gg->busid, gpubusid[gpunum], MAXGPUBUS);
+ 
+-		   case PIDDELIM:
+-			if (gp)
++		/*
++		** continue searching for per-process stats for this GPU
++		*/
++		if (gp)
++		{
++			for (pp = start; pp < p; pp++)
+ 			{
+-				pidparse(version, start, gp);
++				if (*pp != PIDDELIM)
++					continue;
++
++				// new PID delimiter (#) found
++				//
++				if (! pidparse(version, pp+1, gp))
++					return -1;
+ 
+ 				gp->gpu.nrgpus++;
+-				gp->gpu.gpulist = 1<<(gpunum-1);
++				gp->gpu.gpulist = 1<<gpunum;
+ 				gp++;
+ 
+-				(gg-1)->nrprocs++;
++				gg->nrprocs++;	// per GPU
++				nrprocs++;	// total
+ 			}
+ 		}
+ 
+-		if (delimnow == 0 || *(p+1) == 0)
++		gpunum++;
++		gg++;
++
++		if (delimnext == 0 || *(p+1) == 0)
+ 			break;
+ 
+-		start     = p+1;
+-		delimlast = delimnow;
++		start = p+1;
+ 	}
++
++	return nrprocs;
+ }
+ 
+ 
+ /*
+ ** Parse GPU statistics string
++**
++** Return value:  1 - success
++**                0 - failed
+ */
+-static void
++static int
+ gpuparse(int version, char *p, struct pergpu *gg)
+ {
++	int nr;
++
+ 	switch (version)
+ 	{
+ 	   case 1:
+-		(void) sscanf(p, "%d %d %lld %lld %lld %lld %lld %lld", 
++		nr = sscanf(p, "%d %d %lld %lld %lld %lld %lld %lld",
+ 			&(gg->gpupercnow), &(gg->mempercnow),
+ 			&(gg->memtotnow),  &(gg->memusenow),
+ 			&(gg->samples),    &(gg->gpuperccum),
+ 			&(gg->memperccum), &(gg->memusecum));
+ 
++		if (nr < 8)	// parse error: unexpected data
++			return 0;
++
+ 		gg->nrprocs = 0;
+ 
+ 		break;
+ 	}
++
++	return 1;
+ }
+ 
+ 
+ /*
+ ** Parse PID statistics string
++**
++** Return value:  1 - success
++**                0 - failed
+ */
+-static void
++static int
+ pidparse(int version, char *p, struct gpupidstat *gp)
+ {
++	int nr;
++
+ 	switch (version)
+ 	{
+ 	   case 1:
+-		(void) sscanf(p, "%c %ld %d %d %lld %lld %lld %lld",
++		nr = sscanf(p, "%c %ld %d %d %lld %lld %lld %lld",
+ 			&(gp->gpu.state),   &(gp->pid),    
+ 			&(gp->gpu.gpubusy), &(gp->gpu.membusy),
+ 			&(gp->gpu.timems),
+ 			&(gp->gpu.memnow), &(gp->gpu.memcum),
+ 		        &(gp->gpu.sample));
++
++		if (nr < 8)	// parse error: unexpected data
++	 		return 0;
+ 		break;
+ 	}
++
++	return 1;
+ }
+ 
+ 
+diff --git a/photoproc.c b/photoproc.c
+index dc1c4ba..4e783bb 100644
+--- a/photoproc.c
++++ b/photoproc.c
+@@ -216,7 +216,8 @@ photoproc(struct tstat *tasklist, int maxtask)
+ 	*/
+ 	regainrootprivs();
+ 
+-	netatop_probe();
++	if (connectnetatop)
++		netatop_probe();
+ 
+ 	if (! droprootprivs())
+ 		mcleanstop(42, "failed to drop root privs\n");
+-- 
+2.45.4
+

--- a/SPECS/atop/atop.spec
+++ b/SPECS/atop/atop.spec
@@ -2,7 +2,7 @@
 Summary:        An advanced interactive monitor to view the load on system and process level
 Name:           atop
 Version:        2.6.0
-Release:        9%{?dist}
+Release:        10%{?dist}
 License:        GPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -13,6 +13,7 @@ Patch0:         nvme_support.patch
 Patch1:         atop-sysconfig.patch
 Patch2:         atop-2.3.0-newer-gcc.patch
 Patch3:         9cb119713b5e6be43671fe1856fb4bd49ff91fa7.patch
+Patch4:         CVE-2025-31160.patch
 BuildRequires:  gcc
 BuildRequires:  make
 BuildRequires:  ncurses-devel
@@ -45,6 +46,7 @@ http://www.atcomputing.nl/Tools/atop/kernpatch.html
 %patch1  -b .sysconfig
 %patch2 -p1 -b .newer-gcc
 %patch3 -p1 -b .service
+%patch4 -p1
 
 # Correct unit file path
 sed -i "s|%{_sysconfdir}/default/atop|%{_sysconfdir}/sysconfig/atop|g" atop.service
@@ -93,6 +95,9 @@ install -Dp -m 0644 atop-rotate.* %{buildroot}%{_unitdir}/
 %{_sbindir}/atopacctd
 
 %changelog
+* Mon 10 Nov 2025 Aditya Singh <v-aditysing@microsoft.com> - 2.6.0-10
+- Added Patch for CVE-2025-31160
+
 * Wed Sep 20 2023 Jon Slobodzian <joslobo@microsoft.com> - 2.6.0-9
 - Recompile with stack-protection fixed gcc version (CVE-2023-4039)
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Patch atop for CVE-2025-31160

- Upstream patch is backported manually.
- Part of patch has been removed from "phtoproc.c" file, as it is not present in our version of atop (2.6.0-9). 
   Same has been implemented in Debian fix for this CVE as well. Link of Debian fix for reference for this change:
   1. https://security-tracker.debian.org/tracker/CVE-2025-31160
   2. https://sources.debian.org/src/atop/2.8.1-1%2Bdeb12u1/photoproc.c   

Upstream Patch reference:
https://github.com/Atoptool/atop/commit/ec8f3038497fcf493c6ff9c9f98f7a7c6216a1cb

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- new file: SPECS/atop/CVE-2025-31160.patch
- modified: SPECS/atop/atop.spec

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2025-31160

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build was successful.
[atop-2.6.0-10.cm2.src.rpm.log](https://github.com/user-attachments/files/23453856/atop-2.6.0-10.cm2.src.rpm.log)

- Patch applies cleanly.
<img width="1127" height="288" alt="image" src="https://github.com/user-attachments/assets/d2790ee6-6a56-4b7d-bc18-a571d6b6ab51" />

- Installation Check
<img width="1742" height="495" alt="image" src="https://github.com/user-attachments/assets/96c8f879-61d6-4165-9a04-7ac8651f4ae6" />

-Uninstallation Check
<img width="1731" height="492" alt="image" src="https://github.com/user-attachments/assets/84486b0b-150e-4565-8310-546c6a1d391b" />