### PR TITLE
feat(grub2): disable Xen module builds

### DIFF
--- a/base/comps/components.toml
+++ b/base/comps/components.toml
@@ -81,7 +81,6 @@ includes = ["**/*.comp.toml", "components-full.toml", "component-check-disableme
 [components.gpm]
 [components.grep]
 [components.groff]
-[components.grub2]
 [components.grubby]
 [components.gssproxy]
 [components.gzip]

--- a/base/comps/grub2/grub2.comp.toml
+++ b/base/comps/grub2/grub2.comp.toml
@@ -1,0 +1,18 @@
+[components.grub2]
+
+# Disable Xen module builds — not applicable to Azure Linux (Hyper-V/KVM).
+# grub.macros enables with_xen_arch and with_xen_pvh_arch on x86_64 by default,
+# producing grub2-xen-x64-modules and grub2-xen_pvh-i386-modules subpackages.
+[[components.grub2.overlays]]
+description = "Disable Xen module build (with_xen_arch) in grub.macros"
+type = "file-search-replace"
+file = "grub.macros"
+regex = '%global with_xen_arch 1'
+replacement = '%global with_xen_arch 0'
+
+[[components.grub2.overlays]]
+description = "Disable Xen PVH module build (with_xen_pvh_arch) in grub.macros"
+type = "file-search-replace"
+file = "grub.macros"
+regex = '%global with_xen_pvh_arch 1'
+replacement = '%global with_xen_pvh_arch 0'


### PR DESCRIPTION
Azure Linux targets Hyper-V/KVM, not Xen. The upstream grub.macros enables with_xen_arch and with_xen_pvh_arch on x86_64, producing grub2-xen-x64-modules and grub2-xen_pvh-i386-modules subpackages.

Force both to 0 via file-search-replace overlays on grub.macros. Verified: build succeeds and no Xen module subpackages are produced.