### PR TITLE
fix(bats): skip %check to unblock bootstrap build

### DIFF
--- a/base/comps/component-check-disablement.toml
+++ b/base/comps/component-check-disablement.toml
@@ -4,6 +4,7 @@
 description = "Components with check failures during initial distro bringup"
 components = [
     "SDL3_image",
+    "bats",
     "containerd",
     "dnf",
     "fakeroot",


### PR DESCRIPTION
bats 1.12.0 added 155 new `bats_pipe.bats` tests that assume a full interactive environment (TTYs, unrestricted pipes). These fail in the koji/mock build chroot, causing the entire RPM build to fail even though bats itself compiles and installs correctly.

Added `bats` to the check-skip-initial-failures list in `component-check-disablement.toml` to unblock the bootstrap.

**Testing:** [Build passed](https://controltower-dev-jwisitgpr74k6-gjb0fchvgkbnamgp.b01.azurefd.net/workflow/fc01c693-bc9d-41fb-19d7-08de8f67a324)