### PR TITLE
fix(vm-base): use vhd-fixed format with force_size for Azure compatility

### DIFF
--- a/base/images/vm-base/vm-base.kiwi
+++ b/base/images/vm-base/vm-base.kiwi
@@ -15,7 +15,8 @@
         <release-version>4.0</release-version>
         <type
             image="oem"
-            format="vhdx"
+            format="vhd-fixed"
+            formatoptions="force_size"
             initrd_system="dracut"
             filesystem="ext4"
             kernelcmdline="console=ttyS0 rd.shell=0"
@@ -25,7 +26,7 @@
             bootpartition="false"
             efipartsize="200">
             <bootloader name="systemd_boot" timeout="0" />
-            <size unit="G">4</size>
+            <size unit="M">4096</size>
             <initrd action="setup">
                 <dracut uefi="true"/>
             </initrd>


### PR DESCRIPTION
This PR switches from `vhdx` to `vhd-fixed` format with `force_size` option to produce a proper fixed VHD with MB-aligned virtual size. Azure requires the VHD virtual size to be an exact whole number of MB.

- Change format from "vhdx" to "vhd-fixed"
- Add formatoptions="force_size" to ensure exact size alignment
- Change disk size from 4G to 4096M for explicit MB specification

Note: With this change, the image has a `.vhdfixed` extension:  `base/out/images/vm-base/azl4-vm-base.x86_64-0.1.vhdfixed`

Validated by building fix sized image, uploading to azure storage account, publishing to SIG and deploy azure VM.