### PR TITLE
fix: disable python-stestr doc generation to fix build

### DIFF
--- a/base/comps/components-full.toml
+++ b/base/comps/components-full.toml
@@ -2409,7 +2409,6 @@
 [components.python-stack-data]
 [components.python-starlette]
 [components.python-statsmodels]
-[components.python-stestr]
 [components.python-stevedore]
 [components.python-strict-rfc3339]
 [components.python-sure]

--- a/base/comps/python-stestr/python-stestr.comp.toml
+++ b/base/comps/python-stestr/python-stestr.comp.toml
@@ -1,0 +1,11 @@
+[components.python-stestr]
+
+# cliff.sphinxext uses argparse.HelpFormatter._format_actions_usage, a private API
+# removed in Python 3.14. This crashes sphinx-build during %build when generating docs.
+# Disable doc generation while we figure out what to do about this.
+# Fixed in cliff: https://opendev.org/openstack/cliff/commit/391261c849c994ca2d3f42926497e633047ed8c7
+[[components.python-stestr.overlays]]
+description = "Disable doc generation — cliff.sphinxext is incompatible with Python 3.14 (uses removed argparse._format_actions_usage)"
+type = "spec-search-replace"
+regex = '^%global with_doc 1$'
+replacement = '%global with_doc 0'


### PR DESCRIPTION
`python-cliff` in Fedora has not yet been updated with a [fix ](https://opendev.org/openstack/cliff/commit/391261c849c994ca2d3f42926497e633047ed8c7) for `python3.14`. This breaks doc generation for `python-stestr`. For now, disable doc generation.