### PR TITLE
fix(atlas): use liblapack.a instead of removed liblapack_pic.a

### DIFF
--- a/base/comps/atlas/atlas.comp.toml
+++ b/base/comps/atlas/atlas.comp.toml
@@ -1,0 +1,13 @@
+[components.atlas]
+
+# Fedora's lapack-static 3.12.0-10 dropped the separate liblapack_pic.a file
+# (it was redundant since static libs are now built with -fPIC by default).
+# The spec references the old name in %prep when building a pruned LAPACK archive.
+# Fixed upstream in atlas-3.10.3-33 (rawhide):
+#   https://src.fedoraproject.org/rpms/atlas/c/f253f3a2d6c1 (rhbz#2433875)
+# This overlay can be removed once we import from a Fedora version that includes the fix.
+[[components.atlas.overlays]]
+description = "Fix liblapack_pic.a reference — renamed to liblapack.a in lapack-static 3.12.0-10"
+type = "spec-search-replace"
+regex = 'liblapack_pic\.a'
+replacement = "liblapack.a"

--- a/base/comps/components-full.toml
+++ b/base/comps/components-full.toml
@@ -337,7 +337,6 @@
 [components.at-spi2-core]
 [components.atf]
 [components.atkmm]
-[components.atlas]
 [components.atril]
 [components.augeas]
 [components.autoconf-archive]


### PR DESCRIPTION
Fixes upstream issue: https://bugzilla.redhat.com/show_bug.cgi?id=2433875 found it f44.

>
> - The main issue was caused by the changes in lapack packaging -> the _pic libraries were discontinued
>...
>Resolves: rhbz#2433875
>...

https://src.fedoraproject.org/rpms/atlas/c/f253f3a2d6c1