### PR TITLE
feat(qemu): disable Xen support

### DIFF
--- a/base/comps/components-full.toml
+++ b/base/comps/components-full.toml
@@ -4739,7 +4739,6 @@
 [components.qcustomplot]
 [components.qdbm]
 [components.qdox]
-[components.qemu]
 [components.qhull]
 [components.qjson]
 [components.qpdf]

--- a/base/comps/qemu/qemu.comp.toml
+++ b/base/comps/qemu/qemu.comp.toml
@@ -1,0 +1,10 @@
+[components.qemu]
+
+# Disable Xen support — not applicable to Azure Linux's Hyper-V/KVM environment.
+# The upstream spec enables Xen when %fedora is set (which it is on our builders),
+# so we must explicitly override have_xen back to 0.
+[[components.qemu.overlays]]
+description = "Disable Xen support - not needed for Azure Linux (Hyper-V/KVM only)"
+type = "spec-search-replace"
+regex = '%global have_xen 1'
+replacement = '%global have_xen 0'


### PR DESCRIPTION
Azure Linux targets Hyper-V/KVM, not Xen. Since our builders have the %fedora macro set, the upstream spec enables Xen on x86_64/aarch64 by default, pulling in xen-devel at build time and libxenstore.so.4 at runtime.

Override have_xen back to 0 via overlay. Verified: build succeeds and no output RPMs carry xen dependencies.

Part of fixing: [workitem](https://dev.azure.com/mariner-org/mariner/_workitems/edit/18553)