### PR TITLE
workaround(libspf2): disable doxygen call graphs to fix noarch rpmdiff failure

### DIFF
--- a/base/comps/components-full.toml
+++ b/base/comps/components-full.toml
@@ -997,7 +997,6 @@
 [components.libsoup]
 [components.libspatialite]
 [components.libspectre]
-[components.libspf2]
 [components.libspiro]
 [components.libspng]
 [components.libsrtp]

--- a/base/comps/libspf2/disable-call-graphs.patch
+++ b/base/comps/libspf2/disable-call-graphs.patch
@@ -1,0 +1,23 @@
+Subject: Disable doxygen call graphs for reproducible noarch builds
+
+Doxygen's SHORT_NAMES numbering is non-deterministic across different
+filesystems/hosts due to readdir() ordering affecting the global
+first-come-first-served counter in convertNameToFile(). This causes
+call graph filenames (*_cgraph.map/md5/png) to differ between
+architectures, breaking Koji's noarch rpmdiff check.
+
+Disable CALL_GRAPH to remove the non-deterministic output files.
+The HTML pages, class/file indexes, and all textual content are
+unaffected.
+
+--- a/Doxyfile.in
++++ b/Doxyfile.in
+@@ -1122,7 +1122,7 @@
+ # So in most cases it will be better to enable call graphs for selected 
+ # functions only using the \callgraph command.
+ 
+-CALL_GRAPH             = YES
++CALL_GRAPH             = NO
+ 
+ # If the GRAPHICAL_HIERARCHY and HAVE_DOT tags are set to YES then doxygen 
+ # will graphical hierarchy of all classes instead of a textual one.

--- a/base/comps/libspf2/libspf2.comp.toml
+++ b/base/comps/libspf2/libspf2.comp.toml
@@ -1,0 +1,51 @@
+[components.libspf2]
+
+# Disable doxygen call graphs to fix noarch rpmdiff failure.
+#
+# Root cause: doxygen's SHORT_NAMES numbering (a00001, a00002, ...) is assigned
+# via a global first-come-first-served counter (g_usedNamesCount in util.cpp's
+# convertNameToFile()). The number depends on the order convertNameToFile() is
+# called, which is influenced by:
+#
+#   1. readDir() in doxygen.cpp iterates directories via DirIterator (dir.cpp),
+#      which wraps ghc::filesystem::directory_iterator — i.e. POSIX readdir().
+#      readdir() order is filesystem/host-dependent and not guaranteed by POSIX.
+#
+#   2. Although doxygen sorts the discovered file list (dirResultList and
+#      inputNameLinkedMap) before parsing, the output generation phase calls
+#      convertNameToFile() through multi-threaded pipelines (generateFileSources,
+#      generateFileDocs, generateClassDocs all use ThreadPool) and hash-based
+#      containers (std::unordered_map/set), making call order non-deterministic.
+#
+# AZL's x86_64 and aarch64 builders have different filesystem configurations
+# that produce different readdir() ordering, causing the call graph files
+# (*_cgraph.map/md5/png) in the noarch -apidocs subpackage to have different
+# short-name sequences on each architecture. This triggers Koji's noarch
+# rpmdiff check.
+#
+# The call graphs are not essential to the API documentation — the HTML pages,
+# class/file indexes, and all textual content remain identical. Disabling
+# CALL_GRAPH and CALLER_GRAPH removes the nondeterministic files entirely.
+#
+# This is an upstream doxygen design issue (no known upstream bug filed).
+# A proper fix would require doxygen to derive SHORT_NAMES numbers from a
+# deterministic function of the input name (e.g. hashing) rather than a
+# global counter.
+# 
+# This overlay is a TEMPORARY WORKAROUND until the upstream doxygen issue is
+# addressed and the fix makes it into the distribution's doxygen package.
+
+[[components.libspf2.overlays]]
+type = "patch-add"
+description = "Disable doxygen call graphs to fix noarch rpmdiff failure caused by readdir() nondeterminism in SHORT_NAMES numbering"
+source = "disable-call-graphs.patch"
+
+# The spec uses explicit %patch calls (not %autopatch/%patchlist), so patch-add
+# only registers the Patch tag — we need to apply it ourselves.
+[[components.libspf2.overlays]]
+type = "spec-append-lines"
+section = "%prep"
+description = "Apply the disable-call-graphs patch"
+lines = [
+    "%patch -P4 -p1",
+]


### PR DESCRIPTION
Add a dedicated comp.toml for libspf2 with a patch-add overlay that sets
CALL_GRAPH=NO in Doxyfile.in, plus a spec-append-lines overlay to apply
the patch in %prep. This eliminates nondeterministic SHORT_NAMES-numbered
call graph files (*_cgraph.map/md5/png) that differ between x86_64 and
aarch64 builders, causing Koji's noarch rpmdiff check to fail.

Root cause: doxygen's convertNameToFile() in util.cpp assigns SHORT_NAMES
numbers via a global first-come-first-served counter (g_usedNamesCount).
The call order is influenced by POSIX readdir() nondeterminism in file
discovery and multi-threaded output generation pipelines, making the
numbering host/architecture-dependent. AZL's overlayfs-backed builders
surface this nondeterminism; Fedora's tmpfs-backed builders do not. This
is an upstream doxygen design issue with no known fix.

The inline [components.libspf2] entry is moved from components-full.toml
to a dedicated base/comps/libspf2/libspf2.comp.toml file to house the
overlay and patch.

This overlay is a TEMPORARY WORKAROUND until the upstream doxygen
issue is addressed and the fix makes it into the distribution's doxygen
package.