### PR TITLE
Patch libvirt for CVE-2025-12748

### DIFF
--- a/SPECS/libvirt/CVE-2025-12748.patch
+++ b/SPECS/libvirt/CVE-2025-12748.patch
@@ -1,0 +1,1300 @@
+From 508a5ab49e83c1ac272108daae9ae92d906cde95 Mon Sep 17 00:00:00 2001
+From: Marc Deslauriers <marc.deslauriers@ubuntu.com>
+Date: Mon, 8 Dec 2025 13:08:06 -0500
+Subject: [PATCH 1/9] Pre-requisite for CVE-2025-12748
+
+Upstream Patch reference:
+1. https://git.launchpad.net/ubuntu/+source/libvirt/patch/?id=508a5ab49e83c1ac272108daae9ae92d906cde95
+2. https://git.launchpad.net/ubuntu/+source/libvirt/patch/?id=fabc09641da50196e4d0de949426023baccb41ae
+3. https://git.launchpad.net/ubuntu/+source/libvirt/patch/?id=f15dc1a7de65ab16163908b92cb479c713f8f052 
+---
+ src/qemu/qemu_driver.c    |  46 ++++---
+ src/qemu/qemu_saveimage.c | 268 +++++++++++++++++++++++---------------
+ src/qemu/qemu_saveimage.h |  21 ++-
+ 3 files changed, 202 insertions(+), 133 deletions(-)
+
+diff --git a/src/qemu/qemu_driver.c b/src/qemu/qemu_driver.c
+index 4e680bc..9cf2c3e 100644
+--- a/src/qemu/qemu_driver.c
++++ b/src/qemu/qemu_driver.c
+@@ -5910,9 +5910,12 @@ qemuDomainRestoreFlags(virConnectPtr conn,
+ 
+     virNWFilterReadLockFilterUpdates();
+ 
+-    fd = qemuSaveImageOpen(driver, NULL, path, &def, &data,
++    if (qemuSaveImageGetMetadata(driver, NULL, path, &def, &data) < 0)
++        goto cleanup;
++
++    fd = qemuSaveImageOpen(driver, path,
+                            (flags & VIR_DOMAIN_SAVE_BYPASS_CACHE) != 0,
+-                           &wrapperFd, false, false);
++                           &wrapperFd, false);
+     if (fd < 0)
+         goto cleanup;
+ 
+@@ -5999,15 +6002,11 @@ qemuDomainSaveImageGetXMLDesc(virConnectPtr conn, const char *path,
+     virQEMUDriver *driver = conn->privateData;
+     char *ret = NULL;
+     g_autoptr(virDomainDef) def = NULL;
+-    int fd = -1;
+     virQEMUSaveData *data = NULL;
+ 
+     virCheckFlags(VIR_DOMAIN_SAVE_IMAGE_XML_SECURE, NULL);
+ 
+-    fd = qemuSaveImageOpen(driver, NULL, path, &def, &data,
+-                           false, NULL, false, false);
+-
+-    if (fd < 0)
++    if (qemuSaveImageGetMetadata(driver, NULL, path, &def, &data) < 0)
+         goto cleanup;
+ 
+     if (virDomainSaveImageGetXMLDescEnsureACL(conn, def) < 0)
+@@ -6017,7 +6016,6 @@ qemuDomainSaveImageGetXMLDesc(virConnectPtr conn, const char *path,
+ 
+  cleanup:
+     virQEMUSaveDataFree(data);
+-    VIR_FORCE_CLOSE(fd);
+     return ret;
+ }
+ 
+@@ -6041,9 +6039,10 @@ qemuDomainSaveImageDefineXML(virConnectPtr conn, const char *path,
+     else if (flags & VIR_DOMAIN_SAVE_PAUSED)
+         state = 0;
+ 
+-    fd = qemuSaveImageOpen(driver, NULL, path, &def, &data,
+-                           false, NULL, true, false);
++    if (qemuSaveImageGetMetadata(driver, NULL, path, &def, &data) < 0)
++        goto cleanup;
+ 
++    fd = qemuSaveImageOpen(driver, path, 0, NULL, false);
+     if (fd < 0)
+         goto cleanup;
+ 
+@@ -6100,7 +6099,6 @@ qemuDomainManagedSaveGetXMLDesc(virDomainPtr dom, unsigned int flags)
+     g_autofree char *path = NULL;
+     char *ret = NULL;
+     g_autoptr(virDomainDef) def = NULL;
+-    int fd = -1;
+     virQEMUSaveData *data = NULL;
+     qemuDomainObjPrivate *priv;
+ 
+@@ -6123,15 +6121,13 @@ qemuDomainManagedSaveGetXMLDesc(virDomainPtr dom, unsigned int flags)
+         goto cleanup;
+     }
+ 
+-    if ((fd = qemuSaveImageOpen(driver, priv->qemuCaps, path, &def, &data,
+-                                false, NULL, false, false)) < 0)
++    if (qemuSaveImageGetMetadata(driver, priv->qemuCaps, path, &def, &data) < 0)
+         goto cleanup;
+ 
+     ret = qemuDomainDefFormatXML(driver, priv->qemuCaps, def, flags);
+ 
+  cleanup:
+     virQEMUSaveDataFree(data);
+-    VIR_FORCE_CLOSE(fd);
+     virDomainObjEndAPI(&vm);
+     return ret;
+ }
+@@ -6187,14 +6183,26 @@ qemuDomainObjRestore(virConnectPtr conn,
+     virQEMUSaveData *data = NULL;
+     virFileWrapperFd *wrapperFd = NULL;
+ 
+-    fd = qemuSaveImageOpen(driver, NULL, path, &def, &data,
+-                           bypass_cache, &wrapperFd, false, true);
+-    if (fd < 0) {
+-        if (fd == -3)
+-            ret = 1;
++    ret = qemuSaveImageGetMetadata(driver, NULL, path, &def, &data);
++    if (ret < 0) {
++        if (qemuSaveImageIsCorrupt(driver, path)) {
++            if (unlink(path) < 0) {
++                virReportSystemError(errno,
++                                     _("cannot remove corrupt file: %1$s"),
++                                     path);
++                ret = -1;
++            } else {
++                virResetLastError();
++                ret = 1;
++            }
++        }
+         goto cleanup;
+     }
+ 
++    fd = qemuSaveImageOpen(driver, path, bypass_cache, &wrapperFd, false);
++    if (fd < 0)
++        goto cleanup;
++
+     if (virHookPresent(VIR_HOOK_DRIVER_QEMU)) {
+         int hookret;
+ 
+diff --git a/src/qemu/qemu_saveimage.c b/src/qemu/qemu_saveimage.c
+index e14e298..5f14d07 100644
+--- a/src/qemu/qemu_saveimage.c
++++ b/src/qemu/qemu_saveimage.c
+@@ -90,6 +90,90 @@ virQEMUSaveDataFree(virQEMUSaveData *data)
+ 
+ G_DEFINE_AUTOPTR_CLEANUP_FUNC(virQEMUSaveData, virQEMUSaveDataFree);
+ 
++static int
++qemuSaveImageReadHeader(int fd, virQEMUSaveData **ret_data)
++{
++    g_autoptr(virQEMUSaveData) data = NULL;
++    virQEMUSaveHeader *header;
++    size_t xml_len;
++    size_t cookie_len;
++
++    data = g_new0(virQEMUSaveData, 1);
++    header = &data->header;
++    if (saferead(fd, header, sizeof(*header)) != sizeof(*header)) {
++         virReportError(VIR_ERR_OPERATION_FAILED,
++                        "%s", _("failed to read qemu header"));
++         return -1;
++    }
++
++    if (memcmp(header->magic, QEMU_SAVE_MAGIC, sizeof(header->magic)) != 0) {
++        if (memcmp(header->magic, QEMU_SAVE_PARTIAL, sizeof(header->magic)) == 0) {
++            virReportError(VIR_ERR_OPERATION_FAILED, "%s",
++                           _("save image is incomplete"));
++            return -1;
++        }
++
++        virReportError(VIR_ERR_OPERATION_FAILED, "%s",
++                       _("image magic is incorrect"));
++        return -1;
++    }
++
++    if (header->version > QEMU_SAVE_VERSION) {
++        /* convert endianness and try again */
++        qemuSaveImageBswapHeader(header);
++    }
++
++    if (header->version > QEMU_SAVE_VERSION) {
++        virReportError(VIR_ERR_OPERATION_FAILED,
++                       _("image version is not supported (%1$d > %2$d)"),
++                       header->version, QEMU_SAVE_VERSION);
++        return -1;
++    }
++
++    if (header->compressed >= QEMU_SAVE_FORMAT_LAST) {
++        virReportError(VIR_ERR_OPERATION_FAILED,
++                       _("unsupported save image format: %1$d"), header->compressed);
++        return -1;
++    }
++
++    if (header->data_len <= 0) {
++        virReportError(VIR_ERR_OPERATION_FAILED,
++                       _("invalid header data length: %1$d"), header->data_len);
++        return -1;
++    }
++
++    if (header->cookieOffset)
++        xml_len = header->cookieOffset;
++    else
++        xml_len = header->data_len;
++
++    cookie_len = header->data_len - xml_len;
++
++    data->xml = g_new0(char, xml_len);
++
++    if (saferead(fd, data->xml, xml_len) != xml_len) {
++        virReportError(VIR_ERR_OPERATION_FAILED,
++                       "%s", _("failed to read domain XML"));
++        return -1;
++    }
++
++    if (cookie_len > 0) {
++        data->cookie = g_new0(char, cookie_len);
++
++        if (saferead(fd, data->cookie, cookie_len) != cookie_len) {
++            virReportError(VIR_ERR_OPERATION_FAILED, "%s",
++                           _("failed to read cookie"));
++            return -1;
++        }
++    }
++
++    if (ret_data)
++        *ret_data = g_steal_pointer(&data);
++
++    return 0;
++}
++
++
+ /**
+  * This function steals @domXML on success.
+  */
+@@ -414,41 +498,99 @@ qemuSaveImageGetCompressionProgram(const char *imageFormat,
+ 
+ 
+ /**
+- * qemuSaveImageOpen:
++ * qemuSaveImageIsCorrupt:
+  * @driver: qemu driver data
++ * @path: path of the save image
++ *
++ * Returns true if the save image file identified by @path does not exist or
++ * has a corrupt header. Returns false otherwise.
++ */
++
++bool
++qemuSaveImageIsCorrupt(virQEMUDriver *driver, const char *path)
++{
++    g_autoptr(virQEMUDriverConfig) cfg = virQEMUDriverGetConfig(driver);
++    VIR_AUTOCLOSE fd = -1;
++    virQEMUSaveHeader header;
++
++    if ((fd = qemuDomainOpenFile(cfg, NULL, path, O_RDONLY, NULL)) < 0)
++        return true;
++
++    if (saferead(fd, &header, sizeof(header)) != sizeof(header))
++        return true;
++
++    if (memcmp(header.magic, QEMU_SAVE_MAGIC, sizeof(header.magic)) != 0 ||
++        memcmp(header.magic, QEMU_SAVE_PARTIAL, sizeof(header.magic)) == 0)
++        return true;
++
++    return false;
++}
++
++
++/**
++ * qemuSaveImageGetMetadata:
++ * @driver: qemu driver dataqemuSaveImageOpen
+  * @qemuCaps: pointer to qemuCaps if the domain is running or NULL
+  * @path: path of the save image
+  * @ret_def: returns domain definition created from the XML stored in the image
+  * @ret_data: returns structure filled with data from the image header
++ *
++ * Open the save image file, read libvirt's save image metadata, and populate
++ * the @ret_def and @ret_data structures. Returns 0 on success and -1 on failure.
++ */
++int
++qemuSaveImageGetMetadata(virQEMUDriver *driver,
++                         virQEMUCaps *qemuCaps,
++                         const char *path,
++                         virDomainDef **ret_def,
++                         virQEMUSaveData **ret_data)
++{
++    g_autoptr(virQEMUDriverConfig) cfg = virQEMUDriverGetConfig(driver);
++    VIR_AUTOCLOSE fd = -1;
++    virQEMUSaveData *data;
++    g_autoptr(virDomainDef) def = NULL;
++    int rc;
++
++    if ((fd = qemuDomainOpenFile(cfg, NULL, path, O_RDONLY, NULL)) < 0)
++        return -1;
++
++    if ((rc = qemuSaveImageReadHeader(fd, ret_data)) < 0)
++        return rc;
++
++    data = *ret_data;
++    /* Create a domain from this XML */
++    if (!(def = virDomainDefParseString(data->xml, driver->xmlopt, qemuCaps,
++                                        VIR_DOMAIN_DEF_PARSE_INACTIVE |
++                                        VIR_DOMAIN_DEF_PARSE_SKIP_VALIDATE)))
++        return -1;
++
++    *ret_def = g_steal_pointer(&def);
++
++    return 0;
++}
++
++
++/**
++ * qemuSaveImageOpen:
++ * @driver: qemu driver data
++ * @path: path of the save image
+  * @bypass_cache: bypass cache when opening the file
+  * @wrapperFd: returns the file wrapper structure
+  * @open_write: open the file for writing (for updates)
+- * @unlink_corrupt: remove the image file if it is corrupted
+  *
+- * Returns the opened fd of the save image file and fills the appropriate fields
+- * on success. On error returns -1 on most failures, -3 if corrupt image was
+- * unlinked (no error raised).
++ * Returns the opened fd of the save image file on success, -1 on failure.
+  */
+ int
+ qemuSaveImageOpen(virQEMUDriver *driver,
+-                  virQEMUCaps *qemuCaps,
+                   const char *path,
+-                  virDomainDef **ret_def,
+-                  virQEMUSaveData **ret_data,
+                   bool bypass_cache,
+                   virFileWrapperFd **wrapperFd,
+-                  bool open_write,
+-                  bool unlink_corrupt)
++                  bool open_write)
+ {
+     g_autoptr(virQEMUDriverConfig) cfg = virQEMUDriverGetConfig(driver);
+     VIR_AUTOCLOSE fd = -1;
+     int ret = -1;
+-    g_autoptr(virQEMUSaveData) data = NULL;
+-    virQEMUSaveHeader *header;
+-    g_autoptr(virDomainDef) def = NULL;
+     int oflags = open_write ? O_RDWR : O_RDONLY;
+-    size_t xml_len;
+-    size_t cookie_len;
+ 
+     if (bypass_cache) {
+         int directFlag = virFileDirectFdFlag();
+@@ -468,101 +610,11 @@ qemuSaveImageOpen(virQEMUDriver *driver,
+                                            VIR_FILE_WRAPPER_BYPASS_CACHE)))
+         return -1;
+ 
+-    data = g_new0(virQEMUSaveData, 1);
+-
+-    header = &data->header;
+-    if (saferead(fd, header, sizeof(*header)) != sizeof(*header)) {
+-        if (unlink_corrupt) {
+-            if (unlink(path) < 0) {
+-                virReportSystemError(errno,
+-                                     _("cannot remove corrupt file: %s"),
+-                                     path);
+-                return -1;
+-            } else {
+-                return -3;
+-            }
+-        }
+-
+-        virReportError(VIR_ERR_OPERATION_FAILED,
+-                       "%s", _("failed to read qemu header"));
+-        return -1;
+-    }
+-
+-    if (memcmp(header->magic, QEMU_SAVE_MAGIC, sizeof(header->magic)) != 0) {
+-        if (memcmp(header->magic, QEMU_SAVE_PARTIAL, sizeof(header->magic)) == 0) {
+-            if (unlink_corrupt) {
+-                if (unlink(path) < 0) {
+-                    virReportSystemError(errno,
+-                                         _("cannot remove corrupt file: %s"),
+-                                         path);
+-                    return -1;
+-                } else {
+-                    return -3;
+-                }
+-            }
+-
+-            virReportError(VIR_ERR_OPERATION_FAILED, "%s",
+-                           _("save image is incomplete"));
+-            return -1;
+-        }
+-
+-        virReportError(VIR_ERR_OPERATION_FAILED, "%s",
+-                       _("image magic is incorrect"));
+-        return -1;
+-    }
+-
+-    if (header->version > QEMU_SAVE_VERSION) {
+-        /* convert endianness and try again */
+-        qemuSaveImageBswapHeader(header);
+-    }
+-
+-    if (header->version > QEMU_SAVE_VERSION) {
+-        virReportError(VIR_ERR_OPERATION_FAILED,
+-                       _("image version is not supported (%d > %d)"),
+-                       header->version, QEMU_SAVE_VERSION);
+-        return -1;
+-    }
+-
+-    if (header->data_len <= 0) {
+-        virReportError(VIR_ERR_OPERATION_FAILED,
+-                       _("invalid header data length: %d"), header->data_len);
+-        return -1;
+-    }
+-
+-    if (header->cookieOffset)
+-        xml_len = header->cookieOffset;
+-    else
+-        xml_len = header->data_len;
+-
+-    cookie_len = header->data_len - xml_len;
+-
+-    data->xml = g_new0(char, xml_len);
+-
+-    if (saferead(fd, data->xml, xml_len) != xml_len) {
+-        virReportError(VIR_ERR_OPERATION_FAILED,
+-                       "%s", _("failed to read domain XML"));
+-        return -1;
+-    }
+-
+-    if (cookie_len > 0) {
+-        data->cookie = g_new0(char, cookie_len);
+-
+-        if (saferead(fd, data->cookie, cookie_len) != cookie_len) {
+-            virReportError(VIR_ERR_OPERATION_FAILED, "%s",
+-                           _("failed to read cookie"));
+-            return -1;
+-        }
+-    }
+-
+-    /* Create a domain from this XML */
+-    if (!(def = virDomainDefParseString(data->xml, driver->xmlopt, qemuCaps,
+-                                        VIR_DOMAIN_DEF_PARSE_INACTIVE |
+-                                        VIR_DOMAIN_DEF_PARSE_SKIP_VALIDATE)))
++    /* Read the header to position the file pointer for QEMU. Unfortunately we
++     * can't use lseek with virFileWrapperFD. */
++    if (qemuSaveImageReadHeader(fd, NULL) < 0)
+         return -1;
+ 
+-    *ret_def = g_steal_pointer(&def);
+-    *ret_data = g_steal_pointer(&data);
+-
+     ret = fd;
+     fd = -1;
+ 
+diff --git a/src/qemu/qemu_saveimage.h b/src/qemu/qemu_saveimage.h
+index 45c5f35..0dcdba2 100644
+--- a/src/qemu/qemu_saveimage.h
++++ b/src/qemu/qemu_saveimage.h
+@@ -70,17 +70,26 @@ qemuSaveImageStartVM(virConnectPtr conn,
+                      qemuDomainAsyncJob asyncJob)
+     ATTRIBUTE_NONNULL(4) ATTRIBUTE_NONNULL(5) ATTRIBUTE_NONNULL(6);
+ 
++bool
++qemuSaveImageIsCorrupt(virQEMUDriver *driver,
++                       const char *path)
++    ATTRIBUTE_NONNULL(2);
++
++int
++qemuSaveImageGetMetadata(virQEMUDriver *driver,
++                         virQEMUCaps *qemuCaps,
++                         const char *path,
++                         virDomainDef **ret_def,
++                         virQEMUSaveData **ret_data)
++    ATTRIBUTE_NONNULL(4) ATTRIBUTE_NONNULL(5);
++
+ int
+ qemuSaveImageOpen(virQEMUDriver *driver,
+-                  virQEMUCaps *qemuCaps,
+                   const char *path,
+-                  virDomainDef **ret_def,
+-                  virQEMUSaveData **ret_data,
+                   bool bypass_cache,
+                   virFileWrapperFd **wrapperFd,
+-                  bool open_write,
+-                  bool unlink_corrupt)
+-    ATTRIBUTE_NONNULL(3) ATTRIBUTE_NONNULL(4);
++                  bool open_write)
++    ATTRIBUTE_NONNULL(2) ATTRIBUTE_NONNULL(4);
+ 
+ int
+ qemuSaveImageGetCompressionProgram(const char *imageFormat,
+-- 
+2.43.0
+
+From f0c391572604abb82745ac96af942d39f854e990 Mon Sep 17 00:00:00 2001
+From: Marc Deslauriers <marc.deslauriers@ubuntu.com>
+Date: Mon, 8 Dec 2025 13:08:06 -0500
+Subject: [PATCH 2/9] conf: Add virDomainDefIDsParseString
+
+Upstream Patch reference:
+1. https://git.launchpad.net/ubuntu/+source/libvirt/patch/?id=f0c391572604abb82745ac96af942d39f854e990
+2. https://git.launchpad.net/ubuntu/+source/libvirt/patch/?id=9df25774df5c6deef221bfb5b2a629d0066c7faf
+3. https://git.launchpad.net/ubuntu/+source/libvirt/patch/?id=fc32ad12e77b486d3546aeccc0687e3a713561f5
+4. https://git.launchpad.net/ubuntu/+source/libvirt/patch/?id=29025d237545249e271719ecec1ba0ec03c8d2c3
+5. https://git.launchpad.net/ubuntu/+source/libvirt/patch/?id=8f45c59db100a2a51d9a36dffc081068be94e17e
+6. https://git.launchpad.net/ubuntu/+source/libvirt/patch/?id=218e4e08bee6906c43a3b29cdc629f6b92368b14
+7. https://git.launchpad.net/ubuntu/+source/libvirt/patch/?id=a79fb711143eb7e950fda889436bdd46e1515d73
+8. https://git.launchpad.net/ubuntu/+source/libvirt/patch/?id=d8e7d974dc418345c1454632d26ed1b59997fc52
+---
+ src/conf/domain_conf.c   | 48 ++++++++++++++++++++++++++++++++++++++++
+ src/conf/domain_conf.h   |  3 +++
+ src/libvirt_private.syms |  1 +
+ 3 files changed, 52 insertions(+)
+
+diff --git a/src/conf/domain_conf.c b/src/conf/domain_conf.c
+index f88405a..5a5c2d3 100644
+--- a/src/conf/domain_conf.c
++++ b/src/conf/domain_conf.c
+@@ -20524,6 +20524,54 @@ virDomainDefParse(const char *xmlStr,
+     return def;
+ }
+ 
++virDomainDef *
++virDomainDefIDsParseString(const char *xmlStr,
++                           virDomainXMLOption *xmlopt,
++                           unsigned int flags)
++{
++    g_autoptr(virDomainDef) def = NULL;
++    g_autoptr(xmlDoc) xml = NULL;
++    g_autoptr(xmlXPathContext) ctxt = NULL;
++    bool uuid_generated = false;
++    int keepBlanksDefault = xmlKeepBlanksDefault(0);
++    xmlNodePtr root;
++
++    if (!(xml = virXMLParse(NULL, xmlStr, _("(domain_definition)"), "domain.rng",
++                            false))) {
++        xmlKeepBlanksDefault(keepBlanksDefault);
++        return NULL;
++    }
++
++    xmlKeepBlanksDefault(keepBlanksDefault);
++
++    root = xmlDocGetRootElement(xml);
++    if (!virXMLNodeNameEqual(root, "domain")) {
++        virReportError(VIR_ERR_XML_ERROR,
++                       _("unexpected root element <%s>, "
++                         "expecting <domain>"),
++                       root->name);
++        return NULL;
++    }
++
++    if (!(ctxt = virXMLXPathContextNew(xml))) {
++        return NULL;
++    }
++
++    ctxt->node = root;
++
++    def = virDomainDefNew(xmlopt);
++    if (!def)
++        return NULL;
++
++    if (virDomainDefParseIDs(def, ctxt, flags, &uuid_generated) < 0)
++        return NULL;
++
++    if (uuid_generated)
++        memset(def->uuid, 0, VIR_UUID_BUFLEN);
++
++    return g_steal_pointer(&def);
++}
++
+ virDomainDef *
+ virDomainDefParseString(const char *xmlStr,
+                         virDomainXMLOption *xmlopt,
+diff --git a/src/conf/domain_conf.h b/src/conf/domain_conf.h
+index c4a8dcc..066e365 100644
+--- a/src/conf/domain_conf.h
++++ b/src/conf/domain_conf.h
+@@ -3490,6 +3490,9 @@ virDomainDiskDef *virDomainDiskDefParse(const char *xmlStr,
+ virStorageSource *virDomainDiskDefParseSource(const char *xmlStr,
+                                               virDomainXMLOption *xmlopt,
+                                               unsigned int flags);
++virDomainDef * virDomainDefIDsParseString(const char *xmlStr,
++                                          virDomainXMLOption *xmlopt,
++                                          unsigned int flags);
+ virDomainDef *virDomainDefParseString(const char *xmlStr,
+                                       virDomainXMLOption *xmlopt,
+                                       void *parseOpaque,
+diff --git a/src/libvirt_private.syms b/src/libvirt_private.syms
+index b98cb0f..09850e1 100644
+--- a/src/libvirt_private.syms
++++ b/src/libvirt_private.syms
+@@ -336,6 +336,7 @@ virDomainDefHasUSB;
+ virDomainDefHasVcpusOffline;
+ virDomainDefHasVDPANet;
+ virDomainDefHasVFIOHostdev;
++virDomainDefIDsParseString;
+ virDomainDefLifecycleActionAllowed;
+ virDomainDefMaybeAddController;
+ virDomainDefMaybeAddInput;
+-- 
+2.43.0
+
+From 9df25774df5c6deef221bfb5b2a629d0066c7faf Mon Sep 17 00:00:00 2001
+From: Marc Deslauriers <marc.deslauriers@ubuntu.com>
+Date: Mon, 8 Dec 2025 13:08:06 -0500
+Subject: [PATCH 3/9] bhyve: Check ACLs before parsing the whole domain XML
+
+---
+ src/bhyve/bhyve_driver.c | 24 ++++++++++++++++++------
+ 1 file changed, 18 insertions(+), 6 deletions(-)
+
+diff --git a/src/bhyve/bhyve_driver.c b/src/bhyve/bhyve_driver.c
+index eccf9b4..f933376 100644
+--- a/src/bhyve/bhyve_driver.c
++++ b/src/bhyve/bhyve_driver.c
+@@ -520,6 +520,15 @@ bhyveDomainDefineXMLFlags(virConnectPtr conn, const char *xml, unsigned int flag
+     if (!caps)
+         return NULL;
+ 
++    /* Avoid parsing the whole domain definition for ACL checks */
++    if (!(def = virDomainDefIDsParseString(xml, provconn->xmlopt, parse_flags)))
++        return NULL;
++
++    if (virDomainDefineXMLFlagsEnsureACL(conn, def) < 0)
++        return NULL;
++
++    g_clear_pointer(&def, virDomainDefFree);
++
+     if ((def = virDomainDefParseString(xml, privconn->xmlopt,
+                                        NULL, parse_flags)) == NULL)
+         goto cleanup;
+@@ -527,9 +536,6 @@ bhyveDomainDefineXMLFlags(virConnectPtr conn, const char *xml, unsigned int flag
+     if (virXMLCheckIllegalChars("name", def->name, "\n") < 0)
+         goto cleanup;
+ 
+-    if (virDomainDefineXMLFlagsEnsureACL(conn, def) < 0)
+-        goto cleanup;
+-
+     if (bhyveDomainAssignAddresses(def, NULL) < 0)
+         goto cleanup;
+ 
+@@ -904,11 +910,17 @@ bhyveDomainCreateXML(virConnectPtr conn,
+     if (flags & VIR_DOMAIN_START_AUTODESTROY)
+         start_flags |= VIR_BHYVE_PROCESS_START_AUTODESTROY;
+ 
+-    if ((def = virDomainDefParseString(xml, privconn->xmlopt,
+-                                       NULL, parse_flags)) == NULL)
+-        goto cleanup;
++    /* Avoid parsing the whole domain definition for ACL checks */
++    if (!(def = virDomainDefIDsParseString(xml, provconn->xmlopt, parse_flags)))
++        return NULL;
+ 
+     if (virDomainCreateXMLEnsureACL(conn, def) < 0)
++        return NULL;
++
++    g_clear_pointer(&def, virDomainDefFree);
++
++    if ((def = virDomainDefParseString(xml, privconn->xmlopt,
++                                       NULL, parse_flags)) == NULL)
+         goto cleanup;
+ 
+     if (bhyveDomainAssignAddresses(def, NULL) < 0)
+-- 
+2.43.0
+
+From fc32ad12e77b486d3546aeccc0687e3a713561f5 Mon Sep 17 00:00:00 2001
+From: Marc Deslauriers <marc.deslauriers@ubuntu.com>
+Date: Mon, 8 Dec 2025 13:08:06 -0500
+Subject: [PATCH 4/9] libxl: Check ACLs before parsing the whole domain XML
+
+---
+ src/libxl/libxl_driver.c | 20 +++++++++++++++-----
+ 1 file changed, 15 insertions(+), 5 deletions(-)
+
+diff --git a/src/libxl/libxl_driver.c b/src/libxl/libxl_driver.c
+index 23a28dc..942a36f 100644
+--- a/src/libxl/libxl_driver.c
++++ b/src/libxl/libxl_driver.c
+@@ -1020,13 +1020,18 @@ libxlDomainCreateXML(virConnectPtr conn, const char *xml,
+     if (flags & VIR_DOMAIN_START_VALIDATE)
+         parse_flags |= VIR_DOMAIN_DEF_PARSE_VALIDATE_SCHEMA;
+ 
+-    if (!(def = virDomainDefParseString(xml, driver->xmlopt,
+-                                        NULL, parse_flags)))
++    if (!(def = virDomainDefIDsParseString(xml, driver->xmlopt, parse_flags)))
+         goto cleanup;
+ 
+     if (virDomainCreateXMLEnsureACL(conn, def) < 0)
+         goto cleanup;
+ 
++    g_clear_pointer(&def, virDomainDefFree);
++
++    if (!(def = virDomainDefParseString(xml, driver->xmlopt,
++                                        NULL, parse_flags)))
++        goto cleanup;
++
+     if (!(vm = virDomainObjListAdd(driver->domains, &def,
+                                    driver->xmlopt,
+                                    VIR_DOMAIN_OBJ_LIST_ADD_LIVE |
+@@ -2813,6 +2818,14 @@ libxlDomainDefineXMLFlags(virConnectPtr conn, const char *xml, unsigned int flag
+     if (flags & VIR_DOMAIN_DEFINE_VALIDATE)
+         parse_flags |= VIR_DOMAIN_DEF_PARSE_VALIDATE_SCHEMA;
+ 
++    if (!(def = virDomainDefIDsParseString(xml, driver->xmlopt, parse_flags)))
++        goto cleanup;
++
++    if (virDomainDefineXMLFlagsEnsureACL(conn, def) < 0)
++        goto cleanup;
++
++    g_clear_pointer(&def, virDomainDefFree);
++
+     if (!(def = virDomainDefParseString(xml, driver->xmlopt,
+                                         NULL, parse_flags)))
+         goto cleanup;
+@@ -2820,9 +2833,6 @@ libxlDomainDefineXMLFlags(virConnectPtr conn, const char *xml, unsigned int flag
+     if (virXMLCheckIllegalChars("name", def->name, "\n") < 0)
+         goto cleanup;
+ 
+-    if (virDomainDefineXMLFlagsEnsureACL(conn, def) < 0)
+-        goto cleanup;
+-
+     if (!(vm = virDomainObjListAdd(driver->domains, &def,
+                                    driver->xmlopt,
+                                    0,
+-- 
+2.43.0
+
+From 29025d237545249e271719ecec1ba0ec03c8d2c3 Mon Sep 17 00:00:00 2001
+From: Marc Deslauriers <marc.deslauriers@ubuntu.com>
+Date: Mon, 8 Dec 2025 13:08:06 -0500
+Subject: [PATCH 5/9] lxc: Check ACLs before parsing the whole domain XML
+
+---
+ src/lxc/lxc_driver.c | 22 +++++++++++++++++-----
+ 1 file changed, 17 insertions(+), 5 deletions(-)
+
+diff --git a/src/lxc/lxc_driver.c b/src/lxc/lxc_driver.c
+index 3cdf73c..c6f9476 100644
+--- a/src/lxc/lxc_driver.c
++++ b/src/lxc/lxc_driver.c
+@@ -416,6 +416,15 @@ lxcDomainDefineXMLFlags(virConnectPtr conn, const char *xml, unsigned int flags)
+     if (!(caps = virLXCDriverGetCapabilities(driver, false)))
+         goto cleanup;
+ 
++    /* Avoid parsing the whole domain definition for ACL checks */
++    if (!(def = virDomainDefIDsParseString(xml, driver->xmlopt, parse_flags)))
++        goto cleanup;
++
++    if (virDomainDefineXMLFlagsEnsureACL(conn, def) < 0)
++        goto cleanup;
++
++    g_clear_pointer(&def, virDomainDefFree);
++
+     if (!(def = virDomainDefParseString(xml, driver->xmlopt,
+                                         NULL, parse_flags)))
+         goto cleanup;
+@@ -423,9 +432,6 @@ lxcDomainDefineXMLFlags(virConnectPtr conn, const char *xml, unsigned int flags)
+     if (virXMLCheckIllegalChars("name", def->name, "\n") < 0)
+         goto cleanup;
+ 
+-    if (virDomainDefineXMLFlagsEnsureACL(conn, def) < 0)
+-        goto cleanup;
+-
+     if (virSecurityManagerVerify(driver->securityManager, def) < 0)
+         goto cleanup;
+ 
+@@ -1100,13 +1106,19 @@ lxcDomainCreateXMLWithFiles(virConnectPtr conn,
+     if (!(caps = virLXCDriverGetCapabilities(driver, false)))
+         goto cleanup;
+ 
+-    if (!(def = virDomainDefParseString(xml, driver->xmlopt,
+-                                        NULL, parse_flags)))
++    /* Avoid parsing the whole domain definition for ACL checks */
++    if (!(def = virDomainDefIDsParseString(xml, driver->xmlopt, parse_flags)))
+         goto cleanup;
+ 
+     if (virDomainCreateXMLWithFilesEnsureACL(conn, def) < 0)
+         goto cleanup;
+ 
++    g_clear_pointer(&def, virDomainDefFree);
++
++    if (!(def = virDomainDefParseString(xml, driver->xmlopt,
++                                        NULL, parse_flags)))
++        goto cleanup;
++
+     if (virSecurityManagerVerify(driver->securityManager, def) < 0)
+         goto cleanup;
+ 
+-- 
+2.43.0
+
+From 8f45c59db100a2a51d9a36dffc081068be94e17e Mon Sep 17 00:00:00 2001
+From: Marc Deslauriers <marc.deslauriers@ubuntu.com>
+Date: Mon, 8 Dec 2025 13:08:06 -0500
+Subject: [PATCH 6/9] vz: Check ACLs before parsing the whole domain XML
+
+---
+ src/vz/vz_driver.c | 18 ++++++++++++------
+ 1 file changed, 12 insertions(+), 6 deletions(-)
+
+diff --git a/src/vz/vz_driver.c b/src/vz/vz_driver.c
+index 23b7795..6a3709c 100644
+--- a/src/vz/vz_driver.c
++++ b/src/vz/vz_driver.c
+@@ -799,6 +799,15 @@ vzDomainDefineXMLFlags(virConnectPtr conn, const char *xml, unsigned int flags)
+     if (flags & VIR_DOMAIN_DEFINE_VALIDATE)
+         parse_flags |= VIR_DOMAIN_DEF_PARSE_VALIDATE_SCHEMA;
+ 
++    /* Avoid parsing the whole domain definition for ACL checks */
++    if (!(def = virDomainDefIDsParseString(xml, driver->xmlopt, parse_flags)))
++        return NULL;
++
++    if (virDomainDefineXMLFlagsEnsureACL(conn, def) < 0)
++        return NULL;
++
++    g_clear_pointer(&def, virDomainDefFree);
++
+     if ((def = virDomainDefParseString(xml, driver->xmlopt,
+                                        NULL, parse_flags)) == NULL)
+         goto cleanup;
+@@ -806,9 +815,6 @@ vzDomainDefineXMLFlags(virConnectPtr conn, const char *xml, unsigned int flags)
+     if (virXMLCheckIllegalChars("name", def->name, "\n") < 0)
+         goto cleanup;
+ 
+-    if (virDomainDefineXMLFlagsEnsureACL(conn, def) < 0)
+-        goto cleanup;
+-
+     dom = virDomainObjListFindByUUID(driver->domains, def->uuid);
+     if (dom == NULL) {
+         virResetLastError();
+@@ -2993,9 +2999,9 @@ vzDomainMigratePrepare3Params(virConnectPtr conn,
+                      | VZ_MIGRATION_COOKIE_DOMAIN_NAME) < 0)
+         goto cleanup;
+ 
+-    if (!(def = virDomainDefParseString(dom_xml, driver->xmlopt,
+-                                        NULL,
+-                                        VIR_DOMAIN_DEF_PARSE_INACTIVE)))
++    /* Avoid parsing the whole domain definition for ACL checks */
++    if (!(def = virDomainDefIDsParseString(dom_xml, driver->xmlopt,
++                                           VIR_DOMAIN_DEF_PARSE_INACTIVE)))
+         goto cleanup;
+ 
+     if (dname) {
+-- 
+2.43.0
+
+From 218e4e08bee6906c43a3b29cdc629f6b92368b14 Mon Sep 17 00:00:00 2001
+From: Marc Deslauriers <marc.deslauriers@ubuntu.com>
+Date: Mon, 8 Dec 2025 13:08:06 -0500
+Subject: [PATCH 7/9] ch: Check ACLs before parsing the whole domain XML
+
+---
+ src/ch/ch_driver.c | 23 +++++++++++++++++------
+ 1 file changed, 17 insertions(+), 6 deletions(-)
+
+diff --git a/src/ch/ch_driver.c b/src/ch/ch_driver.c
+index 464bcef..c86d43c 100644
+--- a/src/ch/ch_driver.c
++++ b/src/ch/ch_driver.c
+@@ -228,14 +228,19 @@ chDomainCreateXML(virConnectPtr conn,
+     if (flags & VIR_DOMAIN_START_VALIDATE)
+         parse_flags |= VIR_DOMAIN_DEF_PARSE_VALIDATE_SCHEMA;
+ 
++    /* Avoid parsing the whole domain definition for ACL checks */
++    if (!(vmdef = virDomainDefIDsParseString(xml, driver->xmlopt, parse_flags)))
++        return NULL;
++
++    if (virDomainCreateXMLEnsureACL(conn, vmdef) < 0)
++        return NULL;
++
++    g_clear_pointer(&vmdef, virDomainDefFree);
+ 
+     if ((vmdef = virDomainDefParseString(xml, driver->xmlopt,
+                                          NULL, parse_flags)) == NULL)
+         goto cleanup;
+ 
+-    if (virDomainCreateXMLEnsureACL(conn, vmdef) < 0)
+-        goto cleanup;
+-
+     if (!(vm = virDomainObjListAdd(driver->domains,
+                                    &vmdef,
+                                    driver->xmlopt,
+@@ -311,6 +316,15 @@ chDomainDefineXMLFlags(virConnectPtr conn, const char *xml, unsigned int flags)
+     if (flags & VIR_DOMAIN_START_VALIDATE)
+         parse_flags |= VIR_DOMAIN_DEF_PARSE_VALIDATE_SCHEMA;
+ 
++    /* Avoid parsing the whole domain definition for ACL checks */
++    if (!(vmdef = virDomainDefIDsParseString(xml, driver->xmlopt, parse_flags)))
++        return NULL;
++
++    if (virDomainDefineXMLFlagsEnsureACL(conn, vmdef) < 0)
++        return NULL;
++
++    g_clear_pointer(&vmdef, virDomainDefFree);
++
+     if ((vmdef = virDomainDefParseString(xml, driver->xmlopt,
+                                          NULL, parse_flags)) == NULL)
+         goto cleanup;
+@@ -318,9 +332,6 @@ chDomainDefineXMLFlags(virConnectPtr conn, const char *xml, unsigned int flags)
+     if (virXMLCheckIllegalChars("name", vmdef->name, "\n") < 0)
+         goto cleanup;
+ 
+-    if (virDomainDefineXMLFlagsEnsureACL(conn, vmdef) < 0)
+-        goto cleanup;
+-
+     if (!(vm = virDomainObjListAdd(driver->domains, &vmdef,
+                                    driver->xmlopt,
+                                    0, NULL)))
+-- 
+2.43.0
+
+From a79fb711143eb7e950fda889436bdd46e1515d73 Mon Sep 17 00:00:00 2001
+From: Marc Deslauriers <marc.deslauriers@ubuntu.com>
+Date: Mon, 8 Dec 2025 13:08:06 -0500
+Subject: [PATCH 8/9] qemu: Check ACLs before parsing the whole domain XML
+
+---
+ src/qemu/qemu_driver.c    | 92 ++++++++++++++++++++-------------------
+ src/qemu/qemu_migration.c | 23 +++++++++-
+ src/qemu/qemu_migration.h |  4 +-
+ src/qemu/qemu_saveimage.c | 25 +++++++++--
+ src/qemu/qemu_saveimage.h |  4 +-
+ 5 files changed, 97 insertions(+), 51 deletions(-)
+
+diff --git a/src/qemu/qemu_driver.c b/src/qemu/qemu_driver.c
+index 9cf2c3e..4a779e7 100644
+--- a/src/qemu/qemu_driver.c
++++ b/src/qemu/qemu_driver.c
+@@ -1719,11 +1719,17 @@ static virDomainPtr qemuDomainCreateXML(virConnectPtr conn,
+ 
+     virNWFilterReadLockFilterUpdates();
+ 
+-    if (!(def = virDomainDefParseString(xml, driver->xmlopt,
+-                                        NULL, parse_flags)))
+-        goto cleanup;
++    /* Avoid parsing the whole domain definition for ACL checks */
++    if (!(def = virDomainDefIDsParseString(xml, driver->xmlopt, parse_flags)))
++        return NULL;
+ 
+     if (virDomainCreateXMLEnsureACL(conn, def) < 0)
++        return NULL;
++
++    g_clear_pointer(&def, virDomainDefFree);
++
++    if (!(def = virDomainDefParseString(xml, driver->xmlopt,
++                                        NULL, parse_flags)))
+         goto cleanup;
+ 
+     if (!(vm = virDomainObjListAdd(driver->domains, &def,
+@@ -5910,7 +5916,9 @@ qemuDomainRestoreFlags(virConnectPtr conn,
+ 
+     virNWFilterReadLockFilterUpdates();
+ 
+-    if (qemuSaveImageGetMetadata(driver, NULL, path, &def, &data) < 0)
++    if (qemuSaveImageGetMetadata(driver, NULL, path,
++                                 virDomainRestoreFlagsEnsureACL,
++                                 conn, &def, &data) < 0)
+         goto cleanup;
+ 
+     fd = qemuSaveImageOpen(driver, path,
+@@ -5919,9 +5927,6 @@ qemuDomainRestoreFlags(virConnectPtr conn,
+     if (fd < 0)
+         goto cleanup;
+ 
+-    if (virDomainRestoreFlagsEnsureACL(conn, def) < 0)
+-        goto cleanup;
+-
+     if (virHookPresent(VIR_HOOK_DRIVER_QEMU)) {
+         int hookret;
+ 
+@@ -6006,10 +6011,9 @@ qemuDomainSaveImageGetXMLDesc(virConnectPtr conn, const char *path,
+ 
+     virCheckFlags(VIR_DOMAIN_SAVE_IMAGE_XML_SECURE, NULL);
+ 
+-    if (qemuSaveImageGetMetadata(driver, NULL, path, &def, &data) < 0)
+-        goto cleanup;
+-
+-    if (virDomainSaveImageGetXMLDescEnsureACL(conn, def) < 0)
++    if (qemuSaveImageGetMetadata(driver, NULL, path,
++                                 virDomainSaveImageGetXMLDescEnsureACL,
++                                 conn, &def, &data) < 0)
+         goto cleanup;
+ 
+     ret = qemuDomainDefFormatXML(driver, NULL, def, flags);
+@@ -6039,16 +6043,15 @@ qemuDomainSaveImageDefineXML(virConnectPtr conn, const char *path,
+     else if (flags & VIR_DOMAIN_SAVE_PAUSED)
+         state = 0;
+ 
+-    if (qemuSaveImageGetMetadata(driver, NULL, path, &def, &data) < 0)
++    if (qemuSaveImageGetMetadata(driver, NULL, path,
++                                 virDomainSaveImageDefineXMLEnsureACL,
++                                 conn, &def, &data) < 0)
+         goto cleanup;
+ 
+     fd = qemuSaveImageOpen(driver, path, 0, NULL, false);
+     if (fd < 0)
+         goto cleanup;
+ 
+-    if (virDomainSaveImageDefineXMLEnsureACL(conn, def) < 0)
+-        goto cleanup;
+-
+     if (STREQ(data->xml, dxml) &&
+         (state < 0 || state == data->header.was_running)) {
+         /* no change to the XML */
+@@ -6121,7 +6124,8 @@ qemuDomainManagedSaveGetXMLDesc(virDomainPtr dom, unsigned int flags)
+         goto cleanup;
+     }
+ 
+-    if (qemuSaveImageGetMetadata(driver, priv->qemuCaps, path, &def, &data) < 0)
++    if (qemuSaveImageGetMetadata(driver, priv->qemuCaps, path,
++                                 NULL, NULL, &def, &data) < 0)
+         goto cleanup;
+ 
+     ret = qemuDomainDefFormatXML(driver, priv->qemuCaps, def, flags);
+@@ -6183,7 +6187,7 @@ qemuDomainObjRestore(virConnectPtr conn,
+     virQEMUSaveData *data = NULL;
+     virFileWrapperFd *wrapperFd = NULL;
+ 
+-    ret = qemuSaveImageGetMetadata(driver, NULL, path, &def, &data);
++    ret = qemuSaveImageGetMetadata(driver, NULL, path, NULL, NULL, &def, &data);
+     if (ret < 0) {
+         if (qemuSaveImageIsCorrupt(driver, path)) {
+             if (unlink(path) < 0) {
+@@ -6599,6 +6603,15 @@ qemuDomainDefineXMLFlags(virConnectPtr conn,
+     if (flags & VIR_DOMAIN_DEFINE_VALIDATE)
+         parse_flags |= VIR_DOMAIN_DEF_PARSE_VALIDATE_SCHEMA;
+ 
++    /* Avoid parsing the whole domain definition for ACL checks */
++    if (!(def = virDomainDefIDsParseString(xml, driver->xmlopt, parse_flags)))
++        return NULL;
++
++    if (virDomainDefineXMLFlagsEnsureACL(conn, def) < 0)
++        return NULL;
++
++    g_clear_pointer(&def, virDomainDefFree);
++
+     if (!(def = virDomainDefParseString(xml, driver->xmlopt,
+                                         NULL, parse_flags)))
+         return NULL;
+@@ -6606,9 +6619,6 @@ qemuDomainDefineXMLFlags(virConnectPtr conn,
+     if (virXMLCheckIllegalChars("name", def->name, "\n") < 0)
+         goto cleanup;
+ 
+-    if (virDomainDefineXMLFlagsEnsureACL(conn, def) < 0)
+-        goto cleanup;
+-
+     if (!(vm = virDomainObjListAdd(driver->domains, &def,
+                                    driver->xmlopt,
+                                    0, &oldDef)))
+@@ -11283,10 +11293,9 @@ qemuDomainMigratePrepareTunnel(virConnectPtr dconn,
+         return -1;
+     }
+ 
+-    if (!(def = qemuMigrationAnyPrepareDef(driver, NULL, dom_xml, dname, &origname)))
+-        return -1;
+-
+-    if (virDomainMigratePrepareTunnelEnsureACL(dconn, def) < 0)
++    if (!(def = qemuMigrationAnyPrepareDef(driver, NULL, dom_xml, dname, &origname,
++                                           dconn,
++                                           virDomainMigratePrepareTunnelEnsureACL)))
+         return -1;
+ 
+     return qemuMigrationDstPrepareTunnel(driver, dconn,
+@@ -11337,10 +11346,9 @@ qemuDomainMigratePrepare2(virConnectPtr dconn,
+         return -1;
+     }
+ 
+-    if (!(def = qemuMigrationAnyPrepareDef(driver, NULL, dom_xml, dname, &origname)))
+-        return -1;
+-
+-    if (virDomainMigratePrepare2EnsureACL(dconn, def) < 0)
++    if (!(def = qemuMigrationAnyPrepareDef(driver, NULL, dom_xml, dname, &origname,
++                                           dconn,
++                                           virDomainMigratePrepare2EnsureACL)))
+         return -1;
+ 
+     /* Do not use cookies in v2 protocol, since the cookie
+@@ -11560,10 +11568,9 @@ qemuDomainMigratePrepare3(virConnectPtr dconn,
+                                                    QEMU_MIGRATION_DESTINATION)))
+         return -1;
+ 
+-    if (!(def = qemuMigrationAnyPrepareDef(driver, NULL, dom_xml, dname, &origname)))
+-        return -1;
+-
+-    if (virDomainMigratePrepare3EnsureACL(dconn, def) < 0)
++    if (!(def = qemuMigrationAnyPrepareDef(driver, NULL, dom_xml, dname, &origname,
++                                           dconn,
++                                           virDomainMigratePrepare3EnsureACL)))
+         return -1;
+ 
+     return qemuMigrationDstPrepareDirect(driver, dconn,
+@@ -11672,10 +11679,9 @@ qemuDomainMigratePrepare3Params(virConnectPtr dconn,
+         return -1;
+     }
+ 
+-    if (!(def = qemuMigrationAnyPrepareDef(driver, NULL, dom_xml, dname, &origname)))
+-        return -1;
+-
+-    if (virDomainMigratePrepare3ParamsEnsureACL(dconn, def) < 0)
++    if (!(def = qemuMigrationAnyPrepareDef(driver, NULL, dom_xml, dname, &origname,
++                                           dconn,
++                                           virDomainMigratePrepare3ParamsEnsureACL)))
+         return -1;
+ 
+     return qemuMigrationDstPrepareDirect(driver, dconn,
+@@ -11717,10 +11723,9 @@ qemuDomainMigratePrepareTunnel3(virConnectPtr dconn,
+                                                    QEMU_MIGRATION_DESTINATION)))
+         return -1;
+ 
+-    if (!(def = qemuMigrationAnyPrepareDef(driver, NULL, dom_xml, dname, &origname)))
+-        return -1;
+-
+-    if (virDomainMigratePrepareTunnel3EnsureACL(dconn, def) < 0)
++    if (!(def = qemuMigrationAnyPrepareDef(driver, NULL, dom_xml, dname, &origname,
++                                           dconn,
++                                           virDomainMigratePrepareTunnel3EnsureACL)))
+         return -1;
+ 
+     return qemuMigrationDstPrepareTunnel(driver, dconn,
+@@ -11769,10 +11774,9 @@ qemuDomainMigratePrepareTunnel3Params(virConnectPtr dconn,
+                                                    QEMU_MIGRATION_DESTINATION)))
+         return -1;
+ 
+-    if (!(def = qemuMigrationAnyPrepareDef(driver, NULL, dom_xml, dname, &origname)))
+-        return -1;
+-
+-    if (virDomainMigratePrepareTunnel3ParamsEnsureACL(dconn, def) < 0)
++    if (!(def = qemuMigrationAnyPrepareDef(driver, NULL, dom_xml, dname, &origname,
++                                           dconn,
++                                           virDomainMigratePrepareTunnel3ParamsEnsureACL)))
+         return -1;
+ 
+     return qemuMigrationDstPrepareTunnel(driver, dconn,
+diff --git a/src/qemu/qemu_migration.c b/src/qemu/qemu_migration.c
+index 8001792..5a57036 100644
+--- a/src/qemu/qemu_migration.c
++++ b/src/qemu/qemu_migration.c
+@@ -3330,7 +3330,9 @@ qemuMigrationAnyPrepareDef(virQEMUDriver *driver,
+                            virQEMUCaps *qemuCaps,
+                            const char *dom_xml,
+                            const char *dname,
+-                           char **origname)
++                           char **origname,
++                           virConnectPtr sconn,
++                           int (*ensureACL)(virConnectPtr, virDomainDef *))
+ {
+     virDomainDef *def;
+     char *name = NULL;
+@@ -3341,6 +3343,24 @@ qemuMigrationAnyPrepareDef(virQEMUDriver *driver,
+         return NULL;
+     }
+ 
++    if (ensureACL) {
++        g_autoptr(virDomainDef) aclDef = NULL;
++
++        /* Avoid parsing the whole domain definition for ACL checks */
++        if (!(aclDef = virDomainDefIDsParseString(dom_xml, driver->xmlopt,
++                                                  VIR_DOMAIN_DEF_PARSE_INACTIVE)))
++            return NULL;
++
++        if (dname) {
++            VIR_FREE(aclDef->name);
++            aclDef->name = g_strdup(dname);
++        }
++
++        if (ensureACL(sconn, aclDef) < 0) {
++            return NULL;
++        }
++    }
++
+     if (!(def = virDomainDefParseString(dom_xml, driver->xmlopt,
+                                         qemuCaps,
+                                         VIR_DOMAIN_DEF_PARSE_INACTIVE |
+@@ -4066,6 +4086,7 @@ qemuMigrationSrcRun(virQEMUDriver *driver,
+             if (!(persistDef = qemuMigrationAnyPrepareDef(driver,
+                                                           priv->qemuCaps,
+                                                           persist_xml,
++                                                          NULL, NULL,
+                                                           NULL, NULL)))
+                 goto error;
+         } else {
+diff --git a/src/qemu/qemu_migration.h b/src/qemu/qemu_migration.h
+index dd74f8b..c3ee5f6 100644
+--- a/src/qemu/qemu_migration.h
++++ b/src/qemu/qemu_migration.h
+@@ -120,7 +120,9 @@ qemuMigrationAnyPrepareDef(virQEMUDriver *driver,
+                            virQEMUCaps *qemuCaps,
+                            const char *dom_xml,
+                            const char *dname,
+-                           char **origname);
++                           char **origname,
++                           virConnectPtr sconn,
++                           int (*ensureACL)(virConnectPtr, virDomainDef *));
+ 
+ int
+ qemuMigrationDstPrepareTunnel(virQEMUDriver *driver,
+diff --git a/src/qemu/qemu_saveimage.c b/src/qemu/qemu_saveimage.c
+index 5f14d07..0e84c39 100644
+--- a/src/qemu/qemu_saveimage.c
++++ b/src/qemu/qemu_saveimage.c
+@@ -532,16 +532,21 @@ qemuSaveImageIsCorrupt(virQEMUDriver *driver, const char *path)
+  * @driver: qemu driver dataqemuSaveImageOpen
+  * @qemuCaps: pointer to qemuCaps if the domain is running or NULL
+  * @path: path of the save image
++ * @ensureACL: ACL callback to check against the definition or NULL
++ * @conn: parameter for the @ensureACL callback
+  * @ret_def: returns domain definition created from the XML stored in the image
+  * @ret_data: returns structure filled with data from the image header
+  *
+- * Open the save image file, read libvirt's save image metadata, and populate
+- * the @ret_def and @ret_data structures. Returns 0 on success and -1 on failure.
++ * Open the save image file, read libvirt's save image metadata, optionally
++ * check ACLs before parsing the whole domain definition and populate the
++ * @ret_def and @ret_data structures. Returns 0 on success and -1 on failure.
+  */
+ int
+ qemuSaveImageGetMetadata(virQEMUDriver *driver,
+                          virQEMUCaps *qemuCaps,
+                          const char *path,
++                         int (*ensureACL)(virConnectPtr, virDomainDef *),
++                         virConnectPtr conn,
+                          virDomainDef **ret_def,
+                          virQEMUSaveData **ret_data)
+ {
+@@ -549,6 +554,8 @@ qemuSaveImageGetMetadata(virQEMUDriver *driver,
+     VIR_AUTOCLOSE fd = -1;
+     virQEMUSaveData *data;
+     g_autoptr(virDomainDef) def = NULL;
++    unsigned int parse_flags = VIR_DOMAIN_DEF_PARSE_INACTIVE |
++                               VIR_DOMAIN_DEF_PARSE_SKIP_VALIDATE;
+     int rc;
+ 
+     if ((fd = qemuDomainOpenFile(cfg, NULL, path, O_RDONLY, NULL)) < 0)
+@@ -558,10 +565,20 @@ qemuSaveImageGetMetadata(virQEMUDriver *driver,
+         return rc;
+ 
+     data = *ret_data;
++
++    if (ensureACL) {
++        /* Parse only the IDs for ACL checks */
++        g_autoptr(virDomainDef) aclDef = virDomainDefIDsParseString(data->xml,
++                                                                    driver->xmlopt,
++                                                                    parse_flags);
++
++        if (!aclDef || ensureACL(conn, aclDef) < 0)
++            return -1;
++    }
++
+     /* Create a domain from this XML */
+     if (!(def = virDomainDefParseString(data->xml, driver->xmlopt, qemuCaps,
+-                                        VIR_DOMAIN_DEF_PARSE_INACTIVE |
+-                                        VIR_DOMAIN_DEF_PARSE_SKIP_VALIDATE)))
++                                        parse_flags)))
+         return -1;
+ 
+     *ret_def = g_steal_pointer(&def);
+diff --git a/src/qemu/qemu_saveimage.h b/src/qemu/qemu_saveimage.h
+index 0dcdba2..d36b1bf 100644
+--- a/src/qemu/qemu_saveimage.h
++++ b/src/qemu/qemu_saveimage.h
+@@ -79,9 +79,11 @@ int
+ qemuSaveImageGetMetadata(virQEMUDriver *driver,
+                          virQEMUCaps *qemuCaps,
+                          const char *path,
++                         int (*ensureACL)(virConnectPtr, virDomainDef *),
++                         virConnectPtr conn,
+                          virDomainDef **ret_def,
+                          virQEMUSaveData **ret_data)
+-    ATTRIBUTE_NONNULL(4) ATTRIBUTE_NONNULL(5);
++    ATTRIBUTE_NONNULL(6) ATTRIBUTE_NONNULL(7);
+ 
+ int
+ qemuSaveImageOpen(virQEMUDriver *driver,
+-- 
+2.43.0
+
+From d8e7d974dc418345c1454632d26ed1b59997fc52 Mon Sep 17 00:00:00 2001
+From: Marc Deslauriers <marc.deslauriers@ubuntu.com>
+Date: Mon, 8 Dec 2025 13:08:06 -0500
+Subject: [PATCH 9/9] bhyve: s/provconn/privcon/
+
+---
+ src/bhyve/bhyve_driver.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/bhyve/bhyve_driver.c b/src/bhyve/bhyve_driver.c
+index f933376..9451f79 100644
+--- a/src/bhyve/bhyve_driver.c
++++ b/src/bhyve/bhyve_driver.c
+@@ -521,7 +521,7 @@ bhyveDomainDefineXMLFlags(virConnectPtr conn, const char *xml, unsigned int flag
+         return NULL;
+ 
+     /* Avoid parsing the whole domain definition for ACL checks */
+-    if (!(def = virDomainDefIDsParseString(xml, provconn->xmlopt, parse_flags)))
++    if (!(def = virDomainDefIDsParseString(xml, privconn->xmlopt, parse_flags)))
+         return NULL;
+ 
+     if (virDomainDefineXMLFlagsEnsureACL(conn, def) < 0)
+@@ -911,7 +911,7 @@ bhyveDomainCreateXML(virConnectPtr conn,
+         start_flags |= VIR_BHYVE_PROCESS_START_AUTODESTROY;
+ 
+     /* Avoid parsing the whole domain definition for ACL checks */
+-    if (!(def = virDomainDefIDsParseString(xml, provconn->xmlopt, parse_flags)))
++    if (!(def = virDomainDefIDsParseString(xml, privconn->xmlopt, parse_flags)))
+         return NULL;
+ 
+     if (virDomainCreateXMLEnsureACL(conn, def) < 0)
+-- 
+2.43.0
+

--- a/SPECS/libvirt/libvirt.spec
+++ b/SPECS/libvirt/libvirt.spec
@@ -9,7 +9,7 @@
 Summary:        Virtualization API library that supports KVM, QEMU, Xen, ESX etc
 Name:           libvirt
 Version:        7.10.0
-Release:        10%{?dist}
+Release:        11%{?dist}
 License:        LGPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -20,8 +20,9 @@ Source0:        https://libvirt.org/sources/%{name}-%{version}.tar.xz
 Patch1:         CVE-2023-2700.patch
 Patch2:         CVE-2024-1441.patch
 Patch3:         CVE-2024-2496.patch
-Patch4:		    CVE-2024-2494.patch
+Patch4:         CVE-2024-2494.patch
 Patch5:         CVE-2024-4418.patch
+Patch6:         CVE-2025-12748.patch
 
 BuildRequires:  audit-libs-devel
 BuildRequires:  augeas
@@ -1059,6 +1060,9 @@ exit 0
 %{_libdir}/libnss_libvirt_guest.so.2
 
 %changelog
+* Mon Jan 19 2026 Akhila Guruju <v-guakhila@microsoft.com> - 7.10.0-11
+- Patch CVE-2025-12748
+
 * Wed May 22 2024 Juan Camposeco <juanarturoc@microsoft.com> - 7.10.0-10
 - Patch to address CVE-2024-4418
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Patch libvirt for CVE-2025-12748

Backported: NO

Patch Reference:
For pre-requisite
1. https://git.launchpad.net/ubuntu/+source/libvirt/patch/?id=508a5ab49e83c1ac272108daae9ae92d906cde95
2. https://git.launchpad.net/ubuntu/+source/libvirt/patch/?id=fabc09641da50196e4d0de949426023baccb41ae
3. https://git.launchpad.net/ubuntu/+source/libvirt/patch/?id=f15dc1a7de65ab16163908b92cb479c713f8f052

for CVE
1. https://git.launchpad.net/ubuntu/+source/libvirt/patch/?id=f0c391572604abb82745ac96af942d39f854e990
2. https://git.launchpad.net/ubuntu/+source/libvirt/patch/?id=9df25774df5c6deef221bfb5b2a629d0066c7faf
3. https://git.launchpad.net/ubuntu/+source/libvirt/patch/?id=fc32ad12e77b486d3546aeccc0687e3a713561f5
4. https://git.launchpad.net/ubuntu/+source/libvirt/patch/?id=29025d237545249e271719ecec1ba0ec03c8d2c3
5. https://git.launchpad.net/ubuntu/+source/libvirt/patch/?id=8f45c59db100a2a51d9a36dffc081068be94e17e
6. https://git.launchpad.net/ubuntu/+source/libvirt/patch/?id=218e4e08bee6906c43a3b29cdc629f6b92368b14
7. https://git.launchpad.net/ubuntu/+source/libvirt/patch/?id=a79fb711143eb7e950fda889436bdd46e1515d73
8. https://git.launchpad.net/ubuntu/+source/libvirt/patch/?id=d8e7d974dc418345c1454632d26ed1b59997fc52

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- new file:   SPECS/libvirt/CVE-2025-12748.patch
- modified:   SPECS/libvirt/libvirt.spec

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2025-12748

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: [Buddy Build](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=1029690&view=results)
