### PR TITLE
workaround(psutils): disable gnulib unbundling to fix build failure

### DIFF
--- a/base/comps/components-full.toml
+++ b/base/comps/components-full.toml
@@ -2099,7 +2099,6 @@
 [components.protobuf]
 [components.protozero]
 [components.prrte]
-[components.psutils]
 [components.pugixml]
 [components.pulseaudio]
 [components.py3c]

--- a/base/comps/psutils/psutils.comp.toml
+++ b/base/comps/psutils/psutils.comp.toml
@@ -1,0 +1,23 @@
+[components.psutils]
+
+# Disable gnulib unbundling to use the bundled gnulib copy (same as RHEL).
+#
+# Fedora's gnulib-devel 0-55 (f43-updates) has a packaging bug where
+# gnulib-tool.py expects .gnulib-tool.py adjacent to itself in /usr/bin/,
+# but the gnulib spec installs it to /usr/share/gnulib/ instead. This
+# causes a build failure in %prep:
+#
+#   python3: can't open file '/usr/bin/.gnulib-tool.py': [Errno 2] No such file or directory
+#
+# Fedora hasn't hit this yet because no package has been rebuilt against
+# gnulib-0-55 (the fc44 mass-rebuild still used gnulib-0-52 from fc42).
+#
+# Using bundled gnulib is safe — upstream psutils already ships a gnulib
+# snapshot in its tarball, and the unbundling only replaces the
+# relocatable-perl module with a system copy.
+#
+# Undo this TEMPORARY WORKAROUND when upstream Fedora gnulib packaging is fixed.
+# We will generally want to follow Fedora's Bundled Libraries Policy, which
+# strongly discourages shipping bundled copies of libraries/code.
+[components.psutils.build]
+without = ["psutils_enables_unbundling_gnulib"]


### PR DESCRIPTION
Fedora's gnulib-devel 0-55 (f43-updates) has a packaging bug where gnulib-tool.py expects .gnulib-tool.py in /usr/bin/ but the gnulib spec installs it to /usr/share/gnulib/, causing psutils %prep to fail with:

  python3: can't open file '/usr/bin/.gnulib-tool.py': No such file or directory

Fedora F43 mass rebuild built fine because F43 initially shipped with gnulib-devel 0-52 which did not have this packaging problem.

Disable the psutils_enables_unbundling_gnulib bcond (matching RHEL behavior) so the bundled gnulib snapshot is used instead. This gates both the gnulib-devel BuildRequires and the gnulib-tool --import call in %prep, so no additional overlays are needed.

This workaround will need to be removed once gnulib-tool.py packaging is fixed in upstream Fedora. Ideally we want to unbundle libraries in accordance with Fedora's packaging guidelines and allow for faster CVE resolution for CVEs found in gnulib across the entire distribution.