### PR TITLE
fix(systemd): disable Xen support to fix missing xen-devel build dependency

### DIFF
--- a/base/comps/systemd/systemd.comp.toml
+++ b/base/comps/systemd/systemd.comp.toml
@@ -15,3 +15,15 @@ description = "Lower Conflicts on setup from 2.15.0-3 to 2.15.0-1 to match AZL's
 type = "spec-search-replace"
 regex = '^Conflicts:\s+setup < 2\.15\.0-3$'
 replacement = "Conflicts:      setup < 2.15.0-1"
+
+[[components.systemd.overlays]]
+description = "Remove xen-devel BuildRequires — not available in AZL (AZL targets Hyper-V/Azure, not Xen)"
+type = "spec-remove-tag"
+tag = "BuildRequires"
+value = "xen-devel"
+
+[[components.systemd.overlays]]
+description = "Disable Xen in meson — set have_xen to 0 so -Dxenctrl=disabled (no targeted overlay for %global)"
+type = "spec-search-replace"
+regex = '%global have_xen 1'
+replacement = "%global have_xen 0"


### PR DESCRIPTION
The upstream Fedora systemd spec (258.4) gates Xen support behind `%if 0%{?fedora}`, which is true in AZL because azurelinux-release defines `%fedora 43` in macros.dist for broad Fedora spec compatibility. Since AZL does not ship xen-devel (Azure Linux targets Hyper-V, not Xen), the BuildRequires on xen-devel fails dependency resolution (mock exit status 30).

Add two overlays:
- spec-remove-tag: remove BuildRequires on xen-devel
- spec-search-replace: set %global have_xen 0 so meson gets -Dxenctrl=disabled

This matches RHEL's approach — Fedora explicitly gates xen-devel behind `%if 0%{?fedora}` because RHEL/CentOS do not build Xen support either.