### PR TITLE
fix: replace 'invokable' with 'invocable'.

### DIFF
--- a/.github/agents/azl-diagnose.agent.md
+++ b/.github/agents/azl-diagnose.agent.md
@@ -3,7 +3,7 @@ name: azl-diagnose
 description: Diagnose build failures — fetch Koji task info/logs, investigate upstream sources, identify root cause, and suggest fixes. Accepts task IDs, URLs, package names, or general queries.
 argument-hint: Ask a question about a package (e.g., `kernel`) or give a task ID/URL (e.g., `1234`, `https://koji.example.com/koji/taskinfo?taskID=1234`).
 agents: ["*"]
-user-invokable: true
+user-invocable: true
 disable-model-invocation: false
 handoffs:
   - label: Attempt to diagnose and fix the issue

--- a/.github/agents/spec-review.agent.md
+++ b/.github/agents/spec-review.agent.md
@@ -3,7 +3,7 @@ name: spec-review
 description: 'Reviews spec files against best practices and summarizes findings in a JSON file.'
 argument-hint: 'What to review (name or path). Optionally: guideline URLs/git repos, KB & report paths.'
 agents: ["*"]
-user-invokable: true
+user-invocable: true
 disable-model-invocation: false
 ---
 1. **Triage spec files** - Categorize specs by type/ecosystem to guide targeted KB generation


### PR DESCRIPTION
Fixing a typo in the `user-invocable` agent parameter name. Reference: [GitHub docs](https://docs.github.com/en/copilot/reference/custom-agents-configuration).