### PR TITLE
fix(azurelinux-rpm-config): symlink azurelinux lua dir to fedora one

### DIFF
--- a/base/comps/azurelinux-rpm-config/azurelinux-rpm-config.comp.toml
+++ b/base/comps/azurelinux-rpm-config/azurelinux-rpm-config.comp.toml
@@ -27,6 +27,12 @@ overlays = [
     { type = "spec-prepend-lines", section = "%install", lines = ["mkdir -p %{buildroot}/usr/lib/rpm", "ln -sf redhat %{buildroot}/usr/lib/rpm/azurelinux"] },
     { type = "spec-prepend-lines", section = "%files", lines = ["/usr/lib/rpm/azurelinux"] },
 
+    # Create symlink for lua dir: /usr/lib/rpm/lua/azurelinux -> /usr/lib/rpm/lua/fedora
+    # This allows the distro-specific name to be used with minimal required churn to
+    # spread references to the standard path in Fedora.
+    { type = "spec-append-lines", section = "%install", lines = ["ln -sf fedora %{buildroot}%{_rpmluadir}/azurelinux"] },
+    { type = "spec-append-lines", section = "%files", lines = ["%{_rpmluadir}/azurelinux"] },
+
     #
     # Overlays for non-spec files.
     #


### PR DESCRIPTION
Adds a symlink from /usr/lib/rpm/lua/azurelinux to /usr/lib/rpm/lua/fedora, similar to what we did for the rpm vendor dir. This allows existing references to the fedora lua dir as well as new azurelinux references to resolve.

Without this change, there are references to `azurelinux.common` as a lua module that do not resolve correctly.

_**Validation**: rebuilt azurelinux-rpm-config, and then rebuilt memtest86+ against it; without this fix, the build failed during SRPM assembly and with the fix RPM build worked correctly._