### PR TITLE
Upgrade `libpng` to 1.6.57 for CVE-2026-34757

### DIFF
--- a/SPECS/libpng/libpng.signatures.json
+++ b/SPECS/libpng/libpng.signatures.json
@@ -1,5 +1,5 @@
 {
   "Signatures": {
-    "libpng-1.6.56.tar.xz": "f7d8bf1601b7804f583a254ab343a6549ca6cf27d255c302c47af2d9d36a6f18"
+    "libpng-1.6.57.tar.xz": "d10c20d7171569804cae8dfc13ba6dcd0662c41ed39d43d4d429314aafb10a80"
   }
 }

--- a/SPECS/libpng/libpng.spec
+++ b/SPECS/libpng/libpng.spec
@@ -1,6 +1,6 @@
 Summary:        contains libraries for reading and writing PNG files.
 Name:           libpng
-Version:        1.6.56
+Version:        1.6.57
 Release:        1%{?dist}
 License:        zlib
 Vendor:         Microsoft Corporation
@@ -57,6 +57,9 @@ make %{?_smp_mflags} -k check
 %{_mandir}/man3/*
 
 %changelog
+* Sat Apr 11 2026 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 1.6.57-1
+- Auto-upgrade to 1.6.57 - for CVE-2026-34757
+
 * Sat Mar 28 2026 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 1.6.56-1
 - Auto-upgrade to 1.6.56 - for CVE-2026-33636, CVE-2026-33416
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -10901,8 +10901,8 @@
         "type": "other",
         "other": {
           "name": "libpng",
-          "version": "1.6.56",
-          "downloadUrl": "https://downloads.sourceforge.net/libpng/libpng-1.6.56.tar.xz"
+          "version": "1.6.57",
+          "downloadUrl": "https://downloads.sourceforge.net/libpng/libpng-1.6.57.tar.xz"
         }
       }
     },


### PR DESCRIPTION
Upgrade pipeline - > https://dev.azure.com/mariner-org/mariner/_build/results?buildId=1091838&view=results
Buddy Build - > https://dev.azure.com/mariner-org/mariner/_build/results?buildId=1091891&view=results