### PR TITLE
fix(cloud-init): correct service file typos in no-single-process.patch

### DIFF
--- a/SPECS/cloud-init/cloud-init.spec
+++ b/SPECS/cloud-init/cloud-init.spec
@@ -1,7 +1,7 @@
 Summary:        Cloud instance init scripts
 Name:           cloud-init
 Version:        24.3.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        GPLv3
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -144,6 +144,9 @@ make check %{?_smp_mflags}
 %config(noreplace) %{_sysconfdir}/cloud/cloud.cfg.d/10-azure-kvp.cfg
 
 %changelog
+* Thu Feb 12 2026 Sean Dougherty <sdougherty@microsoft.com> - 24.3.1-3
+- correct typos in no-single-process.patch
+
 * Fri Jun 27 2025 Archana Shettigar <v-shettigara@microsoft.com> - 24.3.1-2
 - Patch CVE-2024-6174 & CVE-2024-11584
 

--- a/SPECS/cloud-init/no-single-process.patch
+++ b/SPECS/cloud-init/no-single-process.patch
@@ -5,8 +5,8 @@ Author: Brett Holman <brett.holman@canonical.com>
 Last-Update: 2024-08-02
 
 diff -ruN a/cloudinit/cmd/status.py b/cloudinit/cmd/status.py
---- a/cloudinit/cmd/status.py	2024-08-30 14:19:57.000000000 -0700
-+++ b/cloudinit/cmd/status.py	2024-09-30 16:12:15.632570075 -0700
+--- a/cloudinit/cmd/status.py	2026-02-12 21:33:39.035227272 +0000
++++ b/cloudinit/cmd/status.py	2026-02-12 21:34:46.978947389 +0000
 @@ -318,9 +318,8 @@
      for service in [
          "cloud-final.service",
@@ -19,8 +19,8 @@ diff -ruN a/cloudinit/cmd/status.py b/cloudinit/cmd/status.py
          try:
              stdout = query_systemctl(
 diff -ruN a/cloudinit/config/cc_mounts.py b/cloudinit/config/cc_mounts.py
---- a/cloudinit/config/cc_mounts.py	2024-08-30 14:19:57.000000000 -0700
-+++ b/cloudinit/config/cc_mounts.py	2024-09-30 16:12:50.281703594 -0700
+--- a/cloudinit/config/cc_mounts.py	2026-02-12 21:33:39.035227272 +0000
++++ b/cloudinit/config/cc_mounts.py	2026-02-12 21:34:51.298929670 +0000
 @@ -525,7 +525,7 @@
      # fs_spec, fs_file, fs_vfstype, fs_mntops, fs-freq, fs_passno
      uses_systemd = cloud.distro.uses_systemd()
@@ -31,8 +31,8 @@ diff -ruN a/cloudinit/config/cc_mounts.py b/cloudinit/config/cc_mounts.py
          else "defaults,nobootwait"
      )
 diff -ruN a/cloudinit/config/schemas/schema-cloud-config-v1.json b/cloudinit/config/schemas/schema-cloud-config-v1.json
---- a/cloudinit/config/schemas/schema-cloud-config-v1.json	2024-08-30 14:19:57.000000000 -0700
-+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json	2024-09-30 16:13:48.717358398 -0700
+--- a/cloudinit/config/schemas/schema-cloud-config-v1.json	2026-02-12 21:33:39.039227255 +0000
++++ b/cloudinit/config/schemas/schema-cloud-config-v1.json	2026-02-12 21:34:51.302929653 +0000
 @@ -2022,12 +2022,12 @@
          },
          "mount_default_fields": {
@@ -49,8 +49,8 @@ diff -ruN a/cloudinit/config/schemas/schema-cloud-config-v1.json b/cloudinit/con
              "2"
            ],
 diff -ruN a/systemd/cloud-config.service.tmpl b/systemd/cloud-config.service.tmpl
---- a/systemd/cloud-config.service.tmpl	2024-08-30 14:19:57.000000000 -0700
-+++ b/systemd/cloud-config.service.tmpl	2024-09-30 16:04:45.242125447 -0700
+--- a/systemd/cloud-config.service.tmpl	2026-02-12 21:33:39.063227156 +0000
++++ b/systemd/cloud-config.service.tmpl	2026-02-12 21:34:55.438912689 +0000
 @@ -10,14 +10,7 @@
  
  [Service]
