### PR TITLE
Update bcc to add subpackage libbpf-tools

### DIFF
--- a/SPECS/bcc/bcc.spec
+++ b/SPECS/bcc/bcc.spec
@@ -155,6 +155,12 @@ find %{buildroot}%{_lib64dir} -name '*.a' -delete
 
 %files examples
 %{_datadir}/%{name}/examples/*
+%exclude %{_datadir}/%{name}/examples/*.pyc
+%exclude %{_datadir}/%{name}/examples/*.pyo
+%exclude %{_datadir}/%{name}/examples/*/*.pyc
+%exclude %{_datadir}/%{name}/examples/*/*.pyo
+%exclude %{_datadir}/%{name}/examples/*/*/*.pyc
+%exclude %{_datadir}/%{name}/examples/*/*/*.pyo
 
 %files tools
 %{_datadir}/%{name}/introspection/*


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Add new subpackage `libbpf-tools` to the `bcc` package. Resulting binaries are placed in `/usr/sbin/bpf-*` and contain  "bpf" as a prefix similar to other distros (Fedora, Alpine Linux)

There is a way to add the prefix at compile time but it is in versions `[v0.30.0](https://github.com/iovisor/bcc/releases/tag/v0.30.0)` https://github.com/iovisor/bcc/commit/3469bf1d94a6b8f5deb34586e6c8e4ffec8dd0be

Related LISA test: https://github.com/microsoft/lisa/pull/4161
Related Bug: https://microsoft.visualstudio.com/OS/_workitems/edit/60562791/

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add libbpf-tools to bcc

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- https://dev.azure.com/mariner-org/mariner/_build/results?buildId=1019402&view=results
- tested local build + install and was able to run binaries

```
$ sudo /usr/sbin/bpf-execsnoop
PCOMM            PID    PPID   RET ARGS
sh               1007071 698      0 /bin/sh -c -- ip route show dev eth0 | awk '/default/ {print $3 }' 
ip               1007072 1007071   0 /usr/sbin/ip route show dev eth0 
awk              1007073 1007071   0 /usr/bin/awk /default/ {print $3 } 
sh               1007074 698      0 /bin/sh -c -- ip -f inet6  route show dev eth0 | awk '/default/ {print $3 }' 
ip               1007075 1007074   0 /usr/sbin/ip -f inet6 route show dev eth0 
awk              1007076 1007074   0 /usr/bin/awk /default/ {print $3 } 
sh               1007077 698      0 /bin/sh -c -- /usr/libexec/hypervkvpd/hv_get_dns_info 
hv_get_dns_info  1007077 698      0 /usr/libexec/hypervkvpd/hv_get_dns_info 
cat              1007078 1007077   0 /usr/bin/cat /etc/resolv.conf 
awk              1007079 1007077   0 /usr/bin/awk /^nameserver/ { print $2 }
^C
$ sudo /usr/sbin/bpf-biolatency
Tracing block device I/O... Hit Ctrl-C to end.
^C

     usecs               : count    distribution
         0 -> 1          : 0        |                                        |
         2 -> 3          : 0        |                                        |
         4 -> 7          : 0        |                                        |
         8 -> 15         : 0        |                                        |
        16 -> 31         : 0        |                                        |
        32 -> 63         : 0        |                                        |
        64 -> 127        : 0        |                                        |
       128 -> 255        : 0        |                                        |
       256 -> 511        : 0        |                                        |
       512 -> 1023       : 11       |*                                       |
      1024 -> 2047       : 258      |****************************************|
      2048 -> 4095       : 121      |******************                      |
```
