### PR TITLE
fix(libdeflate): disable mingw bcond to fix noarch rpmdiff failure

### DIFF
--- a/base/comps/components-full.toml
+++ b/base/comps/components-full.toml
@@ -752,7 +752,6 @@
 [components.libdc1394]
 [components.libdca]
 [components.libdecor]
-[components.libdeflate]
 [components.libdex]
 [components.libdicom]
 [components.libdisplay-info]

--- a/base/comps/libdeflate/libdeflate.comp.toml
+++ b/base/comps/libdeflate/libdeflate.comp.toml
@@ -1,0 +1,7 @@
+[components.libdeflate]
+
+[components.libdeflate.build]
+# Disable MinGW cross-compilation subpackages. AZL has no MinGW support and
+# the mingw debuginfo RPMs cause noarch rpmdiff failures due to non-deterministic
+# find ordering in mingw-find-debuginfo.sh across x86_64 and aarch64 builders.
+without = ["mingw"]


### PR DESCRIPTION
## Summary

The `mingw32-libdeflate-debuginfo` noarch RPM differs across x86_64 and
aarch64 because `mingw-find-debuginfo.sh` produces different output when
hardlinked binaries (`libdeflate-gzip.exe` / `libdeflate-gunzip.exe`) are
encountered in different `find` order (filesystem-dependent).

AZL has no MinGW support (zero mingw packages in the curated component
list), so the mingw subpackages are unused artifacts from the Fedora spec.

## The Fix

Disable the `mingw` bcond via a component overlay (`without = ["mingw"]`),
following the same pattern used by `kernel` (`without = ["debug"]`) and
`dnf5` (`without = ["plugin_rhsm"]`).

This passes `--without mingw` to rpmbuild, skipping all 43 lines of
MinGW-specific logic in the spec. No MinGW subpackages are produced,
eliminating the noarch rpmdiff mismatch entirely.

### Before (12+ RPMs including noarch mingw):
- `mingw32-libdeflate`, `mingw32-libdeflate-debuginfo` (noarch — mismatched across arches)
- `libdeflate`, `libdeflate-devel`, `libdeflate-utils`, etc.

### After (6 native RPMs only):
- `libdeflate`, `libdeflate-devel`, `libdeflate-utils`, `libdeflate-debuginfo`, `libdeflate-debugsource`, `libdeflate-utils-debuginfo`

## Files Changed

- `base/comps/libdeflate/libdeflate.comp.toml` — new overlay with `without = ["mingw"]`
- `base/comps/components-full.toml` — removed bare `[components.libdeflate]` (now in dedicated toml)

## Verification

**Koji scratch build passed** ✅
- Task ID: **222659**
- Task URL: https://52.249.25.247/koji/taskinfo?taskID=222659
- Both x86_64 and aarch64 `buildArch` tasks closed successfully
- No noarch rpmdiff error

**Local build verified** with `azldev comp build -p libdeflate`:
- 6 native RPMs produced, zero mingw RPMs
