### PR TITLE
feat(dnf5): convenience symlink for tdnf

### DIFF
--- a/base/comps/dnf5/dnf5.comp.toml
+++ b/base/comps/dnf5/dnf5.comp.toml
@@ -5,3 +5,29 @@
 without = [
     "plugin_rhsm"
 ]
+
+# Upstream packaging of dnf5 includes compatibility symlinks
+# for microdnf and other earlier versions of dnf. We provide the
+# same for tdnf, for the benefit of earlier customers of Azure
+# Linux.
+[[components.dnf5.overlays]]
+description = "Report that the dnf5 package provides tdnf for compatibility"
+type = "spec-add-tag"
+tag = "Provides"
+value = "tdnf = %{version}-%{release}"
+
+[[components.dnf5.overlays]]
+description = "Include the tdnf compat symlink in the package"
+type = "spec-append-lines"
+section = "%files"
+lines = [
+    "%{_bindir}/tdnf"
+]
+
+[[components.dnf5.overlays]]
+description = "Provide /usr/bin/tdnf as a compat symlink to dnf5"
+type = "spec-append-lines"
+section = "%install"
+lines = [
+    "ln -sr %{buildroot}%{_bindir}/dnf5 %{buildroot}%{_bindir}/tdnf"
+]


### PR DESCRIPTION
The upstream Fedora package of `dnf5` establishes a precedent of providing convenience symlinks for outmoded variants of `dnf`, notably including `microdnf`.

This follows suit, adding a convenience symlink for `tdnf`, to ease transition from customers of Azure Linux 3.0.

Validation: locally built `dnf5` RPM and confirmed that symlink is present.