### PR TITLE
fix(rubygems): Remove rubygems component (source package)

### DIFF
--- a/base/comps/rubygems/rubygems.comp.toml
+++ b/base/comps/rubygems/rubygems.comp.toml
@@ -1,4 +1,0 @@
-[components.rubygems]
-
-[components.rubygems.build]
-check = { skip = true, skip_reason = "Disabling checks for initial set of failures." }


### PR DESCRIPTION
    Upstream produces the binary (noarch) rpm 'rubygems' from *both* the
    'rubygems' and 'ruby' source packages. In f43, the 'rubygems' rpm
    comes from a successful build of the 'ruby' source package, and the
    'rubygems' source package has never built successfully in f43.
    
    This drops building (or attempting to build) the 'rubygems' source
    package.
    
    Long term, we should work with upstream to fix 'rubygems' rpms coming
    from multiple source packages.