@@ -68,8 +68,8 @@ diff -ruN a/systemd/cloud-config.service.tmpl b/systemd/cloud-config.service.tmp
  TimeoutSec=0
  
 diff -ruN a/systemd/cloud-config.target b/systemd/cloud-config.target
---- a/systemd/cloud-config.target	2024-08-30 14:19:57.000000000 -0700
-+++ b/systemd/cloud-config.target	2024-09-30 16:14:21.895676757 -0700
+--- a/systemd/cloud-config.target	2026-02-12 21:33:39.063227156 +0000
++++ b/systemd/cloud-config.target	2026-02-12 21:34:58.966898218 +0000
 @@ -14,5 +14,5 @@
  
  [Unit]
@@ -77,10 +77,10 @@ diff -ruN a/systemd/cloud-config.target b/systemd/cloud-config.target
 -Wants=cloud-init-local.service cloud-init-network.service
 -After=cloud-init-local.service cloud-init-network.service
 +Wants=cloud-init-local.service cloud-init.service
-+After=cloud-init-local.service cloud-init.servic
++After=cloud-init-local.service cloud-init.service
 diff -ruN a/systemd/cloud-final.service.tmpl b/systemd/cloud-final.service.tmpl
---- a/systemd/cloud-final.service.tmpl	2024-08-30 14:19:57.000000000 -0700
-+++ b/systemd/cloud-final.service.tmpl	2024-09-30 16:06:04.764625254 -0700
+--- a/systemd/cloud-final.service.tmpl	2026-02-12 21:33:39.063227156 +0000
++++ b/systemd/cloud-final.service.tmpl	2026-02-12 21:36:57.798410809 +0000
 @@ -15,16 +15,10 @@
  
  [Service]
@@ -101,8 +101,8 @@ diff -ruN a/systemd/cloud-final.service.tmpl b/systemd/cloud-final.service.tmpl
  # Restart NetworkManager if it is present and running.
  ExecStartPost=/bin/sh -c 'u=NetworkManager.service; \
 diff -ruN a/systemd/cloud-init-local.service.tmpl b/systemd/cloud-init-local.service.tmpl
---- a/systemd/cloud-init-local.service.tmpl	2024-08-30 14:19:57.000000000 -0700
-+++ b/systemd/cloud-init-local.service.tmpl	2024-09-30 16:07:21.911075080 -0700
+--- a/systemd/cloud-init-local.service.tmpl	2026-02-12 21:33:39.063227156 +0000
++++ b/systemd/cloud-init-local.service.tmpl	2026-02-12 21:36:57.798410809 +0000
 @@ -7,6 +7,7 @@
  {% endif %}
  Wants=network-pre.target
@@ -128,8 +128,8 @@ diff -ruN a/systemd/cloud-init-local.service.tmpl b/systemd/cloud-init-local.ser
  TimeoutSec=0
  
 diff -ruN a/systemd/cloud-init-main.service.tmpl b/systemd/cloud-init-main.service.tmpl
---- a/systemd/cloud-init-main.service.tmpl	2024-08-30 14:19:57.000000000 -0700
-+++ b/systemd/cloud-init-main.service.tmpl	1969-12-31 16:00:00.000000000 -0800
+--- a/systemd/cloud-init-main.service.tmpl	2026-02-12 21:33:39.063227156 +0000
++++ b/systemd/cloud-init-main.service.tmpl	1970-01-01 00:00:00.000000000 +0000
 @@ -1,52 +0,0 @@
 -## template:jinja
 -# systemd ordering resources
@@ -184,8 +184,8 @@ diff -ruN a/systemd/cloud-init-main.service.tmpl b/systemd/cloud-init-main.servi
 -[Install]
 -WantedBy=cloud-init.target
 diff -ruN a/systemd/cloud-init-network.service.tmpl b/systemd/cloud-init-network.service.tmpl
