### PR TITLE
[Medium] Patch python-virtualenv for CVE-2026-1703 & CVE-2026-24049

### DIFF
--- a/SPECS/python-virtualenv/CVE-2026-1703v0.patch
+++ b/SPECS/python-virtualenv/CVE-2026-1703v0.patch
@@ -1,0 +1,35 @@
+From 4c651b70d60ed91b13663bcda9b3ed41748d0124 Mon Sep 17 00:00:00 2001
+From: Seth Michael Larson <seth@python.org>
+Date: Fri, 30 Jan 2026 09:49:11 -0600
+Subject: [PATCH] Use os.path.commonpath() instead of commonprefix()
+
+Upstream Patch Reference: https://github.com/pypa/pip/commit/8e227a9be4faa9594e05d02ca05a413a2a4e7735.patch
+---
+ news/+1ee322a1.bugfix.rst        | 1 +
+ pip/_internal/utils/unpacking.py | 2 +-
+ 2 files changed, 2 insertions(+), 1 deletion(-)
+ create mode 100644 news/+1ee322a1.bugfix.rst
+
+diff --git a/news/+1ee322a1.bugfix.rst b/news/+1ee322a1.bugfix.rst
+new file mode 100644
+index 0000000..edb1b32
+--- /dev/null
++++ b/news/+1ee322a1.bugfix.rst
+@@ -0,0 +1 @@
++Use a path-segment prefix comparison, not char-by-char.
+diff --git a/pip/_internal/utils/unpacking.py b/pip/_internal/utils/unpacking.py
+index 78b5c13..0b26525 100644
+--- a/pip/_internal/utils/unpacking.py
++++ b/pip/_internal/utils/unpacking.py
+@@ -81,7 +81,7 @@ def is_within_directory(directory: str, target: str) -> bool:
+     abs_directory = os.path.abspath(directory)
+     abs_target = os.path.abspath(target)
+ 
+-    prefix = os.path.commonprefix([abs_directory, abs_target])
++    prefix = os.path.commonpath([abs_directory, abs_target])
+     return prefix == abs_directory
+ 
+ 
+-- 
+2.45.4
+

--- a/SPECS/python-virtualenv/CVE-2026-1703v1.patch
+++ b/SPECS/python-virtualenv/CVE-2026-1703v1.patch
@@ -1,0 +1,26 @@
+From 4c651b70d60ed91b13663bcda9b3ed41748d0124 Mon Sep 17 00:00:00 2001
+From: Seth Michael Larson <seth@python.org>
+Date: Fri, 30 Jan 2026 09:49:11 -0600
+Subject: [PATCH] Use os.path.commonpath() instead of commonprefix()
+
+Upstream Patch Reference: https://github.com/pypa/pip/commit/8e227a9be4faa9594e05d02ca05a413a2a4e7735.patch
+---
+ pip/_internal/utils/unpacking.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/pip/_internal/utils/unpacking.py b/pip/_internal/utils/unpacking.py
+index 875e30e..4abe64b 100644
+--- a/pip/_internal/utils/unpacking.py
++++ b/pip/_internal/utils/unpacking.py
+@@ -82,7 +82,7 @@ def is_within_directory(directory: str, target: str) -> bool:
+     abs_directory = os.path.abspath(directory)
+     abs_target = os.path.abspath(target)
+ 
+-    prefix = os.path.commonprefix([abs_directory, abs_target])
++    prefix = os.path.commonpath([abs_directory, abs_target])
+     return prefix == abs_directory
+ 
+ 
+-- 
+2.45.4
+

