### PR TITLE
fix: skip tests on packages that timeout after 24 hours

### DIFF
--- a/base/comps/components-full.toml
+++ b/base/comps/components-full.toml
@@ -644,8 +644,6 @@
 [components.ghc-code-page]
 [components.ghc-colour]
 [components.ghc-comonad]
-[components.ghc-conduit-extra]
-build = { check = { skip = true, skip_reason = "Tests fail due to lacking network access, and get stuck until they hit mock's 24 hour timeout." } }
 [components.ghc-conduit]
 [components.ghc-constraints]
 [components.ghc-contravariant]
@@ -3697,8 +3695,6 @@ build = { check = { skip = true, skip_reason = "Tests fail due to lacking networ
 [components.rubygem-delorean]
 [components.rubygem-diff-lcs]
 [components.rubygem-domain_name]
-[components.rubygem-em-http-request]
-build = { check = { skip = true, skip_reason = "Tests fail due to lacking network access, and get stuck until they hit mock's 24 hour timeout." } }
 [components.rubygem-em-socksify]
 [components.rubygem-erubi]
 [components.rubygem-ethon]

--- a/base/comps/ghc-conduit-extra/ghc-conduit-extra.comp.toml
+++ b/base/comps/ghc-conduit-extra/ghc-conduit-extra.comp.toml
@@ -1,0 +1,4 @@
+[components.rubygem-em-http-request]
+
+[components.rubygem-em-http-request.build]
+check = { skip = true, skip_reason = "Tests fail due to lacking network access, and get stuck until they hit mock's 24 hour timeout." }

--- a/base/comps/rubygem-em-http-request/rubygem-em-http-request.comp.toml
+++ b/base/comps/rubygem-em-http-request/rubygem-em-http-request.comp.toml
@@ -1,0 +1,4 @@
+[components.ghc-conduit-extra]
+
+[components.ghc-conduit-extra.build]
+check = { skip = true, skip_reason = "Tests fail due to lacking network access, and get stuck until they hit mock's 24 hour timeout." }


### PR DESCRIPTION
We have 2 tasks that were blocked indefinitely in %check section, and hit the mock 24hr limit

build-ghc-conduit-extra (koji 55455)
Failure: Test suite hung during %check phase.

build-rubygem-em-http-request (koji 58968)
Failure: Test suite hung during %check phase (rspec tests).

Both have the exact same root cause: Mock's 24-hour command timeout (Timeout(86400) = 86400 seconds = 24 hours).
Tests require network access (ping: google.com: Temporary failure in name resolution)