### PR TITLE
fix(golang-github-mwitkow-conntrack): enable %check by removing flaky test suite

### DIFF
--- a/base/comps/golang-github-mwitkow-conntrack/golang-github-mwitkow-conntrack.comp.toml
+++ b/base/comps/golang-github-mwitkow-conntrack/golang-github-mwitkow-conntrack.comp.toml
@@ -11,5 +11,7 @@
 description = "Remove listener_test.go and dialer_test.go due to race condition in ListenerTestSuite"
 type = "spec-append-lines"
 section = "%prep"
-lines = ["# Remove ListenerTestSuite tests - flaky due to race condition (no sleep after conn.Close())", "rm -f listener_test.go dialer_test.go"]
-
+lines = [
+    "# Remove ListenerTestSuite tests - flaky due to race condition (no sleep after conn.Close())",
+    "rm -f listener_test.go dialer_test.go",
+]


### PR DESCRIPTION
The upstream codebase is abandoned (https://github.com/mwitkow/go-conntrack/issues/14). listener_test.go has a race condition in TestMonitoringNormalConns: the test calls conn.Close() and immediately checks the connection counter, but the counter is incremented asynchronously when the server processes the close. Missing a sleep between close and assertion causes intermittent failures:

  listener_test.go:81:
    Error:      Not equal:
                expected: 2
                actual  : 1
    Messages:   the closed conn counter must be incremented after connection was closed

dialer_test.go extends ListenerTestSuite so must also be removed.

Rather than skipping %check entirely, remove only the flaky suite files so promhelper_test.go and tracehelper_test.go can still run.

Tested: Built successfully with %check passing, package installs correctly with Go source files present in /usr/share/gocode/src/github.com/mwitkow/go-conntrack/