### PR TITLE
workaround: disable gdal for now

### DIFF
--- a/base/comps/components-full.toml
+++ b/base/comps/components-full.toml
@@ -297,7 +297,8 @@
 [components.gcr]
 [components.gcr3]
 [components.gd]
-[components.gdal]
+# WORKAROUND: Disable gdal to avoid it crashing koji builders.
+# [components.gdal]
 [components.gdb]
 [components.gdcm]
 [components.gdk-pixbuf2]


### PR DESCRIPTION
We're still seeing OOM crash loops building `gdal`; let's disable it for now.