### PR TITLE
Fix ptest for subunit

### DIFF
--- a/SPECS/subunit/subunit.spec
+++ b/SPECS/subunit/subunit.spec
@@ -198,8 +198,7 @@ touch -r c++/SubunitTestProgressListener.h \
 
 %check
 %if %{without bootstrap}
-pip3 install "testtools == 2.7.2"
-pip3 install iso8601 testscenarios fixtures
+pip3 install "testtools <= 2.7.2" iso8601 testscenarios fixtures
 # Run the tests for python3
 export LD_LIBRARY_PATH=$PWD/.libs
 export PYTHON=%{python3}


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Fixed ptest failure for subunit
Work item: https://dev.azure.com/mariner-org/mariner/_workitems/edit/16237

The test failure is caused by a version incompatibility between testtools and subunit. During import, `subunit/tests/test_test_protocol.py` tries to import legacy testtools doubles `Python26TestResult` and `Python27TestResult`. In current environments with `testtools>=2.8.0`, these legacy classes have been removed/renamed (error hint suggests 'Python3TestResult').
So forcibly installing the compatible version of testtools in %check section

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- subunit.spec

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-YYYY-XXXX

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local Build
<img width="807" height="477" alt="Screenshot 2026-03-05 093020" src="https://github.com/user-attachments/assets/16d7334d-fa16-4c82-9d74-5e4fe1c60c46" />
