### PR TITLE
workaround(python-jaraco-context): pin to 6.0.1 to avoid missing coherent-licensed dep

### DIFF
--- a/base/comps/components-full.toml
+++ b/base/comps/components-full.toml
@@ -1939,7 +1939,6 @@
 [components.python-cliff]
 [components.python-cligj]
 [components.python-cloudpickle]
-[components.python-coherent-licensed]
 [components.python-coincidence]
 [components.python-colorlog]
 [components.python-colour]

--- a/base/comps/python-jaraco-context/python-jaraco-context.comp.toml
+++ b/base/comps/python-jaraco-context/python-jaraco-context.comp.toml
@@ -1,7 +1,11 @@
 [components.python-jaraco-context]
-
-[components.python-jaraco-context.build]
-# Tests pass (14/14) but require python-jaraco-test >= 5.6.0 (rawhide),
-# while AZL currently has 5.5.0 (f43). Re-enable once python-jaraco-test
-# is updated or pinned to rawhide.
-check = { skip = true, skip_reason = "Disabling checks for initial set of failures." }
+# TODO: Remove snapshot pin once python-coherent-licensed lands in F43 stable (or F44+ is adopted).
+# Pin snapshot to before the broken 6.0.2/6.1.0 updates were pushed to the f43 branch.
+# These updates added a dynamic BuildRequires on python-coherent-licensed, which was never
+# shipped in F43 stable (the Fedora Koji build was trashcanned and the Bodhi update abandoned).
+# The last good f43 version is 6.0.1-9.fc43.
+# Refs:
+#   https://packages.fedoraproject.org/pkgs/python-jaraco-context/python3-jaraco-context/
+#   https://koji.fedoraproject.org/koji/buildinfo?buildID=2919309 (coherent-licensed trashcanned)
+#   https://src.fedoraproject.org/rpms/python-jaraco-context/tree/f43
+spec = { type = "upstream", upstream-distro = { name = "fedora", version = "43", snapshot = "2026-01-05T00:00:00Z" } }


### PR DESCRIPTION
python-jaraco-context 6.1.0 (and 6.0.2) on the Fedora f43 distgit branch introduced a dynamic BuildRequires on python-coherent-licensed via pyproject.toml build-system.requires. However, python-coherent-licensed was never shipped in the Fedora 43 stable or updates repos — the Koji build (https://koji.fedoraproject.org/koji/buildinfo?buildID=2919309) was trashcanned and the Bodhi update was abandoned. This means the f43 branch tip is unbuildable even in Fedora's own infrastructure.

Pin the component snapshot to 2026-01-05 (before the 6.0.2 update was pushed on 2026-01-06), which resolves to version 6.0.1-9.fc43 — the last version that was actually shipped in F43 stable.

This also removes the python-coherent-licensed component that was previously added solely to satisfy this broken dependency, and removes the %check skip since 6.0.1's test extras don't require jaraco-test >= 5.6.0 (that dep was added in 6.0.2+). Tests pass: 9 passed, 1 deselected.

Tested: built locally, smoke-tested in mock chroot (import succeeds, version reports 6.0.1).
