### PR TITLE
[Medium] Patch kubernetes for CVE-2025-52881

### DIFF
--- a/SPECS/kubernetes/CVE-2025-52881.patch
+++ b/SPECS/kubernetes/CVE-2025-52881.patch
@@ -1,0 +1,67 @@
+From ff94f9991bd32076c871ef0ad8bc1b763458e480 Mon Sep 17 00:00:00 2001
+From: Aleksa Sarai <cyphar@cyphar.com>
+Date: Thu, 19 Jun 2025 10:19:41 +1000
+Subject: [PATCH] *: switch to safer securejoin.Reopen
+
+filepath-securejoin v0.3 gave us a much safer re-open primitive, we
+should use it to avoid any theoretical attacks. Rather than using it
+direcly, add a small pathrs wrapper to make libpathrs migrations in the
+future easier...
+
+Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>
+
+Upstream Patch Reference: https://github.com/opencontainers/runc/commit/ff94f9991bd32076c871ef0ad8bc1b763458e480.patch
+---
+ .../runc/libcontainer/standard_init_linux.go        | 13 ++++++++-----
+ 1 file changed, 8 insertions(+), 5 deletions(-)
+
+diff --git a/vendor/github.com/opencontainers/runc/libcontainer/standard_init_linux.go b/vendor/github.com/opencontainers/runc/libcontainer/standard_init_linux.go
+index 809dad5d..5ec1fe26 100644
+--- a/vendor/github.com/opencontainers/runc/libcontainer/standard_init_linux.go
++++ b/vendor/github.com/opencontainers/runc/libcontainer/standard_init_linux.go
+@@ -12,6 +12,7 @@ import (
+ 	"github.com/sirupsen/logrus"
+ 	"golang.org/x/sys/unix"
+ 
++	"github.com/opencontainers/runc/internal/pathrs"
+ 	"github.com/opencontainers/runc/libcontainer/apparmor"
+ 	"github.com/opencontainers/runc/libcontainer/configs"
+ 	"github.com/opencontainers/runc/libcontainer/keys"
+@@ -27,6 +28,7 @@ type linuxStandardInit struct {
+ 	fifoFd        int
+ 	logFd         int
+ 	mountFds      []int
++	fifoFile      *os.File
+ 	config        *initConfig
+ }
+ 
+@@ -234,13 +236,13 @@ func (l *linuxStandardInit) Init() error {
+ 	// user process. We open it through /proc/self/fd/$fd, because the fd that
+ 	// was given to us was an O_PATH fd to the fifo itself. Linux allows us to
+ 	// re-open an O_PATH fd through /proc.
+-	fifoPath := "/proc/self/fd/" + strconv.Itoa(l.fifoFd)
+-	fd, err := unix.Open(fifoPath, unix.O_WRONLY|unix.O_CLOEXEC, 0)
++	fifoFile, err := pathrs.Reopen(l.fifoFile, unix.O_WRONLY|unix.O_CLOEXEC)
+ 	if err != nil {
+-		return &os.PathError{Op: "open exec fifo", Path: fifoPath, Err: err}
++		return fmt.Errorf("reopen exec fifo: %w", err)
+ 	}
+-	if _, err := unix.Write(fd, []byte("0")); err != nil {
+-		return &os.PathError{Op: "write exec fifo", Path: fifoPath, Err: err}
++	defer fifoFile.Close()
++	if _, err := fifoFile.Write([]byte("0")); err != nil {
++		return &os.PathError{Op: "write exec fifo", Path: fifoFile.Name(), Err: err}
+ 	}
+ 
+ 	// Close the O_PATH fifofd fd before exec because the kernel resets
+@@ -249,6 +251,7 @@ func (l *linuxStandardInit) Init() error {
+ 	// N.B. the core issue itself (passing dirfds to the host filesystem) has
+ 	// since been resolved.
+ 	// https://github.com/torvalds/linux/blob/v4.9/fs/exec.c#L1290-L1318
++	_ = fifoFile.Close()
+ 	_ = unix.Close(l.fifoFd)
+ 
+ 	s := l.config.SpecState
+-- 
+2.45.4
+

--- a/SPECS/kubernetes/kubernetes.spec
+++ b/SPECS/kubernetes/kubernetes.spec
@@ -10,7 +10,7 @@
 Summary:        Microsoft Kubernetes
 Name:           kubernetes
 Version:        1.30.10
-Release:        17%{?dist}
+Release:        18%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -31,6 +31,7 @@ Patch9:         CVE-2025-31133.patch
 Patch10:        CVE-2025-52565.patch
 Patch11:        CVE-2025-13281.patch
 Patch12:        CVE-2025-65637.patch
+Patch13:        CVE-2025-52881.patch
 BuildRequires:  flex-devel
 BuildRequires:  glibc-static >= 2.38-16%{?dist}
 BuildRequires:  golang < 1.25
@@ -282,9 +283,11 @@ fi
 %{_exec_prefix}/local/bin/pause
 
 %changelog
+* Thu Dec 18 2025 Aditya Singh <v-aditysing@microsoft.com> - 1.30.10-18
+- Address CVE-2025-52881
+
 * Tue Dec 16 2025 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 1.30.10-17
 - Patch for CVE-2025-13281, CVE-2025-65637
-
 
 * Mon Dec 1 2025 Andrew Phelps <anphel@microsoft.com> - 1.30.10-16
 - Bump to rebuild with updated glibc


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Patch kubernetes for CVE-2025-52881

- Patch has been backported manually.
- "procfs_securejoin.go" file has not been added as the "Reopen()" is already declared in one of the go files which has been imported for CVE-2025-52565.
- Changes in "libcontainer/exeseal/cloned_binary_linux.go" file has not been included as this file does not exist in our version of kubernetes <1.30.10-16>
- "fifoFile" has been added to struct "linuxStandardInit" in "libcontainer/standard_init_linux.go" file for completeness.

- Upstream Patch Reference: https://github.com/opencontainers/runc/commit/ff94f9991bd32076c871ef0ad8bc1b763458e480.patch

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- new file: SPECS/kubernetes/CVE-2025-52881.patch
- modified: SPECS/kubernetes/kubernetes.spec

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #15167 
- #15192 

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2025-52881

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build was successful

- Build log:
[kubernetes-1.30.10-17.azl3.src.rpm.log](https://github.com/user-attachments/files/23925422/kubernetes-1.30.10-17.azl3.src.rpm.log)

- Patch applies cleanly:
<img width="1182" height="812" alt="image" src="https://github.com/user-attachments/assets/ec55b61a-7134-4852-9642-41799c8b69df" />
