### PR TITLE
fix: do not pin to older gcc

### DIFF
--- a/base/comps/components.toml
+++ b/base/comps/components.toml
@@ -62,7 +62,7 @@ spec = { type = "upstream", upstream-distro = { name = "fedora", version = "rawh
 [components.fstrm]
 [components.fuse]
 [components.gawk]
-[components.gcc14]
+[components.gcc]
 [components.gdbm]
 [components.gdisk]
 [components.gettext]


### PR DESCRIPTION
gcc14 is only present for compatibility purpose; we should be using `gcc`.