### PR TITLE
feat(rpmautospec): include building python-rpmautospec

### DIFF
--- a/base/comps/components-full.toml
+++ b/base/comps/components-full.toml
@@ -2631,6 +2631,7 @@
 [components.python-roman-numerals-py]
 [components.python-rpds-py]
 [components.python-rpm-generators]
+[components.python-rpmautospec]
 [components.python-rpmautospec-core]
 [components.python-rsa]
 [components.python-rst-linker]


### PR DESCRIPTION
Add the `python-rpmautospec` package into our build, as we need its functionality in our koji builds.