### PR TITLE
fix(uboot-tools): remove unnecessary release bump overlay

### DIFF
--- a/base/comps/uboot-tools/uboot-tools.comp.toml
+++ b/base/comps/uboot-tools/uboot-tools.comp.toml
@@ -1,12 +1,5 @@
 [components.uboot-tools]
 
-# TODO: Remove this overlay once automatic incremental release bumping is available.
-[[components.uboot-tools.overlays]]
-description = "Bump release for Azure Linux rebuild with toolsonly disabled"
-type = "spec-update-tag"
-tag = "Release"
-value = "2%{?candidate:.%{candidate}}%{?dist}"
-
 [components.uboot-tools.build]
 # Disable the "toolsonly" bcond to skip building firmware images for ARM dev
 # boards (Raspberry Pi, Rockchip, Allwinner, etc.). These require


### PR DESCRIPTION
The release bump was not needed — this is the first build of uboot-tools in Azure Linux, so there is no prior NVR to conflict with.