### PR TITLE
fix(mock-ccache): set mock ccache to default to disabled

### DIFF
--- a/distro/mock/azl4/stage1/azurelinux-4.0.tpl
+++ b/distro/mock/azl4/stage1/azurelinux-4.0.tpl
@@ -8,7 +8,7 @@ config_opts['chroot_setup_cmd'] = 'install @{% if mirrored %}buildsys-{% endif %
 config_opts['log_config_file'] = '/etc/mock/logging.ini'
 
 # Plugin config
-config_opts['plugin_conf']['ccache_enable'] = True
+config_opts['plugin_conf']['ccache_enable'] = False
 
 # Failure behavior
 config_opts['cleanup_on_success'] = False

--- a/distro/mock/azl4/stage2/azurelinux-4.0.tpl
+++ b/distro/mock/azl4/stage2/azurelinux-4.0.tpl
@@ -32,7 +32,6 @@ config_opts['chroot_setup_cmd'] += ' xz'
 config_opts['log_config_file'] = '/etc/mock/logging.ini'
 
 # Plugin config
-# NOTE: We disable ccache until its dependencies are available for stage2.
 config_opts['plugin_conf']['ccache_enable'] = False
 
 # Failure behavior


### PR DESCRIPTION
Some packages (e.g. java-25-openjdk-portable) refuse to be built with ccache. Additionally, using ccache is not likely to yield speed improvements in the default case; only repeated same-package builds with no between-build cleaning would benefit. So this defaults to disabling the mock ccache plugin.

The mock ccache plugin can be enabled on a per-build basis with the azldev parameter like:

azldev comp build --mock-config-opt enable-plugin=ccache ...
