### PR TITLE
workaround(azurelinux-release): bind-mount /proc/version for CBL-Mariner compat

### DIFF
--- a/base/comps/azurelinux-release/90-default.preset
+++ b/base/comps/azurelinux-release/90-default.preset
@@ -28,6 +28,10 @@ enable auditd.service
 
 enable audit-rules.service
 
+# Backward-compat: override /proc/version so tools that grep for "Mariner"
+# can identify Azure Linux
+enable proc-version-override.service
+
 # Locally-running service
 enable restorecond.service
 
@@ -371,4 +375,3 @@ enable gpio-manager.service
 
 # Enable authselect-apply-changes.service
 enable authselect-apply-changes.service
-

--- a/base/comps/azurelinux-release/azurelinux-release.spec
+++ b/base/comps/azurelinux-release/azurelinux-release.spec
@@ -36,7 +36,7 @@ Summary:        Azure Linux release files
 Name:           azurelinux-release
 Version:        4.0
 # TODO(azl): Review whether we can move back to autorelease (with conditional -p)
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        MIT
 URL:            https://aka.ms/azurelinux
 
@@ -49,6 +49,8 @@ Source14:       distro-template.swidtag
 Source15:       distro-variant-template.swidtag
 Source16:       20-azurelinux-defaults.conf
 Source17:       20-azure.conf
+Source18:       proc-version-override.service
+Source19:       proc-version-override.sh
 
 BuildArch:      noarch
 
@@ -391,6 +393,10 @@ ln -s --relative %{buildroot}%{_swidtagdir} %{buildroot}%{_sysconfdir}/swid/swid
 # Install DNF 5 configuration defaults
 install -Dm0644 %{SOURCE16} -t %{buildroot}%{_prefix}/share/dnf5/libdnf.conf.d/
 
+# Install proc-version-override (backward-compat for tools that grep /proc/version for "Mariner")
+install -Dm0644 %{SOURCE18} -t %{buildroot}%{_unitdir}/
+install -Dm0755 %{SOURCE19} %{buildroot}%{_libexecdir}/proc-version-override
+
 
 %files common
 %license licenses/LICENSE
@@ -419,6 +425,8 @@ install -Dm0644 %{SOURCE16} -t %{buildroot}%{_prefix}/share/dnf5/libdnf.conf.d/
 %dir %{_sysconfdir}/swid
 %{_sysconfdir}/swid/swidtags.d
 %{_prefix}/share/dnf5/libdnf.conf.d/20-azurelinux-defaults.conf
+%{_unitdir}/proc-version-override.service
+%{_libexecdir}/proc-version-override
 
 
 %if %{with basic}
@@ -455,5 +463,8 @@ install -Dm0644 %{SOURCE16} -t %{buildroot}%{_prefix}/share/dnf5/libdnf.conf.d/
 
 
 %changelog
+* Tue Apr 01 2026 Rachel Menge <rachelmenge@microsoft.com> - 4.0-3
+- Add proc-version-override service for Guest-Configuration-Extension compat
+
 * Fri Feb 27 2026 Reuben Olinsky <reubeno@microsoft.com> - 4.0-2
 - Initial version

--- a/base/comps/azurelinux-release/proc-version-override.service
+++ b/base/comps/azurelinux-release/proc-version-override.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Override /proc/version for legacy OS detection (CBL-Mariner compat)
+Before=waagent.service cloud-init.service cloud-init-local.service
+After=local-fs.target
+ConditionVirtualization=vm
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/libexec/proc-version-override
+ExecStop=-/bin/umount /proc/version
+ExecStopPost=-/bin/rm -f /run/proc_version_override
+
+[Install]
+WantedBy=multi-user.target

--- a/base/comps/azurelinux-release/proc-version-override.sh
+++ b/base/comps/azurelinux-release/proc-version-override.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Generate a /proc/version override that includes both "CBL-Mariner" and
+# "azurelinux" identifiers, then bind-mount it over /proc/version.
+#
+# This preserves backward compatibility with tools that grep /proc/version
+# for "Mariner" (e.g. Guest-Configuration-Extension) while also advertising
+# the current distro name.
+
+set -euo pipefail
+
+OVERRIDE=/run/proc_version_override
+
+# `mount --bind` on a file target is not idempotent; repeated runs can stack
+# mounts on /proc/version. Unwind any existing mount layers before reading
+# the real /proc/version and rebinding.
+while findmnt -n /proc/version >/dev/null 2>&1; do
+    umount /proc/version
+done
+
+# Build a version string using the real kernel version, replacing only
+# the (user@host) field with (root@CBL-Mariner-azurelinux).
+#
+# Real /proc/version format:
+#   Linux version <uname -r> (mockbuild@koji-builder-...) (gcc (GCC) ...) #1 SMP ...
+# Override:
+#   Linux version <uname -r> (root@CBL-Mariner-azurelinux) (gcc (GCC) ...) #1 SMP ...
+#
+# We strip the first parenthesized group (user@host) and keep everything
+# after it (compiler info, build config, timestamp) verbatim.
+# Also replace "Red Hat" in the GCC version string so tools that pattern-match
+# /proc/version (e.g. GCE's guest-configuration-shim) don't misidentify AZL as
+# RHEL based on the compiler tag.
+KVER=$(uname -r)
+TAIL=$(sed 's/^[^)]*)[[:space:]]*//' /proc/version | sed 's/Red Hat/Azure Linux/g')
+
+install -m 0444 /dev/null "$OVERRIDE"
+cat > "$OVERRIDE" <<EOF
+Linux version ${KVER} (root@CBL-Mariner-azurelinux) ${TAIL}
+EOF
+chmod 0444 "$OVERRIDE"
+
+mount --bind "$OVERRIDE" /proc/version
+mount -o remount,bind,ro /proc/version


### PR DESCRIPTION

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./LICENSES-AND-NOTICES/SPECS/data/licenses.json`, `./LICENSES-AND-NOTICES/SPECS/LICENSES-MAP.md`, `./LICENSES-AND-NOTICES/SPECS/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

Extensions grep /proc/version for "Mariner" to detect the OS. AZL no longer includes that string since it builds with Fedora's kernel toolchain.

Add a systemd oneshot service that generates a /proc/version override at boot, replacing the user@host field with "root@CBL-Mariner-azurelinux", and bind-mounts it over /proc/version. This preserves the real kernel version, compiler string, and build timestamp while satisfying legacy detection logic.

The service runs early (before walinuxagent and cloud-init) and only activates inside VMs (ConditionVirtualization=vm).

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- workaround(azurelinux-release): bind-mount /proc/version for CBL-Mariner compat

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- https://dev.azure.com/mariner-org/mariner/_workitems/edit/18482?src=WorkItemMention&src-action=artifact_link

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: 971055
