### PR TITLE
Add stub workflow to trigger toml branch spec reviews

### DIFF
--- a/.github/workflows/spec-review-stub.yml
+++ b/.github/workflows/spec-review-stub.yml
@@ -1,0 +1,52 @@
+# Stub workflow — A copy of this workflow must live on the default branch (3.0) so that the pull_request_target
+# event can trigger it with access to secrets. It then delegates all real work to the reusable template on
+# tomls/base/main, which has the scripts, prompts, and agent definitions.
+#
+# This two-stage design lets fork PRs trigger the review safely: the stub runs in the
+# context of the default branch (with secret access), but the template checks out only
+# .spec files (data) from the PR head — never executable code.
+#
+# A stub is needed because pull_request_target workflows always run in the context of the default branch, so they can't
+# directly use a reusable workflow from the PR head (which would be a security risk since untrusted code could leak
+# the secrets). By having the stub on the default branch, we can safely ensure only the trusted reusable workflow from
+# the base is used, while still allowing the PR head to provide the .spec files as data input.
+name: Spec Review
+
+# pull_request_target is required here: we need secret access (COPILOT_TOKEN) to run the
+# spec review agent on fork PRs. The stub itself runs NO code from the PR — it only
+# delegates to a trusted reusable workflow pinned to tomls/base/main, which sparse-checks
+# out only .spec data files (never executable code) from the PR head.
+on: # zizmor: ignore[dangerous-triggers]
+  pull_request_target:
+    # Only trigger on PRs targeting the toml base branch which modify .spec files. We do
+    # not want to affect PRs targeting other branches.
+
+    branches:
+      - tomls/base/main
+    paths:
+      - '**/*.spec'
+
+permissions: {}
+
+concurrency:
+  group: spec-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    # Prevent forks from running a stale/vulnerable copy of this stub with Actions enabled
+    if: github.repository == 'microsoft/azurelinux'
+    # Intentionally branch-pinned to our own repo so the
+    # reusable workflow picks up prompt/script/agent updates automatically.
+    uses: microsoft/azurelinux/.github/workflows/spec-review.yml@tomls/base/main # zizmor: ignore[unpinned-uses]
+    permissions:
+      contents: read
+      pull-requests: write # Post review comments and inline annotations on PRs
+    with:
+      pr-head-sha: ${{ github.event.pull_request.head.sha }}
+      pr-head-repo: ${{ github.event.pull_request.head.repo.full_name }}
+      pr-number: ${{ github.event.pull_request.number }}
+      repo: ${{ github.repository }}
+      scripts-ref: tomls/base/main
+    secrets:
+      COPILOT_TOKEN: ${{ secrets.COPILOT_TOKEN }}


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Add a stub corresponding to https://github.com/microsoft/azurelinux/pull/15770

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Add stub workflow that only triggers on PRs to toml branch.
