### PR TITLE
[Medium] Patch coredns for CVE-2025-68151

### DIFF
--- a/SPECS/coredns/CVE-2025-68151.patch
+++ b/SPECS/coredns/CVE-2025-68151.patch
@@ -1,0 +1,1408 @@
+From 0d8cbb1a6bcb6bc9c1a489865278b8725fa20812 Mon Sep 17 00:00:00 2001
+From: Ville Vesilehto <ville@vesilehto.fi>
+Date: Thu, 18 Dec 2025 05:08:59 +0200
+Subject: [PATCH] Merge commit from fork
+
+Add configurable resource limits to prevent potential DoS vectors
+via connection/stream exhaustion on gRPC, HTTPS, and HTTPS/3 servers.
+
+New configuration plugins:
+- grpc_server: configure max_streams, max_connections
+- https: configure max_connections
+- https3: configure max_streams
+
+Changes:
+- Use netutil.LimitListener for connection limiting
+- Use gRPC MaxConcurrentStreams and message size limits
+- Add QUIC MaxIncomingStreams for HTTPS/3 stream limiting
+- Set secure defaults: 256 max streams, 200 max connections
+- Setting any limit to 0 means unbounded/fallback to previous impl
+
+Defaults are applied automatically when plugins are omitted from
+config.
+
+Includes tests and integration tests.
+
+Signed-off-by: Ville Vesilehto <ville@vesilehto.fi>
+
+Upstream Patch Reference: https://github.com/coredns/coredns/commit/0d8cbb1a6bcb6bc9c1a489865278b8725fa20812.patch
+---
+ core/dnsserver/config.go                  |  12 ++
+ core/dnsserver/server_grpc.go             |  67 +++++++-
+ core/dnsserver/server_https.go            |  32 +++-
+ core/dnsserver/server_https_test.go       |  61 ++++++++
+ core/dnsserver/server_quic.go             |  29 +++-
+ core/dnsserver/zdirectives.go             |   2 +
+ core/plugin/zplugin.go                    |   2 +
+ go.mod                                    |   2 +-
+ plugin.cfg                                |   2 +
+ plugin/chaos/zowners.go                   |   2 +-
+ plugin/grpc_server/README.md              |  51 +++++++
+ plugin/grpc_server/setup.go               |  79 ++++++++++
+ plugin/grpc_server/setup_test.go          | 169 +++++++++++++++++++++
+ plugin/https/README.md                    |  47 ++++++
+ plugin/https/setup.go                     |  63 ++++++++
+ plugin/https/setup_test.go                | 144 ++++++++++++++++++
+ test/grpc_test.go                         |  69 ++++++++-
+ test/https_test.go                        | 177 ++++++++++++++++++++++
+ vendor/golang.org/x/net/netutil/listen.go |  87 +++++++++++
+ vendor/modules.txt                        |   1 +
+ 20 files changed, 1074 insertions(+), 24 deletions(-)
+ create mode 100644 plugin/grpc_server/README.md
+ create mode 100644 plugin/grpc_server/setup.go
+ create mode 100644 plugin/grpc_server/setup_test.go
+ create mode 100644 plugin/https/README.md
+ create mode 100644 plugin/https/setup.go
+ create mode 100644 plugin/https/setup_test.go
+ create mode 100644 test/https_test.go
+ create mode 100644 vendor/golang.org/x/net/netutil/listen.go
+
+diff --git a/core/dnsserver/config.go b/core/dnsserver/config.go
+index cba5795..9bdf4a7 100644
+--- a/core/dnsserver/config.go
++++ b/core/dnsserver/config.go
+@@ -62,6 +62,18 @@ type Config struct {
+ 	// This is nil if not specified, allowing for a default to be used.
+ 	MaxQUICWorkerPoolSize *int
+ 
++	// MaxGRPCStreams defines the maximum number of concurrent streams per gRPC connection.
++	// This is nil if not specified, allowing for a default to be used.
++	MaxGRPCStreams *int
++
++	// MaxGRPCConnections defines the maximum number of concurrent gRPC connections.
++	// This is nil if not specified, allowing for a default to be used.
++	MaxGRPCConnections *int
++
++	// MaxHTTPSConnections defines the maximum number of concurrent HTTPS connections.
++	// This is nil if not specified, allowing for a default to be used.
++	MaxHTTPSConnections *int
++
+ 	// Timeouts for TCP, TLS and HTTPS servers.
+ 	ReadTimeout  time.Duration
+ 	WriteTimeout time.Duration
+diff --git a/core/dnsserver/server_grpc.go b/core/dnsserver/server_grpc.go
+index 9d7a95a..c77987e 100644
+--- a/core/dnsserver/server_grpc.go
++++ b/core/dnsserver/server_grpc.go
+@@ -15,17 +15,35 @@ import (
+ 	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
+ 	"github.com/miekg/dns"
+ 	"github.com/opentracing/opentracing-go"
++	"golang.org/x/net/netutil"
+ 	"google.golang.org/grpc"
+ 	"google.golang.org/grpc/peer"
+ )
+ 
++const (
++	// maxDNSMessageBytes is the maximum size of a DNS message on the wire.
++	maxDNSMessageBytes = dns.MaxMsgSize
++
++	// maxProtobufPayloadBytes accounts for protobuf overhead.
++	// Field tag=1 (1 byte) + length varint for 65535 (3 bytes) = 4 bytes total
++	maxProtobufPayloadBytes = maxDNSMessageBytes + 4
++
++	// DefaultGRPCMaxStreams is the default maximum number of concurrent streams per connection.
++	DefaultGRPCMaxStreams = 256
++
++	// DefaultGRPCMaxConnections is the default maximum number of concurrent connections.
++	DefaultGRPCMaxConnections = 200
++)
++
+ // ServergRPC represents an instance of a DNS-over-gRPC server.
+ type ServergRPC struct {
+ 	*Server
+ 	*pb.UnimplementedDnsServiceServer
+-	grpcServer *grpc.Server
+-	listenAddr net.Addr
+-	tlsConfig  *tls.Config
++	grpcServer     *grpc.Server
++	listenAddr     net.Addr
++	tlsConfig      *tls.Config
++	maxStreams     int
++	maxConnections int
+ }
+ 
+ // NewServergRPC returns a new CoreDNS GRPC server and compiles all plugin in to it.
+@@ -49,7 +67,22 @@ func NewServergRPC(addr string, group []*Config) (*ServergRPC, error) {
+ 		tlsConfig.NextProtos = []string{"h2"}
+ 	}
+ 
+-	return &ServergRPC{Server: s, tlsConfig: tlsConfig}, nil
++	maxStreams := DefaultGRPCMaxStreams
++	if len(group) > 0 && group[0] != nil && group[0].MaxGRPCStreams != nil {
++		maxStreams = *group[0].MaxGRPCStreams
++	}
++
++	maxConnections := DefaultGRPCMaxConnections
++	if len(group) > 0 && group[0] != nil && group[0].MaxGRPCConnections != nil {
++		maxConnections = *group[0].MaxGRPCConnections
++	}
++
++	return &ServergRPC{
++		Server:         s,
++		tlsConfig:      tlsConfig,
++		maxStreams:     maxStreams,
++		maxConnections: maxConnections,
++	}, nil
+ }
+ 
+ // Compile-time check to ensure Server implements the caddy.GracefulServer interface
+@@ -61,21 +94,36 @@ func (s *ServergRPC) Serve(l net.Listener) error {
+ 	s.listenAddr = l.Addr()
+ 	s.m.Unlock()
+ 
++	serverOpts := []grpc.ServerOption{
++		grpc.MaxRecvMsgSize(maxProtobufPayloadBytes),
++		grpc.MaxSendMsgSize(maxProtobufPayloadBytes),
++	}
++
++	// Only set MaxConcurrentStreams if not unbounded (0)
++	if s.maxStreams > 0 {
++		serverOpts = append(serverOpts, grpc.MaxConcurrentStreams(uint32(s.maxStreams)))
++	}
++
+ 	if s.Tracer() != nil {
+ 		onlyIfParent := func(parentSpanCtx opentracing.SpanContext, method string, req, resp interface{}) bool {
+ 			return parentSpanCtx != nil
+ 		}
+-		intercept := otgrpc.OpenTracingServerInterceptor(s.Tracer(), otgrpc.IncludingSpans(onlyIfParent))
+-		s.grpcServer = grpc.NewServer(grpc.UnaryInterceptor(intercept))
+-	} else {
+-		s.grpcServer = grpc.NewServer()
++		serverOpts = append(serverOpts, grpc.UnaryInterceptor(otgrpc.OpenTracingServerInterceptor(s.Tracer(), otgrpc.IncludingSpans(onlyIfParent))))
+ 	}
+ 
++	s.grpcServer = grpc.NewServer(serverOpts...)
++
+ 	pb.RegisterDnsServiceServer(s.grpcServer, s)
+ 
+ 	if s.tlsConfig != nil {
+ 		l = tls.NewListener(l, s.tlsConfig)
+ 	}
++
++	// Wrap listener to limit concurrent connections
++	if s.maxConnections > 0 {
++		l = netutil.LimitListener(l, s.maxConnections)
++	}
++
+ 	return s.grpcServer.Serve(l)
+ }
+ 
+@@ -122,6 +170,9 @@ func (s *ServergRPC) Stop() (err error) {
+ // any normal server. We use a custom responseWriter to pick up the bytes we need to write
+ // back to the client as a protobuf.
+ func (s *ServergRPC) Query(ctx context.Context, in *pb.DnsPacket) (*pb.DnsPacket, error) {
++	if len(in.GetMsg()) > dns.MaxMsgSize {
++		return nil, fmt.Errorf("dns message exceeds size limit: %d", len(in.GetMsg()))
++	}
+ 	msg := new(dns.Msg)
+ 	err := msg.Unpack(in.Msg)
+ 	if err != nil {
+diff --git a/core/dnsserver/server_https.go b/core/dnsserver/server_https.go
+index cddf598..6304138 100644
+--- a/core/dnsserver/server_https.go
++++ b/core/dnsserver/server_https.go
+@@ -18,15 +18,23 @@ import (
+ 	"github.com/coredns/coredns/plugin/pkg/response"
+ 	"github.com/coredns/coredns/plugin/pkg/reuseport"
+ 	"github.com/coredns/coredns/plugin/pkg/transport"
++
++	"golang.org/x/net/netutil"
++)
++
++const (
++	// DefaultHTTPSMaxConnections is the default maximum number of concurrent connections.
++	DefaultHTTPSMaxConnections = 200
+ )
+ 
+ // ServerHTTPS represents an instance of a DNS-over-HTTPS server.
+ type ServerHTTPS struct {
+ 	*Server
+-	httpsServer  *http.Server
+-	listenAddr   net.Addr
+-	tlsConfig    *tls.Config
+-	validRequest func(*http.Request) bool
++	httpsServer    *http.Server
++	listenAddr     net.Addr
++	tlsConfig      *tls.Config
++	validRequest   func(*http.Request) bool
++	maxConnections int
+ }
+ 
+ // loggerAdapter is a simple adapter around CoreDNS logger made to implement io.Writer in order to log errors from HTTP server
+@@ -80,8 +88,17 @@ func NewServerHTTPS(addr string, group []*Config) (*ServerHTTPS, error) {
+ 		IdleTimeout:  s.idleTimeout,
+ 		ErrorLog:     stdlog.New(&loggerAdapter{}, "", 0),
+ 	}
++	maxConnections := DefaultHTTPSMaxConnections
++	if len(group) > 0 && group[0] != nil && group[0].MaxHTTPSConnections != nil {
++		maxConnections = *group[0].MaxHTTPSConnections
++	}
++
+ 	sh := &ServerHTTPS{
+-		Server: s, tlsConfig: tlsConfig, httpsServer: srv, validRequest: validator,
++		Server:         s,
++		tlsConfig:      tlsConfig,
++		httpsServer:    srv,
++		validRequest:   validator,
++		maxConnections: maxConnections,
+ 	}
+ 	sh.httpsServer.Handler = sh
+ 
+@@ -97,6 +114,11 @@ func (s *ServerHTTPS) Serve(l net.Listener) error {
+ 	s.listenAddr = l.Addr()
+ 	s.m.Unlock()
+ 
++	// Wrap listener to limit concurrent connections (before TLS)
++	if s.maxConnections > 0 {
++		l = netutil.LimitListener(l, s.maxConnections)
++	}
++
+ 	if s.tlsConfig != nil {
+ 		l = tls.NewListener(l, s.tlsConfig)
+ 	}
+diff --git a/core/dnsserver/server_https_test.go b/core/dnsserver/server_https_test.go
+index 0099681..4a19513 100644
+--- a/core/dnsserver/server_https_test.go
++++ b/core/dnsserver/server_https_test.go
+@@ -65,3 +65,64 @@ func TestCustomHTTPRequestValidator(t *testing.T) {
+ 		})
+ 	}
+ }
++
++func TestNewServerHTTPSWithCustomLimits(t *testing.T) {
++	maxConnections := 100
++	c := Config{
++		Zone:                "example.com.",
++		Transport:           "https",
++		TLSConfig:           &tls.Config{},
++		ListenHosts:         []string{"127.0.0.1"},
++		Port:                "443",
++		MaxHTTPSConnections: &maxConnections,
++	}
++
++	server, err := NewServerHTTPS("127.0.0.1:443", []*Config{&c})
++	if err != nil {
++		t.Fatalf("NewServerHTTPS() with custom limits failed: %v", err)
++	}
++
++	if server.maxConnections != maxConnections {
++		t.Errorf("Expected maxConnections = %d, got %d", maxConnections, server.maxConnections)
++	}
++}
++
++func TestNewServerHTTPSDefaults(t *testing.T) {
++	c := Config{
++		Zone:        "example.com.",
++		Transport:   "https",
++		TLSConfig:   &tls.Config{},
++		ListenHosts: []string{"127.0.0.1"},
++		Port:        "443",
++	}
++
++	server, err := NewServerHTTPS("127.0.0.1:443", []*Config{&c})
++	if err != nil {
++		t.Fatalf("NewServerHTTPS() failed: %v", err)
++	}
++
++	if server.maxConnections != DefaultHTTPSMaxConnections {
++		t.Errorf("Expected default maxConnections = %d, got %d", DefaultHTTPSMaxConnections, server.maxConnections)
++	}
++}
++
++func TestNewServerHTTPSZeroLimits(t *testing.T) {
++	zero := 0
++	c := Config{
++		Zone:                "example.com.",
++		Transport:           "https",
++		TLSConfig:           &tls.Config{},
++		ListenHosts:         []string{"127.0.0.1"},
++		Port:                "443",
++		MaxHTTPSConnections: &zero,
++	}
++
++	server, err := NewServerHTTPS("127.0.0.1:443", []*Config{&c})
++	if err != nil {
++		t.Fatalf("NewServerHTTPS() with zero limits failed: %v", err)
++	}
++
++	if server.maxConnections != 0 {
++		t.Errorf("Expected maxConnections = 0, got %d", server.maxConnections)
++	}
++}
+diff --git a/core/dnsserver/server_quic.go b/core/dnsserver/server_quic.go
+index a744cd0..ed362b5 100644
+--- a/core/dnsserver/server_quic.go
++++ b/core/dnsserver/server_quic.go
+@@ -146,12 +146,29 @@ func (s *ServerQUIC) serveQUICConnection(conn quic.Connection) {
+ 			return
+ 		}
+ 
+-		// Use a bounded worker pool
+-		s.streamProcessPool <- struct{}{} // Acquire a worker slot, may block
+-		go func(st quic.Stream, cn quic.Connection) {
+-			defer func() { <-s.streamProcessPool }() // Release worker slot
+-			s.serveQUICStream(st, cn)
+-		}(stream, conn)
++		// Use a bounded worker pool with context cancellation
++		select {
++		case s.streamProcessPool <- struct{}{}:
++			// Got worker slot immediately
++			go func(st quic.Stream, cn quic.Connection) {
++				defer func() { <-s.streamProcessPool }() // Release worker slot
++				s.serveQUICStream(st, cn)
++			}(stream, conn)
++		default:
++			// Worker pool full, check for context cancellation
++			go func(st quic.Stream, cn quic.Connection) {
++				select {
++				case s.streamProcessPool <- struct{}{}:
++					// Got worker slot after waiting
++					defer func() { <-s.streamProcessPool }() // Release worker slot
++					s.serveQUICStream(st, cn)
++				case <-conn.Context().Done():
++					// Connection context was cancelled while waiting
++					st.Close()
++					return
++				}
++			}(stream, conn)
++		}
+ 	}
+ }
+ 
+diff --git a/core/dnsserver/zdirectives.go b/core/dnsserver/zdirectives.go
+index 805281e..ad31b22 100644
+--- a/core/dnsserver/zdirectives.go
++++ b/core/dnsserver/zdirectives.go
+@@ -15,6 +15,8 @@ var Directives = []string{
+ 	"cancel",
+ 	"tls",
+ 	"quic",
++	"grpc_server",
++	"https",
+ 	"timeouts",
+ 	"reload",
+ 	"nsid",
+diff --git a/core/plugin/zplugin.go b/core/plugin/zplugin.go
+index 5cdb101..a357ddc 100644
+--- a/core/plugin/zplugin.go
++++ b/core/plugin/zplugin.go
+@@ -27,9 +27,11 @@ import (
+ 	_ "github.com/coredns/coredns/plugin/forward"
+ 	_ "github.com/coredns/coredns/plugin/geoip"
+ 	_ "github.com/coredns/coredns/plugin/grpc"
++	_ "github.com/coredns/coredns/plugin/grpc_server"
+ 	_ "github.com/coredns/coredns/plugin/header"
+ 	_ "github.com/coredns/coredns/plugin/health"
+ 	_ "github.com/coredns/coredns/plugin/hosts"
++	_ "github.com/coredns/coredns/plugin/https"
+ 	_ "github.com/coredns/coredns/plugin/k8s_external"
+ 	_ "github.com/coredns/coredns/plugin/kubernetes"
+ 	_ "github.com/coredns/coredns/plugin/loadbalance"
+diff --git a/go.mod b/go.mod
+index e1e2cc8..827cc36 100644
+--- a/go.mod
++++ b/go.mod
+@@ -1,6 +1,6 @@
+ module github.com/coredns/coredns
+ 
+-go 1.20
++go 1.22.0
+ 
+ require (
+ 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible
+diff --git a/plugin.cfg b/plugin.cfg
+index e9eb1db..b41f941 100644
+--- a/plugin.cfg
++++ b/plugin.cfg
+@@ -24,6 +24,8 @@ geoip:geoip
+ cancel:cancel
+ tls:tls
+ quic:quic
++grpc_server:grpc_server
++https:https
+ timeouts:timeouts
+ reload:reload
+ nsid:nsid
+diff --git a/plugin/chaos/zowners.go b/plugin/chaos/zowners.go
+index 419ca3c..b9553f3 100644
+--- a/plugin/chaos/zowners.go
++++ b/plugin/chaos/zowners.go
+@@ -1,4 +1,4 @@
+ package chaos
+ 
+ // Owners are all GitHub handlers of all maintainers.
+-var Owners = []string{"Tantalor93", "bradbeam", "chrisohaver", "darshanime", "dilyevsky", "ekleiner", "greenpau", "ihac", "inigohu", "isolus", "jameshartig", "johnbelamaric", "miekg", "mqasimsarfraz", "nchrisdk", "nitisht", "pmoroney", "rajansandeep", "rdrozhdzh", "rtreffer", "snebel29", "stp-ip", "superq", "varyoo", "ykhr53", "yongtang", "zouyee"}
++var Owners = []string{"Tantalor93", "bradbeam", "chrisohaver", "darshanime", "dilyevsky", "ekleiner", "greenpau", "ihac", "inigohu", "isolus", "jameshartig", "johnbelamaric", "miekg", "mqasimsarfraz", "nchrisdk", "nitisht", "pmoroney", "rajansandeep", "rdrozhdzh", "rtreffer", "snebel29", "stp-ip", "superq", "thevilledev", "varyoo", "ykhr53", "yongtang", "zouyee"}
+diff --git a/plugin/grpc_server/README.md b/plugin/grpc_server/README.md
+new file mode 100644
+index 0000000..1a19bb1
+--- /dev/null
++++ b/plugin/grpc_server/README.md
+@@ -0,0 +1,51 @@
++# grpc_server
++
++## Name
++
++*grpc_server* - configures DNS-over-gRPC server options.
++
++## Description
++
++The *grpc_server* plugin allows you to configure parameters for the DNS-over-gRPC server to fine-tune the security posture and performance of the server.
++
++This plugin can only be used once per gRPC listener block.
++
++## Syntax
++
++```txt
++grpc_server {
++    max_streams POSITIVE_INTEGER
++    max_connections POSITIVE_INTEGER
++}
++```
++
++* `max_streams` limits the number of concurrent gRPC streams per connection. This helps prevent unbounded streams on a single connection, exhausting server resources. The default value is 256 if not specified. Set to 0 for unbounded.
++* `max_connections` limits the number of concurrent TCP connections to the gRPC server. The default value is 200 if not specified. Set to 0 for unbounded.
++
++## Examples
++
++Set custom limits for maximum streams and connections:
++
++```
++grpc://.:8053 {
++    tls cert.pem key.pem
++    grpc_server {
++        max_streams 50
++        max_connections 100
++    }
++    whoami
++}
++```
++
++Set values to 0 for unbounded, matching CoreDNS behaviour before v1.14.0:
++
++```
++grpc://.:8053 {
++    tls cert.pem key.pem
++    grpc_server {
++        max_streams 0
++        max_connections 0
++    }
++    whoami
++}
++```
+diff --git a/plugin/grpc_server/setup.go b/plugin/grpc_server/setup.go
+new file mode 100644
+index 0000000..0cecd7d
+--- /dev/null
++++ b/plugin/grpc_server/setup.go
+@@ -0,0 +1,79 @@
++package grpc_server
++
++import (
++	"strconv"
++
++	"github.com/coredns/caddy"
++	"github.com/coredns/coredns/core/dnsserver"
++	"github.com/coredns/coredns/plugin"
++)
++
++func init() {
++	caddy.RegisterPlugin("grpc_server", caddy.Plugin{
++		ServerType: "dns",
++		Action:     setup,
++	})
++}
++
++func setup(c *caddy.Controller) error {
++	err := parseGRPCServer(c)
++	if err != nil {
++		return plugin.Error("grpc_server", err)
++	}
++	return nil
++}
++
++func parseGRPCServer(c *caddy.Controller) error {
++	config := dnsserver.GetConfig(c)
++
++	// Skip the "grpc_server" directive itself
++	c.Next()
++
++	// Get any arguments on the "grpc_server" line
++	args := c.RemainingArgs()
++	if len(args) > 0 {
++		return c.ArgErr()
++	}
++
++	// Process all nested directives in the block
++	for c.NextBlock() {
++		switch c.Val() {
++		case "max_streams":
++			args := c.RemainingArgs()
++			if len(args) != 1 {
++				return c.ArgErr()
++			}
++			val, err := strconv.Atoi(args[0])
++			if err != nil {
++				return c.Errf("invalid max_streams value '%s': %v", args[0], err)
++			}
++			if val < 0 {
++				return c.Errf("max_streams must be a non-negative integer: %d", val)
++			}
++			if config.MaxGRPCStreams != nil {
++				return c.Err("max_streams already defined for this server block")
++			}
++			config.MaxGRPCStreams = &val
++		case "max_connections":
++			args := c.RemainingArgs()
++			if len(args) != 1 {
++				return c.ArgErr()
++			}
++			val, err := strconv.Atoi(args[0])
++			if err != nil {
++				return c.Errf("invalid max_connections value '%s': %v", args[0], err)
++			}
++			if val < 0 {
++				return c.Errf("max_connections must be a non-negative integer: %d", val)
++			}
++			if config.MaxGRPCConnections != nil {
++				return c.Err("max_connections already defined for this server block")
++			}
++			config.MaxGRPCConnections = &val
++		default:
++			return c.Errf("unknown property '%s'", c.Val())
++		}
++	}
++
++	return nil
++}
+diff --git a/plugin/grpc_server/setup_test.go b/plugin/grpc_server/setup_test.go
+new file mode 100644
+index 0000000..75fb749
+--- /dev/null
++++ b/plugin/grpc_server/setup_test.go
+@@ -0,0 +1,169 @@
++package grpc_server
++
++import (
++	"fmt"
++	"strings"
++	"testing"
++
++	"github.com/coredns/caddy"
++	"github.com/coredns/coredns/core/dnsserver"
++)
++
++func TestSetup(t *testing.T) {
++	tests := []struct {
++		input                  string
++		shouldErr              bool
++		expectedErrContent     string
++		expectedMaxStreams     *int
++		expectedMaxConnections *int
++	}{
++		// Valid configurations
++		{
++			input:     `grpc_server`,
++			shouldErr: false,
++		},
++		{
++			input: `grpc_server {
++			}`,
++			shouldErr: false,
++		},
++		{
++			input: `grpc_server {
++				max_streams 100
++			}`,
++			shouldErr:          false,
++			expectedMaxStreams: intPtr(100),
++		},
++		{
++			input: `grpc_server {
++				max_connections 200
++			}`,
++			shouldErr:              false,
++			expectedMaxConnections: intPtr(200),
++		},
++		{
++			input: `grpc_server {
++				max_streams 50
++				max_connections 100
++			}`,
++			shouldErr:              false,
++			expectedMaxStreams:     intPtr(50),
++			expectedMaxConnections: intPtr(100),
++		},
++		// Zero values (unbounded)
++		{
++			input: `grpc_server {
++				max_streams 0
++			}`,
++			shouldErr:          false,
++			expectedMaxStreams: intPtr(0),
++		},
++		{
++			input: `grpc_server {
++				max_connections 0
++			}`,
++			shouldErr:              false,
++			expectedMaxConnections: intPtr(0),
++		},
++		// Error cases
++		{
++			input: `grpc_server {
++				max_streams
++			}`,
++			shouldErr:          true,
++			expectedErrContent: "Wrong argument count",
++		},
++		{
++			input: `grpc_server {
++				max_streams abc
++			}`,
++			shouldErr:          true,
++			expectedErrContent: "invalid max_streams value",
++		},
++		{
++			input: `grpc_server {
++				max_streams -1
++			}`,
++			shouldErr:          true,
++			expectedErrContent: "must be a non-negative integer",
++		},
++		{
++			input: `grpc_server {
++				max_streams 100
++				max_streams 200
++			}`,
++			shouldErr:          true,
++			expectedErrContent: "already defined",
++		},
++		{
++			input: `grpc_server {
++				unknown_option 123
++			}`,
++			shouldErr:          true,
++			expectedErrContent: "unknown property",
++		},
++		{
++			input:              `grpc_server extra_arg`,
++			shouldErr:          true,
++			expectedErrContent: "Wrong argument count",
++		},
++	}
++
++	for i, test := range tests {
++		c := caddy.NewTestController("dns", test.input)
++		err := setup(c)
++
++		if test.shouldErr && err == nil {
++			t.Errorf("Test %d (%s): Expected error but got none", i, test.input)
++			continue
++		}
++
++		if !test.shouldErr && err != nil {
++			t.Errorf("Test %d (%s): Expected no error but got: %v", i, test.input, err)
++			continue
++		}
++
++		if test.shouldErr && test.expectedErrContent != "" {
++			if !strings.Contains(err.Error(), test.expectedErrContent) {
++				t.Errorf("Test %d (%s): Expected error containing '%s' but got: %v",
++					i, test.input, test.expectedErrContent, err)
++			}
++			continue
++		}
++
++		if !test.shouldErr {
++			config := dnsserver.GetConfig(c)
++			assertIntPtrValue(t, i, test.input, "MaxGRPCStreams", config.MaxGRPCStreams, test.expectedMaxStreams)
++			assertIntPtrValue(t, i, test.input, "MaxGRPCConnections", config.MaxGRPCConnections, test.expectedMaxConnections)
++		}
++	}
++}
++
++func intPtr(v int) *int {
++	return &v
++}
++
++func assertIntPtrValue(t *testing.T, testIndex int, testInput, fieldName string, actual, expected *int) {
++	t.Helper()
++	if actual == nil && expected == nil {
++		return
++	}
++
++	if (actual == nil) != (expected == nil) {
++		t.Errorf("Test %d (%s): Expected %s to be %v, but got %v",
++			testIndex, testInput, fieldName, formatNilableInt(expected), formatNilableInt(actual))
++		return
++	}
++
++	if *actual != *expected {
++		t.Errorf("Test %d (%s): Expected %s to be %d, but got %d",
++			testIndex, testInput, fieldName, *expected, *actual)
++	}
++}
++
++func formatNilableInt(v *int) string {
++	if v == nil {
++		return "nil"
++	}
++	return fmt.Sprintf("%d", *v)
++}
+diff --git a/plugin/https/README.md b/plugin/https/README.md
+new file mode 100644
+index 0000000..938c2db
+--- /dev/null
++++ b/plugin/https/README.md
+@@ -0,0 +1,47 @@
++# https
++
++## Name
++
++*https* - configures DNS-over-HTTPS (DoH) server options.
++
++## Description
++
++The *https* plugin allows you to configure parameters for the DNS-over-HTTPS (DoH) server to fine-tune the security posture and performance of the server.
++
++This plugin can only be used once per HTTPS listener block.
++
++## Syntax
++
++```txt
++https {
++    max_connections POSITIVE_INTEGER
++}
++```
++
++* `max_connections` limits the number of concurrent TCP connections to the HTTPS server. The default value is 200 if not specified. Set to 0 for unbounded.
++
++## Examples
++
++Set custom limits for maximum connections:
++
++```
++https://.:443 {
++    tls cert.pem key.pem
++    https {
++        max_connections 100
++    }
++    whoami
++}
++```
++
++Set values to 0 for unbounded, matching CoreDNS behaviour before v1.14.0:
++
++```
++https://.:443 {
++    tls cert.pem key.pem
++    https {
++        max_connections 0
++    }
++    whoami
++}
++```
+diff --git a/plugin/https/setup.go b/plugin/https/setup.go
+new file mode 100644
+index 0000000..727a378
+--- /dev/null
++++ b/plugin/https/setup.go
+@@ -0,0 +1,63 @@
++package https
++
++import (
++	"strconv"
++
++	"github.com/coredns/caddy"
++	"github.com/coredns/coredns/core/dnsserver"
++	"github.com/coredns/coredns/plugin"
++)
++
++func init() {
++	caddy.RegisterPlugin("https", caddy.Plugin{
++		ServerType: "dns",
++		Action:     setup,
++	})
++}
++
++func setup(c *caddy.Controller) error {
++	err := parseDOH(c)
++	if err != nil {
++		return plugin.Error("https", err)
++	}
++	return nil
++}
++
++func parseDOH(c *caddy.Controller) error {
++	config := dnsserver.GetConfig(c)
++
++	// Skip the "https" directive itself
++	c.Next()
++
++	// Get any arguments on the "https" line
++	args := c.RemainingArgs()
++	if len(args) > 0 {
++		return c.ArgErr()
++	}
++
++	// Process all nested directives in the block
++	for c.NextBlock() {
++		switch c.Val() {
++		case "max_connections":
++			args := c.RemainingArgs()
++			if len(args) != 1 {
++				return c.ArgErr()
++			}
++			val, err := strconv.Atoi(args[0])
++			if err != nil {
++				return c.Errf("invalid max_connections value '%s': %v", args[0], err)
++			}
++			if val < 0 {
++				return c.Errf("max_connections must be a non-negative integer: %d", val)
++			}
++			if config.MaxHTTPSConnections != nil {
++				return c.Err("max_connections already defined for this server block")
++			}
++			config.MaxHTTPSConnections = &val
++		default:
++			return c.Errf("unknown property '%s'", c.Val())
++		}
++	}
++
++	return nil
++}
+diff --git a/plugin/https/setup_test.go b/plugin/https/setup_test.go
+new file mode 100644
+index 0000000..cb7020a
+--- /dev/null
++++ b/plugin/https/setup_test.go
+@@ -0,0 +1,144 @@
++package https
++
++import (
++	"fmt"
++	"strings"
++	"testing"
++
++	"github.com/coredns/caddy"
++	"github.com/coredns/coredns/core/dnsserver"
++)
++
++func TestSetup(t *testing.T) {
++	tests := []struct {
++		input                  string
++		shouldErr              bool
++		expectedErrContent     string
++		expectedMaxConnections *int
++	}{
++		// Valid configurations
++		{
++			input:     `https`,
++			shouldErr: false,
++		},
++		{
++			input: `https {
++			}`,
++			shouldErr: false,
++		},
++		{
++			input: `https {
++				max_connections 200
++			}`,
++			shouldErr:              false,
++			expectedMaxConnections: intPtr(200),
++		},
++		// Zero values (unbounded)
++		{
++			input: `https {
++				max_connections 0
++			}`,
++			shouldErr:              false,
++			expectedMaxConnections: intPtr(0),
++		},
++		// Error cases
++		{
++			input: `https {
++				max_connections
++			}`,
++			shouldErr:          true,
++			expectedErrContent: "Wrong argument count",
++		},
++		{
++			input: `https {
++				max_connections abc
++			}`,
++			shouldErr:          true,
++			expectedErrContent: "invalid max_connections value",
++		},
++		{
++			input: `https {
++				max_connections -1
++			}`,
++			shouldErr:          true,
++			expectedErrContent: "must be a non-negative integer",
++		},
++		{
++			input: `https {
++				max_connections 100
++				max_connections 200
++			}`,
++			shouldErr:          true,
++			expectedErrContent: "already defined",
++		},
++		{
++			input: `https {
++				unknown_option 123
++			}`,
++			shouldErr:          true,
++			expectedErrContent: "unknown property",
++		},
++		{
++			input:              `https extra_arg`,
++			shouldErr:          true,
++			expectedErrContent: "Wrong argument count",
++		},
++	}
++
++	for i, test := range tests {
++		c := caddy.NewTestController("dns", test.input)
++		err := setup(c)
++
++		if test.shouldErr && err == nil {
++			t.Errorf("Test %d (%s): Expected error but got none", i, test.input)
++			continue
++		}
++
++		if !test.shouldErr && err != nil {
++			t.Errorf("Test %d (%s): Expected no error but got: %v", i, test.input, err)
++			continue
++		}
++
++		if test.shouldErr && test.expectedErrContent != "" {
++			if !strings.Contains(err.Error(), test.expectedErrContent) {
++				t.Errorf("Test %d (%s): Expected error containing '%s' but got: %v",
++					i, test.input, test.expectedErrContent, err)
++			}
++			continue
++		}
++
++		if !test.shouldErr {
++			config := dnsserver.GetConfig(c)
++			assertIntPtrValue(t, i, test.input, "MaxHTTPSConnections", config.MaxHTTPSConnections, test.expectedMaxConnections)
++		}
++	}
++}
++
++func intPtr(v int) *int {
++	return &v
++}
++
++func assertIntPtrValue(t *testing.T, testIndex int, testInput, fieldName string, actual, expected *int) {
++	t.Helper()
++	if actual == nil && expected == nil {
++		return
++	}
++
++	if (actual == nil) != (expected == nil) {
++		t.Errorf("Test %d (%s): Expected %s to be %v, but got %v",
++			testIndex, testInput, fieldName, formatNilableInt(expected), formatNilableInt(actual))
++		return
++	}
++
++	if *actual != *expected {
++		t.Errorf("Test %d (%s): Expected %s to be %d, but got %d",
++			testIndex, testInput, fieldName, *expected, *actual)
++	}
++}
++
++func formatNilableInt(v *int) string {
++	if v == nil {
++		return "nil"
++	}
++	return fmt.Sprintf("%d", *v)
++}
+diff --git a/test/grpc_test.go b/test/grpc_test.go
+index 37504c9..d9cd9fb 100644
+--- a/test/grpc_test.go
++++ b/test/grpc_test.go
+@@ -2,6 +2,8 @@ package test
+ 
+ import (
+ 	"context"
++	"crypto/tls"
++	"net"
+ 	"testing"
+ 	"time"
+ 
+@@ -12,10 +14,20 @@ import (
+ 	"google.golang.org/grpc/credentials/insecure"
+ )
+ 
++var grpcCorefile = `grpc://.:0 {
++	whoami
++}`
++
++var grpcConnectionLimitCorefile = `grpc://.:0 {
++	tls ../plugin/tls/test_cert.pem ../plugin/tls/test_key.pem ../plugin/tls/test_ca.pem
++	grpc_server {
++		max_connections 2
++	}
++	whoami
++}`
++
+ func TestGrpc(t *testing.T) {
+-	corefile := `grpc://.:0 {
+-		whoami
+-	}`
++	corefile := grpcCorefile
+ 
+ 	g, _, tcp, err := CoreDNSServerAndPorts(corefile)
+ 	if err != nil {
+@@ -56,3 +68,54 @@ func TestGrpc(t *testing.T) {
+ 		t.Errorf("Expected 2 RRs in additional section, but got %d", len(d.Extra))
+ 	}
+ }
++
++// TestGRPCConnectionLimit tests that connection limits are enforced
++func TestGRPCConnectionLimit(t *testing.T) {
++	g, _, tcp, err := CoreDNSServerAndPorts(grpcConnectionLimitCorefile)
++	if err != nil {
++		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
++	}
++	defer g.Stop()
++
++	const maxConns = 2
++
++	// Create TLS connections to hold them open
++	tlsConfig := &tls.Config{InsecureSkipVerify: true}
++	conns := make([]net.Conn, 0, maxConns+1)
++	defer func() {
++		for _, c := range conns {
++			c.Close()
++		}
++	}()
++
++	// Open connections up to the limit - these should succeed
++	for i := range maxConns {
++		conn, err := tls.Dial("tcp", tcp, tlsConfig)
++		if err != nil {
++			t.Fatalf("Connection %d failed (should succeed): %v", i+1, err)
++		}
++		conns = append(conns, conn)
++	}
++
++	// Try to open more connections beyond the limit - should timeout
++	conn, err := tls.DialWithDialer(
++		&net.Dialer{Timeout: 100 * time.Millisecond},
++		"tcp", tcp, tlsConfig,
++	)
++	if err == nil {
++		conn.Close()
++		t.Fatal("Connection beyond limit should have timed out")
++	}
++
++	// Close one connection and verify a new one can be established
++	conns[0].Close()
++	conns = conns[1:]
++
++	time.Sleep(10 * time.Millisecond)
++
++	conn, err = tls.Dial("tcp", tcp, tlsConfig)
++	if err != nil {
++		t.Fatalf("Connection after freeing slot failed: %v", err)
++	}
++	conns = append(conns, conn)
++}
+diff --git a/test/https_test.go b/test/https_test.go
+new file mode 100644
+index 0000000..2bf4940
+--- /dev/null
++++ b/test/https_test.go
+@@ -0,0 +1,177 @@
++package test
++
++import (
++	"bytes"
++	"crypto/tls"
++	"io"
++	"net"
++	"net/http"
++	"testing"
++	"time"
++
++	"github.com/miekg/dns"
++)
++
++var httpsCorefile = `https://.:0 {
++	tls ../plugin/tls/test_cert.pem ../plugin/tls/test_key.pem ../plugin/tls/test_ca.pem
++	whoami
++}`
++
++var httpsLimitCorefile = `https://.:0 {
++	tls ../plugin/tls/test_cert.pem ../plugin/tls/test_key.pem ../plugin/tls/test_ca.pem
++	https {
++		max_connections 2
++	}
++	whoami
++}`
++
++func TestHTTPS(t *testing.T) {
++	s, _, tcp, err := CoreDNSServerAndPorts(httpsCorefile)
++	if err != nil {
++		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
++	}
++	defer s.Stop()
++
++	// Create HTTPS client with TLS config
++	tlsConfig := &tls.Config{
++		InsecureSkipVerify: true,
++	}
++	client := &http.Client{
++		Transport: &http.Transport{
++			TLSClientConfig: tlsConfig,
++		},
++		Timeout: 5 * time.Second,
++	}
++
++	// Create DNS query
++	m := new(dns.Msg)
++	m.SetQuestion("whoami.example.org.", dns.TypeA)
++	msg, err := m.Pack()
++	if err != nil {
++		t.Fatalf("Failed to pack DNS message: %v", err)
++	}
++
++	// Make DoH request
++	url := "https://" + tcp + "/dns-query"
++	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(msg))
++	if err != nil {
++		t.Fatalf("Failed to create request: %v", err)
++	}
++	req.Header.Set("Content-Type", "application/dns-message")
++	req.Header.Set("Accept", "application/dns-message")
++
++	resp, err := client.Do(req)
++	if err != nil {
++		t.Fatalf("Failed to make request: %v", err)
++	}
++	defer resp.Body.Close()
++
++	if resp.StatusCode != http.StatusOK {
++		t.Fatalf("Expected status 200, got %d", resp.StatusCode)
++	}
++
++	body, err := io.ReadAll(resp.Body)
++	if err != nil {
++		t.Fatalf("Failed to read response: %v", err)
++	}
++
++	d := new(dns.Msg)
++	err = d.Unpack(body)
++	if err != nil {
++		t.Fatalf("Failed to unpack response: %v", err)
++	}
++
++	if d.Rcode != dns.RcodeSuccess {
++		t.Errorf("Expected success but got %d", d.Rcode)
++	}
++
++	if len(d.Extra) != 2 {
++		t.Errorf("Expected 2 RRs in additional section, but got %d", len(d.Extra))
++	}
++}
++
++// TestHTTPSWithLimits tests that the server starts and works with configured limits
++func TestHTTPSWithLimits(t *testing.T) {
++	s, _, tcp, err := CoreDNSServerAndPorts(httpsLimitCorefile)
++	if err != nil {
++		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
++	}
++	defer s.Stop()
++
++	client := &http.Client{
++		Transport: &http.Transport{
++			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
++		},
++		Timeout: 5 * time.Second,
++	}
++
++	m := new(dns.Msg)
++	m.SetQuestion("whoami.example.org.", dns.TypeA)
++	msg, _ := m.Pack()
++
++	req, _ := http.NewRequest(http.MethodPost, "https://"+tcp+"/dns-query", bytes.NewReader(msg))
++	req.Header.Set("Content-Type", "application/dns-message")
++
++	resp, err := client.Do(req)
++	if err != nil {
++		t.Fatalf("Request failed: %s", err)
++	}
++	defer resp.Body.Close()
++
++	if resp.StatusCode != http.StatusOK {
++		t.Fatalf("Expected status 200, got %d", resp.StatusCode)
++	}
++}
++
++// TestHTTPSConnectionLimit tests that connection limits are enforced
++func TestHTTPSConnectionLimit(t *testing.T) {
++	s, _, tcp, err := CoreDNSServerAndPorts(httpsLimitCorefile)
++	if err != nil {
++		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
++	}
++	defer s.Stop()
++
++	const maxConns = 2
++	const totalConns = 4
++
++	// Create raw TLS connections to hold them open
++	conns := make([]net.Conn, 0, totalConns)
++	defer func() {
++		for _, c := range conns {
++			c.Close()
++		}
++	}()
++
++	// Open connections up to the limit - these should succeed
++	for i := range maxConns {
++		conn, err := tls.Dial("tcp", tcp, &tls.Config{InsecureSkipVerify: true})
++		if err != nil {
++			t.Fatalf("Connection %d failed (should succeed): %v", i+1, err)
++		}
++		conns = append(conns, conn)
++	}
++
++	// Try to open more connections beyond the limit
++	// The LimitListener blocks Accept() until a slot is free, so Dial with timeout should fail
++	conn, err := tls.DialWithDialer(
++		&net.Dialer{Timeout: 100 * time.Millisecond},
++		"tcp", tcp,
++		&tls.Config{InsecureSkipVerify: true},
++	)
++	if err == nil {
++		conn.Close()
++		t.Fatal("Connection beyond limit should have timed out")
++	}
++
++	// Close one connection and verify a new one can be established
++	conns[0].Close()
++	conns = conns[1:]
++
++	time.Sleep(10 * time.Millisecond) // Give the listener time to accept
++
++	conn, err = tls.Dial("tcp", tcp, &tls.Config{InsecureSkipVerify: true})
++	if err != nil {
++		t.Fatalf("Connection after freeing slot failed: %v", err)
++	}
++	conns = append(conns, conn)
++}
+diff --git a/vendor/golang.org/x/net/netutil/listen.go b/vendor/golang.org/x/net/netutil/listen.go
+new file mode 100644
+index 0000000..f8b779e
+--- /dev/null
++++ b/vendor/golang.org/x/net/netutil/listen.go
+@@ -0,0 +1,87 @@
++// Copyright 2013 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++// Package netutil provides network utility functions, complementing the more
++// common ones in the net package.
++package netutil // import "golang.org/x/net/netutil"
++
++import (
++	"net"
++	"sync"
++)
++
++// LimitListener returns a Listener that accepts at most n simultaneous
++// connections from the provided Listener.
++func LimitListener(l net.Listener, n int) net.Listener {
++	return &limitListener{
++		Listener: l,
++		sem:      make(chan struct{}, n),
++		done:     make(chan struct{}),
++	}
++}
++
++type limitListener struct {
++	net.Listener
++	sem       chan struct{}
++	closeOnce sync.Once     // ensures the done chan is only closed once
++	done      chan struct{} // no values sent; closed when Close is called
++}
++
++// acquire acquires the limiting semaphore. Returns true if successfully
++// acquired, false if the listener is closed and the semaphore is not
++// acquired.
++func (l *limitListener) acquire() bool {
++	select {
++	case <-l.done:
++		return false
++	case l.sem <- struct{}{}:
++		return true
++	}
++}
++func (l *limitListener) release() { <-l.sem }
++
++func (l *limitListener) Accept() (net.Conn, error) {
++	if !l.acquire() {
++		// If the semaphore isn't acquired because the listener was closed, expect
++		// that this call to accept won't block, but immediately return an error.
++		// If it instead returns a spurious connection (due to a bug in the
++		// Listener, such as https://golang.org/issue/50216), we immediately close
++		// it and try again. Some buggy Listener implementations (like the one in
++		// the aforementioned issue) seem to assume that Accept will be called to
++		// completion, and may otherwise fail to clean up the client end of pending
++		// connections.
++		for {
++			c, err := l.Listener.Accept()
++			if err != nil {
++				return nil, err
++			}
++			c.Close()
++		}
++	}
++
++	c, err := l.Listener.Accept()
++	if err != nil {
++		l.release()
++		return nil, err
++	}
++	return &limitListenerConn{Conn: c, release: l.release}, nil
++}
++
++func (l *limitListener) Close() error {
++	err := l.Listener.Close()
++	l.closeOnce.Do(func() { close(l.done) })
++	return err
++}
++
++type limitListenerConn struct {
++	net.Conn
++	releaseOnce sync.Once
++	release     func()
++}
++
++func (l *limitListenerConn) Close() error {
++	err := l.Conn.Close()
++	l.releaseOnce.Do(l.release)
++	return err
++}
+diff --git a/vendor/modules.txt b/vendor/modules.txt
+index a98c3b4..38675fc 100644
+--- a/vendor/modules.txt
++++ b/vendor/modules.txt
+@@ -528,6 +528,7 @@ golang.org/x/net/internal/socket
+ golang.org/x/net/internal/timeseries
+ golang.org/x/net/ipv4
+ golang.org/x/net/ipv6
++golang.org/x/net/netutil
+ golang.org/x/net/trace
+ # golang.org/x/oauth2 v0.11.0
+ ## explicit; go 1.18
+-- 
+2.45.4
+

--- a/SPECS/coredns/coredns.spec
+++ b/SPECS/coredns/coredns.spec
@@ -3,7 +3,7 @@
 Summary:        Fast and flexible DNS server
 Name:           coredns
 Version:        1.11.1
-Release:        24%{?dist}
+Release:        25%{?dist}
 License:        Apache License 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -48,6 +48,7 @@ Patch12:        CVE-2024-51744.patch
 Patch13:        CVE-2025-47950.patch
 Patch14:        CVE-2025-58063.patch
 Patch15:        CVE-2025-59530.patch
+Patch16:        CVE-2025-68151.patch
 
 BuildRequires:  msft-golang
 
@@ -86,6 +87,9 @@ install -p -m 755 -t %{buildroot}%{_bindir} %{name}
 %{_bindir}/%{name}
 
 %changelog
+* Mon Jan 19 2026 Aditya Singh <v-aditysing@microsoft.com> - 1.11.1-25
+- Patch for CVE-2025-68151
+
 * Mon Oct 27 2025 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 1.11.1-24
 - Patch for CVE-2025-59530
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Patch coredns for CVE-2025-68151
- Upstream patch has been backported manually.
- Patch for `https3` module has not been included as this module does not exist in our version of coredns.
- `vendor/golang.org/x/net/netutil/listen.go` has been added to vendor directory and updated "module.txt" for the same.
- 2 test cases from upstream patch are not included in `test/grpc_test.go` file as a lot of code to has to be added for few missing APIs.
- Updated go language to 1.22.0 from 1.20 in `go.mod` file as some parts of the patch were not compiling with go 1.20. 

- Upstream Patch Reference: https://github.com/coredns/coredns/commit/0d8cbb1a6bcb6bc9c1a489865278b8725fa20812.patch

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- modified: SPECS/coredns/coredns.spec
- new file: SPECS/coredns/CVE-2025-68151.patch

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2025-68151

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build was successful.
- License check script shows no warning.

- Build log
[coredns-1.11.1-25.cm2.src.rpm.log](https://github.com/user-attachments/files/24705708/coredns-1.11.1-25.cm2.src.rpm.log)
[coredns-1.11.1-25.cm2.src.rpm.test.log](https://github.com/user-attachments/files/24705711/coredns-1.11.1-25.cm2.src.rpm.test.log)

- Patch applies cleanly
<img width="1310" height="810" alt="image" src="https://github.com/user-attachments/assets/cc0fb412-ec18-41a3-8d3a-b4c036f04d3e" />

- Installation Check
<img width="1725" height="417" alt="image" src="https://github.com/user-attachments/assets/90faca01-319d-46c0-8c3f-f95818b9ac30" />

- Uninstallation Check
<img width="1723" height="417" alt="image" src="https://github.com/user-attachments/assets/515b5fd3-cef0-4241-ab19-5bbbdc6ef048" />