### PR TITLE
fix(unbound): add dns-root-data source package for missing dep

### DIFF
--- a/base/comps/components-full.toml
+++ b/base/comps/components-full.toml
@@ -197,6 +197,7 @@
 [components.dlm]
 [components.dnf-plugins-core]
 [components.dnsmasq]
+[components.dns-root-data]
 [components.docbook-dtds]
 [components.docbook-style-dsssl]
 [components.docbook-style-xsl]


### PR DESCRIPTION
`dns-root-data` is required by `unbound-libs`, which is required by `gnutls-dane`, which is in turn required by `wget2-libs`, which is required by `wget2.