### PR TITLE
vm-base image: remove 'systemd.getty_auto=false' from kernelcmdline

### DIFF
--- a/base/images/vm-base/vm-base.kiwi
+++ b/base/images/vm-base/vm-base.kiwi
@@ -18,7 +18,7 @@
             format="vhdx"
             initrd_system="dracut"
             filesystem="ext4"
-            kernelcmdline="console=ttyS0 rd.shell=0 systemd.getty_auto=false"
+            kernelcmdline="console=ttyS0 rd.shell=0"
             firmware="uefi"
             overlayroot="false"
             eficsm="false"


### PR DESCRIPTION
it's helpful for systemd to automatically enable gettys for system console(s)
