### PR TITLE
[Medium] Patch cups for CVE-2025-58436 and CVE-2025-61915

### DIFF
--- a/SPECS/cups/CVE-2025-58436.patch
+++ b/SPECS/cups/CVE-2025-58436.patch
@@ -1,0 +1,579 @@
+From 5d414f1f91bdca118413301b148f0b188eb1cdc6 Mon Sep 17 00:00:00 2001
+From: Zdenek Dohnal <zdohnal@redhat.com>
+Date: Mon, 13 Oct 2025 10:16:48 +0200
+Subject: [PATCH] Fix unresponsive cupsd process caused by a slow client
+
+If client is very slow, it will slow cupsd process for other clients.
+The fix is the best effort without turning scheduler cupsd into
+multithreaded process which would be too complex and error-prone when
+backporting to 2.4.x series.
+
+The fix for unencrypted communication is to follow up on communication
+only if there is the whole line on input, and the waiting time is
+guarded by timeout.
+
+Encrypted communication now starts after we have the whole client hello
+packet, which conflicts with optional upgrade support to HTTPS via
+methods other than method OPTIONS, so this optional support defined in
+RFC 2817, section 3.1 is removed. Too slow or incomplete requests are
+handled by connection timeout.
+
+Fixes CVE-2025-58436
+Upstream-reference: https://github.com/OpenPrinting/cups/commit/5d414f1f91bdca118413301b148f0b188eb1cdc6.patch
+---
+ cups/http-private.h |   7 +-
+ cups/http.c         |  80 +++++++++++++-------
+ cups/tls-gnutls.c   |   4 +-
+ scheduler/client.c  | 177 ++++++++++++++++++++++++++++----------------
+ scheduler/client.h  |   3 +
+ scheduler/select.c  |  12 +++
+ 6 files changed, 189 insertions(+), 94 deletions(-)
+
+diff --git a/cups/http-private.h b/cups/http-private.h
+index 212fea7..c5d0b28 100644
+--- a/cups/http-private.h
++++ b/cups/http-private.h
+@@ -116,6 +116,7 @@ extern "C" {
+  * Constants...
+  */
+ 
++#  define _HTTP_MAX_BUFFER	32768	/* Size of read buffer */
+ #  define _HTTP_MAX_SBUFFER	65536	/* Size of (de)compression buffer */
+ #  define _HTTP_RESOLVE_DEFAULT	0	/* Just resolve with default options */
+ #  define _HTTP_RESOLVE_STDERR	1	/* Log resolve progress to stderr */
+@@ -227,8 +228,8 @@ struct _http_s				/**** HTTP connection structure ****/
+   http_encoding_t	data_encoding;	/* Chunked or not */
+   int			_data_remaining;/* Number of bytes left (deprecated) */
+   int			used;		/* Number of bytes used in buffer */
+-  char			buffer[HTTP_MAX_BUFFER];
+-					/* Buffer for incoming data */
++  char			_buffer[HTTP_MAX_BUFFER];
++					/* Old read buffer (deprecated) */
+   int			_auth_type;	/* Authentication in use (deprecated) */
+   unsigned char		_md5_state[88];	/* MD5 state (deprecated) */
+   char			nonce[HTTP_MAX_VALUE];
+@@ -302,6 +303,8 @@ struct _http_s				/**** HTTP connection structure ****/
+ 					/* Allocated field values */
+   			*default_fields[HTTP_FIELD_MAX];
+ 					/* Default field values, if any */
++  char			buffer[_HTTP_MAX_BUFFER];
++					/* Read buffer */
+ };
+ #  endif /* !_HTTP_NO_PRIVATE */
+ 
+diff --git a/cups/http.c b/cups/http.c
+index 8d69ce3..415c5d9 100644
+--- a/cups/http.c
++++ b/cups/http.c
+@@ -52,7 +52,7 @@ static http_t		*http_create(const char *host, int port,
+ static void		http_debug_hex(const char *prefix, const char *buffer,
+ 			               int bytes);
+ #endif /* DEBUG */
+-static ssize_t		http_read(http_t *http, char *buffer, size_t length);
++static ssize_t		http_read(http_t *http, char *buffer, size_t length, int timeout);
+ static ssize_t		http_read_buffered(http_t *http, char *buffer, size_t length);
+ static ssize_t		http_read_chunk(http_t *http, char *buffer, size_t length);
+ static int		http_send(http_t *http, http_state_t request,
+@@ -1175,7 +1175,7 @@ httpGets(char   *line,			/* I - Line to read into */
+         return (NULL);
+       }
+ 
+-      bytes = http_read(http, http->buffer + http->used, (size_t)(HTTP_MAX_BUFFER - http->used));
++      bytes = http_read(http, http->buffer + http->used, (size_t)(_HTTP_MAX_BUFFER - http->used), http->wait_value);
+ 
+       DEBUG_printf(("4httpGets: read " CUPS_LLFMT " bytes.", CUPS_LLCAST bytes));
+ 
+@@ -1693,24 +1693,13 @@ httpPeek(http_t *http,			/* I - HTTP connection */
+ 
+     ssize_t	buflen;			/* Length of read for buffer */
+ 
+-    if (!http->blocking)
+-    {
+-      while (!httpWait(http, http->wait_value))
+-      {
+-	if (http->timeout_cb && (*http->timeout_cb)(http, http->timeout_data))
+-	  continue;
+-
+-	return (0);
+-      }
+-    }
+-
+     if ((size_t)http->data_remaining > sizeof(http->buffer))
+       buflen = sizeof(http->buffer);
+     else
+       buflen = (ssize_t)http->data_remaining;
+ 
+     DEBUG_printf(("2httpPeek: Reading %d bytes into buffer.", (int)buflen));
+-    bytes = http_read(http, http->buffer, (size_t)buflen);
++    bytes = http_read(http, http->buffer, (size_t)buflen, http->wait_value);
+ 
+     DEBUG_printf(("2httpPeek: Read " CUPS_LLFMT " bytes into buffer.",
+                   CUPS_LLCAST bytes));
+@@ -1731,9 +1720,9 @@ httpPeek(http_t *http,			/* I - HTTP connection */
+     int		zerr;			/* Decompressor error */
+     z_stream	stream;			/* Copy of decompressor stream */
+ 
+-    if (http->used > 0 && ((z_stream *)http->stream)->avail_in < HTTP_MAX_BUFFER)
++    if (http->used > 0 && ((z_stream *)http->stream)->avail_in < _HTTP_MAX_BUFFER)
+     {
+-      size_t buflen = HTTP_MAX_BUFFER - ((z_stream *)http->stream)->avail_in;
++      size_t buflen = _HTTP_MAX_BUFFER - ((z_stream *)http->stream)->avail_in;
+ 					/* Number of bytes to copy */
+ 
+       if (((z_stream *)http->stream)->avail_in > 0 &&
+@@ -1991,7 +1980,7 @@ httpRead2(http_t *http,			/* I - HTTP connection */
+ 
+       if (bytes == 0)
+       {
+-        ssize_t buflen = HTTP_MAX_BUFFER - (ssize_t)((z_stream *)http->stream)->avail_in;
++        ssize_t buflen = _HTTP_MAX_BUFFER - (ssize_t)((z_stream *)http->stream)->avail_in;
+ 					/* Additional bytes for buffer */
+ 
+         if (buflen > 0)
+@@ -2740,7 +2729,7 @@ int					/* O - 1 to continue, 0 to stop */
+ _httpUpdate(http_t        *http,	/* I - HTTP connection */
+             http_status_t *status)	/* O - Current HTTP status */
+ {
+-  char		line[32768],		/* Line from connection... */
++  char		line[_HTTP_MAX_BUFFER],	/* Line from connection... */
+ 		*value;			/* Pointer to value on line */
+   http_field_t	field;			/* Field index */
+   int		major, minor;		/* HTTP version numbers */
+@@ -2748,12 +2737,46 @@ _httpUpdate(http_t        *http,	/* I - HTTP connection */
+ 
+   DEBUG_printf(("_httpUpdate(http=%p, status=%p), state=%s", (void *)http, (void *)status, httpStateString(http->state)));
+ 
++  /* When doing non-blocking I/O, make sure we have a whole line... */
++  if (!http->blocking)
++  {
++    ssize_t	bytes;			/* Bytes "peeked" from connection */
++
++    /* See whether our read buffer is full... */
++    DEBUG_printf(("2_httpUpdate: used=%d", http->used));
++
++    if (http->used > 0 && !memchr(http->buffer, '\n', (size_t)http->used) && (size_t)http->used < sizeof(http->buffer))
++    {
++      /* No, try filling in more data... */
++      if ((bytes = http_read(http, http->buffer + http->used, sizeof(http->buffer) - (size_t)http->used, /*timeout*/0)) > 0)
++      {
++	DEBUG_printf(("2_httpUpdate: Read %d bytes.", (int)bytes));
++	http->used += (int)bytes;
++      }
++    }
++
++    /* Peek at the incoming data... */
++    if (!http->used || !memchr(http->buffer, '\n', (size_t)http->used))
++    {
++      /* Don't have a full line, tell the reader to try again when there is more data... */
++      DEBUG_puts("1_htttpUpdate: No newline in buffer yet.");
++      if ((size_t)http->used == sizeof(http->buffer))
++	*status = HTTP_STATUS_ERROR;
++      else
++	*status = HTTP_STATUS_CONTINUE;
++      return (0);
++    }
++
++    DEBUG_puts("2_httpUpdate: Found newline in buffer.");
++  }
++
+  /*
+   * Grab a single line from the connection...
+   */
+ 
+   if (!httpGets(line, sizeof(line), http))
+   {
++    DEBUG_puts("1_httpUpdate: Error reading request line.");
+     *status = HTTP_STATUS_ERROR;
+     return (0);
+   }
+@@ -4074,7 +4097,8 @@ http_debug_hex(const char *prefix,	/* I - Prefix for line */
+ static ssize_t				/* O - Number of bytes read or -1 on error */
+ http_read(http_t *http,			/* I - HTTP connection */
+           char   *buffer,		/* I - Buffer */
+-          size_t length)		/* I - Maximum bytes to read */
++          size_t length,		/* I - Maximum bytes to read */
++          int    timeout)		/* I - Wait timeout */
+ {
+   ssize_t	bytes;			/* Bytes read */
+ 
+@@ -4083,7 +4107,7 @@ http_read(http_t *http,			/* I - HTTP connection */
+ 
+   if (!http->blocking || http->timeout_value > 0.0)
+   {
+-    while (!httpWait(http, http->wait_value))
++    while (!_httpWait(http, timeout, 1))
+     {
+       if (http->timeout_cb && (*http->timeout_cb)(http, http->timeout_data))
+ 	continue;
+@@ -4201,7 +4225,7 @@ http_read_buffered(http_t *http,	/* I - HTTP connection */
+     else
+       bytes = (ssize_t)length;
+ 
+-    DEBUG_printf(("2http_read: Grabbing %d bytes from input buffer.",
++    DEBUG_printf(("8http_read_buffered: Grabbing %d bytes from input buffer.",
+                   (int)bytes));
+ 
+     memcpy(buffer, http->buffer, (size_t)bytes);
+@@ -4211,7 +4235,7 @@ http_read_buffered(http_t *http,	/* I - HTTP connection */
+       memmove(http->buffer, http->buffer + bytes, (size_t)http->used);
+   }
+   else
+-    bytes = http_read(http, buffer, length);
++    bytes = http_read(http, buffer, length, http->wait_value);
+ 
+   return (bytes);
+ }
+@@ -4554,15 +4578,15 @@ http_set_timeout(int    fd,		/* I - File descriptor */
+ static void
+ http_set_wait(http_t *http)		/* I - HTTP connection */
+ {
+-  if (http->blocking)
+-  {
+-    http->wait_value = (int)(http->timeout_value * 1000);
++  http->wait_value = (int)(http->timeout_value * 1000);
+ 
+-    if (http->wait_value <= 0)
++  if (http->wait_value <= 0)
++  {
++    if (http->blocking)
+       http->wait_value = 60000;
++    else
++      http->wait_value = 1000;
+   }
+-  else
+-    http->wait_value = 10000;
+ }
+ 
+ 
+diff --git a/cups/tls-gnutls.c b/cups/tls-gnutls.c
+index 4850383..0bc6d62 100644
+--- a/cups/tls-gnutls.c
++++ b/cups/tls-gnutls.c
+@@ -1506,10 +1506,10 @@ _httpTLSStart(http_t *http)		/* I - Connection to server */
+ 
+       if (!cupsMakeServerCredentials(tls_keypath, hostname[0] ? hostname : tls_common_name, 0, NULL, time(NULL) + 365 * 86400))
+       {
+-	DEBUG_puts("4_httpTLSStart: cupsMakeServerCredentials failed.");
++	DEBUG_printf(("4_httpTLSStart: cupsMakeServerCredentials failed: %s", cupsLastErrorString()));
+ 	http->error  = errno = EINVAL;
+ 	http->status = HTTP_STATUS_ERROR;
+-	_cupsSetError(IPP_STATUS_ERROR_INTERNAL, _("Unable to create server credentials."), 1);
++//	_cupsSetError(IPP_STATUS_ERROR_INTERNAL, _("Unable to create server credentials."), 1);	
+ 
+ 	return (-1);
+       }
+diff --git a/scheduler/client.c b/scheduler/client.c
+index 80bc48f..b5c4c36 100644
+--- a/scheduler/client.c
++++ b/scheduler/client.c
+@@ -41,11 +41,11 @@
+ 
+ static int		check_if_modified(cupsd_client_t *con,
+ 			                  struct stat *filestats);
+-static int		compare_clients(cupsd_client_t *a, cupsd_client_t *b,
+-			                void *data);
+ #ifdef HAVE_SSL
+-static int		cupsd_start_tls(cupsd_client_t *con, http_encryption_t e);
++static int		check_start_tls(cupsd_client_t *con);
+ #endif /* HAVE_SSL */
++static int		compare_clients(cupsd_client_t *a, cupsd_client_t *b,
++			                void *data);
+ static char		*get_file(cupsd_client_t *con, struct stat *filestats,
+ 			          char *filename, size_t len);
+ static http_status_t	install_cupsd_conf(cupsd_client_t *con);
+@@ -420,14 +420,20 @@ cupsdAcceptClient(cupsd_listener_t *lis)/* I - Listener socket */
+   if (lis->encryption == HTTP_ENCRYPTION_ALWAYS)
+   {
+    /*
+-    * https connection; go secure...
++    * HTTPS connection, force TLS negotiation...
+     */
+ 
+-    if (cupsd_start_tls(con, HTTP_ENCRYPTION_ALWAYS))
+-      cupsdCloseClient(con);
++    con->tls_start = time(NULL);
++    con->encryption = HTTP_ENCRYPTION_ALWAYS;
+   }
+   else
++  {
++   /*
++    * HTTP connection, but check for HTTPS negotiation on first data...
++    */
++
+     con->auto_ssl = 1;
++  }
+ #endif /* HAVE_SSL */
+ }
+ 
+@@ -664,17 +670,46 @@ cupsdReadClient(cupsd_client_t *con)	/* I - Client to read from */
+ 
+     con->auto_ssl = 0;
+ 
+-    if (recv(httpGetFd(con->http), buf, 1, MSG_PEEK) == 1 &&
+-        (!buf[0] || !strchr("DGHOPT", buf[0])))
++    if (recv(httpGetFd(con->http), buf, 5, MSG_PEEK) == 5 && buf[0] == 0x16 && buf[1] == 3 && buf[2])
+     {
+      /*
+-      * Encrypt this connection...
++      * Client hello record, encrypt this connection...
+       */
+ 
+-      cupsdLogClient(con, CUPSD_LOG_DEBUG2, "Saw first byte %02X, auto-negotiating SSL/TLS session.", buf[0] & 255);
++      cupsdLogClient(con, CUPSD_LOG_DEBUG2, "Saw client hello record, auto-negotiating TLS session.");
++      con->tls_start = time(NULL);
++      con->encryption = HTTP_ENCRYPTION_ALWAYS;
++    }
++  }
+ 
+-      if (cupsd_start_tls(con, HTTP_ENCRYPTION_ALWAYS))
+-        cupsdCloseClient(con);
++  if (con->tls_start)
++  {
++   /*
++    * Try negotiating TLS...
++    */
++
++    int tls_status = check_start_tls(con);
++
++    if (tls_status < 0)
++    {
++     /*
++      * TLS negotiation failed, close the connection.
++      */
++
++      cupsdCloseClient(con);
++      return;
++    }
++    else if (tls_status == 0)
++    {
++     /*
++      * Nothing to do yet...
++      */
++
++      if ((time(NULL) - con->tls_start) > 5)
++      {
++	// Timeout, close the connection...
++	cupsdCloseClient(con);
++      }
+ 
+       return;
+     }
+@@ -838,9 +873,7 @@ cupsdReadClient(cupsd_client_t *con)	/* I - Client to read from */
+         * Parse incoming parameters until the status changes...
+ 	*/
+ 
+-        while ((status = httpUpdate(con->http)) == HTTP_STATUS_CONTINUE)
+-	  if (!httpGetReady(con->http))
+-	    break;
++	status = httpUpdate(con->http);
+ 
+ 	if (status != HTTP_STATUS_OK && status != HTTP_STATUS_CONTINUE)
+ 	{
+@@ -989,31 +1022,11 @@ cupsdReadClient(cupsd_client_t *con)	/* I - Client to read from */
+ 
+       if (!_cups_strcasecmp(httpGetField(con->http, HTTP_FIELD_CONNECTION), "Upgrade") && strstr(httpGetField(con->http, HTTP_FIELD_UPGRADE), "TLS/") != NULL && !httpIsEncrypted(con->http))
+       {
+-#ifdef HAVE_SSL
+-       /*
+-        * Do encryption stuff...
+-	*/
+-
+-        httpClearFields(con->http);
+-
+-	if (!cupsdSendHeader(con, HTTP_STATUS_SWITCHING_PROTOCOLS, NULL, CUPSD_AUTH_NONE))
+-	{
+-	  cupsdCloseClient(con);
+-	  return;
+-	}
+-
+-        if (cupsd_start_tls(con, HTTP_ENCRYPTION_REQUIRED))
+-        {
+-	  cupsdCloseClient(con);
+-	  return;
+-	}
+-#else
+ 	if (!cupsdSendError(con, HTTP_STATUS_NOT_IMPLEMENTED, CUPSD_AUTH_NONE))
+ 	{
+ 	  cupsdCloseClient(con);
+ 	  return;
+ 	}
+-#endif /* HAVE_SSL */
+       }
+ 
+       httpClearFields(con->http);
+@@ -1059,11 +1072,10 @@ cupsdReadClient(cupsd_client_t *con)	/* I - Client to read from */
+ 	  return;
+ 	}
+ 
+-        if (cupsd_start_tls(con, HTTP_ENCRYPTION_REQUIRED))
+-        {
+-	  cupsdCloseClient(con);
+-	  return;
+-	}
++        con->tls_start = time(NULL);
++	con->tls_upgrade = 1;
++	con->encryption = HTTP_ENCRYPTION_REQUIRED;
++	return;
+ #else
+ 	if (!cupsdSendError(con, HTTP_STATUS_NOT_IMPLEMENTED, CUPSD_AUTH_NONE))
+ 	{
+@@ -2769,6 +2781,69 @@ check_if_modified(
+ }
+ 
+ 
++#ifdef HAVE_SSL
++/*
++ * 'check_start_tls()' - Start encryption on a connection.
++ */
++
++static int				/* O - 0 to continue, 1 on success, -1 on error */
++check_start_tls(cupsd_client_t *con)	/* I - Client connection */
++{
++  unsigned char	chello[4096];		/* Client hello record */
++  ssize_t	chello_bytes;		/* Bytes read/peeked */
++  int		chello_len;		/* Length of record */
++
++
++ /*
++  * See if we have a good and complete client hello record...
++  */
++
++  if ((chello_bytes = recv(httpGetFd(con->http), (char *)chello, sizeof(chello), MSG_PEEK)) < 5)
++    return (0);				/* Not enough bytes (yet) */
++
++  if (chello[0] != 0x016 || chello[1] != 3 || chello[2] == 0)
++    return (-1);			/* Not a TLS Client Hello record */
++
++  chello_len = (chello[3] << 8) | chello[4];
++
++  if ((chello_len + 5) > chello_bytes)
++    return (0);				/* Not enough bytes yet */
++
++ /*
++  * OK, we do, try negotiating...
++  */
++
++  con->tls_start = 0;
++
++  if (httpEncryption(con->http, con->encryption))
++  {
++    cupsdLogClient(con, CUPSD_LOG_ERROR, "Unable to encrypt connection: %s", cupsLastErrorString());
++    return (-1);
++  }
++
++  cupsdLogClient(con, CUPSD_LOG_DEBUG, "Connection now encrypted.");
++
++  if (con->tls_upgrade)
++  {
++    // Respond to the original OPTIONS command...
++    con->tls_upgrade = 0;
++
++    httpClearFields(con->http);
++    httpClearCookie(con->http);
++    httpSetField(con->http, HTTP_FIELD_CONTENT_LENGTH, "0");
++
++    if (!cupsdSendHeader(con, HTTP_STATUS_OK, NULL, CUPSD_AUTH_NONE))
++    {
++      cupsdCloseClient(con);
++      return (-1);
++    }
++  }
++
++  return (1);
++}
++#endif /* HAVE_SSL */
++
++
+ /*
+  * 'compare_clients()' - Compare two client connections.
+  */
+@@ -2789,28 +2864,6 @@ compare_clients(cupsd_client_t *a,	/* I - First client */
+ }
+ 
+ 
+-#ifdef HAVE_SSL
+-/*
+- * 'cupsd_start_tls()' - Start encryption on a connection.
+- */
+-
+-static int				/* O - 0 on success, -1 on error */
+-cupsd_start_tls(cupsd_client_t    *con,	/* I - Client connection */
+-                http_encryption_t e)	/* I - Encryption mode */
+-{
+-  if (httpEncryption(con->http, e))
+-  {
+-    cupsdLogClient(con, CUPSD_LOG_ERROR, "Unable to encrypt connection: %s",
+-                   cupsLastErrorString());
+-    return (-1);
+-  }
+-
+-  cupsdLogClient(con, CUPSD_LOG_DEBUG, "Connection now encrypted.");
+-  return (0);
+-}
+-#endif /* HAVE_SSL */
+-
+-
+ /*
+  * 'get_file()' - Get a filename and state info.
+  */
+diff --git a/scheduler/client.h b/scheduler/client.h
+index ddf58db..552631e 100644
+--- a/scheduler/client.h
++++ b/scheduler/client.h
+@@ -57,6 +57,9 @@ struct cupsd_client_s
+   cups_lang_t		*language;	/* Language to use */
+ #ifdef HAVE_SSL
+   int			auto_ssl;	/* Automatic test for SSL/TLS */
++  time_t		tls_start;	/* Do TLS negotiation? */
++  int			tls_upgrade;	/* Doing TLS upgrade via OPTIONS? */
++  http_encryption_t	encryption;	/* Type of TLS negotiation */
+ #endif /* HAVE_SSL */
+   http_addr_t		clientaddr;	/* Client's server address */
+   char			clientname[256];/* Client's server name for connection */
+diff --git a/scheduler/select.c b/scheduler/select.c
+index 06079c3..d01f3fa 100644
+--- a/scheduler/select.c
++++ b/scheduler/select.c
+@@ -408,6 +408,9 @@ cupsdDoSelect(long timeout)		/* I - Timeout in seconds */
+ 
+   cupsd_in_select = 1;
+ 
++  // Prevent 100% CPU by releasing control before the kevent call...
++  usleep(1);
++
+   if (timeout >= 0 && timeout < 86400)
+   {
+     ktimeout.tv_sec  = timeout;
+@@ -454,6 +457,9 @@ cupsdDoSelect(long timeout)		/* I - Timeout in seconds */
+     struct epoll_event	*event;		/* Current event */
+ 
+ 
++    // Prevent 100% CPU by releasing control before the epoll_wait call...
++    usleep(1);
++
+     if (timeout >= 0 && timeout < 86400)
+       nfds = epoll_wait(cupsd_epoll_fd, cupsd_epoll_events, MaxFDs,
+                 	timeout * 1000);
+@@ -546,6 +552,9 @@ cupsdDoSelect(long timeout)		/* I - Timeout in seconds */
+     }
+   }
+ 
++  // Prevent 100% CPU by releasing control before the poll call...
++  usleep(1);
++
+   if (timeout >= 0 && timeout < 86400)
+     nfds = poll(cupsd_pollfds, (nfds_t)count, timeout * 1000);
+   else
+@@ -599,6 +608,9 @@ cupsdDoSelect(long timeout)		/* I - Timeout in seconds */
+   cupsd_current_input  = cupsd_global_input;
+   cupsd_current_output = cupsd_global_output;
+ 
++  // Prevent 100% CPU by releasing control before the select call...
++  usleep(1);
++
+   if (timeout >= 0 && timeout < 86400)
+   {
+     stimeout.tv_sec  = timeout;
+-- 
+2.45.4
+

--- a/SPECS/cups/CVE-2025-61915.patch
+++ b/SPECS/cups/CVE-2025-61915.patch
@@ -1,0 +1,491 @@
+From db8d560262c22a21ee1e55dfd62fa98d9359bcb0 Mon Sep 17 00:00:00 2001
+From: Zdenek Dohnal <zdohnal@redhat.com>
+Date: Fri, 21 Nov 2025 07:36:36 +0100
+Subject: [PATCH] Fix various issues in cupsd
+
+Various issues were found by @SilverPlate3, recognized as CVE-2025-61915:
+
+- out of bound write when handling IPv6 addresses,
+- cupsd crash caused by null dereference when ErrorPolicy value is empty,
+
+On the top of that, Mike Sweet noticed vulnerability via domain socket,
+exploitable locally if attacker has access to domain socket and knows username
+of user within a group which is present in CUPS system groups:
+
+- rewrite of cupsd.conf via PeerCred authorization via domain socket
+
+The last vulnerability is fixed by introducing PeerCred directive for cups-files.conf,
+which controls whether PeerCred is enabled/disabled for user in CUPS system groups.
+
+Fixes CVE-2025-61915
+Upstream-reference: https://github.com/OpenPrinting/cups/commit/db8d560262c22a21ee1e55dfd62fa98d9359bcb0.patch
+---
+ conf/cups-files.conf.in              |  3 ++
+ config-scripts/cups-defaults.m4      |  9 +++++
+ config.h.in                          |  7 ++++
+ configure                            | 22 ++++++++++
+ doc/help/man-cups-files.conf.html    | 11 +++--
+ man/cups-files.conf.5                | 21 ++++++----
+ scheduler/auth.c                     |  8 +++-
+ scheduler/auth.h                     |  7 ++++
+ scheduler/client.c                   |  2 +-
+ scheduler/conf.c                     | 60 ++++++++++++++++++++++++----
+ test/run-stp-tests.sh                |  2 +-
+ vcnet/config.h                       |  7 ++++
+ xcode/CUPS.xcodeproj/project.pbxproj |  2 -
+ xcode/config.h                       |  7 ++++
+ 14 files changed, 145 insertions(+), 23 deletions(-)
+
+diff --git a/conf/cups-files.conf.in b/conf/cups-files.conf.in
+index af11fcc..bd95403 100644
+--- a/conf/cups-files.conf.in
++++ b/conf/cups-files.conf.in
+@@ -19,6 +19,9 @@
+ SystemGroup @CUPS_SYSTEM_GROUPS@
+ @CUPS_SYSTEM_AUTHKEY@
+ 
++# Are Unix domain socket peer credentials used for authorization?
++PeerCred @CUPS_PEER_CRED@
++
+ # User that is substituted for unauthenticated (remote) root accesses...
+ #RemoteRoot remroot
+ 
+diff --git a/config-scripts/cups-defaults.m4 b/config-scripts/cups-defaults.m4
+index 9e05bd4..24fab45 100644
+--- a/config-scripts/cups-defaults.m4
++++ b/config-scripts/cups-defaults.m4
+@@ -121,6 +121,15 @@ AC_ARG_WITH(log_level, [  --with-log-level        set default LogLevel value, de
+ AC_SUBST(CUPS_LOG_LEVEL)
+ AC_DEFINE_UNQUOTED(CUPS_DEFAULT_LOG_LEVEL, "$CUPS_LOG_LEVEL")
+ 
++dnl Default PeerCred
++AC_ARG_WITH([peer_cred], AS_HELP_STRING([--with-peer-cred], [set default PeerCred value (on/off/root-only), default=on]), [
++    CUPS_PEER_CRED="$withval"
++], [
++    CUPS_PEER_CRED="on"
++])
++AC_SUBST([CUPS_PEER_CRED])
++AC_DEFINE_UNQUOTED([CUPS_DEFAULT_PEER_CRED], ["$CUPS_PEER_CRED"], [Default PeerCred value.])
++
+ dnl Default AccessLogLevel
+ AC_ARG_WITH(access_log_level, [  --with-access-log-level set default AccessLogLevel value, default=none],
+ 	CUPS_ACCESS_LOG_LEVEL="$withval",
+diff --git a/config.h.in b/config.h.in
+index b5fdbd5..a7f5aa4 100644
+--- a/config.h.in
++++ b/config.h.in
+@@ -94,6 +94,13 @@
+ #define CUPS_DEFAULT_ERROR_POLICY "stop-printer"
+ 
+ 
++/*
++ * Default PeerCred value...
++ */
++
++#define CUPS_DEFAULT_PEER_CRED "on"
++
++
+ /*
+  * Default MaxCopies value...
+  */
+diff --git a/configure b/configure
+index 074c18a..58a24d3 100755
+--- a/configure
++++ b/configure
+@@ -671,6 +671,7 @@ CUPS_BROWSING
+ CUPS_SYNC_ON_CLOSE
+ CUPS_PAGE_LOG_FORMAT
+ CUPS_ACCESS_LOG_LEVEL
++CUPS_PEER_CRED
+ CUPS_LOG_LEVEL
+ CUPS_FATAL_ERRORS
+ CUPS_ERROR_POLICY
+@@ -929,6 +930,7 @@ with_max_log_size
+ with_error_policy
+ with_fatal_errors
+ with_log_level
++with_peer_cred
+ with_access_log_level
+ enable_page_logging
+ enable_sync_on_close
+@@ -1666,6 +1668,8 @@ Optional Packages:
+   --with-error-policy     set default ErrorPolicy value, default=stop-printer
+   --with-fatal-errors     set default FatalErrors value, default=config
+   --with-log-level        set default LogLevel value, default=warn
++  --with-peer-cred        set default PeerCred value (on/off/root-only),
++                          default=on
+   --with-access-log-level set default AccessLogLevel value, default=none
+   --with-local-protocols  set default BrowseLocalProtocols, default=""
+   --with-cups-user        set default user for CUPS
+@@ -10257,6 +10261,24 @@ printf "%s\n" "#define CUPS_DEFAULT_LOG_LEVEL \"$CUPS_LOG_LEVEL\"" >>confdefs.h
+ 
+ 
+ 
++# Check whether --with-peer_cred was given.
++if test ${with_peer_cred+y}
++then :
++  withval=$with_peer_cred;
++    CUPS_PEER_CRED="$withval"
++
++else $as_nop
++
++    CUPS_PEER_CRED="on"
++
++fi
++
++
++
++printf "%s\n" "#define CUPS_DEFAULT_PEER_CRED \"$CUPS_PEER_CRED\"" >>confdefs.h
++
++
++
+ # Check whether --with-access_log_level was given.
+ if test ${with_access_log_level+y}
+ then :
+diff --git a/doc/help/man-cups-files.conf.html b/doc/help/man-cups-files.conf.html
+index a429e02..7348ebc 100644
+--- a/doc/help/man-cups-files.conf.html
++++ b/doc/help/man-cups-files.conf.html
+@@ -122,6 +122,13 @@ The default is "/var/log/cups/page_log".
+ <dt><a name="PassEnv"></a><b>PassEnv </b><i>variable </i>[ ... <i>variable </i>]
+ <dd style="margin-left: 5.0em">Passes the specified environment variable(s) to child processes.
+ Note: the standard CUPS filter and backend environment variables cannot be overridden using this directive.
++<dt><a name="PeerCred"></a><b>PeerCred off</b>
++<dd style="margin-left: 5.0em"><dt><b>PeerCred on</b>
++<dd style="margin-left: 5.0em"><dt><b>PeerCred root-only</b>
++<dd style="margin-left: 5.0em">Specifies whether peer credentials are used for authorization when communicating over the UNIX domain socket.
++When <b>on</b>, the peer credentials of any user are accepted for authorization.
++The value <b>off</b> disables the use of peer credentials entirely, while the value <b>root-only</b> allows peer credentials only for the root user.
++Note: for security reasons, the <b>on</b> setting is reduced to <b>root-only</b> for authorization of PUT requests.
+ <dt><a name="RemoteRoot"></a><b>RemoteRoot </b><i>username</i>
+ <dd style="margin-left: 5.0em">Specifies the username that is associated with unauthenticated accesses by clients claiming to be the root user.
+ The default is "remroot".
+@@ -212,9 +219,7 @@ command is used instead.
+ <b>subscriptions.conf</b>(5),
+ CUPS Online Help (<a href="http://localhost:631/help">http://localhost:631/help</a>)
+ <h2 class="title"><a name="COPYRIGHT">Copyright</a></h2>
+-Copyright &copy; 2020 by Michael R Sweet
+-<br>
+-Copyright &copy; 2007-2019 by Apple Inc.
++Copyright &copy; 2020-2025 by OpenPrinting.
+ 
+ </body>
+ </html>
+diff --git a/man/cups-files.conf.5 b/man/cups-files.conf.5
+index 1cfb627..5000306 100644
+--- a/man/cups-files.conf.5
++++ b/man/cups-files.conf.5
+@@ -1,14 +1,12 @@
+ .\"
+ .\" cups-files.conf man page for CUPS.
+ .\"
+-.\" Copyright © 2020 by Michael R Sweet
+-.\" Copyright © 2007-2019 by Apple Inc.
+-.\" Copyright © 1997-2006 by Easy Software Products.
++.\" Copyright © 2020-2025 by OpenPrinting.
+ .\"
+ .\" Licensed under Apache License v2.0.  See the file "LICENSE" for more
+ .\" information.
+ .\"
+-.TH cups-files.conf 5 "CUPS" "14 November 2020" "Apple Inc."
++.TH cups-files.conf 5 "CUPS" "2025-10-08" "OpenPrinting"
+ .SH NAME
+ cups\-files.conf \- file and directory configuration file for cups
+ .SH DESCRIPTION
+@@ -166,6 +164,17 @@ The default is "/var/log/cups/page_log".
+ \fBPassEnv \fIvariable \fR[ ... \fIvariable \fR]
+ Passes the specified environment variable(s) to child processes.
+ Note: the standard CUPS filter and backend environment variables cannot be overridden using this directive.
++.\"#PeerCred
++.TP 5
++\fBPeerCred off\fR
++.TP 5
++\fBPeerCred on\fR
++.TP 5
++\fBPeerCred root-only\fR
++Specifies whether peer credentials are used for authorization when communicating over the UNIX domain socket.
++When \fBon\fR, the peer credentials of any user are accepted for authorization.
++The value \fBoff\fR disables the use of peer credentials entirely, while the value \fBroot-only\fR allows peer credentials only for the root user.
++Note: for security reasons, the \fBon\fR setting is reduced to \fBroot-only\fR for authorization of PUT requests.
+ .\"#RemoteRoot
+ .TP 5
+ \fBRemoteRoot \fIusername\fR
+@@ -294,6 +303,4 @@ command is used instead.
+ .BR subscriptions.conf (5),
+ CUPS Online Help (http://localhost:631/help)
+ .SH COPYRIGHT
+-Copyright \[co] 2020 by Michael R Sweet
+-.br
+-Copyright \[co] 2007-2019 by Apple Inc.
++Copyright \[co] 2020-2025 by OpenPrinting.
+diff --git a/scheduler/auth.c b/scheduler/auth.c
+index a94a5fe..544a904 100644
+--- a/scheduler/auth.c
++++ b/scheduler/auth.c
+@@ -390,7 +390,7 @@ cupsdAuthorize(cupsd_client_t *con)	/* I - Client connection */
+   }
+ #endif /* HAVE_AUTHORIZATION_H */
+ #if defined(SO_PEERCRED) && defined(AF_LOCAL)
+-  else if (!strncmp(authorization, "PeerCred ", 9) &&
++  else if (PeerCred != CUPSD_PEERCRED_OFF && !strncmp(authorization, "PeerCred ", 9) &&
+            con->http->hostaddr->addr.sa_family == AF_LOCAL && con->best)
+   {
+    /*
+@@ -433,6 +433,12 @@ cupsdAuthorize(cupsd_client_t *con)	/* I - Client connection */
+     }
+ #endif /* HAVE_AUTHORIZATION_H */
+ 
++    if ((PeerCred == CUPSD_PEERCRED_ROOTONLY || httpGetState(con->http) == HTTP_STATE_PUT_RECV) && strcmp(authorization + 9, "root"))
++    {
++      cupsdLogClient(con, CUPSD_LOG_INFO, "User \"%s\" is not allowed to use peer credentials.", authorization + 9);
++      return;
++    }
++
+     if ((pwd = getpwnam(authorization + 9)) == NULL)
+     {
+       cupsdLogClient(con, CUPSD_LOG_ERROR, "User \"%s\" does not exist.", authorization + 9);
+diff --git a/scheduler/auth.h b/scheduler/auth.h
+index d7079eb..03caa7d 100644
+--- a/scheduler/auth.h
++++ b/scheduler/auth.h
+@@ -48,6 +48,10 @@
+ #define CUPSD_AUTH_LIMIT_ALL	127	/* Limit all requests */
+ #define CUPSD_AUTH_LIMIT_IPP	128	/* Limit IPP requests */
+ 
++#define CUPSD_PEERCRED_OFF	0	/* Don't allow PeerCred authorization */
++#define CUPSD_PEERCRED_ON	1	/* Allow PeerCred authorization for all users */
++#define CUPSD_PEERCRED_ROOTONLY	2	/* Allow PeerCred authorization for root user */
++
+ #define IPP_ANY_OPERATION	(ipp_op_t)0
+ 					/* Any IPP operation */
+ #define IPP_BAD_OPERATION	(ipp_op_t)-1
+@@ -105,6 +109,9 @@ typedef struct cupsd_client_s cupsd_client_t;
+ 
+ VAR cups_array_t	*Locations	VALUE(NULL);
+ 					/* Authorization locations */
++VAR int			PeerCred	VALUE(CUPSD_PEERCRED_ON);
++					/* Allow PeerCred authorization? */
++
+ #ifdef HAVE_SSL
+ VAR http_encryption_t	DefaultEncryption VALUE(HTTP_ENCRYPT_REQUIRED);
+ 					/* Default encryption for authentication */
+diff --git a/scheduler/client.c b/scheduler/client.c
+index 5b54799..80bc48f 100644
+--- a/scheduler/client.c
++++ b/scheduler/client.c
+@@ -2270,7 +2270,7 @@ cupsdSendHeader(
+       auth_size = sizeof(auth_str) - (size_t)(auth_key - auth_str);
+ 
+ #if defined(SO_PEERCRED) && defined(AF_LOCAL)
+-      if (httpAddrFamily(httpGetAddress(con->http)) == AF_LOCAL)
++      if (PeerCred != CUPSD_PEERCRED_OFF && httpAddrFamily(httpGetAddress(con->http)) == AF_LOCAL)
+       {
+         strlcpy(auth_key, ", PeerCred", auth_size);
+         auth_key += 10;
+diff --git a/scheduler/conf.c b/scheduler/conf.c
+index 0b557d4..b4181f2 100644
+--- a/scheduler/conf.c
++++ b/scheduler/conf.c
+@@ -49,6 +49,7 @@ typedef enum
+ {
+   CUPSD_VARTYPE_INTEGER,		/* Integer option */
+   CUPSD_VARTYPE_TIME,			/* Time interval option */
++  CUPSD_VARTYPE_NULLSTRING,		/* String option or NULL/empty string */
+   CUPSD_VARTYPE_STRING,			/* String option */
+   CUPSD_VARTYPE_BOOLEAN,		/* Boolean option */
+   CUPSD_VARTYPE_PATHNAME,		/* File/directory name option */
+@@ -71,7 +72,7 @@ static const cupsd_var_t	cupsd_vars[] =
+ {
+   { "AutoPurgeJobs", 		&JobAutoPurge,		CUPSD_VARTYPE_BOOLEAN },
+ #if defined(HAVE_DNSSD) || defined(HAVE_AVAHI)
+-  { "BrowseDNSSDSubTypes",	&DNSSDSubTypes,		CUPSD_VARTYPE_STRING },
++  { "BrowseDNSSDSubTypes",	&DNSSDSubTypes,		CUPSD_VARTYPE_NULLSTRING },
+ #endif /* HAVE_DNSSD || HAVE_AVAHI */
+   { "BrowseWebIF",		&BrowseWebIF,		CUPSD_VARTYPE_BOOLEAN },
+   { "Browsing",			&Browsing,		CUPSD_VARTYPE_BOOLEAN },
+@@ -124,7 +125,7 @@ static const cupsd_var_t	cupsd_vars[] =
+   { "MaxSubscriptionsPerPrinter",&MaxSubscriptionsPerPrinter,	CUPSD_VARTYPE_INTEGER },
+   { "MaxSubscriptionsPerUser",	&MaxSubscriptionsPerUser,	CUPSD_VARTYPE_INTEGER },
+   { "MultipleOperationTimeout",	&MultipleOperationTimeout,	CUPSD_VARTYPE_TIME },
+-  { "PageLogFormat",		&PageLogFormat,		CUPSD_VARTYPE_STRING },
++  { "PageLogFormat",		&PageLogFormat,		CUPSD_VARTYPE_NULLSTRING },
+   { "PreserveJobFiles",		&JobFiles,		CUPSD_VARTYPE_TIME },
+   { "PreserveJobHistory",	&JobHistory,		CUPSD_VARTYPE_TIME },
+   { "ReloadTimeout",		&ReloadTimeout,		CUPSD_VARTYPE_TIME },
+@@ -798,6 +799,13 @@ cupsdReadConfiguration(void)
+   IdleExitTimeout = 60;
+ #endif /* HAVE_ONDEMAND */
+ 
++  if (!strcmp(CUPS_DEFAULT_PEER_CRED, "off"))
++    PeerCred = CUPSD_PEERCRED_OFF;
++  else if (!strcmp(CUPS_DEFAULT_PEER_CRED, "root-only"))
++    PeerCred = CUPSD_PEERCRED_ROOTONLY;
++  else
++    PeerCred = CUPSD_PEERCRED_ON;
++
+  /*
+   * Setup environment variables...
+   */
+@@ -1864,7 +1872,7 @@ get_addr_and_mask(const char *value,	/* I - String from config file */
+ 
+     family  = AF_INET6;
+ 
+-    for (i = 0, ptr = value + 1; *ptr && i < 8; i ++)
++    for (i = 0, ptr = value + 1; *ptr && i >= 0 && i < 8; i ++)
+     {
+       if (*ptr == ']')
+         break;
+@@ -2013,7 +2021,7 @@ get_addr_and_mask(const char *value,	/* I - String from config file */
+ #ifdef AF_INET6
+       if (family == AF_INET6)
+       {
+-        if (i > 128)
++        if (i < 0 || i > 128)
+ 	  return (0);
+ 
+         i = 128 - i;
+@@ -2047,7 +2055,7 @@ get_addr_and_mask(const char *value,	/* I - String from config file */
+       else
+ #endif /* AF_INET6 */
+       {
+-        if (i > 32)
++        if (i < 0 || i > 32)
+ 	  return (0);
+ 
+         mask[0] = 0xffffffff;
+@@ -2957,7 +2965,17 @@ parse_variable(
+ 	cupsdSetString((char **)var->ptr, temp);
+ 	break;
+ 
++    case CUPSD_VARTYPE_NULLSTRING :
++	cupsdSetString((char **)var->ptr, value);
++	break;
++
+     case CUPSD_VARTYPE_STRING :
++        if (!value)
++        {
++	  cupsdLogMessage(CUPSD_LOG_ERROR, "Missing value for %s on line %d of %s.", line, linenum, filename);
++	  return (0);
++        }
++
+ 	cupsdSetString((char **)var->ptr, value);
+ 	break;
+   }
+@@ -3477,9 +3495,10 @@ read_cupsd_conf(cups_file_t *fp)	/* I - File to read from */
+ 		      line, value ? " " : "", value ? value : "", linenum,
+ 		      ConfigurationFile, CupsFilesFile);
+     }
+-    else
+-      parse_variable(ConfigurationFile, linenum, line, value,
+-                     sizeof(cupsd_vars) / sizeof(cupsd_vars[0]), cupsd_vars);
++    else if (!parse_variable(ConfigurationFile, linenum, line, value,
++			     sizeof(cupsd_vars) / sizeof(cupsd_vars[0]), cupsd_vars) &&
++	     (FatalErrors & CUPSD_FATAL_CONFIG))
++      return (0);
+   }
+ 
+   return (1);
+@@ -3639,6 +3658,31 @@ read_cups_files_conf(cups_file_t *fp)	/* I - File to read from */
+ 	    break;
+       }
+     }
++    else if (!_cups_strcasecmp(line, "PeerCred") && value)
++    {
++     /*
++      * PeerCred {off,on,root-only}
++      */
++
++      if (!_cups_strcasecmp(value, "off"))
++      {
++        PeerCred = CUPSD_PEERCRED_OFF;
++      }
++      else if (!_cups_strcasecmp(value, "on"))
++      {
++        PeerCred = CUPSD_PEERCRED_ON;
++      }
++      else if (!_cups_strcasecmp(value, "root-only"))
++      {
++        PeerCred = CUPSD_PEERCRED_ROOTONLY;
++      }
++      else
++      {
++	cupsdLogMessage(CUPSD_LOG_ERROR, "Unknown PeerCred \"%s\" on line %d of %s.", value, linenum, CupsFilesFile);
++        if (FatalErrors & CUPSD_FATAL_CONFIG)
++          return (0);
++      }
++    }
+     else if (!_cups_strcasecmp(line, "PrintcapFormat") && value)
+     {
+      /*
+diff --git a/test/run-stp-tests.sh b/test/run-stp-tests.sh
+index 4498a8c..b6932de 100755
+--- a/test/run-stp-tests.sh
++++ b/test/run-stp-tests.sh
+@@ -511,7 +511,7 @@ fi
+ 
+ cat >$BASE/cups-files.conf <<EOF
+ FileDevice yes
+-Printcap
++Printcap $BASE/printcap
+ User $user
+ ServerRoot $BASE
+ StateDir $BASE
+diff --git a/vcnet/config.h b/vcnet/config.h
+index 165a28d..d5af97a 100644
+--- a/vcnet/config.h
++++ b/vcnet/config.h
+@@ -177,6 +177,13 @@ typedef unsigned long useconds_t;
+ #define CUPS_DEFAULT_ERROR_POLICY "stop-printer"
+ 
+ 
++/*
++ * Default PeerCred value...
++ */
++
++#define CUPS_DEFAULT_PEER_CRED "on"
++
++
+ /*
+  * Default MaxCopies value...
+  */
+diff --git a/xcode/CUPS.xcodeproj/project.pbxproj b/xcode/CUPS.xcodeproj/project.pbxproj
+index 4208d10..388bd5c 100644
+--- a/xcode/CUPS.xcodeproj/project.pbxproj
++++ b/xcode/CUPS.xcodeproj/project.pbxproj
+@@ -3433,7 +3433,6 @@
+ 		72220FB313330BCE00FCA411 /* mime.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = mime.c; path = ../scheduler/mime.c; sourceTree = "<group>"; };
+ 		72220FB413330BCE00FCA411 /* mime.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = mime.h; path = ../scheduler/mime.h; sourceTree = "<group>"; };
+ 		72220FB513330BCE00FCA411 /* type.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = type.c; path = ../scheduler/type.c; sourceTree = "<group>"; };
+-		7226369B18AE6D19004ED309 /* org.cups.cups-lpd.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "org.cups.cups-lpd.plist"; path = "../scheduler/org.cups.cups-lpd.plist"; sourceTree = SOURCE_ROOT; };
+ 		7226369C18AE6D19004ED309 /* org.cups.cupsd.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = org.cups.cupsd.plist; path = ../scheduler/org.cups.cupsd.plist; sourceTree = SOURCE_ROOT; };
+ 		7226369D18AE73BB004ED309 /* config.h.in */ = {isa = PBXFileReference; lastKnownFileType = text; name = config.h.in; path = ../config.h.in; sourceTree = "<group>"; };
+ 		722A24EE2178D00C000CAB20 /* debug-internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "debug-internal.h"; path = "../cups/debug-internal.h"; sourceTree = "<group>"; };
+@@ -5062,7 +5061,6 @@
+ 			isa = PBXGroup;
+ 			children = (
+ 				72E65BDC18DC852700097E89 /* Makefile */,
+-				7226369B18AE6D19004ED309 /* org.cups.cups-lpd.plist */,
+ 				72E65BD518DC818400097E89 /* org.cups.cups-lpd.plist.in */,
+ 				72496E171A13A03B0051899C /* org.cups.cups-lpdAT.service.in */,
+ 				72496E161A13A03B0051899C /* org.cups.cups-lpd.socket */,
+diff --git a/xcode/config.h b/xcode/config.h
+index 13ae01f..ad2987d 100644
+--- a/xcode/config.h
++++ b/xcode/config.h
+@@ -96,6 +96,13 @@
+ #define CUPS_DEFAULT_ERROR_POLICY "stop-printer"
+ 
+ 
++/*
++ * Default PeerCred value...
++ */
++
++#define CUPS_DEFAULT_PEER_CRED "on"
++
++
+ /*
+  * Default MaxCopies value...
+  */
+-- 
+2.45.4
+

--- a/SPECS/cups/cups.spec
+++ b/SPECS/cups/cups.spec
@@ -12,7 +12,7 @@
 Summary:        CUPS printing system
 Name:           cups
 Version:        2.3.3%{OP_VER}
-Release:        10%{?dist}
+Release:        11%{?dist}
 License:        ASL 2.0 with exceptions
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -67,6 +67,8 @@ Patch17:        CVE-2022-26691.patch
 Patch18:	CVE-2024-35235.patch
 Patch19:	CVE-2025-58060.patch
 Patch20:	CVE-2025-58364.patch
+Patch21:	CVE-2025-61915.patch
+Patch22:	CVE-2025-58436.patch
 #### UPSTREAM PATCHES (starts with 1000) ####
 ##### Patches removed because IMHO they aren't no longer needed
 ##### but still I'll leave them in git in case their removal
@@ -272,6 +274,8 @@ to CUPS daemon. This solution will substitute printer drivers and raw queues in 
 %patch18 -p1
 %patch19 -p1
 %patch20 -p1
+%patch21 -p1
+%patch22 -p1
 
 # LSPP support.
 %patch100 -p1 -b .lspp
@@ -663,6 +667,9 @@ rm -f %{cups_serverbin}/backend/smb
 %{_mandir}/man7/ippeveps.7.gz
 
 %changelog
+* Wed Dec 17 2025 BinduSri Adabala <v-badabala@microsoft.com> - 2.3.3op2-11
+- Patch for CVE-2025-61915 and CVE-2025-58436
+
 * Sat Sep 13 2025 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 2.3.3op2-10
 - Patch for CVE-2025-58364, CVE-2025-58060
 - Fix patch of CVE-2024-35235


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Patch cups for CVE-2025-58436 and CVE-2025-61915

For CVE-2025-58436 [Medium]:
Astrolabe Patch Reference: https://github.com/OpenPrinting/cups/commit/5d414f1f91bdca118413301b148f0b188eb1cdc6
Patch Modified: Yes
- In `scheduler/client.c` file Upstream patch used 'HAVE_TLS', But current version[2.3.3op2] is using 'HAVE_SSL' so used `HAVE_SSL` following existing codebase.

For CVE-2025-61915 [Medium]:
Astrolabe Patch Reference: https://github.com/OpenPrinting/cups/commit/db8d560262c22a21ee1e55dfd62fa98d9359bcb0
Patch Modified:  No

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- new file:   ../SPECS/cups/CVE-2025-58436.patch
- new file:   ../SPECS/cups/CVE-2025-61915.patch
- modified:   ../SPECS/cups/cups.spec

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**


###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2025-58436
- https://nvd.nist.gov/vuln/detail/CVE-2025-61915

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local Build:
[cups-2.3.3op2-11.cm2.src.rpm.log](https://github.com/user-attachments/files/24218676/cups-2.3.3op2-11.cm2.src.rpm.log)
- Patch applies cleanly
<img width="637" height="646" alt="image" src="https://github.com/user-attachments/assets/daff4610-cad7-4b4e-acce-2741d4f74e1f" />
- Installation check
<img width="1722" height="640" alt="image" src="https://github.com/user-attachments/assets/07aabbd3-ed0a-4af8-aa93-097eef44d74d" />
<img width="1722" height="361" alt="image" src="https://github.com/user-attachments/assets/1ea11e99-8cd3-4e0d-82c7-af3b0b172323" />

