### PR TITLE
Reduce OSGuard OS disk size to 30 GB to align with AKS minimum requirement

### DIFF
--- a/toolkit/imageconfigs/osguard-amd64.yaml
+++ b/toolkit/imageconfigs/osguard-amd64.yaml
@@ -5,7 +5,7 @@ storage:
   bootType: efi
   disks:
   - partitionTableType: gpt
-    maxSize: 40G
+    maxSize: 30G
     partitions:
     - id: esp
       type: esp

--- a/toolkit/imageconfigs/osguard-ci-amd64.yaml
+++ b/toolkit/imageconfigs/osguard-ci-amd64.yaml
@@ -5,7 +5,7 @@ storage:
   bootType: efi
   disks:
   - partitionTableType: gpt
-    maxSize: 40G
+    maxSize: 30G
     partitions:
     - id: esp
       type: esp

--- a/toolkit/imageconfigs/templates/osguard-base.yaml
+++ b/toolkit/imageconfigs/templates/osguard-base.yaml
@@ -3,7 +3,7 @@ storage:
 
   disks:
     - partitionTableType: gpt
-      maxSize: 40G
+      maxSize: 30G
       partitions:
         - id: esp
           type: esp


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Reduce OSGuard OS disk size to 30 GB to match AKS requirements. Reference: https://learn.microsoft.com/en-us/azure/aks/use-multiple-node-pools. It mentions "You can also reduce the default size of the OS disk using --node-osdisk-size, but keep in mind the minimum size for AKS images is 30 GB." Without this change, some AKS E2E test scenarios would require increasing the default OS disk size beyond 40 GB. We’d also need to document this requirement for OSGuard.


###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Reduce OSGuard OS disk size to 30 GB


###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Issues
https://mariner-org.visualstudio.com/mariner/_workitems/edit/16554

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->

