### PR TITLE
feat: remove vm-base.kiwi package file

### DIFF
--- a/base/images/vm-base/vm-base.kiwi
+++ b/base/images/vm-base/vm-base.kiwi
@@ -71,7 +71,6 @@
         <package name="dracut-kiwi-oem-repart" />
         <package name="elfutils" />
         <package name="elfutils-default-yama-scope" />
-        <package name="file" />
         <package name="firewalld" />
         <package name="glibc" />
         <package name="glibc-langpack-en" />


### PR DESCRIPTION
The file package will be pulled in by other packages (e.g. grub2-tools, grub2-pc, etc) and should not be explicitly listed.
