### PR TITLE
fix(openpace): add missing $0 placeholder in install-data-local find -exec calls

### DIFF
--- a/base/comps/components-full.toml
+++ b/base/comps/components-full.toml
@@ -1957,7 +1957,6 @@
 [components.openjpeg]
 [components.openjph]
 [components.openmpi]
-[components.openpace]
 [components.openpgm]
 [components.opensc]
 [components.openslide]

--- a/base/comps/openpace/fix-install-data-local-missing-dollar0.patch
+++ b/base/comps/openpace/fix-install-data-local-missing-dollar0.patch
@@ -1,0 +1,13 @@
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -117,8 +117,8 @@
+ 
+ install-data-local:
+ 	$(INSTALL) -d $(DESTDIR)$(htmldir)
+-	find $(srcdir)/docs -type d -exec sh -c 'for f in $$@; do $(MKDIR_P)            "$(DESTDIR)$(htmldir)/$${f##$(srcdir)/docs/}"; done' {} +
+-	find $(srcdir)/docs -type f -exec sh -c 'for f in $$@; do $(INSTALL_DATA) "$$f" "$(DESTDIR)$(htmldir)/$${f##$(srcdir)/docs/}"; done' {} +
++	find $(srcdir)/docs -type d -exec sh -c 'for f in $$@; do $(MKDIR_P)            "$(DESTDIR)$(htmldir)/$${f##$(srcdir)/docs/}"; done' _ {} +
++	find $(srcdir)/docs -type f -exec sh -c 'for f in $$@; do $(INSTALL_DATA) "$$f" "$(DESTDIR)$(htmldir)/$${f##$(srcdir)/docs/}"; done' _ {} +
+ 
+ uninstall-local:
+ 	rm -rf $(DESTDIR)$(htmldir)

--- a/base/comps/openpace/openpace.comp.toml
+++ b/base/comps/openpace/openpace.comp.toml
@@ -1,0 +1,25 @@
+[components.openpace]
+
+[[components.openpace.overlays]]
+description = """
+Fix install-data-local silently dropping one documentation file per build.
+
+The upstream Makefile.am uses 'find -exec sh -c ... {} +' without a dummy $0
+placeholder. Per POSIX, the first argument after 'sh -c script' becomes $0 and
+is excluded from $@, causing the first file returned by find to be silently
+dropped. Different filesystem types return files in different find order, so
+different files are dropped on x86_64 vs aarch64 builders, causing noarch
+rpmdiff failures in Koji.
+
+TODO: push change to upstream
+"""
+type = "patch-add"
+source = "fix-install-data-local-missing-dollar0.patch"
+
+[[components.openpace.overlays]]
+description = "Apply the install-data-local fix patch after existing patches"
+type = "spec-search-replace"
+section = "%prep"
+regex = '^%patch 1 -p1 -b \.unsupported-tests$'
+replacement = """%patch 1 -p1 -b .unsupported-tests
+%patch 2 -p1"""


### PR DESCRIPTION
## Summary

The `install-data-local` target in openpace's `Makefile.am` uses
`find -exec sh -c '...' {} +` without a dummy `$0` placeholder.
Per POSIX, the first argument after `sh -c script` becomes `$0` and is
excluded from `$@`, causing the first file returned by `find` to be
silently dropped on every build.

This causes noarch rpmdiff failures in Koji because different filesystem
types on x86_64 vs aarch64 builders return files in different `find`
order, so different files are dropped on each architecture.

## The Fix

Add the conventional `_` placeholder as `$0` before `{}` on both
`find` calls in `install-data-local`:

```diff
-find $(srcdir)/docs -type d -exec sh -c '...' {} +
+find $(srcdir)/docs -type d -exec sh -c '...' _ {} +
-find $(srcdir)/docs -type f -exec sh -c '...' {} +
+find $(srcdir)/docs -type f -exec sh -c '...' _ {} +
```

## Alternatives considered

- **`rsync -a`** — simplest but adds a build dependency
- **`find | xargs`** — avoids the `sh -c` `$0` trap but introduces quoting differences
- **`cp -a`** — clearer but loses batching optimization

The minimal `_` fix was chosen as the smallest correct change with no
behavior or dependency changes.

## Verification

**Koji scratch build passed** ✅
- Task ID: **222601**
- Task URL: https://52.249.25.247/koji/taskinfo?taskID=222601
- Both x86_64 and aarch64 `buildArch` tasks closed successfully
- No noarch rpmdiff error — doc files now match across architectures

**Local build verified** with `azldev comp build -p openpace`:
- All 6 RPMs built cleanly
- All 177 doc files present in `openpace-doc` noarch RPM (previously 176)

## References

- POSIX `sh -c` specification: https://pubs.opengroup.org/onlinepubs/9699919799/utilities/sh.html
- ShellCheck SC2156: https://www.shellcheck.net/wiki/SC2156
- Upstream PR: https://github.com/frankmorgner/openpace/pull/TBD
