### PR TITLE
fix(beakerlib): disable conflicting python-platform.patch overlay

### DIFF
--- a/base/comps/beakerlib/beakerlib.comp.toml
+++ b/base/comps/beakerlib/beakerlib.comp.toml
@@ -1,0 +1,12 @@
+[components.beakerlib]
+
+# Azure Linux defines both %fedora (from the Fedora 43 chroot) and %rhel=10
+# (from distro build defines). The upstream spec applies python3.patch on Fedora
+# and python-platform.patch on RHEL>7, expecting them to be mutually exclusive.
+# Since both conditions are true here, the patches conflict (same shebang lines).
+# Disable python-platform.patch — Azure Linux uses python3, not platform-python.
+[[components.beakerlib.overlays]]
+description = "Skip python-platform.patch (Patch3) which conflicts with python3.patch (Patch2) when both %fedora and %rhel are defined"
+type = "spec-search-replace"
+regex = '%patch -P 3 -p1'
+replacement = '# Disabled for Azure Linux: python-platform.patch conflicts with python3.patch'

--- a/base/comps/components-full.toml
+++ b/base/comps/components-full.toml
@@ -351,7 +351,6 @@
 [components.bcel]
 [components.bcg729]
 [components.bdftopcf]
-[components.beakerlib]
 [components.beust-jcommander]
 [components.biber]
 [components.bind9-next]


### PR DESCRIPTION
The upstream Fedora spec for beakerlib applies python3.patch (Patch2) when %fedora is defined and python-platform.patch (Patch3) when %rhel > 7, expecting these conditions to be mutually exclusive. Azure Linux defines both %fedora=43 (from the Fedora 43 build chroot) and %rhel=10 (from distro build defines), causing both patches to apply. Since both modify the same Python shebang lines (#!/usr/bin/env python), Patch3 fails because Patch2 has already changed them.

Add a spec-search-replace overlay to comment out %patch -P 3 in %prep. Azure Linux uses python3 (Fedora-style), not /usr/libexec/platform-python (RHEL-specific), so Patch2 alone provides the correct behavior.

Move beakerlib from inline definition in components-full.toml to a dedicated beakerlib/beakerlib.comp.toml to hold the overlay.
