### PR TITLE
fix: address build failures due to missing dependencies

### DIFF
--- a/base/comps/components-full.toml
+++ b/base/comps/components-full.toml
@@ -6994,7 +6994,6 @@
 [components.triehash]
 [components.trilead-ssh2]
 [components.trivy]
-[components.trustee-guest-components]
 [components.tslib]
 [components.tss2]
 [components.ttembed]

--- a/base/comps/components-full.toml
+++ b/base/comps/components-full.toml
@@ -5615,7 +5615,6 @@
 [components.rust-git2-curl]
 [components.rust-git2]
 [components.rust-gix-actor]
-[components.rust-gix-archive]
 [components.rust-gix-attributes]
 [components.rust-gix-bitmap]
 [components.rust-gix-blame]

--- a/base/comps/components-full.toml
+++ b/base/comps/components-full.toml
@@ -6774,7 +6774,6 @@
 [components.rust-zbus_macros]
 [components.rust-zbus_names]
 [components.rust-zerocopy-derive]
-[components.rust-zerocopy]
 [components.rust-zerofrom-derive]
 [components.rust-zerofrom]
 [components.rust-zeroize]

--- a/base/comps/components-full.toml
+++ b/base/comps/components-full.toml
@@ -6324,7 +6324,6 @@
 [components.rust-scan_fmt]
 [components.rust-scc]
 [components.rust-scheduled-thread-pool]
-[components.rust-schemars]
 [components.rust-schemars_derive]
 [components.rust-scoped-tls]
 [components.rust-scoped_threadpool]

--- a/base/comps/components-full.toml
+++ b/base/comps/components-full.toml
@@ -1325,7 +1325,6 @@
 [components.golang-uber-zap]
 [components.golang-x-arch]
 [components.golang-x-crypto]
-[components.golang-x-exp]
 [components.golang-x-mod]
 [components.golang-x-net]
 [components.golang-x-oauth2]

--- a/base/comps/components-full.toml
+++ b/base/comps/components-full.toml
@@ -7034,7 +7034,6 @@
 [components.utf8proc]
 [components.uthash]
 [components.uuid]
-[components.uv]
 [components.v4l-utils]
 [components.vala]
 [components.valgrind]

--- a/base/comps/components-full.toml
+++ b/base/comps/components-full.toml
@@ -1057,7 +1057,6 @@
 [components.golang-github-eclipse-paho-mqtt]
 [components.golang-github-elazarl-goproxy]
 [components.golang-github-emicklei-restful]
-[components.golang-github-envoyproxy-control-plane]
 [components.golang-github-envoyproxy-protoc-gen-validate]
 [components.golang-github-errors]
 [components.golang-github-etcd-io-gofail]

--- a/base/comps/golang-github-envoyproxy-control-plane/golang-github-envoyproxy-control-plane.comp.toml
+++ b/base/comps/golang-github-envoyproxy-control-plane/golang-github-envoyproxy-control-plane.comp.toml
@@ -1,0 +1,14 @@
+# golang-github-sagikazarmark-crypt has been a dead package since Fedora 43, which breaks
+# the transitive dependency chain: %go_generate_buildrequires generates imports that
+# transitively pull in golang-sigs-k8s-aws-iam-authenticator-devel →
+# golang-github-spf13-viper-devel → golang(github.com/sagikazarmark/crypt/config).
+# Remove this overlay once golang-github-sagikazarmark-crypt is available or viper
+# no longer requires it.
+[components.golang-github-envoyproxy-control-plane]
+
+[[components.golang-github-envoyproxy-control-plane.overlays]]
+description = "Disable dynamic BuildRequires generation — transitive dep on dead golang-github-sagikazarmark-crypt"
+type = "spec-search-replace"
+section = "%generate_buildrequires"
+regex = '%go_generate_buildrequires'
+replacement = '# Disabled: transitive dep on dead golang-github-sagikazarmark-crypt (see comp.toml)'

