### PR TITLE
Resolved ptest failures in `espeak-ng` package

### DIFF
--- a/SPECS/espeak-ng/espeak-ng.spec
+++ b/SPECS/espeak-ng/espeak-ng.spec
@@ -62,8 +62,7 @@ rm -vrf %{buildroot}%{_datadir}/vim/registry
 
 %check
 # Disable parallel build
-%define _smp_mflags -j1
-%make_build check
+%make_build -j1 check
 
 %ldconfig_scriptlets
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Resolved ptest failures in `espeak-ng` package by disabling parallel build in check section.

In brief, during the `espeak-ng` test build, `libtool` attempts to link the espeak test library `src/libespeak-ng-test.la`, which depends on many objects generated from `src/libespeak-ng/*.c`. The build logs show `libtool` compile steps producing PIC objects under `src/libespeak-ng/.lib` and `libtool` wrapper (.lo).
 
However, the error indicates the expected wrapper file `src/libespeak-ng/test_la-translate.lo` is not a valid libtool object, typically meaning the file either does not exist as a proper ".lo" text wrapper or otherwise corrupted. In the test log file, this seems to be the root cause of the issue, where the library is linked before being built. This mismatch commonly occurs when using Automake's subdir-objects with custom suffix rules or parallel/concurrent builds that race on object generation.

###### AI Analysis relevance (In %) / Reasoning <!-- REQUIRED -->
AI Analysis relevance (In %): 99

###### Build/Dependency Information <!-- REQUIRED -->
The PR is a leaf PR which builds alone successfully.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- modified: SPECS/espeak-ng/espeak-ng.spec

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- Work Item: https://dev.azure.com/mariner-org/mariner/_workitems/edit/14940

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build was successful.
<img width="640" height="548" alt="image" src="https://github.com/user-attachments/assets/f688d35d-e7d6-4d1c-ac4d-92b0226c2d5d" />

- Screenshot to confirm that the check section is built serially.
<img width="1880" height="702" alt="image" src="https://github.com/user-attachments/assets/5d068ad1-0404-430f-a54c-88e4c6b8d27b" />

- License check script shows no warning.

- Build logs:
[espeak-ng-1.52.0-2.azl3.src.rpm.log](https://github.com/user-attachments/files/25539073/espeak-ng-1.52.0-2.azl3.src.rpm.log)
[espeak-ng-1.52.0-2.azl3.src.rpm.test.log](https://github.com/user-attachments/files/25539064/espeak-ng-1.52.0-2.azl3.src.rpm.test.log)