### PR TITLE
containerd2: Backport fix for credential leak in CRI error logs

### DIFF
--- a/SPECS/containerd2/containerd2.spec
+++ b/SPECS/containerd2/containerd2.spec
@@ -5,7 +5,7 @@
 Summary: Industry-standard container runtime
 Name: %{upstream_name}2
 Version: 2.0.0
-Release: 16%{?dist}
+Release: 17%{?dist}
 License: ASL 2.0
 Group: Tools/Container
 URL: https://www.containerd.io
@@ -25,6 +25,7 @@ Patch5:	multi-snapshotters-support.patch
 Patch6:	tardev-support.patch
 Patch7: CVE-2024-25621.patch
 Patch8: CVE-2025-64329.patch
+Patch9: fix-credential-leak-in-cri-errors.patch
 %{?systemd_requires}
 
 BuildRequires: golang < 1.25
@@ -100,6 +101,9 @@ fi
 %dir /opt/containerd/lib
 
 %changelog
+* Tue Jan 21 2026 Aadhar Agarwal <aadagarwal@microsoft.com> - 2.0.0-17
+- Backport fix for credential leak in CRI error logs
+
 * Mon Nov 24 2025 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 2.0.0-16
 - Patch for CVE-2025-64329
 

--- a/SPECS/containerd2/fix-credential-leak-in-cri-errors.patch
+++ b/SPECS/containerd2/fix-credential-leak-in-cri-errors.patch
@@ -1,0 +1,401 @@
+From a34e45d0fa2a7ddefff1a0871c9bf9e3c62bda17 Mon Sep 17 00:00:00 2001
+From: Andrey Noskov <andreyn@microsoft.com>
+Date: Thu, 6 Nov 2025 13:34:38 +0100
+Subject: [PATCH 1/2] fix: redact all query parameters in CRI error logs
+
+Signed-off-by: Andrey Noskov <andreyn@microsoft.com>
+---
+ .../cri/instrument/instrumented_service.go    |   8 ++
+ internal/cri/util/sanitize.go                 |  93 +++++++++++++
+ internal/cri/util/sanitize_test.go            | 128 ++++++++++++++++++
+ 3 files changed, 229 insertions(+)
+ create mode 100644 internal/cri/util/sanitize.go
+ create mode 100644 internal/cri/util/sanitize_test.go
+
+diff --git a/internal/cri/instrument/instrumented_service.go b/internal/cri/instrument/instrumented_service.go
+index c2f5c8de99..f06315a6bd 100644
+--- a/internal/cri/instrument/instrumented_service.go
++++ b/internal/cri/instrument/instrumented_service.go
+@@ -351,6 +351,8 @@ func (in *instrumentedService) PullImage(ctx context.Context, r *runtime.PullIma
+ 	log.G(ctx).Infof("PullImage %q", r.GetImage().GetImage())
+ 	defer func() {
+ 		if err != nil {
++			// Sanitize error to remove sensitive information
++			err = ctrdutil.SanitizeError(err)
+ 			log.G(ctx).WithError(err).Errorf("PullImage %q failed", r.GetImage().GetImage())
+ 		} else {
+ 			log.G(ctx).Infof("PullImage %q returns image reference %q",
+@@ -369,6 +371,8 @@ func (in *instrumentedService) ListImages(ctx context.Context, r *runtime.ListIm
+ 	log.G(ctx).Tracef("ListImages with filter %+v", r.GetFilter())
+ 	defer func() {
+ 		if err != nil {
++			// Sanitize error to remove sensitive information
++			err = ctrdutil.SanitizeError(err)
+ 			log.G(ctx).WithError(err).Errorf("ListImages with filter %+v failed", r.GetFilter())
+ 		} else {
+ 			log.G(ctx).Tracef("ListImages with filter %+v returns image list %+v",
+@@ -386,6 +390,8 @@ func (in *instrumentedService) ImageStatus(ctx context.Context, r *runtime.Image
+ 	log.G(ctx).Tracef("ImageStatus for %q", r.GetImage().GetImage())
+ 	defer func() {
+ 		if err != nil {
++			// Sanitize error to remove sensitive information
++			err = ctrdutil.SanitizeError(err)
+ 			log.G(ctx).WithError(err).Errorf("ImageStatus for %q failed", r.GetImage().GetImage())
+ 		} else {
+ 			log.G(ctx).Tracef("ImageStatus for %q returns image status %+v",
+@@ -404,6 +410,8 @@ func (in *instrumentedService) RemoveImage(ctx context.Context, r *runtime.Remov
+ 	log.G(ctx).Infof("RemoveImage %q", r.GetImage().GetImage())
+ 	defer func() {
+ 		if err != nil {
++			// Sanitize error to remove sensitive information
++			err = ctrdutil.SanitizeError(err)
+ 			log.G(ctx).WithError(err).Errorf("RemoveImage %q failed", r.GetImage().GetImage())
+ 		} else {
+ 			log.G(ctx).Infof("RemoveImage %q returns successfully", r.GetImage().GetImage())
+diff --git a/internal/cri/util/sanitize.go b/internal/cri/util/sanitize.go
+new file mode 100644
+index 0000000000..d50a15ebf6
+--- /dev/null
++++ b/internal/cri/util/sanitize.go
+@@ -0,0 +1,93 @@
++/*
++   Copyright The containerd Authors.
++
++   Licensed under the Apache License, Version 2.0 (the "License");
++   you may not use this file except in compliance with the License.
++   You may obtain a copy of the License at
++
++       http://www.apache.org/licenses/LICENSE-2.0
++
++   Unless required by applicable law or agreed to in writing, software
++   distributed under the License is distributed on an "AS IS" BASIS,
++   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++   See the License for the specific language governing permissions and
++   limitations under the License.
++*/
++
++package util
++
++import (
++	"errors"
++	"net/url"
++	"strings"
++)
++
++// SanitizeError sanitizes an error by redacting sensitive information in URLs.
++// If the error contains a *url.Error, it parses and sanitizes the URL.
++// Otherwise, it returns the error unchanged.
++func SanitizeError(err error) error {
++	if err == nil {
++		return nil
++	}
++
++	// Check if the error is or contains a *url.Error
++	var urlErr *url.Error
++	if errors.As(err, &urlErr) {
++		// Parse and sanitize the URL
++		sanitizedURL := sanitizeURL(urlErr.URL)
++		if sanitizedURL != urlErr.URL {
++			// Wrap with sanitized url.Error
++			return &sanitizedError{
++				original:     err,
++				sanitizedURL: sanitizedURL,
++				urlError:     urlErr,
++			}
++		}
++		return err
++	}
++
++	// No sanitization needed for non-URL errors
++	return err
++}
++
++// sanitizeURL properly parses a URL and redacts all query parameters.
++func sanitizeURL(rawURL string) string {
++	parsed, err := url.Parse(rawURL)
++	if err != nil {
++		// If URL parsing fails, return original (malformed URLs shouldn't leak tokens)
++		return rawURL
++	}
++
++	// Check if URL has query parameters
++	query := parsed.Query()
++	if len(query) == 0 {
++		return rawURL
++	}
++
++	// Redact all query parameters
++	for param := range query {
++		query.Set(param, "[REDACTED]")
++	}
++
++	// Reconstruct URL with sanitized query
++	parsed.RawQuery = query.Encode()
++	return parsed.String()
++}
++
++// sanitizedError wraps an error containing a *url.Error with a sanitized URL.
++type sanitizedError struct {
++	original     error
++	sanitizedURL string
++	urlError     *url.Error
++}
++
++// Error returns the error message with the sanitized URL.
++func (e *sanitizedError) Error() string {
++	// Replace all occurrences of the original URL with the sanitized version
++	return strings.ReplaceAll(e.original.Error(), e.urlError.URL, e.sanitizedURL)
++}
++
++// Unwrap returns the original error for error chain traversal.
++func (e *sanitizedError) Unwrap() error {
++	return e.original
++}
+diff --git a/internal/cri/util/sanitize_test.go b/internal/cri/util/sanitize_test.go
+new file mode 100644
+index 0000000000..03e4fb2694
+--- /dev/null
++++ b/internal/cri/util/sanitize_test.go
+@@ -0,0 +1,128 @@
++/*
++   Copyright The containerd Authors.
++
++   Licensed under the Apache License, Version 2.0 (the "License");
++   you may not use this file except in compliance with the License.
++   You may obtain a copy of the License at
++
++       http://www.apache.org/licenses/LICENSE-2.0
++
++   Unless required by applicable law or agreed to in writing, software
++   distributed under the License is distributed on an "AS IS" BASIS,
++   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++   See the License for the specific language governing permissions and
++   limitations under the License.
++*/
++
++package util
++
++import (
++	"errors"
++	"fmt"
++	"net/url"
++	"testing"
++
++	"github.com/stretchr/testify/assert"
++	"github.com/stretchr/testify/require"
++)
++
++func TestSanitizeError_SimpleURLError(t *testing.T) {
++	// Create a url.Error with sensitive info
++	originalURL := "https://storage.blob.core.windows.net/container/blob?sig=SECRET&sv=2020"
++	urlErr := &url.Error{
++		Op:  "Get",
++		URL: originalURL,
++		Err: fmt.Errorf("connection timeout"),
++	}
++
++	// Sanitize
++	sanitized := SanitizeError(urlErr)
++	require.NotNil(t, sanitized)
++
++	// Check it's a sanitizedError with correct properties
++	sanitizedErr, ok := sanitized.(*sanitizedError)
++	require.True(t, ok, "Should return *sanitizedError type")
++	assert.Equal(t, urlErr, sanitizedErr.original)
++	assert.Equal(t, urlErr, sanitizedErr.urlError)
++	assert.Equal(t, "https://storage.blob.core.windows.net/container/blob?sig=%5BREDACTED%5D&sv=%5BREDACTED%5D", sanitizedErr.sanitizedURL)
++
++	// Test Error() method - verifies ReplaceAll functionality
++	expected := "Get \"https://storage.blob.core.windows.net/container/blob?sig=%5BREDACTED%5D&sv=%5BREDACTED%5D\": connection timeout"
++	assert.Equal(t, expected, sanitized.Error())
++}
++
++func TestSanitizeError_WrappedError(t *testing.T) {
++	originalURL := "https://storage.blob.core.windows.net/blob?sig=SECRET&sv=2020"
++	urlErr := &url.Error{
++		Op:  "Get",
++		URL: originalURL,
++		Err: fmt.Errorf("timeout"),
++	}
++
++	wrappedErr := fmt.Errorf("image pull failed: %w", urlErr)
++
++	// Sanitize
++	sanitized := SanitizeError(wrappedErr)
++
++	// Test Error() method with wrapped error - verifies ReplaceAll works in wrapped context
++	sanitizedMsg := sanitized.Error()
++	assert.NotContains(t, sanitizedMsg, "SECRET", "Secret should be sanitized")
++	assert.Contains(t, sanitizedMsg, "image pull failed", "Wrapper message should be preserved")
++	assert.Contains(t, sanitizedMsg, "%5BREDACTED%5D", "Should contain sanitized marker")
++
++	// Should still be able to unwrap to url.Error
++	var targetURLErr *url.Error
++	assert.True(t, errors.As(sanitized, &targetURLErr),
++		"Should be able to find *url.Error in sanitized error chain")
++
++	// Verify url.Error properties are preserved
++	assert.Equal(t, "Get", targetURLErr.Op)
++	assert.Contains(t, targetURLErr.Err.Error(), "timeout")
++}
++
++func TestSanitizeError_NonURLError(t *testing.T) {
++	// Regular error without url.Error
++	regularErr := fmt.Errorf("some error occurred")
++
++	sanitized := SanitizeError(regularErr)
++
++	// Should return the exact same error object
++	assert.Equal(t, regularErr, sanitized,
++		"Non-URL errors should pass through unchanged")
++}
++
++func TestSanitizeError_NilError(t *testing.T) {
++	sanitized := SanitizeError(nil)
++	assert.Nil(t, sanitized, "nil error should return nil")
++}
++
++func TestSanitizeError_NoQueryParams(t *testing.T) {
++	// URL without any query parameters
++	urlErr := &url.Error{
++		Op:  "Get",
++		URL: "https://registry.example.com/v2/image/manifests/latest",
++		Err: fmt.Errorf("not found"),
++	}
++
++	sanitized := SanitizeError(urlErr)
++
++	// Should return the same error object (no sanitization needed)
++	assert.Equal(t, urlErr, sanitized,
++		"Errors without query params should pass through unchanged")
++}
++
++func TestSanitizedError_Unwrap(t *testing.T) {
++	originalURL := "https://storage.blob.core.windows.net/blob?sig=SECRET"
++	urlErr := &url.Error{
++		Op:  "Get",
++		URL: originalURL,
++		Err: fmt.Errorf("timeout"),
++	}
++
++	sanitized := SanitizeError(urlErr)
++
++	// Should be able to unwrap
++	unwrapped := errors.Unwrap(sanitized)
++	assert.NotNil(t, unwrapped, "Should be able to unwrap sanitized error")
++	assert.Equal(t, urlErr, unwrapped, "Unwrapped should be the original error")
++}
+-- 
+2.45.4
+
+
+From 50e383e3907d04aeaec85853edfaa9ab34be1006 Mon Sep 17 00:00:00 2001
+From: Aadhar Agarwal <aadagarwal@microsoft.com>
+Date: Tue, 20 Jan 2026 22:16:30 +0000
+Subject: [PATCH 2/2] fix: sanitize error before gRPC return to prevent
+ credential leak in pod events
+
+PR #12491 fixed credential leaks in containerd logs but the gRPC error
+returned to kubelet still contained sensitive information. This was
+visible in Kubernetes pod events via `kubectl describe pod`.
+
+The issue was that SanitizeError was called inside the defer block,
+but errgrpc.ToGRPC(err) was evaluated before the defer ran, so the
+gRPC message contained the original unsanitized error.
+
+Move SanitizeError before the return statement so both the logged
+error and the gRPC error are sanitized.
+
+Ref: #5453
+Signed-off-by: Aadhar Agarwal <aadagarwal@microsoft.com>
+---
+ .../cri/instrument/instrumented_service.go    | 24 ++++++++++++-------
+ 1 file changed, 16 insertions(+), 8 deletions(-)
+
+diff --git a/internal/cri/instrument/instrumented_service.go b/internal/cri/instrument/instrumented_service.go
+index f06315a6bd..4379f95997 100644
+--- a/internal/cri/instrument/instrumented_service.go
++++ b/internal/cri/instrument/instrumented_service.go
+@@ -351,8 +351,6 @@ func (in *instrumentedService) PullImage(ctx context.Context, r *runtime.PullIma
+ 	log.G(ctx).Infof("PullImage %q", r.GetImage().GetImage())
+ 	defer func() {
+ 		if err != nil {
+-			// Sanitize error to remove sensitive information
+-			err = ctrdutil.SanitizeError(err)
+ 			log.G(ctx).WithError(err).Errorf("PullImage %q failed", r.GetImage().GetImage())
+ 		} else {
+ 			log.G(ctx).Infof("PullImage %q returns image reference %q",
+@@ -361,6 +359,10 @@ func (in *instrumentedService) PullImage(ctx context.Context, r *runtime.PullIma
+ 		span.RecordError(err)
+ 	}()
+ 	res, err = in.c.PullImage(ctrdutil.WithNamespace(ctx), r)
++	// Sanitize error to remove sensitive information from both logs and returned gRPC error
++	if err != nil {
++		err = ctrdutil.SanitizeError(err)
++	}
+ 	return res, errgrpc.ToGRPC(err)
+ }
+ 
+@@ -371,8 +373,6 @@ func (in *instrumentedService) ListImages(ctx context.Context, r *runtime.ListIm
+ 	log.G(ctx).Tracef("ListImages with filter %+v", r.GetFilter())
+ 	defer func() {
+ 		if err != nil {
+-			// Sanitize error to remove sensitive information
+-			err = ctrdutil.SanitizeError(err)
+ 			log.G(ctx).WithError(err).Errorf("ListImages with filter %+v failed", r.GetFilter())
+ 		} else {
+ 			log.G(ctx).Tracef("ListImages with filter %+v returns image list %+v",
+@@ -380,6 +380,10 @@ func (in *instrumentedService) ListImages(ctx context.Context, r *runtime.ListIm
+ 		}
+ 	}()
+ 	res, err = in.c.ListImages(ctrdutil.WithNamespace(ctx), r)
++	// Sanitize error to remove sensitive information from both logs and returned gRPC error
++	if err != nil {
++		err = ctrdutil.SanitizeError(err)
++	}
+ 	return res, errgrpc.ToGRPC(err)
+ }
+ 
+@@ -390,8 +394,6 @@ func (in *instrumentedService) ImageStatus(ctx context.Context, r *runtime.Image
+ 	log.G(ctx).Tracef("ImageStatus for %q", r.GetImage().GetImage())
+ 	defer func() {
+ 		if err != nil {
+-			// Sanitize error to remove sensitive information
+-			err = ctrdutil.SanitizeError(err)
+ 			log.G(ctx).WithError(err).Errorf("ImageStatus for %q failed", r.GetImage().GetImage())
+ 		} else {
+ 			log.G(ctx).Tracef("ImageStatus for %q returns image status %+v",
+@@ -399,6 +401,10 @@ func (in *instrumentedService) ImageStatus(ctx context.Context, r *runtime.Image
+ 		}
+ 	}()
+ 	res, err = in.c.ImageStatus(ctrdutil.WithNamespace(ctx), r)
++	// Sanitize error to remove sensitive information from both logs and returned gRPC error
++	if err != nil {
++		err = ctrdutil.SanitizeError(err)
++	}
+ 	return res, errgrpc.ToGRPC(err)
+ }
+ 
+@@ -410,8 +416,6 @@ func (in *instrumentedService) RemoveImage(ctx context.Context, r *runtime.Remov
+ 	log.G(ctx).Infof("RemoveImage %q", r.GetImage().GetImage())
+ 	defer func() {
+ 		if err != nil {
+-			// Sanitize error to remove sensitive information
+-			err = ctrdutil.SanitizeError(err)
+ 			log.G(ctx).WithError(err).Errorf("RemoveImage %q failed", r.GetImage().GetImage())
+ 		} else {
+ 			log.G(ctx).Infof("RemoveImage %q returns successfully", r.GetImage().GetImage())
+@@ -419,6 +423,10 @@ func (in *instrumentedService) RemoveImage(ctx context.Context, r *runtime.Remov
+ 		span.RecordError(err)
+ 	}()
+ 	res, err := in.c.RemoveImage(ctrdutil.WithNamespace(ctx), r)
++	// Sanitize error to remove sensitive information from both logs and returned gRPC error
++	if err != nil {
++		err = ctrdutil.SanitizeError(err)
++	}
+ 	return res, errgrpc.ToGRPC(err)
+ }
+ 
+-- 
+2.45.4
+


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
- Backports a fix for a credential leak vulnerability in containerd2's CRI error handling. When image pulls fail from private registries using URL-based authentication (e.g., Azure Blob Storage with SAS tokens), sensitive query parameters were being exposed in both containerd logs and Kubernetes pod events (visible via kubectl describe pod).

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Adds fix-credential-leak-in-cri-errors.patch containing two upstream commits:
    - Initial fix to redact query parameters in CRI error logs - https://github.com/containerd/containerd/pull/12491/changes/3e2cee2bf141e8786b6af69b799d1bdadadf60b0
    - Follow-up fix to sanitize errors before gRPC return to prevent credential leak in pod events - https://github.com/containerd/containerd/pull/12801/changes/7b11d6cae471a6e33d70ed662dfd781594838aaf
- Bumps release to 2.0.0-17

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://github.com/containerd/containerd/issues/5453

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Buddy build [Pass](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=1034177&view=results)
- Tested the containerd fix on an AKS cluster running Azure Linux 3.0. Created an image pull failure scenario by blocking blob storage IPs with iptables REJECT rules, then deployed a pod referencing an ACR image. Both kubectl describe pod events and journalctl -u containerd logs show all SAS token query parameters properly replaced with [REDACTED]. The fix successfully prevents credential exposure in error messages when image pulls fail.
- Ran the pre-release AKS tests 

