### PR TITLE
feat: remove vm-base.kiwi package systemd-rpm-macros

### DIFF
--- a/base/images/vm-base/vm-base.kiwi
+++ b/base/images/vm-base/vm-base.kiwi
@@ -103,7 +103,6 @@
         <package name="systemd" />
         <package name="systemd-networkd" />
         <package name="systemd-resolved" />
-        <package name="systemd-rpm-macros" />
         <package name="tar" />
         <package name="tpm2-tss" />
         <package name="unzip" />


### PR DESCRIPTION
We don't need any rpm-macros files in the base image, those are needed only for building packages.
