### PR TITLE
Upgrade `vim` to 9.2.0315 for CVE-2026-34714, CVE-2026-34982, CVE-2026-35177

### DIFF
--- a/SPECS/vim/vim.signatures.json
+++ b/SPECS/vim/vim.signatures.json
@@ -1,5 +1,5 @@
 {
   "Signatures": {
-    "vim-9.2.0088.tar.gz": "9ac94db07ef61d42c43ac8b84f39a00eae488d1d63092b33b9217a81bd5b565d"
+    "vim-9.2.0315.tar.gz": "e39ae8a591be8959ebafb0c90e1cee3b662c0c6aa910d0d19a2df7309ebd7a65"
   }
 }

--- a/SPECS/vim/vim.spec
+++ b/SPECS/vim/vim.spec
@@ -1,7 +1,7 @@
 %define debug_package %{nil}
 Summary:        Text editor
 Name:           vim
-Version:        9.2.0088
+Version:        9.2.0315
 Release:        1%{?dist}
 License:        Vim
 Vendor:         Microsoft Corporation
@@ -203,6 +203,9 @@ fi
 %{_datarootdir}/vim/vim*/README.txt
 
 %changelog
+* Tue Apr 07 2026 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 9.2.0315-1
+- Auto-upgrade to 9.2.0315 - for CVE-2026-34714, CVE-2026-34982, CVE-2026-35177
+
 * Sun Mar 01 2026 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 9.2.0088-1
 - Auto-upgrade to 9.2.0088 - for CVE-2026-28417, CVE-2026-28418, CVE-2026-28419, CVE-2026-28420, CVE-2026-28421, CVE-2026-28422
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -29447,8 +29447,8 @@
         "type": "other",
         "other": {
           "name": "vim",
-          "version": "9.2.0088",
-          "downloadUrl": "https://github.com/vim/vim/archive/v9.2.0088.tar.gz"
+          "version": "9.2.0315",
+          "downloadUrl": "https://github.com/vim/vim/archive/v9.2.0315.tar.gz"
         }
       }
     },


### PR DESCRIPTION
Upgrade Pipeline https://dev.azure.com/mariner-org/mariner/_build/results?buildId=1088185&view=results

Upgrade vim to 9.2.0315 for CVE-2026-34714, CVE-2026-34982, CVE-2026-35177