### PR TITLE
feat: Disable systemd udev rule that sets default io scheduler to bfq

### DIFF
--- a/base/comps/systemd/systemd.comp.toml
+++ b/base/comps/systemd/systemd.comp.toml
@@ -27,3 +27,10 @@ description = "Disable Xen in meson — set have_xen to 0 so -Dxenctrl=disabled 
 type = "spec-search-replace"
 regex = '%global have_xen 1'
 replacement = "%global have_xen 0"
+
+[[components.systemd.overlays]]
+description = "Disable udev rule that sets default io scheduler to bfq"
+type = "file-search-replace"
+file = "60-block-scheduler.rules"
+regex = "(?m)^"
+replacement = "#"


### PR DESCRIPTION
This disables (comments out) the udev rule that sets the default io scheduler to 'bfq'. We do not want that as the kernel default of 'none' (or 'mq-deadline' for single-queue devices) provides better raw performance, especially in the Azure cloud where all drives are virtualized and the underlying hypervisor can better handle io scheduling if needed.
