### PR TITLE
fix: add opencsd to TOMLs

### DIFF
--- a/base/comps/components-full.toml
+++ b/base/comps/components-full.toml
@@ -1302,6 +1302,7 @@
 [components.openbox]
 [components.opencl-headers]
 [components.opencore-amr]
+[components.opencsd]
 [components.opendmarc]
 [components.openexr2]
 [components.openfec]


### PR DESCRIPTION
aarch64 builds of `kernel` have a `BuildRequires` against `opencsd-devel`, which is built from `opencsd.spec.`

From manual inspection, I see no other new transitive build or runtime dependencies.