### PR TITLE
workaround(rust-podman-sequoia): fix clang-sys runtime feature unification panic

### DIFF
--- a/base/comps/components-full.toml
+++ b/base/comps/components-full.toml
@@ -3226,7 +3226,6 @@
 [components.rust-pin-project-lite]
 [components.rust-pin-utils]
 [components.rust-pkg-config]
-[components.rust-podman-sequoia]
 [components.rust-potential_utf]
 [components.rust-powerfmt]
 [components.rust-powerfmt-macros]

--- a/base/comps/rust-podman-sequoia/enable-dlwrap-clang-runtime.patch
+++ b/base/comps/rust-podman-sequoia/enable-dlwrap-clang-runtime.patch
@@ -1,0 +1,10 @@
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -98,6 +98,7 @@
+ 
+ [build-dependencies.dlwrap]
+ version = "0.3.7"
++features = ["clang-runtime"]
+ 
+ [build-dependencies.regex]
+ version = "1"

--- a/base/comps/rust-podman-sequoia/rust-podman-sequoia.comp.toml
+++ b/base/comps/rust-podman-sequoia/rust-podman-sequoia.comp.toml
@@ -1,0 +1,25 @@
+[components.rust-podman-sequoia]
+
+# Fix build failure: clang-sys "runtime" feature unification causes panic
+# in dlwrap's build script because libclang is loaded via dlopen but
+# clang_sys::load() is never called.
+#
+# When bindgen (a transitive build-dep) enables clang-sys/runtime, Cargo
+# feature unification applies it to the shared clang-sys instance used by
+# dlwrap's clang dependency. But without dlwrap's clang-runtime feature,
+# the clang crate doesn't know to call load() first — causing a panic:
+#   "a `libclang` shared library is not loaded on this thread"
+#
+# The clang-runtime feature (added in dlwrap 0.3.9) propagates the runtime
+# feature through clang and clang-sys, ensuring load() is called.
+#
+# Fedora hit the same issue with 0.2.0-4.fc44 mass rebuild and resolved
+# it by bumping to 0.3.2 and adding the equivalent patch to enable building 
+# dlwrap with the clang-runtime feature in the podman-sequoia toml:
+#   https://src.fedoraproject.org/rpms/rust-podman-sequoia/c/7f0694fa51b07b8d1f2cb839f685365731306a1b?branch=f44
+# Upstream podman-sequoia change:
+#   https://github.com/ueno/podman-sequoia/commit/9bedf62e6d538c1c28b7e7fbece0113c5a151d18
+[[components.rust-podman-sequoia.overlays]]
+description = "Enable dlwrap clang-runtime feature to fix libclang loading panic caused by Cargo feature unification with bindgen"
+type = "patch-add"
+source = "enable-dlwrap-clang-runtime.patch"


### PR DESCRIPTION
Enable dlwrap's clang-runtime feature to fix a build failure caused by Cargo feature unification. When bindgen enables clang-sys/runtime, the runtime feature propagates to dlwrap's clang dependency, but without clang-runtime enabled, clang_sys::load() is never called — causing a panic: 'a libclang shared library is not loaded on this thread'.

This matches Fedora f43's approach (rust-dlwrap built with -f clang-runtime).

- Move rust-podman-sequoia from inline components-full.toml to dedicated comp.toml with a patch-add overlay
- Add enable-dlwrap-clang-runtime.patch to set features = ["clang-runtime"] on the dlwrap build-dependency in Cargo.toml

This workaround goes away when we move to a newer version of `podman-sequoia` that contains this type of patch. See upstream patch - https://github.com/ueno/podman-sequoia/commit/9bedf62e6d538c1c28b7e7fbece0113c5a151d18