### PR TITLE
fix: don't hardcode vendor and distribution, following model using for dist

### DIFF
--- a/distro/azurelinux.distro.toml
+++ b/distro/azurelinux.distro.toml
@@ -10,7 +10,3 @@ mock-config-aarch64 = "mock/azurelinux-4.0-aarch64.cfg"
 
 [distros.azurelinux.versions.'4.0'.default-component-config]
 spec = { type = "upstream", upstream-distro = { name = "fedora", version = "43" } }
-
-[distros.azurelinux.versions.'4.0'.default-component-config.build.defines]
-vendor = "Microsoft Corporation"
-distribution = "Azure Linux"

--- a/distro/mock/azurelinux-4.0.tpl
+++ b/distro/mock/azurelinux-4.0.tpl
@@ -15,6 +15,8 @@ config_opts['cleanup_on_success'] = False
 config_opts['cleanup_on_failure'] = False
 
 config_opts['macros']['%dist'] = '.azl4'
+config_opts['macros']['%vendor'] = 'Microsoft Corporation'
+config_opts['macros']['%distribution'] = 'Azure Linux'
 config_opts['dist'] = 'azl4'
 config_opts['extra_chroot_dirs'] = ['/run/lock']
 config_opts['releasever'] = '43'


### PR DESCRIPTION
Rather than hardcoding the distribution and vendor for our RPMs in our distro file (and therefore per-package macro file) this change pushes them through `mock` (and will need an associated change on the `koji` side).

This allows a separate change to `azldev` to suppress writing the per-package macro file at all if there are no macros, which limits the surface of the `Source9999` problems we've been seeing.