### PR TITLE
fix: add necessary packages to vm-base.kiwi

### DIFF
--- a/base/images/vm-base/vm-base.kiwi
+++ b/base/images/vm-base/vm-base.kiwi
@@ -31,7 +31,7 @@
             </initrd>
         </type>
     </preferences>
-       
+
     <repository type="rpm-md" alias="fedora-43-everything">
         <source
             path="https://fedora.mirrorservice.org/fedora/linux/releases/43/Everything/x86_64/os/" />
@@ -55,6 +55,8 @@
         <package name="dnf-plugins-core" />
         <package name="dnf" />
         <package name="dracut-config-generic" />
+        <package name="dracut-kiwi-oem-repart"/>
+        <package name="glibc-langpack-en" />
         <package name="glibc-locale-source" />
         <package name="glibc-minimal-langpack" />
         <package name="glibc" />


### PR DESCRIPTION
Building a vm image with `kiwi` was broken due to missing packages in `vm-base.kiwi`. This change adds `dracut-kiwi-oem-repart` and `glibc-langpack-en`, which `kiwi` complained about before I added them. Now this successfully creates an image:
```
sudo kiwi \
  --loglevel 10 \
  --kiwi-file vm-base.kiwi \
  system build \
  --description ./base/images/vm-base \
  --target-dir ./base/out/images
```