### PR TITLE
fix: use 'git' protocol for dist-git mirror

### DIFF
--- a/overrides/fedora.distro.azl.sources.toml
+++ b/overrides/fedora.distro.azl.sources.toml
@@ -1,3 +1,3 @@
 [distros.fedora]
-dist-git-base-uri = "https://azl.src.kojiaks.internal/rpms/$pkg.git"
+dist-git-base-uri = "git://azl.src.kojiaks.internal/rpms/$pkg.git"
 lookaside-base-uri = "https://azltempstaginglookaside.blob.core.windows.net/repo/pkgs/$pkg/$filename/$hashtype/$hash/$filename"


### PR DESCRIPTION
Fixing invalid protocol set for the dist-git mirror in #16030. The HTTPS option is not available, yet.