### PR TITLE
fix: remove non-existent component

### DIFF
--- a/base/comps/dnf5/dnf5.comp.toml
+++ b/base/comps/dnf5/dnf5.comp.toml
@@ -5,5 +5,3 @@
 without = [
     "plugin_rhsm"
 ]
-
-[components.dnf5-plugins]


### PR DESCRIPTION
`dnf5-plugins` does not exist upstream; it was a (human) hallucination :smile: