### PR TITLE
Do not truncate arbitrary host files with imager

### DIFF
--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -1840,8 +1840,12 @@ func ProvisionUserSSHCerts(installChroot safechroot.ChrootInterface, username st
 		return
 	}
 	authorizedKeysTempFile := tmpFile.Name()
-	tmpFile.Close()
 	defer os.Remove(authorizedKeysTempFile)
+
+	if err = tmpFile.Close(); err != nil {
+		logger.Log.Warnf("Failed to close temporary authorized_keys file: %v", err)
+		return
+	}
 
 	allSSHKeys := []string(nil)
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*

- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->

Improve temporary file handling in `ProvisionUserSSHCerts()`. The function previously used a hardcoded `/tmp/authorized_keys` path which could cause issues if the file already exists. Using `os.CreateTemp()` ensures each invocation gets a unique temporary file, avoiding potential collisions and edge cases with pre-existing files.

###### Change Log  <!-- REQUIRED -->

- Replace hardcoded `/tmp/authorized_keys` with `os.CreateTemp()` to generate unique temporary filenames
- Simplify file creation logic by removing the exists-check and truncate path

###### Does this affect the toolchain?  <!-- REQUIRED -->

**NO**

###### Associated issues  <!-- optional -->

- https://microsoft.visualstudio.com/OS/_workitems/edit/60670861

###### Links to CVEs  <!-- optional -->

- N/A

###### Test Methodology

- Pipeline build id: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=1019280&view=results
