### PR TITLE
fix: remove duplicate systemd-resolved line from vm-base.kiwi

### DIFF
--- a/base/images/vm-base/vm-base.kiwi
+++ b/base/images/vm-base/vm-base.kiwi
@@ -87,7 +87,6 @@
         <package name="systemd-boot" />
         <package name="systemd-networkd" />
         <package name="systemd-resolved" />
-        <package name="systemd-resolved" />
         <package name="systemd" />
         <package name="tar" />
         <package name="util-linux" />


### PR DESCRIPTION
fix: remove duplicate systemd-resolved line from vm-base.kiwi