### PR TITLE
chore: update stage2 TOML URI

### DIFF
--- a/distro/mock/azl4/stage2/azurelinux-4.0.tpl
+++ b/distro/mock/azl4/stage2/azurelinux-4.0.tpl
@@ -81,8 +81,7 @@ user_agent={{ user_agent }}
 
 [koji]
 name=koji
-baseurl=http://20.88.251.114/kojifiles/repos-dist/azl4-bootstrap-rpms-tag-20260227/latest/$basearch/
-cost=1
+baseurl=http://20.88.251.114/kojifiles/repos-dist/azl4-bootstrap-rpms-tag-20260405/latest/$basearch/
 enabled=1
 skip_if_unavailable=False
 """


### PR DESCRIPTION
This updates the Stage2 TOML URI, which is used by local Stage2 builds.

Also removes the 'cost' value that had mistakenly ended up in the mock config, and which was preventing locally built packages from overriding the prebuilt koji packages.