### PR TITLE
Vm base definition updates

### DIFF
--- a/base/images/vm-base/vm-base.kiwi
+++ b/base/images/vm-base/vm-base.kiwi
@@ -56,6 +56,7 @@
         <package name="dnf" />
         <package name="dracut-config-generic" />
         <package name="dracut-kiwi-oem-repart"/>
+        <package name="firewalld"/>
         <package name="glibc-langpack-en" />
         <package name="glibc-locale-source" />
         <package name="glibc-minimal-langpack" />


### PR DESCRIPTION
2 minor updates to the kiwi `vm-base` image definition:

1) add `firewalld` package
2) remove duplicate `systemd-resolved` entry