--- a/SPECS/python-virtualenv/CVE-2026-1703v2.patch
+++ b/SPECS/python-virtualenv/CVE-2026-1703v2.patch
@@ -1,0 +1,35 @@
+From 4c651b70d60ed91b13663bcda9b3ed41748d0124 Mon Sep 17 00:00:00 2001
+From: Seth Michael Larson <seth@python.org>
+Date: Fri, 30 Jan 2026 09:49:11 -0600
+Subject: [PATCH] Use os.path.commonpath() instead of commonprefix()
+
+Upstream Patch Reference: https://github.com/pypa/pip/commit/8e227a9be4faa9594e05d02ca05a413a2a4e7735.patch
+---
+ news/+1ee322a1.bugfix.rst        | 1 +
+ pip/_internal/utils/unpacking.py | 2 +-
+ 2 files changed, 2 insertions(+), 1 deletion(-)
+ create mode 100644 news/+1ee322a1.bugfix.rst
+
+diff --git a/news/+1ee322a1.bugfix.rst b/news/+1ee322a1.bugfix.rst
+new file mode 100644
+index 0000000..edb1b32
+--- /dev/null
++++ b/news/+1ee322a1.bugfix.rst
+@@ -0,0 +1 @@
++Use a path-segment prefix comparison, not char-by-char.
+diff --git a/pip/_internal/utils/unpacking.py b/pip/_internal/utils/unpacking.py
+index 7252dc2..4ce2b15 100644
+--- a/pip/_internal/utils/unpacking.py
++++ b/pip/_internal/utils/unpacking.py
+@@ -94,7 +94,7 @@ def is_within_directory(directory, target):
+     abs_directory = os.path.abspath(directory)
+     abs_target = os.path.abspath(target)
+ 
+-    prefix = os.path.commonprefix([abs_directory, abs_target])
++    prefix = os.path.commonpath([abs_directory, abs_target])
+     return prefix == abs_directory
+ 
+ 
+-- 
+2.45.4
+

