### PR TITLE
cloud-hypervisor: upgrade to 48.0.246

### DIFF
--- a/SPECS/cloud-hypervisor/cloud-hypervisor.signatures.json
+++ b/SPECS/cloud-hypervisor/cloud-hypervisor.signatures.json
@@ -1,6 +1,6 @@
 {
   "Signatures": {
-    "cloud-hypervisor-41.0.139-vendor.tar.gz": "44d4f5770968c2482d7da25bb18cd399b8eb9b6a5f1de5aa816083954d1c8241",
-    "cloud-hypervisor-41.0.139.tar.gz": "116191af642c8c57710205cefab0787a5fd903e3a946638b1380cac732a8e381"
+    "cloud-hypervisor-48.0.246.tar.gz": "627775016abe81d478258065e41495d11822dde6a892cab5d234eefc6ffed802",
+    "cloud-hypervisor-48.0.246-vendor.tar.gz": "a314204b25b980f7055f5ac4bcdbb43051e8f7d29c3c05468653475bda3d87fe"
   }
 }

--- a/SPECS/cloud-hypervisor/cloud-hypervisor.spec
+++ b/SPECS/cloud-hypervisor/cloud-hypervisor.spec
@@ -4,8 +4,8 @@
 
 Name:           cloud-hypervisor
 Summary:        Cloud Hypervisor is an open source Virtual Machine Monitor (VMM) that runs on top of the KVM hypervisor and the Microsoft Hypervisor (MSHV).
-Version:        41.0.139
-Release:        3%{?dist}
+Version:        48.0.246
+Release:        1%{?dist}
 License:        ASL 2.0 OR BSD-3-clause
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -137,6 +137,9 @@ cargo build --release --target=%{rust_musl_target} %{cargo_pkg_feature_opts} %{c
 %license LICENSES/CC-BY-4.0.txt
 
 %changelog
+* Fri Jan 23 2026 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 48.0.246-1
+- Auto-upgrade to 48.0.246
+
 * Wed Oct 15 2025 Kavya Sree Kaitepalli <kkaitepalli@microsoft.com> - 41.0.139-3
 - Bump release to rebuild with rust
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -1797,8 +1797,8 @@
         "type": "other",
         "other": {
           "name": "cloud-hypervisor",
-          "version": "41.0.139",
-          "downloadUrl": "https://github.com/microsoft/cloud-hypervisor/archive/refs/tags/msft/v41.0.139.tar.gz"
+          "version": "48.0.246",
+          "downloadUrl": "https://github.com/microsoft/cloud-hypervisor/archive/refs/tags/msft/v48.0.246.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?

Upgrade cloud-hypervisor to `48.0.246` . This:
- Solves a regression introduced by recent rust upgrade to `1.90` ([rust: Upgrade to 1.90.0 by KavyaSree2610 · Pull Request #14819 · microsoft/azurelinux](https://github.com/microsoft/azurelinux/pull/14819)) which affects the pod sandboxing scenario
- Enables pod sandboxing on ARM L1VH.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- cloud-hypervisor

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- CI https://dev.azure.com/mariner-org/mariner/_build/results?buildId=1034046&view=results (failed buddy build since new rust 1.90 wasn't being used, which is needed to build CH 48)
  -  budy build https://dev.azure.com/mariner-org/mariner/_build/results?buildId=1034111&view=results
  - image build https://dev.azure.com/mariner-org/mariner/Mariner%20Core%20Devs/_build/results?buildId=1034161&view=logs&j=bbe135f3-541e-58e6-8b02-61d4669cdf5f&t=7a1ca92f-9941-5d9a-8509-c6499be803f9&l=4772
  - test https://dev.azure.com/mariner-org/mariner/_build/results?buildId=1034289&view=ms.vss-test-web.build-test-results-tab [pass]
