### PR TITLE
fix(python3.14): disable experimental JIT to resolve clang/llvm dependency

### DIFF
--- a/base/comps/components.toml
+++ b/base/comps/components.toml
@@ -278,7 +278,6 @@ includes = ["**/*.comp.toml", "components-full.toml", "component-check-disableme
 [components.python-systemd]
 [components.python-urllib3]
 [components.python-wcwidth]
-[components.'python3.14']
 [components.pytz]
 [components.PyYAML]
 [components.quota]

--- a/base/comps/python3.14/python3.14.comp.toml
+++ b/base/comps/python3.14/python3.14.comp.toml
@@ -1,0 +1,9 @@
+[components.'python3.14']
+
+[components.'python3.14'.build]
+# Disable the experimental JIT compiler (PEP 744).
+# This matches RHEL, which also disables JIT: https://src.fedoraproject.org/rpms/python3.14/pull-request/76
+# The upstream spec requires clang(major) = 19 / llvm(major) = 19 to build JIT stencils,
+# but AZL ships LLVM 21. JIT is experimental, off-by-default, and has minimal impact
+# on server workloads.
+without = ["jit"]


### PR DESCRIPTION
The upstream Fedora 43 spec requires clang(major) = 19 / llvm(major) = 19 to build JIT stencils, but AZL ships LLVM 21. Disable JIT entirely, matching the RHEL approach: https://src.fedoraproject.org/rpms/python3.14/pull-request/76

JIT is experimental and off-by-default (requires PYTHON_JIT=1 at runtime).

- Create dedicated python3.14.comp.toml with build.without = ["jit"]
- Remove inline entry from components.toml
