### PR TITLE
support aarch64 kiwi

### DIFF
--- a/base/images/vm-base/vm-base.kiwi
+++ b/base/images/vm-base/vm-base.kiwi
@@ -35,7 +35,7 @@
 
     <repository type="rpm-md" alias="fedora-43-everything">
         <source
-            path="https://fedora.mirrorservice.org/fedora/linux/releases/43/Everything/x86_64/os/" />
+            path="https://fedora.mirrorservice.org/fedora/linux/releases/43/Everything/$arch/os/" />
     </repository>
 
     <packages type="image">
@@ -125,9 +125,12 @@
     <packages type="bootstrap">
         <package name="dracut-network" />
         <package name="filesystem" />
-        <package name="grub2-efi-x64-modules" />
-        <package name="grub2-efi-x64" />
+        <package name="grub2-efi-x64-modules" arch="x86_64" />
+        <package name="grub2-efi-x64" arch="x86_64" />
+        <package name="grub2-efi-aa64-modules" arch="aarch64" />
+        <package name="grub2-efi-aa64" arch="aarch64" />
         <package name="shim" arch="x86_64" />
+        <package name="shim" arch="aarch64" />
     </packages>
 
     <!--


### PR DESCRIPTION
Modify the kiwi file to support both arm64 and x86 kiwi image builds

working runs: 
https://52.249.25.247/koji/taskinfo?taskID=222892
https://52.249.25.247/koji/taskinfo?taskID=222891