### PR TITLE
Upgrade `vim` to 9.2.0315 for CVE-2026-34714, CVE-2026-34982, CVE-2026-35177

### DIFF
--- a/SPECS/vim/vim.signatures.json
+++ b/SPECS/vim/vim.signatures.json
@@ -1,6 +1,6 @@
 {
   "Signatures": {
     "macros.vim": "98d2e285e93e339defc13ef1dc4fa76f24e3fca6282e4196a3dae45de778eab8",
-    "vim-9.2.0240.tar.gz": "ec7acf94e80d01f651278fd81d42f1144b5ea39c5447816bb8db79ecb44c3d2b"
+    "vim-9.2.0315.tar.gz": "e39ae8a591be8959ebafb0c90e1cee3b662c0c6aa910d0d19a2df7309ebd7a65"
   }
 }

--- a/SPECS/vim/vim.spec
+++ b/SPECS/vim/vim.spec
@@ -1,7 +1,7 @@
 %define debug_package %{nil}
 Summary:        Text editor
 Name:           vim
-Version:        9.2.0240
+Version:        9.2.0315
 Release:        1%{?dist}
 License:        Vim
 Vendor:         Microsoft Corporation
@@ -223,6 +223,9 @@ fi
 %{_rpmconfigdir}/macros.d/macros.vim
 
 %changelog
+* Tue Apr 07 2026 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 9.2.0315-1
+- Auto-upgrade to 9.2.0315 - for CVE-2026-34714, CVE-2026-34982, CVE-2026-35177
+
 * Wed Mar 25 2026 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 9.2.0240-1
 - Auto-upgrade to 9.2.0240 - for CVE-2026-33412
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -29986,8 +29986,8 @@
         "type": "other",
         "other": {
           "name": "vim",
-          "version": "9.2.0240",
-          "downloadUrl": "https://github.com/vim/vim/archive/v9.2.0240.tar.gz"
+          "version": "9.2.0315",
+          "downloadUrl": "https://github.com/vim/vim/archive/v9.2.0315.tar.gz"
         }
       }
     },


### PR DESCRIPTION
Upgrade Pipeline - > https://dev.azure.com/mariner-org/mariner/_build/results?buildId=1088184&view=results
Upgrade `vim` to 9.2.0315 for CVE-2026-34714, CVE-2026-34982, CVE-2026-35177