### PR TITLE
increase vm-base image size from 2g->4g

### DIFF
--- a/base/images/vm-base/vm-base.kiwi
+++ b/base/images/vm-base/vm-base.kiwi
@@ -25,7 +25,7 @@
             bootpartition="false"
             efipartsize="200">
             <bootloader name="systemd_boot" timeout="0" />
-            <size unit="G">2</size>
+            <size unit="G">4</size>
             <initrd action="setup">
                 <dracut uefi="true"/>
             </initrd>


### PR DESCRIPTION
The larger size is needed to accomodate increasing number of packages. Can be revisited/adjusted later as well.

Cc @binujp 