### PR TITLE
workaround(azurelinux-release): disable autorelease to avoid parse error in koji

### DIFF
--- a/base/comps/azurelinux-release/azurelinux-release.spec
+++ b/base/comps/azurelinux-release/azurelinux-release.spec
@@ -1,4 +1,4 @@
-%define release_name "Alpha1"
+%define release_name Alpha1
 %define is_evergreen 0
 
 # Define this to 1 for Branched releases prior to RC


### PR DESCRIPTION
This cleans up some metadata and also works around an issues we're seeing with rpmautospec in koji parsing the spec.