### PR TITLE
Build fix for pngcrush

### DIFF
--- a/SPECS-EXTENDED/pngcrush/pngcrush-1.8.13-fix-undeclared-identifier.patch
+++ b/SPECS-EXTENDED/pngcrush/pngcrush-1.8.13-fix-undeclared-identifier.patch
@@ -1,0 +1,25 @@
+From 720533055469af660e8e79a127999d1c626e95f7 Mon Sep 17 00:00:00 2001
+From: John Bowler <jbowler@acm.org>
+Date: Thu, 1 Feb 2024 05:06:45 -0800
+Subject: [PATCH] Check for defined PNG_IGNORE_ADLER32
+
+The check was missing round the first usage, it was there in the second.
+---
+ pngcrush.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/pngcrush.c b/pngcrush.c
+index 102bb39..43b1fe5 100644
+--- a/pngcrush.c
++++ b/pngcrush.c
+@@ -5524,8 +5524,10 @@ int main(int argc, char *argv[])
+                      * they were already checked in the pngcrush_measure_idat
+                      * function
+                      */
++# ifdef PNG_IGNORE_ADLER32
+                     png_set_option(read_ptr, PNG_IGNORE_ADLER32,
+                         PNG_OPTION_ON);
++# endif
+                     png_set_crc_action(read_ptr, PNG_CRC_QUIET_USE,
+                                        PNG_CRC_QUIET_USE);
+                 }

--- a/SPECS-EXTENDED/pngcrush/pngcrush.spec
+++ b/SPECS-EXTENDED/pngcrush/pngcrush.spec
@@ -6,12 +6,13 @@ Distribution:   Azure Linux
 Summary:        Optimizer for PNG (Portable Network Graphics) files
 Name:           pngcrush
 Version:        1.8.13
-Release:        11%{?dist}
+Release:        12%{?dist}
 License:        zlib
 URL:            http://pmt.sourceforge.net/%{name}/
 Source0:        http://downloads.sourceforge.net/pmt/%{name}-%{version}-nolib.tar.xz
 # from Debian sid.
 Source1:        %{name}.sgml
+Patch0:         pngcrush-1.8.13-fix-undeclared-identifier.patch
 BuildRequires:  docbook-utils
 BuildRequires:  gcc
 BuildRequires:  libpng-devel
@@ -26,7 +27,7 @@ remove unwanted ancillary chunks, or to add certain chunks including gAMA,
 tRNS, iCCP, and textual chunks. 
 
 %prep
-%autosetup -n %{name}-%{version}-nolib
+%autosetup -p1 -n %{name}-%{version}-nolib
 cp %{SOURCE1} . 
 
 %build
@@ -46,6 +47,9 @@ docbook2man %{name}.sgml
 %doc %{_mandir}/man1/%{name}.1.gz
 
 %changelog
+* Fri Dec 19 2025 Ratiranjan Behera <v-ratbehera@microsoft.com> - 1.8.13-12
+- Added patch from Fedora to fix build.
+
 * Mon Mar 06 2023 Muhammad Falak R Wani <mwani@microsoft.com> - 1.8.13-11
 - Initial CBL-Mariner import from Fedora 36 (license: MIT).
 - License Verified


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
- Fixed issue 'undeclared-identifier' for pngcrush. 

###### Build/Dependency Packages <!-- REQUIRED -->
Please Build the following packages to build pngcrush:
python-webencodings libsamplerate python-rdflib python-sphinxygen v4l-utils cdparanoia graphene libogg libtheora libvisual libvorbis lv2 fftw serd sord sound-theme-freedesktop sratom zix cldr-emoji-annotation iso-codes libasyncns libcanberra libdbusmenu gstreamer1 gstreamer1-plugins-base speexdsp webrtc-audio-processing rtkit unicode-emoji unicode-ucd sbc lilv orc docbook-style-dsssl openjade perl-SGMLSpm elinks gpm linuxconsoletools ibus pipewire pulseaudio SDL2 docbook-utils

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- new file:   SPECS-EXTENDED/pngcrush/pngcrush-1.8.13-fix-undeclared-identifier.patch
- modified:   SPECS-EXTENDED/pngcrush/pngcrush.spec

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Build Logs:
[pngcrush-1.8.13-12.azl3.src.rpm.log](https://github.com/user-attachments/files/24293519/pngcrush-1.8.13-12.azl3.src.rpm.log)
[pulseaudio-16.1-2.azl3.src.rpm.test.log](https://github.com/user-attachments/files/24293520/pulseaudio-16.1-2.azl3.src.rpm.test.log)

- Build Summary:

<img width="302" height="341" alt="image" src="https://github.com/user-attachments/assets/24264a89-42c1-4e8a-8fa2-c0b0fd81942f" />

- Failed SRPM test fail:

<img width="1566" height="351" alt="image" src="https://github.com/user-attachments/assets/8d9062fe-c691-4a6a-82e6-c52d7abb718d" />

-Installation Check:

<img width="719" height="70" alt="image" src="https://github.com/user-attachments/assets/a19cb457-041c-498c-8b39-763477b1f52e" />

-Uninstallation Check:

<img width="779" height="137" alt="image" src="https://github.com/user-attachments/assets/7657311f-a90d-4e77-9dc8-1c953e41fcac" />

- Pipeline build id: xxxx
