### PR TITLE
[Low] Patch rpm-ostree for CVE-2025-58160

### DIFF
--- a/SPECS/rpm-ostree/CVE-2025-58160.patch
+++ b/SPECS/rpm-ostree/CVE-2025-58160.patch
@@ -1,0 +1,481 @@
+From 4c52ca5266a3920fc5dfeebda2accf15ee7fb278 Mon Sep 17 00:00:00 2001
+From: Carl Lerche <me@carllerche.com>
+Date: Fri, 29 Aug 2025 12:08:48 -0700
+Subject: [PATCH] fmt: fix ANSI escape sequence injection vulnerability (#3368)
+
+Fixes a security vulnerability where ANSI escape sequences in user input
+could be injected into terminal output, potentially allowing attackers to
+manipulate terminal behavior through log messages and error displays.
+
+The vulnerability occurred when user-controlled content was formatted using
+Display (`{}`) instead of Debug (`{:?}`) formatting, allowing raw ANSI
+sequences to pass through unescaped.
+
+Changes:
+- Add streaming ANSI escape wrapper to avoid string allocations
+- Escape message content in default and pretty formatters
+- Escape error Display content in all error formatting paths
+- Add comprehensive integration tests for all formatter types
+
+The fix specifically targets untrusted user input while preserving the
+ability for applications to deliberately include formatting in trusted
+contexts like thread names.
+
+Security impact: Prevents terminal injection attacks such as title bar
+manipulation, screen clearing, and other malicious terminal control
+sequences that could be injected through log messages.
+
+Upstream Patch reference: https://github.com/tokio-rs/tracing/commit/4c52ca5266a3920fc5dfeebda2accf15ee7fb278.patch
+---
+ .../tracing-subscriber/.cargo-checksum.json   |   2 +-
+ .../src/fmt/format/escape.rs                  |  51 ++++
+ .../tracing-subscriber/src/fmt/format/mod.rs  |  15 +-
+ .../src/fmt/format/pretty.rs                  |   9 +-
+ .../tracing-subscriber/tests/ansi_escaping.rs | 281 ++++++++++++++++++
+ 5 files changed, 350 insertions(+), 8 deletions(-)
+ create mode 100644 vendor/tracing-subscriber/src/fmt/format/escape.rs
+ create mode 100644 vendor/tracing-subscriber/tests/ansi_escaping.rs
+
+diff --git a/vendor/tracing-subscriber/.cargo-checksum.json b/vendor/tracing-subscriber/.cargo-checksum.json
+index ffaa7811..66a13fce 100644
+--- a/vendor/tracing-subscriber/.cargo-checksum.json
++++ b/vendor/tracing-subscriber/.cargo-checksum.json
+@@ -1 +1 @@
+-{"files":{"CHANGELOG.md":"190806805a76c97c518a5bb80389c7c24a0be57e05cf8f80142f28c9ce8f1c43","Cargo.toml":"8ec256b25e1127fb2204000e2c7e7c61e2b6e4b75accfa7e4ef42ad78da73e19","LICENSE":"898b1ae9821e98daf8964c8d6c7f61641f5f5aa78ad500020771c0939ee0dea1","README.md":"48a396fea9f0d6712b727941c425edb0842426460fdf2c653cf9705520436c38","benches/enter.rs":"4a94a04e2abd07950ef2f0b646f4dcdf4ff00abf6396edb5a53c8b41b7691b1a","benches/filter.rs":"6374005ffa47fa19880bb95e3e37406f40ea72a02c5136f4d5eb4c663d452b18","benches/filter_log.rs":"612716bdf9a188093e84d014a4847f18157f148f7d64e54150cd5c91ac709a8a","benches/fmt.rs":"5a0ff37967ffef3a221eebb78855d031e2e883a8a67528c8e794cc6f16cbee8a","benches/support/mod.rs":"72bef51154da9c9b3d81300195c1929a818858fa4b4fc2aa07b49ca586f4cd39","src/field/debug.rs":"4ab50198a0b042d92fefa77b5cac0aef7ba6936149fa555f4b6e2036dcd7f2d7","src/field/delimited.rs":"e6b2dcbf9cb1e9b5e862b462f91190adaf8e14f9c2c5d2048ad651f49cfa2007","src/field/display.rs":"9c06a52919dbe9bfd4cf7eec39293240c9facebe052a2fecc2f21184beb5195f","src/field/mod.rs":"c8af30eb8ac0b759169052f828eaa045f9ab94af46d00f8b42beec6c96ff31ca","src/filter/directive.rs":"7ecf87b17afbddadbc385764c2d9c1fda4b020a08d75f741f8e34c7dc475bd74","src/filter/env/directive.rs":"628f9f566ccee924d43d79b287c569abfc32c2fb74e078958aed6cb8285cfb4f","src/filter/env/field.rs":"9f2ceaedf2e2ecefaff863347ef8dfa85cd5f64a0fd09a0f77f64f412c9bb548","src/filter/env/mod.rs":"7f864a5ef0c008c7fe9a21d0a94bb87dd72746e628ff3e68c18b0fd173763918","src/filter/filter_fn.rs":"0debbc4a4b4d2a57b2a06905017ac908bf34b0a64aaf961535fbf6f4d5a700a9","src/filter/layer_filters.rs":"16ff19fed003b913de4f85a03b31864d71ee73c7ce86b07c80da07fe633f682e","src/filter/level.rs":"cc449757aac47caaf19dd5ba4d74c8efbcd7531fcd6c13da0c5f6fdda12cc9ca","src/filter/mod.rs":"8ebfd0dc92415ff27ec552f20919e598842a87186f13f120449053a96e1e3307","src/filter/targets.rs":"5cec882366d7f12de0a88f7daaac8499785ce9e3832619f251876a02ae19a6bf","src/fmt/fmt_layer.rs":"a0717f1021a2033c0c73cfeeeff6daeedc739366dac5adc5da533cab92314881","src/fmt/format/json.rs":"1a38c049e1bf99efaf7db1f1fd26d3a5bb1e768fc1524c95816708e5d39fca35","src/fmt/format/mod.rs":"4d56527fa739b56548d548eee9566c5c9f50c8ab3fde0caea5550f2cbdcdecc2","src/fmt/format/pretty.rs":"c4b73a5d52401c3d0aff7e0cb646a40d582f5cac7227ac2160b97c4f2383f6b6","src/fmt/mod.rs":"3ce827df196306bf1a5d1cc79b81f2df2ab161918cca49023f06e0765a39df5c","src/fmt/time/datetime.rs":"778d4604d800e46b940087394e7b72750738b554e02aea523fa9820ab0768c08","src/fmt/time/mod.rs":"e8ab9ab9415e425b2634d0cc6ab96b7c63e5b004f290b08aad18c3e0ce92cbe3","src/fmt/time/time_crate.rs":"d9fede9482fc9875131fd9e7cb12b8d8a59c941071d0d0400020ad1d5e44296f","src/fmt/writer.rs":"224d0080b58b268d60f24ff6de74f8442b4b6cccf1fa01ccf032c9a5d5a9e3df","src/layer/context.rs":"2478693e2faffdf2e519b6d37e1c3aa3dd75088185accc2b68ffa8612bf73195","src/layer/layered.rs":"ba918a9b944f2c083cbb75d6d7f99f90083aa0a29cf3f4f1dd78aa034e09ade6","src/layer/mod.rs":"e1804cfe91051020cac63fb1067d196552ebb844b6c6d1d2279b97dbec1c64df","src/layer/tests.rs":"3e974d627c4bc4269cfa10c82c890e596c9d46af8e6bc03c6c117bde1237e948","src/lib.rs":"ee6bf8d994dc0af592584cda0f2bf38e022945ab36377aa040b88fd354ffe59c","src/macros.rs":"e184bffc6b5999c48e365ad08343dca764a5fb711b789beb26bd1d5f1d767726","src/prelude.rs":"088635def33be9a4c4b6ed934dc22540c555e27d62f7625a43aa9c0e525ca467","src/registry/extensions.rs":"7333aefd69c767212a7924c57283442430edccb17092c91e02a7d13b2d312b11","src/registry/mod.rs":"4f0108e75e0f6e239b8eb69fcad052f25e3b887e412e951e0cbec02cf13f05d5","src/registry/sharded.rs":"972bdd94f43a33ef1f2ebf96ea69ebe4c1d4b0215e69315a3b525783c2025696","src/registry/stack.rs":"9ef333d6a8a28a064e80ff1e376dbb07bc597009010ec332b2dc3ab435d737c2","src/reload.rs":"41fa9a1a28fef626e302a80a68d665492e73ef6d1a2a3c2a7aac5d6c9a0bb496","src/sync.rs":"7f78f3de5b618a999be0e61f936a233975e7769f1ebb55a0e48c3d199e9c45e3","src/util.rs":"55b4e9d63112f9d5a12a287273a9b1212741058384332d3edc024168cacfd627","tests/cached_layer_filters_dont_break_other_layers.rs":"b2084542a014abeff821b30b2b8c21e32bfdcffae53ce5335fb588f557fa4244","tests/duplicate_spans.rs":"48f596bbfabcc6618244afddcf3c3f2e915b9d79284f17bdd0e0616ad29929be","tests/field_filter.rs":"c44d88ab711164a2b1b3a09377284b469f79ddf4651416515a035782c7c64b79","tests/filter.rs":"a43d23e867af779031b6245047092aca57ee26980a8f3faa19036542bcd37f06","tests/filter_log.rs":"e0cd9d394dbfeeb80570a7686bc7f588c5489657980436810711ed8852f86169","tests/fmt_max_level_hint.rs":"d4c6d6f976ae41ab8052fa610a7337ad7150802cbd5634cb30fc45c1f215cfcd","tests/hinted_layer_filters_dont_break_other_layers.rs":"d5ba9cfb6784cf59f007e673ad549dc722d109f6b3d4a69f6aa11b25ca10b469","tests/layer_filter_interests_are_cached.rs":"d036d1c4bc3754e94ebfdda9c841f4858ccec40aba0720f3fbf26c817bfe5a83","tests/layer_filters/boxed.rs":"04db459721a26d6502a2b3fbe42154c5a451021a9374a18c017d10971f44e0c0","tests/layer_filters/downcast_raw.rs":"9b90ead571543cbe14e89b4fe637360d9baf3069f6f656ed3bdf65e7318648f1","tests/layer_filters/filter_scopes.rs":"02611bc58d0d8a67a127eca8cab1b2d9a9901bd2c8a8daad41adf6089b28aee0","tests/layer_filters/main.rs":"0316d611c740e234b78ed9a9dae392fe80472c1e8b004a007ad2dd87d068c67b","tests/layer_filters/targets.rs":"138e3f9ddd68571d94c5aff9d54ee2fbc5f44724c6ee42477a411740ccb79ee6","tests/layer_filters/trees.rs":"4df7b5cf12da44a9255c56e5b80e2b0cf84820230ba916f324c67bc3ee4e4605","tests/multiple_layer_filter_interests_cached.rs":"1ea195f03e58d715228ec1b604f85bda2fc82812d05b2f6370d5edd34a035f32","tests/registry_max_level_hint.rs":"ba386d32b8d13832d7009163241c3d0723488c0393d85647eb9368776251e4fc","tests/registry_with_subscriber.rs":"13b92ed68d9013aefefbc4c73e695c690630e4460634206d214db4c19abb7c0f","tests/reload.rs":"4566386b1b26e6609f5a4bf0e6bef1c2245a591d12417cee189b26dfa14f7f95","tests/same_len_filters.rs":"50c8f5fa1494773410a9f52a56b303534a01a023b186cf2f3131e5e7706eb156","tests/support.rs":"75559505af8018012739d24b3c8743dd079b4d3a8ae28f08b4586a961720aa7b","tests/unhinted_layer_filters_dont_break_other_layers.rs":"519cfef4977e511af938546d4208c645a28248c8ed8666daf180f0ad32f0a261","tests/utils.rs":"2b04ce2d8b56a9062a025900104853e081eae8e3f113f990a915d5f9dea6577b"},"package":"5d81bfa81424cc98cb034b837c985b7a290f592e5b4322f353f94a0ab0f9f594"}
+\ No newline at end of file
++{"files":{"CHANGELOG.md":"190806805a76c97c518a5bb80389c7c24a0be57e05cf8f80142f28c9ce8f1c43","Cargo.toml":"8ec256b25e1127fb2204000e2c7e7c61e2b6e4b75accfa7e4ef42ad78da73e19","LICENSE":"898b1ae9821e98daf8964c8d6c7f61641f5f5aa78ad500020771c0939ee0dea1","README.md":"48a396fea9f0d6712b727941c425edb0842426460fdf2c653cf9705520436c38","benches/enter.rs":"4a94a04e2abd07950ef2f0b646f4dcdf4ff00abf6396edb5a53c8b41b7691b1a","benches/filter.rs":"6374005ffa47fa19880bb95e3e37406f40ea72a02c5136f4d5eb4c663d452b18","benches/filter_log.rs":"612716bdf9a188093e84d014a4847f18157f148f7d64e54150cd5c91ac709a8a","benches/fmt.rs":"5a0ff37967ffef3a221eebb78855d031e2e883a8a67528c8e794cc6f16cbee8a","benches/support/mod.rs":"72bef51154da9c9b3d81300195c1929a818858fa4b4fc2aa07b49ca586f4cd39","src/field/debug.rs":"4ab50198a0b042d92fefa77b5cac0aef7ba6936149fa555f4b6e2036dcd7f2d7","src/field/delimited.rs":"e6b2dcbf9cb1e9b5e862b462f91190adaf8e14f9c2c5d2048ad651f49cfa2007","src/field/display.rs":"9c06a52919dbe9bfd4cf7eec39293240c9facebe052a2fecc2f21184beb5195f","src/field/mod.rs":"c8af30eb8ac0b759169052f828eaa045f9ab94af46d00f8b42beec6c96ff31ca","src/filter/directive.rs":"7ecf87b17afbddadbc385764c2d9c1fda4b020a08d75f741f8e34c7dc475bd74","src/filter/env/directive.rs":"628f9f566ccee924d43d79b287c569abfc32c2fb74e078958aed6cb8285cfb4f","src/filter/env/field.rs":"9f2ceaedf2e2ecefaff863347ef8dfa85cd5f64a0fd09a0f77f64f412c9bb548","src/filter/env/mod.rs":"7f864a5ef0c008c7fe9a21d0a94bb87dd72746e628ff3e68c18b0fd173763918","src/filter/filter_fn.rs":"0debbc4a4b4d2a57b2a06905017ac908bf34b0a64aaf961535fbf6f4d5a700a9","src/filter/layer_filters.rs":"16ff19fed003b913de4f85a03b31864d71ee73c7ce86b07c80da07fe633f682e","src/filter/level.rs":"cc449757aac47caaf19dd5ba4d74c8efbcd7531fcd6c13da0c5f6fdda12cc9ca","src/filter/mod.rs":"8ebfd0dc92415ff27ec552f20919e598842a87186f13f120449053a96e1e3307","src/filter/targets.rs":"5cec882366d7f12de0a88f7daaac8499785ce9e3832619f251876a02ae19a6bf","src/fmt/fmt_layer.rs":"a0717f1021a2033c0c73cfeeeff6daeedc739366dac5adc5da533cab92314881","src/fmt/format/json.rs":"1a38c049e1bf99efaf7db1f1fd26d3a5bb1e768fc1524c95816708e5d39fca35","src/fmt/format/mod.rs":"4daeb1cb13aea2353d36ea88e2c1d4367be02ff6be91480ffb5270ec586d6c61","src/fmt/format/pretty.rs":"ae55cec0026b8e5c0b259e815d7ae9be0be8e6d7976bd16339789260843a5b7c","src/fmt/mod.rs":"3ce827df196306bf1a5d1cc79b81f2df2ab161918cca49023f06e0765a39df5c","src/fmt/time/datetime.rs":"778d4604d800e46b940087394e7b72750738b554e02aea523fa9820ab0768c08","src/fmt/time/mod.rs":"e8ab9ab9415e425b2634d0cc6ab96b7c63e5b004f290b08aad18c3e0ce92cbe3","src/fmt/time/time_crate.rs":"d9fede9482fc9875131fd9e7cb12b8d8a59c941071d0d0400020ad1d5e44296f","src/fmt/writer.rs":"224d0080b58b268d60f24ff6de74f8442b4b6cccf1fa01ccf032c9a5d5a9e3df","src/layer/context.rs":"2478693e2faffdf2e519b6d37e1c3aa3dd75088185accc2b68ffa8612bf73195","src/layer/layered.rs":"ba918a9b944f2c083cbb75d6d7f99f90083aa0a29cf3f4f1dd78aa034e09ade6","src/layer/mod.rs":"e1804cfe91051020cac63fb1067d196552ebb844b6c6d1d2279b97dbec1c64df","src/layer/tests.rs":"3e974d627c4bc4269cfa10c82c890e596c9d46af8e6bc03c6c117bde1237e948","src/lib.rs":"ee6bf8d994dc0af592584cda0f2bf38e022945ab36377aa040b88fd354ffe59c","src/macros.rs":"e184bffc6b5999c48e365ad08343dca764a5fb711b789beb26bd1d5f1d767726","src/prelude.rs":"088635def33be9a4c4b6ed934dc22540c555e27d62f7625a43aa9c0e525ca467","src/registry/extensions.rs":"7333aefd69c767212a7924c57283442430edccb17092c91e02a7d13b2d312b11","src/registry/mod.rs":"4f0108e75e0f6e239b8eb69fcad052f25e3b887e412e951e0cbec02cf13f05d5","src/registry/sharded.rs":"972bdd94f43a33ef1f2ebf96ea69ebe4c1d4b0215e69315a3b525783c2025696","src/registry/stack.rs":"9ef333d6a8a28a064e80ff1e376dbb07bc597009010ec332b2dc3ab435d737c2","src/reload.rs":"41fa9a1a28fef626e302a80a68d665492e73ef6d1a2a3c2a7aac5d6c9a0bb496","src/sync.rs":"7f78f3de5b618a999be0e61f936a233975e7769f1ebb55a0e48c3d199e9c45e3","src/util.rs":"55b4e9d63112f9d5a12a287273a9b1212741058384332d3edc024168cacfd627","tests/cached_layer_filters_dont_break_other_layers.rs":"b2084542a014abeff821b30b2b8c21e32bfdcffae53ce5335fb588f557fa4244","tests/duplicate_spans.rs":"48f596bbfabcc6618244afddcf3c3f2e915b9d79284f17bdd0e0616ad29929be","tests/field_filter.rs":"c44d88ab711164a2b1b3a09377284b469f79ddf4651416515a035782c7c64b79","tests/filter.rs":"a43d23e867af779031b6245047092aca57ee26980a8f3faa19036542bcd37f06","tests/filter_log.rs":"e0cd9d394dbfeeb80570a7686bc7f588c5489657980436810711ed8852f86169","tests/fmt_max_level_hint.rs":"d4c6d6f976ae41ab8052fa610a7337ad7150802cbd5634cb30fc45c1f215cfcd","tests/hinted_layer_filters_dont_break_other_layers.rs":"d5ba9cfb6784cf59f007e673ad549dc722d109f6b3d4a69f6aa11b25ca10b469","tests/layer_filter_interests_are_cached.rs":"d036d1c4bc3754e94ebfdda9c841f4858ccec40aba0720f3fbf26c817bfe5a83","tests/layer_filters/boxed.rs":"04db459721a26d6502a2b3fbe42154c5a451021a9374a18c017d10971f44e0c0","tests/layer_filters/downcast_raw.rs":"9b90ead571543cbe14e89b4fe637360d9baf3069f6f656ed3bdf65e7318648f1","tests/layer_filters/filter_scopes.rs":"02611bc58d0d8a67a127eca8cab1b2d9a9901bd2c8a8daad41adf6089b28aee0","tests/layer_filters/main.rs":"0316d611c740e234b78ed9a9dae392fe80472c1e8b004a007ad2dd87d068c67b","tests/layer_filters/targets.rs":"138e3f9ddd68571d94c5aff9d54ee2fbc5f44724c6ee42477a411740ccb79ee6","tests/layer_filters/trees.rs":"4df7b5cf12da44a9255c56e5b80e2b0cf84820230ba916f324c67bc3ee4e4605","tests/multiple_layer_filter_interests_cached.rs":"1ea195f03e58d715228ec1b604f85bda2fc82812d05b2f6370d5edd34a035f32","tests/registry_max_level_hint.rs":"ba386d32b8d13832d7009163241c3d0723488c0393d85647eb9368776251e4fc","tests/registry_with_subscriber.rs":"13b92ed68d9013aefefbc4c73e695c690630e4460634206d214db4c19abb7c0f","tests/reload.rs":"4566386b1b26e6609f5a4bf0e6bef1c2245a591d12417cee189b26dfa14f7f95","tests/same_len_filters.rs":"50c8f5fa1494773410a9f52a56b303534a01a023b186cf2f3131e5e7706eb156","tests/support.rs":"75559505af8018012739d24b3c8743dd079b4d3a8ae28f08b4586a961720aa7b","tests/unhinted_layer_filters_dont_break_other_layers.rs":"519cfef4977e511af938546d4208c645a28248c8ed8666daf180f0ad32f0a261","tests/utils.rs":"2b04ce2d8b56a9062a025900104853e081eae8e3f113f990a915d5f9dea6577b"},"package":"5d81bfa81424cc98cb034b837c985b7a290f592e5b4322f353f94a0ab0f9f594"}
+diff --git a/vendor/tracing-subscriber/src/fmt/format/escape.rs b/vendor/tracing-subscriber/src/fmt/format/escape.rs
+new file mode 100644
+index 00000000..9f45d332
+--- /dev/null
++++ b/vendor/tracing-subscriber/src/fmt/format/escape.rs
+@@ -0,0 +1,51 @@
++//! ANSI escape sequence sanitization to prevent terminal injection attacks.
++
++use std::fmt::{self, Write};
++
++/// A wrapper that implements `fmt::Debug` and `fmt::Display` and escapes ANSI sequences on-the-fly.
++/// This avoids creating intermediate strings while providing security against terminal injection.
++pub(super) struct Escape<T>(pub(super) T);
++
++/// Helper struct that escapes ANSI sequences as characters are written
++struct EscapingWriter<'a, 'b> {
++    inner: &'a mut fmt::Formatter<'b>,
++}
++
++impl<'a, 'b> fmt::Write for EscapingWriter<'a, 'b> {
++    fn write_str(&mut self, s: &str) -> fmt::Result {
++        // Stream the string character by character, escaping ANSI and C1 control sequences
++        for ch in s.chars() {
++            match ch {
++                // C0 control characters that can be used in terminal escape sequences
++                '\x1b' => self.inner.write_str("\\x1b")?,  // ESC
++                '\x07' => self.inner.write_str("\\x07")?,  // BEL
++                '\x08' => self.inner.write_str("\\x08")?,  // BS
++                '\x0c' => self.inner.write_str("\\x0c")?,  // FF
++                '\x7f' => self.inner.write_str("\\x7f")?,  // DEL
++                
++                // C1 control characters (\x80-\x9f) - 8-bit control codes
++                // These can be used as alternative escape sequences in some terminals
++                ch if ch as u32 >= 0x80 && ch as u32 <= 0x9f => {
++                    write!(self.inner, "\\u{{{:x}}}", ch as u32)?
++                },
++                
++                _ => self.inner.write_char(ch)?,
++            }
++        }
++        Ok(())
++    }
++}
++
++impl<T: fmt::Debug> fmt::Debug for Escape<T> {
++    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
++        let mut escaping_writer = EscapingWriter { inner: f };
++        write!(escaping_writer, "{:?}", self.0)
++    }
++}
++
++impl<T: fmt::Display> fmt::Display for Escape<T> {
++    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
++        let mut escaping_writer = EscapingWriter { inner: f };
++        write!(escaping_writer, "{}", self.0)
++    }
++}
+diff --git a/vendor/tracing-subscriber/src/fmt/format/mod.rs b/vendor/tracing-subscriber/src/fmt/format/mod.rs
+index 38485f3c..50989ea6 100644
+--- a/vendor/tracing-subscriber/src/fmt/format/mod.rs
++++ b/vendor/tracing-subscriber/src/fmt/format/mod.rs
+@@ -19,6 +19,10 @@ use tracing_log::NormalizeEvent;
+ #[cfg(feature = "ansi")]
+ use ansi_term::{Colour, Style};
+ 
++
++mod escape;
++use escape::Escape;
++
+ #[cfg(feature = "json")]
+ mod json;
+ #[cfg(feature = "json")]
+@@ -1063,7 +1067,7 @@ impl<'a> field::Visit for DefaultVisitor<'a> {
+                 field,
+                 &format_args!(
+                     "{} {}{}{}{}",
+-                    value,
++                    Escape(&format_args!("{}", value)),
+                     italic.paint(field.name()),
+                     italic.paint(".sources"),
+                     self.writer.dimmed().paint("="),
+@@ -1071,7 +1075,7 @@ impl<'a> field::Visit for DefaultVisitor<'a> {
+                 ),
+             )
+         } else {
+-            self.record_debug(field, &format_args!("{}", value))
++            self.record_debug(field, &format_args!("{}", Escape(&format_args!("{}", value))))
+         }
+     }
+ 
+@@ -1082,7 +1086,10 @@ impl<'a> field::Visit for DefaultVisitor<'a> {
+ 
+         self.maybe_pad();
+         self.result = match field.name() {
+-            "message" => write!(self.writer, "{:?}", value),
++            "message" => {
++                // Escape ANSI characters to prevent malicious patterns (e.g., terminal injection attacks)
++                write!(self.writer, "{:?}", Escape(value))
++            },
+             // Skip fields that are actually log metadata that have already been handled
+             #[cfg(feature = "tracing-log")]
+             name if name.starts_with("log.") => Ok(()),
+@@ -1124,7 +1131,7 @@ impl<'a> Display for ErrorSourceList<'a> {
+         let mut list = f.debug_list();
+         let mut curr = Some(self.0);
+         while let Some(curr_err) = curr {
+-            list.entry(&format_args!("{}", curr_err));
++            list.entry(&Escape(&format_args!("{}", curr_err)));
+             curr = curr_err.source();
+         }
+         list.finish()
+diff --git a/vendor/tracing-subscriber/src/fmt/format/pretty.rs b/vendor/tracing-subscriber/src/fmt/format/pretty.rs
+index a3903ff5..79cdf073 100644
+--- a/vendor/tracing-subscriber/src/fmt/format/pretty.rs
++++ b/vendor/tracing-subscriber/src/fmt/format/pretty.rs
+@@ -360,7 +360,7 @@ impl<'a> field::Visit for PrettyVisitor<'a> {
+                 field,
+                 &format_args!(
+                     "{}, {}{}.sources{}: {}",
+-                    value,
++                    Escape(&format_args!("{}", value)),
+                     bold.prefix(),
+                     field,
+                     bold.infix(self.style),
+@@ -368,7 +368,7 @@ impl<'a> field::Visit for PrettyVisitor<'a> {
+                 ),
+             )
+         } else {
+-            self.record_debug(field, &format_args!("{}", value))
++            self.record_debug(field, &Escape(&format_args!("{}", value)))
+         }
+     }
+ 
+@@ -378,7 +378,10 @@ impl<'a> field::Visit for PrettyVisitor<'a> {
+         }
+         let bold = self.bold();
+         match field.name() {
+-            "message" => self.write_padded(&format_args!("{}{:?}", self.style.prefix(), value,)),
++            "message" => {
++                // Escape ANSI characters to prevent malicious patterns (e.g., terminal injection attacks)
++                self.write_padded(&format_args!("{}{:?}", self.style.prefix(), Escape(value)))
++            },
+             // Skip fields that are actually log metadata that have already been handled
+             #[cfg(feature = "tracing-log")]
+             name if name.starts_with("log.") => self.result = Ok(()),
+diff --git a/vendor/tracing-subscriber/tests/ansi_escaping.rs b/vendor/tracing-subscriber/tests/ansi_escaping.rs
+new file mode 100644
+index 00000000..120a44b5
+--- /dev/null
++++ b/vendor/tracing-subscriber/tests/ansi_escaping.rs
+@@ -0,0 +1,281 @@
++use std::sync::{Arc, Mutex};
++use tracing_subscriber::fmt::MakeWriter;
++
++/// Shared test writer that collects output for verification
++#[derive(Debug, Clone)]
++struct TestWriter {
++    buf: Arc<Mutex<Vec<u8>>>,
++}
++
++impl TestWriter {
++    fn new() -> Self {
++        Self {
++            buf: Arc::new(Mutex::new(Vec::new())),
++        }
++    }
++
++    fn get_output(&self) -> String {
++        let buf = self.buf.lock().unwrap();
++        String::from_utf8_lossy(&buf).to_string()
++    }
++}
++
++impl std::io::Write for TestWriter {
++    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
++        self.buf.lock().unwrap().extend_from_slice(buf);
++        Ok(buf.len())
++    }
++
++    fn flush(&mut self) -> std::io::Result<()> {
++        Ok(())
++    }
++}
++
++impl<'a> MakeWriter<'a> for TestWriter {
++    type Writer = TestWriter;
++
++    fn make_writer(&'a self) -> Self::Writer {
++        self.clone()
++    }
++}
++
++/// Test that basic security expectations are met - this is a smoke test
++/// for the ANSI escaping functionality using public APIs only
++#[test]
++fn test_error_ansi_escaping() {
++    use std::fmt;
++
++    #[derive(Debug)]
++    struct MaliciousError(&'static str);
++
++    impl fmt::Display for MaliciousError {
++        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
++            write!(f, "{}", self.0)
++        }
++    }
++
++    impl std::error::Error for MaliciousError {}
++
++    let writer = TestWriter::new();
++    let subscriber = tracing_subscriber::fmt::Subscriber::builder()
++        .with_writer(writer.clone())
++        .with_ansi(false)
++        .without_time()
++        .with_target(false)
++        .with_level(false)
++        .finish();
++
++    tracing::subscriber::with_default(subscriber, || {
++        let malicious_error = MaliciousError("\x1b]0;PWNED\x07\x1b[2J\x08\x0c\x7f");
++
++        // This demonstrates that errors are logged - the actual escaping
++        // is tested by our internal unit tests
++        tracing::error!(error = %malicious_error, "An error occurred");
++    });
++
++    let output = writer.get_output();
++
++    // Just verify that something was logged
++    assert!(
++        output.contains("An error occurred"),
++        "Error message should be logged"
++    );
++}
++
++/// Test that ANSI escape sequences in log messages are properly escaped
++#[test]
++fn test_message_ansi_escaping() {
++    let writer = TestWriter::new();
++    let subscriber = tracing_subscriber::fmt::Subscriber::builder()
++        .with_writer(writer.clone())
++        .with_ansi(false)
++        .without_time()
++        .with_target(false)
++        .with_level(false)
++        .finish();
++
++    tracing::subscriber::with_default(subscriber, || {
++        let malicious_input = "\x1b]0;PWNED\x07\x1b[2J\x08\x0c\x7f";
++
++        // This should not cause ANSI injection
++        tracing::info!("User input: {}", malicious_input);
++    });
++
++    let output = writer.get_output();
++
++    // Verify ANSI sequences are escaped
++    assert!(
++        !output.contains('\x1b'),
++        "Message output should not contain raw ESC characters"
++    );
++    assert!(
++        !output.contains('\x07'),
++        "Message output should not contain raw BEL characters"
++    );
++}
++
++/// Test that JSON formatter properly escapes ANSI sequences
++#[cfg(feature = "json")]
++#[test]
++fn test_json_ansi_escaping() {
++    let writer = TestWriter::new();
++    let subscriber = tracing_subscriber::fmt::Subscriber::builder()
++        .json()
++        .with_writer(writer.clone())
++        .finish();
++
++    tracing::subscriber::with_default(subscriber, || {
++        let malicious_input = "\x1b]0;PWNED\x07\x1b[2J";
++
++        // JSON formatter should escape ANSI sequences
++        tracing::info!("Testing: {}", malicious_input);
++        tracing::info!(user_input = %malicious_input, "Field test");
++    });
++
++    let output = writer.get_output();
++
++    // JSON should escape ANSI sequences as Unicode escapes
++    assert!(
++        !output.contains('\x1b'),
++        "JSON output should not contain raw ESC characters"
++    );
++    assert!(
++        !output.contains('\x07'),
++        "JSON output should not contain raw BEL characters"
++    );
++}
++
++/// Test that pretty formatter properly escapes ANSI sequences  
++#[cfg(feature = "ansi")]
++#[test]
++fn test_pretty_ansi_escaping() {
++    let writer = TestWriter::new();
++    let subscriber = tracing_subscriber::fmt::Subscriber::builder()
++        .pretty()
++        .with_writer(writer.clone())
++        .with_ansi(false)
++        .without_time()
++        .with_target(false)
++        .finish();
++
++    tracing::subscriber::with_default(subscriber, || {
++        let malicious_input = "\x1b]0;PWNED\x07\x1b[2J";
++
++        // Pretty formatter should escape ANSI sequences
++        tracing::info!("Testing: {}", malicious_input);
++    });
++
++    let output = writer.get_output();
++
++    // Verify ANSI sequences are escaped
++    assert!(
++        !output.contains('\x1b'),
++        "Pretty output should not contain raw ESC characters"
++    );
++    assert!(
++        !output.contains('\x07'),
++        "Pretty output should not contain raw BEL characters"
++    );
++}
++
++/// Comprehensive test for ANSI sanitization that prevents injection attacks
++#[test]
++fn ansi_sanitization_prevents_injection() {
++    let writer = TestWriter::new();
++    let subscriber = tracing_subscriber::fmt::Subscriber::builder()
++        .with_writer(writer.clone())
++        .with_ansi(false)
++        .without_time()
++        .with_target(false)
++        .with_level(false)
++        .finish();
++
++    #[derive(Debug)]
++    struct MaliciousError {
++        content: String,
++    }
++
++    impl std::fmt::Display for MaliciousError {
++        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
++            // This Display implementation contains ANSI escape sequences
++            write!(f, "Error: {}", self.content)
++        }
++    }
++
++    tracing::subscriber::with_default(subscriber, || {
++        // Test 1: Field values should remain properly escaped by Debug (baseline)
++        let malicious_field_value = "\x1b]0;PWNED\x07\x1b[2J";
++        tracing::error!(malicious_field = malicious_field_value, "Field test");
++
++        // Test 2: Message content vulnerability should be mitigated
++        let malicious_error = MaliciousError {
++            content: "\x1b]0;PWNED\x07\x1b[2J".to_string(),
++        };
++        tracing::error!("{}", malicious_error);
++    });
++
++    let output = writer.get_output();
++
++    // Field values should contain escaped sequences like \u{1b}
++    assert!(
++        output.contains("\\u{1b}"),
++        "Field values should be escaped by Debug formatting"
++    );
++
++    // Message content should be sanitized
++    assert!(
++        output.contains("\\x1b"),
++        "Message content should be sanitized"
++    );
++    assert!(
++        !output.contains("\x1b]0;PWNED"),
++        "Message content should not contain raw ANSI sequences"
++    );
++    assert!(
++        !output.contains("\x07"),
++        "Message content should not contain raw control characters"
++    );
++}
++
++/// Test that C1 control characters (\x80-\x9f) are also properly escaped
++#[test]
++fn test_c1_control_characters_escaping() {
++    let writer = TestWriter::new();
++    let subscriber = tracing_subscriber::fmt::Subscriber::builder()
++        .with_writer(writer.clone())
++        .with_ansi(false)
++        .without_time()
++        .with_target(false)
++        .with_level(false)
++        .finish();
++
++    tracing::subscriber::with_default(subscriber, || {
++        // Test C1 control characters that can be used in 8-bit terminal escape sequences
++        let c1_controls = "\u{80}\u{85}\u{90}\u{9b}\u{9c}\u{9d}\u{9e}\u{9f}"; // Various C1 controls including CSI
++
++        // This should escape C1 control characters to prevent 8-bit escape sequences
++        tracing::info!("C1 controls: {}", c1_controls);
++    });
++
++    let output = writer.get_output();
++
++    // Verify C1 control characters are escaped
++    assert!(
++        !output.contains('\u{80}'),
++        "Output should not contain raw C1 control characters"
++    );
++    assert!(
++        !output.contains('\u{9b}'),
++        "Output should not contain raw CSI character"
++    );
++    assert!(
++        !output.contains('\u{9c}'),
++        "Output should not contain raw ST character"
++    );
++
++    // Should contain Unicode escapes for C1 characters
++    assert!(
++        output.contains("\\u{80}") || output.contains("\\u{8"),
++        "Should contain escaped C1 characters"
++    );
++}
+-- 
+2.45.4
+

--- a/SPECS/rpm-ostree/rpm-ostree.spec
+++ b/SPECS/rpm-ostree/rpm-ostree.spec
@@ -1,7 +1,7 @@
 Summary:        Commit RPMs to an OSTree repository
 Name:           rpm-ostree
 Version:        2022.1
-Release:        7%{?dist}
+Release:        8%{?dist}
 License:        LGPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -13,6 +13,8 @@ Patch2:         CVE-2022-31394.patch
 Patch3:         rpm-ostree-drop-lint-which-treats-warning-as-error.patch
 Patch4:         CVE-2022-47085.patch
 Patch5:         CVE-2023-26964.patch
+Patch6:         CVE-2025-58160.patch
+
 BuildRequires:  attr-devel
 BuildRequires:  autoconf
 BuildRequires:  autogen
@@ -158,6 +160,9 @@ make check
 %{_datadir}/gir-1.0/*-1.0.gir
 
 %changelog
+* Wed Jan 07 2026 BinduSri Adabala <v-badabala@microsoft.com> - 2022.1-8
+- Patch for CVE-2025-58160
+
 * Thu Aug 22 2024 Sumedh Sharma <sumsharma@microsoft.com> - 2022.1-7
 - Add patch to resolve CVE-2023-26964 in vendored 'h2' sources
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Patch rpm-ostree for CVE-2025-58160
patch modified: Yes
- Did not applied patch for `tracing-subscriber/CHANGELOG.md` and `tracing-subscriber/Cargo.toml` files, as those changes are     not part of CVE fix.
- Astrolabe Patch Reference: https://github.com/tokio-rs/tracing/commit/4c52ca5266a3920fc5dfeebda2accf15ee7fb278
###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- new file:   ../SPECS/rpm-ostree/CVE-2025-58160.patch
- modified:   ../SPECS/rpm-ostree/rpm-ostree.spec

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2025-58160

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local Build:
[rpm-ostree-2022.1-8.cm2.src.rpm.log](https://github.com/user-attachments/files/24474166/rpm-ostree-2022.1-8.cm2.src.rpm.log)
[rpm-ostree-2022.1-8.cm2.src.rpm.test.log](https://github.com/user-attachments/files/24474181/rpm-ostree-2022.1-8.cm2.src.rpm.test.log)


- Patch applies cleanly:
<img width="1413" height="420" alt="image" src="https://github.com/user-attachments/assets/b6626566-1fb8-4bc4-9486-89398e39dab3" />

- Installation Check:
<img width="1712" height="315" alt="image" src="https://github.com/user-attachments/assets/ded5d370-45a5-4fb1-9868-91d60d4433c6" />

- Uninstallation Check:
<img width="1713" height="306" alt="image" src="https://github.com/user-attachments/assets/ee49cee0-a293-4094-b2ec-29325708e833" />
