### PR TITLE
[Medium] Patch rust for CVE-2026-33056 and CVE-2026-33055

### DIFF
--- a/SPECS-EXTENDED/389-ds-base/389-ds-base.spec
+++ b/SPECS-EXTENDED/389-ds-base/389-ds-base.spec
@@ -68,7 +68,7 @@ ExcludeArch: i686
 Summary:          389 Directory Server (%{variant})
 Name:             389-ds-base
 Version:          3.1.1
-Release:          11%{?dist}
+Release:          12%{?dist}
 License:          GPL-3.0-or-later AND (0BSD OR Apache-2.0 OR MIT) AND (Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT) AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR MIT OR Zlib) AND (Apache-2.0 OR MIT) AND (CC-BY-4.0 AND MIT) AND (MIT OR Apache-2.0) AND Unicode-DFS-2016 AND (MIT OR CC0-1.0) AND (MIT OR Unlicense) AND 0BSD AND Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MIT AND ISC AND MPL-2.0 AND PSF-2.0
 URL:              https://www.port389.org
 Vendor:           Microsoft Corporation
@@ -733,6 +733,9 @@ exit 0
 %endif
 
 %changelog
+* Tue Mar 31 2026 BinduSri Adabala <v-badabala@microsoft.com> - 3.1.1-12
+- Bump release to rebuild with rust
+
 * Wed Feb 11 2026 BinduSri Adabala <v-badabala@microsoft.com> - 3.1.1-11
 - Bump release to rebuild with rust
 

--- a/SPECS-EXTENDED/ripgrep/ripgrep.spec
+++ b/SPECS-EXTENDED/ripgrep/ripgrep.spec
@@ -20,7 +20,7 @@
 
 Name:           ripgrep
 Version:        13.0.0
-Release:        13%{?dist}
+Release:        14%{?dist}
 Summary:        A search tool that combines ag with grep
 License:        MIT AND Unlicense
 Vendor:         Microsoft Corporation
@@ -104,6 +104,9 @@ install -Dm 644 complete/_rg %{buildroot}%{_datadir}/zsh/site-functions/_rg
 %{_datadir}/zsh
 
 %changelog
+* Tue Mar 31 2026 BinduSri Adabala <v-badabala@microsoft.com> - 13.0.0-14
+- Bump release to rebuild with rust
+
 * Wed Feb 11 2026 BinduSri Adabala <v-badabala@microsoft.com> - 13.0.0-13
 - Bump release to rebuild with rust
 

--- a/SPECS-EXTENDED/rust-cbindgen/rust-cbindgen.spec
+++ b/SPECS-EXTENDED/rust-cbindgen/rust-cbindgen.spec
@@ -2,7 +2,7 @@
 Summary:        Tool for generating C bindings to Rust code
 Name:           rust-cbindgen
 Version:        0.24.3
-Release:        9%{?dist}
+Release:        10%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -96,6 +96,9 @@ RUSTFLAGS=%{rustflags} cargo test --release
 %endif
 
 %changelog
+* Tue Mar 31 2026 BinduSri Adabala <v-badabala@microsoft.com> - 0.24.3-10
+- Bump release to rebuild with rust
+
 * Wed Feb 11 2026 BinduSri Adabala <v-badabala@microsoft.com> - 0.24.3-9
 - Bump release to rebuild with rust
 

--- a/SPECS-EXTENDED/tardev-snapshotter/tardev-snapshotter.spec
+++ b/SPECS-EXTENDED/tardev-snapshotter/tardev-snapshotter.spec
@@ -3,7 +3,7 @@
 Summary: Tardev Snapshotter for containerd
 Name: tardev-snapshotter
 Version: 3.2.0.tardev1
-Release: 7%{?dist}
+Release: 8%{?dist}
 License: ASL 2.0
 Group: Tools/Container
 Vendor: Microsoft Corporation
@@ -67,6 +67,9 @@ fi
 %config(noreplace) %{_unitdir}/%{name}.service
 
 %changelog
+* Tue Mar 31 2026 BinduSri Adabala <v-badabala@microsoft.com> - 3.2.0.tardev1-8
+- Bump release to rebuild with rust
+
 * Wed Feb 11 2026 BinduSri Adabala <v-badabala@microsoft.com> - 3.2.0.tardev1-7
 - Bump release to rebuild with rust
 

--- a/SPECS/clamav/clamav.spec
+++ b/SPECS/clamav/clamav.spec
@@ -1,7 +1,7 @@
 Summary:        Open source antivirus engine
 Name:           clamav
 Version:        1.0.9
-Release:        4%{?dist}
+Release:        5%{?dist}
 License:        ASL 2.0 AND BSD AND bzip2-1.0.4 AND GPLv2 AND LGPLv2+ AND MIT AND Public Domain AND UnRar
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -136,6 +136,9 @@ fi
 %dir %attr(-,clamav,clamav) %{_sharedstatedir}/clamav
 
 %changelog
+* Tue Mar 31 2026 BinduSri Adabala <v-badabala@microsoft.com> - 1.0.9-5
+- Bump release to rebuild with rust
+
 * Wed Feb 11 2026 BinduSri Adabala <v-badabala@microsoft.com> - 1.0.9-4
 - Bump release to rebuild with rust
 

--- a/SPECS/cloud-hypervisor/cloud-hypervisor.spec
+++ b/SPECS/cloud-hypervisor/cloud-hypervisor.spec
@@ -5,7 +5,7 @@
 Name:           cloud-hypervisor
 Summary:        Cloud Hypervisor is an open source Virtual Machine Monitor (VMM) that runs on top of the KVM hypervisor and the Microsoft Hypervisor (MSHV).
 Version:        48.0.246
