### PR TITLE
fix(fcode-utils): fix GCC 15/C23 build failure with -std=gnu17 overlay

### DIFF
--- a/base/comps/components-full.toml
+++ b/base/comps/components-full.toml
@@ -534,7 +534,6 @@
 [components.fakeroot]
 [components.fast_float]
 [components.fcgi]
-[components.fcode-utils]
 [components.fdk-aac-free]
 [components.fdupes]
 [components.fedora-iot-config]

--- a/base/comps/fcode-utils/fcode-utils.comp.toml
+++ b/base/comps/fcode-utils/fcode-utils.comp.toml
@@ -1,0 +1,16 @@
+[components.fcode-utils]
+
+# Upstream project is dormant (last release v1.0.3 in 2014). The codebase uses
+# K&R-style function pointer declarations (e.g. void (*funct)()) and redefines
+# bool via typedef, which are incompatible with C23 defaults in GCC 15:
+#   1. bool is a keyword in C23; typedef to bool is a hard error
+#   2. () means zero params in C23; calling through () pointers with args is an error
+#   3. Incompatible pointer type assignments are promoted to errors
+# An upstream fix (partial) exists but is not merged: https://github.com/openbios/fcode-utils/pull/32
+# Fedora has not patched this either as of rawhide (Feb 2026).
+# Force C17 mode to restore pre-C23 semantics until upstream modernizes.
+[[components.fcode-utils.overlays]]
+description = "Fix GCC 15/C23 build failures by forcing C17 mode for K&R-style function pointers and bool typedef"
+type = "spec-search-replace"
+regex = 'CFLAGS=.%\{optflags\}.'
+replacement = 'CFLAGS="%{optflags} -std=gnu17"'


### PR DESCRIPTION
fcode-utils 1.0.3 fails to build with GCC 15's default C23 mode due to:
  1. typedef to 'bool' (a C23 keyword) in shared/types.h
  2. K&R-style empty-parameter function pointers treated as zero-arg in C23
  3. -Wincompatible-pointer-types promoted to error

The upstream project is dormant (last release 2014). A partial fix exists as an unmerged PR: https://github.com/openbios/fcode-utils/pull/32

Fedora is also affected — fcode-utils has failed all mass rebuilds since fc42 (fc42-4, fc43-5, fc44-6 all failed in Fedora Koji). The last successful Fedora build was 1.0.3-3.fc42, before the C23 transition.

Add a spec-search-replace overlay to force -std=gnu17 in CFLAGS, restoring pre-C23 semantics. Move the component from an inline entry in components-full.toml to a dedicated comp.toml to hold the overlay.

Validated: prep-sources clean, build succeeds, smoke-tested toke/detok/ romheaders in mock chroot.