### PR TITLE
feat(kernel): Remove debug kernel

### DIFF
--- a/base/comps/kernel/kernel.comp.toml
+++ b/base/comps/kernel/kernel.comp.toml
@@ -2,6 +2,7 @@
 
 # Set rhel to 0 to avoid deps on non-existent cert packages
 # (rhel=10 would engage RHEL-specific BuildRequires)
+# Add without = ["debug"] to skip debug kernel variant and reduce build time
 [components.kernel.build]
 defines = { rhel = "0" }
 without = ["debug"]


### PR DESCRIPTION
Disable the debug kernel build by adding --without debug to the kernel component build config. As it is unnecessary overhead.

The Fedora kernel spec builds both base and debug variants by default. With debugbuildsenabled=1 (the default), this means compiling the entire kernel twice. Passing --without debug skips the debug variant, roughly halving wall-clock build time.

Unmodified taskID=94143 built x86 kernel in 2:59:23 total time
This branch on taskID=100493 built x86 kernel in 1:00:01 total time