### PR TITLE
fix: enable rpmautospec in mock config

### DIFF
--- a/distro/mock/azurelinux-4.0.tpl
+++ b/distro/mock/azurelinux-4.0.tpl
@@ -21,6 +21,16 @@ config_opts['package_manager'] = 'dnf5'
 config_opts['update_before_build'] = False
 config_opts['root'] = 'azl-4.0-{{ target_arch }}'
 
+# When rpmautospec is enabled,
+# the %autorelease and %autochangelog macros can be used in spec files
+# to automatically generate release numbers and changelog entries based
+# on the git history, eliminating the need to manually maintain them.
+config_opts['plugin_conf']['rpmautospec_enable'] = True
+config_opts['plugin_conf']['rpmautospec_opts'] = {
+    'requires': ['rpmautospec'],
+    'cmd_base': ['/usr/bin/rpmautospec', 'process-distgit'],
+}
+
 config_opts['dnf.conf'] = """
 [main]
 zchunk=true


### PR DESCRIPTION
This pull request updates the `azurelinux-4.0.tpl` mock configuration to enable and configure the `rpmautospec` plugin, which preprocesses %autorelease and %autochangelog to count and pull the release value and change logs from Fedora upstream and fix the build failure of a few packages.

This change will work together with updated azldev (with preserving the upstream `.git` dir per package to mock, PR: https://github.com/gim-home/azldev-preview/pull/468) to fix the changelog issue in packages with `%autorelease` and `%autochangelog`.

Local build needs `mock_rpmautospec` installed, in Koji pipeline, the rpmautospec Koji plugin (`python3-rpmautospec-koji`) is needed at the hub level to entirely resolve the changelog issues.


**Enhancements to RPM build automation:**

* Enabled the `rpmautospec` plugin by setting `config_opts['plugin_conf']['rpmautospec_enable'] = True` in the mock configuration for handling of release numbers and changelogs in spec files.
* Configured `rpmautospec` options to require the `rpmautospec` package and use `/usr/bin/rpmautospec process-distgit` as the command base for processing.

Tested with `azldev comp build -p gnome-keyring`:
```
╭───────────────┬───────────────────────────────────────────────────────────────────────────┬────────────────────────────────────────────────────────────────────────────────────────────╮
│ COMPONENTNAME │ SRPM PATHS                                                                │ RPM PATHS                                                                                  │
├───────────────┼───────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────┤
│ gnome-keyring │ /home/liunan/Fedora/azurelinux/base/out/gnome-keyring-48.0-4.azl4.src.rpm │ /home/liunan/Fedora/azurelinux/base/out/gnome-keyring-48.0-4.azl4.x86_64.rpm               │
│               │                                                                           │ /home/liunan/Fedora/azurelinux/base/out/gnome-keyring-debuginfo-48.0-4.azl4.x86_64.rpm     │
│               │                                                                           │ /home/liunan/Fedora/azurelinux/base/out/gnome-keyring-debugsource-48.0-4.azl4.x86_64.rpm   │
│               │                                                                           │ /home/liunan/Fedora/azurelinux/base/out/gnome-keyring-pam-48.0-4.azl4.x86_64.rpm           │
│               │                                                                           │ /home/liunan/Fedora/azurelinux/base/out/gnome-keyring-pam-debuginfo-48.0-4.azl4.x86_64.rpm │
```
