### PR TITLE
feat: set the default snapshot to midnight 2026/02/24 PST

### DIFF
--- a/distro/azurelinux.distro.toml
+++ b/distro/azurelinux.distro.toml
@@ -9,4 +9,4 @@ mock-config-x86_64 = "mock/azurelinux-4.0-x86_64.cfg"
 mock-config-aarch64 = "mock/azurelinux-4.0-aarch64.cfg"
 
 [distros.azurelinux.versions.'4.0'.default-component-config]
-spec = { type = "upstream", upstream-distro = { name = "fedora", version = "43", snapshot = "2025-02-24T00:00:00-08:00" } }
+spec = { type = "upstream", upstream-distro = { name = "fedora", version = "43", snapshot = "2026-02-24T00:00:00-08:00" } }


### PR DESCRIPTION
Freezing the versions of the sources we're going to build our packages against by default. The date is set to the time of the last successful lookaside cache sync. I've tested the snapshot feature with a few Koji builds from CT ([example](https://[52.249.25.247/koji/getfile?taskID=190202&volume=DEFAULT&name=azldev.err.log](https://52.249.25.247/koji/getfile?taskID=190202&volume=DEFAULT&name=azldev.err.log))). The build was testing a different date but the logic is the same.