### PR TITLE
[Medium] Patch nasm for CVE-2022-46456

### DIFF
--- a/SPECS/nasm/CVE-2022-46456.patch
+++ b/SPECS/nasm/CVE-2022-46456.patch
@@ -1,0 +1,85 @@
+From e05867ce3dfe303186f6c66df20251bfd828fd49 Mon Sep 17 00:00:00 2001
+From: "H. Peter Anvin" <hpa@zytor.com>
+Date: Sat, 30 Aug 2025 16:16:43 -0700
+Subject: [PATCH] ndisasm: make the assembler (hopefully) work again
+
+- Significantly overhauled the disassembler internals to make
+  better use of the information already in the instruction template
+  and to reduce the implementation differences with the assembler
+- Add APX support to the disassembler
+- Fix problem with disassembler truncating addresses of jumps
+- Fix generation of invalid EAs in 16-bit mode
+- Fix array overrun for types in a few modules
+- Fix invalid ND flag on near JMP
+
+Signed-off-by: H. Peter Anvin (Intel) <hpa@zytor.com>
+
+Upstream Patch Reference: https://github.com/netwide-assembler/nasm/commit/e05867ce3dfe303186f6c66df20251bfd828fd49
+---
+ output/outdbg.c | 43 +++++++++++++++++++++++++++++++++++++++----
+ 1 file changed, 39 insertions(+), 4 deletions(-)
+
+diff --git a/output/outdbg.c b/output/outdbg.c
+index e7a9a4e..04cb3dd 100644
+--- a/output/outdbg.c
++++ b/output/outdbg.c
+@@ -408,9 +408,44 @@ dbg_pragma(const struct pragma *pragma)
+     return DIRR_OK;
+ }
+ 
+-static const char * const types[] = {
+-    "unknown", "label", "byte", "word", "dword", "float", "qword", "tbyte"
+-};
++static const char *type_name(uint32_t type)
++{
++    switch (TYM_TYPE(type)) {
++    case TY_UNKNOWN:
++        return "unknown";
++    case TY_LABEL:
++        return "label";
++    case TY_BYTE:
++        return "byte";
++    case TY_WORD:
++        return "word";
++    case TY_DWORD:
++        return "dword";
++    case TY_FLOAT:
++        return "float";
++    case TY_QWORD:
++        return "qword";
++    case TY_TBYTE:
++        return "tbyte";
++    case TY_OWORD:
++        return "oword";
++    case TY_YWORD:
++        return "yword";
++    case TY_ZWORD:
++        return "zword";
++    case TY_COMMON:
++        return "common";
++    case TY_SEG:
++        return "seg";
++    case TY_EXTERN:
++        return "extern";
++    case TY_EQU:
++        return "equ";
++    default:
++        return "<invalid type code>";
++    }
++}
++
+ static void dbgdbg_init(void)
+ {
+     fprintf(ofile, "dbg init: debug information enabled\n");
+@@ -457,7 +492,7 @@ static void dbgdbg_output(int output_type, void *param)
+ static void dbgdbg_typevalue(int32_t type)
+ {
+     fprintf(ofile, "dbg typevalue: %s(%"PRIX32")\n",
+-            types[TYM_TYPE(type) >> 3], TYM_ELEMENTS(type));
++            type_name(type), TYM_ELEMENTS(type));
+ }
+ 
+ static void
+-- 
+2.45.4
+

--- a/SPECS/nasm/nasm.spec
+++ b/SPECS/nasm/nasm.spec
@@ -1,20 +1,23 @@
 Summary:        Netwide Assembler.
 Name:           nasm
 Version:        2.16.01
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        BSD
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
 Group:          System Environment/Libraries
 URL:            https://www.nasm.us
 Source0:        http://www.nasm.us/pub/nasm/releasebuilds/%{version}/%{name}-%{version}.tar.gz
+Patch0:         CVE-2022-46456.patch
+BuildRequires:  perl
+BuildRequires:  perl(File::Find)
 ExclusiveArch:  x86_64
 
 %description
 NASM (Netwide Assembler) is an 80x86 assembler designed for portability and modularity. It includes a disassembler as well.
 
 %prep
-%setup -q
+%autosetup -p1
 
 %build
 %configure
@@ -33,6 +36,9 @@ make %{?_smp_mflags} -k test
 %{_datadir}/*
 
 %changelog
+* Mon Mar 09 2026 Ratiranjan Behera <v-ratbehera@microsoft.com> - 2.16.01-2
+- Add patch for CVE-2022-46456
+
 * Fri Oct 27 2023 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 2.16.01-1
 - Auto-upgrade to 2.16.01 - Azure Linux 3.0 - package upgrades
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
Patch nasm for CVE-2022-46456
Upstream Patch reference: https://github.com/netwide-assembler/nasm/commit/e05867ce3dfe303186f6c66df20251bfd828fd49
Patch modified: Yes

- This PR addresses the global buffer overflow in `nasm` caused by unsafe indexing in the `dbgdbg_typevalue()` function located in `output/outdbg.c`.
- Although the upstream patch includes changes across multiple files such as Makefile.in, asm/*, disasm/*, include/*, x86/*, and test/segover.asm etc, those changes primarily consist of refactoring, restructuring, new source files, regenerated tables, test additions, and other unrelated functional updates to this CVE.
- The vulnerability is isolated exclusively to `dbgdbg_typevalue()` in `output/outdbg.c`. No other files are required to fix this issue in nasm‑2.16.01. Patching `output/outdbg.c` alone is sufficient to fully resolve this CVE.

Additional build fix:
- Local build fails in asm/warnings.pl with `Can't locate File/Find.pm in @INC`.
The minimal build chroot lacks the File::Find Perl module, Adding the appropriate Perl BuildRequires  in spec file to resolves the issue.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- new file:   SPECS/nasm/CVE-2022-46456.patch
- modified:   SPECS/nasm/nasm.spec

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- 
<img width="917" height="58" alt="image" src="https://github.com/user-attachments/assets/c15cefa3-41a4-43a7-93ae-a468dea887ae" />

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2022-46456

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local build was successful.
<img width="350" height="131" alt="CVE-2022-46456_BuildSuccess" src="https://github.com/user-attachments/assets/380ed77e-a2bb-422d-9967-14f4d449d290" />

- Patch applies cleanly.
<img width="590" height="80" alt="CVE-2022-46456_PatchApplication" src="https://github.com/user-attachments/assets/f2f57841-e020-44c8-b231-8f9c45df6c95" />

- Logs:
[nasm-2.16.01-2.azl3.src.rpm.test.log](https://github.com/user-attachments/files/25860835/nasm-2.16.01-2.azl3.src.rpm.test.log)
[nasm-2.16.01-2.azl3.src.rpm.log](https://github.com/user-attachments/files/25860836/nasm-2.16.01-2.azl3.src.rpm.log)

- Check Installation:
<img width="838" height="204" alt="image" src="https://github.com/user-attachments/assets/f5b44021-f44b-46b4-9e0e-05616e9b2730" />

- Check uninstallation:
<img width="836" height="161" alt="image" src="https://github.com/user-attachments/assets/68003404-4449-4d5c-a5e4-2b08a52c300a" />

