### PR TITLE
fix(tags): do not hard-code dist tag in TOML

### DIFF
--- a/distro/azurelinux.distro.toml
+++ b/distro/azurelinux.distro.toml
@@ -12,6 +12,5 @@ mock-config-aarch64 = "mock/azurelinux-4.0-aarch64.cfg"
 spec = { type = "upstream", upstream-distro = { name = "fedora", version = "43" } }
 
 [distros.azurelinux.versions.'4.0'.default-component-config.build.defines]
-dist = ".azl4"
 vendor = "Microsoft Corporation"
 distribution = "Azure Linux"

--- a/distro/mock/azurelinux-4.0.tpl
+++ b/distro/mock/azurelinux-4.0.tpl
@@ -14,6 +14,7 @@ config_opts['plugin_conf']['ccache_enable'] = True
 config_opts['cleanup_on_success'] = False
 config_opts['cleanup_on_failure'] = False
 
+config_opts['macros']['%dist'] = '.azl4'
 config_opts['dist'] = 'azl4'
 config_opts['extra_chroot_dirs'] = ['/run/lock']
 config_opts['releasever'] = '43'


### PR DESCRIPTION
Hard-coding the `dist` tag prevents koji from overriding it on a per-target/tag basis. This change stops *forcing* it via TOML overlay, and instead arranges for it to be set in local `mock` configs for local builds.