### PR TITLE
fix(glade): add missing BuildRequires for gobject-introspection-devel

### DIFF
--- a/base/comps/components-full.toml
+++ b/base/comps/components-full.toml
@@ -799,7 +799,6 @@
 [components.git]
 [components.gjs]
 [components.gl2ps]
-[components.glade]
 [components.glew]
 [components.glib-networking]
 [components.'glibmm2.4']

--- a/base/comps/glade/glade.comp.toml
+++ b/base/comps/glade/glade.comp.toml
@@ -1,0 +1,9 @@
+[components.glade]
+
+# Backport from Fedora rawhide: https://src.fedoraproject.org/rpms/glade/c/478c15c
+# Required by meson's gnome.generate_gir; missing from f43 spec.
+[[components.glade.overlays]]
+description = "Add missing BuildRequires for gobject-introspection-devel needed by meson gnome.generate_gir"
+type = "spec-add-tag"
+tag = "BuildRequires"
+value = "gobject-introspection-devel"


### PR DESCRIPTION
The glade build fails during meson setup because gobject-introspection-1.0 pkg-config is not found:

  gladeui/meson.build:242:8: ERROR: Dependency "gobject-introspection-1.0"
  not found, tried pkgconfig

The Fedora f43 spec uses %meson which passes --auto-features=enabled, making GObject introspection support mandatory, but does not list gobject-introspection-devel as a BuildRequires.

This was fixed in Fedora rawhide by Yaakov Selkowitz: https://src.fedoraproject.org/rpms/glade/c/478c15c

Add a spec-add-tag overlay to backport the fix until it lands in f43.