### PR TITLE
workaround rust-nix* test failures due to 4-part kernel version issue

### DIFF
--- a/base/comps/components-full.toml
+++ b/base/comps/components-full.toml
@@ -102,7 +102,6 @@
 [components.'rust-nix0.24']
 [components.'rust-nix0.26']
 [components.'rust-nix0.27']
-[components.'rust-nix0.29']
 [components.'rust-object0.36']
 [components.'rust-object0.37']
 [components.'rust-petgraph0.6']

--- a/base/comps/components-full.toml
+++ b/base/comps/components-full.toml
@@ -103,7 +103,6 @@
 [components.'rust-nix0.26']
 [components.'rust-nix0.27']
 [components.'rust-nix0.29']
-[components.'rust-nix0.30']
 [components.'rust-object0.36']
 [components.'rust-object0.37']
 [components.'rust-petgraph0.6']

--- a/base/comps/components-full.toml
+++ b/base/comps/components-full.toml
@@ -5972,7 +5972,6 @@
 [components.rust-new_debug_unreachable]
 [components.rust-newtype-uuid]
 [components.rust-nibble_vec]
-[components.'rust-nix0.23']
 [components.rust-no-panic]
 [components.rust-no-std-net]
 [components.rust-no_std_io2]

--- a/base/comps/components-full.toml
+++ b/base/comps/components-full.toml
@@ -102,7 +102,6 @@
 [components.'rust-nix0.24']
 [components.'rust-nix0.26']
 [components.'rust-nix0.27']
-[components.'rust-nix0.28']
 [components.'rust-nix0.29']
 [components.'rust-nix0.30']
 [components.'rust-object0.36']

