### PR TITLE
fix(gnustep-make): disable RHEL CC=gobjc override that breaks configure

### DIFF
--- a/base/comps/components-full.toml
+++ b/base/comps/components-full.toml
@@ -820,7 +820,6 @@
 [components.gnulib]
 [components.gnuplot]
 [components.gnustep-base]
-[components.gnustep-make]
 [components.gobject-introspection]
 [components.golang-bitbucket-ww-goautoneg]
 [components.golang-cloud-google-auth]

--- a/base/comps/gnustep-make/gnustep-make.comp.toml
+++ b/base/comps/gnustep-make/gnustep-make.comp.toml
@@ -1,0 +1,13 @@
+[components.gnustep-make]
+
+# AZL defines %rhel=10, which triggers the RHEL-specific CC=gobjc override in the
+# upstream spec's %build section. The gobjc compiler can't create executables with
+# AZL's hardened compiler flags (annobin/redhat-hardened-cc1 specs), causing configure
+# to fail with "C compiler cannot create executables". On Fedora, %rhel is unset so
+# the default CC=gcc is used. Remove the RHEL conditional to follow the Fedora path.
+
+[[components.gnustep-make.overlays]]
+description = "Neutralize RHEL-specific CC=gobjc override — gobjc can't create executables with AZL's hardened compiler flags (annobin/redhat-hardened-cc1 specs), causing configure to fail"
+type = "spec-search-replace"
+regex = 'export CC=gobjc'
+replacement = '# export CC=gobjc  # disabled for AZL — use default CC=gcc'


### PR DESCRIPTION
The upstream Fedora spec has a conditional block in %build:

  %if 0%{?rhel} >= 8
  export CC=gobjc
  %endif

AZL defines %rhel=10, so this activates and sets CC=gobjc. The gobjc compiler cannot create executables when combined with AZL's hardened compiler flags (-specs=redhat-annobin-cc1, -specs=redhat-hardened-cc1), causing configure to fail with "C compiler cannot create executables".

On Fedora, %rhel is unset so the default CC=gcc is used and the build succeeds. On RHEL, the toolchain is configured so gobjc + annobin works. AZL falls in the gap: it has %rhel=10 but uses Fedora's GCC 15 toolchain.

Add a spec-search-replace overlay to comment out the `export CC=gobjc` line, preserving the %if/%endif block structure. This follows the Fedora build path (CC=gcc), which is sufficient since gnustep-make itself doesn't compile Objective-C code — it's a makefile/build system package.

Tested: build succeeds, gnustep-config runs correctly in mock chroot.
