### PR TITLE
workaround(azurelinux-repos): non-existent repos

### DIFF
--- a/base/comps/azurelinux-repos/azurelinux.repo
+++ b/base/comps/azurelinux-repos/azurelinux.repo
@@ -8,7 +8,7 @@ repo_gpgcheck=1
 type=rpm
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-azurelinux-$releasever-$basearch
-skip_if_unavailable=False
+skip_if_unavailable=True
 
 [azurelinux-debuginfo]
 name=Azure Linux $releasever - $basearch - Debug
@@ -19,7 +19,7 @@ repo_gpgcheck=1
 type=rpm
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-azurelinux-$releasever-$basearch
-skip_if_unavailable=False
+skip_if_unavailable=True
 
 [azurelinux-source]
 name=Azure Linux $releasever - Source
@@ -30,4 +30,4 @@ repo_gpgcheck=1
 type=rpm
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-azurelinux-$releasever-$basearch
-skip_if_unavailable=False
+skip_if_unavailable=True


### PR DESCRIPTION
The repos listed in `azurelinux-repos` don't yet exist, but the structure is appropriate. As a workaround, we mark the repos as being ignorable if they 404.

This will allow us to additively inject custom `.repo` files that point to koji dist-release repos for development purposes.