### PR TITLE
feat(libvirt): disable Xen/libxl driver support

### DIFF
--- a/base/comps/components-full.toml
+++ b/base/comps/components-full.toml
@@ -2175,7 +2175,6 @@
 [components.libvirt-dbus]
 [components.libvirt-glib]
 [components.libvirt-python]
-[components.libvirt]
 [components.libvisio]
 [components.libvisual]
 [components.libvma]

--- a/base/comps/libvirt/libvirt.comp.toml
+++ b/base/comps/libvirt/libvirt.comp.toml
@@ -1,0 +1,6 @@
+[components.libvirt]
+
+# Disable Xen/libxl driver — not applicable to Azure Linux's Hyper-V/KVM environment.
+# The upstream spec enables libxl by default on x86_64/aarch64 when %fedora is set.
+[components.libvirt.build]
+without = ["libxl"]


### PR DESCRIPTION
Azure Linux targets Hyper-V/KVM, not Xen. Since our builders have the %fedora macro set, the upstream spec enables the libxl driver on x86_64/aarch64 by default, pulling in xen-devel at build time and producing libvirt-daemon-driver-libxl / libvirt-daemon-xen subpackages with libxenstore.so.4 runtime dependencies.

Disable via build.without = ["libxl"]. Verified: build succeeds, no xen/libxl subpackages are produced, and no output RPMs carry xen dependencies.

Part of fixing: [workitem](https://dev.azure.com/mariner-org/mariner/_workitems/edit/18553)