### PR TITLE
fix(firefox): add overlay to fix GCC 15 compilation errors

### DIFF
--- a/base/comps/components-full.toml
+++ b/base/comps/components-full.toml
@@ -671,7 +671,6 @@
 [components.fido-device-onboard]
 [components.fio]
 [components.firebird]
-[components.firefox]
 [components.fish]
 [components.flac]
 [components.flashrom]

--- a/base/comps/firefox/firefox.comp.toml
+++ b/base/comps/firefox/firefox.comp.toml
@@ -1,0 +1,31 @@
+[components.firefox]
+
+# Firefox 148.0's mfbt/tests/TestIntegerRange.cpp uses uint8_t/uint16_t/uint32_t/uint64_t
+# without #include <cstdint>. GCC 15 (used in Azure Linux bootstrap) enforces stricter
+# C++ standards compliance and no longer leaks these types through transitive includes,
+# causing a compilation failure. The test binaries (controlled by build_tests) are not
+# shipped in the RPM and are only used when run_firefox_tests is enabled (which it is not).
+# Disabling them avoids the broken test compilation without affecting the final package.
+#
+# Upstream spec: https://src.fedoraproject.org/rpms/firefox/blob/f43/f/firefox.spec
+# Koji build failure: task 907428 (aarch64), task 898577 (x86_64)
+# TODO: Remove when upstream Firefox fixes GCC 15 compatibility (missing <cstdint> include).
+[[components.firefox.overlays]]
+description = "Disable build-time test compilation to avoid GCC 15 missing <cstdint> error in TestIntegerRange.cpp"
+type = "spec-search-replace"
+regex = '%global build_tests       1'
+replacement = '%global build_tests       0'
+
+# Firefox 148.0's bundled breakpad crash reporter has a GCC 15 compatibility issue:
+# minidump_descriptor.h references a field 'address_within_principal_mapping_' that
+# does not exist in the class. This fails on x86_64 where the crash reporter is enabled
+# (enable_mozilla_crashreporter = 1). Disabling it aligns with the aarch64/ppc64le
+# configuration and removes the non-essential crash reporter from the build.
+#
+# Upstream spec: https://src.fedoraproject.org/rpms/firefox/blob/f43/f/firefox.spec
+# TODO: Remove when upstream Firefox updates bundled breakpad for GCC 15 compatibility.
+[[components.firefox.overlays]]
+description = "Disable crash reporter to avoid GCC 15 breakpad compilation error in minidump_descriptor.h"
+type = "spec-search-replace"
+regex = '%global enable_mozilla_crashreporter 1'
+replacement = '%global enable_mozilla_crashreporter 0'


### PR DESCRIPTION
Firefox 148.0 fails to build with GCC 15 due to two issues:

1. mfbt/tests/TestIntegerRange.cpp uses uint8_t/uint16_t/uint32_t/uint64_t without #include <cstdint>. GCC 15 no longer leaks these types through transitive includes. Fix: disable build_tests (test binaries are not shipped in the RPM).

2. toolkit/crashreporter/breakpad-client/linux/handler/minidump_descriptor.h references non-existent field 'address_within_principal_mapping_'. Affects x86_64 where crash reporter is enabled. Fix: disable enable_mozilla_crashreporter.

The build failure was masked by './mach build -v 2>&1 | cat -' which swallows the exit code, causing %install to run and packager.py to report AccumulatedErrors for all missing files.


###### Test Methodology
- Verified: local x86_64 build succeeds with both overlays applied.
- Koji Build : https://controltower-dev-jwisitgpr74k6-gjb0fchvgkbnamgp.b01.azurefd.net/workflow/80dfd6c2-ac99-4d67-408b-08de902fbf2b
- Build for after addressing comments: https://controltower-dev-jwisitgpr74k6-gjb0fchvgkbnamgp.b01.azurefd.net/workflow/2c520dc6-4aac-4d08-4098-08de902fbf2b
-