### PR TITLE
feat: replace vm-base.kiwi package ncurses-term with ncurses

### DIFF
--- a/base/images/vm-base/vm-base.kiwi
+++ b/base/images/vm-base/vm-base.kiwi
@@ -88,6 +88,7 @@
         <package name="lz4" />
         <package name="man-db" />
         <package name="nano" />
+        <package name="ncurses" />
         <package name="ncurses-term" />
         <package name="net-tools" />
         <package name="nftables" />


### PR DESCRIPTION
The ncurses-term package contains 'additional terminal descriptions' which we don't need to include by default; what we need is the main ncurses package.
