### PR TITLE
feat: remove vm-base.kiwi package shadow-utils-subid

### DIFF
--- a/base/images/vm-base/vm-base.kiwi
+++ b/base/images/vm-base/vm-base.kiwi
@@ -98,7 +98,6 @@
         <package name="selinux-policy-targeted" />
         <package name="setup" />
         <package name="shadow-utils" />
-        <package name="shadow-utils-subid" />
         <package name="sudo" />
         <package name="systemd" />
         <package name="systemd-networkd" />


### PR DESCRIPTION
This is only needed for managing subordinate uid/gid ranges, and doesn't need to be included by default in our base image.
