### PR TITLE
 Revert removal of Fedora repos from kiwi image definitions

### DIFF
--- a/base/images/container-base/container-base.kiwi
+++ b/base/images/container-base/container-base.kiwi
@@ -21,6 +21,11 @@
         </type>
     </preferences>
 
+    <repository type="rpm-md" alias="fedora-43-everything">
+        <source
+            path="https://fedora.mirrorservice.org/fedora/linux/releases/43/Everything/x86_64/os/" />
+    </repository>
+
     <packages type="image">
         <!-- Core group -->
         <package name="basesystem" />

--- a/base/images/vm-base/vm-base.kiwi
+++ b/base/images/vm-base/vm-base.kiwi
@@ -33,6 +33,11 @@
         </type>
     </preferences>
 
+    <repository type="rpm-md" alias="fedora-43-everything">
+        <source
+            path="https://fedora.mirrorservice.org/fedora/linux/releases/43/Everything/x86_64/os/" />
+    </repository>
+
     <packages type="image">
         <!-- Core group -->
         <package name="azurelinux-release" />


### PR DESCRIPTION
Description:

Reverts the removal of Fedora 43 repository entries from [container-base.kiwi](vscode-file://vscode-app/c:/Users/himajakesari/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [vm-base.kiwi](vscode-file://vscode-app/c:/Users/himajakesari/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).

Why
Removing the repos from the kiwi files broke the default azldev image build workflow. Without inline repos, users were forced to pass --remote-repo and --remote-repo-no-gpgcheck on every build:

Kiwi image definitions should be self-contained so that [azldev image build <name>](vscode-file://vscode-app/c:/Users/himajakesari/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) works out of the box. The --remote-repo flag is intended for supplemental repos, not as a replacement for the base package source.