### PR TITLE
fix (openexr): fix cmake build directory path for Azure Linux

### DIFF
--- a/base/comps/components-full.toml
+++ b/base/comps/components-full.toml
@@ -1951,7 +1951,6 @@
 [components.opendmarc]
 [components.opendnssec]
 [components.openexr2]
-[components.openexr]
 [components.openfec]
 [components.openjade]
 [components.openjpeg]

--- a/base/comps/openexr/openexr.comp.toml
+++ b/base/comps/openexr/openexr.comp.toml
@@ -1,0 +1,7 @@
+[components.openexr]
+
+[[components.openexr.overlays]]
+description = "Use portable %{__cmake_builddir} macro instead of hardcoded redhat-linux-build path"
+type = "spec-search-replace"
+regex = 'redhat-linux-build'
+replacement = '%{__cmake_builddir}'


### PR DESCRIPTION
The cmake build directory is named `%{_vendor}-linux-build` (`azurelinux-linux-build`) due to Azure Linux's `%cmake` macro, but the `openexr.spec` hardcodes `redhat-linux-build`: https://src.fedoraproject.org/rpms/openexr/blob/f43/f/openexr.spec#_99.

This PR fixes cmake build directory path by replacing the hardcoded path with the portable `%{__cmake_builddir}` macro so the unzip command finds the right directory.

Tested by `azldev comp build -p openexr`:
```
╭───────────────┬──────────────────────────────────────────────────────────────────────┬────────────────────────────────────────────────────────────────────────────────────────╮
│ COMPONENTNAME │ SRPM PATHS                                                           │ RPM PATHS                                                                              │
├───────────────┼──────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────┤
│ openexr       │ /home/liunan/Fedora/azurelinux/base/out/openexr-3.2.4-6.azl4.src.rpm │ /home/liunan/Fedora/azurelinux/base/out/openexr-3.2.4-6.azl4.x86_64.rpm                │
│               │                                                                      │ /home/liunan/Fedora/azurelinux/base/out/openexr-debuginfo-3.2.4-6.azl4.x86_64.rpm      │
│               │                                                                      │ /home/liunan/Fedora/azurelinux/base/out/openexr-debugsource-3.2.4-6.azl4.x86_64.rpm    │
│               │                                                                      │ /home/liunan/Fedora/azurelinux/base/out/openexr-devel-3.2.4-6.azl4.x86_64.rpm          │
│               │                                                                      │ /home/liunan/Fedora/azurelinux/base/out/openexr-libs-3.2.4-6.azl4.x86_64.rpm           │
│               │                                                                      │ /home/liunan/Fedora/azurelinux/base/out/openexr-libs-debuginfo-3.2.4-6.azl4.x86_64.rpm │
╰───────────────┴──────────────────────────────────────────────────────────────────────┴────────────────────────────────────────────────────────────────────────────────────────╯
```