--- a/base/comps/golang-x-exp/golang-x-exp.comp.toml
+++ b/base/comps/golang-x-exp/golang-x-exp.comp.toml
@@ -1,0 +1,9 @@
+# The spec uses %go_generate_buildrequires which auto-detects Go imports. Without the
+# bootstrap bcond, this generates a dependency on golang(golang.org/x/tools/go/packages/packagestest)
+# which golang-x-tools does not provide. Enabling bootstrap skips dynamic dep generation,
+# %build (no CLI binaries), and %check (tests). Only the -devel Go library subpackage
+# is produced.
+[components.golang-x-exp]
+
+[components.golang-x-exp.build]
+with = ["bootstrap"]

--- a/base/comps/rust-gix-archive/rust-gix-archive.comp.toml
+++ b/base/comps/rust-gix-archive/rust-gix-archive.comp.toml
@@ -1,0 +1,6 @@
+# Pin to commit that supports rust-zip 8.x (the F43 spec requires zip 5.x-7.x
+# which is not available in the build tag).
+# Remove this pin once Koji builders can see prior completed builds as deps.
+# https://src.fedoraproject.org/rpms/rust-gix-archive/c/b435a6a075cdc705d25c60e17366c570e0880c08
+[components.rust-gix-archive]
+spec = { type = "upstream", upstream-commit = "b435a6a075cdc705d25c60e17366c570e0880c08" }

--- a/base/comps/rust-schemars/rust-schemars.comp.toml
+++ b/base/comps/rust-schemars/rust-schemars.comp.toml
@@ -1,0 +1,6 @@
+# Pin to commit that ships an in-sync version of rust-schemars_derive, avoiding a
+# missing crate(schemars_derive/default) = 1.2.0 build failure.
+# Remove this pin once Koji builders can see prior completed builds as deps.
+# https://src.fedoraproject.org/rpms/rust-schemars/c/566b6f412bd5454682bdf8d15a33f1b5d4329418
+[components.rust-schemars]
+spec = { type = "upstream", upstream-commit = "566b6f412bd5454682bdf8d15a33f1b5d4329418" }

--- a/base/comps/rust-zerocopy/rust-zerocopy.comp.toml
+++ b/base/comps/rust-zerocopy/rust-zerocopy.comp.toml
@@ -1,0 +1,6 @@
+# Pin to commit that ships an in-sync version of rust-zerocopy-derive, avoiding a
+# missing crate(zerocopy-derive/default) = 0.8.31 build failure.
+# Remove this pin once Koji builders can see prior completed builds as deps.
+# https://src.fedoraproject.org/rpms/rust-zerocopy/c/a093bbbabb313f5318b1d934e865edefcdb474ef
+[components.rust-zerocopy]
+spec = { type = "upstream", upstream-commit = "a093bbbabb313f5318b1d934e865edefcdb474ef" }

--- a/base/comps/trustee-guest-components/trustee-guest-components.comp.toml
+++ b/base/comps/trustee-guest-components/trustee-guest-components.comp.toml
@@ -1,0 +1,5 @@
+# Pin to older commit to avoid missing crate(canon-json) and crate(kbs-types) deps
+# which are not available in the build tag at the latest F43 version.
+# https://src.fedoraproject.org/rpms/trustee-guest-components/c/7ac284fd661640027d26cbe0711072c1c835f28e
+[components.trustee-guest-components]
+spec = { type = "upstream", upstream-commit = "7ac284fd661640027d26cbe0711072c1c835f28e" }

--- a/base/comps/uv/uv.comp.toml
+++ b/base/comps/uv/uv.comp.toml
@@ -1,0 +1,4 @@
+# Pin to 0.10.12 to avoid missing crate(astral-tokio-tar/default) build dependency.
+# https://src.fedoraproject.org/rpms/uv/c/07f74430e59fb84e925e6d7b238f0b334a42c97c
+[components.uv]
+spec = { type = "upstream", upstream-commit = "07f74430e59fb84e925e6d7b238f0b334a42c97c" }


### PR DESCRIPTION
Add version pins via commit and workaround for some components that failed due to missing dependencies in build root. This change should be rebase-and-merged.