### PR TITLE
fix(opencv): remove CVE-2025-53644 patch targeting deleted bundled openjpeg

### DIFF
--- a/base/comps/components-full.toml
+++ b/base/comps/components-full.toml
@@ -1144,7 +1144,6 @@
 [components.openbox]
 [components.opencl-headers]
 [components.opencore-amr]
-[components.opencv]
 [components.openexr2]
 [components.openfec]
 [components.openjade]

--- a/base/comps/opencv/opencv.comp.toml
+++ b/base/comps/opencv/opencv.comp.toml
@@ -1,0 +1,18 @@
+[components.opencv]
+
+# CVE-2025-53644 patch targets bundled 3rdparty/openjpeg, which Fedora's spec
+# deletes during %prep (it uses system openjpeg2-devel instead). The patch
+# can't find the file and fails. Remove both the patch declaration and its
+# application. The CVE fix belongs in the system openjpeg package, not here.
+# Upstream Fedora offending commit: https://src.fedoraproject.org/rpms/opencv/c/f7431cf
+
+[[components.opencv.overlays]]
+description = "Remove CVE-2025-53644 patch — targets bundled openjpeg that is deleted in %prep; fix belongs in system openjpeg package"
+type = "patch-remove"
+file = "**/a39db41390de546d18962ee1278bd6dbb715f466.patch"
+
+[[components.opencv.overlays]]
+description = "Remove application of CVE-2025-53644 patch (see above)"
+type = "spec-search-replace"
+regex = '%patch.*cve2025-53644'
+replacement = ""


### PR DESCRIPTION
The upstream Fedora spec (f7431cf) added a patch for CVE-2025-53644 that modifies 3rdparty/openjpeg/openjp2/jp2.c, but the spec's %prep deletes the bundled 3rdparty/openjpeg directory since it uses system openjpeg2-devel instead. This causes the build to fail with "can't find file to patch".

Add overlays to remove the Patch17 declaration and its %patch application. The CVE fix should be tracked in the system openjpeg package.

Also remove stale opencv entries from components-full.toml that conflict with their dedicated comp.toml files.