### PR TITLE
[Low] patch binutils for CVE-2025-1147, CVE-2025-1148, CVE-2025-11839

### DIFF
--- a/SPECS/binutils/CVE-2025-1147.patch
+++ b/SPECS/binutils/CVE-2025-1147.patch
@@ -1,0 +1,110 @@
+From 7be4186c22f89a87fff048c28910f5d26a0f61ce Mon Sep 17 00:00:00 2001
+From: Dmitry Klochkov <dmitry.klochkov@bell-sw.com>
+Date: Tue, 9 Sep 2025 12:06:25 +0200
+Subject: [PATCH] nm: fix treating an ifunc symbol as a stab if
+ '--ifunc-chars=--' is given
+
+If an ifunc symbol is processed in print_symbol(), a 'type' field of a
+'syminfo' structure is set to any character specified by a user with an
+'--ifunc-chars' option.  But afterwards the 'type' field is used to
+check whether a symbol is a stab in print_symbol_info_{bsd,sysv}()
+functions in order to print additional stab related data.  If the 'type'
+field equals '-', a symbol is treated as a stab.  If '--ifunc-chars=--'
+is given, all ifunc symbols will be treated as stab symbols and
+uninitialized stab related fields of the 'syminfo' structure will be
+printed which can lead to segmentation fault.
+
+To fix this, check if a symbol is a stab before override the 'type'
+field.  Also, add a test case for this fix.
+
+	PR binutils/32556
+	* nm.c (extended_symbol_info): Add is_stab.
+	(print_symbol): Check if a symbol is a stab.
+	(print_symbol_info_bsd): Use info->is_stab.
+	(print_symbol_info_sysv): Use info->is_stab.
+	* testsuite/binutils-all/nm.exp: Test nm --ifunc-chars=--.
+
+Bug: https://sourceware.org/bugzilla/show_bug.cgi?id=32556
+Fixes: e6f6aa8d184 ("Add option to nm to change the characters displayed for ifunc symbols")
+Signed-off-by: Dmitry Klochkov <dmitry.klochkov@bell-sw.com>
+
+Upstream Patch Reference: https://git.launchpad.net/ubuntu/+source/binutils/tree/debian/patches/CVE-2025-1147.patch?id=2938c598064e4b8513e1d0614a522732e8401080
+---
+ binutils/nm.c                          | 10 +++++++---
+ binutils/testsuite/binutils-all/nm.exp | 17 +++++++++++++++++
+ 2 files changed, 24 insertions(+), 3 deletions(-)
+
+diff --git a/binutils/nm.c b/binutils/nm.c
+index 82ccec68..ad4d2afb 100644
+--- a/binutils/nm.c
++++ b/binutils/nm.c
+@@ -65,6 +65,7 @@ struct extended_symbol_info
+   bfd_vma ssize;
+   elf_symbol_type *elfinfo;
+   coff_symbol_type *coffinfo;
++  bool is_stab;
+   /* FIXME: We should add more fields for Type, Line, Section.  */
+ };
+ #define SYM_VALUE(sym)       (sym->sinfo->value)
+@@ -938,8 +939,11 @@ print_symbol (bfd *        abfd,
+ 
+   bfd_get_symbol_info (abfd, sym, &syminfo);
+ 
++  info.is_stab = false;
++  if (syminfo.type == '-')
++    info.is_stab = true;
+   /* PR 22967 - Distinguish between local and global ifunc symbols.  */
+-  if (syminfo.type == 'i'
++  else if (syminfo.type == 'i'
+       && sym->flags & BSF_GNU_INDIRECT_FUNCTION)
+     {
+       if (ifunc_type_chars == NULL || ifunc_type_chars[0] == 0)
+@@ -1688,7 +1692,7 @@ print_symbol_info_bsd (struct extended_symbol_info *info, bfd *abfd)
+ 
+   printf (" %c", SYM_TYPE (info));
+ 
+-  if (SYM_TYPE (info) == '-')
++  if (info->is_stab)
+     {
+       /* A stab.  */
+       printf (" ");
+@@ -1717,7 +1721,7 @@ print_symbol_info_sysv (struct extended_symbol_info *info, bfd *abfd)
+ 
+   printf ("|   %c  |", SYM_TYPE (info));
+ 
+-  if (SYM_TYPE (info) == '-')
++  if (info->is_stab)
+     {
+       /* A stab.  */
+       printf ("%18s|  ", SYM_STAB_NAME (info));		/* (C) Type.  */
+diff --git a/binutils/testsuite/binutils-all/nm.exp b/binutils/testsuite/binutils-all/nm.exp
+index 93753199..beb10dd8 100644
+--- a/binutils/testsuite/binutils-all/nm.exp
++++ b/binutils/testsuite/binutils-all/nm.exp
+@@ -335,6 +335,23 @@ if [is_elf_format] {
+ 	    fail "$testname (local ifunc)"
+ 	}
+ 
++	# PR 32556
++	# Test nm --ifunc-chars=--
++
++	set got [binutils_run $NM "$NMFLAGS --ifunc-chars=-- $tmpfile"]
++
++	if [regexp -line "^\\S+ - global_foo$" $got] then {
++	    pass "$testname=-- (global ifunc)"
++	} else {
++	    fail "$testname=-- (global ifunc)"
++	}
++
++	if [regexp -line "^\\S+ - local_foo$" $got] then {
++	    pass "$testname=-- (local ifunc)"
++	} else {
++	    fail "$testname=-- (local ifunc)"
++	}
++
+ 	if { $verbose < 1 } {
+ 	    remote_file host delete "tmpdir/ifunc.o"
+ 	}
+-- 
+2.45.4
+

--- a/SPECS/binutils/CVE-2025-1148.patch
+++ b/SPECS/binutils/CVE-2025-1148.patch
@@ -1,0 +1,592 @@
+From d4115c2c8d447e297ae353892de89192c1996211 Mon Sep 17 00:00:00 2001
+From: Alan Modra <amodra@gmail.com>
+Date: Sat, 11 Jan 2025 16:19:09 +1030
+Subject: [PATCH] Replace xmalloc with stat_alloc in ld parser
+
+A few place dealing with ld script handling made some attempt to free
+memory, but this was generally ignored and would be quite a lot of
+work to implement.  Instead, use the stat_obstack rather than
+mallocing in many more cases.
+
+	* ldexp.c (exp_get_fill): Use stat_alloc for fill.
+	* ldfile.c (ldfile_try_open_bfd): Don't free yylval fields.
+	* ldgram.y: Replace xmalloc with stat_alloc throughout.
+	* ldlang.c (stat_memdup, stat_strdup): New functions.
+	(ldirname): Use stat_memdup.  Don't strdup ".".
+	(output_section_callback_sort): Use stat_alloc.
+	(output_section_callback_tree_to_list): Don't free.
+	(lang_memory_region_lookup): Use stat_strdup.
+	(lang_memory_region_alias): Likewise.
+	(add_excluded_libs): Use stat_alloc and stat_memdup.
+	(ldlang_add_undef, ldlang_add_require_defined): Use stat_strdup.
+	(lang_add_nocrossref, lang_leave_overlay): Use stat_alloc.
+	(realsymbol): Use stat_strdup for return value and always
+	free symbol.
+	(lang_new_vers_pattern, lang_new_vers_node): Use stat_alloc.
+	(lang_finalize_version_expr_head): Don't free.  Delete FIXME.
+	(lang_register_vers_node): Don't free.
+	(lang_add_vers_depend): Use stat_alloc.
+	(lang_do_version_exports_section): Likewise.
+	(lang_add_unique): Use stat_alloc and stat_strdup.
+	(lang_append_dynamic_list): Use stat_alloc.
+	* ldlang.h (stat_memdup, stat_strdup): Declare.
+	* ldlex.l: Replace xstrdup with stat_strdup throughout.
+	Replace xmemdup with stat_memdup too.
+	* lexsup.c (parse_args): Don't free export list or dynamic
+	list.
+
+Upstream Patch Reference: https://git.launchpad.net/ubuntu/+source/binutils/tree/debian/patches/CVE-2025-1148.patch?id=2938c598064e4b8513e1d0614a522732e8401080
+---
+ ld/ldexp.c  |  4 +--
+ ld/ldfile.c | 17 ++---------
+ ld/ldgram.y | 21 ++++++-------
+ ld/ldlang.c | 87 ++++++++++++++++++++++++++---------------------------
+ ld/ldlang.h |  4 +++
+ ld/ldlex.l  | 23 +++++++-------
+ ld/lexsup.c | 22 +-------------
+ 7 files changed, 74 insertions(+), 104 deletions(-)
+
+diff --git a/ld/ldexp.c b/ld/ldexp.c
+index 02c76f8b..36a59b90 100644
+--- a/ld/ldexp.c
++++ b/ld/ldexp.c
+@@ -1590,7 +1590,7 @@ exp_get_fill (etree_type *tree, fill_type *def, char *name)
+     {
+       unsigned char *dst;
+       unsigned char *s;
+-      fill = (fill_type *) xmalloc ((len + 1) / 2 + sizeof (*fill) - 1);
++      fill = stat_alloc ((len + 1) / 2 + sizeof (*fill) - 1);
+       fill->size = (len + 1) / 2;
+       dst = fill->data;
+       s = (unsigned char *) expld.result.str;
+@@ -1615,7 +1615,7 @@ exp_get_fill (etree_type *tree, fill_type *def, char *name)
+     }
+   else
+     {
+-      fill = (fill_type *) xmalloc (4 + sizeof (*fill) - 1);
++      fill = stat_alloc (4 + sizeof (*fill) - 1);
+       val = expld.result.value;
+       fill->data[0] = (val >> 24) & 0xff;
+       fill->data[1] = (val >> 16) & 0xff;
+diff --git a/ld/ldfile.c b/ld/ldfile.c
+index 9d0af06f..13eea5de 100644
+--- a/ld/ldfile.c
++++ b/ld/ldfile.c
+@@ -211,18 +211,11 @@ ldfile_try_open_bfd (const char *attempt,
+ 			  if (token == ',')
+ 			    {
+ 			      if ((token = yylex ()) != NAME)
+-				{
+-				  free (arg1);
+-				  continue;
+-				}
++				continue;
+ 			      arg2 = yylval.name;
+ 			      if ((token = yylex ()) != ','
+ 				  || (token = yylex ()) != NAME)
+-				{
+-				  free (arg1);
+-				  free (arg2);
+-				  continue;
+-				}
++				continue;
+ 			      arg3 = yylval.name;
+ 			      token = yylex ();
+ 			    }
+@@ -241,18 +234,12 @@ ldfile_try_open_bfd (const char *attempt,
+ 			      if (strcmp (arg, lang_get_output_target ()) != 0)
+ 				skip = 1;
+ 			    }
+-			  free (arg1);
+-			  free (arg2);
+-			  free (arg3);
+ 			  break;
+ 			case NAME:
+ 			case LNAME:
+ 			case VERS_IDENTIFIER:
+ 			case VERS_TAG:
+-			  free (yylval.name);
+-			  break;
+ 			case INT:
+-			  free (yylval.bigint.str);
+ 			  break;
+ 			}
+ 		      token = yylex ();
+diff --git a/ld/ldgram.y b/ld/ldgram.y
+index 31e0071c..85c89eb1 100644
+--- a/ld/ldgram.y
++++ b/ld/ldgram.y
+@@ -524,7 +524,7 @@ section_name_spec:
+ sect_flag_list:	NAME
+ 			{
+ 			  struct flag_info_list *n;
+-			  n = ((struct flag_info_list *) xmalloc (sizeof *n));
++			  n = stat_alloc (sizeof *n);
+ 			  if ($1[0] == '!')
+ 			    {
+ 			      n->with = without_flags;
+@@ -542,7 +542,7 @@ sect_flag_list:	NAME
+ 	|	sect_flag_list '&' NAME
+ 			{
+ 			  struct flag_info_list *n;
+-			  n = ((struct flag_info_list *) xmalloc (sizeof *n));
++			  n = stat_alloc (sizeof *n);
+ 			  if ($3[0] == '!')
+ 			    {
+ 			      n->with = without_flags;
+@@ -563,7 +563,7 @@ sect_flags:
+ 		INPUT_SECTION_FLAGS '(' sect_flag_list ')'
+ 			{
+ 			  struct flag_info *n;
+-			  n = ((struct flag_info *) xmalloc (sizeof *n));
++			  n = stat_alloc (sizeof *n);
+ 			  n->flag_list = $3;
+ 			  n->flags_initialized = false;
+ 			  n->not_with_flags = 0;
+@@ -576,7 +576,7 @@ exclude_name_list:
+ 		exclude_name_list wildcard_name
+ 			{
+ 			  struct name_list *tmp;
+-			  tmp = (struct name_list *) xmalloc (sizeof *tmp);
++			  tmp = stat_alloc (sizeof *tmp);
+ 			  tmp->name = $2;
+ 			  tmp->next = $1;
+ 			  $$ = tmp;
+@@ -585,7 +585,7 @@ exclude_name_list:
+ 		wildcard_name
+ 			{
+ 			  struct name_list *tmp;
+-			  tmp = (struct name_list *) xmalloc (sizeof *tmp);
++			  tmp = stat_alloc (sizeof *tmp);
+ 			  tmp->name = $1;
+ 			  tmp->next = NULL;
+ 			  $$ = tmp;
+@@ -596,7 +596,7 @@ section_name_list:
+ 		section_name_list opt_comma section_name_spec
+ 			{
+ 			  struct wildcard_list *tmp;
+-			  tmp = (struct wildcard_list *) xmalloc (sizeof *tmp);
++			  tmp = stat_alloc (sizeof *tmp);
+ 			  tmp->next = $1;
+ 			  tmp->spec = $3;
+ 			  $$ = tmp;
+@@ -605,7 +605,7 @@ section_name_list:
+ 		section_name_spec
+ 			{
+ 			  struct wildcard_list *tmp;
+-			  tmp = (struct wildcard_list *) xmalloc (sizeof *tmp);
++			  tmp = stat_alloc (sizeof *tmp);
+ 			  tmp->next = NULL;
+ 			  tmp->spec = $1;
+ 			  $$ = tmp;
+@@ -890,7 +890,7 @@ nocrossref_list:
+ 		{
+ 		  struct lang_nocrossref *n;
+ 
+-		  n = (struct lang_nocrossref *) xmalloc (sizeof *n);
++		  n = stat_alloc (sizeof *n);
+ 		  n->name = $1;
+ 		  n->next = $2;
+ 		  $$ = n;
+@@ -899,7 +899,7 @@ nocrossref_list:
+ 		{
+ 		  struct lang_nocrossref *n;
+ 
+-		  n = (struct lang_nocrossref *) xmalloc (sizeof *n);
++		  n = stat_alloc (sizeof *n);
+ 		  n->name = $1;
+ 		  n->next = $3;
+ 		  $$ = n;
+@@ -1172,8 +1172,7 @@ phdr_opt:
+ 		{
+ 		  struct lang_output_section_phdr_list *n;
+ 
+-		  n = ((struct lang_output_section_phdr_list *)
+-		       xmalloc (sizeof *n));
++		  n = stat_alloc (sizeof *n);
+ 		  n->name = $3;
+ 		  n->used = false;
+ 		  n->next = $1;
+diff --git a/ld/ldlang.c b/ld/ldlang.c
+index 2610be99..9ccb703f 100644
+--- a/ld/ldlang.c
++++ b/ld/ldlang.c
+@@ -169,6 +169,23 @@ stat_alloc (size_t size)
+   return obstack_alloc (&stat_obstack, size);
+ }
+ 
++void *
++stat_memdup (const void *src, size_t copy_size, size_t alloc_size)
++{
++  void *ret = obstack_alloc (&stat_obstack, alloc_size);
++  memcpy (ret, src, copy_size);
++  if (alloc_size > copy_size)
++    memset ((char *) ret + copy_size, 0, alloc_size - copy_size);
++  return ret;
++}
++
++char *
++stat_strdup (const char *str)
++{
++  size_t len = strlen (str) + 1;
++  return stat_memdup (str, len, len);
++}
++
+ static int
+ name_match (const char *pattern, const char *name)
+ {
+@@ -181,15 +198,13 @@ static char *
+ ldirname (const char *name)
+ {
+   const char *base = lbasename (name);
+-  char *dirname;
+ 
+   while (base > name && IS_DIR_SEPARATOR (base[-1]))
+     --base;
+-  if (base == name)
+-    return strdup (".");
+-  dirname = strdup (name);
+-  dirname[base - name] = '\0';
+-  return dirname;
++  size_t len = base - name;
++  if (len == 0)
++    return ".";
++  return stat_memdup (name, len, len + 1);
+ }
+ 
+ /* If PATTERN is of the form archive:file, return a pointer to the
+@@ -578,7 +593,7 @@ output_section_callback_fast (lang_wild_statement_type *ptr,
+   if (unique_section_p (section, os))
+     return;
+ 
+-  node = (lang_section_bst_type *) xmalloc (sizeof (lang_section_bst_type));
++  node = stat_alloc (sizeof (*node));
+   node->left = 0;
+   node->right = 0;
+   node->section = section;
+@@ -604,8 +619,6 @@ output_section_callback_tree_to_list (lang_wild_statement_type *ptr,
+ 
+   if (tree->right)
+     output_section_callback_tree_to_list (ptr, tree->right, output);
+-
+-  free (tree);
+ }
+ 
+ /* Specialized, optimized routines for handling different kinds of
+@@ -1371,7 +1384,7 @@ lang_memory_region_lookup (const char *const name, bool create)
+ 
+   new_region = stat_alloc (sizeof (lang_memory_region_type));
+ 
+-  new_region->name_list.name = xstrdup (name);
++  new_region->name_list.name = stat_strdup (name);
+   new_region->name_list.next = NULL;
+   new_region->next = NULL;
+   new_region->origin_exp = NULL;
+@@ -1426,7 +1439,7 @@ lang_memory_region_alias (const char *alias, const char *region_name)
+ 
+   /* Add alias to region name list.  */
+   n = stat_alloc (sizeof (lang_memory_region_name));
+-  n->name = xstrdup (alias);
++  n->name = stat_strdup (alias);
+   n->next = region->name_list.next;
+   region->name_list.next = n;
+ }
+@@ -2972,11 +2985,9 @@ add_excluded_libs (const char *list)
+       end = strpbrk (p, ",:");
+       if (end == NULL)
+ 	end = p + strlen (p);
+-      entry = (struct excluded_lib *) xmalloc (sizeof (*entry));
++      entry = stat_alloc (sizeof (*entry));
+       entry->next = excluded_libs;
+-      entry->name = (char *) xmalloc (end - p + 1);
+-      memcpy (entry->name, p, end - p);
+-      entry->name[end - p] = '\0';
++      entry->name = stat_memdup (p, end - p, end - p + 1);
+       excluded_libs = entry;
+       if (*end == '\0')
+ 	break;
+@@ -3967,7 +3978,7 @@ ldlang_add_undef (const char *const name, bool cmdline ATTRIBUTE_UNUSED)
+   new_undef->next = ldlang_undef_chain_list_head;
+   ldlang_undef_chain_list_head = new_undef;
+ 
+-  new_undef->name = xstrdup (name);
++  new_undef->name = stat_strdup (name);
+ 
+   if (link_info.output_bfd != NULL)
+     insert_undefined (new_undef->name);
+@@ -4046,7 +4057,7 @@ ldlang_add_require_defined (const char *const name)
+   ldlang_add_undef (name, true);
+   ptr = stat_alloc (sizeof (*ptr));
+   ptr->next = require_defined_symbol_list;
+-  ptr->name = strdup (name);
++  ptr->name = stat_strdup (name);
+   require_defined_symbol_list = ptr;
+ }
+ 
+@@ -8719,7 +8730,7 @@ lang_add_nocrossref (lang_nocrossref_type *l)
+ {
+   struct lang_nocrossrefs *n;
+ 
+-  n = (struct lang_nocrossrefs *) xmalloc (sizeof *n);
++  n = stat_alloc (sizeof *n);
+   n->next = nocrossref_list;
+   n->list = l;
+   n->onlyfirst = false;
+@@ -8909,7 +8920,7 @@ lang_leave_overlay (etree_type *lma_expr,
+ 	{
+ 	  lang_nocrossref_type *nc;
+ 
+-	  nc = (lang_nocrossref_type *) xmalloc (sizeof *nc);
++	  nc = stat_alloc (sizeof *nc);
+ 	  nc->name = l->os->name;
+ 	  nc->next = nocrossref;
+ 	  nocrossref = nc;
+@@ -9089,13 +9100,10 @@ realsymbol (const char *pattern)
+   if (changed)
+     {
+       *s = '\0';
+-      return symbol;
+-    }
+-  else
+-    {
+-      free (symbol);
+-      return pattern;
++      pattern = stat_strdup (symbol);
+     }
++  free (symbol);
++  return pattern;
+ }
+ 
+ /* This is called for each variable name or match expression.  NEW_NAME is
+@@ -9110,7 +9118,7 @@ lang_new_vers_pattern (struct bfd_elf_version_expr *orig,
+ {
+   struct bfd_elf_version_expr *ret;
+ 
+-  ret = (struct bfd_elf_version_expr *) xmalloc (sizeof *ret);
++  ret = stat_alloc (sizeof *ret);
+   ret->next = orig;
+   ret->symver = 0;
+   ret->script = 0;
+@@ -9147,7 +9155,8 @@ lang_new_vers_node (struct bfd_elf_version_expr *globals,
+ {
+   struct bfd_elf_version_tree *ret;
+ 
+-  ret = (struct bfd_elf_version_tree *) xcalloc (1, sizeof *ret);
++  ret = stat_alloc (sizeof (*ret));
++  memset (ret, 0, sizeof (*ret));
+   ret->globals.list = globals;
+   ret->locals.list = locals;
+   ret->match = lang_vers_match;
+@@ -9229,15 +9238,7 @@ lang_finalize_version_expr_head (struct bfd_elf_version_expr_head *head)
+ 		    }
+ 		  while (e1 && strcmp (e1->pattern, e->pattern) == 0);
+ 
+-		  if (last == NULL)
+-		    {
+-		      /* This is a duplicate.  */
+-		      /* FIXME: Memory leak.  Sometimes pattern is not
+-			 xmalloced alone, but in larger chunk of memory.  */
+-		      /* free (e->pattern); */
+-		      free (e);
+-		    }
+-		  else
++		  if (last != NULL)
+ 		    {
+ 		      e->next = last->next;
+ 		      last->next = e;
+@@ -9277,7 +9278,6 @@ lang_register_vers_node (const char *name,
+     {
+       einfo (_("%X%P: anonymous version tag cannot be combined"
+ 	       " with other version tags\n"));
+-      free (version);
+       return;
+     }
+ 
+@@ -9370,7 +9370,7 @@ lang_add_vers_depend (struct bfd_elf_version_deps *list, const char *name)
+   struct bfd_elf_version_deps *ret;
+   struct bfd_elf_version_tree *t;
+ 
+-  ret = (struct bfd_elf_version_deps *) xmalloc (sizeof *ret);
++  ret = stat_alloc (sizeof *ret);
+   ret->next = list;
+ 
+   for (t = link_info.version_info; t != NULL; t = t->next)
+@@ -9403,7 +9403,7 @@ lang_do_version_exports_section (void)
+ 	continue;
+ 
+       len = sec->size;
+-      contents = (char *) xmalloc (len);
++      contents = stat_alloc (len);
+       if (!bfd_get_section_contents (is->the_bfd, sec, contents, 0, len))
+ 	einfo (_("%X%P: unable to read .exports section contents\n"), sec);
+ 
+@@ -9414,8 +9414,6 @@ lang_do_version_exports_section (void)
+ 	  p = strchr (p, '\0') + 1;
+ 	}
+ 
+-      /* Do not free the contents, as we used them creating the regex.  */
+-
+       /* Do not include this section in the link.  */
+       sec->flags |= SEC_EXCLUDE | SEC_KEEP;
+     }
+@@ -9479,8 +9477,8 @@ lang_add_unique (const char *name)
+     if (strcmp (ent->name, name) == 0)
+       return;
+ 
+-  ent = (struct unique_sections *) xmalloc (sizeof *ent);
+-  ent->name = xstrdup (name);
++  ent = stat_alloc (sizeof *ent);
++  ent->name = stat_strdup (name);
+   ent->next = unique_section_list;
+   unique_section_list = ent;
+ }
+@@ -9503,7 +9501,8 @@ lang_append_dynamic_list (struct bfd_elf_dynamic_list **list_p,
+     {
+       struct bfd_elf_dynamic_list *d;
+ 
+-      d = (struct bfd_elf_dynamic_list *) xcalloc (1, sizeof *d);
++      d = stat_alloc (sizeof (*d));
++      memset (d, 0, sizeof (*d));
+       d->head.list = dynamic;
+       d->match = lang_vers_match;
+       *list_p = d;
+diff --git a/ld/ldlang.h b/ld/ldlang.h
+index f68ae27b..496e25ca 100644
+--- a/ld/ldlang.h
++++ b/ld/ldlang.h
+@@ -640,6 +640,10 @@ extern void lang_for_each_statement_worker
+   (void (*) (lang_statement_union_type *), lang_statement_union_type *);
+ extern void *stat_alloc
+   (size_t);
++extern void * stat_memdup
++  (const void *, size_t, size_t);
++extern char *stat_strdup
++  (const char *);
+ extern void strip_excluded_output_sections
+   (void);
+ extern void lang_clear_os_map
+diff --git a/ld/ldlex.l b/ld/ldlex.l
+index 25b4bcaa..a77ee7de 100644
+--- a/ld/ldlex.l
++++ b/ld/ldlex.l
+@@ -187,7 +187,8 @@ V_IDENTIFIER [*?.$_a-zA-Z\[\]\-\!\^\\]([*?.$_a-zA-Z0-9\[\]\-\!\^\\]|::)*
+ 					   && (yytext[1] == 'x'
+ 					       || yytext[1] == 'X'))
+ 				    {
+-				      yylval.bigint.str = xstrdup (yytext + 2);
++				      yylval.bigint.str
++					= stat_strdup (yytext + 2);
+ 				    }
+ 				  return INT;
+ 				}
+@@ -360,30 +361,30 @@ V_IDENTIFIER [*?.$_a-zA-Z\[\]\-\!\^\\]([*?.$_a-zA-Z0-9\[\]\-\!\^\\]|::)*
+ 
+ <MRI>{FILENAMECHAR1}{NOCFILENAMECHAR}*	{
+ /* Filename without commas, needed to parse mri stuff */
+-				  yylval.name = xstrdup (yytext);
++				  yylval.name = stat_strdup (yytext);
+ 				  return NAME;
+ 				}
+ 
+ 
+ <BOTH,INPUTLIST>{FILENAMECHAR1}{FILENAMECHAR}*	{
+-				  yylval.name = xstrdup (yytext);
++				  yylval.name = stat_strdup (yytext);
+ 				  return NAME;
+ 				}
+ <INPUTLIST>"="{FILENAMECHAR1}{FILENAMECHAR}*	{
+ /* Filename to be prefixed by --sysroot or when non-sysrooted, nothing.  */
+-				  yylval.name = xstrdup (yytext);
++				  yylval.name = stat_strdup (yytext);
+ 				  return NAME;
+ 				}
+ <BOTH,INPUTLIST>"-l"{FILENAMECHAR}+ {
+-				  yylval.name = xstrdup (yytext + 2);
++				  yylval.name = stat_strdup (yytext + 2);
+ 				  return LNAME;
+ 				}
+ <EXPRESSION>{SYMBOLNAMECHAR1}{SYMBOLNAMECHAR}* {
+-				  yylval.name = xstrdup (yytext);
++				  yylval.name = stat_strdup (yytext);
+ 				  return NAME;
+ 				}
+ <EXPRESSION>"/DISCARD/"		{
+-				  yylval.name = xstrdup (yytext);
++				  yylval.name = yylval.name = stat_strdup (yytext);
+ 				  return NAME;
+ 				}
+ <EXPRESSION>"-l"{NOCFILENAMECHAR}+ {
+@@ -402,7 +403,7 @@ V_IDENTIFIER [*?.$_a-zA-Z\[\]\-\!\^\\]([*?.$_a-zA-Z0-9\[\]\-\!\^\\]|::)*
+ 		  }
+ 		else
+ 		  {
+-		    yylval.name = xstrdup (yytext);
++		    yylval.name = stat_strdup (yytext);
+ 		    return NAME;
+ 		  }
+ 	}
+@@ -411,7 +412,7 @@ V_IDENTIFIER [*?.$_a-zA-Z\[\]\-\!\^\\]([*?.$_a-zA-Z0-9\[\]\-\!\^\\]|::)*
+ 					/* No matter the state, quotes
+ 					   give what's inside.  */
+ 					bfd_size_type len;
+-					yylval.name = xstrdup (yytext + 1);
++					yylval.name = stat_memdup (yytext + 1, yyleng - 2, yyleng - 1);
+ 					/* PR ld/20906.  A corrupt input file
+ 					   can contain bogus strings.  */
+ 					len = strlen (yylval.name);
+@@ -431,10 +432,10 @@ V_IDENTIFIER [*?.$_a-zA-Z\[\]\-\!\^\\]([*?.$_a-zA-Z0-9\[\]\-\!\^\\]|::)*
+ 
+ <VERS_NODE>extern		{ RTOKEN(EXTERN); }
+ 
+-<VERS_NODE>{V_IDENTIFIER}	{ yylval.name = xstrdup (yytext);
++<VERS_NODE>{V_IDENTIFIER}	{ yylval.name = stat_strdup (yytext);
+ 				  return VERS_IDENTIFIER; }
+ 
+-<VERS_SCRIPT>{V_TAG}		{ yylval.name = xstrdup (yytext);
++<VERS_SCRIPT>{V_TAG}		{ yylval.name = stat_strdup (yytext);
+ 				  return VERS_TAG; }
+ 
+ <VERS_START>"{"			{ BEGIN(VERS_SCRIPT); return *yytext; }
+diff --git a/ld/lexsup.c b/ld/lexsup.c
+index 00274c50..7272e5f8 100644
+--- a/ld/lexsup.c
++++ b/ld/lexsup.c
+@@ -1844,16 +1844,6 @@ parse_args (unsigned argc, char **argv)
+ 	  if (opt_dynamic_list != dynamic_list_data)
+ 	    opt_dynamic_list = dynamic_list;
+ 	}
+-      else
+-	{
+-	  /* Free the export list.  */
+-	  for (; head->next != NULL; head = next)
+-	    {
+-	      next = head->next;
+-	      free (head);
+-	    }
+-	  free (export_list);
+-	}
+     }
+ 
+   switch (opt_dynamic_list)
+@@ -1877,17 +1867,7 @@ parse_args (unsigned argc, char **argv)
+ 	break;
+       case symbolic:
+ 	link_info.symbolic = true;
+-	if (link_info.dynamic_list)
+-	  {
+-	    struct bfd_elf_version_expr *ent, *next;
+-	    for (ent = link_info.dynamic_list->head.list; ent; ent = next)
+-	      {
+-		next = ent->next;
+-		free (ent);
+-	      }
+-	    free (link_info.dynamic_list);
+-	    link_info.dynamic_list = NULL;
+-	  }
++	link_info.dynamic_list = NULL;
+ 	break;
+       case symbolic_functions:
+ 	link_info.dynamic = true;
+-- 
+2.45.4
+

--- a/SPECS/binutils/CVE-2025-11839.patch
+++ b/SPECS/binutils/CVE-2025-11839.patch
@@ -1,0 +1,28 @@
+From 12ef7d5b7b02d0023db645d86eb9d0797bc747fe Mon Sep 17 00:00:00 2001
+From: Nick Clifton <nickc@redhat.com>
+Date: Mon, 3 Nov 2025 11:49:02 +0000
+Subject: [PATCH] Remove call to abort in the DGB debug format printing code,
+ thus allowing the display of a fuzzed input file to complete without
+ triggering an abort.
+
+PR 33448
+Upstream Patch Reference: https://git.launchpad.net/ubuntu/+source/binutils/tree/debian/patches/CVE-2025-11839.patch?id=cca82fc71351b30e5f983a74296709f4c57bd0b4
+---
+ binutils/prdbg.c | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/binutils/prdbg.c b/binutils/prdbg.c
+index ed53cf5c..4d7181bb 100644
+--- a/binutils/prdbg.c
++++ b/binutils/prdbg.c
+@@ -2468,7 +2468,6 @@ tg_tag_type (void *p, const char *name, unsigned int id,
+       t = "union class ";
+       break;
+     default:
+-      abort ();
+       return false;
+     }
+ 
+-- 
+2.45.4
+

--- a/SPECS/binutils/binutils.spec
+++ b/SPECS/binutils/binutils.spec
@@ -21,7 +21,7 @@
 Summary:        Contains a linker, an assembler, and other tools
 Name:           binutils
 Version:        2.37
-Release:        19%{?dist}
+Release:        20%{?dist}
 License:        GPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -60,6 +60,9 @@ Patch25:        CVE-2025-11412.patch
 Patch26:        CVE-2025-11414.patch
 Patch27:        CVE-2025-11082.patch
 Patch28:        CVE-2025-11083.patch
+Patch29:        CVE-2025-1147.patch
+Patch30:        CVE-2025-1148.patch
+Patch31:        CVE-2025-11839.patch
 Provides:       bundled(libiberty)
 
 # Moving macro before the "SourceX" tags breaks PR checks parsing the specs.
@@ -316,6 +319,9 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %do_files aarch64-linux-gnu %{build_aarch64}
 
 %changelog
+* Wed Jan 07 2026 Jyoti Kanase <v-jykanase@microsoft.com> - 2.37-20
+- Patch for CVE-2025-1147, CVE-2025-1148, CVE-2025-11839
+
 * Thu Oct 23 2025 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 2.37-19
 - Patch for CVE-2025-11083, CVE-2025-11082
 

--- a/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_aarch64.txt
@@ -12,8 +12,8 @@ zlib-devel-1.2.13-2.cm2.aarch64.rpm
 file-5.40-3.cm2.aarch64.rpm
 file-devel-5.40-3.cm2.aarch64.rpm
 file-libs-5.40-3.cm2.aarch64.rpm
-binutils-2.37-19.cm2.aarch64.rpm
-binutils-devel-2.37-19.cm2.aarch64.rpm
+binutils-2.37-20.cm2.aarch64.rpm
+binutils-devel-2.37-20.cm2.aarch64.rpm
 gmp-6.2.1-4.cm2.aarch64.rpm
 gmp-devel-6.2.1-4.cm2.aarch64.rpm
 mpfr-4.1.0-2.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -12,8 +12,8 @@ zlib-devel-1.2.13-2.cm2.x86_64.rpm
 file-5.40-3.cm2.x86_64.rpm
 file-devel-5.40-3.cm2.x86_64.rpm
 file-libs-5.40-3.cm2.x86_64.rpm
-binutils-2.37-19.cm2.x86_64.rpm
-binutils-devel-2.37-19.cm2.x86_64.rpm
+binutils-2.37-20.cm2.x86_64.rpm
+binutils-devel-2.37-20.cm2.x86_64.rpm
 gmp-6.2.1-4.cm2.x86_64.rpm
 gmp-devel-6.2.1-4.cm2.x86_64.rpm
 mpfr-4.1.0-2.cm2.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_aarch64.txt
+++ b/toolkit/resources/manifests/package/toolchain_aarch64.txt
@@ -9,9 +9,9 @@ bash-5.1.8-4.cm2.aarch64.rpm
 bash-debuginfo-5.1.8-4.cm2.aarch64.rpm
 bash-devel-5.1.8-4.cm2.aarch64.rpm
 bash-lang-5.1.8-4.cm2.aarch64.rpm
-binutils-2.37-19.cm2.aarch64.rpm
-binutils-debuginfo-2.37-19.cm2.aarch64.rpm
-binutils-devel-2.37-19.cm2.aarch64.rpm
+binutils-2.37-20.cm2.aarch64.rpm
+binutils-debuginfo-2.37-20.cm2.aarch64.rpm
+binutils-devel-2.37-20.cm2.aarch64.rpm
 bison-3.7.6-2.cm2.aarch64.rpm
 bison-debuginfo-3.7.6-2.cm2.aarch64.rpm
 bzip2-1.0.8-1.cm2.aarch64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -9,10 +9,10 @@ bash-5.1.8-4.cm2.x86_64.rpm
 bash-debuginfo-5.1.8-4.cm2.x86_64.rpm
 bash-devel-5.1.8-4.cm2.x86_64.rpm
 bash-lang-5.1.8-4.cm2.x86_64.rpm
-binutils-2.37-19.cm2.x86_64.rpm
-binutils-aarch64-linux-gnu-2.37-19.cm2.x86_64.rpm
-binutils-debuginfo-2.37-19.cm2.x86_64.rpm
-binutils-devel-2.37-19.cm2.x86_64.rpm
+binutils-2.37-20.cm2.x86_64.rpm
+binutils-aarch64-linux-gnu-2.37-20.cm2.x86_64.rpm
+binutils-debuginfo-2.37-20.cm2.x86_64.rpm
+binutils-devel-2.37-20.cm2.x86_64.rpm
 bison-3.7.6-2.cm2.x86_64.rpm
 bison-debuginfo-3.7.6-2.cm2.x86_64.rpm
 bzip2-1.0.8-1.cm2.x86_64.rpm
@@ -47,7 +47,7 @@ cracklib-lang-2.9.7-5.cm2.x86_64.rpm
 createrepo_c-0.17.5-1.cm2.x86_64.rpm
 createrepo_c-debuginfo-0.17.5-1.cm2.x86_64.rpm
 createrepo_c-devel-0.17.5-1.cm2.x86_64.rpm
-cross-binutils-common-2.37-19.cm2.noarch.rpm
+cross-binutils-common-2.37-20.cm2.noarch.rpm
 cross-gcc-common-11.2.0-9.cm2.noarch.rpm
 curl-8.8.0-7.cm2.x86_64.rpm
 curl-debuginfo-8.8.0-7.cm2.x86_64.rpm


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
patch binutils for CVE-2025-1147, CVE-2025-1148, CVE-2025-11839
Patch Modified: No
CVE-2025-1147 : [https://[sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;a=patch;h=7be4186c22f89a87fff048c28910f5d26a0f61ce](https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;a=patch;h=7be4186c22f89a87fff048c28910f5d26a0f61ce)](https://git.launchpad.net/ubuntu/+source/binutils/tree/debian/patches/CVE-2025-1147.patch?id=2938c598064e4b8513e1d0614a522732e8401080)
CVE-2025-1148 : https://git.launchpad.net/ubuntu/+source/binutils/tree/debian/patches/CVE-2025-1148.patch?id=2938c598064e4b8513e1d0614a522732e8401080
CVE-2025-11839 : https://git.launchpad.net/ubuntu/+source/binutils/tree/debian/patches/CVE-2025-11839.patch?id=cca82fc71351b30e5f983a74296709f4c57bd0b4
###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- binutils.spec

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2025-1147
- https://nvd.nist.gov/vuln/detail/CVE-2025-1148
- https://nvd.nist.gov/vuln/detail/CVE-2025-11839

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build
<img width="656" height="464" alt="Screenshot 2026-01-07 172535" src="https://github.com/user-attachments/assets/bb2c1adc-081e-4c45-9f4a-38d8322f7002" />
<img width="1182" height="176" alt="Screenshot 2026-01-07 172616" src="https://github.com/user-attachments/assets/1f234a19-73f1-4294-a22c-2d20da9b262c" />

