### PR TITLE
Bug Fix: Provide seccomp default profile as a config file in Moby-Engine Package

### DIFF
--- a/SPECS/moby-engine/moby-engine.spec
+++ b/SPECS/moby-engine/moby-engine.spec
@@ -3,7 +3,7 @@
 Summary: The open-source application container engine
 Name:    moby-engine
 Version: 25.0.3
-Release: 14%{?dist}
+Release: 15%{?dist}
 License: ASL 2.0
 Group:   Tools/Container
 URL: https://mobyproject.org
@@ -105,6 +105,8 @@ mkdir -p %{buildroot}%{_unitdir}
 install -p -m 644 %{SOURCE1} %{buildroot}%{_unitdir}/docker.service
 install -p -m 644 %{SOURCE2} %{buildroot}%{_unitdir}/docker.socket
 
+install -vpDm 644 profiles/seccomp/default.json %{buildroot}%{_sysconfdir}/seccomp/default-profile-template.json
+
 %post
 if ! grep -q "^docker:" /etc/group; then
     groupadd --system docker
@@ -120,10 +122,14 @@ fi
 %license LICENSE NOTICE
 %{_bindir}/dockerd
 %{_libexecdir}/docker-proxy
-%{_sysconfdir}/*
+%{_sysconfdir}/udev
+%config(noreplace) %{_sysconfdir}/seccomp/default-profile-template.json
 %{_unitdir}/*
 
 %changelog
+* Thu Jan 22 2026 Madhur Aggarwal <madaggarwal@microsoft.com> - 25.0.3-15
+- Provide seccomp/default.json as a Config (noreplace) File
+
 * Sat Nov 15 2025 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 25.0.3-14
 - Patch for CVE-2025-58183
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
The PR provides support to package the default seccomp profile JSON as a Config File in the moby-engine package

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Installed the default seccomp profile with read permissions
- Changed the packaging from `%{_sysconfdir}/*` to `%{_sysconfdir}/udev`, ensuring (using `rpm -qpl`) that all files are correctly packaged. This change was required since the seccomp profile needs to be packaged as a config file in the `%{_sysconfdir}/seccomp/` path.
- Packaged the default seccomp profile as a `config(noreplace)` file, so users can port updates from `.rpmnew` without losing user customizations to this file. 
Named the file as `default-profile-template.json` to indicate that it is a template file, and `--security-opt` command is required to override the pre-compiled binary of this file with the contents of this template.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- Fixes [BUG 60352679](https://microsoft.visualstudio.com/OS/_workitems/edit/60352679)
   Bug Statement: [3][PostgreSQL] Addition of seccomp file in moby-engine package

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
verify_docker() LISA tests all pass (`verify_docker_seccomp_profile`, `verify_docker_dotnet50_app`, `verify_docker_dotnet31_app`, `verify_docker_python_app`, `verify_docker_java_app`, `verify_docker_wordpress_app`)

- Buddy Build: [1037410](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=1037410&view=results)
- Delta Build: [1037419](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=1037419&view=results)
- Full Build: [1037445](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=1037445&view=results), Build RPMs AMD64: [1037525](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=1037525&view=results) ARM64 [1037543](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=1037543&view=results) 
