### PR TITLE
workaround(cloud-init): ds-identify path mismatch preventing cloud-init from starting

### DIFF
--- a/base/comps/cloud-init/cloud-init.comp.toml
+++ b/base/comps/cloud-init/cloud-init.comp.toml
@@ -11,3 +11,18 @@ description = "Add the CPE parsing bug fix patch file"
 type = "file-add"
 source = "fix-avoid-incorrect-CPE-parsing-on-Azure-Linux.patch"
 file = "fix-avoid-incorrect-CPE-parsing-on-Azure-Linux.patch"
+
+# The upstream spec does not pass --distro to setup.py install, so the Jinja2
+# template for cloud-init-generator renders with no variant and falls through to
+# the default path /usr/lib/cloud-init/ds-identify. However, ds-identify is
+# installed to /usr/libexec/cloud-init/ (because /etc/redhat-release exists in
+# the build chroot). This mismatch causes cloud-init-generator to fail with
+# exit status 3 at boot, preventing cloud-init from running.
+# Fix by adding --distro=fedora so the generator template picks the correct
+# /usr/libexec/cloud-init/ds-identify path.
+[[components.cloud-init.overlays]]
+description = "Fix ds-identify path mismatch: pass --distro=fedora to setup.py so cloud-init-generator uses /usr/libexec/cloud-init/ds-identify"
+type = "spec-search-replace"
+section = "%install"
+regex = '%py3_install -- --init-system=systemd'
+replacement = '%py3_install -- --init-system=systemd --distro=fedora'


### PR DESCRIPTION
Workaround cloud-init issue in vm-base images built with stage2 RPMs.
Follow-up bug: https://dev.azure.com/mariner-org/mariner/_workitems/edit/18738

Issue:
vm-base images built with stage2 RPMs have an issue where cloud-init does not run.
Cloud-init fails to start with:
`(sd-exec-[704]: /usr/lib/systemd/system-generators/cloud-init-generator failed with exit status 3.`

Root Cause:
A path mismatch in cloud-init 25.2 between where ds-identify is installed vs where the generator script looks for it:

Installed to: /usr/libexec/cloud-init/ds-identify (because /etc/redhat-release exists in the mock build chroot, triggering the usr/libexec path in setup.py)
Generator looks in: /usr/lib/cloud-init/ds-identify (because setup.py install is not passed --distro, so the Jinja2 template falls through to the default else branch)

On AZL4, the variant is unset, producing the wrong path.


Background:

The upstream spec does not pass --distro to setup.py install, so the
Jinja2 template for cloud-init-generator renders with no variant and
falls through to the default path /usr/lib/cloud-init/ds-identify.
However, ds-identify is installed to /usr/libexec/cloud-init/ because
/etc/redhat-release exists in the build chroot. This mismatch causes
cloud-init-generator to exit with status 3 at boot, preventing
cloud-init from running entirely.

Add overlay to pass --distro=fedora to setup.py so the generator
template selects the correct /usr/libexec/cloud-init/ds-identify path.

Verification: 
built cloud-init locally and installed on local vm-base vhd. Booted with `azldev image boot --image-path ./azl4-vm-base.x86_64-0.1-2.vhdfixed --test-password-file ~/.azl-test-pw` and confirmed cloud-init runs and I can login with a test user account.