-Release:        4%{?dist}
+Release:        5%{?dist}
 License:        ASL 2.0 OR BSD-3-clause
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -139,6 +139,9 @@ cargo build --release --target=%{rust_musl_target} %{cargo_pkg_feature_opts} %{c
 %license LICENSES/CC-BY-4.0.txt
 
 %changelog
+* Tue Mar 31 2026 BinduSri Adabala <v-badabala@microsoft.com> - 48.0.246-5
+- Bump release to rebuild with rust
+
 * Mon Mar 09 2026 BinduSri Adabala <v-badabala@microsoft.com> - 48.0.246-4
 - Bump release to rebuild with rust
 

--- a/SPECS/flux/flux.spec
+++ b/SPECS/flux/flux.spec
@@ -22,7 +22,7 @@
 Summary:        Influx data language
 Name:           flux
 Version:        0.194.5
-Release:        8%{?dist}
+Release:        9%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -146,6 +146,9 @@ RUSTFLAGS=%{rustflags} cargo test --release
 %{_includedir}/influxdata/flux.h
 
 %changelog
+* Tue Mar 31 2026 BinduSri Adabala <v-badabala@microsoft.com> - 0.194.5-9
+- Bump release to rebuild with rust
+
 * Wed Feb 11 2026 BinduSri Adabala <v-badabala@microsoft.com> - 0.194.5-8
 - Bump release to rebuild with rust
 

--- a/SPECS/influxdb/influxdb.spec
+++ b/SPECS/influxdb/influxdb.spec
@@ -18,7 +18,7 @@
 Summary:        Scalable datastore for metrics, events, and real-time analytics
 Name:           influxdb
 Version:        2.7.5
-Release:        14%{?dist}
+Release:        15%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -162,6 +162,9 @@ go test ./...
 %{_tmpfilesdir}/influxdb.conf
 
 %changelog
+* Tue Mar 31 2026 BinduSri Adabala <v-badabala@microsoft.com> - 2.7.5-15
+- Bump release to rebuild with rust
+
 * Mon Feb 23 2026 BinduSri Adabala <v-badabala@microsoft.com> - 2.7.5-14
 - Bump release to rebuild with rust
 

--- a/SPECS/kata-containers-cc/kata-containers-cc.spec
+++ b/SPECS/kata-containers-cc/kata-containers-cc.spec
@@ -3,7 +3,7 @@
 
 Name:         kata-containers-cc
 Version:      3.15.0.aks0
-Release:      8%{?dist}
+Release:      9%{?dist}
 Summary:      Kata Confidential Containers package developed for Confidential Containers on AKS
 License:      ASL 2.0
 URL:          https://github.com/microsoft/kata-containers
@@ -150,6 +150,9 @@ fi
 %{tools_pkg}/tools/osbuilder/node-builder/azure-linux/agent-install/usr/lib/systemd/system/kata-agent.service
 
 %changelog
+* Tue Mar 31 2026 BinduSri Adabala <v-badabala@microsoft.com> - 3.15.0-aks0-9
+- Bump release to rebuild with rust
+
 * Wed Feb 11 2026 BinduSri Adabala <v-badabala@microsoft.com> - 3.15.0-aks0-8
 - Bump release to rebuild with rust
 

--- a/SPECS/kata-containers/kata-containers.spec
+++ b/SPECS/kata-containers/kata-containers.spec
@@ -2,7 +2,7 @@
 
 Name:           kata-containers
 Version:        3.19.1.kata2
-Release:        7%{?dist}
+Release:        8%{?dist}
 
 Summary:        Kata Containers package developed for Pod Sandboxing on AKS
 License:        ASL 2.0
@@ -117,6 +117,9 @@ popd
 %{tools_pkg}/tools/osbuilder/node-builder/azure-linux/agent-install/usr/lib/systemd/system/kata-agent.service
 
 %changelog
+* Tue Mar 31 2026 BinduSri Adabala <v-badabala@microsoft.com> - 3.19.1.kata2-8
+- Bump release to rebuild with rust
+
 * Mon Mar 09 2026 BinduSri Adabala <v-badabala@microsoft.com> - 3.19.1.kata2-7
 - Bump release to rebuild with rust
 

--- a/SPECS/librsvg2/librsvg2.spec
+++ b/SPECS/librsvg2/librsvg2.spec
@@ -8,7 +8,7 @@
 Summary:        An SVG library based on cairo
 Name:           librsvg2
 Version:        2.58.1
-Release:        6%{?dist}
+Release:        7%{?dist}
 License:        LGPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -125,6 +125,9 @@ rm -vrf %{buildroot}%{_docdir}
 %{_bindir}/rsvg-convert
 
 %changelog
+* Tue Mar 31 2026 BinduSri Adabala <v-badabala@microsoft.com> - 2.58.1-7
+- Bump release to rebuild with rust
+
 * Wed Feb 11 2026 BinduSri Adabala <v-badabala@microsoft.com> - 2.58.1-6
 - Bump release to rebuild with rust
 

--- a/SPECS/mesa/mesa.spec
+++ b/SPECS/mesa/mesa.spec
@@ -67,7 +67,7 @@
 Name:           mesa
 Summary:        Mesa graphics libraries
 Version:        24.0.1
-Release:        6%{?dist}
+Release:        7%{?dist}
 License:        BSD
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -741,6 +741,9 @@ popd
 %endif
 
 %changelog
+* Tue Mar 31 2026 BinduSri Adabala <v-badabala@microsoft.com> - 24.0.1-7
+- Bump release to rebuild with rust
+
 * Wed Feb 11 2026 BinduSri Adabala <v-badabala@microsoft.com> - 24.0.1-6
 - Bump release to rebuild with rust
 

--- a/SPECS/netavark/netavark.spec
+++ b/SPECS/netavark/netavark.spec
@@ -11,7 +11,7 @@
 
 Name:          netavark
 Version:       1.10.3
-Release:       7%{?dist}
+Release:       8%{?dist}
 Summary:       OCI network stack
 License:       ASL 2.0 and BSD and MIT
 Vendor:        Microsoft Corporation
@@ -225,6 +225,9 @@ popd
 %{_unitdir}/%{name}-firewalld-reload.service
 
 %changelog
+* Tue Mar 31 2026 BinduSri Adabala <v-badabala@microsoft.com> - 1.10.3-8
+- Bump release to rebuild with rust
+
 * Tue Mar 10 2026 BinduSri Adabala <v-badabala@microsoft.com> - 1.10.3-7
 - Bump release to rebuild with rust
 

--- a/SPECS/rpm-ostree/rpm-ostree.spec
+++ b/SPECS/rpm-ostree/rpm-ostree.spec
@@ -1,7 +1,7 @@
 Summary:        Commit RPMs to an OSTree repository
 Name:           rpm-ostree
 Version:        2024.4
-Release:        8%{?dist}
+Release:        9%{?dist}
 License:        LGPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -180,6 +180,9 @@ make check
 %{_datadir}/gir-1.0/*-1.0.gir
 
 %changelog
+* Tue Mar 31 2026 BinduSri Adabala <v-badabala@microsoft.com> - 2024.4-9
+- Bump release to rebuild with rust
+
 * Tue Feb 17 2026 Azure Linux Security Servicing Account <azurelinux-security@microsoft.com> - 2024.4-8
 - Patch for CVE-2026-25541 & CVE-2025-58160
 

--- a/SPECS/rust/CVE-2026-33055.patch
+++ b/SPECS/rust/CVE-2026-33055.patch
@@ -1,0 +1,661 @@
+From de1a5870e603758f430073688691165f21a33946 Mon Sep 17 00:00:00 2001
+From: Alex Crichton <alex@alexcrichton.com>
+Date: Thu, 19 Mar 2026 16:56:51 -0500
+Subject: [PATCH] archive: Unconditionally honor PAX size (#441)
+
+This synchronizes our behavior with most other tar parsers
+(including astral-tokio-tar and Go archive/tar) ensuring
+that we don't parse things differently.
+
+The problem with parsing size in particular differently is
+it's easy to craft a tar archive that appears completely differently
+between two parsers. This is the case with e.g. crates.io where
+astral-tokio-tar is used for validation server side, but cargo uses
+the `tar` crate to upload.
+
+With this, the two projects agree.
+
+Signed-off-by: Colin Walters <walters@verbum.org>
+Co-authored-by: Colin Walters <walters@verbum.org>
+
+Upstream Patch reference: https://github.com/alexcrichton/tar-rs/commit/de1a5870e603758f430073688691165f21a33946.patch
+
+---
+ vendor/tar-0.4.38/.cargo-checksum.json |   2 +-
+ vendor/tar-0.4.38/Cargo.toml           |  10 ++
+ vendor/tar-0.4.38/src/archive.rs       |   9 +-
+ vendor/tar-0.4.38/tests/all.rs         | 151 +++++++++++++++++++++++++
+ vendor/tar-0.4.43/.cargo-checksum.json |   2 +-
+ vendor/tar-0.4.43/Cargo.toml           |  10 ++
+ vendor/tar-0.4.43/src/archive.rs       |   9 +-
+ vendor/tar-0.4.43/tests/all.rs         | 151 +++++++++++++++++++++++++
+ vendor/tar-0.4.44/.cargo-checksum.json |   2 +-
+ vendor/tar-0.4.44/Cargo.toml           |  10 ++
+ vendor/tar-0.4.44/src/archive.rs       |   9 +-
+ vendor/tar-0.4.44/tests/all.rs         | 151 +++++++++++++++++++++++++
+ 12 files changed, 501 insertions(+), 15 deletions(-)
+
+diff --git a/vendor/tar-0.4.38/.cargo-checksum.json b/vendor/tar-0.4.38/.cargo-checksum.json
+index 29f36527e..86f6e4b6a 100644
+--- a/vendor/tar-0.4.38/.cargo-checksum.json
++++ b/vendor/tar-0.4.38/.cargo-checksum.json
+@@ -1 +1 @@
+-{"files":{".cargo_vcs_info.json":"e45d0dcacca796a5216a6c06af829c4951e4a6a50a45a49c17f3e57cd6d37d4d",".github/dependabot.yml":"d04c9b0253b2bbae886b59a11399ea260397b460cd9f5712d692d1c85f8ec090",".github/workflows/main.yml":"2cb0bdc03adee75e18d8c9115c16baaae15136d6b7c47ad7f5ffc00d2dca7267","Cargo.lock":"9872bf9e41b9cadee45b688c9537030a993ca49a266fc7859029d8c74810d1d5","Cargo.toml":"8353c71aa4d394efa7aaeac3004d0a16fd0c7124b7bd57ea91ba87a7b2015f15","Cargo.toml.orig":"cf5ae4c1847ad24f5314d0ae865ad72d58cb050362611effd8a1d84e0e541b37","LICENSE-APACHE":"a60eea817514531668d7e00765731449fe14d059d3249e0bc93b36de45f759f2","LICENSE-MIT":"378f5840b258e2779c39418f3f2d7b2ba96f1c7917dd6be0713f88305dbda397","README.md":"71079f1a0962c2cf288058f38d24735bddabd1427ac2dee72ec18cc5ae4bceed","examples/extract_file.rs":"dc487f6631d824175afc3ee33de99e80718a8ca3f9e57fddd7cac0a46c07d3ae","examples/list.rs":"36e412205eaffea8ab7f39be4173594b74e36acb369e091362b1975ee4a7a14b","examples/raw_list.rs":"0a735576ac354457d6d5a4d395d044fae99bf67a7c69960ca784a6f6a1743651","examples/write.rs":"419ac3e4155035e32b52cd8e6ae987a2d99cf82f60abbfb315c2a2c4f8e8fd19","src/archive.rs":"4eac362ffc7bf629fcecf88ca43cec96a1753c9e0a759722d916a9931c093e25","src/builder.rs":"2914f394d44c133557532bf5765fe63e0def30ec0b447f8f2bc620e932a2036a","src/entry.rs":"2f3ff18dc0c693f425488f946e8a7d250c4020134ca870fe5522d9a95b6a6ae0","src/entry_type.rs":"0786688729a96b4a3135b28d40b95c3d4feaad66b9574c490cbea14814ab975f","src/error.rs":"a20813fbc52f1f2e3a79654f62de6001759f6504a06acee5b0819d4865398587","src/header.rs":"fb2b1fa943c19635826b3f2becfb82527be7d08fdac115af840da3ff06152908","src/lib.rs":"5468e413205c907c367c35d28a528389103d68fd6a5b5979bbedba7c9e6b6c99","src/pax.rs":"54002e31151f9c50e02a3da26b3cacd1d3c9a3902daee008ab76d112cf5a2430","tests/all.rs":"567a05d54e369d22efe40f3507a26e21f7878b95bd05c811250b2c350761791b","tests/entry.rs":"97b7927f14027c2f9bce2dc5f565ede00b9c37da41d0ee95144be8c0cb8c6983","tests/header/mod.rs":"02b05639f63c39a47559650c7209817bb60282deb4f679d5b001ed936343d9de"},"package":"4b55807c0344e1e6c04d7c965f5289c39a8d94ae23ed5c0b57aabac549f871c6"}
++{"files":{".cargo_vcs_info.json":"e45d0dcacca796a5216a6c06af829c4951e4a6a50a45a49c17f3e57cd6d37d4d",".github/dependabot.yml":"d04c9b0253b2bbae886b59a11399ea260397b460cd9f5712d692d1c85f8ec090",".github/workflows/main.yml":"2cb0bdc03adee75e18d8c9115c16baaae15136d6b7c47ad7f5ffc00d2dca7267","Cargo.lock":"9872bf9e41b9cadee45b688c9537030a993ca49a266fc7859029d8c74810d1d5","Cargo.toml":"6000e6f99d39717fb9eb65ca1b03ad2b5499a4831a52d4b83f9a8c77e41368b3","Cargo.toml.orig":"cf5ae4c1847ad24f5314d0ae865ad72d58cb050362611effd8a1d84e0e541b37","LICENSE-APACHE":"a60eea817514531668d7e00765731449fe14d059d3249e0bc93b36de45f759f2","LICENSE-MIT":"378f5840b258e2779c39418f3f2d7b2ba96f1c7917dd6be0713f88305dbda397","README.md":"71079f1a0962c2cf288058f38d24735bddabd1427ac2dee72ec18cc5ae4bceed","examples/extract_file.rs":"dc487f6631d824175afc3ee33de99e80718a8ca3f9e57fddd7cac0a46c07d3ae","examples/list.rs":"36e412205eaffea8ab7f39be4173594b74e36acb369e091362b1975ee4a7a14b","examples/raw_list.rs":"0a735576ac354457d6d5a4d395d044fae99bf67a7c69960ca784a6f6a1743651","examples/write.rs":"419ac3e4155035e32b52cd8e6ae987a2d99cf82f60abbfb315c2a2c4f8e8fd19","src/archive.rs":"7749c1f9b57b671a913dcd4e44c2d22a39dfe0795bf33454c0d97d79705b2c38","src/builder.rs":"2914f394d44c133557532bf5765fe63e0def30ec0b447f8f2bc620e932a2036a","src/entry.rs":"2f3ff18dc0c693f425488f946e8a7d250c4020134ca870fe5522d9a95b6a6ae0","src/entry_type.rs":"0786688729a96b4a3135b28d40b95c3d4feaad66b9574c490cbea14814ab975f","src/error.rs":"a20813fbc52f1f2e3a79654f62de6001759f6504a06acee5b0819d4865398587","src/header.rs":"fb2b1fa943c19635826b3f2becfb82527be7d08fdac115af840da3ff06152908","src/lib.rs":"5468e413205c907c367c35d28a528389103d68fd6a5b5979bbedba7c9e6b6c99","src/pax.rs":"54002e31151f9c50e02a3da26b3cacd1d3c9a3902daee008ab76d112cf5a2430","tests/all.rs":"2e23cb167407eb50acdec21f3693fcfa744be577a912b50466933251be404932","tests/entry.rs":"97b7927f14027c2f9bce2dc5f565ede00b9c37da41d0ee95144be8c0cb8c6983","tests/header/mod.rs":"02b05639f63c39a47559650c7209817bb60282deb4f679d5b001ed936343d9de"},"package":"4b55807c0344e1e6c04d7c965f5289c39a8d94ae23ed5c0b57aabac549f871c6"}
+diff --git a/vendor/tar-0.4.38/Cargo.toml b/vendor/tar-0.4.38/Cargo.toml
+index 23771b564..3606d283c 100644
+--- a/vendor/tar-0.4.38/Cargo.toml
++++ b/vendor/tar-0.4.38/Cargo.toml
+@@ -27,6 +27,16 @@ version = "0.2.8"
+ [dev-dependencies.tempfile]
+ version = "3"
+ 
++[dev-dependencies.astral-tokio-tar]
++version = "0.5"
++
++[dev-dependencies.tokio]
++version = "1"
++features = ["macros", "rt"]
++
++[dev-dependencies.tokio-stream]
++version = "0.1"
++
+ [features]
+ default = ["xattr"]
+ [target."cfg(unix)".dependencies.libc]
+diff --git a/vendor/tar-0.4.38/src/archive.rs b/vendor/tar-0.4.38/src/archive.rs
+index 056eb71a1..19e8d13c6 100644
+--- a/vendor/tar-0.4.38/src/archive.rs
++++ b/vendor/tar-0.4.38/src/archive.rs
+@@ -302,10 +302,11 @@ impl<'a> EntriesFields<'a> {
+ 
+         let file_pos = self.next;
+         let mut size = header.entry_size()?;
+-        if size == 0 {
+-            if let Some(pax_size) = pax_size {
+-                size = pax_size;
+-            }
++        // If this exists, it must override the header size. Disagreement among
++        // parsers allows construction of malicious archives that appear different
++        // when parsed.
++        if let Some(pax_size) = pax_size {
++            size = pax_size;
+         }
+         let ret = EntryFields {
+             size: size,
+diff --git a/vendor/tar-0.4.38/tests/all.rs b/vendor/tar-0.4.38/tests/all.rs
+index 11103bd6b..f7cceaf2a 100644
+--- a/vendor/tar-0.4.38/tests/all.rs
++++ b/vendor/tar-0.4.38/tests/all.rs
+@@ -1385,3 +1385,154 @@ fn header_size_overflow() {
+         err
+     );
+ }
++
++/// Build the PAX size smuggling archive described in the original report.
++///
++/// A PAX extended header declares `size=2048` for a regular file whose
++/// actual header size field is 8. A symlink entry is hidden inside the
++/// inflated region. A correct parser honours the PAX size and skips over
++/// the symlink; a buggy one reads only the header size and exposes it.
++fn build_pax_smuggle_archive() -> Vec<u8> {
++    const B: usize = 512;
++    const INFLATED: usize = 2048;
++    let end_of_archive = || std::iter::repeat(0u8).take(B * 2);
++
++    let mut ar: Vec<u8> = Vec::new();
++
++    // PAX extended header declaring size=2048 for the next entry.
++    let pax_rec = format!("13 size={INFLATED}\n");
++    let mut pax_hdr = Header::new_ustar();
++    pax_hdr.set_path("./PaxHeaders/regular").unwrap();
++    pax_hdr.set_size(pax_rec.as_bytes().len() as u64);
++    pax_hdr.set_entry_type(EntryType::XHeader);
++    pax_hdr.set_cksum();
++    ar.extend_from_slice(pax_hdr.as_bytes());
++    ar.extend_from_slice(pax_rec.as_bytes());
++    ar.resize(ar.len().next_multiple_of(B), 0);
++
++    // Regular file whose header says size=8, but PAX says 2048.
++    let content = b"regular\n";
++    let mut file_hdr = Header::new_ustar();
++    file_hdr.set_path("regular.txt").unwrap();
++    file_hdr.set_size(content.len() as u64);
++    file_hdr.set_entry_type(EntryType::Regular);
++    file_hdr.set_cksum();
++    ar.extend_from_slice(file_hdr.as_bytes());
++    let mark = ar.len();
++    ar.extend_from_slice(content);
++    ar.resize(ar.len().next_multiple_of(B), 0);
++
++    // Smuggled symlink hidden in the inflated region.
++    let mut sym_hdr = Header::new_ustar();
++    sym_hdr.set_path("smuggled").unwrap();
++    sym_hdr.set_size(0);
++    sym_hdr.set_entry_type(EntryType::Symlink);
++    sym_hdr.set_link_name("/etc/shadow").unwrap();
++    sym_hdr.set_cksum();
++    ar.extend_from_slice(sym_hdr.as_bytes());
++    ar.extend(end_of_archive());
++
++    // Pad to fill the inflated window.
++    let used = ar.len() - mark;
++    let pad = INFLATED.saturating_sub(used);
++    ar.extend(std::iter::repeat(0u8).take(pad.next_multiple_of(B)));
++
++    // End-of-archive.
++    ar.extend(end_of_archive());
++    ar
++}
++
++/// Regression test for PAX size smuggling.
++///
++/// A crafted archive uses a PAX extended header to declare a file size (2048)
++/// larger than the header's octal size field (8). Before the fix, `tar-rs`
++/// only applied the PAX size override when the header size was 0, so it would
++/// read the small header size, advance too little, and expose a symlink entry
++/// hidden in the "padding" area. After the fix, the PAX size unconditionally
++/// overrides the header size, causing the parser to skip over the smuggled
++/// symlink — matching the behavior of compliant parsers.
++#[test]
++fn pax_size_smuggled_symlink() {
++    let data = build_pax_smuggle_archive();
++
++    let mut archive = Archive::new(random_cursor_reader(&data[..]));
++    let entries: Vec<_> = archive
++        .entries()
++        .unwrap()
++        .map(|e| {
++            let e = e.unwrap();
++            let path = e.path().unwrap().to_path_buf();
++            let kind = e.header().entry_type();
++            let link = e.link_name().unwrap().map(|l| l.to_path_buf());
++            (path, kind, link)
++        })
++        .collect();
++
++    // With the fix applied, only "regular.txt" should be visible.
++    // The smuggled symlink must NOT appear.
++    let expected: Vec<(PathBuf, EntryType, Option<PathBuf>)> =
++        vec![(PathBuf::from("regular.txt"), EntryType::Regular, None)];
++    assert_eq!(
++        entries, expected,
++        "smuggled symlink visible or unexpected entries\n\
++         got: {entries:?}"
++    );
++}
++
++/// Cross-validate that `tar` and `astral-tokio-tar` parse the PAX size
++/// smuggling archive identically, guarding against parsing differentials.
++#[tokio::test]
++async fn pax_size_smuggle_matches_astral_tokio_tar() {
++    use tokio_stream::StreamExt;
++
++    let data = build_pax_smuggle_archive();
++
++    // Parse with sync tar.
++    let sync_entries: Vec<_> = {
++        let mut ar = Archive::new(&data[..]);
++        ar.entries()
++            .unwrap()
++            .map(|e| {
++                let e = e.unwrap();
++                let path = e.path().unwrap().to_path_buf();
++                let kind = e.header().entry_type();
++                let link = e.link_name().unwrap().map(|l| l.to_path_buf());
++                (path, kind, link)
++            })
++            .collect()
++    };
++
++    // Parse with async astral-tokio-tar.
++    let async_entries: Vec<_> = {
++        let mut ar = tokio_tar::Archive::new(&data[..]);
++        let mut entries = ar.entries().unwrap();
++        let mut result = Vec::new();
++        while let Some(e) = entries.next().await {
++            let e = e.unwrap();
++            let entry_type = e.header().entry_type();
++            result.push((
++                e.path().unwrap().to_path_buf(),
++                // Map through the raw byte so the two crates' EntryTypes compare.
++                EntryType::new(entry_type.as_byte()),
++                e.link_name().unwrap().map(|l| l.to_path_buf()),
++            ));
++        }
++        result
++    };
++
++    // Assert exact expected content for both parsers independently,
++    // so we verify correctness — not just mutual agreement.
++    let expected: Vec<(PathBuf, EntryType, Option<PathBuf>)> =
++        vec![(PathBuf::from("regular.txt"), EntryType::Regular, None)];
++
++    assert_eq!(
++        sync_entries, expected,
++        "tar-rs produced unexpected entries (smuggled symlink visible?)\n\
++         got: {sync_entries:?}"
++    );
++    assert_eq!(
++        async_entries, expected,
++        "astral-tokio-tar produced unexpected entries (smuggled symlink visible?)\n\
++         got: {async_entries:?}"
++    );
++}
+diff --git a/vendor/tar-0.4.43/.cargo-checksum.json b/vendor/tar-0.4.43/.cargo-checksum.json
+index d060264b5..d636c7013 100644
+--- a/vendor/tar-0.4.43/.cargo-checksum.json
++++ b/vendor/tar-0.4.43/.cargo-checksum.json
+@@ -1 +1 @@
+-{"files":{".cargo_vcs_info.json":"025fd4291d3a3d5e2526d4caa043c7c93cbf14d7ff86625217ec5eb50cff16aa",".github/dependabot.yml":"d04c9b0253b2bbae886b59a11399ea260397b460cd9f5712d692d1c85f8ec090",".github/workflows/main.yml":"6c844d85c298b164d0aa3f704ec9c4dd5df7748458d99ff65c4b99c4b1b18cf1","Cargo.lock":"4cd48beffdb2f2c3d877b25416981d7e03d174f4978aa209f57c8577c25eaa20","Cargo.toml":"1c485088be21ebf8749ce7894365429c16f1be2b99ebcb14f038255dc19323d9","Cargo.toml.orig":"cacd8e8c4aa358255d6f49effaaef01fcf285b4b36657673d5035624b8b2873b","LICENSE-APACHE":"a60eea817514531668d7e00765731449fe14d059d3249e0bc93b36de45f759f2","LICENSE-MIT":"378f5840b258e2779c39418f3f2d7b2ba96f1c7917dd6be0713f88305dbda397","README.md":"71079f1a0962c2cf288058f38d24735bddabd1427ac2dee72ec18cc5ae4bceed","examples/extract_file.rs":"dc487f6631d824175afc3ee33de99e80718a8ca3f9e57fddd7cac0a46c07d3ae","examples/list.rs":"36e412205eaffea8ab7f39be4173594b74e36acb369e091362b1975ee4a7a14b","examples/raw_list.rs":"0a735576ac354457d6d5a4d395d044fae99bf67a7c69960ca784a6f6a1743651","examples/write.rs":"419ac3e4155035e32b52cd8e6ae987a2d99cf82f60abbfb315c2a2c4f8e8fd19","src/archive.rs":"b9ad64d9ab2ed89aa885ac57f912feabdffeaccc120ce351a72091fc6dc79f5d","src/builder.rs":"d552134c0a4e937ab133bd312aa05b37ad780e450ba4a8597143368cbc6d253c","src/entry.rs":"370dc8cc216254b7b8dcdd063af41aee69382cc7363dd6bd4536b15030e2c198","src/entry_type.rs":"e22cf19e52310cf19f9a43e4191bb71a98c703274211265266565d9533730f6d","src/error.rs":"a20813fbc52f1f2e3a79654f62de6001759f6504a06acee5b0819d4865398587","src/header.rs":"eefe3426044e672e5134a5368c951de226d971fcf76a2f37b1cf847fda9ec37e","src/lib.rs":"b0c121cc2fdea38dad19e70bec6fd167d7a8dd87bb4d8c33016af78e1b1be9e1","src/pax.rs":"54c991798b22d6b5b7b9de2bd53aea5cfc48c494b61c26fa9867587d926b4b51","tests/all.rs":"7cc3b6fdf7ad77826305a414986af889d2971ea26a67e08df42a2f8fdfe76f91","tests/entry.rs":"51f229be18b27b5db94e21254897ffab747f707cac9cb270c4f902b57031a092","tests/header/mod.rs":"78fead69835262dbdcb35b6259cd664a70964e050b855417b5b29ae28f31c9fc"},"package":"c65998313f8e17d0d553d28f91a0df93e4dbbbf770279c7bc21ca0f09ea1a1f6"}
++{"files":{".cargo_vcs_info.json":"025fd4291d3a3d5e2526d4caa043c7c93cbf14d7ff86625217ec5eb50cff16aa",".github/dependabot.yml":"d04c9b0253b2bbae886b59a11399ea260397b460cd9f5712d692d1c85f8ec090",".github/workflows/main.yml":"6c844d85c298b164d0aa3f704ec9c4dd5df7748458d99ff65c4b99c4b1b18cf1","Cargo.lock":"4cd48beffdb2f2c3d877b25416981d7e03d174f4978aa209f57c8577c25eaa20","Cargo.toml":"f54da242e78bbac532c606787b71dbbc63cc6bb196a60535256cacbe2a88481d","Cargo.toml.orig":"cacd8e8c4aa358255d6f49effaaef01fcf285b4b36657673d5035624b8b2873b","LICENSE-APACHE":"a60eea817514531668d7e00765731449fe14d059d3249e0bc93b36de45f759f2","LICENSE-MIT":"378f5840b258e2779c39418f3f2d7b2ba96f1c7917dd6be0713f88305dbda397","README.md":"71079f1a0962c2cf288058f38d24735bddabd1427ac2dee72ec18cc5ae4bceed","examples/extract_file.rs":"dc487f6631d824175afc3ee33de99e80718a8ca3f9e57fddd7cac0a46c07d3ae","examples/list.rs":"36e412205eaffea8ab7f39be4173594b74e36acb369e091362b1975ee4a7a14b","examples/raw_list.rs":"0a735576ac354457d6d5a4d395d044fae99bf67a7c69960ca784a6f6a1743651","examples/write.rs":"419ac3e4155035e32b52cd8e6ae987a2d99cf82f60abbfb315c2a2c4f8e8fd19","src/archive.rs":"b6e4314e201e49cd67399e8da934558c8c634d1be4b31c4957f379f930199db8","src/builder.rs":"d552134c0a4e937ab133bd312aa05b37ad780e450ba4a8597143368cbc6d253c","src/entry.rs":"370dc8cc216254b7b8dcdd063af41aee69382cc7363dd6bd4536b15030e2c198","src/entry_type.rs":"e22cf19e52310cf19f9a43e4191bb71a98c703274211265266565d9533730f6d","src/error.rs":"a20813fbc52f1f2e3a79654f62de6001759f6504a06acee5b0819d4865398587","src/header.rs":"eefe3426044e672e5134a5368c951de226d971fcf76a2f37b1cf847fda9ec37e","src/lib.rs":"b0c121cc2fdea38dad19e70bec6fd167d7a8dd87bb4d8c33016af78e1b1be9e1","src/pax.rs":"54c991798b22d6b5b7b9de2bd53aea5cfc48c494b61c26fa9867587d926b4b51","tests/all.rs":"f3c8c7cd942a00716686f4e96ac08cc4fdddac5aa413e39801fe54f13dd0c1a2","tests/entry.rs":"51f229be18b27b5db94e21254897ffab747f707cac9cb270c4f902b57031a092","tests/header/mod.rs":"78fead69835262dbdcb35b6259cd664a70964e050b855417b5b29ae28f31c9fc"},"package":"c65998313f8e17d0d553d28f91a0df93e4dbbbf770279c7bc21ca0f09ea1a1f6"}
+diff --git a/vendor/tar-0.4.43/Cargo.toml b/vendor/tar-0.4.43/Cargo.toml
+index dde403094..2b57fb31b 100644
+--- a/vendor/tar-0.4.43/Cargo.toml
++++ b/vendor/tar-0.4.43/Cargo.toml
+@@ -71,6 +71,16 @@ version = "0.2.8"
+ [dev-dependencies.tempfile]
+ version = "3"
+ 
++[dev-dependencies.astral-tokio-tar]
++version = "0.5"
++
++[dev-dependencies.tokio]
++version = "1"
++features = ["macros", "rt"]
++
++[dev-dependencies.tokio-stream]
++version = "0.1"
++
+ [features]
+ default = ["xattr"]
+ 
+diff --git a/vendor/tar-0.4.43/src/archive.rs b/vendor/tar-0.4.43/src/archive.rs
+index 17938a8c0..519049ef4 100644
+--- a/vendor/tar-0.4.43/src/archive.rs
++++ b/vendor/tar-0.4.43/src/archive.rs
+@@ -351,10 +351,11 @@ impl<'a> EntriesFields<'a> {
+ 
+         let file_pos = self.next;
+         let mut size = header.entry_size()?;
+-        if size == 0 {
+-            if let Some(pax_size) = pax_size {
+-                size = pax_size;
+-            }
++        // If this exists, it must override the header size. Disagreement among
++        // parsers allows construction of malicious archives that appear different
++        // when parsed.
++        if let Some(pax_size) = pax_size {
++            size = pax_size;
+         }
+         let ret = EntryFields {
+             size: size,
+diff --git a/vendor/tar-0.4.43/tests/all.rs b/vendor/tar-0.4.43/tests/all.rs
+index 0e1c2613b..686157678 100644
+--- a/vendor/tar-0.4.43/tests/all.rs
++++ b/vendor/tar-0.4.43/tests/all.rs
+@@ -1715,3 +1715,154 @@ fn pax_and_gnu_uid_gid() {
+         }
+     }
+ }
++
++/// Build the PAX size smuggling archive described in the original report.
++///
++/// A PAX extended header declares `size=2048` for a regular file whose
++/// actual header size field is 8. A symlink entry is hidden inside the
++/// inflated region. A correct parser honours the PAX size and skips over
++/// the symlink; a buggy one reads only the header size and exposes it.
++fn build_pax_smuggle_archive() -> Vec<u8> {
++    const B: usize = 512;
++    const INFLATED: usize = 2048;
++    let end_of_archive = || std::iter::repeat(0u8).take(B * 2);
++
++    let mut ar: Vec<u8> = Vec::new();
++
++    // PAX extended header declaring size=2048 for the next entry.
++    let pax_rec = format!("13 size={INFLATED}\n");
++    let mut pax_hdr = Header::new_ustar();
++    pax_hdr.set_path("./PaxHeaders/regular").unwrap();
++    pax_hdr.set_size(pax_rec.as_bytes().len() as u64);
++    pax_hdr.set_entry_type(EntryType::XHeader);
++    pax_hdr.set_cksum();
++    ar.extend_from_slice(pax_hdr.as_bytes());
++    ar.extend_from_slice(pax_rec.as_bytes());
++    ar.resize(ar.len().next_multiple_of(B), 0);
++
++    // Regular file whose header says size=8, but PAX says 2048.
++    let content = b"regular\n";
++    let mut file_hdr = Header::new_ustar();
++    file_hdr.set_path("regular.txt").unwrap();
++    file_hdr.set_size(content.len() as u64);
++    file_hdr.set_entry_type(EntryType::Regular);
++    file_hdr.set_cksum();
++    ar.extend_from_slice(file_hdr.as_bytes());
++    let mark = ar.len();
++    ar.extend_from_slice(content);
++    ar.resize(ar.len().next_multiple_of(B), 0);
++
++    // Smuggled symlink hidden in the inflated region.
++    let mut sym_hdr = Header::new_ustar();
++    sym_hdr.set_path("smuggled").unwrap();
++    sym_hdr.set_size(0);
++    sym_hdr.set_entry_type(EntryType::Symlink);
++    sym_hdr.set_link_name("/etc/shadow").unwrap();
++    sym_hdr.set_cksum();
++    ar.extend_from_slice(sym_hdr.as_bytes());
++    ar.extend(end_of_archive());
++
++    // Pad to fill the inflated window.
++    let used = ar.len() - mark;
++    let pad = INFLATED.saturating_sub(used);
++    ar.extend(std::iter::repeat(0u8).take(pad.next_multiple_of(B)));
++
++    // End-of-archive.
++    ar.extend(end_of_archive());
++    ar
++}
++
++/// Regression test for PAX size smuggling.
++///
++/// A crafted archive uses a PAX extended header to declare a file size (2048)
++/// larger than the header's octal size field (8). Before the fix, `tar-rs`
++/// only applied the PAX size override when the header size was 0, so it would
++/// read the small header size, advance too little, and expose a symlink entry
++/// hidden in the "padding" area. After the fix, the PAX size unconditionally
++/// overrides the header size, causing the parser to skip over the smuggled
++/// symlink — matching the behavior of compliant parsers.
++#[test]
++fn pax_size_smuggled_symlink() {
++    let data = build_pax_smuggle_archive();
++
++    let mut archive = Archive::new(random_cursor_reader(&data[..]));
++    let entries: Vec<_> = archive
++        .entries()
++        .unwrap()
++        .map(|e| {
++            let e = e.unwrap();
++            let path = e.path().unwrap().to_path_buf();
++            let kind = e.header().entry_type();
++            let link = e.link_name().unwrap().map(|l| l.to_path_buf());
++            (path, kind, link)
++        })
++        .collect();
++
++    // With the fix applied, only "regular.txt" should be visible.
++    // The smuggled symlink must NOT appear.
++    let expected: Vec<(PathBuf, EntryType, Option<PathBuf>)> =
++        vec![(PathBuf::from("regular.txt"), EntryType::Regular, None)];
++    assert_eq!(
++        entries, expected,
++        "smuggled symlink visible or unexpected entries\n\
++         got: {entries:?}"
++    );
++}
++
++/// Cross-validate that `tar` and `astral-tokio-tar` parse the PAX size
++/// smuggling archive identically, guarding against parsing differentials.
++#[tokio::test]
++async fn pax_size_smuggle_matches_astral_tokio_tar() {
++    use tokio_stream::StreamExt;
++
++    let data = build_pax_smuggle_archive();
++
++    // Parse with sync tar.
++    let sync_entries: Vec<_> = {
++        let mut ar = Archive::new(&data[..]);
++        ar.entries()
++            .unwrap()
++            .map(|e| {
++                let e = e.unwrap();
++                let path = e.path().unwrap().to_path_buf();
++                let kind = e.header().entry_type();
++                let link = e.link_name().unwrap().map(|l| l.to_path_buf());
++                (path, kind, link)
++            })
++            .collect()
++    };
++
++    // Parse with async astral-tokio-tar.
++    let async_entries: Vec<_> = {
++        let mut ar = tokio_tar::Archive::new(&data[..]);
++        let mut entries = ar.entries().unwrap();
++        let mut result = Vec::new();
++        while let Some(e) = entries.next().await {
++            let e = e.unwrap();
++            let entry_type = e.header().entry_type();
++            result.push((
++                e.path().unwrap().to_path_buf(),
++                // Map through the raw byte so the two crates' EntryTypes compare.
++                EntryType::new(entry_type.as_byte()),
++                e.link_name().unwrap().map(|l| l.to_path_buf()),
++            ));
++        }
++        result
++    };
++
++    // Assert exact expected content for both parsers independently,
++    // so we verify correctness — not just mutual agreement.
++    let expected: Vec<(PathBuf, EntryType, Option<PathBuf>)> =
++        vec![(PathBuf::from("regular.txt"), EntryType::Regular, None)];
++
++    assert_eq!(
++        sync_entries, expected,
++        "tar-rs produced unexpected entries (smuggled symlink visible?)\n\
++         got: {sync_entries:?}"
++    );
++    assert_eq!(
++        async_entries, expected,
++        "astral-tokio-tar produced unexpected entries (smuggled symlink visible?)\n\
++         got: {async_entries:?}"
++    );
++}
+diff --git a/vendor/tar-0.4.44/.cargo-checksum.json b/vendor/tar-0.4.44/.cargo-checksum.json
+index 3542b9ce8..d0c8d6ef8 100644
+--- a/vendor/tar-0.4.44/.cargo-checksum.json
++++ b/vendor/tar-0.4.44/.cargo-checksum.json
+@@ -1 +1 @@
+-{"files":{".cargo_vcs_info.json":"bd0530055d1e8045030571042267ea5674c6cc4bd6af4bbd9d1a80f96578bf30",".github/dependabot.yml":"d04c9b0253b2bbae886b59a11399ea260397b460cd9f5712d692d1c85f8ec090",".github/workflows/main.yml":"3127e0a0379272a0f9b31e7d910b9de08ddf6b0c08b95f80825e5a07cdb0df91","Cargo.lock":"d861d685d22978a03927adb7e90992836adbed746dde53b1f256268a95911da3","Cargo.toml":"b3822faba576e8faef11ab664ff71adcf46dc547c21684e7ddf502b321ca9004","Cargo.toml.orig":"2692096c2923e0b549ea93ad2754becbbe0213469ad4a96bb5b1ffdf6546915f","LICENSE-APACHE":"a60eea817514531668d7e00765731449fe14d059d3249e0bc93b36de45f759f2","LICENSE-MIT":"378f5840b258e2779c39418f3f2d7b2ba96f1c7917dd6be0713f88305dbda397","README.md":"71079f1a0962c2cf288058f38d24735bddabd1427ac2dee72ec18cc5ae4bceed","examples/extract_file.rs":"dc487f6631d824175afc3ee33de99e80718a8ca3f9e57fddd7cac0a46c07d3ae","examples/list.rs":"36e412205eaffea8ab7f39be4173594b74e36acb369e091362b1975ee4a7a14b","examples/raw_list.rs":"0a735576ac354457d6d5a4d395d044fae99bf67a7c69960ca784a6f6a1743651","examples/write.rs":"419ac3e4155035e32b52cd8e6ae987a2d99cf82f60abbfb315c2a2c4f8e8fd19","src/archive.rs":"8755087ac4437356d74ee7e10a589986763d80e14e2c105edc3e2936c9358534","src/builder.rs":"50d6d4cbdad2722ff9524cef44453fa500b145b7757ef19e2ccdfab1d08aa6c9","src/entry.rs":"4dd1b8cc43917989b0b9c7f3e9e39798b1c5676ba3ecc0135b52b85de659c66b","src/entry_type.rs":"e22cf19e52310cf19f9a43e4191bb71a98c703274211265266565d9533730f6d","src/error.rs":"a20813fbc52f1f2e3a79654f62de6001759f6504a06acee5b0819d4865398587","src/header.rs":"12994aef80d5bdae8015de90e25f071ba46d897fb3ba3fc4e0103f02a9d3c235","src/lib.rs":"b0c121cc2fdea38dad19e70bec6fd167d7a8dd87bb4d8c33016af78e1b1be9e1","src/pax.rs":"54c991798b22d6b5b7b9de2bd53aea5cfc48c494b61c26fa9867587d926b4b51","tests/all.rs":"938658f554c93a0c9c90df8814da3155ce98d94494b01b04acf037b7af6d8070","tests/entry.rs":"51f229be18b27b5db94e21254897ffab747f707cac9cb270c4f902b57031a092","tests/header/mod.rs":"78fead69835262dbdcb35b6259cd664a70964e050b855417b5b29ae28f31c9fc"},"package":"1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"}
++{"files":{".cargo_vcs_info.json":"bd0530055d1e8045030571042267ea5674c6cc4bd6af4bbd9d1a80f96578bf30",".github/dependabot.yml":"d04c9b0253b2bbae886b59a11399ea260397b460cd9f5712d692d1c85f8ec090",".github/workflows/main.yml":"3127e0a0379272a0f9b31e7d910b9de08ddf6b0c08b95f80825e5a07cdb0df91","Cargo.lock":"d861d685d22978a03927adb7e90992836adbed746dde53b1f256268a95911da3","Cargo.toml":"68dee6d589be1e01b8b7999d3e1400e33ee41d4dd0d76bf47dab67dc6e650dca","Cargo.toml.orig":"2692096c2923e0b549ea93ad2754becbbe0213469ad4a96bb5b1ffdf6546915f","LICENSE-APACHE":"a60eea817514531668d7e00765731449fe14d059d3249e0bc93b36de45f759f2","LICENSE-MIT":"378f5840b258e2779c39418f3f2d7b2ba96f1c7917dd6be0713f88305dbda397","README.md":"71079f1a0962c2cf288058f38d24735bddabd1427ac2dee72ec18cc5ae4bceed","examples/extract_file.rs":"dc487f6631d824175afc3ee33de99e80718a8ca3f9e57fddd7cac0a46c07d3ae","examples/list.rs":"36e412205eaffea8ab7f39be4173594b74e36acb369e091362b1975ee4a7a14b","examples/raw_list.rs":"0a735576ac354457d6d5a4d395d044fae99bf67a7c69960ca784a6f6a1743651","examples/write.rs":"419ac3e4155035e32b52cd8e6ae987a2d99cf82f60abbfb315c2a2c4f8e8fd19","src/archive.rs":"3be4a747829796b8f3cceeb65d020026cff65b8d7cf7776a1b4d76704c968a1f","src/builder.rs":"50d6d4cbdad2722ff9524cef44453fa500b145b7757ef19e2ccdfab1d08aa6c9","src/entry.rs":"4dd1b8cc43917989b0b9c7f3e9e39798b1c5676ba3ecc0135b52b85de659c66b","src/entry_type.rs":"e22cf19e52310cf19f9a43e4191bb71a98c703274211265266565d9533730f6d","src/error.rs":"a20813fbc52f1f2e3a79654f62de6001759f6504a06acee5b0819d4865398587","src/header.rs":"12994aef80d5bdae8015de90e25f071ba46d897fb3ba3fc4e0103f02a9d3c235","src/lib.rs":"b0c121cc2fdea38dad19e70bec6fd167d7a8dd87bb4d8c33016af78e1b1be9e1","src/pax.rs":"54c991798b22d6b5b7b9de2bd53aea5cfc48c494b61c26fa9867587d926b4b51","tests/all.rs":"f1e779cbaf93a7767d7dff8a2c7fabe050f5c86acddd514c1bce7af83c0863d1","tests/entry.rs":"51f229be18b27b5db94e21254897ffab747f707cac9cb270c4f902b57031a092","tests/header/mod.rs":"78fead69835262dbdcb35b6259cd664a70964e050b855417b5b29ae28f31c9fc"},"package":"1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"}
+diff --git a/vendor/tar-0.4.44/Cargo.toml b/vendor/tar-0.4.44/Cargo.toml
+index d66917554..b8f1d7889 100644
+--- a/vendor/tar-0.4.44/Cargo.toml
++++ b/vendor/tar-0.4.44/Cargo.toml
+@@ -75,6 +75,16 @@ version = "0.2.8"
+ [dev-dependencies.tempfile]
+ version = "3"
+ 
++[dev-dependencies.astral-tokio-tar]
++version = "0.5"
++
++[dev-dependencies.tokio]
++version = "1"
++features = ["macros", "rt"]
++
++[dev-dependencies.tokio-stream]
++version = "0.1"
++
+ [target."cfg(unix)".dependencies.libc]
+ version = "0.2"
+ 
+diff --git a/vendor/tar-0.4.44/src/archive.rs b/vendor/tar-0.4.44/src/archive.rs
+index 459c28b65..cbc56f9f6 100644
+--- a/vendor/tar-0.4.44/src/archive.rs
++++ b/vendor/tar-0.4.44/src/archive.rs
+@@ -352,10 +352,11 @@ impl<'a> EntriesFields<'a> {
+ 
+         let file_pos = self.next;
+         let mut size = header.entry_size()?;
+-        if size == 0 {
+-            if let Some(pax_size) = pax_size {
+-                size = pax_size;
+-            }
++        // If this exists, it must override the header size. Disagreement among
++        // parsers allows construction of malicious archives that appear different
++        // when parsed.
++        if let Some(pax_size) = pax_size {
++            size = pax_size;
+         }
+         let ret = EntryFields {
+             size: size,
+diff --git a/vendor/tar-0.4.44/tests/all.rs b/vendor/tar-0.4.44/tests/all.rs
+index 0ad67f988..450993e0a 100644
+--- a/vendor/tar-0.4.44/tests/all.rs
++++ b/vendor/tar-0.4.44/tests/all.rs
+@@ -1744,3 +1744,154 @@ fn pax_and_gnu_uid_gid() {
+         }
+     }
+ }
++
++/// Build the PAX size smuggling archive described in the original report.
++///
++/// A PAX extended header declares `size=2048` for a regular file whose
++/// actual header size field is 8. A symlink entry is hidden inside the
++/// inflated region. A correct parser honours the PAX size and skips over
++/// the symlink; a buggy one reads only the header size and exposes it.
++fn build_pax_smuggle_archive() -> Vec<u8> {
++    const B: usize = 512;
++    const INFLATED: usize = 2048;
++    let end_of_archive = || std::iter::repeat(0u8).take(B * 2);
++
++    let mut ar: Vec<u8> = Vec::new();
++
++    // PAX extended header declaring size=2048 for the next entry.
++    let pax_rec = format!("13 size={INFLATED}\n");
++    let mut pax_hdr = Header::new_ustar();
++    pax_hdr.set_path("./PaxHeaders/regular").unwrap();
++    pax_hdr.set_size(pax_rec.as_bytes().len() as u64);
++    pax_hdr.set_entry_type(EntryType::XHeader);
++    pax_hdr.set_cksum();
++    ar.extend_from_slice(pax_hdr.as_bytes());
++    ar.extend_from_slice(pax_rec.as_bytes());
++    ar.resize(ar.len().next_multiple_of(B), 0);
++
++    // Regular file whose header says size=8, but PAX says 2048.
++    let content = b"regular\n";
++    let mut file_hdr = Header::new_ustar();
++    file_hdr.set_path("regular.txt").unwrap();
++    file_hdr.set_size(content.len() as u64);
++    file_hdr.set_entry_type(EntryType::Regular);
++    file_hdr.set_cksum();
++    ar.extend_from_slice(file_hdr.as_bytes());
++    let mark = ar.len();
++    ar.extend_from_slice(content);
++    ar.resize(ar.len().next_multiple_of(B), 0);
++
++    // Smuggled symlink hidden in the inflated region.
++    let mut sym_hdr = Header::new_ustar();
++    sym_hdr.set_path("smuggled").unwrap();
++    sym_hdr.set_size(0);
++    sym_hdr.set_entry_type(EntryType::Symlink);
++    sym_hdr.set_link_name("/etc/shadow").unwrap();
++    sym_hdr.set_cksum();
++    ar.extend_from_slice(sym_hdr.as_bytes());
++    ar.extend(end_of_archive());
++
++    // Pad to fill the inflated window.
++    let used = ar.len() - mark;
++    let pad = INFLATED.saturating_sub(used);
++    ar.extend(std::iter::repeat(0u8).take(pad.next_multiple_of(B)));
++
++    // End-of-archive.
++    ar.extend(end_of_archive());
++    ar
++}
++
++/// Regression test for PAX size smuggling.
++///
++/// A crafted archive uses a PAX extended header to declare a file size (2048)
++/// larger than the header's octal size field (8). Before the fix, `tar-rs`
++/// only applied the PAX size override when the header size was 0, so it would
++/// read the small header size, advance too little, and expose a symlink entry
++/// hidden in the "padding" area. After the fix, the PAX size unconditionally
++/// overrides the header size, causing the parser to skip over the smuggled
++/// symlink — matching the behavior of compliant parsers.
++#[test]
++fn pax_size_smuggled_symlink() {
++    let data = build_pax_smuggle_archive();
++
++    let mut archive = Archive::new(random_cursor_reader(&data[..]));
++    let entries: Vec<_> = archive
++        .entries()
++        .unwrap()
++        .map(|e| {
++            let e = e.unwrap();
++            let path = e.path().unwrap().to_path_buf();
++            let kind = e.header().entry_type();
++            let link = e.link_name().unwrap().map(|l| l.to_path_buf());
++            (path, kind, link)
++        })
++        .collect();
++
++    // With the fix applied, only "regular.txt" should be visible.
++    // The smuggled symlink must NOT appear.
++    let expected: Vec<(PathBuf, EntryType, Option<PathBuf>)> =
++        vec![(PathBuf::from("regular.txt"), EntryType::Regular, None)];
++    assert_eq!(
++        entries, expected,
++        "smuggled symlink visible or unexpected entries\n\
++         got: {entries:?}"
++    );
++}
++
++/// Cross-validate that `tar` and `astral-tokio-tar` parse the PAX size
++/// smuggling archive identically, guarding against parsing differentials.
++#[tokio::test]
++async fn pax_size_smuggle_matches_astral_tokio_tar() {
++    use tokio_stream::StreamExt;
++
++    let data = build_pax_smuggle_archive();
++
++    // Parse with sync tar.
++    let sync_entries: Vec<_> = {
++        let mut ar = Archive::new(&data[..]);
++        ar.entries()
++            .unwrap()
++            .map(|e| {
++                let e = e.unwrap();
++                let path = e.path().unwrap().to_path_buf();
++                let kind = e.header().entry_type();
++                let link = e.link_name().unwrap().map(|l| l.to_path_buf());
++                (path, kind, link)
++            })
++            .collect()
++    };
++
++    // Parse with async astral-tokio-tar.
++    let async_entries: Vec<_> = {
++        let mut ar = tokio_tar::Archive::new(&data[..]);
++        let mut entries = ar.entries().unwrap();
++        let mut result = Vec::new();
++        while let Some(e) = entries.next().await {
++            let e = e.unwrap();
++            let entry_type = e.header().entry_type();
++            result.push((
++                e.path().unwrap().to_path_buf(),
++                // Map through the raw byte so the two crates' EntryTypes compare.
++                EntryType::new(entry_type.as_byte()),
++                e.link_name().unwrap().map(|l| l.to_path_buf()),
++            ));
++        }
++        result
++    };
++
++    // Assert exact expected content for both parsers independently,
++    // so we verify correctness — not just mutual agreement.
++    let expected: Vec<(PathBuf, EntryType, Option<PathBuf>)> =
++        vec![(PathBuf::from("regular.txt"), EntryType::Regular, None)];
++
++    assert_eq!(
++        sync_entries, expected,
++        "tar-rs produced unexpected entries (smuggled symlink visible?)\n\
++         got: {sync_entries:?}"
++    );
++    assert_eq!(
++        async_entries, expected,
++        "astral-tokio-tar produced unexpected entries (smuggled symlink visible?)\n\
++         got: {async_entries:?}"
++    );
++}
+-- 
+2.43.0
+

--- a/SPECS/rust/CVE-2026-33055_1.75.patch
+++ b/SPECS/rust/CVE-2026-33055_1.75.patch
@@ -1,0 +1,450 @@
+From de1a5870e603758f430073688691165f21a33946 Mon Sep 17 00:00:00 2001
+From: Alex Crichton <alex@alexcrichton.com>
+Date: Thu, 19 Mar 2026 16:56:51 -0500
+Subject: [PATCH] archive: Unconditionally honor PAX size (#441)
+
+This synchronizes our behavior with most other tar parsers
+(including astral-tokio-tar and Go archive/tar) ensuring
+that we don't parse things differently.
+
+The problem with parsing size in particular differently is
+it's easy to craft a tar archive that appears completely differently
+between two parsers. This is the case with e.g. crates.io where
+astral-tokio-tar is used for validation server side, but cargo uses
+the `tar` crate to upload.
+
+With this, the two projects agree.
+
+Signed-off-by: Colin Walters <walters@verbum.org>
+Co-authored-by: Colin Walters <walters@verbum.org>
+
+Upstream Patch reference: https://github.com/alexcrichton/tar-rs/commit/de1a5870e603758f430073688691165f21a33946.patch
+
+---
+ vendor/tar-0.4.38/.cargo-checksum.json |   2 +-
+ vendor/tar-0.4.38/Cargo.toml           |  10 ++
+ vendor/tar-0.4.38/src/archive.rs       |   9 +-
+ vendor/tar-0.4.38/tests/all.rs         | 151 +++++++++++++++++++++++++
+ vendor/tar/.cargo-checksum.json        |   2 +-
+ vendor/tar/Cargo.toml                  |  10 ++
+ vendor/tar/src/archive.rs              |   9 +-
+ vendor/tar/tests/all.rs                | 151 +++++++++++++++++++++++++
+ 8 files changed, 334 insertions(+), 10 deletions(-)
+
+diff --git a/vendor/tar-0.4.38/.cargo-checksum.json b/vendor/tar-0.4.38/.cargo-checksum.json
+index 16ed33bac..0d41bb20a 100644
+--- a/vendor/tar-0.4.38/.cargo-checksum.json
++++ b/vendor/tar-0.4.38/.cargo-checksum.json
+@@ -1 +1 @@
+-{"files":{"Cargo.lock":"9872bf9e41b9cadee45b688c9537030a993ca49a266fc7859029d8c74810d1d5","Cargo.toml":"8353c71aa4d394efa7aaeac3004d0a16fd0c7124b7bd57ea91ba87a7b2015f15","LICENSE-APACHE":"a60eea817514531668d7e00765731449fe14d059d3249e0bc93b36de45f759f2","LICENSE-MIT":"378f5840b258e2779c39418f3f2d7b2ba96f1c7917dd6be0713f88305dbda397","README.md":"71079f1a0962c2cf288058f38d24735bddabd1427ac2dee72ec18cc5ae4bceed","examples/extract_file.rs":"dc487f6631d824175afc3ee33de99e80718a8ca3f9e57fddd7cac0a46c07d3ae","examples/list.rs":"36e412205eaffea8ab7f39be4173594b74e36acb369e091362b1975ee4a7a14b","examples/raw_list.rs":"0a735576ac354457d6d5a4d395d044fae99bf67a7c69960ca784a6f6a1743651","examples/write.rs":"419ac3e4155035e32b52cd8e6ae987a2d99cf82f60abbfb315c2a2c4f8e8fd19","src/archive.rs":"4eac362ffc7bf629fcecf88ca43cec96a1753c9e0a759722d916a9931c093e25","src/builder.rs":"2914f394d44c133557532bf5765fe63e0def30ec0b447f8f2bc620e932a2036a","src/entry.rs":"2f3ff18dc0c693f425488f946e8a7d250c4020134ca870fe5522d9a95b6a6ae0","src/entry_type.rs":"0786688729a96b4a3135b28d40b95c3d4feaad66b9574c490cbea14814ab975f","src/error.rs":"a20813fbc52f1f2e3a79654f62de6001759f6504a06acee5b0819d4865398587","src/header.rs":"fb2b1fa943c19635826b3f2becfb82527be7d08fdac115af840da3ff06152908","src/lib.rs":"5468e413205c907c367c35d28a528389103d68fd6a5b5979bbedba7c9e6b6c99","src/pax.rs":"54002e31151f9c50e02a3da26b3cacd1d3c9a3902daee008ab76d112cf5a2430","tests/all.rs":"567a05d54e369d22efe40f3507a26e21f7878b95bd05c811250b2c350761791b","tests/entry.rs":"97b7927f14027c2f9bce2dc5f565ede00b9c37da41d0ee95144be8c0cb8c6983","tests/header/mod.rs":"02b05639f63c39a47559650c7209817bb60282deb4f679d5b001ed936343d9de"},"package":"4b55807c0344e1e6c04d7c965f5289c39a8d94ae23ed5c0b57aabac549f871c6"}
++{"files":{"Cargo.lock":"9872bf9e41b9cadee45b688c9537030a993ca49a266fc7859029d8c74810d1d5","Cargo.toml":"6000e6f99d39717fb9eb65ca1b03ad2b5499a4831a52d4b83f9a8c77e41368b3","LICENSE-APACHE":"a60eea817514531668d7e00765731449fe14d059d3249e0bc93b36de45f759f2","LICENSE-MIT":"378f5840b258e2779c39418f3f2d7b2ba96f1c7917dd6be0713f88305dbda397","README.md":"71079f1a0962c2cf288058f38d24735bddabd1427ac2dee72ec18cc5ae4bceed","examples/extract_file.rs":"dc487f6631d824175afc3ee33de99e80718a8ca3f9e57fddd7cac0a46c07d3ae","examples/list.rs":"36e412205eaffea8ab7f39be4173594b74e36acb369e091362b1975ee4a7a14b","examples/raw_list.rs":"0a735576ac354457d6d5a4d395d044fae99bf67a7c69960ca784a6f6a1743651","examples/write.rs":"419ac3e4155035e32b52cd8e6ae987a2d99cf82f60abbfb315c2a2c4f8e8fd19","src/archive.rs":"7749c1f9b57b671a913dcd4e44c2d22a39dfe0795bf33454c0d97d79705b2c38","src/builder.rs":"2914f394d44c133557532bf5765fe63e0def30ec0b447f8f2bc620e932a2036a","src/entry.rs":"2f3ff18dc0c693f425488f946e8a7d250c4020134ca870fe5522d9a95b6a6ae0","src/entry_type.rs":"0786688729a96b4a3135b28d40b95c3d4feaad66b9574c490cbea14814ab975f","src/error.rs":"a20813fbc52f1f2e3a79654f62de6001759f6504a06acee5b0819d4865398587","src/header.rs":"fb2b1fa943c19635826b3f2becfb82527be7d08fdac115af840da3ff06152908","src/lib.rs":"5468e413205c907c367c35d28a528389103d68fd6a5b5979bbedba7c9e6b6c99","src/pax.rs":"54002e31151f9c50e02a3da26b3cacd1d3c9a3902daee008ab76d112cf5a2430","tests/all.rs":"2e23cb167407eb50acdec21f3693fcfa744be577a912b50466933251be404932","tests/entry.rs":"97b7927f14027c2f9bce2dc5f565ede00b9c37da41d0ee95144be8c0cb8c6983","tests/header/mod.rs":"02b05639f63c39a47559650c7209817bb60282deb4f679d5b001ed936343d9de"},"package":"4b55807c0344e1e6c04d7c965f5289c39a8d94ae23ed5c0b57aabac549f871c6"}
+diff --git a/vendor/tar-0.4.38/Cargo.toml b/vendor/tar-0.4.38/Cargo.toml
+index 23771b564..3606d283c 100644
+--- a/vendor/tar-0.4.38/Cargo.toml
++++ b/vendor/tar-0.4.38/Cargo.toml
+@@ -27,6 +27,16 @@ version = "0.2.8"
+ [dev-dependencies.tempfile]
+ version = "3"
+ 
++[dev-dependencies.astral-tokio-tar]
++version = "0.5"
++
++[dev-dependencies.tokio]
++version = "1"
++features = ["macros", "rt"]
++
++[dev-dependencies.tokio-stream]
++version = "0.1"
++
+ [features]
+ default = ["xattr"]
+ [target."cfg(unix)".dependencies.libc]
+diff --git a/vendor/tar-0.4.38/src/archive.rs b/vendor/tar-0.4.38/src/archive.rs
+index 056eb71a1..19e8d13c6 100644
+--- a/vendor/tar-0.4.38/src/archive.rs
++++ b/vendor/tar-0.4.38/src/archive.rs
+@@ -302,10 +302,11 @@ impl<'a> EntriesFields<'a> {
+ 
+         let file_pos = self.next;
+         let mut size = header.entry_size()?;
+-        if size == 0 {
+-            if let Some(pax_size) = pax_size {
+-                size = pax_size;
+-            }
++        // If this exists, it must override the header size. Disagreement among
++        // parsers allows construction of malicious archives that appear different
++        // when parsed.
++        if let Some(pax_size) = pax_size {
++            size = pax_size;
+         }
+         let ret = EntryFields {
+             size: size,
+diff --git a/vendor/tar-0.4.38/tests/all.rs b/vendor/tar-0.4.38/tests/all.rs
+index 11103bd6b..f7cceaf2a 100644
+--- a/vendor/tar-0.4.38/tests/all.rs
++++ b/vendor/tar-0.4.38/tests/all.rs
+@@ -1385,3 +1385,154 @@ fn header_size_overflow() {
+         err
+     );
+ }
++
++/// Build the PAX size smuggling archive described in the original report.
++///
++/// A PAX extended header declares `size=2048` for a regular file whose
++/// actual header size field is 8. A symlink entry is hidden inside the
++/// inflated region. A correct parser honours the PAX size and skips over
++/// the symlink; a buggy one reads only the header size and exposes it.
++fn build_pax_smuggle_archive() -> Vec<u8> {
++    const B: usize = 512;
++    const INFLATED: usize = 2048;
++    let end_of_archive = || std::iter::repeat(0u8).take(B * 2);
++
++    let mut ar: Vec<u8> = Vec::new();
++
++    // PAX extended header declaring size=2048 for the next entry.
++    let pax_rec = format!("13 size={INFLATED}\n");
++    let mut pax_hdr = Header::new_ustar();
++    pax_hdr.set_path("./PaxHeaders/regular").unwrap();
++    pax_hdr.set_size(pax_rec.as_bytes().len() as u64);
++    pax_hdr.set_entry_type(EntryType::XHeader);
++    pax_hdr.set_cksum();
++    ar.extend_from_slice(pax_hdr.as_bytes());
++    ar.extend_from_slice(pax_rec.as_bytes());
++    ar.resize(ar.len().next_multiple_of(B), 0);
++
++    // Regular file whose header says size=8, but PAX says 2048.
++    let content = b"regular\n";
++    let mut file_hdr = Header::new_ustar();
++    file_hdr.set_path("regular.txt").unwrap();
++    file_hdr.set_size(content.len() as u64);
++    file_hdr.set_entry_type(EntryType::Regular);
++    file_hdr.set_cksum();
++    ar.extend_from_slice(file_hdr.as_bytes());
++    let mark = ar.len();
++    ar.extend_from_slice(content);
++    ar.resize(ar.len().next_multiple_of(B), 0);
++
++    // Smuggled symlink hidden in the inflated region.
++    let mut sym_hdr = Header::new_ustar();
++    sym_hdr.set_path("smuggled").unwrap();
++    sym_hdr.set_size(0);
++    sym_hdr.set_entry_type(EntryType::Symlink);
++    sym_hdr.set_link_name("/etc/shadow").unwrap();
++    sym_hdr.set_cksum();
++    ar.extend_from_slice(sym_hdr.as_bytes());
++    ar.extend(end_of_archive());
++
++    // Pad to fill the inflated window.
++    let used = ar.len() - mark;
++    let pad = INFLATED.saturating_sub(used);
++    ar.extend(std::iter::repeat(0u8).take(pad.next_multiple_of(B)));
++
++    // End-of-archive.
++    ar.extend(end_of_archive());
++    ar
++}
++
++/// Regression test for PAX size smuggling.
++///
++/// A crafted archive uses a PAX extended header to declare a file size (2048)
++/// larger than the header's octal size field (8). Before the fix, `tar-rs`
++/// only applied the PAX size override when the header size was 0, so it would
++/// read the small header size, advance too little, and expose a symlink entry
++/// hidden in the "padding" area. After the fix, the PAX size unconditionally
++/// overrides the header size, causing the parser to skip over the smuggled
++/// symlink — matching the behavior of compliant parsers.
++#[test]
++fn pax_size_smuggled_symlink() {
++    let data = build_pax_smuggle_archive();
++
++    let mut archive = Archive::new(random_cursor_reader(&data[..]));
++    let entries: Vec<_> = archive
++        .entries()
++        .unwrap()
++        .map(|e| {
++            let e = e.unwrap();
++            let path = e.path().unwrap().to_path_buf();
++            let kind = e.header().entry_type();
++            let link = e.link_name().unwrap().map(|l| l.to_path_buf());
++            (path, kind, link)
++        })
++        .collect();
++
++    // With the fix applied, only "regular.txt" should be visible.
++    // The smuggled symlink must NOT appear.
++    let expected: Vec<(PathBuf, EntryType, Option<PathBuf>)> =
++        vec![(PathBuf::from("regular.txt"), EntryType::Regular, None)];
++    assert_eq!(
++        entries, expected,
++        "smuggled symlink visible or unexpected entries\n\
++         got: {entries:?}"
++    );
++}
++
++/// Cross-validate that `tar` and `astral-tokio-tar` parse the PAX size
++/// smuggling archive identically, guarding against parsing differentials.
++#[tokio::test]
++async fn pax_size_smuggle_matches_astral_tokio_tar() {
++    use tokio_stream::StreamExt;
++
++    let data = build_pax_smuggle_archive();
++
++    // Parse with sync tar.
++    let sync_entries: Vec<_> = {
++        let mut ar = Archive::new(&data[..]);
++        ar.entries()
++            .unwrap()
++            .map(|e| {
++                let e = e.unwrap();
++                let path = e.path().unwrap().to_path_buf();
++                let kind = e.header().entry_type();
++                let link = e.link_name().unwrap().map(|l| l.to_path_buf());
++                (path, kind, link)
++            })
++            .collect()
++    };
++
++    // Parse with async astral-tokio-tar.
++    let async_entries: Vec<_> = {
++        let mut ar = tokio_tar::Archive::new(&data[..]);
++        let mut entries = ar.entries().unwrap();
++        let mut result = Vec::new();
++        while let Some(e) = entries.next().await {
++            let e = e.unwrap();
++            let entry_type = e.header().entry_type();
++            result.push((
++                e.path().unwrap().to_path_buf(),
++                // Map through the raw byte so the two crates' EntryTypes compare.
++                EntryType::new(entry_type.as_byte()),
++                e.link_name().unwrap().map(|l| l.to_path_buf()),
++            ));
++        }
++        result
++    };
++
++    // Assert exact expected content for both parsers independently,
++    // so we verify correctness — not just mutual agreement.
++    let expected: Vec<(PathBuf, EntryType, Option<PathBuf>)> =
++        vec![(PathBuf::from("regular.txt"), EntryType::Regular, None)];
++
++    assert_eq!(
++        sync_entries, expected,
++        "tar-rs produced unexpected entries (smuggled symlink visible?)\n\
++         got: {sync_entries:?}"
++    );
++    assert_eq!(
++        async_entries, expected,
++        "astral-tokio-tar produced unexpected entries (smuggled symlink visible?)\n\
++         got: {async_entries:?}"
++    );
++}
+diff --git a/vendor/tar/.cargo-checksum.json b/vendor/tar/.cargo-checksum.json
+index 433701f56..30337d738 100644
+--- a/vendor/tar/.cargo-checksum.json
++++ b/vendor/tar/.cargo-checksum.json
+@@ -1 +1 @@
+-{"files":{"Cargo.lock":"734d770757fa895a8c4e215b8063840d33083d007e02d70dfb47a07cd348b933","Cargo.toml":"1e1da319c4d28693a3e42e014ed00828480994b55b15003052f21f2342a346bb","LICENSE-APACHE":"a60eea817514531668d7e00765731449fe14d059d3249e0bc93b36de45f759f2","LICENSE-MIT":"378f5840b258e2779c39418f3f2d7b2ba96f1c7917dd6be0713f88305dbda397","README.md":"71079f1a0962c2cf288058f38d24735bddabd1427ac2dee72ec18cc5ae4bceed","examples/extract_file.rs":"dc487f6631d824175afc3ee33de99e80718a8ca3f9e57fddd7cac0a46c07d3ae","examples/list.rs":"36e412205eaffea8ab7f39be4173594b74e36acb369e091362b1975ee4a7a14b","examples/raw_list.rs":"0a735576ac354457d6d5a4d395d044fae99bf67a7c69960ca784a6f6a1743651","examples/write.rs":"419ac3e4155035e32b52cd8e6ae987a2d99cf82f60abbfb315c2a2c4f8e8fd19","src/archive.rs":"44b5de68d031997c0ceb4b3904973470f4020dbfeb910c09ebef31fecf9065f7","src/builder.rs":"2914f394d44c133557532bf5765fe63e0def30ec0b447f8f2bc620e932a2036a","src/entry.rs":"e73bbec8dbd20a7ab5453c45b908b3a02e0c7f3854cf9716f87120f556e4f0e2","src/entry_type.rs":"0786688729a96b4a3135b28d40b95c3d4feaad66b9574c490cbea14814ab975f","src/error.rs":"a20813fbc52f1f2e3a79654f62de6001759f6504a06acee5b0819d4865398587","src/header.rs":"fb2b1fa943c19635826b3f2becfb82527be7d08fdac115af840da3ff06152908","src/lib.rs":"5468e413205c907c367c35d28a528389103d68fd6a5b5979bbedba7c9e6b6c99","src/pax.rs":"0509d9afa47ae9f1658bf7d02d12a9791f717971736c4e2041c5fb5f7c5354c8","tests/all.rs":"81bfe5fb71e8d2dd7455c126fc77aa40c2011a2cd5871d785e39e6fb053bf352","tests/entry.rs":"f89b56fc984d17ca2050b0ecda365974b1ff8c3fa0fd7a9363248e824638b8fc","tests/header/mod.rs":"02b05639f63c39a47559650c7209817bb60282deb4f679d5b001ed936343d9de"},"package":"b16afcea1f22891c49a00c751c7b63b2233284064f11a200fc624137c51e2ddb"}
++{"files":{"Cargo.lock":"734d770757fa895a8c4e215b8063840d33083d007e02d70dfb47a07cd348b933","Cargo.toml":"c0189de96e6e7e3f10ce2b9ab47544df2c77033045f2600c2807331cf02e558d","LICENSE-APACHE":"a60eea817514531668d7e00765731449fe14d059d3249e0bc93b36de45f759f2","LICENSE-MIT":"378f5840b258e2779c39418f3f2d7b2ba96f1c7917dd6be0713f88305dbda397","README.md":"71079f1a0962c2cf288058f38d24735bddabd1427ac2dee72ec18cc5ae4bceed","examples/extract_file.rs":"dc487f6631d824175afc3ee33de99e80718a8ca3f9e57fddd7cac0a46c07d3ae","examples/list.rs":"36e412205eaffea8ab7f39be4173594b74e36acb369e091362b1975ee4a7a14b","examples/raw_list.rs":"0a735576ac354457d6d5a4d395d044fae99bf67a7c69960ca784a6f6a1743651","examples/write.rs":"419ac3e4155035e32b52cd8e6ae987a2d99cf82f60abbfb315c2a2c4f8e8fd19","src/archive.rs":"a44e3ad23d9f6432e47279a6ea33648b732c9bd0d2cd39c5e1c3bf0cff988d93","src/builder.rs":"2914f394d44c133557532bf5765fe63e0def30ec0b447f8f2bc620e932a2036a","src/entry.rs":"e73bbec8dbd20a7ab5453c45b908b3a02e0c7f3854cf9716f87120f556e4f0e2","src/entry_type.rs":"0786688729a96b4a3135b28d40b95c3d4feaad66b9574c490cbea14814ab975f","src/error.rs":"a20813fbc52f1f2e3a79654f62de6001759f6504a06acee5b0819d4865398587","src/header.rs":"fb2b1fa943c19635826b3f2becfb82527be7d08fdac115af840da3ff06152908","src/lib.rs":"5468e413205c907c367c35d28a528389103d68fd6a5b5979bbedba7c9e6b6c99","src/pax.rs":"0509d9afa47ae9f1658bf7d02d12a9791f717971736c4e2041c5fb5f7c5354c8","tests/all.rs":"a6a7c7c3a347e2eeec7369f4bf999adeb5b03b14107b0a55ab766e958cf03bb5","tests/entry.rs":"f89b56fc984d17ca2050b0ecda365974b1ff8c3fa0fd7a9363248e824638b8fc","tests/header/mod.rs":"02b05639f63c39a47559650c7209817bb60282deb4f679d5b001ed936343d9de"},"package":"b16afcea1f22891c49a00c751c7b63b2233284064f11a200fc624137c51e2ddb"}
+diff --git a/vendor/tar/Cargo.toml b/vendor/tar/Cargo.toml
+index 3fe607f97..c5a298225 100644
+--- a/vendor/tar/Cargo.toml
++++ b/vendor/tar/Cargo.toml
+@@ -38,6 +38,16 @@ version = "0.2.8"
+ [dev-dependencies.tempfile]
+ version = "3"
+ 
++[dev-dependencies.astral-tokio-tar]
++version = "0.5"
++
++[dev-dependencies.tokio]
++version = "1"
++features = ["macros", "rt"]
++
++[dev-dependencies.tokio-stream]
++version = "0.1"
++
+ [features]
+ default = ["xattr"]
+ 
+diff --git a/vendor/tar/src/archive.rs b/vendor/tar/src/archive.rs
+index 9ee31deff..13bc67a6d 100644
+--- a/vendor/tar/src/archive.rs
++++ b/vendor/tar/src/archive.rs
+@@ -342,10 +342,11 @@ impl<'a> EntriesFields<'a> {
+ 
+         let file_pos = self.next;
+         let mut size = header.entry_size()?;
+-        if size == 0 {
+-            if let Some(pax_size) = pax_size {
+-                size = pax_size;
+-            }
++        // If this exists, it must override the header size. Disagreement among
++        // parsers allows construction of malicious archives that appear different
++        // when parsed.
++        if let Some(pax_size) = pax_size {
++            size = pax_size;
+         }
+         let ret = EntryFields {
+             size: size,
+diff --git a/vendor/tar/tests/all.rs b/vendor/tar/tests/all.rs
+index a7954e1fb..a0ed13513 100644
+--- a/vendor/tar/tests/all.rs
++++ b/vendor/tar/tests/all.rs
+@@ -1515,3 +1515,154 @@ fn pax_and_gnu_uid_gid() {
+         }
+     }
+ }
++
++/// Build the PAX size smuggling archive described in the original report.
++///
++/// A PAX extended header declares `size=2048` for a regular file whose
++/// actual header size field is 8. A symlink entry is hidden inside the
++/// inflated region. A correct parser honours the PAX size and skips over
++/// the symlink; a buggy one reads only the header size and exposes it.
++fn build_pax_smuggle_archive() -> Vec<u8> {
++    const B: usize = 512;
++    const INFLATED: usize = 2048;
++    let end_of_archive = || std::iter::repeat(0u8).take(B * 2);
++
++    let mut ar: Vec<u8> = Vec::new();
++
++    // PAX extended header declaring size=2048 for the next entry.
++    let pax_rec = format!("13 size={INFLATED}\n");
++    let mut pax_hdr = Header::new_ustar();
++    pax_hdr.set_path("./PaxHeaders/regular").unwrap();
++    pax_hdr.set_size(pax_rec.as_bytes().len() as u64);
++    pax_hdr.set_entry_type(EntryType::XHeader);
++    pax_hdr.set_cksum();
++    ar.extend_from_slice(pax_hdr.as_bytes());
++    ar.extend_from_slice(pax_rec.as_bytes());
++    ar.resize(ar.len().next_multiple_of(B), 0);
++
++    // Regular file whose header says size=8, but PAX says 2048.
++    let content = b"regular\n";
++    let mut file_hdr = Header::new_ustar();
++    file_hdr.set_path("regular.txt").unwrap();
++    file_hdr.set_size(content.len() as u64);
++    file_hdr.set_entry_type(EntryType::Regular);
++    file_hdr.set_cksum();
++    ar.extend_from_slice(file_hdr.as_bytes());
++    let mark = ar.len();
++    ar.extend_from_slice(content);
++    ar.resize(ar.len().next_multiple_of(B), 0);
++
++    // Smuggled symlink hidden in the inflated region.
++    let mut sym_hdr = Header::new_ustar();
++    sym_hdr.set_path("smuggled").unwrap();
++    sym_hdr.set_size(0);
++    sym_hdr.set_entry_type(EntryType::Symlink);
++    sym_hdr.set_link_name("/etc/shadow").unwrap();
++    sym_hdr.set_cksum();
++    ar.extend_from_slice(sym_hdr.as_bytes());
++    ar.extend(end_of_archive());
++
++    // Pad to fill the inflated window.
++    let used = ar.len() - mark;
++    let pad = INFLATED.saturating_sub(used);
++    ar.extend(std::iter::repeat(0u8).take(pad.next_multiple_of(B)));
++
++    // End-of-archive.
++    ar.extend(end_of_archive());
++    ar
++}
++
++/// Regression test for PAX size smuggling.
++///
++/// A crafted archive uses a PAX extended header to declare a file size (2048)
++/// larger than the header's octal size field (8). Before the fix, `tar-rs`
++/// only applied the PAX size override when the header size was 0, so it would
++/// read the small header size, advance too little, and expose a symlink entry
++/// hidden in the "padding" area. After the fix, the PAX size unconditionally
++/// overrides the header size, causing the parser to skip over the smuggled
++/// symlink — matching the behavior of compliant parsers.
++#[test]
++fn pax_size_smuggled_symlink() {
++    let data = build_pax_smuggle_archive();
++
++    let mut archive = Archive::new(random_cursor_reader(&data[..]));
++    let entries: Vec<_> = archive
++        .entries()
++        .unwrap()
++        .map(|e| {
++            let e = e.unwrap();
++            let path = e.path().unwrap().to_path_buf();
++            let kind = e.header().entry_type();
++            let link = e.link_name().unwrap().map(|l| l.to_path_buf());
++            (path, kind, link)
++        })
++        .collect();
++
++    // With the fix applied, only "regular.txt" should be visible.
++    // The smuggled symlink must NOT appear.
++    let expected: Vec<(PathBuf, EntryType, Option<PathBuf>)> =
++        vec![(PathBuf::from("regular.txt"), EntryType::Regular, None)];
++    assert_eq!(
++        entries, expected,
++        "smuggled symlink visible or unexpected entries\n\
++         got: {entries:?}"
++    );
++}
++
++/// Cross-validate that `tar` and `astral-tokio-tar` parse the PAX size
++/// smuggling archive identically, guarding against parsing differentials.
++#[tokio::test]
++async fn pax_size_smuggle_matches_astral_tokio_tar() {
++    use tokio_stream::StreamExt;
++
++    let data = build_pax_smuggle_archive();
++
++    // Parse with sync tar.
++    let sync_entries: Vec<_> = {
++        let mut ar = Archive::new(&data[..]);
++        ar.entries()
++            .unwrap()
++            .map(|e| {
++                let e = e.unwrap();
++                let path = e.path().unwrap().to_path_buf();
++                let kind = e.header().entry_type();
++                let link = e.link_name().unwrap().map(|l| l.to_path_buf());
++                (path, kind, link)
++            })
++            .collect()
++    };
++
++    // Parse with async astral-tokio-tar.
++    let async_entries: Vec<_> = {
++        let mut ar = tokio_tar::Archive::new(&data[..]);
++        let mut entries = ar.entries().unwrap();
++        let mut result = Vec::new();
++        while let Some(e) = entries.next().await {
++            let e = e.unwrap();
++            let entry_type = e.header().entry_type();
++            result.push((
++                e.path().unwrap().to_path_buf(),
++                // Map through the raw byte so the two crates' EntryTypes compare.
++                EntryType::new(entry_type.as_byte()),
++                e.link_name().unwrap().map(|l| l.to_path_buf()),
++            ));
++        }
++        result
++    };
++
++    // Assert exact expected content for both parsers independently,
++    // so we verify correctness — not just mutual agreement.
++    let expected: Vec<(PathBuf, EntryType, Option<PathBuf>)> =
++        vec![(PathBuf::from("regular.txt"), EntryType::Regular, None)];
++
++    assert_eq!(
++        sync_entries, expected,
++        "tar-rs produced unexpected entries (smuggled symlink visible?)\n\
++         got: {sync_entries:?}"
++    );
++    assert_eq!(
++        async_entries, expected,
++        "astral-tokio-tar produced unexpected entries (smuggled symlink visible?)\n\
++         got: {async_entries:?}"
++    );
++}
+-- 
+2.43.0
+

--- a/SPECS/rust/CVE-2026-33056.patch
+++ b/SPECS/rust/CVE-2026-33056.patch
@@ -1,0 +1,420 @@
+From 17b1fd84e632071cb8eef9d3709bf347bd266446 Mon Sep 17 00:00:00 2001
+From: Alex Crichton <alex@alexcrichton.com>
+Date: Thu, 19 Mar 2026 16:58:05 -0500
+Subject: [PATCH] archive: Prevent symlink-directory collision chmod attack
+ (#442)
+
+When unpacking a tarball containing a symlink followed by a directory
+entry with the same path, unpack_dir previously used fs::metadata()
+which follows symlinks. This allowed an attacker to modify permissions
+on arbitrary directories outside the extraction path.
+
+The fix uses fs::symlink_metadata() to detect symlinks and refuse to
+treat them as valid existing directories.
+
+Document more exhaustively+consistently security caveats.
+
+Reported-by: Sergei Zimmerman <https://github.com/xokdvium>
+Assisted-by: OpenCode (Claude claude-opus-4-5)
+
+Signed-off-by: Colin Walters <walters@verbum.org>
+Co-authored-by: Colin Walters <walters@verbum.org>
+
+Upstream Patch reference: https://github.com/alexcrichton/tar-rs/commit/17b1fd84e632071cb8eef9d3709bf347bd266446.patch
+
+---
+ vendor/tar-0.4.38/.cargo-checksum.json |  2 +-
+ vendor/tar-0.4.38/src/archive.rs       | 18 +++++++--
+ vendor/tar-0.4.38/src/entry.rs         |  7 ++--
+ vendor/tar-0.4.38/tests/entry.rs       | 56 ++++++++++++++++++++++++++
+ vendor/tar-0.4.43/.cargo-checksum.json |  2 +-
+ vendor/tar-0.4.43/src/archive.rs       | 18 +++++++--
+ vendor/tar-0.4.43/src/entry.rs         |  7 ++--
+ vendor/tar-0.4.43/tests/entry.rs       | 56 ++++++++++++++++++++++++++
+ vendor/tar-0.4.44/.cargo-checksum.json |  2 +-
+ vendor/tar-0.4.44/src/archive.rs       | 18 +++++++--
+ vendor/tar-0.4.44/src/entry.rs         |  7 ++--
+ vendor/tar-0.4.44/tests/entry.rs       | 56 ++++++++++++++++++++++++++
+ 12 files changed, 228 insertions(+), 21 deletions(-)
+
+diff --git a/vendor/tar-0.4.38/.cargo-checksum.json b/vendor/tar-0.4.38/.cargo-checksum.json
+index 49dec43b5..29f36527e 100644
+--- a/vendor/tar-0.4.38/.cargo-checksum.json
++++ b/vendor/tar-0.4.38/.cargo-checksum.json
+@@ -1 +1 @@
+-{"files":{".cargo_vcs_info.json":"e45d0dcacca796a5216a6c06af829c4951e4a6a50a45a49c17f3e57cd6d37d4d",".github/dependabot.yml":"d04c9b0253b2bbae886b59a11399ea260397b460cd9f5712d692d1c85f8ec090",".github/workflows/main.yml":"2cb0bdc03adee75e18d8c9115c16baaae15136d6b7c47ad7f5ffc00d2dca7267","Cargo.lock":"9872bf9e41b9cadee45b688c9537030a993ca49a266fc7859029d8c74810d1d5","Cargo.toml":"8353c71aa4d394efa7aaeac3004d0a16fd0c7124b7bd57ea91ba87a7b2015f15","Cargo.toml.orig":"cf5ae4c1847ad24f5314d0ae865ad72d58cb050362611effd8a1d84e0e541b37","LICENSE-APACHE":"a60eea817514531668d7e00765731449fe14d059d3249e0bc93b36de45f759f2","LICENSE-MIT":"378f5840b258e2779c39418f3f2d7b2ba96f1c7917dd6be0713f88305dbda397","README.md":"71079f1a0962c2cf288058f38d24735bddabd1427ac2dee72ec18cc5ae4bceed","examples/extract_file.rs":"dc487f6631d824175afc3ee33de99e80718a8ca3f9e57fddd7cac0a46c07d3ae","examples/list.rs":"36e412205eaffea8ab7f39be4173594b74e36acb369e091362b1975ee4a7a14b","examples/raw_list.rs":"0a735576ac354457d6d5a4d395d044fae99bf67a7c69960ca784a6f6a1743651","examples/write.rs":"419ac3e4155035e32b52cd8e6ae987a2d99cf82f60abbfb315c2a2c4f8e8fd19","src/archive.rs":"85a0091e02690c62379137988cd9b2689009536a0b941f1ab0581db26e9ebce6","src/builder.rs":"2914f394d44c133557532bf5765fe63e0def30ec0b447f8f2bc620e932a2036a","src/entry.rs":"705016636f7fdcad4fe20d7d2672be2b94cc53bb05e47628f5212b89e17a40fe","src/entry_type.rs":"0786688729a96b4a3135b28d40b95c3d4feaad66b9574c490cbea14814ab975f","src/error.rs":"a20813fbc52f1f2e3a79654f62de6001759f6504a06acee5b0819d4865398587","src/header.rs":"fb2b1fa943c19635826b3f2becfb82527be7d08fdac115af840da3ff06152908","src/lib.rs":"5468e413205c907c367c35d28a528389103d68fd6a5b5979bbedba7c9e6b6c99","src/pax.rs":"54002e31151f9c50e02a3da26b3cacd1d3c9a3902daee008ab76d112cf5a2430","tests/all.rs":"567a05d54e369d22efe40f3507a26e21f7878b95bd05c811250b2c350761791b","tests/entry.rs":"c1411ee09da9edb659b508867f0960e804966dfd33801f4a7afaefda331479dd","tests/header/mod.rs":"02b05639f63c39a47559650c7209817bb60282deb4f679d5b001ed936343d9de"},"package":"4b55807c0344e1e6c04d7c965f5289c39a8d94ae23ed5c0b57aabac549f871c6"}
+\ No newline at end of file
++{"files":{".cargo_vcs_info.json":"e45d0dcacca796a5216a6c06af829c4951e4a6a50a45a49c17f3e57cd6d37d4d",".github/dependabot.yml":"d04c9b0253b2bbae886b59a11399ea260397b460cd9f5712d692d1c85f8ec090",".github/workflows/main.yml":"2cb0bdc03adee75e18d8c9115c16baaae15136d6b7c47ad7f5ffc00d2dca7267","Cargo.lock":"9872bf9e41b9cadee45b688c9537030a993ca49a266fc7859029d8c74810d1d5","Cargo.toml":"8353c71aa4d394efa7aaeac3004d0a16fd0c7124b7bd57ea91ba87a7b2015f15","Cargo.toml.orig":"cf5ae4c1847ad24f5314d0ae865ad72d58cb050362611effd8a1d84e0e541b37","LICENSE-APACHE":"a60eea817514531668d7e00765731449fe14d059d3249e0bc93b36de45f759f2","LICENSE-MIT":"378f5840b258e2779c39418f3f2d7b2ba96f1c7917dd6be0713f88305dbda397","README.md":"71079f1a0962c2cf288058f38d24735bddabd1427ac2dee72ec18cc5ae4bceed","examples/extract_file.rs":"dc487f6631d824175afc3ee33de99e80718a8ca3f9e57fddd7cac0a46c07d3ae","examples/list.rs":"36e412205eaffea8ab7f39be4173594b74e36acb369e091362b1975ee4a7a14b","examples/raw_list.rs":"0a735576ac354457d6d5a4d395d044fae99bf67a7c69960ca784a6f6a1743651","examples/write.rs":"419ac3e4155035e32b52cd8e6ae987a2d99cf82f60abbfb315c2a2c4f8e8fd19","src/archive.rs":"4eac362ffc7bf629fcecf88ca43cec96a1753c9e0a759722d916a9931c093e25","src/builder.rs":"2914f394d44c133557532bf5765fe63e0def30ec0b447f8f2bc620e932a2036a","src/entry.rs":"2f3ff18dc0c693f425488f946e8a7d250c4020134ca870fe5522d9a95b6a6ae0","src/entry_type.rs":"0786688729a96b4a3135b28d40b95c3d4feaad66b9574c490cbea14814ab975f","src/error.rs":"a20813fbc52f1f2e3a79654f62de6001759f6504a06acee5b0819d4865398587","src/header.rs":"fb2b1fa943c19635826b3f2becfb82527be7d08fdac115af840da3ff06152908","src/lib.rs":"5468e413205c907c367c35d28a528389103d68fd6a5b5979bbedba7c9e6b6c99","src/pax.rs":"54002e31151f9c50e02a3da26b3cacd1d3c9a3902daee008ab76d112cf5a2430","tests/all.rs":"567a05d54e369d22efe40f3507a26e21f7878b95bd05c811250b2c350761791b","tests/entry.rs":"97b7927f14027c2f9bce2dc5f565ede00b9c37da41d0ee95144be8c0cb8c6983","tests/header/mod.rs":"02b05639f63c39a47559650c7209817bb60282deb4f679d5b001ed936343d9de"},"package":"4b55807c0344e1e6c04d7c965f5289c39a8d94ae23ed5c0b57aabac549f871c6"}
+diff --git a/vendor/tar-0.4.38/src/archive.rs b/vendor/tar-0.4.38/src/archive.rs
+index 1bed51249..056eb71a1 100644
+--- a/vendor/tar-0.4.38/src/archive.rs
++++ b/vendor/tar-0.4.38/src/archive.rs
+@@ -88,9 +88,21 @@ impl<R: Read> Archive<R> {
+     /// extracting each file in turn to the location specified by the entry's
+     /// path name.
+     ///
+-    /// This operation is relatively sensitive in that it will not write files
+-    /// outside of the path specified by `dst`. Files in the archive which have
+-    /// a '..' in their path are skipped during the unpacking process.
++    /// # Security
++    ///
++    /// A best-effort is made to prevent writing files outside `dst` (paths
++    /// containing `..` are skipped, symlinks are validated). However, there
++    /// have been historical bugs in this area, and more may exist. For this
++    /// reason, when processing untrusted archives, stronger sandboxing is
++    /// encouraged: e.g. the [`cap-std`] crate and/or OS-level
++    /// containerization/virtualization.
++    ///
++    /// If `dst` does not exist, it is created. Unpacking into an existing
++    /// directory merges content. This function assumes `dst` is not
++    /// concurrently modified by untrusted processes. Protecting against
++    /// TOCTOU races is out of scope for this crate.
++    ///
++    /// [`cap-std`]: https://docs.rs/cap-std/
+     ///
+     /// # Examples
+     ///
+diff --git a/vendor/tar-0.4.38/src/entry.rs b/vendor/tar-0.4.38/src/entry.rs
+index 8f0b62acf..287d68904 100644
+--- a/vendor/tar-0.4.38/src/entry.rs
++++ b/vendor/tar-0.4.38/src/entry.rs
+@@ -210,8 +210,9 @@ impl<'a, R: Read> Entry<'a, R> {
+     /// also be propagated to the path `dst`. Any existing file at the location
+     /// `dst` will be overwritten.
+     ///
+-    /// This function carefully avoids writing outside of `dst`. If the file has
+-    /// a '..' in its path, this function will skip it and return false.
++    /// # Security
++    ///
++    /// See [`Archive::unpack`].
+     ///
+     /// # Examples
+     ///
+@@ -430,7 +431,7 @@ impl<'a> EntryFields<'a> {
+         // If the directory already exists just let it slide
+         fs::create_dir(dst).or_else(|err| {
+             if err.kind() == ErrorKind::AlreadyExists {
+-                let prev = fs::metadata(dst);
++                let prev = fs::symlink_metadata(dst);
+                 if prev.map(|m| m.is_dir()).unwrap_or(false) {
+                     return Ok(());
+                 }
+diff --git a/vendor/tar-0.4.38/tests/entry.rs b/vendor/tar-0.4.38/tests/entry.rs
+index fa8eeaee7..5e874fa5d 100644
+--- a/vendor/tar-0.4.38/tests/entry.rs
++++ b/vendor/tar-0.4.38/tests/entry.rs
+@@ -377,3 +377,59 @@ fn modify_symlink_just_created() {
+     t!(t!(File::open(&test)).read_to_end(&mut contents));
+     assert_eq!(contents.len(), 0);
+ }
++
++/// Test that unpacking a tarball with a symlink followed by a directory entry
++/// with the same name does not allow modifying permissions of arbitrary directories
++/// outside the extraction path.
++#[test]
++#[cfg(unix)]
++fn symlink_dir_collision_does_not_modify_external_dir_permissions() {
++    use ::std::fs;
++    use ::std::os::unix::fs::PermissionsExt;
++
++    let td = Builder::new().prefix("tar").tempdir().unwrap();
++
++    let target_dir = td.path().join("target-dir");
++    fs::create_dir(&target_dir).unwrap();
++    fs::set_permissions(&target_dir, fs::Permissions::from_mode(0o700)).unwrap();
++    let before_mode = fs::metadata(&target_dir).unwrap().permissions().mode() & 0o7777;
++    assert_eq!(before_mode, 0o700);
++
++    let extract_dir = td.path().join("extract-dir");
++    fs::create_dir(&extract_dir).unwrap();
++
++    let mut ar = tar::Builder::new(Vec::new());
++
++    let mut header = tar::Header::new_gnu();
++    header.set_size(0);
++    header.set_entry_type(tar::EntryType::Symlink);
++    header.set_path("foo").unwrap();
++    header.set_link_name(&target_dir).unwrap();
++    header.set_mode(0o777);
++    header.set_cksum();
++    ar.append(&header, &[][..]).unwrap();
++
++    let mut header = tar::Header::new_gnu();
++    header.set_size(0);
++    header.set_entry_type(tar::EntryType::Directory);
++    header.set_path("foo").unwrap();
++    header.set_mode(0o777);
++    header.set_cksum();
++    ar.append(&header, &[][..]).unwrap();
++
++    let bytes = ar.into_inner().unwrap();
++    let mut ar = tar::Archive::new(&bytes[..]);
++
++    let result = ar.unpack(&extract_dir);
++    assert!(result.is_err());
++
++    let symlink_path = extract_dir.join("foo");
++    assert!(symlink_path
++        .symlink_metadata()
++        .unwrap()
++        .file_type()
++        .is_symlink());
++
++    let after_mode = fs::metadata(&target_dir).unwrap().permissions().mode() & 0o7777;
++    assert_eq!(after_mode, 0o700);
++}
+diff --git a/vendor/tar-0.4.43/.cargo-checksum.json b/vendor/tar-0.4.43/.cargo-checksum.json
+index 58b2036c3..d060264b5 100644
+--- a/vendor/tar-0.4.43/.cargo-checksum.json
++++ b/vendor/tar-0.4.43/.cargo-checksum.json
+@@ -1 +1 @@
+-{"files":{".cargo_vcs_info.json":"025fd4291d3a3d5e2526d4caa043c7c93cbf14d7ff86625217ec5eb50cff16aa",".github/dependabot.yml":"d04c9b0253b2bbae886b59a11399ea260397b460cd9f5712d692d1c85f8ec090",".github/workflows/main.yml":"6c844d85c298b164d0aa3f704ec9c4dd5df7748458d99ff65c4b99c4b1b18cf1","Cargo.lock":"4cd48beffdb2f2c3d877b25416981d7e03d174f4978aa209f57c8577c25eaa20","Cargo.toml":"1c485088be21ebf8749ce7894365429c16f1be2b99ebcb14f038255dc19323d9","Cargo.toml.orig":"cacd8e8c4aa358255d6f49effaaef01fcf285b4b36657673d5035624b8b2873b","LICENSE-APACHE":"a60eea817514531668d7e00765731449fe14d059d3249e0bc93b36de45f759f2","LICENSE-MIT":"378f5840b258e2779c39418f3f2d7b2ba96f1c7917dd6be0713f88305dbda397","README.md":"71079f1a0962c2cf288058f38d24735bddabd1427ac2dee72ec18cc5ae4bceed","examples/extract_file.rs":"dc487f6631d824175afc3ee33de99e80718a8ca3f9e57fddd7cac0a46c07d3ae","examples/list.rs":"36e412205eaffea8ab7f39be4173594b74e36acb369e091362b1975ee4a7a14b","examples/raw_list.rs":"0a735576ac354457d6d5a4d395d044fae99bf67a7c69960ca784a6f6a1743651","examples/write.rs":"419ac3e4155035e32b52cd8e6ae987a2d99cf82f60abbfb315c2a2c4f8e8fd19","src/archive.rs":"913500dfb2484e1ae7e38a8de23b7d0c3522eeae956c1cbcb765cc9f14504190","src/builder.rs":"d552134c0a4e937ab133bd312aa05b37ad780e450ba4a8597143368cbc6d253c","src/entry.rs":"ef0583b82c214348875074a911a24e43007d9672c6dec12aaacee852cd3f71c8","src/entry_type.rs":"e22cf19e52310cf19f9a43e4191bb71a98c703274211265266565d9533730f6d","src/error.rs":"a20813fbc52f1f2e3a79654f62de6001759f6504a06acee5b0819d4865398587","src/header.rs":"eefe3426044e672e5134a5368c951de226d971fcf76a2f37b1cf847fda9ec37e","src/lib.rs":"b0c121cc2fdea38dad19e70bec6fd167d7a8dd87bb4d8c33016af78e1b1be9e1","src/pax.rs":"54c991798b22d6b5b7b9de2bd53aea5cfc48c494b61c26fa9867587d926b4b51","tests/all.rs":"7cc3b6fdf7ad77826305a414986af889d2971ea26a67e08df42a2f8fdfe76f91","tests/entry.rs":"07f1a9fbe30bc0d7d0af8c93a27cb33dce7e949bc198dc182bf2326ce08464d6","tests/header/mod.rs":"78fead69835262dbdcb35b6259cd664a70964e050b855417b5b29ae28f31c9fc"},"package":"c65998313f8e17d0d553d28f91a0df93e4dbbbf770279c7bc21ca0f09ea1a1f6"}
+\ No newline at end of file
++{"files":{".cargo_vcs_info.json":"025fd4291d3a3d5e2526d4caa043c7c93cbf14d7ff86625217ec5eb50cff16aa",".github/dependabot.yml":"d04c9b0253b2bbae886b59a11399ea260397b460cd9f5712d692d1c85f8ec090",".github/workflows/main.yml":"6c844d85c298b164d0aa3f704ec9c4dd5df7748458d99ff65c4b99c4b1b18cf1","Cargo.lock":"4cd48beffdb2f2c3d877b25416981d7e03d174f4978aa209f57c8577c25eaa20","Cargo.toml":"1c485088be21ebf8749ce7894365429c16f1be2b99ebcb14f038255dc19323d9","Cargo.toml.orig":"cacd8e8c4aa358255d6f49effaaef01fcf285b4b36657673d5035624b8b2873b","LICENSE-APACHE":"a60eea817514531668d7e00765731449fe14d059d3249e0bc93b36de45f759f2","LICENSE-MIT":"378f5840b258e2779c39418f3f2d7b2ba96f1c7917dd6be0713f88305dbda397","README.md":"71079f1a0962c2cf288058f38d24735bddabd1427ac2dee72ec18cc5ae4bceed","examples/extract_file.rs":"dc487f6631d824175afc3ee33de99e80718a8ca3f9e57fddd7cac0a46c07d3ae","examples/list.rs":"36e412205eaffea8ab7f39be4173594b74e36acb369e091362b1975ee4a7a14b","examples/raw_list.rs":"0a735576ac354457d6d5a4d395d044fae99bf67a7c69960ca784a6f6a1743651","examples/write.rs":"419ac3e4155035e32b52cd8e6ae987a2d99cf82f60abbfb315c2a2c4f8e8fd19","src/archive.rs":"b9ad64d9ab2ed89aa885ac57f912feabdffeaccc120ce351a72091fc6dc79f5d","src/builder.rs":"d552134c0a4e937ab133bd312aa05b37ad780e450ba4a8597143368cbc6d253c","src/entry.rs":"370dc8cc216254b7b8dcdd063af41aee69382cc7363dd6bd4536b15030e2c198","src/entry_type.rs":"e22cf19e52310cf19f9a43e4191bb71a98c703274211265266565d9533730f6d","src/error.rs":"a20813fbc52f1f2e3a79654f62de6001759f6504a06acee5b0819d4865398587","src/header.rs":"eefe3426044e672e5134a5368c951de226d971fcf76a2f37b1cf847fda9ec37e","src/lib.rs":"b0c121cc2fdea38dad19e70bec6fd167d7a8dd87bb4d8c33016af78e1b1be9e1","src/pax.rs":"54c991798b22d6b5b7b9de2bd53aea5cfc48c494b61c26fa9867587d926b4b51","tests/all.rs":"7cc3b6fdf7ad77826305a414986af889d2971ea26a67e08df42a2f8fdfe76f91","tests/entry.rs":"51f229be18b27b5db94e21254897ffab747f707cac9cb270c4f902b57031a092","tests/header/mod.rs":"78fead69835262dbdcb35b6259cd664a70964e050b855417b5b29ae28f31c9fc"},"package":"c65998313f8e17d0d553d28f91a0df93e4dbbbf770279c7bc21ca0f09ea1a1f6"}
+diff --git a/vendor/tar-0.4.43/src/archive.rs b/vendor/tar-0.4.43/src/archive.rs
+index 924e54a26..17938a8c0 100644
+--- a/vendor/tar-0.4.43/src/archive.rs
++++ b/vendor/tar-0.4.43/src/archive.rs
+@@ -92,9 +92,21 @@ impl<R: Read> Archive<R> {
+     /// extracting each file in turn to the location specified by the entry's
+     /// path name.
+     ///
+-    /// This operation is relatively sensitive in that it will not write files
+-    /// outside of the path specified by `dst`. Files in the archive which have
+-    /// a '..' in their path are skipped during the unpacking process.
++    /// # Security
++    ///
++    /// A best-effort is made to prevent writing files outside `dst` (paths
++    /// containing `..` are skipped, symlinks are validated). However, there
++    /// have been historical bugs in this area, and more may exist. For this
++    /// reason, when processing untrusted archives, stronger sandboxing is
++    /// encouraged: e.g. the [`cap-std`] crate and/or OS-level
++    /// containerization/virtualization.
++    ///
++    /// If `dst` does not exist, it is created. Unpacking into an existing
++    /// directory merges content. This function assumes `dst` is not
++    /// concurrently modified by untrusted processes. Protecting against
++    /// TOCTOU races is out of scope for this crate.
++    ///
++    /// [`cap-std`]: https://docs.rs/cap-std/
+     ///
+     /// # Examples
+     ///
+diff --git a/vendor/tar-0.4.43/src/entry.rs b/vendor/tar-0.4.43/src/entry.rs
+index b6b48b47e..c9f3b9f61 100644
+--- a/vendor/tar-0.4.43/src/entry.rs
++++ b/vendor/tar-0.4.43/src/entry.rs
+@@ -212,8 +212,9 @@ impl<'a, R: Read> Entry<'a, R> {
+     /// also be propagated to the path `dst`. Any existing file at the location
+     /// `dst` will be overwritten.
+     ///
+-    /// This function carefully avoids writing outside of `dst`. If the file has
+-    /// a '..' in its path, this function will skip it and return false.
++    /// # Security
++    ///
++    /// See [`Archive::unpack`].
+     ///
+     /// # Examples
+     ///
+@@ -446,7 +447,7 @@ impl<'a> EntryFields<'a> {
+         // If the directory already exists just let it slide
+         fs::create_dir(dst).or_else(|err| {
+             if err.kind() == ErrorKind::AlreadyExists {
+-                let prev = fs::metadata(dst);
++                let prev = fs::symlink_metadata(dst);
+                 if prev.map(|m| m.is_dir()).unwrap_or(false) {
+                     return Ok(());
+                 }
+diff --git a/vendor/tar-0.4.43/tests/entry.rs b/vendor/tar-0.4.43/tests/entry.rs
+index 4d612e2cf..92c11f64a 100644
+--- a/vendor/tar-0.4.43/tests/entry.rs
++++ b/vendor/tar-0.4.43/tests/entry.rs
+@@ -409,3 +409,59 @@ fn modify_symlink_just_created() {
+     t!(t!(File::open(&test)).read_to_end(&mut contents));
+     assert_eq!(contents.len(), 0);
+ }
++
++/// Test that unpacking a tarball with a symlink followed by a directory entry
++/// with the same name does not allow modifying permissions of arbitrary directories
++/// outside the extraction path.
++#[test]
++#[cfg(unix)]
++fn symlink_dir_collision_does_not_modify_external_dir_permissions() {
++    use ::std::fs;
++    use ::std::os::unix::fs::PermissionsExt;
++
++    let td = Builder::new().prefix("tar").tempdir().unwrap();
++
++    let target_dir = td.path().join("target-dir");
++    fs::create_dir(&target_dir).unwrap();
++    fs::set_permissions(&target_dir, fs::Permissions::from_mode(0o700)).unwrap();
++    let before_mode = fs::metadata(&target_dir).unwrap().permissions().mode() & 0o7777;
++    assert_eq!(before_mode, 0o700);
++
++    let extract_dir = td.path().join("extract-dir");
++    fs::create_dir(&extract_dir).unwrap();
++
++    let mut ar = tar::Builder::new(Vec::new());
++
++    let mut header = tar::Header::new_gnu();
++    header.set_size(0);
++    header.set_entry_type(tar::EntryType::Symlink);
++    header.set_path("foo").unwrap();
++    header.set_link_name(&target_dir).unwrap();
++    header.set_mode(0o777);
++    header.set_cksum();
++    ar.append(&header, &[][..]).unwrap();
++
++    let mut header = tar::Header::new_gnu();
++    header.set_size(0);
++    header.set_entry_type(tar::EntryType::Directory);
++    header.set_path("foo").unwrap();
++    header.set_mode(0o777);
++    header.set_cksum();
++    ar.append(&header, &[][..]).unwrap();
++
++    let bytes = ar.into_inner().unwrap();
++    let mut ar = tar::Archive::new(&bytes[..]);
++
++    let result = ar.unpack(&extract_dir);
++    assert!(result.is_err());
++
++    let symlink_path = extract_dir.join("foo");
++    assert!(symlink_path
++        .symlink_metadata()
++        .unwrap()
++        .file_type()
++        .is_symlink());
++
++    let after_mode = fs::metadata(&target_dir).unwrap().permissions().mode() & 0o7777;
++    assert_eq!(after_mode, 0o700);
++}
+diff --git a/vendor/tar-0.4.44/.cargo-checksum.json b/vendor/tar-0.4.44/.cargo-checksum.json
+index 078f51cba..3542b9ce8 100644
+--- a/vendor/tar-0.4.44/.cargo-checksum.json
++++ b/vendor/tar-0.4.44/.cargo-checksum.json
+@@ -1 +1 @@
+-{"files":{".cargo_vcs_info.json":"bd0530055d1e8045030571042267ea5674c6cc4bd6af4bbd9d1a80f96578bf30",".github/dependabot.yml":"d04c9b0253b2bbae886b59a11399ea260397b460cd9f5712d692d1c85f8ec090",".github/workflows/main.yml":"3127e0a0379272a0f9b31e7d910b9de08ddf6b0c08b95f80825e5a07cdb0df91","Cargo.lock":"d861d685d22978a03927adb7e90992836adbed746dde53b1f256268a95911da3","Cargo.toml":"b3822faba576e8faef11ab664ff71adcf46dc547c21684e7ddf502b321ca9004","Cargo.toml.orig":"2692096c2923e0b549ea93ad2754becbbe0213469ad4a96bb5b1ffdf6546915f","LICENSE-APACHE":"a60eea817514531668d7e00765731449fe14d059d3249e0bc93b36de45f759f2","LICENSE-MIT":"378f5840b258e2779c39418f3f2d7b2ba96f1c7917dd6be0713f88305dbda397","README.md":"71079f1a0962c2cf288058f38d24735bddabd1427ac2dee72ec18cc5ae4bceed","examples/extract_file.rs":"dc487f6631d824175afc3ee33de99e80718a8ca3f9e57fddd7cac0a46c07d3ae","examples/list.rs":"36e412205eaffea8ab7f39be4173594b74e36acb369e091362b1975ee4a7a14b","examples/raw_list.rs":"0a735576ac354457d6d5a4d395d044fae99bf67a7c69960ca784a6f6a1743651","examples/write.rs":"419ac3e4155035e32b52cd8e6ae987a2d99cf82f60abbfb315c2a2c4f8e8fd19","src/archive.rs":"c23693531825157c481f5addcf05cd48b8bfbb19c7777b7b8b2375cfdb67aa66","src/builder.rs":"50d6d4cbdad2722ff9524cef44453fa500b145b7757ef19e2ccdfab1d08aa6c9","src/entry.rs":"259ba8993987db5ab1fd9d0163e0de54c2168837f74a53f75569a2d303823769","src/entry_type.rs":"e22cf19e52310cf19f9a43e4191bb71a98c703274211265266565d9533730f6d","src/error.rs":"a20813fbc52f1f2e3a79654f62de6001759f6504a06acee5b0819d4865398587","src/header.rs":"12994aef80d5bdae8015de90e25f071ba46d897fb3ba3fc4e0103f02a9d3c235","src/lib.rs":"b0c121cc2fdea38dad19e70bec6fd167d7a8dd87bb4d8c33016af78e1b1be9e1","src/pax.rs":"54c991798b22d6b5b7b9de2bd53aea5cfc48c494b61c26fa9867587d926b4b51","tests/all.rs":"938658f554c93a0c9c90df8814da3155ce98d94494b01b04acf037b7af6d8070","tests/entry.rs":"07f1a9fbe30bc0d7d0af8c93a27cb33dce7e949bc198dc182bf2326ce08464d6","tests/header/mod.rs":"78fead69835262dbdcb35b6259cd664a70964e050b855417b5b29ae28f31c9fc"},"package":"1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"}
+\ No newline at end of file
++{"files":{".cargo_vcs_info.json":"bd0530055d1e8045030571042267ea5674c6cc4bd6af4bbd9d1a80f96578bf30",".github/dependabot.yml":"d04c9b0253b2bbae886b59a11399ea260397b460cd9f5712d692d1c85f8ec090",".github/workflows/main.yml":"3127e0a0379272a0f9b31e7d910b9de08ddf6b0c08b95f80825e5a07cdb0df91","Cargo.lock":"d861d685d22978a03927adb7e90992836adbed746dde53b1f256268a95911da3","Cargo.toml":"b3822faba576e8faef11ab664ff71adcf46dc547c21684e7ddf502b321ca9004","Cargo.toml.orig":"2692096c2923e0b549ea93ad2754becbbe0213469ad4a96bb5b1ffdf6546915f","LICENSE-APACHE":"a60eea817514531668d7e00765731449fe14d059d3249e0bc93b36de45f759f2","LICENSE-MIT":"378f5840b258e2779c39418f3f2d7b2ba96f1c7917dd6be0713f88305dbda397","README.md":"71079f1a0962c2cf288058f38d24735bddabd1427ac2dee72ec18cc5ae4bceed","examples/extract_file.rs":"dc487f6631d824175afc3ee33de99e80718a8ca3f9e57fddd7cac0a46c07d3ae","examples/list.rs":"36e412205eaffea8ab7f39be4173594b74e36acb369e091362b1975ee4a7a14b","examples/raw_list.rs":"0a735576ac354457d6d5a4d395d044fae99bf67a7c69960ca784a6f6a1743651","examples/write.rs":"419ac3e4155035e32b52cd8e6ae987a2d99cf82f60abbfb315c2a2c4f8e8fd19","src/archive.rs":"8755087ac4437356d74ee7e10a589986763d80e14e2c105edc3e2936c9358534","src/builder.rs":"50d6d4cbdad2722ff9524cef44453fa500b145b7757ef19e2ccdfab1d08aa6c9","src/entry.rs":"4dd1b8cc43917989b0b9c7f3e9e39798b1c5676ba3ecc0135b52b85de659c66b","src/entry_type.rs":"e22cf19e52310cf19f9a43e4191bb71a98c703274211265266565d9533730f6d","src/error.rs":"a20813fbc52f1f2e3a79654f62de6001759f6504a06acee5b0819d4865398587","src/header.rs":"12994aef80d5bdae8015de90e25f071ba46d897fb3ba3fc4e0103f02a9d3c235","src/lib.rs":"b0c121cc2fdea38dad19e70bec6fd167d7a8dd87bb4d8c33016af78e1b1be9e1","src/pax.rs":"54c991798b22d6b5b7b9de2bd53aea5cfc48c494b61c26fa9867587d926b4b51","tests/all.rs":"938658f554c93a0c9c90df8814da3155ce98d94494b01b04acf037b7af6d8070","tests/entry.rs":"51f229be18b27b5db94e21254897ffab747f707cac9cb270c4f902b57031a092","tests/header/mod.rs":"78fead69835262dbdcb35b6259cd664a70964e050b855417b5b29ae28f31c9fc"},"package":"1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"}
+diff --git a/vendor/tar-0.4.44/src/archive.rs b/vendor/tar-0.4.44/src/archive.rs
+index 4d569c635..459c28b65 100644
+--- a/vendor/tar-0.4.44/src/archive.rs
++++ b/vendor/tar-0.4.44/src/archive.rs
+@@ -93,9 +93,21 @@ impl<R: Read> Archive<R> {
+     /// extracting each file in turn to the location specified by the entry's
+     /// path name.
+     ///
+-    /// This operation is relatively sensitive in that it will not write files
+-    /// outside of the path specified by `dst`. Files in the archive which have
+-    /// a '..' in their path are skipped during the unpacking process.
++    /// # Security
++    ///
++    /// A best-effort is made to prevent writing files outside `dst` (paths
++    /// containing `..` are skipped, symlinks are validated). However, there
++    /// have been historical bugs in this area, and more may exist. For this
++    /// reason, when processing untrusted archives, stronger sandboxing is
++    /// encouraged: e.g. the [`cap-std`] crate and/or OS-level
++    /// containerization/virtualization.
++    ///
++    /// If `dst` does not exist, it is created. Unpacking into an existing
++    /// directory merges content. This function assumes `dst` is not
++    /// concurrently modified by untrusted processes. Protecting against
++    /// TOCTOU races is out of scope for this crate.
++    ///
++    /// [`cap-std`]: https://docs.rs/cap-std/
+     ///
+     /// # Examples
+     ///
+diff --git a/vendor/tar-0.4.44/src/entry.rs b/vendor/tar-0.4.44/src/entry.rs
+index 843719f0f..6898b0abd 100644
+--- a/vendor/tar-0.4.44/src/entry.rs
++++ b/vendor/tar-0.4.44/src/entry.rs
+@@ -212,8 +212,9 @@ impl<'a, R: Read> Entry<'a, R> {
+     /// also be propagated to the path `dst`. Any existing file at the location
+     /// `dst` will be overwritten.
+     ///
+-    /// This function carefully avoids writing outside of `dst`. If the file has
+-    /// a '..' in its path, this function will skip it and return false.
++    /// # Security
++    ///
++    /// See [`Archive::unpack`].
+     ///
+     /// # Examples
+     ///
+@@ -446,7 +447,7 @@ impl<'a> EntryFields<'a> {
+         // If the directory already exists just let it slide
+         fs::create_dir(dst).or_else(|err| {
+             if err.kind() == ErrorKind::AlreadyExists {
+-                let prev = fs::metadata(dst);
++                let prev = fs::symlink_metadata(dst);
+                 if prev.map(|m| m.is_dir()).unwrap_or(false) {
+                     return Ok(());
+                 }
+diff --git a/vendor/tar-0.4.44/tests/entry.rs b/vendor/tar-0.4.44/tests/entry.rs
+index 4d612e2cf..92c11f64a 100644
+--- a/vendor/tar-0.4.44/tests/entry.rs
++++ b/vendor/tar-0.4.44/tests/entry.rs
+@@ -409,3 +409,59 @@ fn modify_symlink_just_created() {
+     t!(t!(File::open(&test)).read_to_end(&mut contents));
+     assert_eq!(contents.len(), 0);
+ }
++
++/// Test that unpacking a tarball with a symlink followed by a directory entry
++/// with the same name does not allow modifying permissions of arbitrary directories
++/// outside the extraction path.
++#[test]
++#[cfg(unix)]
++fn symlink_dir_collision_does_not_modify_external_dir_permissions() {
++    use ::std::fs;
++    use ::std::os::unix::fs::PermissionsExt;
++
++    let td = Builder::new().prefix("tar").tempdir().unwrap();
++
++    let target_dir = td.path().join("target-dir");
++    fs::create_dir(&target_dir).unwrap();
++    fs::set_permissions(&target_dir, fs::Permissions::from_mode(0o700)).unwrap();
++    let before_mode = fs::metadata(&target_dir).unwrap().permissions().mode() & 0o7777;
++    assert_eq!(before_mode, 0o700);
++
++    let extract_dir = td.path().join("extract-dir");
++    fs::create_dir(&extract_dir).unwrap();
++
++    let mut ar = tar::Builder::new(Vec::new());
++
++    let mut header = tar::Header::new_gnu();
++    header.set_size(0);
++    header.set_entry_type(tar::EntryType::Symlink);
++    header.set_path("foo").unwrap();
++    header.set_link_name(&target_dir).unwrap();
++    header.set_mode(0o777);
++    header.set_cksum();
++    ar.append(&header, &[][..]).unwrap();
++
++    let mut header = tar::Header::new_gnu();
++    header.set_size(0);
++    header.set_entry_type(tar::EntryType::Directory);
++    header.set_path("foo").unwrap();
++    header.set_mode(0o777);
++    header.set_cksum();
++    ar.append(&header, &[][..]).unwrap();
++
++    let bytes = ar.into_inner().unwrap();
++    let mut ar = tar::Archive::new(&bytes[..]);
++
++    let result = ar.unpack(&extract_dir);
++    assert!(result.is_err());
++
++    let symlink_path = extract_dir.join("foo");
++    assert!(symlink_path
++        .symlink_metadata()
++        .unwrap()
++        .file_type()
++        .is_symlink());
++
++    let after_mode = fs::metadata(&target_dir).unwrap().permissions().mode() & 0o7777;
++    assert_eq!(after_mode, 0o700);
++}
+-- 
+2.45.4
+

--- a/SPECS/rust/CVE-2026-33056_1.75.patch
+++ b/SPECS/rust/CVE-2026-33056_1.75.patch
@@ -1,0 +1,290 @@
+From 17b1fd84e632071cb8eef9d3709bf347bd266446 Mon Sep 17 00:00:00 2001
+From: Alex Crichton <alex@alexcrichton.com>
+Date: Thu, 19 Mar 2026 16:58:05 -0500
+Subject: [PATCH] archive: Prevent symlink-directory collision chmod attack
+ (#442)
+
+When unpacking a tarball containing a symlink followed by a directory
+entry with the same path, unpack_dir previously used fs::metadata()
+which follows symlinks. This allowed an attacker to modify permissions
+on arbitrary directories outside the extraction path.
+
+The fix uses fs::symlink_metadata() to detect symlinks and refuse to
+treat them as valid existing directories.
+
+Document more exhaustively+consistently security caveats.
+
+Reported-by: Sergei Zimmerman <https://github.com/xokdvium>
+Assisted-by: OpenCode (Claude claude-opus-4-5)
+
+Signed-off-by: Colin Walters <walters@verbum.org>
+Co-authored-by: Colin Walters <walters@verbum.org>
+
+Upstream Patch reference: https://github.com/alexcrichton/tar-rs/commit/17b1fd84e632071cb8eef9d3709bf347bd266446.patch
+
+---
+ vendor/tar-0.4.38/.cargo-checksum.json |  2 +-
+ vendor/tar-0.4.38/src/archive.rs       | 18 +++++++--
+ vendor/tar-0.4.38/src/entry.rs         |  7 ++--
+ vendor/tar-0.4.38/tests/entry.rs       | 56 ++++++++++++++++++++++++++
+ vendor/tar/.cargo-checksum.json        |  2 +-
+ vendor/tar/src/archive.rs              | 18 +++++++--
+ vendor/tar/src/entry.rs                |  7 ++--
+ vendor/tar/tests/entry.rs              | 56 ++++++++++++++++++++++++++
+ 8 files changed, 152 insertions(+), 14 deletions(-)
+
+diff --git a/vendor/tar-0.4.38/.cargo-checksum.json b/vendor/tar-0.4.38/.cargo-checksum.json
+index 508f784e8..16ed33bac 100644
+--- a/vendor/tar-0.4.38/.cargo-checksum.json
++++ b/vendor/tar-0.4.38/.cargo-checksum.json
+@@ -1 +1 @@
+-{"files":{"Cargo.lock":"9872bf9e41b9cadee45b688c9537030a993ca49a266fc7859029d8c74810d1d5","Cargo.toml":"8353c71aa4d394efa7aaeac3004d0a16fd0c7124b7bd57ea91ba87a7b2015f15","LICENSE-APACHE":"a60eea817514531668d7e00765731449fe14d059d3249e0bc93b36de45f759f2","LICENSE-MIT":"378f5840b258e2779c39418f3f2d7b2ba96f1c7917dd6be0713f88305dbda397","README.md":"71079f1a0962c2cf288058f38d24735bddabd1427ac2dee72ec18cc5ae4bceed","examples/extract_file.rs":"dc487f6631d824175afc3ee33de99e80718a8ca3f9e57fddd7cac0a46c07d3ae","examples/list.rs":"36e412205eaffea8ab7f39be4173594b74e36acb369e091362b1975ee4a7a14b","examples/raw_list.rs":"0a735576ac354457d6d5a4d395d044fae99bf67a7c69960ca784a6f6a1743651","examples/write.rs":"419ac3e4155035e32b52cd8e6ae987a2d99cf82f60abbfb315c2a2c4f8e8fd19","src/archive.rs":"85a0091e02690c62379137988cd9b2689009536a0b941f1ab0581db26e9ebce6","src/builder.rs":"2914f394d44c133557532bf5765fe63e0def30ec0b447f8f2bc620e932a2036a","src/entry.rs":"705016636f7fdcad4fe20d7d2672be2b94cc53bb05e47628f5212b89e17a40fe","src/entry_type.rs":"0786688729a96b4a3135b28d40b95c3d4feaad66b9574c490cbea14814ab975f","src/error.rs":"a20813fbc52f1f2e3a79654f62de6001759f6504a06acee5b0819d4865398587","src/header.rs":"fb2b1fa943c19635826b3f2becfb82527be7d08fdac115af840da3ff06152908","src/lib.rs":"5468e413205c907c367c35d28a528389103d68fd6a5b5979bbedba7c9e6b6c99","src/pax.rs":"54002e31151f9c50e02a3da26b3cacd1d3c9a3902daee008ab76d112cf5a2430","tests/all.rs":"567a05d54e369d22efe40f3507a26e21f7878b95bd05c811250b2c350761791b","tests/entry.rs":"c1411ee09da9edb659b508867f0960e804966dfd33801f4a7afaefda331479dd","tests/header/mod.rs":"02b05639f63c39a47559650c7209817bb60282deb4f679d5b001ed936343d9de"},"package":"4b55807c0344e1e6c04d7c965f5289c39a8d94ae23ed5c0b57aabac549f871c6"}
+\ No newline at end of file
++{"files":{"Cargo.lock":"9872bf9e41b9cadee45b688c9537030a993ca49a266fc7859029d8c74810d1d5","Cargo.toml":"8353c71aa4d394efa7aaeac3004d0a16fd0c7124b7bd57ea91ba87a7b2015f15","LICENSE-APACHE":"a60eea817514531668d7e00765731449fe14d059d3249e0bc93b36de45f759f2","LICENSE-MIT":"378f5840b258e2779c39418f3f2d7b2ba96f1c7917dd6be0713f88305dbda397","README.md":"71079f1a0962c2cf288058f38d24735bddabd1427ac2dee72ec18cc5ae4bceed","examples/extract_file.rs":"dc487f6631d824175afc3ee33de99e80718a8ca3f9e57fddd7cac0a46c07d3ae","examples/list.rs":"36e412205eaffea8ab7f39be4173594b74e36acb369e091362b1975ee4a7a14b","examples/raw_list.rs":"0a735576ac354457d6d5a4d395d044fae99bf67a7c69960ca784a6f6a1743651","examples/write.rs":"419ac3e4155035e32b52cd8e6ae987a2d99cf82f60abbfb315c2a2c4f8e8fd19","src/archive.rs":"4eac362ffc7bf629fcecf88ca43cec96a1753c9e0a759722d916a9931c093e25","src/builder.rs":"2914f394d44c133557532bf5765fe63e0def30ec0b447f8f2bc620e932a2036a","src/entry.rs":"2f3ff18dc0c693f425488f946e8a7d250c4020134ca870fe5522d9a95b6a6ae0","src/entry_type.rs":"0786688729a96b4a3135b28d40b95c3d4feaad66b9574c490cbea14814ab975f","src/error.rs":"a20813fbc52f1f2e3a79654f62de6001759f6504a06acee5b0819d4865398587","src/header.rs":"fb2b1fa943c19635826b3f2becfb82527be7d08fdac115af840da3ff06152908","src/lib.rs":"5468e413205c907c367c35d28a528389103d68fd6a5b5979bbedba7c9e6b6c99","src/pax.rs":"54002e31151f9c50e02a3da26b3cacd1d3c9a3902daee008ab76d112cf5a2430","tests/all.rs":"567a05d54e369d22efe40f3507a26e21f7878b95bd05c811250b2c350761791b","tests/entry.rs":"97b7927f14027c2f9bce2dc5f565ede00b9c37da41d0ee95144be8c0cb8c6983","tests/header/mod.rs":"02b05639f63c39a47559650c7209817bb60282deb4f679d5b001ed936343d9de"},"package":"4b55807c0344e1e6c04d7c965f5289c39a8d94ae23ed5c0b57aabac549f871c6"}
+diff --git a/vendor/tar-0.4.38/src/archive.rs b/vendor/tar-0.4.38/src/archive.rs
+index 1bed51249..056eb71a1 100644
+--- a/vendor/tar-0.4.38/src/archive.rs
++++ b/vendor/tar-0.4.38/src/archive.rs
+@@ -88,9 +88,21 @@ impl<R: Read> Archive<R> {
+     /// extracting each file in turn to the location specified by the entry's
+     /// path name.
+     ///
+-    /// This operation is relatively sensitive in that it will not write files
+-    /// outside of the path specified by `dst`. Files in the archive which have
+-    /// a '..' in their path are skipped during the unpacking process.
++    /// # Security
++    ///
++    /// A best-effort is made to prevent writing files outside `dst` (paths
++    /// containing `..` are skipped, symlinks are validated). However, there
++    /// have been historical bugs in this area, and more may exist. For this
++    /// reason, when processing untrusted archives, stronger sandboxing is
++    /// encouraged: e.g. the [`cap-std`] crate and/or OS-level
++    /// containerization/virtualization.
++    ///
++    /// If `dst` does not exist, it is created. Unpacking into an existing
++    /// directory merges content. This function assumes `dst` is not
++    /// concurrently modified by untrusted processes. Protecting against
++    /// TOCTOU races is out of scope for this crate.
++    ///
++    /// [`cap-std`]: https://docs.rs/cap-std/
+     ///
+     /// # Examples
+     ///
+diff --git a/vendor/tar-0.4.38/src/entry.rs b/vendor/tar-0.4.38/src/entry.rs
+index 8f0b62acf..287d68904 100644
+--- a/vendor/tar-0.4.38/src/entry.rs
++++ b/vendor/tar-0.4.38/src/entry.rs
+@@ -210,8 +210,9 @@ impl<'a, R: Read> Entry<'a, R> {
+     /// also be propagated to the path `dst`. Any existing file at the location
+     /// `dst` will be overwritten.
+     ///
+-    /// This function carefully avoids writing outside of `dst`. If the file has
+-    /// a '..' in its path, this function will skip it and return false.
++    /// # Security
++    ///
++    /// See [`Archive::unpack`].
+     ///
+     /// # Examples
+     ///
+@@ -430,7 +431,7 @@ impl<'a> EntryFields<'a> {
+         // If the directory already exists just let it slide
+         fs::create_dir(dst).or_else(|err| {
+             if err.kind() == ErrorKind::AlreadyExists {
+-                let prev = fs::metadata(dst);
++                let prev = fs::symlink_metadata(dst);
+                 if prev.map(|m| m.is_dir()).unwrap_or(false) {
+                     return Ok(());
+                 }
+diff --git a/vendor/tar-0.4.38/tests/entry.rs b/vendor/tar-0.4.38/tests/entry.rs
+index fa8eeaee7..5e874fa5d 100644
+--- a/vendor/tar-0.4.38/tests/entry.rs
++++ b/vendor/tar-0.4.38/tests/entry.rs
+@@ -377,3 +377,59 @@ fn modify_symlink_just_created() {
+     t!(t!(File::open(&test)).read_to_end(&mut contents));
+     assert_eq!(contents.len(), 0);
+ }
++
++/// Test that unpacking a tarball with a symlink followed by a directory entry
++/// with the same name does not allow modifying permissions of arbitrary directories
++/// outside the extraction path.
++#[test]
++#[cfg(unix)]
++fn symlink_dir_collision_does_not_modify_external_dir_permissions() {
++    use ::std::fs;
++    use ::std::os::unix::fs::PermissionsExt;
++
++    let td = Builder::new().prefix("tar").tempdir().unwrap();
++
++    let target_dir = td.path().join("target-dir");
++    fs::create_dir(&target_dir).unwrap();
++    fs::set_permissions(&target_dir, fs::Permissions::from_mode(0o700)).unwrap();
++    let before_mode = fs::metadata(&target_dir).unwrap().permissions().mode() & 0o7777;
++    assert_eq!(before_mode, 0o700);
++
++    let extract_dir = td.path().join("extract-dir");
++    fs::create_dir(&extract_dir).unwrap();
++
++    let mut ar = tar::Builder::new(Vec::new());
++
++    let mut header = tar::Header::new_gnu();
++    header.set_size(0);
++    header.set_entry_type(tar::EntryType::Symlink);
++    header.set_path("foo").unwrap();
++    header.set_link_name(&target_dir).unwrap();
++    header.set_mode(0o777);
++    header.set_cksum();
++    ar.append(&header, &[][..]).unwrap();
++
++    let mut header = tar::Header::new_gnu();
++    header.set_size(0);
++    header.set_entry_type(tar::EntryType::Directory);
++    header.set_path("foo").unwrap();
++    header.set_mode(0o777);
++    header.set_cksum();
++    ar.append(&header, &[][..]).unwrap();
++
++    let bytes = ar.into_inner().unwrap();
++    let mut ar = tar::Archive::new(&bytes[..]);
++
++    let result = ar.unpack(&extract_dir);
++    assert!(result.is_err());
++
++    let symlink_path = extract_dir.join("foo");
++    assert!(symlink_path
++        .symlink_metadata()
++        .unwrap()
++        .file_type()
++        .is_symlink());
++
++    let after_mode = fs::metadata(&target_dir).unwrap().permissions().mode() & 0o7777;
++    assert_eq!(after_mode, 0o700);
++}
+diff --git a/vendor/tar/.cargo-checksum.json b/vendor/tar/.cargo-checksum.json
+index 77504e32a..433701f56 100644
+--- a/vendor/tar/.cargo-checksum.json
++++ b/vendor/tar/.cargo-checksum.json
+@@ -1 +1 @@
+-{"files":{"Cargo.lock":"734d770757fa895a8c4e215b8063840d33083d007e02d70dfb47a07cd348b933","Cargo.toml":"1e1da319c4d28693a3e42e014ed00828480994b55b15003052f21f2342a346bb","LICENSE-APACHE":"a60eea817514531668d7e00765731449fe14d059d3249e0bc93b36de45f759f2","LICENSE-MIT":"378f5840b258e2779c39418f3f2d7b2ba96f1c7917dd6be0713f88305dbda397","README.md":"71079f1a0962c2cf288058f38d24735bddabd1427ac2dee72ec18cc5ae4bceed","examples/extract_file.rs":"dc487f6631d824175afc3ee33de99e80718a8ca3f9e57fddd7cac0a46c07d3ae","examples/list.rs":"36e412205eaffea8ab7f39be4173594b74e36acb369e091362b1975ee4a7a14b","examples/raw_list.rs":"0a735576ac354457d6d5a4d395d044fae99bf67a7c69960ca784a6f6a1743651","examples/write.rs":"419ac3e4155035e32b52cd8e6ae987a2d99cf82f60abbfb315c2a2c4f8e8fd19","src/archive.rs":"e38b876270e3e4e7bac24fc4bf74e05df362102113cf0e024334a853a824f61e","src/builder.rs":"2914f394d44c133557532bf5765fe63e0def30ec0b447f8f2bc620e932a2036a","src/entry.rs":"0e4b0438cbc4cbec30a821ce8f23619fe9e53c17022a022de609d642e220193c","src/entry_type.rs":"0786688729a96b4a3135b28d40b95c3d4feaad66b9574c490cbea14814ab975f","src/error.rs":"a20813fbc52f1f2e3a79654f62de6001759f6504a06acee5b0819d4865398587","src/header.rs":"fb2b1fa943c19635826b3f2becfb82527be7d08fdac115af840da3ff06152908","src/lib.rs":"5468e413205c907c367c35d28a528389103d68fd6a5b5979bbedba7c9e6b6c99","src/pax.rs":"0509d9afa47ae9f1658bf7d02d12a9791f717971736c4e2041c5fb5f7c5354c8","tests/all.rs":"81bfe5fb71e8d2dd7455c126fc77aa40c2011a2cd5871d785e39e6fb053bf352","tests/entry.rs":"af12d84160e5459ebaee6ecdd68e0c811438c37c0cb881ad210e7f94132b9739","tests/header/mod.rs":"02b05639f63c39a47559650c7209817bb60282deb4f679d5b001ed936343d9de"},"package":"b16afcea1f22891c49a00c751c7b63b2233284064f11a200fc624137c51e2ddb"}
+\ No newline at end of file
++{"files":{"Cargo.lock":"734d770757fa895a8c4e215b8063840d33083d007e02d70dfb47a07cd348b933","Cargo.toml":"1e1da319c4d28693a3e42e014ed00828480994b55b15003052f21f2342a346bb","LICENSE-APACHE":"a60eea817514531668d7e00765731449fe14d059d3249e0bc93b36de45f759f2","LICENSE-MIT":"378f5840b258e2779c39418f3f2d7b2ba96f1c7917dd6be0713f88305dbda397","README.md":"71079f1a0962c2cf288058f38d24735bddabd1427ac2dee72ec18cc5ae4bceed","examples/extract_file.rs":"dc487f6631d824175afc3ee33de99e80718a8ca3f9e57fddd7cac0a46c07d3ae","examples/list.rs":"36e412205eaffea8ab7f39be4173594b74e36acb369e091362b1975ee4a7a14b","examples/raw_list.rs":"0a735576ac354457d6d5a4d395d044fae99bf67a7c69960ca784a6f6a1743651","examples/write.rs":"419ac3e4155035e32b52cd8e6ae987a2d99cf82f60abbfb315c2a2c4f8e8fd19","src/archive.rs":"44b5de68d031997c0ceb4b3904973470f4020dbfeb910c09ebef31fecf9065f7","src/builder.rs":"2914f394d44c133557532bf5765fe63e0def30ec0b447f8f2bc620e932a2036a","src/entry.rs":"e73bbec8dbd20a7ab5453c45b908b3a02e0c7f3854cf9716f87120f556e4f0e2","src/entry_type.rs":"0786688729a96b4a3135b28d40b95c3d4feaad66b9574c490cbea14814ab975f","src/error.rs":"a20813fbc52f1f2e3a79654f62de6001759f6504a06acee5b0819d4865398587","src/header.rs":"fb2b1fa943c19635826b3f2becfb82527be7d08fdac115af840da3ff06152908","src/lib.rs":"5468e413205c907c367c35d28a528389103d68fd6a5b5979bbedba7c9e6b6c99","src/pax.rs":"0509d9afa47ae9f1658bf7d02d12a9791f717971736c4e2041c5fb5f7c5354c8","tests/all.rs":"81bfe5fb71e8d2dd7455c126fc77aa40c2011a2cd5871d785e39e6fb053bf352","tests/entry.rs":"f89b56fc984d17ca2050b0ecda365974b1ff8c3fa0fd7a9363248e824638b8fc","tests/header/mod.rs":"02b05639f63c39a47559650c7209817bb60282deb4f679d5b001ed936343d9de"},"package":"b16afcea1f22891c49a00c751c7b63b2233284064f11a200fc624137c51e2ddb"}
+diff --git a/vendor/tar/src/archive.rs b/vendor/tar/src/archive.rs
+index 760b2cb82..9ee31deff 100644
+--- a/vendor/tar/src/archive.rs
++++ b/vendor/tar/src/archive.rs
+@@ -92,9 +92,21 @@ impl<R: Read> Archive<R> {
+     /// extracting each file in turn to the location specified by the entry's
+     /// path name.
+     ///
+-    /// This operation is relatively sensitive in that it will not write files
+-    /// outside of the path specified by `dst`. Files in the archive which have
+-    /// a '..' in their path are skipped during the unpacking process.
++    /// # Security
++    ///
++    /// A best-effort is made to prevent writing files outside `dst` (paths
++    /// containing `..` are skipped, symlinks are validated). However, there
++    /// have been historical bugs in this area, and more may exist. For this
++    /// reason, when processing untrusted archives, stronger sandboxing is
++    /// encouraged: e.g. the [`cap-std`] crate and/or OS-level
++    /// containerization/virtualization.
++    ///
++    /// If `dst` does not exist, it is created. Unpacking into an existing
++    /// directory merges content. This function assumes `dst` is not
++    /// concurrently modified by untrusted processes. Protecting against
++    /// TOCTOU races is out of scope for this crate.
++    ///
++    /// [`cap-std`]: https://docs.rs/cap-std/
+     ///
+     /// # Examples
+     ///
+diff --git a/vendor/tar/src/entry.rs b/vendor/tar/src/entry.rs
+index c81554fcb..1e6952cea 100644
+--- a/vendor/tar/src/entry.rs
++++ b/vendor/tar/src/entry.rs
+@@ -212,8 +212,9 @@ impl<'a, R: Read> Entry<'a, R> {
+     /// also be propagated to the path `dst`. Any existing file at the location
+     /// `dst` will be overwritten.
+     ///
+-    /// This function carefully avoids writing outside of `dst`. If the file has
+-    /// a '..' in its path, this function will skip it and return false.
++    /// # Security
++    ///
++    /// See [`Archive::unpack`].
+     ///
+     /// # Examples
+     ///
+@@ -446,7 +447,7 @@ impl<'a> EntryFields<'a> {
+         // If the directory already exists just let it slide
+         fs::create_dir(dst).or_else(|err| {
+             if err.kind() == ErrorKind::AlreadyExists {
+-                let prev = fs::metadata(dst);
++                let prev = fs::symlink_metadata(dst);
+                 if prev.map(|m| m.is_dir()).unwrap_or(false) {
+                     return Ok(());
+                 }
+diff --git a/vendor/tar/tests/entry.rs b/vendor/tar/tests/entry.rs
+index 62df663e8..2c2082f06 100644
+--- a/vendor/tar/tests/entry.rs
++++ b/vendor/tar/tests/entry.rs
+@@ -408,3 +408,59 @@ fn modify_symlink_just_created() {
+     t!(t!(File::open(&test)).read_to_end(&mut contents));
+     assert_eq!(contents.len(), 0);
+ }
++
++/// Test that unpacking a tarball with a symlink followed by a directory entry
++/// with the same name does not allow modifying permissions of arbitrary directories
++/// outside the extraction path.
++#[test]
++#[cfg(unix)]
++fn symlink_dir_collision_does_not_modify_external_dir_permissions() {
++    use ::std::fs;
++    use ::std::os::unix::fs::PermissionsExt;
++
++    let td = Builder::new().prefix("tar").tempdir().unwrap();
++
++    let target_dir = td.path().join("target-dir");
++    fs::create_dir(&target_dir).unwrap();
++    fs::set_permissions(&target_dir, fs::Permissions::from_mode(0o700)).unwrap();
++    let before_mode = fs::metadata(&target_dir).unwrap().permissions().mode() & 0o7777;
++    assert_eq!(before_mode, 0o700);
++
++    let extract_dir = td.path().join("extract-dir");
++    fs::create_dir(&extract_dir).unwrap();
++
++    let mut ar = tar::Builder::new(Vec::new());
++
++    let mut header = tar::Header::new_gnu();
++    header.set_size(0);
++    header.set_entry_type(tar::EntryType::Symlink);
++    header.set_path("foo").unwrap();
++    header.set_link_name(&target_dir).unwrap();
++    header.set_mode(0o777);
++    header.set_cksum();
++    ar.append(&header, &[][..]).unwrap();
++
++    let mut header = tar::Header::new_gnu();
++    header.set_size(0);
++    header.set_entry_type(tar::EntryType::Directory);
++    header.set_path("foo").unwrap();
++    header.set_mode(0o777);
++    header.set_cksum();
++    ar.append(&header, &[][..]).unwrap();
++
++    let bytes = ar.into_inner().unwrap();
++    let mut ar = tar::Archive::new(&bytes[..]);
++
++    let result = ar.unpack(&extract_dir);
++    assert!(result.is_err());
++
++    let symlink_path = extract_dir.join("foo");
++    assert!(symlink_path
++        .symlink_metadata()
++        .unwrap()
++        .file_type()
++        .is_symlink());
++
++    let after_mode = fs::metadata(&target_dir).unwrap().permissions().mode() & 0o7777;
++    assert_eq!(after_mode, 0o700);
++}
+-- 
+2.45.4
+

--- a/SPECS/rust/rust-1.75.spec
+++ b/SPECS/rust/rust-1.75.spec
@@ -9,7 +9,7 @@
 Summary:        Rust Programming Language
 Name:           rust
 Version:        1.75.0
-Release:        27%{?dist}
+Release:        28%{?dist}
 License:        (ASL 2.0 OR MIT) AND BSD AND CC-BY-3.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -51,6 +51,8 @@ Patch6:         CVE-2025-58160_1.75.patch
 Patch7:         CVE-2026-25541_1.75.patch
 Patch8:         CVE-2026-25727_1.75.patch
 Patch9:         CVE-2023-48795_1.75.patch
+Patch10:        CVE-2026-33056_1.75.patch
+Patch11:        CVE-2026-33055_1.75.patch
 
 BuildRequires:  binutils
 BuildRequires:  cmake
@@ -185,6 +187,9 @@ rm %{buildroot}%{_bindir}/*.old
 %{_mandir}/man1/*
 
 %changelog
+* Tue Mar 31 2026 BinduSri Adabala <v-badabala@microsoft.com> - 1.75.0-28
+- Add patch for CVE-2026-33056 & CVE-2026-33055
+
 * Wed Mar 25 2026 Aditya Singh <v-aditysing@microsoft.com> - 1.75.0-27
 - Bump to rebuild with updated glibc
 

--- a/SPECS/rust/rust.spec
+++ b/SPECS/rust/rust.spec
@@ -9,7 +9,7 @@
 Summary:        Rust Programming Language
 Name:           rust
 Version:        1.90.0
-Release:        6%{?dist}
+Release:        7%{?dist}
 License:        (ASL 2.0 OR MIT) AND BSD AND CC-BY-3.0
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
@@ -53,6 +53,8 @@ Patch8:         CVE-2026-24116.patch
 Patch9:         CVE-2025-58160.patch
 Patch10:        CVE-2026-25541.patch
 Patch11:        CVE-2026-25727.patch
+Patch12:        CVE-2026-33056.patch
+Patch13:        CVE-2026-33055.patch
 BuildRequires:  binutils
 BuildRequires:  cmake
 # make sure rust relies on curl from CBL-Mariner (instead of using its vendored flavor)
@@ -190,6 +192,9 @@ rm %{buildroot}%{_docdir}/docs/html/.lock
 %{_mandir}/man1/*
 
 %changelog
+* Tue Mar 31 2026 BinduSri Adabala <v-badabala@microsoft.com> - 1.90.0-7
+- Patch for CVE-2026-33056 & CVE-2026-33055
+
 * Wed Mar 25 2026 Aditya Singh <v-aditysing@microsoft.com> - 1.90.0-6
 - Bump to rebuild with updated glibc
 

--- a/SPECS/virtiofsd/virtiofsd.spec
+++ b/SPECS/virtiofsd/virtiofsd.spec
@@ -22,7 +22,7 @@ Name:           virtiofsd
 # Version to be kept in sync with the `asset.virtiofsd.version` field from
 # https://github.com/microsoft/kata-containers/blob/msft-main/versions.yaml
 Version:        1.8.0
-Release:        7%{?dist}
+Release:        8%{?dist}
 Summary:        vhost-user virtio-fs device backend written in Rust
 Group:          Development/Libraries/Rust
 License:        Apache-2.0
@@ -75,6 +75,9 @@ cargo test --release
 %{_datadir}/qemu/vhost-user/50-qemu-virtiofsd.json
 
 %changelog
+* Tue Mar 31 2026 BinduSri Adabala <v-badabala@microsoft.com> - 1.8.0-8
+- Bump release to rebuild with rust
+
 * Wed Feb 11 2026 BinduSri Adabala <v-badabala@microsoft.com> - 1.8.0-7
 - Bump release to rebuild with rust
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
 Patch rust for CVE-2026-33056 and CVE-2026-33055
For CVE-2026-33056:
Patch Modified: No

For CVE-2026-33055:
Patch Modified: Yes
- Backported Cargo.toml file to add dev-dependencies.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- new file:   SPECS/rust/CVE-2026-33055.patch
- new file:   SPECS/rust/CVE-2026-33055_1.75.patch
- new file:   SPECS/rust/CVE-2026-33056.patch
- new file:   SPECS/rust/CVE-2026-33056_1.75.patch
- modified:   SPECS/rust/rust-1.75.spec
- modified:   SPECS/rust/rust.spec

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2026-33056
- https://nvd.nist.gov/vuln/detail/CVE-2026-33055

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: xxxx
