### PR TITLE
feat: add hard-coded 'shim' sources

### DIFF
--- a/base/comps/shim/shim.comp.toml
+++ b/base/comps/shim/shim.comp.toml
@@ -18,17 +18,17 @@ lines = [
 [[components.shim.source-files]]
 filename = "shimx64.efi"
 hash = "7741013d9a24ce554bf6a9df6b776a57b114055e7f80f2bf69c7e1757e2f02f8d2a0b6f3722e33a04ecc81cdd88800ac7b427d4fbde363ac4bf7a49a36f1cc5f"
-hash-type = "sha512"
+hash-type = "SHA512"
 origin = { type = "download", uri = "https://azltempstaginglookaside.blob.core.windows.net/repo/pkgs/shim/shimx64.efi/sha512/7741013d9a24ce554bf6a9df6b776a57b114055e7f80f2bf69c7e1757e2f02f8d2a0b6f3722e33a04ecc81cdd88800ac7b427d4fbde363ac4bf7a49a36f1cc5f/shimx64.efi" }
 
 [[components.shim.source-files]]
 filename = "shimia32.efi"
 hash = "0e3d65da04dde786187e85edbee9550c7ed1e10d40820fb37e46a5e23a769808e36d3e3bbd7edec4deee3065de79e8a798c6ad70218eb80f98c6f29c05c87a76"
-hash-type = "sha512"
+hash-type = "SHA512"
 origin = { type = "download", uri = "https://azltempstaginglookaside.blob.core.windows.net/repo/pkgs/shim/shimia32.efi/sha512/0e3d65da04dde786187e85edbee9550c7ed1e10d40820fb37e46a5e23a769808e36d3e3bbd7edec4deee3065de79e8a798c6ad70218eb80f98c6f29c05c87a76/shimia32.efi" }
 
 [[components.shim.source-files]]
-filename = "shima64.efi"
+filename = "shimaa64.efi"
 hash = "57aa116d1c91a9ec36ab8b46c9164ae19af192bb15a2307269f69e2e838fa3798e310eb49e1c89e5cdceac5a5634028c62570467727ff6e878d3cdea36e84f2d"
-hash-type = "sha512"
+hash-type = "SHA512"
 origin = { type = "download", uri = "https://azltempstaginglookaside.blob.core.windows.net/repo/pkgs/shim/shimaa64.efi/sha512/57aa116d1c91a9ec36ab8b46c9164ae19af192bb15a2307269f69e2e838fa3798e310eb49e1c89e5cdceac5a5634028c62570467727ff6e878d3cdea36e84f2d/shimaa64.efi" }


### PR DESCRIPTION
Adding our own `shim` binaries extracted from the nightly builds of the `shim-unsigned-*` packages.