### PR TITLE
fix(openblas): add missing BuildRequires on python3

### DIFF
--- a/base/comps/components-full.toml
+++ b/base/comps/components-full.toml
@@ -2615,7 +2615,6 @@
 [components.open-vmdk]
 [components.openal-soft]
 [components.openbios]
-[components.openblas]
 [components.openbox]
 [components.opencl-filesystem]
 [components.opencl-headers]

--- a/base/comps/openblas/openblas.comp.toml
+++ b/base/comps/openblas/openblas.comp.toml
@@ -1,0 +1,13 @@
+[components.openblas]
+
+# The openblas %build section runs `make ... lapack-test`, which invokes
+# lapack_testing.py (a Python 3 script). Upstream Fedora doesn't declare
+# BuildRequires: python3 either, but python3 gets pulled in transitively
+# through perl-devel → systemtap-sdt-devel → python3. AZL builds perl
+# without systemtap (build.without = ["perl_enables_systemtap"]), breaking
+# that chain and leaving python3 unavailable in the buildroot.
+[[components.openblas.overlays]]
+description = "Add missing BuildRequires on python3 needed by lapack_testing.py during %build"
+type = "spec-add-tag"
+tag = "BuildRequires"
+value = "python3"


### PR DESCRIPTION
The openblas %build section runs `make ... lapack-test`, which invokes lapack_testing.py — a Python 3 script. Neither the upstream Fedora spec nor AZL declares BuildRequires: python3 explicitly.

In Fedora this works because python3 is pulled in transitively:
  perl-devel → systemtap-sdt-devel → python3
AZL builds perl with `without: ["perl_enables_systemtap"]`, which drops the systemtap-sdt-devel Requires from perl-devel, breaking that chain. The bootstrap build succeeded because it used raw Fedora fc43 packages where this chain was intact; the regular build failed on aarch64 because the AZL-rebuilt perl-devel no longer pulls in python3.

Add BuildRequires: python3 via spec-add-tag overlay. Move the component from inline components-full.toml to a dedicated comp.toml to hold the overlay.