### PR TITLE
feat(fence-agents): remove fence-agents-xenapi from metapackage

### DIFF
--- a/base/comps/components-full.toml
+++ b/base/comps/components-full.toml
@@ -654,7 +654,6 @@
 [components.fedora-iot-config]
 [components.felix-parent]
 [components.felix-utils]
-[components.fence-agents]
 [components.festival-freebsoft-utils]
 [components.festival]
 [components.ffcall]

--- a/base/comps/fence-agents/fence-agents.comp.toml
+++ b/base/comps/fence-agents/fence-agents.comp.toml
@@ -1,0 +1,11 @@
+[components.fence-agents]
+
+# Remove fence-agents-xenapi from the fence-agents-all metapackage.
+# Xen is not applicable to Azure Linux's Hyper-V/KVM environment.
+# Clearing the package name leaves " \\" — a blank continuation that adds
+# only harmless whitespace to the Requires list.
+[[components.fence-agents.overlays]]
+description = "Remove fence-agents-xenapi from fence-agents-all Requires - Xen not needed for Azure Linux"
+type = "spec-search-replace"
+regex = 'fence-agents-xenapi'
+replacement = ''


### PR DESCRIPTION
Azure Linux targets Hyper-V/KVM, not Xen. Remove fence-agents-xenapi from the fence-agents-all Requires list so it is no longer pulled in by the metapackage. The subpackage is still built but not installed by default.

Verified: build succeeds and fence-agents-all no longer requires fence-agents-xenapi.

Part of fixing: [workitem](https://dev.azure.com/mariner-org/mariner/_workitems/edit/18553)