### PR TITLE
fix(golang-github-clbanning-mxj): enable %check by removing broken example tests

### DIFF
--- a/base/comps/golang-github-clbanning-mxj/golang-github-clbanning-mxj.comp.toml
+++ b/base/comps/golang-github-clbanning-mxj/golang-github-clbanning-mxj.comp.toml
@@ -1,4 +1,12 @@
 [components.golang-github-clbanning-mxj]
 
-[components.golang-github-clbanning-mxj.build]
-check = { skip = true, skip_reason = "Disabling checks for initial set of failures." }
+# Upstream example_test.go references v1 API identifiers (HandleXmlReader, Map, etc.)
+# that don't exist in v2.5.5. Fedora hasn't updated to a fixed version (v2.7+).
+# Remove the broken test file so %check can run the real tests.
+# Issue: https://github.com/clbanning/mxj/blob/v2.5.5/example_test.go references non-existent identifiers
+# Fixed upstream in v2.7.0: https://github.com/clbanning/mxj/commit/458e5dc01578622621dd1997cf19edbaa7972b00
+[[components.golang-github-clbanning-mxj.overlays]]
+description = "Remove example_test.go which references v1 API identifiers not present in v2"
+type = "spec-append-lines"
+section = "%prep"
+lines = ["# Remove broken example tests that reference v1 API identifiers", "rm -f example_test.go"]


### PR DESCRIPTION
The upstream example_test.go at v2.5.5 references v1 API identifiers (HandleXmlReader, HandleJsonReader, Map, etc.) that were removed in v2. This causes Go test compilation failures:

  ./example_test.go:19:1: ExampleHandleXmlReader refers to unknown identifier: HandleXmlReader
  ./example_test.go:151:1: ExampleMap_Struct refers to unknown identifier: Map

Fedora's spec (f43, rawhide) ships v2.5.5 with %check enabled but doesn't exclude the broken tests. The issue is fixed upstream in v2.7.0 where the example functions were updated to use v2 imports and commented out: https://github.com/clbanning/mxj/commit/458e5dc01578622621dd1997cf19edbaa7972b00

Rather than skipping %check entirely, add an overlay to remove only the broken example_test.go during %prep, allowing the real unit tests to run.

Tested: Built successfully with %check passing, verified package installs and Go source files are present in /usr/share/gocode/src/github.com/clbanning/mxj/