### PR TITLE
fix(azurelinux-release): workaround for bootstrapping issue

### DIFF
--- a/base/comps/azurelinux-release/azurelinux-release.spec
+++ b/base/comps/azurelinux-release/azurelinux-release.spec
@@ -63,7 +63,10 @@ Requires:       azurelinux-release-common = %{version}-%{release}
 Recommends:     azurelinux-release-identity-basic
 
 
-BuildRequires:  azurelinux-rpm-config
+# For now we depend on `system-rpm-config`, which is provided both by
+# redhat-rpm-config (while bootstrapping) and azurelinux-rpm-config
+# (after bootstrapping).
+BuildRequires:  system-rpm-config
 BuildRequires:  systemd-rpm-macros
 
 %description

--- a/base/comps/components-full.toml
+++ b/base/comps/components-full.toml
@@ -2572,7 +2572,6 @@
 [components.re2c]
 [components.recode]
 [components.redhat-fonts]
-[components.redhat-rpm-config]
 [components.reflections]
 [components.regexp]
 [components.replacer]


### PR DESCRIPTION
`azurelinux-release` depends on `azurelinux-rpm-config`, appropriately. But during stage-1 builds, the latter doesn't yet exist and we always see a build failure. This changes the `BuildRequires` from `azurelinux-release` to be on `system-rpm-config`, which is `Provide`d by *both* `redhat-rpm-config` and `azurelinux-rpm-config`.

The downside is that the stage1 `azurelinux-release` will have been built with upstream macros and not ours.

Also, this stops importing `redhat-rpm-config`. We should not be building it in any stage.