### PR TITLE
fix(python-beartype): pin python-beartype to upstream commit 9c277e0

### DIFF
--- a/base/comps/components-full.toml
+++ b/base/comps/components-full.toml
@@ -3883,7 +3883,6 @@
 [components.python-backoff]
 [components.python-banal]
 [components.python-bcrypt]
-[components.python-beartype]
 [components.python-beautifulsoup4]
 [components.python-beniget]
 [components.python-betamax]

--- a/base/comps/python-beartype/python-beartype.comp.toml
+++ b/base/comps/python-beartype/python-beartype.comp.toml
@@ -1,0 +1,3 @@
+[components.python-beartype]
+# Pin to upstream commit that fixes build/test issues.
+spec = { type = "upstream", upstream-distro = { name = "fedora", version = "43" }, upstream-commit = "9c277e0bb3a167c998ea68a99df012d5ad082d3e" }


### PR DESCRIPTION
This PR creates dedicated comp.toml for `python-beartype` pinned to f43 upstream commit 9c277e0bb3a1 which fixes build/test issues with Python 3.14.

Validation: waiting for `python-beartype` 0.22.9 tarball is available in koji