--- a/base/comps/rust-nix0.23/fix-4part-kernel-version.patch
+++ b/base/comps/rust-nix0.23/fix-4part-kernel-version.patch
@@ -1,0 +1,22 @@
+diff --git a/test/common/mod.rs b/test/common/mod.rs
+index 7dbdfbf..027611a 100644
+--- a/test/common/mod.rs
++++ b/test/common/mod.rs
+@@ -133,7 +133,16 @@ cfg_if! {
+                     .replace("_", "-")
+                     // Cirrus-CI reports version as 4.19.112+ .  Remove the +
+                     .replace("+", "");
+-                let mut version = Version::parse(fixed_release).unwrap();
++                // Some distros (e.g. Azure Linux) use 4-part kernel versions
++                // like 6.6.121.1-1.azl3.  Semver only accepts 3 numeric
++                // components, so replace the dot after the 3rd component with
++                // a hyphen so the extra part becomes a pre-release suffix
++                // (which we clear below anyway).
++                let fixed_release = match fixed_release.match_indices('.').nth(2) {
++                    Some((pos, _)) => fixed_release[..pos].to_string() + &fixed_release[pos..].replacen('.', "-", 1),
++                    None => fixed_release.to_string(),
++                };
++                let mut version = Version::parse(&fixed_release).unwrap();
+ 
+                 //Keep only numeric parts
+                 version.pre = semver::Prerelease::EMPTY;

--- a/base/comps/rust-nix0.23/rust-nix0.23.comp.toml
+++ b/base/comps/rust-nix0.23/rust-nix0.23.comp.toml
@@ -1,0 +1,16 @@
+[components.'rust-nix0.23']
+
+# Azure Linux kernels use 4-part versions (e.g. 6.6.121.1-1.azl3) which the
+# semver crate in test helpers cannot parse.  Patch the require_kernel_version!
+# macro to handle this by truncating to 3 numeric components.
+[[components.'rust-nix0.23'.overlays]]
+description = "Add patch file to handle 4-part kernel versions in the require_kernel_version test macro"
+type = "file-add"
+file = "fix-4part-kernel-version.patch"
+source = "fix-4part-kernel-version.patch"
+
+[[components.'rust-nix0.23'.overlays]]
+description = "Register the 4-part kernel version fix patch in the spec"
+type = "spec-insert-tag"
+tag = "Patch9999"
+value = "fix-4part-kernel-version.patch"

--- a/base/comps/rust-nix0.28/fix-4part-kernel-version.patch
+++ b/base/comps/rust-nix0.28/fix-4part-kernel-version.patch
@@ -1,0 +1,22 @@
+diff --git a/test/common/mod.rs b/test/common/mod.rs
+index 7dbdfbf..027611a 100644
+--- a/test/common/mod.rs
++++ b/test/common/mod.rs
+@@ -133,7 +133,16 @@ cfg_if! {
+                     .replace("_", "-")
+                     // Cirrus-CI reports version as 4.19.112+ .  Remove the +
+                     .replace("+", "");
+-                let mut version = Version::parse(fixed_release).unwrap();
++                // Some distros (e.g. Azure Linux) use 4-part kernel versions
++                // like 6.6.121.1-1.azl3.  Semver only accepts 3 numeric
++                // components, so replace the dot after the 3rd component with
++                // a hyphen so the extra part becomes a pre-release suffix
++                // (which we clear below anyway).
++                let fixed_release = match fixed_release.match_indices('.').nth(2) {
++                    Some((pos, _)) => fixed_release[..pos].to_string() + &fixed_release[pos..].replacen('.', "-", 1),
++                    None => fixed_release.to_string(),
++                };
++                let mut version = Version::parse(&fixed_release).unwrap();
+ 
+                 //Keep only numeric parts
+                 version.pre = semver::Prerelease::EMPTY;

--- a/base/comps/rust-nix0.28/rust-nix0.28.comp.toml
+++ b/base/comps/rust-nix0.28/rust-nix0.28.comp.toml
@@ -1,0 +1,16 @@
+[components.'rust-nix0.28']
+
+# Azure Linux kernels use 4-part versions (e.g. 6.6.121.1-1.azl3) which the
+# semver crate in test helpers cannot parse.  Patch the require_kernel_version!
+# macro to handle this by truncating to 3 numeric components.
+[[components.'rust-nix0.28'.overlays]]
+description = "Add patch file to handle 4-part kernel versions in the require_kernel_version test macro"
+type = "file-add"
+file = "fix-4part-kernel-version.patch"
+source = "fix-4part-kernel-version.patch"
+
+[[components.'rust-nix0.28'.overlays]]
+description = "Register the 4-part kernel version fix patch in the spec"
+type = "spec-insert-tag"
+tag = "Patch9999"
+value = "fix-4part-kernel-version.patch"

--- a/base/comps/rust-nix0.29/fix-4part-kernel-version.patch
+++ b/base/comps/rust-nix0.29/fix-4part-kernel-version.patch
@@ -1,0 +1,22 @@
+diff --git a/test/common/mod.rs b/test/common/mod.rs
+index 7dbdfbf..027611a 100644
+--- a/test/common/mod.rs
++++ b/test/common/mod.rs
+@@ -133,7 +133,16 @@ cfg_if! {
+                     .replace("_", "-")
+                     // Cirrus-CI reports version as 4.19.112+ .  Remove the +
+                     .replace("+", "");
+-                let mut version = Version::parse(fixed_release).unwrap();
++                // Some distros (e.g. Azure Linux) use 4-part kernel versions
++                // like 6.6.121.1-1.azl3.  Semver only accepts 3 numeric
++                // components, so replace the dot after the 3rd component with
++                // a hyphen so the extra part becomes a pre-release suffix
++                // (which we clear below anyway).
++                let fixed_release = match fixed_release.match_indices('.').nth(2) {
++                    Some((pos, _)) => fixed_release[..pos].to_string() + &fixed_release[pos..].replacen('.', "-", 1),
++                    None => fixed_release.to_string(),
++                };
++                let mut version = Version::parse(&fixed_release).unwrap();
+ 
+                 //Keep only numeric parts
+                 version.pre = semver::Prerelease::EMPTY;

--- a/base/comps/rust-nix0.29/rust-nix0.29.comp.toml
+++ b/base/comps/rust-nix0.29/rust-nix0.29.comp.toml
@@ -1,0 +1,16 @@
+[components.'rust-nix0.29']
+
+# Azure Linux kernels use 4-part versions (e.g. 6.6.121.1-1.azl3) which the
+# semver crate in test helpers cannot parse.  Patch the require_kernel_version!
+# macro to handle this by truncating to 3 numeric components.
+[[components.'rust-nix0.29'.overlays]]
+description = "Add patch file to handle 4-part kernel versions in the require_kernel_version test macro"
+type = "file-add"
+file = "fix-4part-kernel-version.patch"
+source = "fix-4part-kernel-version.patch"
+
+[[components.'rust-nix0.29'.overlays]]
+description = "Register the 4-part kernel version fix patch in the spec"
+type = "spec-insert-tag"
+tag = "Patch9999"
+value = "fix-4part-kernel-version.patch"

--- a/base/comps/rust-nix0.30/fix-4part-kernel-version.patch
+++ b/base/comps/rust-nix0.30/fix-4part-kernel-version.patch
@@ -1,0 +1,22 @@
+diff --git a/test/common/mod.rs b/test/common/mod.rs
+index 7dbdfbf..027611a 100644
+--- a/test/common/mod.rs
++++ b/test/common/mod.rs
+@@ -133,7 +133,16 @@ cfg_if! {
+                     .replace("_", "-")
+                     // Cirrus-CI reports version as 4.19.112+ .  Remove the +
+                     .replace("+", "");
+-                let mut version = Version::parse(fixed_release).unwrap();
++                // Some distros (e.g. Azure Linux) use 4-part kernel versions
++                // like 6.6.121.1-1.azl3.  Semver only accepts 3 numeric
++                // components, so replace the dot after the 3rd component with
++                // a hyphen so the extra part becomes a pre-release suffix
++                // (which we clear below anyway).
++                let fixed_release = match fixed_release.match_indices('.').nth(2) {
++                    Some((pos, _)) => fixed_release[..pos].to_string() + &fixed_release[pos..].replacen('.', "-", 1),
++                    None => fixed_release.to_string(),
++                };
++                let mut version = Version::parse(&fixed_release).unwrap();
+ 
+                 //Keep only numeric parts
+                 version.pre = semver::Prerelease::EMPTY;

--- a/base/comps/rust-nix0.30/rust-nix0.30.comp.toml
+++ b/base/comps/rust-nix0.30/rust-nix0.30.comp.toml
@@ -1,0 +1,16 @@
+[components.'rust-nix0.30']
+
+# Azure Linux kernels use 4-part versions (e.g. 6.6.121.1-1.azl3) which the
+# semver crate in test helpers cannot parse.  Patch the require_kernel_version!
+# macro to handle this by truncating to 3 numeric components.
+[[components.'rust-nix0.30'.overlays]]
+description = "Add patch file to handle 4-part kernel versions in the require_kernel_version test macro"
+type = "file-add"
+file = "fix-4part-kernel-version.patch"
+source = "fix-4part-kernel-version.patch"
+
+[[components.'rust-nix0.30'.overlays]]
+description = "Register the 4-part kernel version fix patch in the spec"
+type = "spec-insert-tag"
+tag = "Patch9999"
+value = "fix-4part-kernel-version.patch"


### PR DESCRIPTION
Azure Linux 3.0 kernels, used on our current Koji builders, have 4-part
version strings (e.g. 6.6.121.1-1.azl3) which the semver crate's
Version::parse() rejects. Two tests (gro, gso) panic on unwrap of the
parse error.

Apply the same fix-4part-kernel-version.patch already used by rust-nix:
truncate to 3 numeric components before parsing so the extra part
becomes a pre-release suffix (which is cleared immediately after).

Apply to rust-nix0.23, rust-nix0.28, rust-nix0.29, rust-nix0.30.

This workaround can be undone when the Koji builders move to a
kernel with 3-part version strings, although the current logic will still
continue to function as intended with a standard 3-part kernel version
string.