### PR TITLE
fix(rust-clap): pin to version 4.6.0

### DIFF
--- a/base/comps/rust-clap/rust-clap.comp.toml
+++ b/base/comps/rust-clap/rust-clap.comp.toml
@@ -1,5 +1,5 @@
-# Pin to 4.5.60 because the 4.5.59 spec has a build dependency on rust-clap_builder 4.5.59,
+# Pin to 4.6.0 because the 4.5.60 spec has a build dependency on rust-clap_builder 4.5.60,
 # which is not available in the F43 repos that the Koji builders use for resolution.
 # Remove this pin once Koji builders can see prior completed builds as deps.
 [components.rust-clap]
-spec = { type = "upstream", upstream-commit = "493321dff0ef91c37b738226b3e34631965ae5da" }
+spec = { type = "upstream", upstream-commit = "1db760fbdb840e91194d8435235ec4d31a60a3d3" }

--- a/base/comps/rust-clap_builder/rust-clap_builder.comp.toml
+++ b/base/comps/rust-clap_builder/rust-clap_builder.comp.toml
@@ -1,4 +1,4 @@
-# Pin to 4.5.60 to be in sync with rust-clap
+# Pin to 4.6.0 to be in sync with rust-clap
 # Remove this pin once rust-clap's pin is removed
 [components.rust-clap_builder]
-spec = { type = "upstream", upstream-commit = "bdbf85f857b5f9acb11f0fe0d5cf18646372066d" }
+spec = { type = "upstream", upstream-commit = "5a94017d90c1355714ea8a665ccaebcdbe78760d" }


### PR DESCRIPTION
f43 repos only provide crate(clap_builder) 4.6.0. We need to move the version forward to build rust-clap