### PR TITLE
fix(fuse3): do not build both 3.16 and 3.17 fuse3 packages

### DIFF
--- a/base/comps/fuse3/fuse3.comp.toml
+++ b/base/comps/fuse3/fuse3.comp.toml
@@ -1,6 +1,2 @@
 [components.fuse3]
-
-# We are temporarily building the Fedora 42 version of fuse3 to aid with bootstrapping
-# issues; notably, Fedora 43 shipped with the *Fedora 42* version of this package.
-[components.fuse3-42]
 spec = { type = "upstream", upstream-name = "fuse3", upstream-distro = { name = "fedora", version = "42" } }


### PR DESCRIPTION
the fuse3 lib had a .so bump between these versions, so both versions cannot be present in the same major release, since all packages built with fuse3 3.16 will have a runtime dep on libfuse3.so.3, while installing fuse3 3.17 will remove libfuse3.so.3 and install libfuse3.so.4.

This restricts us to fuse3 3.16 published in f42.
