### PR TITLE
[Medium] Patch azl-compliance for CVE-2026-25541 and CVE-2026-25727

### DIFF
--- a/SPECS/azl-compliance/CVE-2026-25541.patch
+++ b/SPECS/azl-compliance/CVE-2026-25541.patch
@@ -1,0 +1,122 @@
+From d0293b0e35838123c51ca5dfdf468ecafee4398f Mon Sep 17 00:00:00 2001
+From: Alice Ryhl <aliceryhl@google.com>
+Date: Tue, 3 Feb 2026 14:40:22 +0100
+Subject: [PATCH] Merge commit from fork
+
+* Add repro for integer overflow
+
+Signed-off-by: Alice Ryhl <aliceryhl@google.com>
+
+* Always check overflow in new_cap + offset
+
+Signed-off-by: Alice Ryhl <aliceryhl@google.com>
+
+---------
+
+Signed-off-by: Alice Ryhl <aliceryhl@google.com>
+
+Upstream Patch Reference: https://github.com/tokio-rs/bytes/commit/d0293b0e35838123c51ca5dfdf468ecafee4398f.patch
+---
+ .../vendor/bytes/.cargo-checksum.json         |  2 +-
+ azl-compliance/vendor/bytes/ci/miri.sh        |  3 +++
+ azl-compliance/vendor/bytes/src/bytes_mut.rs  | 20 ++++++++++---------
+ .../vendor/bytes/tests/test_bytes.rs          | 13 ++++++++++++
+ 4 files changed, 28 insertions(+), 10 deletions(-)
+
+diff --git a/azl-compliance/vendor/bytes/.cargo-checksum.json b/azl-compliance/vendor/bytes/.cargo-checksum.json
+index b484945..ac7ab16 100644
+--- a/azl-compliance/vendor/bytes/.cargo-checksum.json
++++ b/azl-compliance/vendor/bytes/.cargo-checksum.json
+@@ -1 +1 @@
+-{"files":{"CHANGELOG.md":"84942cc0550e088aaaa1ddc18ba6ebd5c8e16f67be301923068e2448d3487dc9","Cargo.toml":"ff6380f46c7f9dfe722478b9e0d85588776fa8c00d0bcdc411e9aa2a2153e2ab","LICENSE":"45f522cacecb1023856e46df79ca625dfc550c94910078bd8aec6e02880b3d42","README.md":"c1b2b54999d4829f9f64fb41cbdf05a72d565be0dd078a8633d34631147498a1","SECURITY.md":"a3335079977c2f13bad59e323fdc1056bdae5adfe55f18d15ac2c930d741828c","benches/buf.rs":"72e6b6120b52d568da068f17c66a793d65602e400c595778581b63092e41d8dc","benches/bytes.rs":"f8cc255be7e8afedf6ade95cd529d105c537c5ec51110d46d470a26b497afa05","benches/bytes_mut.rs":"1326fe6224b26826228e02b4133151e756f38152c2d9cfe66adf83af76c3ec98","ci/miri.sh":"1ee54575b55a0e495e52ca1a934beed674bc8f375f03c4cfc3e81d221ec4fe98","ci/test-stable.sh":"b21b9265d8d65c1f3d50c64e40d41c66a870d897325119d1f78d601727bbb562","ci/tsan.sh":"466b86b19225dd26c756cf2252cb1973f87a145642c99364b462ed7ceb55c7dd","clippy.toml":"8522f448dfa3b33ac334ce47d233ebb6b58e8ae115e45107a64fc1b4510fe560","src/buf/buf_impl.rs":"21b9394ae2def1434173174af15d572934643f7d9ace88b7601490ecc9e3a761","src/buf/buf_mut.rs":"96ba9440008b744de8fbffe9c271c383b7f86100984941c6b081d265bc6ef34c","src/buf/chain.rs":"c933958f04c4ecd39a18db34c04ea51cc601180d43ee6924fed2fb44b96fe8c7","src/buf/iter.rs":"d4dca5b7f9b1cb441f22ac1862e28b10086721879163a810955aefb5cd7f3e58","src/buf/limit.rs":"e005ba140b70f68654877c96b981a220477e415ff5c92438c1b0cb9bc866d872","src/buf/mod.rs":"3f60295316d44b510b942abb31a0d975ae488bd4b52c87f5252d73f88f82715a","src/buf/reader.rs":"cda8bc221a1de06c7395d5c6e80f8a5924198eafbc2decc0909082ce8781d789","src/buf/take.rs":"ce7f4644986797dae3e6bdaa8f65c8ff0a9b0d4b80f749c735ed4777b96dcb2c","src/buf/uninit_slice.rs":"ce0029ebe6fd76617a457676e581c756d6026bb02b9c24718286668b962c23a1","src/buf/vec_deque.rs":"8d552c26ac6ce28a471f74c388e4749432e86b1d8f5a9759b9fc32a2549d395f","src/buf/writer.rs":"7589e9ea054d01d133b230130113a2de20b4f221a5e5c754809b583052601ea2","src/bytes.rs":"f7b1e4524e01a4514c0e0f879e1ab9e5d23e2bb0892bc43a5cee08ef2d53b368","src/bytes_mut.rs":"5b8f4af23b03d1586eaa0a7b3b10f112c5c8995f1ab458c23dea842298c3cafe","src/fmt/debug.rs":"97b23cfa1d2701fa187005421302eeb260e635cd4f9a9e02b044ff89fcc8b8ad","src/fmt/hex.rs":"13755ec6f1b79923e1f1a05c51b179a38c03c40bb8ed2db0210e8901812e61e7","src/fmt/mod.rs":"176da4e359da99b8e5cf16e480cb7b978f574876827f1b9bb9c08da4d74ac0f5","src/lib.rs":"ec51841d3e7caaa05e503f217aec405c56a0a9185ab9e0df1d335da9af71ad58","src/loom.rs":"eb3f577d8cce39a84155c241c4dc308f024631f02085833f7fe9f0ea817bcea9","src/serde.rs":"3ecd7e828cd4c2b7db93c807cb1548fad209e674df493edf7cda69a7b04d405d","tests/test_buf.rs":"a7be350258f0433cfb9ba9e4583d6bb356c964ac34a781f586fd78fbd2c4bb02","tests/test_buf_mut.rs":"3e6a12a4f546dbf1a0e1346ab2b7ff707fdaf01a06b21714ca64b141484a76c3","tests/test_bytes.rs":"be820ef74daef8c15aeb80aa94bddd2140c525f0f194b7179b5e56da1781d522","tests/test_bytes_odd_alloc.rs":"aeb7a86bf8b31f67b6f453399f3649e0d3878247debc1325d98e66201b1da15f","tests/test_bytes_vec_alloc.rs":"dd7e3c3a71abcfdcad7e3b2f52a6bd106ad6ea0d4bc634372e81dae097233cf0","tests/test_chain.rs":"e9f094539bb42b3135f50033c44122a6b44cf0f953e51e8b488f43243f1e7f10","tests/test_debug.rs":"13299107172809e8cbbd823964ac9450cd0d6b6de79f2e6a2e0f44b9225a0593","tests/test_iter.rs":"c1f46823df26a90139645fd8728a03138edd95b2849dfec830452a80ddd9726d","tests/test_reader.rs":"bf83669d4e0960dad6aa47b46a9a454814fab626eb83572aba914c3d71618f43","tests/test_serde.rs":"2691f891796ba259de0ecf926de05c514f4912cc5fcd3e6a1591efbcd23ed4d0","tests/test_take.rs":"db01bf6855097f318336e90d12c0725a92cee426d330e477a6bd1d32dac34a27"},"package":"514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"}
+\ No newline at end of file
++{"files":{"CHANGELOG.md":"84942cc0550e088aaaa1ddc18ba6ebd5c8e16f67be301923068e2448d3487dc9","Cargo.toml":"ff6380f46c7f9dfe722478b9e0d85588776fa8c00d0bcdc411e9aa2a2153e2ab","LICENSE":"45f522cacecb1023856e46df79ca625dfc550c94910078bd8aec6e02880b3d42","README.md":"c1b2b54999d4829f9f64fb41cbdf05a72d565be0dd078a8633d34631147498a1","SECURITY.md":"a3335079977c2f13bad59e323fdc1056bdae5adfe55f18d15ac2c930d741828c","benches/buf.rs":"72e6b6120b52d568da068f17c66a793d65602e400c595778581b63092e41d8dc","benches/bytes.rs":"f8cc255be7e8afedf6ade95cd529d105c537c5ec51110d46d470a26b497afa05","benches/bytes_mut.rs":"1326fe6224b26826228e02b4133151e756f38152c2d9cfe66adf83af76c3ec98","ci/miri.sh":"b74d80448f1631b76521be77553eff3eba70d516c218fd6994e201034d7fe175","ci/test-stable.sh":"b21b9265d8d65c1f3d50c64e40d41c66a870d897325119d1f78d601727bbb562","ci/tsan.sh":"466b86b19225dd26c756cf2252cb1973f87a145642c99364b462ed7ceb55c7dd","clippy.toml":"8522f448dfa3b33ac334ce47d233ebb6b58e8ae115e45107a64fc1b4510fe560","src/buf/buf_impl.rs":"21b9394ae2def1434173174af15d572934643f7d9ace88b7601490ecc9e3a761","src/buf/buf_mut.rs":"96ba9440008b744de8fbffe9c271c383b7f86100984941c6b081d265bc6ef34c","src/buf/chain.rs":"c933958f04c4ecd39a18db34c04ea51cc601180d43ee6924fed2fb44b96fe8c7","src/buf/iter.rs":"d4dca5b7f9b1cb441f22ac1862e28b10086721879163a810955aefb5cd7f3e58","src/buf/limit.rs":"e005ba140b70f68654877c96b981a220477e415ff5c92438c1b0cb9bc866d872","src/buf/mod.rs":"3f60295316d44b510b942abb31a0d975ae488bd4b52c87f5252d73f88f82715a","src/buf/reader.rs":"cda8bc221a1de06c7395d5c6e80f8a5924198eafbc2decc0909082ce8781d789","src/buf/take.rs":"ce7f4644986797dae3e6bdaa8f65c8ff0a9b0d4b80f749c735ed4777b96dcb2c","src/buf/uninit_slice.rs":"ce0029ebe6fd76617a457676e581c756d6026bb02b9c24718286668b962c23a1","src/buf/vec_deque.rs":"8d552c26ac6ce28a471f74c388e4749432e86b1d8f5a9759b9fc32a2549d395f","src/buf/writer.rs":"7589e9ea054d01d133b230130113a2de20b4f221a5e5c754809b583052601ea2","src/bytes.rs":"f7b1e4524e01a4514c0e0f879e1ab9e5d23e2bb0892bc43a5cee08ef2d53b368","src/bytes_mut.rs":"f4be08493226096bef0c3db3d700d185d4b971d72ff420aad2ec03673c249d3c","src/fmt/debug.rs":"97b23cfa1d2701fa187005421302eeb260e635cd4f9a9e02b044ff89fcc8b8ad","src/fmt/hex.rs":"13755ec6f1b79923e1f1a05c51b179a38c03c40bb8ed2db0210e8901812e61e7","src/fmt/mod.rs":"176da4e359da99b8e5cf16e480cb7b978f574876827f1b9bb9c08da4d74ac0f5","src/lib.rs":"ec51841d3e7caaa05e503f217aec405c56a0a9185ab9e0df1d335da9af71ad58","src/loom.rs":"eb3f577d8cce39a84155c241c4dc308f024631f02085833f7fe9f0ea817bcea9","src/serde.rs":"3ecd7e828cd4c2b7db93c807cb1548fad209e674df493edf7cda69a7b04d405d","tests/test_buf.rs":"a7be350258f0433cfb9ba9e4583d6bb356c964ac34a781f586fd78fbd2c4bb02","tests/test_buf_mut.rs":"3e6a12a4f546dbf1a0e1346ab2b7ff707fdaf01a06b21714ca64b141484a76c3","tests/test_bytes.rs":"aa919af0c33c2bef50574fd24423cd902026a1b42b635e20dce21f94d0f1f75a","tests/test_bytes_odd_alloc.rs":"aeb7a86bf8b31f67b6f453399f3649e0d3878247debc1325d98e66201b1da15f","tests/test_bytes_vec_alloc.rs":"dd7e3c3a71abcfdcad7e3b2f52a6bd106ad6ea0d4bc634372e81dae097233cf0","tests/test_chain.rs":"e9f094539bb42b3135f50033c44122a6b44cf0f953e51e8b488f43243f1e7f10","tests/test_debug.rs":"13299107172809e8cbbd823964ac9450cd0d6b6de79f2e6a2e0f44b9225a0593","tests/test_iter.rs":"c1f46823df26a90139645fd8728a03138edd95b2849dfec830452a80ddd9726d","tests/test_reader.rs":"bf83669d4e0960dad6aa47b46a9a454814fab626eb83572aba914c3d71618f43","tests/test_serde.rs":"2691f891796ba259de0ecf926de05c514f4912cc5fcd3e6a1591efbcd23ed4d0","tests/test_take.rs":"db01bf6855097f318336e90d12c0725a92cee426d330e477a6bd1d32dac34a27"},"package":"514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"}
+diff --git a/azl-compliance/vendor/bytes/ci/miri.sh b/azl-compliance/vendor/bytes/ci/miri.sh
+index 0158756..161d581 100755
+--- a/azl-compliance/vendor/bytes/ci/miri.sh
++++ b/azl-compliance/vendor/bytes/ci/miri.sh
+@@ -9,3 +9,6 @@ export MIRIFLAGS="-Zmiri-strict-provenance"
+ 
+ cargo miri test
+ cargo miri test --target mips64-unknown-linux-gnuabi64
++
++# run with wrapping integer overflow instead of panic
++cargo miri test --release
+diff --git a/azl-compliance/vendor/bytes/src/bytes_mut.rs b/azl-compliance/vendor/bytes/src/bytes_mut.rs
+index 282aaa7..95d98ff 100644
+--- a/azl-compliance/vendor/bytes/src/bytes_mut.rs
++++ b/azl-compliance/vendor/bytes/src/bytes_mut.rs
+@@ -670,9 +670,14 @@ impl BytesMut {
+ 
+                 let offset = offset_from(self.ptr.as_ptr(), ptr);
+ 
++                let new_cap_plus_offset = match new_cap.checked_add(offset) {
++                    Some(new_cap_plus_offset) => new_cap_plus_offset,
++                    None => panic!("overflow"),
++                };
++
+                 // Compare the condition in the `kind == KIND_VEC` case above
+                 // for more details.
+-                if v_capacity >= new_cap + offset {
++                if v_capacity >= new_cap_plus_offset {
+                     self.cap = new_cap;
+                     // no copy is necessary
+                 } else if v_capacity >= new_cap && offset >= len {
+@@ -685,14 +690,11 @@ impl BytesMut {
+                     self.ptr = vptr(ptr);
+                     self.cap = v.capacity();
+                 } else {
+-                    // calculate offset
+-                    let off = (self.ptr.as_ptr() as usize) - (v.as_ptr() as usize);
+-
+                     // new_cap is calculated in terms of `BytesMut`, not the underlying
+                     // `Vec`, so it does not take the offset into account.
+                     //
+                     // Thus we have to manually add it here.
+-                    new_cap = new_cap.checked_add(off).expect("overflow");
++                    new_cap = new_cap_plus_offset;
+ 
+                     // The vector capacity is not sufficient. The reserve request is
+                     // asking for more than the initial buffer capacity. Allocate more
+@@ -714,13 +716,13 @@ impl BytesMut {
+                     // the unused capacity of the vector is copied over to the new
+                     // allocation, so we need to ensure that we don't have any data we
+                     // care about in the unused capacity before calling `reserve`.
+-                    debug_assert!(off + len <= v.capacity());
+-                    v.set_len(off + len);
++                    debug_assert!(offset + len <= v.capacity());
++                    v.set_len(offset + len);
+                     v.reserve(new_cap - v.len());
+ 
+                     // Update the info
+-                    self.ptr = vptr(v.as_mut_ptr().add(off));
+-                    self.cap = v.capacity() - off;
++                    self.ptr = vptr(v.as_mut_ptr().add(offset));
++                    self.cap = v.capacity() - offset;
+                 }
+ 
+                 return;
+diff --git a/azl-compliance/vendor/bytes/tests/test_bytes.rs b/azl-compliance/vendor/bytes/tests/test_bytes.rs
+index 84c3d5a..ecaa916 100644
+--- a/azl-compliance/vendor/bytes/tests/test_bytes.rs
++++ b/azl-compliance/vendor/bytes/tests/test_bytes.rs
+@@ -1172,3 +1172,16 @@ fn shared_is_unique() {
+     drop(b);
+     assert!(c.is_unique());
+ }
++
++#[test]
++#[should_panic]
++fn bytes_mut_reserve_overflow() {
++    let mut a = BytesMut::from(&b"hello world"[..]);
++    let mut b = a.split_off(5);
++    // Ensure b becomes the unique owner of the backing storage
++    drop(a);
++    // Trigger overflow in new_cap + offset inside reserve
++    b.reserve(usize::MAX - 6);
++    // This call relies on the corrupted cap and may cause UB & HBO
++    b.put_u8(b'h');
++}
+-- 
+2.45.4
+

--- a/SPECS/azl-compliance/CVE-2026-25727.patch
+++ b/SPECS/azl-compliance/CVE-2026-25727.patch
@@ -1,0 +1,66 @@
+From 1c63dc7985b8fa26bd8c689423cc56b7a03841ee Mon Sep 17 00:00:00 2001
+From: Jacob Pratt <jacob@jhpratt.dev>
+Date: Thu, 5 Feb 2026 00:36:13 -0500
+Subject: [PATCH] Avoid denial of service when parsing Rfc2822
+
+Upstream Patch Reference: https://github.com/time-rs/time/commit/1c63dc7985b8fa26bd8c689423cc56b7a03841ee.patch
+---
+ .../src/parsing/combinator/rfc/rfc2822.rs     | 21 ++++++++++++++-----
+ 1 file changed, 16 insertions(+), 5 deletions(-)
+
+diff --git a/azl-compliance/vendor/time/src/parsing/combinator/rfc/rfc2822.rs b/azl-compliance/vendor/time/src/parsing/combinator/rfc/rfc2822.rs
+index 8410de0..af6310c 100644
+--- a/azl-compliance/vendor/time/src/parsing/combinator/rfc/rfc2822.rs
++++ b/azl-compliance/vendor/time/src/parsing/combinator/rfc/rfc2822.rs
+@@ -6,6 +6,8 @@ use crate::parsing::combinator::rfc::rfc2234::wsp;
+ use crate::parsing::combinator::{ascii_char, one_or_more, zero_or_more};
+ use crate::parsing::ParsedItem;
+ 
++const DEPTH_LIMIT: u8 = 32;
++
+ /// Consume the `fws` rule.
+ // The full rule is equivalent to /\r\n[ \t]+|[ \t]+(?:\r\n[ \t]+)*/
+ pub(crate) fn fws(mut input: &[u8]) -> Option<ParsedItem<'_, ()>> {
+@@ -23,14 +25,23 @@ pub(crate) fn fws(mut input: &[u8]) -> Option<ParsedItem<'_, ()>> {
+ /// Consume the `cfws` rule.
+ // The full rule is equivalent to any combination of `fws` and `comment` so long as it is not empty.
+ pub(crate) fn cfws(input: &[u8]) -> Option<ParsedItem<'_, ()>> {
+-    one_or_more(|input| fws(input).or_else(|| comment(input)))(input)
++    one_or_more(|input| fws(input).or_else(|| comment(input, 1)))(input)
+ }
+ 
+ /// Consume the `comment` rule.
+-fn comment(mut input: &[u8]) -> Option<ParsedItem<'_, ()>> {
++fn comment(mut input: &[u8], depth: u8) -> Option<ParsedItem<'_, ()>> {
++    // Avoid stack exhaustion DoS by limiting recursion depth. This will cause highly-nested
++    // comments to fail parsing, but comments *at all* are incredibly rare in practice.
++    //
++    // The error from this will not be descriptive, but the rarity and near-certain maliciousness of
++    // such inputs makes this an acceptable trade-off.
++    if depth == DEPTH_LIMIT {
++        return None;
++    }
++
+     input = ascii_char::<b'('>(input)?.into_inner();
+     input = zero_or_more(fws)(input).into_inner();
+-    while let Some(rest) = ccontent(input) {
++    while let Some(rest) = ccontent(input, depth + 1) {
+         input = rest.into_inner();
+         input = zero_or_more(fws)(input).into_inner();
+     }
+@@ -40,10 +51,10 @@ fn comment(mut input: &[u8]) -> Option<ParsedItem<'_, ()>> {
+ }
+ 
+ /// Consume the `ccontent` rule.
+-fn ccontent(input: &[u8]) -> Option<ParsedItem<'_, ()>> {
++fn ccontent(input: &[u8], depth: u8) -> Option<ParsedItem<'_, ()>> {
+     ctext(input)
+         .or_else(|| quoted_pair(input))
+-        .or_else(|| comment(input))
++        .or_else(|| comment(input, depth))
+ }
+ 
+ /// Consume the `ctext` rule.
+-- 
+2.45.4
+

--- a/SPECS/azl-compliance/azl-compliance.spec
+++ b/SPECS/azl-compliance/azl-compliance.spec
@@ -1,7 +1,7 @@
 Summary:        Azure Linux compliance package to meet all sorts of compliance rules
 Name:           azl-compliance
 Version:        1.0.2
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        BSD-3-Clause
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -9,6 +9,8 @@ Group:          System Environment/Base
 URL:            https://aka.ms/mariner
 Source0:        %{_mariner_sources_url}/%{name}-%{version}.tar.gz
 Patch0:         CVE-2025-4574.patch
+Patch1:         CVE-2026-25541.patch
+Patch2:         CVE-2026-25727.patch
 Requires:       dnf
 Requires:       gnutls
 Requires:       grub2
@@ -54,6 +56,9 @@ cd azl-compliance
 cargo test --release --offline
 
 %changelog
+* Fri Feb 13 2026 Aditya Singh <v-aditysing@microsoft.com> - 1.0.2-3
+- Patch CVE-2026-25541, CVE-2026-25727
+
 * Mon May 19 2025 Akhila Guruju <v-guakhila@microsoft.com> - 1.0.2-2
 - Patch CVE-2025-4574
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
1. Patch `azl-compliance` for CVE-2026-25541
- Upstream patch has been backported manually.
- Source code from upstream patch `None if !allocate => return false,` has not been included in patch as `allocate` variable is not present in the vendor source code.
- Upstream Patch Reference: https://github.com/tokio-rs/bytes/commit/d0293b0e35838123c51ca5dfdf468ecafee4398f.patch

2. Patch `azl-compliance` for CVE-2026-25727
- Upstream patch has been backported manually.
- Patch matches with the upstream patch.
- Upstream Patch Reference: https://github.com/time-rs/time/commit/1c63dc7985b8fa26bd8c689423cc56b7a03841ee.patch

###### Build/Dependency Information <!-- REQUIRED -->
The PR is a leaf PR which builds alone successfully.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- modified: SPECS/azl-compliance/azl-compliance.spec
- added: SPECS/azl-compliance/CVE-2026-25541.patch
- added: SPECS/azl-compliance/CVE-2026-25727.patch

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2026-25541
- https://nvd.nist.gov/vuln/detail/CVE-2026-25727

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build was successful
- Installation and uninstallation check on docker image was successful.
- Patch applies cleanly
<img width="1211" height="315" alt="image" src="https://github.com/user-attachments/assets/42260278-8086-4b6c-954b-79ad30720cc4" />

- Build Log
[azl-compliance-1.0.2-3.cm2.src.rpm.log](https://github.com/user-attachments/files/25287447/azl-compliance-1.0.2-3.cm2.src.rpm.log)
[azl-compliance-1.0.2-3.cm2.src.rpm.test.log](https://github.com/user-attachments/files/25287452/azl-compliance-1.0.2-3.cm2.src.rpm.test.log)