### PR TITLE
systemd: add patches to correct ipc dbus communication issue

### DIFF
--- a/SPECS/systemd/ipc-0001-path-util-add-flavour-of-path_startswith-that-leaves.patch
+++ b/SPECS/systemd/ipc-0001-path-util-add-flavour-of-path_startswith-that-leaves.patch
@@ -1,0 +1,173 @@
+From 69fd960a8d5a5aad6874cc11be6dc258ae7eef23 Mon Sep 17 00:00:00 2001
+From: Lennart Poettering <lennart@poettering.net>
+Date: Mon, 19 May 2025 12:58:52 +0200
+Subject: [PATCH 1/4] path-util: add flavour of path_startswith() that leaves a
+ leading slash in place
+
+(cherry picked from commit ee19edbb9f3455db3f750089082f3e5a925e3a0c)
+(cherry picked from commit 20021e7686426052e3a7505425d7e12085feb2a6)
+---
+ src/basic/fs-util.c       |  2 +-
+ src/basic/mkdir.c         |  4 ++--
+ src/basic/path-util.c     | 39 ++++++++++++++++++++++++++++-----------
+ src/basic/path-util.h     | 10 ++++++++--
+ src/test/test-path-util.c | 16 ++++++++++++++++
+ 5 files changed, 55 insertions(+), 16 deletions(-)
+
+diff --git a/src/basic/fs-util.c b/src/basic/fs-util.c
+index 552986f546..8b2f6cc087 100644
+--- a/src/basic/fs-util.c
++++ b/src/basic/fs-util.c
+@@ -67,7 +67,7 @@ int rmdir_parents(const char *path, const char *stop) {
+                 assert(*slash == '/');
+                 *slash = '\0';
+ 
+-                if (path_startswith_full(stop, p, /* accept_dot_dot= */ false))
++                if (path_startswith_full(stop, p, /* flags= */ 0))
+                         return 0;
+ 
+                 if (rmdir(p) < 0 && errno != ENOENT)
+diff --git a/src/basic/mkdir.c b/src/basic/mkdir.c
+index 6e2b94d024..454739679c 100644
+--- a/src/basic/mkdir.c
++++ b/src/basic/mkdir.c
+@@ -92,7 +92,7 @@ int mkdir_parents_internal(const char *prefix, const char *path, mode_t mode, ui
+         assert(_mkdirat != mkdirat);
+ 
+         if (prefix) {
+-                p = path_startswith_full(path, prefix, /* accept_dot_dot= */ false);
++                p = path_startswith_full(path, prefix, /* flags= */ 0);
+                 if (!p)
+                         return -ENOTDIR;
+         } else
+@@ -137,7 +137,7 @@ int mkdir_parents_internal(const char *prefix, const char *path, mode_t mode, ui
+ 
+                 s[n] = '\0';
+ 
+-                if (!prefix || !path_startswith_full(prefix, path, /* accept_dot_dot= */ false)) {
++                if (!prefix || !path_startswith_full(prefix, path, /* flags= */ 0)) {
+                         r = mkdir_safe_internal(path, mode, uid, gid, flags, _mkdirat);
+                         if (r < 0 && r != -EEXIST)
+                                 return r;
+diff --git a/src/basic/path-util.c b/src/basic/path-util.c
+index 4c952d863c..9b44d5735c 100644
+--- a/src/basic/path-util.c
++++ b/src/basic/path-util.c
+@@ -424,8 +424,8 @@ int path_simplify_and_warn(
+         return 0;
+ }
+ 
+-char *path_startswith_full(const char *path, const char *prefix, bool accept_dot_dot) {
+-        assert(path);
++char* path_startswith_full(const char *original_path, const char *prefix, PathStartWithFlags flags) {
++        assert(original_path);
+         assert(prefix);
+ 
+         /* Returns a pointer to the start of the first component after the parts matched by
+@@ -438,28 +438,45 @@ char *path_startswith_full(const char *path, const char *prefix, bool accept_dot
+          * Returns NULL otherwise.
+          */
+ 
++        const char *path = original_path;
++
+         if ((path[0] == '/') != (prefix[0] == '/'))
+                 return NULL;
+ 
+         for (;;) {
+                 const char *p, *q;
+-                int r, k;
++                int m, n;
+ 
+-                r = path_find_first_component(&path, accept_dot_dot, &p);
+-                if (r < 0)
++                m = path_find_first_component(&path, FLAGS_SET(flags, PATH_STARTSWITH_ACCEPT_DOT_DOT), &p);
++                if (m < 0)
+                         return NULL;
+ 
+-                k = path_find_first_component(&prefix, accept_dot_dot, &q);
+-                if (k < 0)
++                n = path_find_first_component(&prefix, FLAGS_SET(flags, PATH_STARTSWITH_ACCEPT_DOT_DOT), &q);
++                if (n < 0)
+                         return NULL;
+ 
+-                if (k == 0)
+-                        return (char*) (p ?: path);
++                if (n == 0) {
++                        if (!p)
++                                p = path;
++
++                        if (FLAGS_SET(flags, PATH_STARTSWITH_RETURN_LEADING_SLASH)) {
++
++                                if (p <= original_path)
++                                        return NULL;
++
++                                p--;
++
++                                if (*p != '/')
++                                        return NULL;
++                        }
++
++                        return (char*) p;
++                }
+ 
+-                if (r != k)
++                if (m != n)
+                         return NULL;
+ 
+-                if (!strneq(p, q, r))
++                if (!strneq(p, q, m))
+                         return NULL;
+         }
+ }
+diff --git a/src/basic/path-util.h b/src/basic/path-util.h
+index 518f3340bf..763d1fe1a1 100644
+--- a/src/basic/path-util.h
++++ b/src/basic/path-util.h
+@@ -57,9 +57,15 @@ char* path_make_absolute(const char *p, const char *prefix);
+ int safe_getcwd(char **ret);
+ int path_make_absolute_cwd(const char *p, char **ret);
+ int path_make_relative(const char *from, const char *to, char **ret);
+-char *path_startswith_full(const char *path, const char *prefix, bool accept_dot_dot) _pure_;
++
++typedef enum PathStartWithFlags {
++        PATH_STARTSWITH_ACCEPT_DOT_DOT       = 1U << 0,
++        PATH_STARTSWITH_RETURN_LEADING_SLASH = 1U << 1,
++} PathStartWithFlags;
++
++char* path_startswith_full(const char *path, const char *prefix, PathStartWithFlags flags) _pure_;
+ static inline char* path_startswith(const char *path, const char *prefix) {
+-        return path_startswith_full(path, prefix, true);
++        return path_startswith_full(path, prefix, PATH_STARTSWITH_ACCEPT_DOT_DOT);
+ }
+ int path_compare(const char *a, const char *b) _pure_;
+ 
+diff --git a/src/test/test-path-util.c b/src/test/test-path-util.c
+index b9c4ef4126..c9794244d7 100644
+--- a/src/test/test-path-util.c
++++ b/src/test/test-path-util.c
+@@ -541,6 +541,22 @@ TEST(path_startswith) {
+         test_path_startswith_one("/foo/bar/barfoo/", "/fo", NULL, NULL);
+ }
+ 
++static void test_path_startswith_return_leading_slash_one(const char *path, const char *prefix, const char *expected) {
++        const char *p;
++
++        log_debug("/* %s(%s, %s) */", __func__, path, prefix);
++
++        p = path_startswith_full(path, prefix, PATH_STARTSWITH_RETURN_LEADING_SLASH);
++        assert_se(streq(p, expected));
++}
++
++TEST(path_startswith_return_leading_slash) {
++        test_path_startswith_return_leading_slash_one("/foo/bar", "/", "/foo/bar");
++        test_path_startswith_return_leading_slash_one("/foo/bar", "/foo", "/bar");
++        test_path_startswith_return_leading_slash_one("/foo/bar", "/foo/bar", NULL);
++        test_path_startswith_return_leading_slash_one("/foo/bar/", "/foo/bar", "/");
++}
++
+ static void test_prefix_root_one(const char *r, const char *p, const char *expected) {
+         _cleanup_free_ char *s = NULL;
+         const char *t;
+-- 
+2.51.0
+

--- a/SPECS/systemd/ipc-0002-path-util-invert-PATH_STARTSWITH_ACCEPT_DOT_DOT-flag.patch
+++ b/SPECS/systemd/ipc-0002-path-util-invert-PATH_STARTSWITH_ACCEPT_DOT_DOT-flag.patch
@@ -1,0 +1,92 @@
+From 0b9afe68a36c751113e5abbc41964adb42009b16 Mon Sep 17 00:00:00 2001
+From: Lennart Poettering <lennart@poettering.net>
+Date: Fri, 23 May 2025 06:45:40 +0200
+Subject: [PATCH 2/4] path-util: invert PATH_STARTSWITH_ACCEPT_DOT_DOT flag
+
+As requested: https://github.com/systemd/systemd/pull/37572#pullrequestreview-2861928094
+
+(cherry picked from commit ceed11e465f1c8efff1931412a85924d9de7c08d)
+(cherry picked from commit 7ac3220213690e8a8d6d2a6e81e43bd1dce01d69)
+---
+ src/basic/fs-util.c   | 2 +-
+ src/basic/mkdir.c     | 4 ++--
+ src/basic/path-util.c | 4 ++--
+ src/basic/path-util.h | 4 ++--
+ 4 files changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/src/basic/fs-util.c b/src/basic/fs-util.c
+index 8b2f6cc087..5e853a863a 100644
+--- a/src/basic/fs-util.c
++++ b/src/basic/fs-util.c
+@@ -67,7 +67,7 @@ int rmdir_parents(const char *path, const char *stop) {
+                 assert(*slash == '/');
+                 *slash = '\0';
+ 
+-                if (path_startswith_full(stop, p, /* flags= */ 0))
++                if (path_startswith_full(stop, p, PATH_STARTSWITH_REFUSE_DOT_DOT))
+                         return 0;
+ 
+                 if (rmdir(p) < 0 && errno != ENOENT)
+diff --git a/src/basic/mkdir.c b/src/basic/mkdir.c
+index 454739679c..361c142ebe 100644
+--- a/src/basic/mkdir.c
++++ b/src/basic/mkdir.c
+@@ -92,7 +92,7 @@ int mkdir_parents_internal(const char *prefix, const char *path, mode_t mode, ui
+         assert(_mkdirat != mkdirat);
+ 
+         if (prefix) {
+-                p = path_startswith_full(path, prefix, /* flags= */ 0);
++                p = path_startswith_full(path, prefix, PATH_STARTSWITH_REFUSE_DOT_DOT);
+                 if (!p)
+                         return -ENOTDIR;
+         } else
+@@ -137,7 +137,7 @@ int mkdir_parents_internal(const char *prefix, const char *path, mode_t mode, ui
+ 
+                 s[n] = '\0';
+ 
+-                if (!prefix || !path_startswith_full(prefix, path, /* flags= */ 0)) {
++                if (!prefix || !path_startswith_full(prefix, path, PATH_STARTSWITH_REFUSE_DOT_DOT)) {
+                         r = mkdir_safe_internal(path, mode, uid, gid, flags, _mkdirat);
+                         if (r < 0 && r != -EEXIST)
+                                 return r;
+diff --git a/src/basic/path-util.c b/src/basic/path-util.c
+index 9b44d5735c..47266b8206 100644
+--- a/src/basic/path-util.c
++++ b/src/basic/path-util.c
+@@ -447,11 +447,11 @@ char* path_startswith_full(const char *original_path, const char *prefix, PathSt
+                 const char *p, *q;
+                 int m, n;
+ 
+-                m = path_find_first_component(&path, FLAGS_SET(flags, PATH_STARTSWITH_ACCEPT_DOT_DOT), &p);
++                m = path_find_first_component(&path, !FLAGS_SET(flags, PATH_STARTSWITH_REFUSE_DOT_DOT), &p);
+                 if (m < 0)
+                         return NULL;
+ 
+-                n = path_find_first_component(&prefix, FLAGS_SET(flags, PATH_STARTSWITH_ACCEPT_DOT_DOT), &q);
++                n = path_find_first_component(&prefix, !FLAGS_SET(flags, PATH_STARTSWITH_REFUSE_DOT_DOT), &q);
+                 if (n < 0)
+                         return NULL;
+ 
+diff --git a/src/basic/path-util.h b/src/basic/path-util.h
+index 763d1fe1a1..c16c525464 100644
+--- a/src/basic/path-util.h
++++ b/src/basic/path-util.h
+@@ -59,13 +59,13 @@ int path_make_absolute_cwd(const char *p, char **ret);
+ int path_make_relative(const char *from, const char *to, char **ret);
+ 
+ typedef enum PathStartWithFlags {
+-        PATH_STARTSWITH_ACCEPT_DOT_DOT       = 1U << 0,
++        PATH_STARTSWITH_REFUSE_DOT_DOT       = 1U << 0,
+         PATH_STARTSWITH_RETURN_LEADING_SLASH = 1U << 1,
+ } PathStartWithFlags;
+ 
+ char* path_startswith_full(const char *path, const char *prefix, PathStartWithFlags flags) _pure_;
+ static inline char* path_startswith(const char *path, const char *prefix) {
+-        return path_startswith_full(path, prefix, PATH_STARTSWITH_ACCEPT_DOT_DOT);
++        return path_startswith_full(path, prefix, 0);
+ }
+ int path_compare(const char *a, const char *b) _pure_;
+ 
+-- 
+2.51.0
+

--- a/SPECS/systemd/ipc-0003-core-cgroup-avoid-one-unnecessary-strjoina.patch
+++ b/SPECS/systemd/ipc-0003-core-cgroup-avoid-one-unnecessary-strjoina.patch
@@ -1,0 +1,101 @@
+From 9f9c7d231d80e68f4d2117a02bb53f8c2949f048 Mon Sep 17 00:00:00 2001
+From: Mike Yuan <me@yhndnzj.com>
+Date: Thu, 26 Feb 2026 11:06:00 +0100
+Subject: [PATCH 3/4] core/cgroup: avoid one unnecessary strjoina()
+
+(cherry picked from commit 42aee39107fbdd7db1ccd402a2151822b2805e9f)
+(cherry picked from commit 80acea4ef80a4bb78560ed970c34952299b890d6)
+(cherry picked from commit b5fd14693057e5f2c9b4a49603be64ec3608ff6c)
+(cherry picked from commit 21167006574d6b83813c7596759b474f56562412)
+---
+ src/core/cgroup.c | 29 ++++++++++++++---------------
+ 1 file changed, 14 insertions(+), 15 deletions(-)
+
+diff --git a/src/core/cgroup.c b/src/core/cgroup.c
+index f58de95a49..5b8591ca97 100644
+--- a/src/core/cgroup.c
++++ b/src/core/cgroup.c
+@@ -2221,12 +2221,13 @@ static int unit_update_cgroup(
+         return 0;
+ }
+ 
+-static int unit_attach_pid_to_cgroup_via_bus(Unit *u, pid_t pid, const char *suffix_path) {
++static int unit_attach_pid_to_cgroup_via_bus(Unit *u, const char *cgroup_path, pid_t pid) {
+         _cleanup_(sd_bus_error_free) sd_bus_error error = SD_BUS_ERROR_NULL;
+-        char *pp;
+         int r;
+ 
+         assert(u);
++        assert(cgroup_path);
++        assert(pid_is_valid(pid));
+ 
+         if (MANAGER_IS_SYSTEM(u->manager))
+                 return -EINVAL;
+@@ -2234,17 +2235,13 @@ static int unit_attach_pid_to_cgroup_via_bus(Unit *u, pid_t pid, const char *suf
+         if (!u->manager->system_bus)
+                 return -EIO;
+ 
+-        if (!u->cgroup_path)
+-                return -EINVAL;
+-
+         /* Determine this unit's cgroup path relative to our cgroup root */
+-        pp = path_startswith(u->cgroup_path, u->manager->cgroup_root);
++        const char *pp = path_startswith_full(cgroup_path,
++                                              u->manager->cgroup_root,
++                                              PATH_STARTSWITH_RETURN_LEADING_SLASH|PATH_STARTSWITH_REFUSE_DOT_DOT);
+         if (!pp)
+                 return -EINVAL;
+ 
+-        pp = strjoina("/", pp, suffix_path);
+-        path_simplify(pp);
+-
+         r = sd_bus_call_method(u->manager->system_bus,
+                                "org.freedesktop.systemd1",
+                                "/org/freedesktop/systemd1",
+@@ -2284,9 +2281,11 @@ int unit_attach_pids_to_cgroup(Unit *u, Set *pids, const char *suffix_path) {
+                 return r;
+ 
+         if (isempty(suffix_path))
+-                p = u->cgroup_path;
+-        else
++                p = empty_to_root(u->cgroup_path);
++        else {
++                assert(path_is_absolute(suffix_path));
+                 p = prefix_roota(u->cgroup_path, suffix_path);
++        }
+ 
+         delegated_mask = unit_get_delegate_mask(u);
+ 
+@@ -2301,7 +2300,7 @@ int unit_attach_pids_to_cgroup(Unit *u, Set *pids, const char *suffix_path) {
+ 
+                         log_unit_full_errno(u, again ? LOG_DEBUG : LOG_INFO,  r,
+                                             "Couldn't move process "PID_FMT" to%s requested cgroup '%s': %m",
+-                                            pid, again ? " directly" : "", empty_to_root(p));
++                                            pid, again ? " directly" : "", p);
+ 
+                         if (again) {
+                                 int z;
+@@ -2311,9 +2310,9 @@ int unit_attach_pids_to_cgroup(Unit *u, Set *pids, const char *suffix_path) {
+                                  * Since it's more privileged it might be able to move the process across the
+                                  * leaves of a subtree whose top node is not owned by us. */
+ 
+-                                z = unit_attach_pid_to_cgroup_via_bus(u, pid, suffix_path);
++                                z = unit_attach_pid_to_cgroup_via_bus(u, p, pid);
+                                 if (z < 0)
+-                                        log_unit_info_errno(u, z, "Couldn't move process "PID_FMT" to requested cgroup '%s' (directly or via the system bus): %m", pid, empty_to_root(p));
++                                        log_unit_info_errno(u, z, "Couldn't move process "PID_FMT" to requested cgroup '%s' (directly or via the system bus): %m", pid, p);
+                                 else {
+                                         if (ret >= 0)
+                                                 ret++; /* Count successful additions */
+@@ -2351,7 +2350,7 @@ int unit_attach_pids_to_cgroup(Unit *u, Set *pids, const char *suffix_path) {
+                                         continue; /* Success! */
+ 
+                                 log_unit_debug_errno(u, r, "Failed to attach PID " PID_FMT " to requested cgroup %s in controller %s, falling back to unit's cgroup: %m",
+-                                                     pid, empty_to_root(p), cgroup_controller_to_string(c));
++                                                     pid, p, cgroup_controller_to_string(c));
+                         }
+ 
+                         /* So this controller is either not delegate or realized, or something else weird happened. In
+-- 
+2.51.0
+

--- a/SPECS/systemd/ipc-0004-core-validate-input-cgroup-path-more-prudently.patch
+++ b/SPECS/systemd/ipc-0004-core-validate-input-cgroup-path-more-prudently.patch
@@ -1,0 +1,33 @@
+From b4a2391f799d5bd14ad62d831e115251d67a5a90 Mon Sep 17 00:00:00 2001
+From: Mike Yuan <me@yhndnzj.com>
+Date: Thu, 26 Feb 2026 11:06:34 +0100
+Subject: [PATCH 4/4] core: validate input cgroup path more prudently
+
+(cherry picked from commit efa6ba2ab625aaa160ac435a09e6482fc63bdbe8)
+(cherry picked from commit 3cee294fe8cf4fa0eff933ab21416d099942cabd)
+(cherry picked from commit 1d22f706bd04f45f8422e17fbde3f56ece17758a)
+(cherry picked from commit 54588d2dedff54bfb6036670820650e4ea74628f)
+---
+ src/core/dbus-manager.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/src/core/dbus-manager.c b/src/core/dbus-manager.c
+index 9b64a8074d..a9aee2d8f0 100644
+--- a/src/core/dbus-manager.c
++++ b/src/core/dbus-manager.c
+@@ -584,6 +584,12 @@ static int method_get_unit_by_control_group(sd_bus_message *message, void *userd
+         if (r < 0)
+                 return r;
+ 
++        if (!path_is_absolute(cgroup))
++                return sd_bus_error_setf(error, SD_BUS_ERROR_INVALID_ARGS, "Control group path is not absolute: %s", cgroup);
++
++        if (!path_is_normalized(cgroup))
++                return sd_bus_error_setf(error, SD_BUS_ERROR_INVALID_ARGS, "Control group path is not normalized: %s", cgroup);
++
+         u = manager_get_unit_by_cgroup(m, cgroup);
+         if (!u)
+                 return sd_bus_error_setf(error, BUS_ERROR_NO_SUCH_UNIT,
+-- 
+2.51.0
+

--- a/SPECS/systemd/systemd.spec
+++ b/SPECS/systemd/systemd.spec
@@ -1,7 +1,7 @@
 Summary:        Systemd-250
 Name:           systemd
 Version:        250.3
-Release:        23%{?dist}
+Release:        24%{?dist}
 License:        LGPLv2+ AND GPLv2+ AND MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -33,6 +33,10 @@ Patch10:        mariner-2-force-use-of-lz4-for-coredump.patch
 Patch11:        networkd-default-use-domains.patch
 Patch12:	CVE-2023-7008.patch
 Patch13:        CVE-2025-4598.patch
+Patch14:        ipc-0001-path-util-add-flavour-of-path_startswith-that-leaves.patch
+Patch15:        ipc-0002-path-util-invert-PATH_STARTSWITH_ACCEPT_DOT_DOT-flag.patch
+Patch16:        ipc-0003-core-cgroup-avoid-one-unnecessary-strjoina.patch
+Patch17:        ipc-0004-core-validate-input-cgroup-path-more-prudently.patch
 BuildRequires:  audit-devel
 BuildRequires:  cryptsetup-devel
 BuildRequires:  docbook-dtd-xml
@@ -291,6 +295,9 @@ fi
 %files lang -f %{name}.lang
 
 %changelog
+* Thu Mar 05 2026 Dan Streetman <ddstreet@ieee.org> - 250.3-24
+- add patches to fix ipc dbus communication issue
+
 * Tue Sep 16 2025 Akhila Guruju <v-guakhila@microsoft.com> - 250.3-23
 - Patch CVE-2025-4598
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
this adds patches to correct an ipc dbus communication issue

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
no

