### PR TITLE
fix(rootlesskit): make rootlesskit overlay point to the correct package

### DIFF
--- a/base/comps/rootlesskit/rootlesskit.comp.toml
+++ b/base/comps/rootlesskit/rootlesskit.comp.toml
@@ -1,5 +1,5 @@
 [components.rootlesskit]
-# Pin to the f43 commit used to build the current Fedora 43 package.
-# TODO: Drop this override once the default Fedora 43 snapshot
-# in distro/azurelinux.distro.toml advances past this commit.
-spec = { type = "upstream", upstream-name = "golang-github-rootless-containers-rootlesskit", upstream-distro = { name = "fedora", version = "43" }, upstream-commit = "eb6bc70fe34cb6947bb1fb1b61b23e34159273e7" }
+
+# "rootlesskit" was brought into fedora after the default snapshot date for azl4.
+# We have to override the snapshot with the commit pointing to earlist available.
+spec = { type = "upstream", upstream-name = "rootlesskit", upstream-distro = { name = "fedora", version = "43" }, upstream-commit = "0cd7642732a9c9703729b5c8038f687d2640a2ac" }


### PR DESCRIPTION
golang-github-rootless-containers-rootlesskit was replaced with rootlesskit by this commit. https://src.fedoraproject.org/rpms/golang-github-rootless-containers-rootlesskit/c/f0f7e2531ab11f3de0366167ed4ca663fba800a2?branch=rawhide

The following commit brought rootlesskit which provide the above dependency instead. https://src.fedoraproject.org/rpms/rootlesskit/tree/0cd7642732a9c9703729b5c8038f687d2640a2ac

We have to override the default snapshot to make sure the commit refers to the earliest available one after this package was created.

Koji build on the branch is pulling in the correct source tgz:
`23:03:38 INF Downloading source file... progress=2/3 fileName=rootlesskit-2.3.6.tar.gz URI=https://azltempstaginglookaside.blob.core.windows.net/repo/pkgs/rootlesskit/rootlesskit-2.3.6.tar.gz/sha512/8d0680d7181f4c1324173e2709ec4b654d12b92e1fa4167b61efc87f0921bece8b00382ec37238999a6eb69362ad9dc4a6e82c721db92502d82d4294811c30b1/rootlesskit-2.3.6.tar.gz destPath=/tmp/azldev-clone-377082413/rootlesskit-2.3.6.tar.gz`

The build went fine too: https://52.249.25.247/koji/taskinfo?taskID=934697
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change
- Change
- Change

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES/NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-YYYY-XXXX

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: xxxx
