### PR TITLE
fcode-utils: force -std=gnu17 to fix GCC 15 build failure

### DIFF
--- a/base/comps/components.toml
+++ b/base/comps/components.toml
@@ -483,7 +483,7 @@ includes = ["**/*.comp.toml", "component-check-disablement.toml"]
 [components.fast_float]
 [components.fasterxml-oss-parent]
 [components.fcgi]
-[components.fcode-utils]
+
 [components.fcoe-utils]
 [components.fdk-aac-free]
 [components.fdupes]

--- a/base/comps/fcode-utils/fcode-utils.comp.toml
+++ b/base/comps/fcode-utils/fcode-utils.comp.toml
@@ -1,0 +1,14 @@
+[components.fcode-utils]
+
+# GCC 15 defaults to C23 where `bool` is a keyword, conflicting with the
+# project's `typedef enum boolean { FALSE = 0, TRUE = -1 } bool;` in
+# shared/types.h. Force C17 (with GNU extensions) as a conservative workaround
+# until a new upstream release includes the fix.
+# Upstream fix: https://github.com/openbios/fcode-utils/issues/20
+# TODO: Remove this overlay once a new upstream release (> 1.0.3) is available.
+[[components.fcode-utils.overlays]]
+description = "Force -std=gnu17 to work around GCC 15 C23 bool keyword conflict (openbios/fcode-utils#20)"
+type = "spec-search-replace"
+section = "%build"
+regex = 'CFLAGS="%\{optflags\}"'
+replacement = 'CFLAGS="%{optflags} -std=gnu17"'


### PR DESCRIPTION
GCC 15 defaults to C23, where `bool` is a keyword. This conflicts with the `typedef enum boolean { FALSE = 0, TRUE = -1 } bool;` declaration in shared/types.h, causing the build to fail.

Force -std=gnu17 via a CFLAGS overlay as a conservative workaround until a new upstream release (> 1.0.3) includes the fix.

Ref: https://github.com/openbios/fcode-utils/issues/20

_**Validation**: confirmed it (originally) reproduced with a local stage2 build; confirmed build now succeeds with this fix._