### PR TITLE
build: add f42 version of fuse3 as well

### DIFF
--- a/base/comps/components-full.toml
+++ b/base/comps/components-full.toml
@@ -275,7 +275,6 @@
 [components.fribidi]
 [components.fsverity-utils]
 [components.fuse-overlayfs]
-[components.fuse3]
 [components.fusesource-pom]
 [components.game-music-emu]
 [components.gavl]

--- a/base/comps/fuse3/fuse3.comp.toml
+++ b/base/comps/fuse3/fuse3.comp.toml
@@ -1,0 +1,6 @@
+[components.fuse3]
+
+# We are temporarily building the Fedora 42 version of fuse3 to aid with bootstrapping
+# issues; notably, Fedora 43 shipped with the *Fedora 42* version of this package.
+[components.fuse3-42]
+spec = { type = "upstream", upstream-name = "fuse3", upstream-distro = { name = "fedora", version = "42" } }


### PR DESCRIPTION
Fedora 43 shipped with Fedora 42 builds of `fuse3`. As a result, our stage 1 builds of AZL4 link against the F42 version of fuse3-libs, whose primary .so is on version 3. But when we build `fuse3` for stage 1, we only build the F43 version, which is on version 4. When we try to assemble an image from stage 1 artifacts, we can't satisfy the requirements for the older .so.

As a stopgap, this attempts to import *both* F42 and F43 versions of fuse3 (separate azl4 component names, but the resulting RPM should have the same name, different versions).