### PR TITLE
workaround(azurelinux-release): simplify spec to address rpmautospec errors

### DIFF
--- a/base/comps/azurelinux-release/azurelinux-release.spec
+++ b/base/comps/azurelinux-release/azurelinux-release.spec
@@ -33,10 +33,8 @@
 Summary:        Azure Linux release files
 Name:           azurelinux-release
 Version:        4.0
-# The numbering is 0.<r> before a given release is released,
-# and then just <r>.
-# TODO(azl): Review whether -p should be passed to %autorelease for development builds.
-Release:        %autorelease
+# TODO(azl): Review whether we can move back to autorelease (with conditional -p)
+Release:        2%{?dist}
 License:        MIT
 URL:            https://aka.ms/azurelinux
 
@@ -274,14 +272,11 @@ ln -s azurelinux-release %{buildroot}%{_sysconfdir}/system-release
 %global dist_debuginfod_url ima:enforcing https://debuginfod.microsoft.com/ ima:ignore
 # -------------------------------------------------------------------------
 
-# Set the RELEASE_TYPE appropriately
-%define release_type %[0%{?is_development} ? "development" : "stable"]
-
-# TODO(azl): review
+# TODO(azl): review; dynamically generate RELEASE_TYPE from release_type macro
 cat <<EOF >os-release
 NAME="%{dist_name}"
 VERSION="%{dist_version} (%{release_name}%{?prerelease})"
-RELEASE_TYPE=%{release_type}
+RELEASE_TYPE=development
 ID=azurelinux
 VERSION_ID=%{dist_version}
 VERSION_CODENAME=""
@@ -452,4 +447,5 @@ install -Dm0644 %{SOURCE16} -t %{buildroot}%{_prefix}/share/dnf5/libdnf.conf.d/
 
 
 %changelog
-%autochangelog
+* Fri Feb 27 2026 Reuben Olinsky <reubeno@microsoft.com> - 4.0-2
+- Initial version


### PR DESCRIPTION
We're seeing what looks like issues with ternary operators in rpmautospec on `koji` as well as `%autorelease` showing up in comments. I can't reproduce it locally but confirmed this update gets things working in koji.