### PR TITLE
fix(kernel): fix uname -r missing 4th version component

### DIFF
--- a/base/comps/kernel/kernel.comp.toml
+++ b/base/comps/kernel/kernel.comp.toml
@@ -6,7 +6,7 @@ without = ["debug"]
 
 [components.kernel.build.defines]
 # RPM release number for the Azure Linux kernel package
-azl_pkgrelease = "1"
+azl_pkgrelease = "2"
 # 4th version component appended to EXTRAVERSION so uname -r matches source version (6.18.5.1).
 kextraversion = ".1"
 # CBL-Mariner branch number (used in tarball path)


### PR DESCRIPTION
The kernel spec's InitBuildVars rewrites the Makefile EXTRAVERSION to "-${ShortRel}.%{_target_cpu}", producing a 3-component kernel version (6.18.5-1.azl4.x86_64). The 4th component from specrpmversion (6.18.5.1) is lost because KERNELRELEASE is only passed to modules_install/vdso_install, not to the main build.

Add a spec-search-replace overlay that prepends %{?kextraversion} (.1) to EXTRAVERSION, so the compiled kernel version matches the RPM version and module install path (6.18.5.1-1.azl4.x86_64).

```
    %{log_msg "InitBuildVars: Update Makefile"}
    # make sure EXTRAVERSION says what we want it to say
    # Trim the release if this is a CI build, since KERNELVERSION is limited to 64 characters
    ShortRel=$(perl -e "print \"%{release}\" =~ s/\.pr\.[0-9A-Fa-f]{32}//r")
    perl -p -i -e "s/^EXTRAVERSION.*/EXTRAVERSION = -${ShortRel}.%{_target_cpu}${Variant:++${Variant}}/" Makefile
```