---- a/systemd/cloud-init-network.service.tmpl	2024-08-30 14:19:57.000000000 -0700
-+++ b/systemd/cloud-init-network.service.tmpl	1969-12-31 16:00:00.000000000 -0800
+--- a/systemd/cloud-init-network.service.tmpl	2026-02-12 21:33:39.063227156 +0000
++++ b/systemd/cloud-init-network.service.tmpl	1970-01-01 00:00:00.000000000 +0000
 @@ -1,64 +0,0 @@
 -## template:jinja
 -[Unit]
@@ -252,8 +252,8 @@ diff -ruN a/systemd/cloud-init-network.service.tmpl b/systemd/cloud-init-network
 -[Install]
 -WantedBy=cloud-init.target
 diff -ruN a/systemd/cloud-init.service.tmpl b/systemd/cloud-init.service.tmpl
---- a/systemd/cloud-init.service.tmpl	1969-12-31 16:00:00.000000000 -0800
-+++ b/systemd/cloud-init.service.tmpl	2024-09-30 16:10:27.305042289 -0700
+--- a/systemd/cloud-init.service.tmpl	1970-01-01 00:00:00.000000000 +0000
++++ b/systemd/cloud-init.service.tmpl	2026-02-12 21:36:09.202610133 +0000
 @@ -0,0 +1,57 @@
 +## template:jinja
 +[Unit]
@@ -308,14 +308,13 @@ diff -ruN a/systemd/cloud-init.service.tmpl b/systemd/cloud-init.service.tmpl
 +TimeoutSec=0
 +
 +# Output needs to appear in instance console output
-+StandardOutput=journalconsole
++StandardOutput=journal+console
 +
 +[Install]
 +WantedBy=cloud-init.target
-\ No newline at end of file
 diff -ruN a/tests/unittests/config/test_cc_mounts.py b/tests/unittests/config/test_cc_mounts.py
---- a/tests/unittests/config/test_cc_mounts.py	2024-08-30 14:19:57.000000000 -0700
-+++ b/tests/unittests/config/test_cc_mounts.py	2024-09-30 16:15:11.357454290 -0700
+--- a/tests/unittests/config/test_cc_mounts.py	2026-02-12 21:33:39.075227106 +0000
++++ b/tests/unittests/config/test_cc_mounts.py	2026-02-12 21:35:39.638731395 +0000
 @@ -566,9 +566,9 @@
              LABEL=keepme	none	ext4	defaults	0	0
              LABEL=UEFI
@@ -328,4 +327,3 @@ diff -ruN a/tests/unittests/config/test_cc_mounts.py b/tests/unittests/config/te
              /dev/sdb1	none	swap	sw,comment=cloudconfig	0	0
              """  # noqa: E501
              ).strip()
-


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Corrects two typos in the cloud-init patch file, `no-single-process.patch`. 

1. cloud-init.servic (truncated service name in `cloud-config.target`)

This appeared in the `After=` directive:
```
Wants=cloud-init-local.service cloud-init.service
After=cloud-init-local.service cloud-init.servic
```
systemd would attempt to reference a unit called cloud-init.servic, which doesn't exist. 
Effects:
  - cloud-config.target would not properly depend on or order after the cloud-init network stage (cloud-init.service)
  - Services depending on cloud-config.target (like cloud-config.service and cloud-final.service) could start before the network stage completes, causing race conditions with network-dependent cloud-init modules
  - systemd would log warnings about the unknown unit on every boot
2. journalconsole (invalid `StandardOutput=` value in `cloud-init.service.tmpl`)

journalconsole is not a valid systemd `StandardOutput=` value. 
Effects:
  - systemd would reject the directive and fall back to the default (inherit), or in some versions could fail to load the unit entirely
  - Cloud-init network stage output would not appear on the instance serial/VM console, making it significantly harder to debug boot-time provisioning issues — especially in cloud/VM environments where the console log is often the only diagnostic channel

Combined impact: 

The ordering typo was the more severe of the two — it broke the systemd dependency chain that ensures cloud-init stages run sequentially, potentially causing provisioning failures on first boot.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- correct `cloud-init.target`'s After= directive
- correct the `StandardOutput=` for the cloud-init.service template so it does not fallback to 'inherit'

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**


###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
in-prog
