### PR TITLE
feat: remove vm-base.kiwi package kernel

### DIFF
--- a/base/images/vm-base/vm-base.kiwi
+++ b/base/images/vm-base/vm-base.kiwi
@@ -82,7 +82,6 @@
         <package name="iproute" />
         <package name="iputils" />
         <package name="irqbalance" />
-        <package name="kernel" />
         <package name="kernel-tools" />
         <package name="lvm2" />
         <package name="lz4" />


### PR DESCRIPTION
This is only a metapackage that pulls in other packages, and shouldn't be installed by default.
