### PR TITLE
workaround: manually set release for azurelinux-rpm-config

### DIFF
--- a/base/comps/azurelinux-rpm-config/azurelinux-rpm-config.comp.toml
+++ b/base/comps/azurelinux-rpm-config/azurelinux-rpm-config.comp.toml
@@ -11,6 +11,10 @@ overlays = [
     { type = "spec-set-tag", tag = "URL", value = "https://aka.ms/azurelinux" },
     # Set our version.
     { type = "spec-update-tag", tag = "Version", value = "1004" },
+
+    # WORKAROUND: manually bump the Release value for Stage2 bring-up.
+    { type = "spec-update-tag", tag = "Release", value = "2%{?dist}" },
+
     # Provide compatibility with Fedora's upstream version.
     { type = "spec-add-tag", tag = "Provides", value = "redhat-rpm-config = %{version}-%{release}" },
     # Make sure this package takes precedence over (and would replace) any Fedora variant.


### PR DESCRIPTION
To make progress with Stage2 bring-up, we need to rebuild `azurelinux-rpm-config` within an existing Stage1 koji tag. This forces `Release` to `2` to avoid a NEVR conflict within the latter.

Once incremental building is up and running properly, we should back out this overlay and let `%autorelease` work its magic.