### PR TITLE
fix(azurelinux-rpm-config): remove pkg-config symlink overlays

### DIFF
--- a/base/comps/azurelinux-rpm-config/azurelinux-rpm-config.comp.toml
+++ b/base/comps/azurelinux-rpm-config/azurelinux-rpm-config.comp.toml
@@ -27,11 +27,6 @@ overlays = [
     { type = "spec-prepend-lines", section = "%install", lines = ["mkdir -p %{buildroot}/usr/lib/rpm", "ln -sf redhat %{buildroot}/usr/lib/rpm/azurelinux"] },
     { type = "spec-prepend-lines", section = "%files", lines = ["/usr/lib/rpm/azurelinux"] },
 
-    # Create a symlink pkg-config: /usr/bin/<arch>-azurelinux-linux-gnu-pkg-config -> /usr/bin/<arch>-redhat-linux-gnu-pkg-config.
-    # TODO: remove symlinks after bootstrap
-    { type = "spec-prepend-lines", section = "%install", lines = ["mkdir -p %{buildroot}/usr/bin", "for arch in x86_64 aarch64; do", "  ln -sf ${arch}-redhat-linux-gnu-pkg-config %{buildroot}/usr/bin/${arch}-azurelinux-linux-gnu-pkg-config", "done"] },
-    { type = "spec-prepend-lines", section = "%files", lines = ["/usr/bin/*-azurelinux-linux-gnu-pkg-config"] },
-
     #
     # Overlays for non-spec files.
     #


### PR DESCRIPTION
The `/usr/bin/<arch>-azurelinux-linux-gnu-pkg-config` symlinks conflict with `pkgconf-pkg-config` which owns the same paths. These symlinks were added as a bootstrap workaround and are no longer needed.

Validated by building an image successfully and booting both azure and QEMU VMs.