--- a/SPECS/python-virtualenv/CVE-2026-24049v0.patch
+++ b/SPECS/python-virtualenv/CVE-2026-24049v0.patch
@@ -1,0 +1,35 @@
+From 7a7d2de96b22a9adf9208afcc9547e1001569fef Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Alex=20Gr=C3=B6nholm?= <alex.gronholm@nextday.fi>
+Date: Thu, 22 Jan 2026 01:41:14 +0200
+Subject: [PATCH] Fixed security issue around wheel unpack (#675)
+
+A maliciously crafted wheel could cause the permissions of a file outside the unpack tree to be altered.
+
+Fixes CVE-2026-24049.
+Upstream Patch Reference: https://github.com/pypa/wheel/commit/7a7d2de96b22a9adf9208afcc9547e1001569fef.patch
+---
+ setuptools/_vendor/wheel/cli/unpack.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/setuptools/_vendor/wheel/cli/unpack.py b/setuptools/_vendor/wheel/cli/unpack.py
+index d48840e..83dc742 100644
+--- a/setuptools/_vendor/wheel/cli/unpack.py
++++ b/setuptools/_vendor/wheel/cli/unpack.py
+@@ -19,12 +19,12 @@ def unpack(path: str, dest: str = ".") -> None:
+         destination = Path(dest) / namever
+         print(f"Unpacking to: {destination}...", end="", flush=True)
+         for zinfo in wf.filelist:
+-            wf.extract(zinfo, destination)
++            target_path = Path(wf.extract(zinfo, destination))
+ 
+             # Set permissions to the same values as they were set in the archive
+             # We have to do this manually due to
+             # https://github.com/python/cpython/issues/59999
+             permissions = zinfo.external_attr >> 16 & 0o777
+-            destination.joinpath(zinfo.filename).chmod(permissions)
++            target_path.chmod(permissions)
+ 
+     print("OK")
+-- 
+2.45.4
+

--- a/SPECS/python-virtualenv/CVE-2026-24049v1.patch
+++ b/SPECS/python-virtualenv/CVE-2026-24049v1.patch
@@ -1,0 +1,35 @@
+From 7a7d2de96b22a9adf9208afcc9547e1001569fef Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Alex=20Gr=C3=B6nholm?= <alex.gronholm@nextday.fi>
+Date: Thu, 22 Jan 2026 01:41:14 +0200
+Subject: [PATCH] Fixed security issue around wheel unpack (#675)
+
+A maliciously crafted wheel could cause the permissions of a file outside the unpack tree to be altered.
+
+Fixes CVE-2026-24049.
+Upstream Patch Reference: https://github.com/pypa/wheel/commit/7a7d2de96b22a9adf9208afcc9547e1001569fef.patch
+---
+ wheel/cli/unpack.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/wheel/cli/unpack.py b/wheel/cli/unpack.py
+index d48840e..83dc742 100644
+--- a/wheel/cli/unpack.py
++++ b/wheel/cli/unpack.py
+@@ -19,12 +19,12 @@ def unpack(path: str, dest: str = ".") -> None:
+         destination = Path(dest) / namever
+         print(f"Unpacking to: {destination}...", end="", flush=True)
+         for zinfo in wf.filelist:
+-            wf.extract(zinfo, destination)
++            target_path = Path(wf.extract(zinfo, destination))
+ 
+             # Set permissions to the same values as they were set in the archive
+             # We have to do this manually due to
+             # https://github.com/python/cpython/issues/59999
+             permissions = zinfo.external_attr >> 16 & 0o777
+-            destination.joinpath(zinfo.filename).chmod(permissions)
++            target_path.chmod(permissions)
+ 
+     print("OK")
+-- 
+2.45.4
+

--- a/SPECS/python-virtualenv/CVE-2026-24049v2.patch
+++ b/SPECS/python-virtualenv/CVE-2026-24049v2.patch
@@ -1,0 +1,35 @@
+From 7a7d2de96b22a9adf9208afcc9547e1001569fef Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Alex=20Gr=C3=B6nholm?= <alex.gronholm@nextday.fi>
+Date: Thu, 22 Jan 2026 01:41:14 +0200
+Subject: [PATCH] Fixed security issue around wheel unpack (#675)
+
+A maliciously crafted wheel could cause the permissions of a file outside the unpack tree to be altered.
+
+Fixes CVE-2026-24049.
+Upstream Patch Reference: https://github.com/pypa/wheel/commit/7a7d2de96b22a9adf9208afcc9547e1001569fef.patch
+---
+ wheel/cli/unpack.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/wheel/cli/unpack.py b/wheel/cli/unpack.py
+index d48840e..83dc742 100644
+--- a/wheel/cli/unpack.py
++++ b/wheel/cli/unpack.py
+@@ -19,12 +19,12 @@ def unpack(path: str, dest: str = ".") -> None:
+         destination = Path(dest) / namever
+         print(f"Unpacking to: {destination}...", end="", flush=True)
+         for zinfo in wf.filelist:
+-            wf.extract(zinfo, destination)
++            target_path = Path(wf.extract(zinfo, destination))
+ 
+             # Set permissions to the same values as they were set in the archive
+             # We have to do this manually due to
+             # https://github.com/python/cpython/issues/59999
+             permissions = zinfo.external_attr >> 16 & 0o777
+-            destination.joinpath(zinfo.filename).chmod(permissions)
++            target_path.chmod(permissions)
+ 
+     print("OK")
+-- 
+2.45.4
+

--- a/SPECS/python-virtualenv/python-virtualenv.spec
+++ b/SPECS/python-virtualenv/python-virtualenv.spec
@@ -1,7 +1,7 @@
 Summary:        Virtual Python Environment builder
 Name:           python-virtualenv
 Version:        20.26.6
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -13,6 +13,12 @@ Patch1000:      CVE-2025-50181v0.patch
 Patch1001:      CVE-2025-50181v1.patch
 Patch1002:      CVE-2025-50181v2.patch
 Patch1003:      CVE-2025-50181v3.patch
+Patch1004:      CVE-2026-1703v0.patch
+Patch1005:      CVE-2026-1703v1.patch
+Patch1006:      CVE-2026-1703v2.patch
+Patch1007:      CVE-2026-24049v0.patch
+Patch1008:      CVE-2026-24049v1.patch
+Patch1009:      CVE-2026-24049v2.patch
 BuildArch:      noarch
 
 %description
@@ -58,6 +64,8 @@ echo "Manually Patching virtualenv-20.26.6/src/virtualenv/seed/wheels/embed/pip-
 mkdir -p unpacked_pip-24.0-py3-none-any
 unzip src/virtualenv/seed/wheels/embed/pip-24.0-py3-none-any.whl -d unpacked_pip-24.0-py3-none-any
 patch -p1 -d unpacked_pip-24.0-py3-none-any < %{PATCH1000}
+echo "Manually Patching virtualenv-20.26.6/src/virtualenv/seed/wheels/embed/pip-24.0-py3-none-any.whl/pip/_internal/utils/unpacking.py"
+patch -p1 -d unpacked_pip-24.0-py3-none-any < %{PATCH1004}
 # Remove the original file
 rm -f src/virtualenv/seed/wheels/embed/pip-24.0-py3-none-any.whl
 # After patching, re-zip the contents back into a .whl
@@ -70,6 +78,8 @@ echo "Manually Patching virtualenv-20.26.6/src/virtualenv/seed/wheels/embed/pip-
 mkdir -p unpacked_pip-24.2-py3-none-any
 unzip src/virtualenv/seed/wheels/embed/pip-24.2-py3-none-any.whl -d unpacked_pip-24.2-py3-none-any
 patch -p1 -d unpacked_pip-24.2-py3-none-any < %{PATCH1001}
+echo "Manually Patching virtualenv-20.26.6/src/virtualenv/seed/wheels/embed/pip-24.2-py3-none-any.whl/pip/_internal/utils/unpacking.py"
+patch -p1 -d unpacked_pip-24.2-py3-none-any < %{PATCH1005}
 # Remove the original file
 rm -f src/virtualenv/seed/wheels/embed/pip-24.2-py3-none-any.whl
 # After patching, re-zip the contents back into a .whl
@@ -102,6 +112,8 @@ echo "Manually Patching virtualenv-16.7.9-py2.py3-none-any/virtualenv_support/pi
 mkdir -p unpacked_pip-19.3.1-py2.py3-none-any
 unzip unpacked_virtualenv-16.7.9-py2.py3-none-any/virtualenv_support/pip-19.3.1-py2.py3-none-any.whl -d unpacked_pip-19.3.1-py2.py3-none-any
 patch -p1 -d unpacked_pip-19.3.1-py2.py3-none-any < %{PATCH1003}
+echo "Manually Patching virtualenv-16.7.9-py2.py3-none-any/virtualenv_support/pip-19.3.1-py2.py3-none-any.whl/pip/_internal/utils/unpacking.py"
+patch -p1 -d unpacked_pip-19.3.1-py2.py3-none-any < %{PATCH1006}
 # Repack the inner wheel
 rm -f unpacked_virtualenv-16.7.9-py2.py3-none-any/virtualenv_support/pip-19.3.1-py2.py3-none-any.whl
 pushd unpacked_pip-19.3.1-py2.py3-none-any
@@ -114,6 +126,36 @@ rm -f tests/unit/create/virtualenv-16.7.9-py2.py3-none-any.whl
 pushd unpacked_virtualenv-16.7.9-py2.py3-none-any
 zip -r ../tests/unit/create/unpacked_virtualenv-16.7.9-py2.py3-none-any *
 popd
+
+echo "Manually Patching virtualenv-20.26.6/src/virtualenv/seed/wheels/embed/setuptools-75.1.0-py3-none-any.whl/setuptools/_vendor/wheel/cli/unpack.py"
+mkdir -p unpacked_setuptools-75.1.0-py3-none-any
+unzip src/virtualenv/seed/wheels/embed/setuptools-75.1.0-py3-none-any.whl -d unpacked_setuptools-75.1.0-py3-none-any
+patch -p1 -d unpacked_setuptools-75.1.0-py3-none-any < %{PATCH1007}
+rm -f src/virtualenv/seed/wheels/embed/setuptools-75.1.0-py3-none-any.whl
+pushd unpacked_setuptools-75.1.0-py3-none-any
+zip -r ../src/virtualenv/seed/wheels/embed/setuptools-75.1.0-py3-none-any.whl *
+popd
+rm -rf unpacked_setuptools-75.1.0-py3-none-any
+
+echo "Manually Patching virtualenv-20.26.6/src/virtualenv/seed/wheels/embed/wheel-0.42.0-py3-none-any.whl/wheel/cli/unpack.py"
+mkdir -p unpacked_wheel-0.42.0-py3-none-any
+unzip src/virtualenv/seed/wheels/embed/wheel-0.42.0-py3-none-any.whl -d unpacked_wheel-0.42.0-py3-none-any
+patch -p1 -d unpacked_wheel-0.42.0-py3-none-any < %{PATCH1008}
+rm -f src/virtualenv/seed/wheels/embed/wheel-0.42.0-py3-none-any.whl
+pushd unpacked_wheel-0.42.0-py3-none-any
+zip -r ../src/virtualenv/seed/wheels/embed/wheel-0.42.0-py3-none-any.whl *
+popd
+rm -rf unpacked_wheel-0.42.0-py3-none-any
+
+echo "Manually Patching virtualenv-20.26.6/src/virtualenv/seed/wheels/embed/wheel-0.44.0-py3-none-any.whl/wheel/cli/unpack.py"
+mkdir -p unpacked_wheel-0.44.0-py3-none-any
+unzip src/virtualenv/seed/wheels/embed/wheel-0.44.0-py3-none-any.whl -d unpacked_wheel-0.44.0-py3-none-any
+patch -p1 -d unpacked_wheel-0.44.0-py3-none-any < %{PATCH1009}
+rm -f src/virtualenv/seed/wheels/embed/wheel-0.44.0-py3-none-any.whl
+pushd unpacked_wheel-0.44.0-py3-none-any
+zip -r ../src/virtualenv/seed/wheels/embed/wheel-0.44.0-py3-none-any.whl *
+popd
+rm -rf unpacked_wheel-0.44.0-py3-none-any
 
 %generate_buildrequires
 
@@ -136,6 +178,9 @@ tox -e py
 %{_bindir}/virtualenv
 
 %changelog
+* Tue Feb 24 2026 BinduSri Adabala <v-badabala@microsoft.com> - 20.26.6-3
+- Patch for CVE-2026-1703 & CVE-2026-24049
+
 * Wed Jul 09 2025 Aninda Pradhan <v-anipradhan@microsoft.com> - 20.26.6-2
 - Add patch to fix CVE-2025-50181 in urllib3 poolmanager.py
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Patch python-virtualenv for CVE-2026-1703 [Low]:
- Patch modified: Yes
- In` pip-24.2-py3-none-any.whl` [CVE-2026-1703v1.patch] the `news/+1ee322a1.bugfix.rst` new path is not added in patch from upstream patch to maintain compatibility with existing virtualenv cleanup behavior after tightening path validation logic (commonpath). This avoids leaving non-runtime artifacts in site-packages during pip uninstall and allows existing tests to pass without modifying test code.
- Astrolabe patch reference: https://github.com/pypa/pip/commit/8e227a9be4faa9594e05d02ca05a413a2a4e7735.patch

Patch python-virtualenv for CVE-2026-24049 [Medium]:
- Patch modified: Yes
- `docs/news.rst` and `tests/commands/test_unpack.py` files are not present in python-virtualenv source tarball, so patch didn't apply for these two files.
- Astrolabe patch reference: https://github.com/pypa/wheel/commit/7a7d2de96b22a9adf9208afcc9547e1001569fef.patch

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- new file:   ../SPECS/python-virtualenv/CVE-2026-1703v0.patch
- new file:   ../SPECS/python-virtualenv/CVE-2026-1703v1.patch
- new file:   ../SPECS/python-virtualenv/CVE-2026-1703v2.patch
- new file:   ../SPECS/python-virtualenv/CVE-2026-24049v0.patch
- new file:   ../SPECS/python-virtualenv/CVE-2026-24049v1.patch
- new file:   ../SPECS/python-virtualenv/CVE-2026-24049v2.patch
- modified:   ../SPECS/python-virtualenv/python-virtualenv.spec

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2026-1703
- https://nvd.nist.gov/vuln/detail/CVE-2026-24049

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local Build: 
[python-virtualenv-20.26.6-3.cm2.src.rpm.log](https://github.com/user-attachments/files/25537996/python-virtualenv-20.26.6-3.cm2.src.rpm.log)
[python-virtualenv-20.26.6-3.cm2.src.rpm.test.log](https://github.com/user-attachments/files/25538000/python-virtualenv-20.26.6-3.cm2.src.rpm.test.log)
- Patch applies cleanly:
<img width="1353" height="115" alt="image" src="https://github.com/user-attachments/assets/41476618-8cd2-4d5d-8022-f4b63060491f" />
<img width="1306" height="90" alt="image" src="https://github.com/user-attachments/assets/8cb4e743-5032-49c0-a1c0-5abe68ab8941" />
<img width="1362" height="115" alt="image" src="https://github.com/user-attachments/assets/c407f0ba-1860-4b8c-aa92-c8cf0b1faf89" />
<img width="1122" height="60" alt="image" src="https://github.com/user-attachments/assets/55b33f82-c7da-4902-a258-906c68b50c48" />
<img width="1103" height="56" alt="image" src="https://github.com/user-attachments/assets/779cab77-e804-495c-ab67-00bfe3068fae" />
<img width="1032" height="65" alt="image" src="https://github.com/user-attachments/assets/91a35281-679f-4d86-acf1-443a6c1006aa" />

- Installation & Uninstallation check:
<img width="1868" height="445" alt="image" src="https://github.com/user-attachments/assets/99ecd6ea-059b-402f-b3b8-289c15e32c45" />
<img width="1766" height="312" alt="image" src="https://github.com/user-attachments/assets/8ee9de01-4130-4222-b6b9-cff88002c770" />

