### PR TITLE
fix: correct python version to latest

### DIFF
--- a/base/comps/components.toml
+++ b/base/comps/components.toml
@@ -259,7 +259,7 @@ spec = { type = "upstream", upstream-distro = { name = "fedora", version = "rawh
 [components.python-systemd]
 [components.python-urllib3]
 [components.python-wcwidth]
-[components.'python3.9']
+[components.'python3.14']
 [components.pytz]
 [components.PyYAML]
 [components.quota]


### PR DESCRIPTION
The latest stable Python3 release is `3.14`--that's what we should be using instead of the older `3.9`.