### PR TITLE
Update kernel component to build without rhel macro

### DIFF
--- a/base/comps/components.toml
+++ b/base/comps/components.toml
@@ -96,7 +96,6 @@ spec = { type = "upstream", upstream-distro = { name = "fedora", version = "rawh
 [components.jq]
 [components.json-c]
 [components.kbd]
-[components.kernel]
 [components.kernel-srpm-macros]
 [components.keyutils]
 [components.kmod]

--- a/base/comps/kernel/kernel.comp.toml
+++ b/base/comps/kernel/kernel.comp.toml
@@ -1,0 +1,6 @@
+[components.kernel]
+
+# Set rhel to 0 to avoid deps on non-existent cert packages
+# (rhel=10 would engage RHEL-specific BuildRequires)
+[components.kernel.build]
+defines = { rhel = "0" }


### PR DESCRIPTION
Summary
Updates the kernel component configuration to build successfully on Azure Linux by setting rhel=0.

Changes
Added defines = { rhel = "0" } to the kernel component in components.toml
Problem
The upstream Fedora kernel spec file checks for the %rhel macro and, when set (e.g., rhel=10), adds BuildRequires for RHEL-specific certificate packages that don't exist in Azure Linux or Fedora. This caused the kernel build to fail with missing dependency errors.

Solution
Explicitly set rhel=0 to disable RHEL-specific code paths in the kernel spec, allowing the build to complete using standard Fedora dependencies.

Testing
Built kernel successfully with azldev comp build kernel
Built VM image with the custom kernel using azldev image build vm-base
Verified VM boots in QEMU