### PR TITLE
fix(golang-cloud-google): pin golang-cloud-google to older commit and skip %check

### DIFF
--- a/base/comps/component-check-disablement.toml
+++ b/base/comps/component-check-disablement.toml
@@ -14,6 +14,7 @@ components = [
     "glib2",
     "git",
     "gnutls",
+    "golang-cloud-google",
     "golang-cloud-google-storage",
     "golang-dario-mergo",
     "golang-github-aws-smithy",

--- a/base/comps/components-full.toml
+++ b/base/comps/components-full.toml
@@ -990,7 +990,6 @@
 [components.golang-cloud-google-iam]
 [components.golang-cloud-google-longrunning]
 [components.golang-cloud-google-storage]
-[components.golang-cloud-google]
 [components.golang-code-cloudfoundry-bytefmt]
 [components.golang-contrib-opencensus-exporter-ocagent]
 [components.golang-dario-mergo]

--- a/base/comps/golang-cloud-google/golang-cloud-google.comp.toml
+++ b/base/comps/golang-cloud-google/golang-cloud-google.comp.toml
@@ -1,0 +1,3 @@
+[components.golang-cloud-google]
+# Pin to an older commit with matching sources file hash.
+spec = { type = "upstream", upstream-commit = "d385b6877ca9ed6b771cb54f4d0765c5b04d4366" }


### PR DESCRIPTION
Pin `golang-cloud-google` to commit d385b68 which has a matching sources file hash. 
Add to check-skip-initial-failures to fix aliasgen build failure (due to Go 1.24+ stricter -printf vet analyzer).

Validation: [Koji build](https://controltower-dev-jwisitgpr74k6-gjb0fchvgkbnamgp.b01.azurefd.net/workflow/cc6a8050-0547-4470-cda7-08de9447447c)