### PR TITLE
feat: remove vm-base.kiwi package dracut-network

### DIFF
--- a/base/images/vm-base/vm-base.kiwi
+++ b/base/images/vm-base/vm-base.kiwi
@@ -121,7 +121,6 @@
 
     <packages type="bootstrap">
         <package name="azurelinux-release-cloud" />
-        <package name="dracut-network" />
         <package name="filesystem" />
         <package name="grub2-efi-x64-modules" arch="x86_64" />
         <package name="grub2-efi-x64" arch="x86_64" />


### PR DESCRIPTION
This package is only needed when networking is required from the initrd, which isn't the case for us, and it pulls in multiple additional packages:

- NetworkManager
- NetworkManager-libnm
- jq
- libndp
- oniguruma