### PR TITLE
Upgrade `rubygem-rdiscount` to 2.2.7.4 for CVE-2026-35201

### DIFF
--- a/SPECS/rubygem-rdiscount/rubygem-rdiscount.signatures.json
+++ b/SPECS/rubygem-rdiscount/rubygem-rdiscount.signatures.json
@@ -1,5 +1,5 @@
 {
- "Signatures": {
-  "rdiscount-2.2.7.1.tar.gz": "9b868bb68e698814249a6e5c94bd516331d2e59c9c6c3f3c0825748b59e60144"
- }
+  "Signatures": {
+    "rdiscount-2.2.7.4.tar.gz": "d67b9835bc5f33eaf5621e94a0f806cdcf07f99b9bab6f255c8e3a09e05003eb"
+  }
 }

--- a/SPECS/rubygem-rdiscount/rubygem-rdiscount.spec
+++ b/SPECS/rubygem-rdiscount/rubygem-rdiscount.spec
@@ -4,7 +4,7 @@
 
 Summary:       Converts documents in Markdown syntax to HTML
 Name:          rubygem-%{gem_name}
-Version:       2.2.7.1
+Version:       2.2.7.4
 Release:       1%{?dist}
 License:       MIT
 Vendor:	       Microsoft Corporation
@@ -31,6 +31,9 @@ gem install -V --local --force --install-dir %{buildroot}/%{gemdir} %{gem_name}-
 %{gemdir}
 
 %changelog
+* Tue Apr 14 2026 CBL-Mariner Servicing Account <cblmargh@microsoft.com> - 2.2.7.4-1
+- Auto-upgrade to 2.2.7.4 - for CVE-2026-35201
+
 * Wed Mar 13 2024 Riken Maharjan <rmaharjan@microsoft.com> - 2.2.7.1-1
 - Upgrade to 2.2.7.1 - azl3.0 
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -27274,8 +27274,8 @@
         "type": "other",
         "other": {
           "name": "rubygem-rdiscount",
-          "version": "2.2.7.1",
-          "downloadUrl": "https://github.com/davidfstr/rdiscount/archive/refs/tags/2.2.7.1.tar.gz"
+          "version": "2.2.7.4",
+          "downloadUrl": "https://github.com/davidfstr/rdiscount/archive/refs/tags/2.2.7.4.tar.gz"
         }
       }
     },


### PR DESCRIPTION
AutoUpgrade Pipeline - https://dev.azure.com/mariner-org/mariner/_build/results?buildId=1095113&view=results
Buddy Build - > https://dev.azure.com/mariner-org/mariner/_build/results?buildId=1095133&view=results