### PR TITLE
workaround(lilv): pin to Fedora 43 snapshot to fix sord version mismatch

### DIFF
--- a/base/comps/components-full.toml
+++ b/base/comps/components-full.toml
@@ -1049,7 +1049,6 @@
 [components.libxslt]
 [components.libyuv]
 [components.libzip]
-[components.lilv]
 [components.linkchecker]
 [components.linux-atm]
 [components.linuxconsoletools]

--- a/base/comps/lilv/lilv.comp.toml
+++ b/base/comps/lilv/lilv.comp.toml
@@ -1,0 +1,4 @@
+[components.lilv]
+# Pin to a Fedora 43 snapshot that predates the lilv 0.26.x update, which requires sord >= 0.16.20.
+# The build tag currently has sord 0.16.18. Remove the snapshot once sord is updated to >= 0.16.20.
+spec = { type = "upstream", upstream-distro = { name = "fedora", version = "43", snapshot = "2025-06-01T00:00:00-08:00" } }


### PR DESCRIPTION
lilv 0.26.2 (current Fedora 43 HEAD) requires sord >= 0.16.20, but the build tag only has sord 0.16.18. Pin lilv to a pre-update snapshot (2025-06-01) which pulls lilv 0.24.26, compatible with sord >= 0.16.16.

Remove the snapshot once sord is updated to >= 0.16.20 in the build tag.
