### PR TITLE
feat: remove vm-base.kiwi package kernel-tools

### DIFF
--- a/base/images/vm-base/vm-base.kiwi
+++ b/base/images/vm-base/vm-base.kiwi
@@ -83,7 +83,6 @@
         <package name="iputils" />
         <package name="irqbalance" />
         <package name="kernel" />
-        <package name="kernel-tools" />
         <package name="lvm2" />
         <package name="lz4" />
         <package name="man-db" />


### PR DESCRIPTION
This contains tools mostly useful for bare-metal systems; we should not include this by default in our base image. It additionally pulled in:

- kernel-tools-libs
- libnl3
- pciutils-libs