### PR TITLE
fix(erlang-rebar3): pin erlang-rebar3 to 3.27.0 for hex_core 0.15+ compatx_core 0.15+

### DIFF
--- a/base/comps/components-full.toml
+++ b/base/comps/components-full.toml
@@ -612,7 +612,6 @@
 [components.erlang-proper]
 [components.erlang-providers]
 [components.erlang-rebar3-gpb]
-[components.erlang-rebar3]
 [components.erlang-relx]
 [components.erlang-rpm-macros]
 [components.erlang-ssl_verify_fun]

--- a/base/comps/erlang-rebar3/erlang-rebar3.comp.toml
+++ b/base/comps/erlang-rebar3/erlang-rebar3.comp.toml
@@ -1,0 +1,16 @@
+[components.erlang-rebar3]
+# Pin to latest f43 commit which updates to 3.27.0, fixes hex_core 0.15+ API
+# incompatibility, and includes %install/%files fixes for bootstrap mode.
+# Our snapshot (2026-02-24) predates the fix (2026-03-21).
+spec = { type = "upstream", upstream-commit = "851a2e917df6169f4e8aa2bc12dd0d69c4ff73a4" }
+
+# Re-enable bootstrap mode so rebar3 can build itself without needing the old
+# broken erlang-rebar3 3.26.0 in the build tag. The latest upstream commit
+# disabled bootstrap (since Fedora already has a working 3.27.0), but AZL
+# doesn't yet.
+# TODO: Remove this overlay once rebar3 3.27.0 is in the AZL build tag.
+[[components.erlang-rebar3.overlays]]
+description = "Enable bootstrap mode to break self-dependency on broken erlang-rebar3 3.26.0"
+type = "spec-search-replace"
+regex = '^%global bootstrap 0$'
+replacement = '%global bootstrap 1'


### PR DESCRIPTION
Pin to f43 commit 24837f9 which updates to `erlang-rebar3 3.27.0`, fixes the `hex_core 0.15+` API incompatibility (request_to_file/6), and has bootstrap mode enabled so rebar3 can build itself without needing the old broken 3.26.0 in the build tag.
Validation: waiting for erlang-rebar3 3.27.0 tarball uploaded to azl lookaside cache.

