### PR TITLE
fix: obsoletes redhat-rpm-config and adds symlinks

### DIFF
--- a/base/comps/azurelinux-rpm-config/azurelinux-rpm-config.comp.toml
+++ b/base/comps/azurelinux-rpm-config/azurelinux-rpm-config.comp.toml
@@ -23,10 +23,12 @@ overlays = [
     # Note that we don't do the reverse to avoid conflicts with upstream Fedora
     # redhat-rpm-config during bootstrapping (replacing a dir with a symlink is
     # problematic in RPM land).
+    # TODO: remove symlinks after bootstrap
     { type = "spec-prepend-lines", section = "%install", lines = ["mkdir -p %{buildroot}/usr/lib/rpm", "ln -sf redhat %{buildroot}/usr/lib/rpm/azurelinux"] },
     { type = "spec-prepend-lines", section = "%files", lines = ["/usr/lib/rpm/azurelinux"] },
 
     # Create a symlink pkg-config: /usr/bin/<arch>-azurelinux-linux-gnu-pkg-config -> /usr/bin/<arch>-redhat-linux-gnu-pkg-config.
+    # TODO: remove symlinks after bootstrap
     { type = "spec-prepend-lines", section = "%install", lines = ["mkdir -p %{buildroot}/usr/bin", "for arch in x86_64 aarch64; do", "  ln -sf ${arch}-redhat-linux-gnu-pkg-config %{buildroot}/usr/bin/${arch}-azurelinux-linux-gnu-pkg-config", "done"] },
     { type = "spec-prepend-lines", section = "%files", lines = ["/usr/bin/*-azurelinux-linux-gnu-pkg-config"] },
 


### PR DESCRIPTION
This PR adds fix for making `azurelinux-rpm-config` flavored over `redhat-rpm-config` and managing symlinks for compatibility.

**Spec file and compatibility improvements:**
- Added `Name` and `Conflicts` tags to the spec to clarify the package's identity and ensure it replaces conflicting Fedora packages. 
- Removed the global replacement of `(fedora|redhat) -> azurelinux` because it renames the directory path `/usr/lib/rpm/redhat/` to `/usr/lib/rpm/azurelinux/` inside `azurelinux-rpm-config` spec, but `python3-rpm-macros` hardcodes `/usr/lib/rpm/redhat/...` : [Tree - rpms/python-rpm-macros - src.fedoraproject.org](https://src.fedoraproject.org/rpms/python-rpm-macros/blob/f43/f/python-rpm-macros.spec#_149-166).
- Added overlays to create symlinks for `/usr/lib/rpm/azurelinux`.
- Added symlinks for `/usr/bin/<arch>-azurelinux-linux-gnu-pkg-config` to their `redhat` counterparts, ensuring compatibility without interfering with Fedora's package during bootstrapping.
