### PR TITLE
feat: set azurelinux_release release name and prerelease name

### DIFF
--- a/base/comps/azurelinux-release/azurelinux-release.spec
+++ b/base/comps/azurelinux-release/azurelinux-release.spec
@@ -235,8 +235,6 @@ echo "cpe:/o:microsoft:azurelinux:%{version}" > %{buildroot}%{_prefix}/lib/syste
 install -d %{buildroot}%{_sysconfdir}
 ln -s ../usr/lib/azurelinux-release %{buildroot}%{_sysconfdir}/azurelinux-release
 ln -s ../usr/lib/system-release-cpe %{buildroot}%{_sysconfdir}/system-release-cpe
-# TODO(azl): validate
-# ln -s azurelinux-release %{buildroot}%{_sysconfdir}/azurelinux-release
 ln -s azurelinux-release %{buildroot}%{_sysconfdir}/system-release
 
 # Create the common os-release file
@@ -409,8 +407,6 @@ install -Dm0755 %{SOURCE19} %{buildroot}%{_libexecdir}/proc-version-override
 %{_prefix}/lib/system-release-cpe
 %{_sysconfdir}/os-release
 %{_sysconfdir}/azurelinux-release
-# TODO(azl): review
-# %{_sysconfdir}/azurelinux-release
 %{_sysconfdir}/system-release
 %{_sysconfdir}/system-release-cpe
 %attr(0644,root,root) %{_prefix}/lib/issue

--- a/base/comps/azurelinux-release/azurelinux-release.spec
+++ b/base/comps/azurelinux-release/azurelinux-release.spec
@@ -1,4 +1,7 @@
-%define release_name Alpha2
+%define release_name Four
+# Let's remove this prerelease_name before release, and next time we
+# can use the built-in prerelease logic (based on release number < 1)
+%define prerelease_name Alpha2
 %define is_evergreen 0
 
 # Define this to 1 for Branched releases prior to RC
@@ -36,7 +39,7 @@ Summary:        Azure Linux release files
 Name:           azurelinux-release
 Version:        4.0
 # TODO(azl): Review whether we can move back to autorelease (with conditional -p)
-Release:        7%{?dist}
+Release:        8%{?dist}
 License:        MIT
 URL:            https://aka.ms/azurelinux
 
@@ -246,6 +249,8 @@ ln -s azurelinux-release %{buildroot}%{_sysconfdir}/system-release
 %define starts_with(str,prefix) (%{expand:%%{lua:print(starts_with(%1, %2) and "1" or "0")}})
 %if %{starts_with "a%{release}" "a0"}
   %global prerelease \ Prerelease
+%elif "0%{?prerelease_name}" != "0"
+  %global prerelease \ %{prerelease_name}
 %endif
 
 # -------------------------------------------------------------------------
@@ -466,6 +471,9 @@ install -Dm0755 %{SOURCE19} %{buildroot}%{_libexecdir}/proc-version-override
 
 
 %changelog
+* Wed Apr 15 2026 Dan Streetman <ddstreet@ieee.org> - 4.0-8
+- Set prerelease name
+
 * Tue Apr 14 2026 Reuben Olinsky <reubeno@microsoft.com> - 4.0-7
 - Update release name to Alpha2 and extend EOL date
 

--- a/base/comps/azurelinux-release/azurelinux-release.spec
+++ b/base/comps/azurelinux-release/azurelinux-release.spec
@@ -482,7 +482,7 @@ install -Dm0755 %{SOURCE19} %{buildroot}%{_libexecdir}/proc-version-override
 * Wed Apr 08 2026 Dan Streetman <ddstreet@ieee.org> - 4.0-4
 - Configure chrony to use Azure PTP timesource
 
-* Tue Apr 01 2026 Rachel Menge <rachelmenge@microsoft.com> - 4.0-3
+* Wed Apr 01 2026 Rachel Menge <rachelmenge@microsoft.com> - 4.0-3
 - Add proc-version-override service for Guest-Configuration-Extension compat
 
 * Fri Feb 27 2026 Reuben Olinsky <reubeno@microsoft.com> - 4.0-2


### PR DESCRIPTION
We incorrectly already set the release to greater than 0.X, so the built-in prerelease logic won't work this time; so let's add a manually specified prerelease name which we need to manually remove later before actual release.

Also fix a changelog day-of-week error, and remove TODO commented-out creation of a `<VENDOR>_release` (i.e. `microsoft-release`) symlink that we aren't using